### PR TITLE
Fix accessibility focus loss when first focusing on text field

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -865,7 +865,7 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
            @"must be part of the responder chain to function");
   _activeView.textInputDelegate = _textInputDelegate;
 
-  if (!_activeView.window) {
+  if (_activeView.window != keyWindow) {
     [keyWindow addSubview:_activeView];
   }
   [_activeView becomeFirstResponder];
@@ -885,7 +885,7 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
     _activeView = isSecureTextEntry ? _nonAutofillSecureInputView : _nonAutofillInputView;
     [FlutterTextInputPlugin setupInputView:_activeView withConfiguration:configuration];
 
-    if (!_activeView.window) {
+    if (_activeView.window != keyWindow) {
       [keyWindow addSubview:_activeView];
     }
   } else {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -866,7 +866,7 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
   _activeView.textInputDelegate = _textInputDelegate;
 
   if (!_activeView.window) {
-     [keyWindow addSubview:_activeView];
+    [keyWindow addSubview:_activeView];
   }
   [_activeView becomeFirstResponder];
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -780,22 +780,16 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
     [self replaceRange:_selectedTextRange withText:@""];
 }
 
-@end
-
-/**
- * Hides `FlutterTextInputView` from iOS accessibility system so it
- * does not show up twice, once where it is in the `UIView` hierarchy,
- * and a second time as part of the `SemanticsObject` hierarchy.
- */
-@interface FlutterTextInputViewAccessibilityHider : UIView {
-}
-
-@end
-
-@implementation FlutterTextInputViewAccessibilityHider {
-}
-
 - (BOOL)accessibilityElementsHidden {
+  // We are hiding this accessibility element.
+  // There are 2 accessible elements involved in text entry in 2 different parts of the view
+  // hierarchy. This `FlutterTextInputView` is injected at the top of key window. We use this as a
+  // `UITextInput` protocol to bridge text edit events between Flutter and iOS.
+  //
+  // We also create ur own custom `UIAccessibilityElements` tree with our `SemanticsObject` to
+  // mimic the semantics tree from Flutter. We want the text field to be represented as a
+  // `TextInputSemanticsObject` in that `SemanticsObject` tree rather than in this
+  // `FlutterTextInputView` bridge which doesn't appear above a text field from the Flutter side.
   return YES;
 }
 
@@ -806,7 +800,6 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
 @property(nonatomic, retain) FlutterTextInputView* nonAutofillSecureInputView;
 @property(nonatomic, retain) NSMutableArray<FlutterTextInputView*>* inputViews;
 @property(nonatomic, assign) FlutterTextInputView* activeView;
-@property(nonatomic, retain) FlutterTextInputViewAccessibilityHider* inputHider;
 @end
 
 @implementation FlutterTextInputPlugin
@@ -824,7 +817,6 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
     _inputViews = [[NSMutableArray alloc] init];
 
     _activeView = _nonAutofillInputView;
-    _inputHider = [[FlutterTextInputViewAccessibilityHider alloc] init];
   }
 
   return self;
@@ -834,7 +826,6 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
   [self hideTextInput];
   [_nonAutofillInputView release];
   [_nonAutofillSecureInputView release];
-  [_inputHider release];
   [_inputViews release];
 
   [super dealloc];
@@ -873,19 +864,19 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
            @"The application must have a key window since the keyboard client "
            @"must be part of the responder chain to function");
   _activeView.textInputDelegate = _textInputDelegate;
-  if (![_activeView isDescendantOfView:_inputHider]) {
-    [_inputHider addSubview:_activeView];
+
+  if (!_activeView.window) {
+     [keyWindow addSubview:_activeView];
   }
-  [keyWindow addSubview:_inputHider];
   [_activeView becomeFirstResponder];
 }
 
 - (void)hideTextInput {
   [_activeView resignFirstResponder];
-  [_inputHider removeFromSuperview];
 }
 
 - (void)setTextInputClient:(int)client withConfiguration:(NSDictionary*)configuration {
+  UIWindow* keyWindow = [UIApplication sharedApplication].keyWindow;
   NSArray* fields = configuration[@"fields"];
   NSString* clientUniqueId = uniqueIdFromDictionary(configuration);
   bool isSecureTextEntry = [configuration[@"obscureText"] boolValue];
@@ -894,16 +885,19 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
     _activeView = isSecureTextEntry ? _nonAutofillSecureInputView : _nonAutofillInputView;
     [FlutterTextInputPlugin setupInputView:_activeView withConfiguration:configuration];
 
-    if (![_activeView isDescendantOfView:_inputHider]) {
-      [_inputHider addSubview:_activeView];
+    if (!_activeView.window) {
+      [keyWindow addSubview:_activeView];
     }
   } else {
     NSAssert(clientUniqueId != nil, @"The client's unique id can't be null");
     for (FlutterTextInputView* view in _inputViews) {
       [view removeFromSuperview];
     }
-    for (UIView* subview in _inputHider.subviews) {
-      [subview removeFromSuperview];
+
+    for (UIView* view in keyWindow.subviews) {
+      if ([view isKindOfClass:[FlutterTextInputView class]]) {
+        [view removeFromSuperview];
+      }
     }
 
     [_inputViews removeAllObjects];
@@ -921,7 +915,7 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
       }
 
       [FlutterTextInputPlugin setupInputView:newInputView withConfiguration:field];
-      [_inputHider addSubview:newInputView];
+      [keyWindow addSubview:newInputView];
     }
   }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -38,18 +38,29 @@ FLUTTER_ASSERT_ARC
                              result:^(id _Nullable result){
                              }];
 
