### PR TITLE
Remove legacy version of SkCanvas::didConcat44

### DIFF
--- a/shell/common/canvas_spy.cc
+++ b/shell/common/canvas_spy.cc
@@ -53,11 +53,7 @@ void DidDrawCanvas::willRestore() {}
 
 void DidDrawCanvas::didConcat(const SkMatrix& matrix) {}
 
-#ifdef SK_SUPPORT_LEGACY_DIDCONCAT44
-void DidDrawCanvas::didConcat44(const SkScalar[]) {}
-#else
 void DidDrawCanvas::didConcat44(const SkM44&) {}
-#endif
 
 void DidDrawCanvas::didScale(SkScalar, SkScalar) {}
 

--- a/shell/common/canvas_spy.h
+++ b/shell/common/canvas_spy.h
@@ -71,11 +71,7 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void didConcat(const SkMatrix&) override;
-#ifdef SK_SUPPORT_LEGACY_DIDCONCAT44
-  void didConcat44(const SkScalar[]) override;
-#else
   void didConcat44(const SkM44&) override;
-#endif
   void didScale(SkScalar, SkScalar) override;
   void didTranslate(SkScalar, SkScalar) override;
 

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -60,17 +60,10 @@ void MockCanvas::didConcat(const SkMatrix& matrix) {
   draw_calls_.emplace_back(DrawCall{current_layer_, ConcatMatrixData{matrix}});
 }
 
-#ifdef SK_SUPPORT_LEGACY_DIDCONCAT44
-void MockCanvas::didConcat44(const SkScalar matrix[]) {
-  SkM44 m44 = SkM44::ColMajor(matrix);
-  draw_calls_.emplace_back(DrawCall{current_layer_, ConcatMatrix44Data{m44}});
-}
-#else
 void MockCanvas::didConcat44(const SkM44& matrix) {
   draw_calls_.emplace_back(
       DrawCall{current_layer_, ConcatMatrix44Data{matrix}});
 }
-#endif
 
 void MockCanvas::didScale(SkScalar x, SkScalar y) {
   SkMatrix m;

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -145,11 +145,7 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
   void willRestore() override;
   void didRestore() override {}
   void didConcat(const SkMatrix& matrix) override;
-#ifdef SK_SUPPORT_LEGACY_DIDCONCAT44
-  void didConcat44(const SkScalar matrix[]) override;
-#else
   void didConcat44(const SkM44&) override;
-#endif
   void didScale(SkScalar x, SkScalar y) override;
   void didTranslate(SkScalar x, SkScalar y) override;
   void didSetMatrix(const SkMatrix& matrix) override;


### PR DESCRIPTION
Builds flags have been switched, so the old versions aren't needed any
longer.