### PR TITLE
Extend external view embedder on Android

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -640,6 +640,8 @@ FILE: ../../../flutter/shell/platform/android/android_environment_gl.h
 FILE: ../../../flutter/shell/platform/android/android_exports.lst
 FILE: ../../../flutter/shell/platform/android/android_external_texture_gl.cc
 FILE: ../../../flutter/shell/platform/android/android_external_texture_gl.h
+FILE: ../../../flutter/shell/platform/android/android_external_view_embedder.cc
+FILE: ../../../flutter/shell/platform/android/android_external_view_embedder.h
 FILE: ../../../flutter/shell/platform/android/android_native_window.cc
 FILE: ../../../flutter/shell/platform/android/android_native_window.h
 FILE: ../../../flutter/shell/platform/android/android_shell_holder.cc

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -206,8 +206,8 @@ enum class PostPrerollResult { kResubmitFrame, kSuccess };
 
 // Facilitates embedding of platform views within the flow layer tree.
 //
-// Used on iOS and on embedded platforms that provide a system compositor
-// as part of the project arguments.
+// Used on iOS, Android (hybrid composite mode), and on embedded platforms
+// that provide a system compositor as part of the project arguments.
 class ExternalViewEmbedder {
   // TODO(cyanglaz): Make embedder own the `EmbeddedViewParams`.
 

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -18,7 +18,7 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
 
   if (context->view_embedder == nullptr) {
     FML_LOG(ERROR) << "Trying to embed a platform view but the PrerollContext "
-                      "does not support embedding";
+                      "does not support embedding2";
     return;
   }
   context->has_platform_view = true;
@@ -35,7 +35,7 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
 void PlatformViewLayer::Paint(PaintContext& context) const {
   if (context.view_embedder == nullptr) {
     FML_LOG(ERROR) << "Trying to embed a platform view but the PaintContext "
-                      "does not support embedding";
+                      "does not support embedding2";
     return;
   }
   SkCanvas* canvas = context.view_embedder->CompositeEmbeddedView(view_id_);

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -18,7 +18,7 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
 
   if (context->view_embedder == nullptr) {
     FML_LOG(ERROR) << "Trying to embed a platform view but the PrerollContext "
-                      "does not support embedding2";
+                      "does not support embedding";
     return;
   }
   context->has_platform_view = true;
@@ -35,7 +35,7 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
 void PlatformViewLayer::Paint(PaintContext& context) const {
   if (context.view_embedder == nullptr) {
     FML_LOG(ERROR) << "Trying to embed a platform view but the PaintContext "
-                      "does not support embedding2";
+                      "does not support embedding";
     return;
   }
   SkCanvas* canvas = context.view_embedder->CompositeEmbeddedView(view_id_);

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -29,6 +29,8 @@ shared_library("flutter_shell_native") {
     "android_environment_gl.h",
     "android_external_texture_gl.cc",
     "android_external_texture_gl.h",
+    "android_external_view_embedder.cc",
+    "android_external_view_embedder.h",
     "android_native_window.cc",
     "android_native_window.h",
     "android_shell_holder.cc",

--- a/shell/platform/android/android_external_view_embedder.cc
+++ b/shell/platform/android/android_external_view_embedder.cc
@@ -12,9 +12,10 @@ namespace flutter {
 void AndroidExternalViewEmbedder::PrerollCompositeEmbeddedView(
     int view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
+  // TODO(egarciad): Implement hybrid composition.
+  // https://github.com/flutter/flutter/issues/55270
   TRACE_EVENT0("flutter",
                "AndroidExternalViewEmbedder::PrerollCompositeEmbeddedView");
-
   picture_recorders_[view_id] = std::make_unique<SkPictureRecorder>();
   picture_recorders_[view_id]->beginRecording(SkRect::Make(frame_size_));
 
@@ -28,6 +29,8 @@ SkCanvas* AndroidExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
 
 // |ExternalViewEmbedder|
 std::vector<SkCanvas*> AndroidExternalViewEmbedder::GetCurrentCanvases() {
+  // TODO(egarciad): Implement hybrid composition.
+  // https://github.com/flutter/flutter/issues/55270
   std::vector<SkCanvas*> canvases;
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t view_id = composition_order_[i];
@@ -39,6 +42,8 @@ std::vector<SkCanvas*> AndroidExternalViewEmbedder::GetCurrentCanvases() {
 // |ExternalViewEmbedder|
 bool AndroidExternalViewEmbedder::SubmitFrame(GrContext* context,
                                               SkCanvas* background_canvas) {
+  // TODO(egarciad): Implement hybrid composition.
+  // https://github.com/flutter/flutter/issues/55270
   TRACE_EVENT0("flutter", "AndroidExternalViewEmbedder::SubmitFrame");
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t view_id = composition_order_[i];

--- a/shell/platform/android/android_external_view_embedder.cc
+++ b/shell/platform/android/android_external_view_embedder.cc
@@ -72,14 +72,20 @@ void AndroidExternalViewEmbedder::BeginFrame(SkISize frame_size,
   frame_size_ = frame_size;
 }
 
+void AndroidExternalViewEmbedder::ClearFrame() {
+  composition_order_.clear();
+  picture_recorders_.clear();
+  frame_size_ = SkISize::MakeEmpty();
+}
+
 // |ExternalViewEmbedder|
 void AndroidExternalViewEmbedder::CancelFrame() {
-  composition_order_.clear();
+  ClearFrame();
 }
 
 // |ExternalViewEmbedder|
 void AndroidExternalViewEmbedder::FinishFrame() {
-  composition_order_.clear();
+  ClearFrame();
 }
 
 // |ExternalViewEmbedder|

--- a/shell/platform/android/android_external_view_embedder.cc
+++ b/shell/platform/android/android_external_view_embedder.cc
@@ -1,0 +1,84 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/android/android_external_view_embedder.h"
+
+#include "fml/trace_event.h"
+
+namespace flutter {
+
+// |ExternalViewEmbedder|
+void AndroidExternalViewEmbedder::PrerollCompositeEmbeddedView(
+    int view_id,
+    std::unique_ptr<EmbeddedViewParams> params) {
+  TRACE_EVENT0("flutter",
+               "AndroidExternalViewEmbedder::PrerollCompositeEmbeddedView");
+
+  picture_recorders_[view_id] = std::make_unique<SkPictureRecorder>();
+  picture_recorders_[view_id]->beginRecording(SkRect::Make(frame_size_));
+
+  composition_order_.push_back(view_id);
+}
+
+// |ExternalViewEmbedder|
+SkCanvas* AndroidExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
+  return picture_recorders_[view_id]->getRecordingCanvas();
+}
+
+// |ExternalViewEmbedder|
+std::vector<SkCanvas*> AndroidExternalViewEmbedder::GetCurrentCanvases() {
+  std::vector<SkCanvas*> canvases;
+  for (size_t i = 0; i < composition_order_.size(); i++) {
+    int64_t view_id = composition_order_[i];
+    canvases.push_back(picture_recorders_[view_id]->getRecordingCanvas());
+  }
+  return canvases;
+}
+
+// |ExternalViewEmbedder|
+bool AndroidExternalViewEmbedder::SubmitFrame(GrContext* context,
+                                              SkCanvas* background_canvas) {
+  TRACE_EVENT0("flutter", "AndroidExternalViewEmbedder::SubmitFrame");
+  for (size_t i = 0; i < composition_order_.size(); i++) {
+    int64_t view_id = composition_order_[i];
+    background_canvas->drawPicture(
+        picture_recorders_[view_id]->finishRecordingAsPicture());
+  }
+  return true;
+}
+
+// |ExternalViewEmbedder|
+PostPrerollResult AndroidExternalViewEmbedder::PostPrerollAction(
+    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
+  return PostPrerollResult::kSuccess;
+}
+
+// |ExternalViewEmbedder|
+SkCanvas* AndroidExternalViewEmbedder::GetRootCanvas() {
+  // On Android, the root surface is created from the on-screen render target.
+  return nullptr;
+}
+
+// |ExternalViewEmbedder|
+void AndroidExternalViewEmbedder::BeginFrame(SkISize frame_size,
+                                             GrContext* context,
+                                             double device_pixel_ratio) {
+  frame_size_ = frame_size;
+}
+
+// |ExternalViewEmbedder|
+void AndroidExternalViewEmbedder::CancelFrame() {
+  composition_order_.clear();
+}
+
+// |ExternalViewEmbedder|
+void AndroidExternalViewEmbedder::FinishFrame() {
+  composition_order_.clear();
+}
+
+// |ExternalViewEmbedder|
+void AndroidExternalViewEmbedder::EndFrame(
+    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {}
+
+}  // namespace flutter

--- a/shell/platform/android/android_external_view_embedder.h
+++ b/shell/platform/android/android_external_view_embedder.h
@@ -1,0 +1,68 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_VIEW_EMBEDDER_H_
+#define FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_VIEW_EMBEDDER_H_
+
+#include "flutter/flow/embedded_views.h"
+
+#include "third_party/skia/include/core/SkPictureRecorder.h"
+
+namespace flutter {
+
+class AndroidExternalViewEmbedder : public ExternalViewEmbedder {
+ public:
+  // |ExternalViewEmbedder|
+  void PrerollCompositeEmbeddedView(
+      int view_id,
+      std::unique_ptr<flutter::EmbeddedViewParams> params) override;
+
+  // |ExternalViewEmbedder|
+  SkCanvas* CompositeEmbeddedView(int view_id) override;
+
+  // |ExternalViewEmbedder|
+  std::vector<SkCanvas*> GetCurrentCanvases() override;
+
+  // |ExternalViewEmbedder|
+  bool SubmitFrame(GrContext* context, SkCanvas* background_canvas) override;
+
+  // |ExternalViewEmbedder|
+  PostPrerollResult PostPrerollAction(
+      fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
+
+  // |ExternalViewEmbedder|
+  SkCanvas* GetRootCanvas() override;
+
+  // |ExternalViewEmbedder|
+  void BeginFrame(SkISize frame_size,
+                  GrContext* context,
+                  double device_pixel_ratio) override;
+
+  // |ExternalViewEmbedder|
+  void CancelFrame() override;
+
+  // |ExternalViewEmbedder|
+  void FinishFrame() override;
+
+  // |ExternalViewEmbedder|
+  void EndFrame(
+      fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
+
+ private:
+  // The size of the background canvas.
+  SkISize frame_size_;
+
+  // The order of composition. Each entry contains a unique id for the platform
+  // view.
+  std::vector<int64_t> composition_order_;
+
+  // The platform view's picture recorder keyed off the platform view id, which
+  // contains any subsequent operation until the next platform view or the end
+  // of the last leaf node in the layer tree.
+  std::map<int64_t, std::unique_ptr<SkPictureRecorder>> picture_recorders_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_VIEW_EMBEDDER_H_

--- a/shell/platform/android/android_external_view_embedder.h
+++ b/shell/platform/android/android_external_view_embedder.h
@@ -61,6 +61,9 @@ class AndroidExternalViewEmbedder : public ExternalViewEmbedder {
   // contains any subsequent operation until the next platform view or the end
   // of the last leaf node in the layer tree.
   std::map<int64_t, std::unique_ptr<SkPictureRecorder>> picture_recorders_;
+
+  /// Resets the state.
+  void ClearFrame();
 };
 
 }  // namespace flutter

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -32,6 +32,8 @@ AndroidSurfaceGL::AndroidSurfaceGL() {
   if (!offscreen_context_ || !offscreen_context_->IsValid()) {
     offscreen_context_ = nullptr;
   }
+
+  external_view_embedder_ = std::make_unique<AndroidExternalViewEmbedder>();
 }
 
 AndroidSurfaceGL::~AndroidSurfaceGL() = default;
@@ -127,7 +129,7 @@ intptr_t AndroidSurfaceGL::GLContextFBO() const {
 
 // |GPUSurfaceGLDelegate|
 ExternalViewEmbedder* AndroidSurfaceGL::GetExternalViewEmbedder() {
-  return nullptr;
+  return external_view_embedder_.get();
 }
 
 }  // namespace flutter

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -12,6 +12,7 @@
 #include "flutter/shell/gpu/gpu_surface_gl.h"
 #include "flutter/shell/platform/android/android_context_gl.h"
 #include "flutter/shell/platform/android/android_environment_gl.h"
+#include "flutter/shell/platform/android/android_external_view_embedder.h"
 #include "flutter/shell/platform/android/android_surface.h"
 
 namespace flutter {
@@ -64,6 +65,7 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
  private:
   fml::RefPtr<AndroidContextGL> onscreen_context_;
   fml::RefPtr<AndroidContextGL> offscreen_context_;
+  std::unique_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidSurfaceGL);
 };

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -39,6 +39,7 @@ bool GetSkColorType(int32_t buffer_format,
 AndroidSurfaceSoftware::AndroidSurfaceSoftware() {
   GetSkColorType(WINDOW_FORMAT_RGBA_8888, &target_color_type_,
                  &target_alpha_type_);
+  external_view_embedder_ = std::make_unique<AndroidExternalViewEmbedder>();
 }
 
 AndroidSurfaceSoftware::~AndroidSurfaceSoftware() = default;
@@ -137,7 +138,7 @@ bool AndroidSurfaceSoftware::PresentBackingStore(
 
 // |GPUSurfaceSoftwareDelegate|
 ExternalViewEmbedder* AndroidSurfaceSoftware::GetExternalViewEmbedder() {
-  return nullptr;
+  return external_view_embedder_.get();
 }
 
 void AndroidSurfaceSoftware::TeardownOnScreenContext() {}

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -9,6 +9,7 @@
 #include "flutter/fml/platform/android/jni_weak_ref.h"
 #include "flutter/fml/platform/android/scoped_java_ref.h"
 #include "flutter/shell/gpu/gpu_surface_software.h"
+#include "flutter/shell/platform/android/android_external_view_embedder.h"
 #include "flutter/shell/platform/android/android_surface.h"
 
 namespace flutter {
@@ -55,6 +56,7 @@ class AndroidSurfaceSoftware final : public AndroidSurface,
   fml::RefPtr<AndroidNativeWindow> native_window_;
   SkColorType target_color_type_;
   SkAlphaType target_alpha_type_;
+  std::unique_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidSurfaceSoftware);
 };

--- a/shell/platform/android/android_surface_vulkan.cc
+++ b/shell/platform/android/android_surface_vulkan.cc
@@ -13,7 +13,9 @@
 namespace flutter {
 
 AndroidSurfaceVulkan::AndroidSurfaceVulkan()
-    : proc_table_(fml::MakeRefCounted<vulkan::VulkanProcTable>()) {}
+    : proc_table_(fml::MakeRefCounted<vulkan::VulkanProcTable>()) {
+  external_view_embedder_ = std::make_unique<AndroidExternalViewEmbedder>();
+}
 
 AndroidSurfaceVulkan::~AndroidSurfaceVulkan() = default;
 
@@ -73,7 +75,7 @@ bool AndroidSurfaceVulkan::SetNativeWindow(
 }
 
 ExternalViewEmbedder* AndroidSurfaceVulkan::GetExternalViewEmbedder() {
-  return nullptr;
+  return external_view_embedder_.get();
 }
 
 fml::RefPtr<vulkan::VulkanProcTable> AndroidSurfaceVulkan::vk() {

--- a/shell/platform/android/android_surface_vulkan.h
+++ b/shell/platform/android/android_surface_vulkan.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include "flutter/fml/macros.h"
 #include "flutter/shell/gpu/gpu_surface_vulkan_delegate.h"
+#include "flutter/shell/platform/android/android_external_view_embedder.h"
 #include "flutter/shell/platform/android/android_native_window.h"
 #include "flutter/shell/platform/android/android_surface.h"
 #include "flutter/vulkan/vulkan_window.h"
@@ -52,6 +53,7 @@ class AndroidSurfaceVulkan : public AndroidSurface,
  private:
   fml::RefPtr<vulkan::VulkanProcTable> proc_table_;
   fml::RefPtr<AndroidNativeWindow> native_window_;
+  std::unique_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidSurfaceVulkan);
 };


### PR DESCRIPTION
Wires up the external view embedder for Android, which just does the bare minimum work. It doesn't handle most of the features required in hybrid composition.

The external view embedder is used if `AndroidView` is constructed with `compositeMode: AndroidViewCompositeMode.hybrid` after https://github.com/flutter/flutter/pull/55175 is merged.