-  // Find all input views in the input hider view.
-  NSArray<FlutterTextInputView*>* inputFields =
-      [[[textInputPlugin textInputView] superview] subviews];
+  // Find all the FlutterTextInputViews we created.
+  NSArray<FlutterTextInputView*>* inputFields = [[[[textInputPlugin textInputView] superview]
+      subviews]
+      filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"class == %@",
+                                                                   [FlutterTextInputView class]]];
 
-  // Find the inactive autofillable input field.
+  // There are no autofill and the mock framework requested a secure entry. The first and only
+  // inserted FlutterTextInputView should be a secure text entry one.
   FlutterTextInputView* inputView = inputFields[0];
 
   // Verify secureTextEntry is set to the correct value.
   XCTAssertTrue(inputView.secureTextEntry);
 
-  // Clean up mocks
+  // We should have only ever created one FlutterTextInputView.
+  XCTAssertEqual(inputFields.count, 1);
+
+  // The one FlutterTextInputView we inserted into the view hierarchy should be the text input
+  // plugin's active text input view.
+  XCTAssertEqual(inputView, textInputPlugin.textInputView);
+
+  // Clean up.
   [engine stopMocking];
+  [[[[textInputPlugin textInputView] superview] subviews] makeObjectsPerformSelector: @selector(removeFromSuperview)];
 }
 - (void)testAutofillInputViews {
   // Setup test.
@@ -94,9 +105,11 @@ FLUTTER_ASSERT_ARC
                              result:^(id _Nullable result){
                              }];
 
-  // Find all input views in the input hider view.
-  NSArray<FlutterTextInputView*>* inputFields =
-      [[[textInputPlugin textInputView] superview] subviews];
+  // Find all the FlutterTextInputViews we created.
+  NSArray<FlutterTextInputView*>* inputFields = [[[[textInputPlugin textInputView] superview]
+      subviews]
+      filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"class == %@",
+                                                                   [FlutterTextInputView class]]];
 
   XCTAssertEqual(inputFields.count, 2);
 
@@ -108,8 +121,9 @@ FLUTTER_ASSERT_ARC
   // Verify behavior.
   OCMVerify([engine updateEditingClient:0 withState:[OCMArg isNotNil] withTag:@"field2"]);
 
-  // Clean up mocks
+  // Clean up.
   [engine stopMocking];
+  [[[[textInputPlugin textInputView] superview] subviews] makeObjectsPerformSelector: @selector(removeFromSuperview)];
 }
 
 - (void)testAutocorrectionPromptRectAppears {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -60,7 +60,8 @@ FLUTTER_ASSERT_ARC
 
   // Clean up.
   [engine stopMocking];
-  [[[[textInputPlugin textInputView] superview] subviews] makeObjectsPerformSelector: @selector(removeFromSuperview)];
+  [[[[textInputPlugin textInputView] superview] subviews]
+      makeObjectsPerformSelector:@selector(removeFromSuperview)];
 }
 - (void)testAutofillInputViews {
   // Setup test.
@@ -123,7 +124,8 @@ FLUTTER_ASSERT_ARC
 
   // Clean up.
   [engine stopMocking];
-  [[[[textInputPlugin textInputView] superview] subviews] makeObjectsPerformSelector: @selector(removeFromSuperview)];
+  [[[[textInputPlugin textInputView] superview] subviews]
+      makeObjectsPerformSelector:@selector(removeFromSuperview)];
 }
 
 - (void)testAutocorrectionPromptRectAppears {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -4,7 +4,7 @@
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
-#include "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0D6AB6B022BB05E100EEE540"
+               BuildableName = "IosUnitTests.app"
+               BlueprintName = "IosUnitTests"
+               ReferencedContainer = "container:IosUnitTests.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0D6AB6C822BB05E200EEE540"
+               BuildableName = "IosUnitTestsTests.xctest"
+               BlueprintName = "IosUnitTestsTests"
+               ReferencedContainer = "container:IosUnitTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0D6AB6B022BB05E100EEE540"
+            BuildableName = "IosUnitTests.app"
+            BlueprintName = "IosUnitTests"
+            ReferencedContainer = "container:IosUnitTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0D6AB6B022BB05E100EEE540"
+            BuildableName = "IosUnitTests.app"
+            BlueprintName = "IosUnitTests"
+            ReferencedContainer = "container:IosUnitTests.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
@@ -40,7 +40,8 @@ public class EngineLaunchE2ETest {
         .get()
         .getDartExecutor()
         .setMessageHandler(
-            "waiting_for_status", (byteBuffer, binaryReply) -> statusReceived.complete(Boolean.TRUE));
+            "waiting_for_status",
+            (byteBuffer, binaryReply) -> statusReceived.complete(Boolean.TRUE));
 
     // Launching the entrypoint will run the Dart code that sends the "waiting_for_status" platform
     // message.

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
@@ -34,15 +34,15 @@ public class EngineLaunchE2ETest {
     UiThreadStatement.runOnUiThread(() -> engine.set(new FlutterEngine(applicationContext)));
     CompletableFuture<Boolean> statusReceived = new CompletableFuture<>();
 
-    // The default Dart main entrypoint sends back a platform message on the "scenario_status"
+    // The default Dart main entrypoint sends back a platform message on the "waiting_for_status"
     // channel. That will be our launch success assertion condition.
     engine
         .get()
         .getDartExecutor()
         .setMessageHandler(
-            "scenario_status", (byteBuffer, binaryReply) -> statusReceived.complete(Boolean.TRUE));
+            "waiting_for_status", (byteBuffer, binaryReply) -> statusReceived.complete(Boolean.TRUE));
 
-    // Launching the entrypoint will run the Dart code that sends the "scenario_status" platform
+    // Launching the entrypoint will run the Dart code that sends the "waiting_for_status" platform
     // message.
     UiThreadStatement.runOnUiThread(
         () ->
@@ -54,7 +54,7 @@ public class EngineLaunchE2ETest {
     try {
       Boolean result = statusReceived.get(10, TimeUnit.SECONDS);
       if (!result) {
-        fail("expected message on scenario_status not received");
+        fail("expected message on waiting_for_status not received");
       }
     } catch (ExecutionException e) {
       fail(e.getMessage());

--- a/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/project.pbxproj
+++ b/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A42BFB42447E179007E212E /* TextSemanticsFocusTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A42BFB32447E179007E212E /* TextSemanticsFocusTest.m */; };
 		0A57B3BD2323C4BD00DD9521 /* ScreenBeforeFlutter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A57B3BC2323C4BD00DD9521 /* ScreenBeforeFlutter.m */; };
 		0A57B3BF2323C74200DD9521 /* FlutterEngine+ScenariosTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A57B3BE2323C74200DD9521 /* FlutterEngine+ScenariosTest.m */; };
 		0A57B3C22323D2D700DD9521 /* AppLifecycleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A57B3C12323D2D700DD9521 /* AppLifecycleTests.m */; };
