### PR TITLE
Use UTF-16 for C++ text input model

### DIFF
--- a/shell/platform/common/cpp/text_input_model.cc
+++ b/shell/platform/common/cpp/text_input_model.cc
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <codecvt>
-#include <iostream>
 #include <locale>
 
 // TODO(awdavies): Need to fix this regarding issue #47.
@@ -33,9 +32,23 @@ static constexpr char kTextInputTypeName[] = "name";
 // TODO(naifu): This temporary code is to solve link error.(VS2015/2017)
 // https://social.msdn.microsoft.com/Forums/vstudio/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
 std::locale::id std::codecvt<char32_t, char, _Mbstatet>::id;
+std::locale::id std::codecvt<char16_t, char, _Mbstatet>::id;
 #endif  // defined(_MSC_VER)
 
 namespace flutter {
+
+namespace {
+
+// Returns true if |code_point| is a leading surrogate of a surrogate pair.
+bool IsLeadingSurrogate(char32_t code_point) {
+  return (code_point & 0xFFFFFC00) == 0xD800;
+}
+// Returns true if |code_point| is a trailing surrogate of a surrogate pair.
+bool IsTrailingSurrogate(char32_t code_point) {
+  return (code_point & 0xFFFFFC00) == 0xDC00;
+}
+
+}  // namespace
 
 TextInputModel::TextInputModel(int client_id, const rapidjson::Value& config)
     : client_id_(client_id),
@@ -72,15 +85,12 @@ bool TextInputModel::SetEditingState(size_t selection_base,
   if (selection_extent > text.size()) {
     return false;
   }
-  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> utf32conv;
-  text_ = utf32conv.from_bytes(text);
-  // selection_base and selection_extent are relative to UTF-16, so don't
-  // necessarily line up. The full fix would be to use UTF-16 here so
-  // the models align, but for now just make sure it doesn't crash;
-  // longer term the goal is to eliminate having two sources of truth.
+  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>
+      utf16_converter;
+  text_ = utf16_converter.from_bytes(text);
   size_t length = text_.length();
-  selection_base_ = text_.begin() + std::min(selection_base, length);
-  selection_extent_ = text_.begin() + std::min(selection_extent, length);
+  selection_base_ = text_.begin() + selection_base;
+  selection_extent_ = text_.begin() + selection_extent;
   return true;
 }
 
@@ -90,12 +100,24 @@ void TextInputModel::DeleteSelected() {
   selection_extent_ = selection_base_;
 }
 
-void TextInputModel::AddCharacter(char32_t c) {
+void TextInputModel::AddCodePoint(char32_t c) {
+  // TODO: Consider replacing this with manual conversion code if it
+  std::wstring_convert<
+      std::codecvt_utf16<char32_t, 0x10ffff, std::little_endian>, char32_t>
+      utf32_converter;
+  std::string utf16_bytes = utf32_converter.to_bytes(c);
+  std::u16string character_string(
+      reinterpret_cast<const char16_t*>(utf16_bytes.c_str()),
+      utf16_bytes.length() / sizeof(char16_t));
+  AddText(character_string);
+}
+
+void TextInputModel::AddText(const std::u16string& text) {
   if (selection_base_ != selection_extent_) {
     DeleteSelected();
   }
-  selection_extent_ = text_.insert(selection_extent_, c);
-  selection_extent_++;
+  selection_extent_ = text_.insert(selection_extent_, text.begin(), text.end());
+  selection_extent_ += text.length();
   selection_base_ = selection_extent_;
 }
 
@@ -105,7 +127,8 @@ bool TextInputModel::Backspace() {
     return true;
   }
   if (selection_base_ != text_.begin()) {
-    selection_base_ = text_.erase(selection_base_ - 1, selection_base_);
+    int count = IsTrailingSurrogate(*(selection_base_ - 1)) ? 2 : 1;
+    selection_base_ = text_.erase(selection_base_ - count, selection_base_);
     selection_extent_ = selection_base_;
     return true;
   }
@@ -118,7 +141,8 @@ bool TextInputModel::Delete() {
     return true;
   }
   if (selection_base_ != text_.end()) {
-    selection_base_ = text_.erase(selection_base_, selection_base_ + 1);
+    int count = IsLeadingSurrogate(*selection_base_) ? 2 : 1;
+    selection_base_ = text_.erase(selection_base_, selection_base_ + count);
     selection_extent_ = selection_base_;
     return true;
   }
@@ -143,8 +167,9 @@ bool TextInputModel::MoveCursorForward() {
   }
   // If not at the end, move the extent forward.
   if (selection_extent_ != text_.end()) {
-    selection_extent_++;
-    selection_base_++;
+    int count = IsLeadingSurrogate(*selection_base_) ? 2 : 1;
+    selection_base_ += count;
+    selection_extent_ = selection_base_;
     return true;
   }
   return false;
@@ -159,8 +184,9 @@ bool TextInputModel::MoveCursorBack() {
   }
   // If not at the start, move the beginning backward.
   if (selection_base_ != text_.begin()) {
-    selection_base_--;
-    selection_extent_--;
+    int count = IsTrailingSurrogate(*(selection_base_ - 1)) ? 2 : 1;
+    selection_base_ -= count;
+    selection_extent_ = selection_base_;
     return true;
   }
   return false;
@@ -186,9 +212,11 @@ std::unique_ptr<rapidjson::Document> TextInputModel::GetState() const {
                           static_cast<int>(selection_extent_ - text_.begin()),
                           allocator);
   editing_state.AddMember(kSelectionIsDirectionalKey, false, allocator);
-  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> utf8conv;
+  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>
+      utf8_converter;
   editing_state.AddMember(
-      kTextKey, rapidjson::Value(utf8conv.to_bytes(text_), allocator).Move(),
+      kTextKey,
+      rapidjson::Value(utf8_converter.to_bytes(text_), allocator).Move(),
       allocator);
   args->PushBack(editing_state, allocator);
   return args;

--- a/shell/platform/common/cpp/text_input_model.cc
+++ b/shell/platform/common/cpp/text_input_model.cc
@@ -87,7 +87,6 @@ bool TextInputModel::SetEditingState(size_t selection_base,
   std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>
       utf16_converter;
   text_ = utf16_converter.from_bytes(text);
-  size_t length = text_.length();
   selection_base_ = text_.begin() + selection_base;
   selection_extent_ = text_.begin() + selection_extent;
   return true;

--- a/shell/platform/common/cpp/text_input_model.h
+++ b/shell/platform/common/cpp/text_input_model.h
@@ -27,12 +27,18 @@ class TextInputModel {
                        size_t selection_extent,
                        const std::string& text);
 
-  // Adds a character.
+  // Adds a Unicode code point.
   //
   // Either appends after the cursor (when selection base and extent are the
-  // same), or deletes the selected characters, replacing the text with the
-  // character specified.
-  void AddCharacter(char32_t c);
+  // same), or deletes the selected text, replacing it with the given
+  // code point.
+  void AddCodePoint(char32_t c);
+
+  // Adds a UTF-16 text.
+  //
+  // Either appends after the cursor (when selection base and extent are the
+  // same), or deletes the selected text, replacing it with the given text.
+  void AddText(const std::u16string& text);
 
   // Deletes either the selection, or one character ahead of the cursor.
   //
@@ -89,12 +95,12 @@ class TextInputModel {
  private:
   void DeleteSelected();
 
-  std::u32string text_;
+  std::u16string text_;
   int client_id_;
   std::string input_type_;
   std::string input_action_;
-  std::u32string::iterator selection_base_;
-  std::u32string::iterator selection_extent_;
+  std::u16string::iterator selection_base_;
+  std::u16string::iterator selection_extent_;
 };
 
 }  // namespace flutter

--- a/shell/platform/glfw/text_input_plugin.cc
+++ b/shell/platform/glfw/text_input_plugin.cc
@@ -38,7 +38,7 @@ void TextInputPlugin::CharHook(GLFWwindow* window, unsigned int code_point) {
   if (active_model_ == nullptr) {
     return;
   }
-  active_model_->AddCharacter(code_point);
+  active_model_->AddCodePoint(code_point);
   SendStateUpdate(*active_model_);
 }
 
@@ -181,7 +181,7 @@ void TextInputPlugin::SendStateUpdate(const TextInputModel& model) {
 
 void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (model->input_type() == kMultilineInputType) {
-    model->AddCharacter('\n');
+    model->AddCodePoint('\n');
     SendStateUpdate(*model);
   }
   auto args = std::make_unique<rapidjson::Document>(rapidjson::kArrayType);

--- a/shell/platform/windows/key_event_handler.cc
+++ b/shell/platform/windows/key_event_handler.cc
@@ -92,8 +92,8 @@ KeyEventHandler::KeyEventHandler(flutter::BinaryMessenger* messenger)
 
 KeyEventHandler::~KeyEventHandler() = default;
 
-void KeyEventHandler::CharHook(Win32FlutterWindow* window,
-                               char32_t code_point) {}
+void KeyEventHandler::TextHook(Win32FlutterWindow* window,
+                               const std::u16string& code_point) {}
 
 void KeyEventHandler::KeyboardHook(Win32FlutterWindow* window,
                                    int key,

--- a/shell/platform/windows/key_event_handler.h
+++ b/shell/platform/windows/key_event_handler.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_KEY_EVENT_HANDLER_H_
 
 #include <memory>
+#include <string>
 
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/basic_message_channel.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
@@ -34,7 +35,8 @@ class KeyEventHandler : public KeyboardHookHandler {
                     char32_t character) override;
 
   // |KeyboardHookHandler|
-  void CharHook(Win32FlutterWindow* window, char32_t code_point) override;
+  void TextHook(Win32FlutterWindow* window,
+                const std::u16string& text) override;
 
  private:
   // The Flutter system channel for key event messages.

--- a/shell/platform/windows/keyboard_hook_handler.h
+++ b/shell/platform/windows/keyboard_hook_handler.h
@@ -7,6 +7,8 @@
 
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 
+#include <string>
+
 namespace flutter {
 
 class Win32FlutterWindow;
@@ -23,8 +25,9 @@ class KeyboardHookHandler {
                             int action,
                             char32_t character) = 0;
 
-  // A function for hooking into unicode code point input.
-  virtual void CharHook(Win32FlutterWindow* window, char32_t code_point) = 0;
+  // A function for hooking into Unicode text input.
+  virtual void TextHook(Win32FlutterWindow* window,
+                        const std::u16string& text) = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/testing/win32_window_test.cc
+++ b/shell/platform/windows/testing/win32_window_test.cc
@@ -19,7 +19,7 @@ void Win32WindowTest::OnPointerUp(double x, double y, UINT button) {}
 
 void Win32WindowTest::OnPointerLeave() {}
 
-void Win32WindowTest::OnChar(char32_t code_point) {}
+void Win32WindowTest::OnText(const std::u16string& text) {}
 
 void Win32WindowTest::OnKey(int key,
                             int scancode,

--- a/shell/platform/windows/testing/win32_window_test.h
+++ b/shell/platform/windows/testing/win32_window_test.h
@@ -42,7 +42,7 @@ class Win32WindowTest : public Win32Window {
   void OnPointerLeave() override;
 
   // |Win32Window|
-  void OnChar(char32_t code_point) override;
+  void OnText(const std::u16string& text) override;
 
   // |Win32Window|
   void OnKey(int key, int scancode, int action, char32_t character) override;

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -36,12 +36,12 @@ static constexpr char kInternalConsistencyError[] =
 
 namespace flutter {
 
-void TextInputPlugin::CharHook(Win32FlutterWindow* window,
-                               char32_t code_point) {
+void TextInputPlugin::TextHook(Win32FlutterWindow* window,
+                               const std::u16string& text) {
   if (active_model_ == nullptr) {
     return;
   }
-  active_model_->AddCharacter(code_point);
+  active_model_->AddText(text);
   SendStateUpdate(*active_model_);
 }
 
@@ -183,7 +183,7 @@ void TextInputPlugin::SendStateUpdate(const TextInputModel& model) {
 
 void TextInputPlugin::EnterPressed(TextInputModel* model) {
   if (model->input_type() == kMultilineInputType) {
-    model->AddCharacter('\n');
+    model->AddText(std::u16string({u'\n'}));
     SendStateUpdate(*model);
   }
   auto args = std::make_unique<rapidjson::Document>(rapidjson::kArrayType);

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -35,7 +35,8 @@ class TextInputPlugin : public KeyboardHookHandler {
                     char32_t character) override;
 
   // |KeyboardHookHandler|
-  void CharHook(Win32FlutterWindow* window, char32_t code_point) override;
+  void TextHook(Win32FlutterWindow* window,
+                const std::u16string& text) override;
 
  private:
   // Sends the current state of the given model to the Flutter engine.

--- a/shell/platform/windows/win32_flutter_window.cc
+++ b/shell/platform/windows/win32_flutter_window.cc
@@ -161,9 +161,9 @@ void Win32FlutterWindow::OnPointerLeave() {
   }
 }
 
-void Win32FlutterWindow::OnChar(char32_t code_point) {
+void Win32FlutterWindow::OnText(const std::u16string& text) {
   if (process_events_) {
-    SendChar(code_point);
+    SendText(text);
   }
 }
 
@@ -264,9 +264,9 @@ void Win32FlutterWindow::SendPointerLeave() {
   SendPointerEventWithData(event);
 }
 
-void Win32FlutterWindow::SendChar(char32_t code_point) {
+void Win32FlutterWindow::SendText(const std::u16string& text) {
   for (const auto& handler : keyboard_hook_handlers_) {
-    handler->CharHook(this, code_point);
+    handler->TextHook(this, text);
   }
 }
 

--- a/shell/platform/windows/win32_flutter_window.h
+++ b/shell/platform/windows/win32_flutter_window.h
@@ -57,7 +57,7 @@ class Win32FlutterWindow : public Win32Window {
   void OnPointerLeave() override;
 
   // |Win32Window|
-  void OnChar(char32_t code_point) override;
+  void OnText(const std::u16string& text) override;
 
   // |Win32Window|
   void OnKey(int key, int scancode, int action, char32_t character) override;
@@ -112,8 +112,8 @@ class Win32FlutterWindow : public Win32Window {
   // event is called.
   void SendPointerLeave();
 
-  // Reports a keyboard character to Flutter engine.
-  void SendChar(char32_t code_point);
+  // Reports text input to Flutter engine.
+  void SendText(const std::u16string& text);
 
   // Reports a raw keyboard message to Flutter engine.
   void SendKey(int key, int scancode, int action, char32_t character);

--- a/shell/platform/windows/win32_window.h
+++ b/shell/platform/windows/win32_window.h
@@ -102,8 +102,8 @@ class Win32Window {
   // Called when the mouse leaves the window.
   virtual void OnPointerLeave() = 0;
 
-  // Called when character input occurs.
-  virtual void OnChar(char32_t code_point) = 0;
+  // Called when text input occurs.
+  virtual void OnText(const std::u16string& text) = 0;
 
   // Called when raw keyboard input occurs.
   virtual void OnKey(int key, int scancode, int action, char32_t character) = 0;


### PR DESCRIPTION
The C++ text input model used by Windows and Linux currently uses UTF-32. The intention was to facilitate handling of arrow keys, backspace/delete, etc., however since part of what is synchronized with the engine is cursor+selection offsets, and those offsets are defined in terms of UTF-16 code units, this causes very bad interactions with the framework-side model.

This converts to using UTF-16, rather than UTF-32, so that the offsets align with the framework. It also adds surrogate pair handling to the operations that adjust indexes, to avoid breaking surrogate pairs. (Arbitrary grapheme cluster handling is out of scope for this PR; while definitely desirable in the long term, surrogate pair handling is much more critical since improper handling yields invalid UTF-16, which breaks the text field).

This partially fixes https://github.com/flutter/flutter/issues/55014. A framework-side fix is also necessary (since currently both the engine and the framework attempt to handle arrow keys, which is another out-of-scope-for-this-PR issue), but even without the framework fix this dramatically improves the cursor behavior on Windows when there are surrogate pairs somewhere in the string since at least the two sides agree on what indexes mean.

Includes minor plumbing changes to the text input plumbing on Windows so that we're not pointlessly converting from UTF-16 to UTF-32 and then back to UTF-16.