### PR TITLE
[web] Add path-based browser location handling

### DIFF
--- a/lib/web_ui/lib/src/ui/initialization.dart
+++ b/lib/web_ui/lib/src/ui/initialization.dart
@@ -10,7 +10,11 @@ Future<void> webOnlyInitializePlatform({
   engine.AssetManager assetManager,
 }) async {
   if (!debugEmulateFlutterTesterEnvironment) {
-    engine.window.locationStrategy = const engine.HashLocationStrategy();
+    if (engine.usePathStrategy) {
+      engine.window.locationStrategy = const engine.PathLocationStrategy();
+    } else {
+      engine.window.locationStrategy = const engine.HashLocationStrategy();
+    }
   }
 
   engine.webOnlyInitializeEngine();


### PR DESCRIPTION
This change adds another `flutter.web.usePathStrategy` dart define flag so that you can build Flutter Web with a different location strategy. This change needs to land first before https://github.com/flutter/flutter/pull/55232, so that the flutter tool can change it's local web-server behaviour so that the browser is given index.html for previously unknown URLs.

Example usage:
`flutter build web --dart-define=flutter.web.usePathStrategy=true`

Closes: https://github.com/flutter/flutter/issues/33245 - *Flutter_web navigation should provide a way to remove hash symbol(#)*

/cc @jonahwilliams @yjbanov 