@@ -110,6 +111,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0A42BFB32447E179007E212E /* TextSemanticsFocusTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TextSemanticsFocusTest.m; sourceTree = "<group>"; };
+		0A42BFB52447E19F007E212E /* TextSemanticsFocusTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextSemanticsFocusTest.h; sourceTree = "<group>"; };
 		0A57B3BB2323C4BD00DD9521 /* ScreenBeforeFlutter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScreenBeforeFlutter.h; sourceTree = "<group>"; };
 		0A57B3BC2323C4BD00DD9521 /* ScreenBeforeFlutter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ScreenBeforeFlutter.m; sourceTree = "<group>"; };
 		0A57B3BE2323C74200DD9521 /* FlutterEngine+ScenariosTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "FlutterEngine+ScenariosTest.m"; sourceTree = "<group>"; };
@@ -280,6 +283,8 @@
 				68A5B63323EB71D300BDBCDB /* PlatformViewGestureRecognizerTests.m */,
 				0D8470A2240F0B1F0030B565 /* StatusBarTest.h */,
 				0D8470A3240F0B1F0030B565 /* StatusBarTest.m */,
+				0A42BFB32447E179007E212E /* TextSemanticsFocusTest.m */,
+				0A42BFB52447E19F007E212E /* TextSemanticsFocusTest.h */,
 			);
 			path = ScenariosUITests;
 			sourceTree = "<group>";
@@ -498,6 +503,7 @@
 				6816DBA42318358200A51400 /* PlatformViewGoldenTestManager.m in Sources */,
 				248D76EF22E388380012F0C1 /* PlatformViewUITests.m in Sources */,
 				0D8470A4240F0B1F0030B565 /* StatusBarTest.m in Sources */,
