### PR TITLE
Bundle the validation layers and enable them if --enable-vulkan-validation-layers is specified to gn

### DIFF
--- a/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
+++ b/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
@@ -5,7 +5,6 @@
 assert(is_fuchsia)
 
 import("//build/fuchsia/sdk.gni")
-import("//flutter/vulkan/config.gni")
 
 # Builds a flutter_runner
 #
@@ -33,10 +32,6 @@ template("flutter_runner") {
   extra_defines = []
   if (defined(invoker.extra_defines)) {
     extra_defines += invoker.extra_defines
-  }
-
-  if (enable_vulkan_validation_layers) {
-    extra_defines += [ "VULKAN_VALIDATION_LAYERS_ENABLED" ]
   }
 
   executable(target_name) {

--- a/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
+++ b/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
@@ -5,6 +5,7 @@
 assert(is_fuchsia)
 
 import("//build/fuchsia/sdk.gni")
+import("//flutter/vulkan/config.gni")
 
 # Builds a flutter_runner
 #
@@ -32,6 +33,10 @@ template("flutter_runner") {
   extra_defines = []
   if (defined(invoker.extra_defines)) {
     extra_defines += invoker.extra_defines
+  }
+
+  if (enable_vulkan_validation_layers) {
+    extra_defines += [ "VULKAN_VALIDATION_LAYERS_ENABLED" ]
   }
 
   executable(target_name) {

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -63,9 +63,13 @@ bool VulkanSurfaceProducer::Initialize(scenic::Session* scenic_session) {
   std::vector<std::string> extensions = {
       VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME,
   };
+  bool enable_validation_layers = false;
+#ifdef VULKAN_VALIDATION_LAYERS_ENABLED
+  enable_validation_layers = true;
+#endif
   application_ = std::make_unique<vulkan::VulkanApplication>(
       *vk_, "FlutterRunner", std::move(extensions), VK_MAKE_VERSION(1, 0, 0),
-      VK_MAKE_VERSION(1, 1, 0));
+      VK_MAKE_VERSION(1, 1, 0), enable_validation_layers);
 
   if (!application_->IsValid() || !vk_->AreInstanceProcsSetup()) {
     // Make certain the application instance was created and it setup the

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -63,13 +63,13 @@ bool VulkanSurfaceProducer::Initialize(scenic::Session* scenic_session) {
   std::vector<std::string> extensions = {
       VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME,
   };
-  bool enable_validation_layers = false;
-#ifdef VULKAN_VALIDATION_LAYERS_ENABLED
-  enable_validation_layers = true;
-#endif
+
+  // On Fuchsia, the validation layers need to be packaged as part of the
+  // flutter_runner in order to work. As a result, we can use the presence
+  // of the layers to mean that we want the layers enabled.
   application_ = std::make_unique<vulkan::VulkanApplication>(
       *vk_, "FlutterRunner", std::move(extensions), VK_MAKE_VERSION(1, 0, 0),
-      VK_MAKE_VERSION(1, 1, 0), enable_validation_layers);
+      VK_MAKE_VERSION(1, 1, 0), true /* enable_validation_layers */);
 
   if (!application_->IsValid() || !vk_->AreInstanceProcsSetup()) {
     // Make certain the application instance was created and it setup the


### PR DESCRIPTION
The route I'm taking here is to always enable validation layers on Fuchsia if the gn flag is set. This is because having a settings flag is a) problematic regarding components (although my understanding here is very limited), and b) the validation layers .so is 6.5MB in size, so really we don't want to ship them in normal configurations anyway, which makes for much less of a compelling reason to add the complexity of having a runtime argument to enable them.

