### PR TITLE
Report SceneBuilder submetrics through profiling API

### DIFF
--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -123,6 +123,16 @@ part 'engine/vector_math.dart';
 part 'engine/web_experiments.dart';
 part 'engine/window.dart';
 
+/// A benchmark metric that includes frame-related computations prior to
+/// submitting layer and picture operations to the underlying renderer, such as
+/// HTML and CanvasKit. During this phase we compute transforms, clips, and
+/// other information needed for rendering.
+const String kProfilePrerollFrame = 'preroll_frame';
+
+/// A benchmark metric that includes submitting layer and picture information
+/// to the renderer.
+const String kProfileApplyFrame = 'apply_frame';
+
 bool _engineInitialized = false;
 
 final List<ui.VoidCallback> _hotRestartListeners = <ui.VoidCallback>[];

--- a/lib/web_ui/lib/src/engine/compositor/layer_tree.dart
+++ b/lib/web_ui/lib/src/engine/compositor/layer_tree.dart
@@ -69,8 +69,12 @@ class Frame {
 
   /// Rasterize the given layer tree into this frame.
   bool raster(LayerTree layerTree, {bool ignoreRasterCache = false}) {
-    layerTree.preroll(this, ignoreRasterCache: ignoreRasterCache);
-    layerTree.paint(this, ignoreRasterCache: ignoreRasterCache);
+    timeAction<void>(kProfilePrerollFrame, () {
+      layerTree.preroll(this, ignoreRasterCache: ignoreRasterCache);
+    });
+    timeAction<void>(kProfileApplyFrame, () {
+      layerTree.paint(this, ignoreRasterCache: ignoreRasterCache);
+    });
     return true;
   }
 }

--- a/lib/web_ui/lib/src/engine/profiler.dart
+++ b/lib/web_ui/lib/src/engine/profiler.dart
@@ -63,7 +63,7 @@ class Profiler {
 
   static bool isBenchmarkMode = const bool.fromEnvironment(
     'FLUTTER_WEB_ENABLE_PROFILING',
-    defaultValue: true,
+    defaultValue: false,
   );
 
   static Profiler ensureInitialized() {

--- a/lib/web_ui/lib/src/engine/profiler.dart
+++ b/lib/web_ui/lib/src/engine/profiler.dart
@@ -5,7 +5,43 @@
 // @dart = 2.6
 part of engine;
 
+/// A function that receives a benchmark [value] labeleb by [name].
 typedef OnBenchmark = void Function(String name, num value);
+
+/// A function that computes a value of type [R].
+///
+/// Functions of this signature can be passed to [timeAction] for performance
+/// profiling.
+typedef Action<R> = R Function();
+
+/// Uses the [Profiler] to time a synchronous [action] function and reports the
+/// result under the give metric [name].
+///
+/// If profiling is disabled, simply calls [action] and returns the result.
+///
+/// Use this for situations when the cost of an extra closure is negligible.
+/// This function reduces the boilerplate associated with checking if profiling
+/// is enabled and exercising the stopwatch.
+///
+/// Example:
+///
+/// ```
+/// final result = timeAction('expensive_operation', () {
+///   ... expensive work ...
+///   return someValue;
+/// });
+/// ```
+R timeAction<R>(String name, Action<R> action) {
+  if (!Profiler.isBenchmarkMode) {
+    return action();
+  } else {
+    final Stopwatch stopwatch = Stopwatch()..start();
+    final R result = action();
+    stopwatch.stop();
+    Profiler.instance.benchmark(name, stopwatch.elapsedMicroseconds);
+    return result;
+  }
+}
 
 /// The purpose of this class is to facilitate communication of
 /// profiling/benchmark data to the outside world (e.g. a macrobenchmark that's

--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -541,15 +541,19 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// cannot be used further.
   @override
   SurfaceScene build() {
-    _persistedScene.preroll();
-    if (_lastFrameScene == null) {
-      _persistedScene.build();
-    } else {
-      _persistedScene.update(_lastFrameScene);
-    }
-    commitScene(_persistedScene);
-    _lastFrameScene = _persistedScene;
-    return SurfaceScene(_persistedScene.rootElement);
+    timeAction<void>(kProfilePrerollFrame, () {
+      _persistedScene.preroll();
+    });
+    return timeAction<SurfaceScene>(kProfileApplyFrame, () {
+      if (_lastFrameScene == null) {
+        _persistedScene.build();
+      } else {
+        _persistedScene.update(_lastFrameScene);
+      }
+      commitScene(_persistedScene);
+      _lastFrameScene = _persistedScene;
+      return SurfaceScene(_persistedScene.rootElement);
+    });
   }
 
   /// Set properties on the linked scene.  These properties include its bounds,

--- a/lib/web_ui/test/canvas_test.dart
+++ b/lib/web_ui/test/canvas_test.dart
@@ -13,7 +13,6 @@ import 'mock_engine_canvas.dart';
 void main() {
   setUpAll(() {
     WebExperiments.ensureInitialized();
-    Profiler.ensureInitialized();
   });
 
   group('EngineCanvas', () {

--- a/lib/web_ui/test/paragraph_builder_test.dart
+++ b/lib/web_ui/test/paragraph_builder_test.dart
@@ -11,7 +11,6 @@ import 'package:test/test.dart';
 void main() {
   setUpAll(() {
     WebExperiments.ensureInitialized();
-    Profiler.ensureInitialized();
   });
 
   test('Should be able to build and layout a paragraph', () {


### PR DESCRIPTION
Report frame preroll and update times through the profiling API for use in benchmarks.