### PR TITLE
Accessibility null check to catch out of bounds hitTest

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1182,7 +1182,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
     SemanticsNode semanticsNodeUnderCursor =
         getRootSemanticsNode().hitTest(new float[] {event.getX(), event.getY(), 0, 1});
-    if (semanticsNodeUnderCursor.platformViewId != -1) {
+    // semanticsNodeUnderCursor can be null when hovering over non-flutter UI such as
+    // the Android navigation bar due to hitTest() bounds checking.
+    if (semanticsNodeUnderCursor != null && semanticsNodeUnderCursor.platformViewId != -1) {
       return accessibilityViewEmbedder.onAccessibilityHoverEvent(
           semanticsNodeUnderCursor.id, event);
     }

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import android.content.ContentResolver;
 import android.content.Context;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewParent;
 import android.view.accessibility.AccessibilityEvent;
@@ -128,6 +129,32 @@ public class AccessibilityBridgeTest {
         .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
     AccessibilityEvent event = eventCaptor.getAllValues().get(0);
     assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED);
+  }
+
+  @Test
+  public void itHoverOverOutOfBoundsDoesNotCrash() {
+    // SementicsNode.hitTest() returns null when out of bounds.
+    AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    View mockRootView = mock(View.class);
+    Context context = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(context);
+    when(context.getPackageName()).thenReturn("test");
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(mockRootView, mockManager, mockViewEmbedder);
+
+    // Sent a11y tree with platform view.
+    TestSemanticsNode root = new TestSemanticsNode();
+    root.id = 0;
+    TestSemanticsNode platformView = new TestSemanticsNode();
+    platformView.id = 1;
+    platformView.platformViewId = 42;
+    root.children.add(platformView);
+    TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
+    accessibilityBridge.updateSemantics(testSemanticsUpdate.buffer, testSemanticsUpdate.strings);
+
+    // Pass an out of bounds MotionEvent.
+    assert(accessibilityBridge.onAccessibilityHoverEvent(MotionEvent.obtain(1, 1, 1, -10, -10, 0)));
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -154,7 +154,7 @@ public class AccessibilityBridgeTest {
     accessibilityBridge.updateSemantics(testSemanticsUpdate.buffer, testSemanticsUpdate.strings);
 
     // Pass an out of bounds MotionEvent.
-    assertEquals(accessibilityBridge.onAccessibilityHoverEvent(MotionEvent.obtain(1, 1, 1, -10, -10, 0)), true);
+    accessibilityBridge.onAccessibilityHoverEvent(MotionEvent.obtain(1, 1, 1, -10, -10, 0));
   }
 
   AccessibilityBridge setUpBridge() {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -154,7 +154,7 @@ public class AccessibilityBridgeTest {
     accessibilityBridge.updateSemantics(testSemanticsUpdate.buffer, testSemanticsUpdate.strings);
 
     // Pass an out of bounds MotionEvent.
-    assert(accessibilityBridge.onAccessibilityHoverEvent(MotionEvent.obtain(1, 1, 1, -10, -10, 0)));
+    assertEquals(accessibilityBridge.onAccessibilityHoverEvent(MotionEvent.obtain(1, 1, 1, -10, -10, 0)), true);
   }
 
   AccessibilityBridge setUpBridge() {


### PR DESCRIPTION
SemanticsNode.hitTest() will return null when hit testing an out of bounds coordinate. This causes hovering over non-flutter UI elements such as navigation bar to crash with NPE.

Fixes https://github.com/flutter/flutter/issues/34415