+				0A42BFB42447E179007E212E /* TextSemanticsFocusTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/xcshareddata/xcschemes/Scenarios.xcscheme
+++ b/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/xcshareddata/xcschemes/Scenarios.xcscheme
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "248D76C622E388370012F0C1"
+            BuildableName = "Scenarios.app"
+            BlueprintName = "Scenarios"
+            ReferencedContainer = "container:Scenarios.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO"
@@ -51,17 +60,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "248D76C622E388370012F0C1"
-            BuildableName = "Scenarios.app"
-            BlueprintName = "Scenarios"
-            ReferencedContainer = "container:Scenarios.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -89,12 +87,14 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--text-semantics-focus"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--platform-view"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
@@ -23,11 +23,8 @@
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
   self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
 
-  // This argument is used by the XCUITest for Platform Views so that the app
-  // under test will create platform views.
-  // If the test is one of the platform view golden tests,
-  // the launchArgsMap should match the one in the `PlatformVieGoldenTestManager`.
   NSDictionary<NSString*, NSString*>* launchArgsMap = @{
+    // The Platform view golden test args should match `PlatformViewGoldenTestManager`.
     @"--platform-view" : @"platform_view",
     @"--platform-view-no-overlay-intersection" : @"platform_view_no_overlay_intersection",
     @"--platform-view-two-intersecting-overlays" : @"platform_view_two_intersecting_overlays",
@@ -49,18 +46,19 @@
     @"--gesture-reject-eager" : @"platform_view_gesture_reject_eager",
     @"--gesture-accept" : @"platform_view_gesture_accept",
     @"--tap-status-bar" : @"tap_status_bar",
+    @"--text-semantics-focus" : @"text_semantics_focus"
   };
-  __block NSString* platformViewTestName = nil;
+  __block NSString* flutterViewControllerTestName = nil;
   [launchArgsMap
       enumerateKeysAndObjectsUsingBlock:^(NSString* argument, NSString* testName, BOOL* stop) {
         if ([[[NSProcessInfo processInfo] arguments] containsObject:argument]) {
-          platformViewTestName = testName;
+          flutterViewControllerTestName = testName;
           *stop = YES;
         }
       }];
 
-  if (platformViewTestName) {
-    [self readyContextForPlatformViewTests:platformViewTestName];
+  if (flutterViewControllerTestName) {
+    [self setupFlutterViewControllerTest:flutterViewControllerTestName];
   } else if ([[[NSProcessInfo processInfo] arguments] containsObject:@"--screen-before-flutter"]) {
     self.window.rootViewController = [[ScreenBeforeFlutter alloc] initWithEngineRunCompletion:nil];
   } else {
@@ -71,22 +69,26 @@
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
-- (void)readyContextForPlatformViewTests:(NSString*)scenarioIdentifier {
-  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"PlatformViewTest" project:nil];
-  [engine runWithEntrypoint:nil];
-
-  FlutterViewController* flutterViewController;
+- (FlutterViewController*)flutterViewControllerForTest:(NSString*)scenarioIdentifier withEngine:(FlutterEngine*)engine {
   if ([scenarioIdentifier isEqualToString:@"tap_status_bar"]) {
-    flutterViewController = [[FlutterViewController alloc] initWithEngine:engine
+    return [[FlutterViewController alloc] initWithEngine:engine
                                                                   nibName:nil
                                                                    bundle:nil];
   } else {
-    flutterViewController = [[NoStatusBarFlutterViewController alloc] initWithEngine:engine
+    return [[NoStatusBarFlutterViewController alloc] initWithEngine:engine
                                                                              nibName:nil
                                                                               bundle:nil];
   }
+}
+
+- (void)setupFlutterViewControllerTest:(NSString*)scenarioIdentifier {
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"FlutterControllerTest" project:nil];
+  [engine run];
+
+  FlutterViewController* flutterViewController = [self flutterViewControllerForTest:scenarioIdentifier withEngine:engine];
+  
   [engine.binaryMessenger
-      setMessageHandlerOnChannel:@"scenario_status"
+      setMessageHandlerOnChannel:@"waiting_for_status"
             binaryMessageHandler:^(NSData* _Nullable message, FlutterBinaryReply _Nonnull reply) {
               [engine.binaryMessenger
                   sendOnChannel:@"set_scenario"
@@ -103,9 +105,9 @@
               [flutterViewController.view addSubview:text];
             }];
   TextPlatformViewFactory* textPlatformViewFactory =
-      [[TextPlatformViewFactory alloc] initWithMessenger:flutterViewController.binaryMessenger];
+      [[TextPlatformViewFactory alloc] initWithMessenger:engine.binaryMessenger];
   NSObject<FlutterPluginRegistrar>* registrar =
-      [flutterViewController.engine registrarForPlugin:@"scenarios/TextPlatformViewPlugin"];
+      [engine registrarForPlugin:@"scenarios/TextPlatformViewPlugin"];
   [registrar registerViewFactory:textPlatformViewFactory
                                 withId:@"scenarios/textPlatformView"
       gestureRecognizersBlockingPolicy:FlutterPlatformViewGestureRecognizersBlockingPolicyEager];

--- a/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "AppDelegate.h"
+#import "AppDelegate.h"
+
 #import "FlutterEngine+ScenariosTest.h"
 #import "ScreenBeforeFlutter.h"
 #import "TextPlatformView.h"

--- a/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
@@ -69,15 +69,12 @@
   return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
-- (FlutterViewController*)flutterViewControllerForTest:(NSString*)scenarioIdentifier withEngine:(FlutterEngine*)engine {
+- (FlutterViewController*)flutterViewControllerForTest:(NSString*)scenarioIdentifier
+                                            withEngine:(FlutterEngine*)engine {
   if ([scenarioIdentifier isEqualToString:@"tap_status_bar"]) {
-    return [[FlutterViewController alloc] initWithEngine:engine
-                                                                  nibName:nil
-                                                                   bundle:nil];
+    return [[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
   } else {
-    return [[NoStatusBarFlutterViewController alloc] initWithEngine:engine
-                                                                             nibName:nil
-                                                                              bundle:nil];
+    return [[NoStatusBarFlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil];
   }
 }
 
@@ -85,8 +82,9 @@
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"FlutterControllerTest" project:nil];
   [engine run];
 
-  FlutterViewController* flutterViewController = [self flutterViewControllerForTest:scenarioIdentifier withEngine:engine];
-  
+  FlutterViewController* flutterViewController =
+      [self flutterViewControllerForTest:scenarioIdentifier withEngine:engine];
+
   [engine.binaryMessenger
       setMessageHandlerOnChannel:@"waiting_for_status"
             binaryMessageHandler:^(NSData* _Nullable message, FlutterBinaryReply _Nonnull reply) {

--- a/testing/scenario_app/ios/Scenarios/Scenarios/FlutterEngine+ScenariosTest.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/FlutterEngine+ScenariosTest.m
@@ -13,7 +13,7 @@
                     project:nil];
   [self runWithEntrypoint:nil];
   [self.binaryMessenger
-      setMessageHandlerOnChannel:@"scenario_status"
+      setMessageHandlerOnChannel:@"waiting_for_status"
             binaryMessageHandler:^(NSData* message, FlutterBinaryReply reply) {
               [self.binaryMessenger
                   sendOnChannel:@"set_scenario"

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
@@ -6,6 +6,8 @@
 #import <XCTest/XCTest.h>
 #import "ScreenBeforeFlutter.h"
 
+FLUTTER_ASSERT_ARC
+
 @interface XCAppLifecycleTestExpectation : XCTestExpectation
 
 - (instancetype)initForLifecycle:(NSString*)expectedLifecycle forStep:(NSString*)step;

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.h
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.h
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#import <Flutter/Flutter.h>
 #import <XCTest/XCTest.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.h
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.h
@@ -1,0 +1,13 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TextSemanticsFocusTest : XCTestCase
+@property(nonatomic, strong) XCUIApplication* application;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
@@ -1,0 +1,53 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "TextSemanticsFocusTest.h"
+
+@implementation TextSemanticsFocusTest
+
+- (void)setUp {
+  [super setUp];
+  self.continueAfterFailure = NO;
+
+  self.application = [[XCUIApplication alloc] init];
+  self.application.launchArguments = @[ @"--text-semantics-focus" ];
+  [self.application launch];
+}
+
+- (void)testAccessibilityFocusOnTextSemanticsProducesCorrectIosViews {
+  // Find the initial TextInputSemanticsObject which was sent from the mock framework on first frame.
+  XCUIElement* textInputSemanticsObject = [[[self.application textFields] matchingIdentifier:@"flutter textfield"] element];
+  XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:5]);
+  XCTAssertEqual([textInputSemanticsObject valueForKey:@"hasKeyboardFocus"], @(NO));
+  
+  // Since the first mock framework text field isn't focused on, it shouldn't produce a UITextInput
+  // in the view hierarchy.
+  XCUIElement* delegateTextInput = [[self.application textViews] element];
+  XCTAssertFalse([delegateTextInput waitForExistenceWithTimeout:5]);
+  
+  // Nor should there be a keyboard for text entry.
+  XCUIElement* keyboard = [[self.application keyboards] element];
+  XCTAssertFalse([keyboard waitForExistenceWithTimeout:5]);
+
+  // The tap location doesn't matter. The mock framework just sends a focused text field on tap.
+  [textInputSemanticsObject tap];
+  
+  // The new TextInputSemanticsObject now has keyboard focus (the only trait accessible through
+  // UI tests on a XCUIElement).
+  textInputSemanticsObject = [[[self.application textFields] matchingIdentifier:@"focused flutter textfield"] element];
+  XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:5]);
+  XCTAssertEqual([textInputSemanticsObject valueForKey:@"hasKeyboardFocus"], @(YES));
+  
+  // The delegate UITextInput is also inserted on the window and also has keyboard focus to delegate
+  // real text entry events to the framework.
+  delegateTextInput = [[self.application textViews] element];
+  XCTAssertTrue([delegateTextInput waitForExistenceWithTimeout:5]);
+  XCTAssertEqual([delegateTextInput valueForKey:@"hasKeyboardFocus"], @(YES));
+  
+  // Since there is focus, the soft keyboard is visible on the simulator.
+  keyboard = [[self.application keyboards] element];
+  XCTAssertTrue([keyboard waitForExistenceWithTimeout:5]);
+}
+
+@end

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
@@ -20,17 +20,17 @@
   // frame.
   XCUIElement* textInputSemanticsObject =
       [[[self.application textFields] matchingIdentifier:@"flutter textfield"] element];
-  XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:5]);
-  XCTAssertEqual([textInputSemanticsObject valueForKey:@"hasKeyboardFocus"], @(NO));
+  XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:3]);
+  XCTAssertEqualObjects([textInputSemanticsObject valueForKey:@"hasKeyboardFocus"], @(NO));
 
   // Since the first mock framework text field isn't focused on, it shouldn't produce a UITextInput
   // in the view hierarchy.
   XCUIElement* delegateTextInput = [[self.application textViews] element];
-  XCTAssertFalse([delegateTextInput waitForExistenceWithTimeout:5]);
+  XCTAssertFalse([delegateTextInput waitForExistenceWithTimeout:3]);
 
   // Nor should there be a keyboard for text entry.
   XCUIElement* keyboard = [[self.application keyboards] element];
-  XCTAssertFalse([keyboard waitForExistenceWithTimeout:5]);
+  XCTAssertFalse([keyboard waitForExistenceWithTimeout:3]);
 
   // The tap location doesn't matter. The mock framework just sends a focused text field on tap.
   [textInputSemanticsObject tap];
@@ -39,18 +39,18 @@
   // UI tests on a XCUIElement).
   textInputSemanticsObject =
       [[[self.application textFields] matchingIdentifier:@"focused flutter textfield"] element];
-  XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:5]);
-  XCTAssertEqual([textInputSemanticsObject valueForKey:@"hasKeyboardFocus"], @(YES));
+  XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:3]);
+  XCTAssertEqualObjects([textInputSemanticsObject valueForKey:@"hasKeyboardFocus"], @(YES));
 
-  // The delegate UITextInput is also inserted on the window and also has keyboard focus to delegate
-  // real text entry events to the framework.
+  // The delegate UITextInput is also inserted on the window but we make only the
+  // TextInputSemanticsObject visible and not the FlutterTextInputView to avoid confusing
+  // accessibility, it shouldn't be visible to the UI test either.
   delegateTextInput = [[self.application textViews] element];
-  XCTAssertTrue([delegateTextInput waitForExistenceWithTimeout:5]);
-  XCTAssertEqual([delegateTextInput valueForKey:@"hasKeyboardFocus"], @(YES));
+  XCTAssertFalse([delegateTextInput waitForExistenceWithTimeout:3]);
 
-  // Since there is focus, the soft keyboard is visible on the simulator.
+  // But since there is focus, the soft keyboard is visible on the simulator.
   keyboard = [[self.application keyboards] element];
-  XCTAssertTrue([keyboard waitForExistenceWithTimeout:5]);
+  XCTAssertTrue([keyboard waitForExistenceWithTimeout:3]);
 }
 
 @end

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
@@ -16,35 +16,38 @@
 }
 
 - (void)testAccessibilityFocusOnTextSemanticsProducesCorrectIosViews {
-  // Find the initial TextInputSemanticsObject which was sent from the mock framework on first frame.
-  XCUIElement* textInputSemanticsObject = [[[self.application textFields] matchingIdentifier:@"flutter textfield"] element];
+  // Find the initial TextInputSemanticsObject which was sent from the mock framework on first
+  // frame.
+  XCUIElement* textInputSemanticsObject =
+      [[[self.application textFields] matchingIdentifier:@"flutter textfield"] element];
   XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:5]);
   XCTAssertEqual([textInputSemanticsObject valueForKey:@"hasKeyboardFocus"], @(NO));
-  
+
   // Since the first mock framework text field isn't focused on, it shouldn't produce a UITextInput
   // in the view hierarchy.
   XCUIElement* delegateTextInput = [[self.application textViews] element];
   XCTAssertFalse([delegateTextInput waitForExistenceWithTimeout:5]);
-  
+
   // Nor should there be a keyboard for text entry.
   XCUIElement* keyboard = [[self.application keyboards] element];
   XCTAssertFalse([keyboard waitForExistenceWithTimeout:5]);
 
   // The tap location doesn't matter. The mock framework just sends a focused text field on tap.
   [textInputSemanticsObject tap];
-  
+
   // The new TextInputSemanticsObject now has keyboard focus (the only trait accessible through
   // UI tests on a XCUIElement).
-  textInputSemanticsObject = [[[self.application textFields] matchingIdentifier:@"focused flutter textfield"] element];
+  textInputSemanticsObject =
+      [[[self.application textFields] matchingIdentifier:@"focused flutter textfield"] element];
   XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:5]);
   XCTAssertEqual([textInputSemanticsObject valueForKey:@"hasKeyboardFocus"], @(YES));
-  
+
   // The delegate UITextInput is also inserted on the window and also has keyboard focus to delegate
   // real text entry events to the framework.
   delegateTextInput = [[self.application textViews] element];
   XCTAssertTrue([delegateTextInput waitForExistenceWithTimeout:5]);
   XCTAssertEqual([delegateTextInput valueForKey:@"hasKeyboardFocus"], @(YES));
-  
+
   // Since there is focus, the soft keyboard is visible on the simulator.
   keyboard = [[self.application keyboards] element];
   XCTAssertTrue([keyboard waitForExistenceWithTimeout:5]);

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+FLUTTER_ASSERT_ARC
+
 #import "TextSemanticsFocusTest.h"
 
 @implementation TextSemanticsFocusTest

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/TextSemanticsFocusTest.m
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-FLUTTER_ASSERT_ARC
-
 #import "TextSemanticsFocusTest.h"
+
+FLUTTER_ASSERT_ARC
 
 @implementation TextSemanticsFocusTest
 

--- a/testing/scenario_app/lib/main.dart
+++ b/testing/scenario_app/lib/main.dart
@@ -14,6 +14,7 @@ import 'src/animated_color_square.dart';
 import 'src/platform_view.dart';
 import 'src/poppable_screen.dart';
 import 'src/scenario.dart';
+import 'src/send_text_focus_semantics.dart';
 import 'src/touches_scenario.dart';
 
 Map<String, Scenario> _scenarios = <String, Scenario>{
@@ -37,7 +38,8 @@ Map<String, Scenario> _scenarios = <String, Scenario>{
   'platform_view_gesture_reject_eager': PlatformViewForTouchIOSScenario(window, 'platform view touch', id: 11, accept: false),
   'platform_view_gesture_accept': PlatformViewForTouchIOSScenario(window, 'platform view touch', id: 11, accept: true),
   'platform_view_gesture_reject_after_touches_ended': PlatformViewForTouchIOSScenario(window, 'platform view touch', id: 11, accept: false, rejectUntilTouchesEnded: true),
-  'tap_status_bar' : TouchesScenario(window),
+  'tap_status_bar': TouchesScenario(window),
+  'text_semantics_focus': SendTextFocusScemantics(window),
 };
 
 Scenario _currentScenario = _scenarios['animated_color_square'];
@@ -53,7 +55,7 @@ void main() {
     ..scheduleFrame();
   final ByteData data = ByteData(1);
   data.setUint8(0, 1);
-  window.sendPlatformMessage('scenario_status', data, null);
+  window.sendPlatformMessage('waiting_for_status', data, null);
 }
 
 Future<void> _handlePlatformMessage(

--- a/testing/scenario_app/lib/src/channel_util.dart
+++ b/testing/scenario_app/lib/src/channel_util.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 
 /// Util method to replicate the behavior of a `MethodChannel` in the Flutter
 /// framework.
-void sendMethodCall({
+void sendJsonMethodCall({
   @required Window window,
   @required String channel,
   @required String method,

--- a/testing/scenario_app/lib/src/channel_util.dart
+++ b/testing/scenario_app/lib/src/channel_util.dart
@@ -1,0 +1,31 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:meta/meta.dart';
+
+/// Util method to replicate the behavior of a `MethodChannel` in the Flutter
+/// framework.
+void sendMethodCall({
+  @required Window window,
+  @required String channel,
+  @required String method,
+  dynamic arguments,
+  PlatformMessageResponseCallback callback,
+}) {
+  window.sendPlatformMessage(
+    channel,
+    // This recreates a combination of OptionalMethodChannel, JSONMethodCodec,
+    // and _DefaultBinaryMessenger in the framework.
+    utf8.encoder.convert(
+      const JsonCodec().encode(<String, dynamic>{
+        'method': method,
+        'args': arguments,
+      })
+    ).buffer.asByteData(),
+    callback,
+  );
+}

--- a/testing/scenario_app/lib/src/poppable_screen.dart
+++ b/testing/scenario_app/lib/src/poppable_screen.dart
@@ -6,6 +6,8 @@
 import 'dart:convert';
 import 'dart:ui';
 
+import 'package:scenario_app/src/channel_util.dart';
+
 import 'platform_echo_mixin.dart';
 import 'scenario.dart';
 
@@ -72,22 +74,15 @@ class PoppableScreenScenario extends Scenario with PlatformEchoMixin {
   }
 
   void _pop() {
-    window.sendPlatformMessage(
+    sendMethodCall(
+      window: window,
       // 'flutter/platform' is the hardcoded name of the 'platform'
       // `SystemChannel` from the `SystemNavigator` API.
       // https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/services/system_navigator.dart.
-      'flutter/platform',
-      // This recreates a combination of OptionalMethodChannel, JSONMethodCodec,
-      // and _DefaultBinaryMessenger in the framework.
-      utf8.encoder.convert(
-        const JsonCodec().encode(<String, dynamic>{
-          'method': 'SystemNavigator.pop',
-          'args': null,
-        })
-      ).buffer.asByteData(),
+      channel: 'flutter/platform',
+      method: 'SystemNavigator.pop',
       // Don't care about the response. If it doesn't go through, the test
       // will fail.
-      null,
     );
   }
 }

--- a/testing/scenario_app/lib/src/poppable_screen.dart
+++ b/testing/scenario_app/lib/src/poppable_screen.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
-import 'dart:convert';
 import 'dart:ui';
 
 import 'package:scenario_app/src/channel_util.dart';

--- a/testing/scenario_app/lib/src/poppable_screen.dart
+++ b/testing/scenario_app/lib/src/poppable_screen.dart
@@ -73,7 +73,7 @@ class PoppableScreenScenario extends Scenario with PlatformEchoMixin {
   }
 
   void _pop() {
-    sendMethodCall(
+    sendJsonMethodCall(
       window: window,
       // 'flutter/platform' is the hardcoded name of the 'platform'
       // `SystemChannel` from the `SystemNavigator` API.

--- a/testing/scenario_app/lib/src/scenario.dart
+++ b/testing/scenario_app/lib/src/scenario.dart
@@ -17,7 +17,7 @@ abstract class Scenario {
   /// Called by the program when a frame is ready to be drawn.
   ///
   /// See [Window.onBeginFrame] for more details.
-  void onBeginFrame(Duration duration);
+  void onBeginFrame(Duration duration) {}
 
   /// Called by the program when the microtasks from [onBeginFrame] have been
   /// flushed.

--- a/testing/scenario_app/lib/src/send_text_focus_semantics.dart
+++ b/testing/scenario_app/lib/src/send_text_focus_semantics.dart
@@ -5,8 +5,9 @@
 import 'dart:typed_data';
 import 'dart:ui';
 
-import 'package:scenario_app/src/channel_util.dart';
+import 'package:vector_math/vector_math_64.dart';
 
+import 'channel_util.dart';
 import 'scenario.dart';
 
 /// A scenario that sends back messages when touches are received.
@@ -54,7 +55,7 @@ class SendTextFocusScemantics extends Scenario {
         currentValueLength: 0,
         scrollChildren: 0,
         scrollIndex: 0,
-        transform: Float64List.fromList(<double>[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 366.5, 0.0, 1.0]),
+        transform: Matrix4.identity().storage,
         elevation: 0.0,
         thickness: 0.0,
         childrenInTraversalOrder: Int32List(0),
@@ -70,7 +71,19 @@ class SendTextFocusScemantics extends Scenario {
   void onPointerDataPacket(PointerDataPacket packet) {
     // This mimics the framework which shows the FlutterTextInputView before
     // updating the TextInputSemanticsObject.
-    sendMethodCall(
+    sendJsonMethodCall(
+      window: window,
+      channel: 'flutter/textinput',
+      method: 'TextInput.setClient',
+      arguments: <dynamic>[
+        1,
+        // The arguments are text field configurations. It doesn't really matter
+        // since we're just testing text field accessibility here.
+        <String, dynamic>{ 'obscureText': false },
+      ]
+    );
+
+    sendJsonMethodCall(
       window: window,
       channel: 'flutter/textinput',
       method: 'TextInput.show',
@@ -92,7 +105,7 @@ class SendTextFocusScemantics extends Scenario {
         currentValueLength: 0,
         scrollChildren: 0,
         scrollIndex: 0,
-        transform: Float64List.fromList(<double>[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 231.0, 0.0, 1.0]),
+        transform: Matrix4.identity().storage,
         elevation: 0.0,
         thickness: 0.0,
         childrenInTraversalOrder: Int32List(0),

--- a/testing/scenario_app/lib/src/send_text_focus_semantics.dart
+++ b/testing/scenario_app/lib/src/send_text_focus_semantics.dart
@@ -1,0 +1,104 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:scenario_app/src/channel_util.dart';
+
+import 'scenario.dart';
+
+/// A scenario that sends back messages when touches are received.
+class SendTextFocusScemantics extends Scenario {
+  /// Constructor for `SendTextFocusScemantics`.
+  SendTextFocusScemantics(Window window) : super(window);
+
+  @override
+  void onBeginFrame(Duration duration) {
+    // Doesn't matter what we draw. Just paint white.
+    final SceneBuilder builder = SceneBuilder();
+    final PictureRecorder recorder = PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, window.physicalSize.width, window.physicalSize.height),
+      Paint()..color = const Color.fromARGB(255, 255, 255, 255),
+    );
+    final Picture picture = recorder.endRecording();
+
+    builder.addPicture(
+      Offset.zero,
+      picture,
+    );
+    final Scene scene = builder.build();
+    window.render(scene);
+    scene.dispose();
+
+    // On the first frame, also pretend that it drew a text field. Send the
+    // corresponding semantics tree comprised of 1 node for the text field.
+    window.updateSemantics((SemanticsUpdateBuilder()
+      ..updateNode(
+        id: 0,
+        // SemanticsFlag.isTextField.
+        flags: 16,
+        // SemanticsAction.tap.
+        actions: 1,
+        rect: const Rect.fromLTRB(0.0, 0.0, 414.0, 48.0),
+        label: 'flutter textfield',
+        textDirection: TextDirection.ltr,
+        textSelectionBase: -1,
+        textSelectionExtent: -1,
+        platformViewId: -1,
+        maxValueLength: -1,
+        currentValueLength: 0,
+        scrollChildren: 0,
+        scrollIndex: 0,
+        transform: Float64List.fromList(<double>[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 366.5, 0.0, 1.0]),
+        elevation: 0.0,
+        thickness: 0.0,
+        childrenInTraversalOrder: Int32List(0),
+        childrenInHitTestOrder: Int32List(0),
+        additionalActions: Int32List(0),
+      )).build()
+    );
+  }
+
+  // We don't really care about the touch itself. It's just a way for the
+  // XCUITest to communicate timing to the mock framework.
+  @override
+  void onPointerDataPacket(PointerDataPacket packet) {
+    // This mimics the framework which shows the FlutterTextInputView before
+    // updating the TextInputSemanticsObject.
+    sendMethodCall(
+      window: window,
+      channel: 'flutter/textinput',
+      method: 'TextInput.show',
+    );
+
+    window.updateSemantics((SemanticsUpdateBuilder()
+      ..updateNode(
+        id: 0,
+        // SemanticsFlag.isTextField and SemanticsFlag.isFocused.
+        flags: 48,
+        actions: 18433,
+        rect: const Rect.fromLTRB(0.0, 0.0, 414.0, 48.0),
+        label: 'focused flutter textfield',
+        textDirection: TextDirection.ltr,
+        textSelectionBase: 0,
+        textSelectionExtent: 0,
+        platformViewId: -1,
+        maxValueLength: -1,
+        currentValueLength: 0,
+        scrollChildren: 0,
+        scrollIndex: 0,
+        transform: Float64List.fromList(<double>[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 231.0, 0.0, 1.0]),
+        elevation: 0.0,
+        thickness: 0.0,
+        childrenInTraversalOrder: Int32List(0),
+        childrenInHitTestOrder: Int32List(0),
+        additionalActions: Int32List(0),
+      )).build()
+    );
+  }
+}

--- a/testing/scenario_app/lib/src/touches_scenario.dart
+++ b/testing/scenario_app/lib/src/touches_scenario.dart
@@ -13,9 +13,6 @@ class TouchesScenario extends Scenario {
   TouchesScenario(Window window) : super(window);
 
   @override
-  void onBeginFrame(Duration duration) {}
-
-  @override
   void onPointerDataPacket(PointerDataPacket packet) {
     window.sendPlatformMessage(
       'touches_scenario',

--- a/testing/scenario_app/pubspec.yaml
+++ b/testing/scenario_app/pubspec.yaml
@@ -4,8 +4,12 @@ publish_to: none
 # These are for convenience during local development. Changing them will not
 # impact the build.
 dependencies:
- sky_engine:
-   path: ../../../out/host_debug_unopt/gen/dart-pkg/sky_engine
- sky_services:
-   path: ../../../out/host_debug_unopt/gen/dart-pkg/sky_services
- vector_math: ^2.0.8
+  sky_engine:
+    path: ../../../out/host_debug_unopt/gen/dart-pkg/sky_engine
+  sky_services:
+    path: ../../../out/host_debug_unopt/gen/dart-pkg/sky_services
+  vector_math: ^2.0.8
+
+dependency_overrides:
+  meta:
+    path: ../../../third_party/dart/pkg/meta


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/53065

I hope https://github.com/flutter/engine/pull/17493 had good tests since I had to merge :)

The nature of the bug is that despite vague documentation, `accessibilityElementsHidden` on UIView doesn't seem to also hide its subviews from accessibility. When we first focus on a text field from the Flutter side, we create and add a `FlutterTextInputView` onto the view hierarchy above everything else. We intended to hide it but it never worked and since the accessibility bridge also sends various UIAccessibilityPostNotification, the new, higher, invisible `FlutterTextInputView` takes the focus. 

I really wanted to have an integration test for this but unfortunately concluded that we can't have an exact test for this because:

1. VoiceOver (or any assistive technologies with accessibility focus) isn't implemented on the simulator. 
2. Xcode has an accessibility debugger but unfortunately there are no APIs. The undocumented `UIAccessibilityPostNotification(UIAccessibilityResumeAssistiveTechnologyNotification, UIAccessibilityNotificationVoiceOverIdentifier)` crashes on simulator and `UIAccessibilityNotificationSwitchControlIdentifier` is input only (doesn't have focus highlighting). 
3. The accessibility debugger also doesn't work the same way as the VoiceOver. The original issue doesn't actually reproduce using accessibility focus via the simulator accessibility debugger. 

I added some integration tests for the general accessibility bridge semantics node translation and focusing functionalities, but it doesn't test this issue specifically.