### PR TITLE
Use Float32List as Matrix storage inside the Web engine

### DIFF
--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -221,3 +221,36 @@ class _NullTreeSanitizer implements html.NodeTreeSanitizer {
   @override
   void sanitizeTree(html.Node node) {}
 }
+
+/// Converts a matrix represented using [Float64List] to one represented using
+/// [Float32List].
+///
+/// 32-bit precision is sufficient because Flutter Engine itself (as well as
+/// Skia) use 32-bit precision under the hood anyway.
+///
+/// 32-bit matrices require 2x less memory and in V8 they are allocated on the
+/// JavaScript heap, thus avoiding a malloc.
+///
+/// See also:
+/// * https://bugs.chromium.org/p/v8/issues/detail?id=9199
+/// * https://bugs.chromium.org/p/v8/issues/detail?id=2022
+Float32List toMatrix32(Float64List matrix64) {
+  final Float32List matrix32 = Float32List(16);
+  matrix32[15] = matrix64[15];
+  matrix32[14] = matrix64[14];
+  matrix32[13] = matrix64[13];
+  matrix32[12] = matrix64[12];
+  matrix32[11] = matrix64[11];
+  matrix32[10] = matrix64[10];
+  matrix32[9] = matrix64[9];
+  matrix32[8] = matrix64[8];
+  matrix32[7] = matrix64[7];
+  matrix32[6] = matrix64[6];
+  matrix32[5] = matrix64[5];
+  matrix32[4] = matrix64[4];
+  matrix32[3] = matrix64[3];
+  matrix32[2] = matrix64[2];
+  matrix32[1] = matrix64[1];
+  matrix32[0] = matrix64[0];
+  return matrix32;
+}

--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -273,7 +273,7 @@ class BitmapCanvas extends EngineCanvas {
   }
 
   @override
-  void transform(Float64List matrix4) {
+  void transform(Float32List matrix4) {
     _canvasPool.transform(matrix4);
   }
 

--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -374,7 +374,7 @@ class _CanvasPool extends _SaveStackTracking {
   }
 
   @override
-  void transform(Float64List matrix4) {
+  void transform(Float32List matrix4) {
     super.transform(matrix4);
     // Canvas2D transform API:
     //
@@ -838,7 +838,7 @@ class _SaveStackTracking {
   @mustCallSuper
   void skew(double sx, double sy) {
     final Matrix4 skewMatrix = Matrix4.identity();
-    final Float64List storage = skewMatrix.storage;
+    final Float32List storage = skewMatrix.storage;
     storage[1] = sy;
     storage[4] = sx;
     _currentTransform.multiply(skewMatrix);
@@ -846,8 +846,8 @@ class _SaveStackTracking {
 
   /// Multiplies the [currentTransform] matrix by another matrix.
   @mustCallSuper
-  void transform(Float64List matrix4) {
-    _currentTransform.multiply(Matrix4.fromFloat64List(matrix4));
+  void transform(Float32List matrix4) {
+    _currentTransform.multiply(Matrix4.fromFloat32List(matrix4));
   }
 
   /// Adds a rectangle to clipping stack.

--- a/lib/web_ui/lib/src/engine/compositor/canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/canvas.dart
@@ -272,8 +272,8 @@ class SkCanvas {
     skCanvas.callMethod('skew', <double>[sx, sy]);
   }
 
-  void transform(Float64List matrix4) {
-    skCanvas.callMethod('concat', <js.JsArray<double>>[makeSkMatrix(matrix4)]);
+  void transform(Float32List matrix4) {
+    skCanvas.callMethod('concat', <js.JsArray<double>>[makeSkMatrixFromFloat32(matrix4)]);
   }
 
   void translate(double dx, double dy) {

--- a/lib/web_ui/lib/src/engine/compositor/canvas_kit_canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/canvas_kit_canvas.dart
@@ -84,10 +84,10 @@ class CanvasKitCanvas implements ui.Canvas {
     if (matrix4.length != 16) {
       throw ArgumentError('"matrix4" must have 16 entries.');
     }
-    _transform(matrix4);
+    _transform(toMatrix32(matrix4));
   }
 
-  void _transform(Float64List matrix4) {
+  void _transform(Float32List matrix4) {
     _canvas.transform(matrix4);
   }
 

--- a/lib/web_ui/lib/src/engine/compositor/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/compositor/layer_scene_builder.dart
@@ -205,7 +205,7 @@ class LayerSceneBuilder implements ui.SceneBuilder {
     Float64List matrix4, {
     ui.EngineLayer oldLayer,
   }) {
-    final Matrix4 matrix = Matrix4.fromList(matrix4);
+    final Matrix4 matrix = Matrix4.fromFloat32List(toMatrix32(matrix4));
     pushLayer(TransformLayer(matrix));
     return null;
   }

--- a/lib/web_ui/lib/src/engine/compositor/n_way_canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/n_way_canvas.dart
@@ -58,7 +58,7 @@ class SkNWayCanvas {
   }
 
   /// Calls [transform] on all canvases.
-  void transform(Float64List matrix) {
+  void transform(Float32List matrix) {
     for (int i = 0; i < _canvases.length; i++) {
       _canvases[i].transform(matrix);
     }

--- a/lib/web_ui/lib/src/engine/compositor/path.dart
+++ b/lib/web_ui/lib/src/engine/compositor/path.dart
@@ -64,10 +64,10 @@ class SkPath implements ui.Path {
   void addPath(ui.Path path, ui.Offset offset, {Float64List matrix4}) {
     List<double> skMatrix;
     if (matrix4 == null) {
-      skMatrix = makeSkMatrix(
+      skMatrix = makeSkMatrixFromFloat32(
           Matrix4.translationValues(offset.dx, offset.dy, 0.0).storage);
     } else {
-      skMatrix = makeSkMatrix(matrix4);
+      skMatrix = makeSkMatrixFromFloat64(matrix4);
       skMatrix[2] += offset.dx;
       skMatrix[5] += offset.dy;
     }
@@ -175,10 +175,10 @@ class SkPath implements ui.Path {
   void extendWithPath(ui.Path path, ui.Offset offset, {Float64List matrix4}) {
     List<double> skMatrix;
     if (matrix4 == null) {
-      skMatrix = makeSkMatrix(
+      skMatrix = makeSkMatrixFromFloat32(
           Matrix4.translationValues(offset.dx, offset.dy, 0.0).storage);
     } else {
-      skMatrix = makeSkMatrix(matrix4);
+      skMatrix = makeSkMatrixFromFloat64(matrix4);
       skMatrix[2] += offset.dx;
       skMatrix[5] += offset.dy;
     }
@@ -316,7 +316,7 @@ class SkPath implements ui.Path {
   @override
   ui.Path transform(Float64List matrix4) {
     final js.JsObject newPath = _skPath.callMethod('copy');
-    newPath.callMethod('transform', <js.JsArray>[makeSkMatrix(matrix4)]);
+    newPath.callMethod('transform', <js.JsArray>[makeSkMatrixFromFloat64(matrix4)]);
     return SkPath._fromSkPath(newPath);
   }
 

--- a/lib/web_ui/lib/src/engine/compositor/util.dart
+++ b/lib/web_ui/lib/src/engine/compositor/util.dart
@@ -249,9 +249,22 @@ const List<int> _skMatrixIndexToMatrix4Index = <int>[
   3, 7, 15, // Row 3
 ];
 
-/// Converts a 4x4 Flutter matrix (represented as a [Float64List]) to an
+/// Converts a 4x4 Flutter matrix (represented as a [Float32List]) to an
 /// SkMatrix, which is a 3x3 transform matrix.
-js.JsArray<double> makeSkMatrix(Float64List matrix4) {
+js.JsArray<double> makeSkMatrixFromFloat32(Float32List matrix4) {
+  final js.JsArray<double> skMatrix = js.JsArray<double>();
+  skMatrix.length = 9;
+  for (int i = 0; i < 9; ++i) {
+    final int matrix4Index = _skMatrixIndexToMatrix4Index[i];
+    if (matrix4Index < matrix4.length)
+      skMatrix[i] = matrix4[matrix4Index];
+    else
+      skMatrix[i] = 0.0;
+  }
+  return skMatrix;
+}
+
+js.JsArray<double> makeSkMatrixFromFloat64(Float64List matrix4) {
   final js.JsArray<double> skMatrix = js.JsArray<double>();
   skMatrix.length = 9;
   for (int i = 0; i < 9; ++i) {

--- a/lib/web_ui/lib/src/engine/engine_canvas.dart
+++ b/lib/web_ui/lib/src/engine/engine_canvas.dart
@@ -31,7 +31,7 @@ abstract class EngineCanvas {
 
   void skew(double sx, double sy);
 
-  void transform(Float64List matrix4);
+  void transform(Float32List matrix4);
 
   void clipRect(ui.Rect rect);
 
@@ -205,7 +205,7 @@ mixin SaveStackTracking on EngineCanvas {
   @override
   void skew(double sx, double sy) {
     final Matrix4 skewMatrix = Matrix4.identity();
-    final Float64List storage = skewMatrix.storage;
+    final Float32List storage = skewMatrix.storage;
     storage[1] = sy;
     storage[4] = sx;
     _currentTransform.multiply(skewMatrix);
@@ -215,8 +215,8 @@ mixin SaveStackTracking on EngineCanvas {
   ///
   /// Classes that override this method must call `super.transform()`.
   @override
-  void transform(Float64List matrix4) {
-    _currentTransform.multiply(Matrix4.fromFloat64List(matrix4));
+  void transform(Float32List matrix4) {
+    _currentTransform.multiply(Matrix4.fromFloat32List(matrix4));
   }
 
   /// Adds a rectangle to clipping stack.

--- a/lib/web_ui/lib/src/engine/houdini_canvas.dart
+++ b/lib/web_ui/lib/src/engine/houdini_canvas.dart
@@ -354,7 +354,7 @@ mixin SaveElementStackTracking on EngineCanvas {
     // DO NOT USE Matrix4.skew(sx, sy)! It treats sx and sy values as radians,
     // but in our case they are transform matrix values.
     final Matrix4 skewMatrix = Matrix4.identity();
-    final Float64List storage = skewMatrix.storage;
+    final Float32List storage = skewMatrix.storage;
     storage[1] = sy;
     storage[4] = sx;
     _currentTransform.multiply(skewMatrix);
@@ -364,7 +364,7 @@ mixin SaveElementStackTracking on EngineCanvas {
   ///
   /// Classes that override this method must call `super.transform()`.
   @override
-  void transform(Float64List matrix4) {
-    _currentTransform.multiply(Matrix4.fromFloat64List(matrix4));
+  void transform(Float32List matrix4) {
+    _currentTransform.multiply(Matrix4.fromFloat32List(matrix4));
   }
 }

--- a/lib/web_ui/lib/src/engine/render_vertices.dart
+++ b/lib/web_ui/lib/src/engine/render_vertices.dart
@@ -219,7 +219,7 @@ ui.Rect _computeVerticesBounds(Float32List positions, Matrix4 transform) {
 
 ui.Rect _transformBounds(
     Matrix4 transform, double left, double top, double right, double bottom) {
-  final Float64List storage = transform.storage;
+  final Float32List storage = transform.storage;
   final double m0 = storage[0];
   final double m1 = storage[1];
   final double m4 = storage[4];
@@ -525,7 +525,7 @@ class _GlContext {
   }
 
   /// Sets mat4 uniform values.
-  void setUniformMatrix4fv(Object uniform, bool transpose, Float64List value) {
+  void setUniformMatrix4fv(Object uniform, bool transpose, Float32List value) {
     return js_util.callMethod(
         glContext, 'uniformMatrix4fv', <dynamic>[uniform, transpose, value]);
   }

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -122,7 +122,7 @@ class SemanticsNodeUpdate {
   final ui.TextDirection textDirection;
 
   /// See [ui.SemanticsUpdateBuilder.updateNode].
-  final Float64List transform;
+  final Float32List transform;
 
   /// See [ui.SemanticsUpdateBuilder.updateNode].
   final Int32List childrenInTraversalOrder;
@@ -471,8 +471,8 @@ class SemanticsObject {
   }
 
   /// See [ui.SemanticsUpdateBuilder.updateNode].
-  Float64List get transform => _transform;
-  Float64List _transform;
+  Float32List get transform => _transform;
+  Float32List _transform;
 
   static const int _transformIndex = 1 << 16;
 
@@ -828,7 +828,7 @@ class SemanticsObject {
 
     final bool hasZeroRectOffset = _rect.top == 0.0 && _rect.left == 0.0;
     final bool hasIdentityTransform =
-        _transform == null || isIdentityFloat64ListTransform(_transform);
+        _transform == null || isIdentityFloat32ListTransform(_transform);
 
     if (hasZeroRectOffset &&
         hasIdentityTransform &&
@@ -855,12 +855,12 @@ class SemanticsObject {
         effectiveTransformIsIdentity = left == 0.0 && top == 0.0;
       } else {
         // Clone to avoid mutating _transform.
-        effectiveTransform = Matrix4.fromFloat64List(_transform).clone()
+        effectiveTransform = Matrix4.fromFloat32List(_transform).clone()
           ..translate(_rect.left, _rect.top, 0.0);
         effectiveTransformIsIdentity = effectiveTransform.isIdentity();
       }
     } else if (!hasIdentityTransform) {
-      effectiveTransform = Matrix4.fromFloat64List(_transform);
+      effectiveTransform = Matrix4.fromFloat32List(_transform);
       effectiveTransformIsIdentity = false;
     }
 

--- a/lib/web_ui/lib/src/engine/services/message_codecs.dart
+++ b/lib/web_ui/lib/src/engine/services/message_codecs.dart
@@ -177,7 +177,7 @@ class JSONMethodCodec implements MethodCodec {
 ///  * [bool]s
 ///  * [num]s
 ///  * [String]s
-///  * [Uint8List]s, [Int32List]s, [Int64List]s, [Float32List]s
+///  * [Uint8List]s, [Int32List]s, [Int64List]s, [Float64List]s
 ///  * [List]s of supported values
 ///  * [Map]s from supported values to supported values
 ///
@@ -195,7 +195,7 @@ class JSONMethodCodec implements MethodCodec {
 ///  * [Uint8List]\: `byte[]`
 ///  * [Int32List]\: `int[]`
 ///  * [Int64List]\: `long[]`
-///  * [Float32List]\: `double[]`
+///  * [Float64List]\: `double[]`
 ///  * [List]\: `java.util.ArrayList`
 ///  * [Map]\: `java.util.HashMap`
 ///
@@ -207,7 +207,7 @@ class JSONMethodCodec implements MethodCodec {
 ///    32-bit two's complement; `NSNumber numberWithLong:` otherwise
 ///  * [double]\: `NSNumber numberWithDouble:`
 ///  * [String]\: `NSString`
-///  * [Uint8List], [Int32List], [Int64List], [Float32List]\:
+///  * [Uint8List], [Int32List], [Int64List], [Float64List]\:
 ///    `FlutterStandardTypedData`
 ///  * [List]\: `NSArray`
 ///  * [Map]\: `NSDictionary`
@@ -240,7 +240,7 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   // * Strings are encoded using their UTF-8 representation. First the length
   //   of that in bytes is encoded using the expanding format, then follows the
   //   UTF-8 encoding itself.
-  // * Uint8Lists, Int32Lists, Int64Lists, and Float32Lists are encoded by first
+  // * Uint8Lists, Int32Lists, Int64Lists, and Float64Lists are encoded by first
   //   encoding the list's element count in the expanding format, then the
   //   smallest number of zero bytes needed to align the position in the full
   //   message with a multiple of the number of bytes per element, then the
@@ -263,7 +263,7 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   static const int _valueUint8List = 8;
   static const int _valueInt32List = 9;
   static const int _valueInt64List = 10;
-  static const int _valueFloat32List = 11;
+  static const int _valueFloat64List = 11;
   static const int _valueList = 12;
   static const int _valueMap = 13;
 
@@ -339,10 +339,10 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
       buffer.putUint8(_valueInt64List);
       writeSize(buffer, value.length);
       buffer.putInt64List(value);
-    } else if (value is Float32List) {
-      buffer.putUint8(_valueFloat32List);
+    } else if (value is Float64List) {
+      buffer.putUint8(_valueFloat64List);
       writeSize(buffer, value.length);
-      buffer.putFloat32List(value);
+      buffer.putFloat64List(value);
     } else if (value is List) {
       buffer.putUint8(_valueList);
       writeSize(buffer, value.length);
@@ -422,9 +422,9 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
         final int length = readSize(buffer);
         result = buffer.getInt64List(length);
         break;
-      case _valueFloat32List:
+      case _valueFloat64List:
         final int length = readSize(buffer);
-        result = buffer.getFloat32List(length);
+        result = buffer.getFloat64List(length);
         break;
       case _valueList:
         final int length = readSize(buffer);

--- a/lib/web_ui/lib/src/engine/services/message_codecs.dart
+++ b/lib/web_ui/lib/src/engine/services/message_codecs.dart
@@ -177,7 +177,7 @@ class JSONMethodCodec implements MethodCodec {
 ///  * [bool]s
 ///  * [num]s
 ///  * [String]s
-///  * [Uint8List]s, [Int32List]s, [Int64List]s, [Float64List]s
+///  * [Uint8List]s, [Int32List]s, [Int64List]s, [Float32List]s
 ///  * [List]s of supported values
 ///  * [Map]s from supported values to supported values
 ///
@@ -195,7 +195,7 @@ class JSONMethodCodec implements MethodCodec {
 ///  * [Uint8List]\: `byte[]`
 ///  * [Int32List]\: `int[]`
 ///  * [Int64List]\: `long[]`
-///  * [Float64List]\: `double[]`
+///  * [Float32List]\: `double[]`
 ///  * [List]\: `java.util.ArrayList`
 ///  * [Map]\: `java.util.HashMap`
 ///
@@ -207,7 +207,7 @@ class JSONMethodCodec implements MethodCodec {
 ///    32-bit two's complement; `NSNumber numberWithLong:` otherwise
 ///  * [double]\: `NSNumber numberWithDouble:`
 ///  * [String]\: `NSString`
-///  * [Uint8List], [Int32List], [Int64List], [Float64List]\:
+///  * [Uint8List], [Int32List], [Int64List], [Float32List]\:
 ///    `FlutterStandardTypedData`
 ///  * [List]\: `NSArray`
 ///  * [Map]\: `NSDictionary`
@@ -240,7 +240,7 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   // * Strings are encoded using their UTF-8 representation. First the length
   //   of that in bytes is encoded using the expanding format, then follows the
   //   UTF-8 encoding itself.
-  // * Uint8Lists, Int32Lists, Int64Lists, and Float64Lists are encoded by first
+  // * Uint8Lists, Int32Lists, Int64Lists, and Float32Lists are encoded by first
   //   encoding the list's element count in the expanding format, then the
   //   smallest number of zero bytes needed to align the position in the full
   //   message with a multiple of the number of bytes per element, then the
@@ -263,7 +263,7 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
   static const int _valueUint8List = 8;
   static const int _valueInt32List = 9;
   static const int _valueInt64List = 10;
-  static const int _valueFloat64List = 11;
+  static const int _valueFloat32List = 11;
   static const int _valueList = 12;
   static const int _valueMap = 13;
 
@@ -339,10 +339,10 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
       buffer.putUint8(_valueInt64List);
       writeSize(buffer, value.length);
       buffer.putInt64List(value);
-    } else if (value is Float64List) {
-      buffer.putUint8(_valueFloat64List);
+    } else if (value is Float32List) {
+      buffer.putUint8(_valueFloat32List);
       writeSize(buffer, value.length);
-      buffer.putFloat64List(value);
+      buffer.putFloat32List(value);
     } else if (value is List) {
       buffer.putUint8(_valueList);
       writeSize(buffer, value.length);
@@ -422,9 +422,9 @@ class StandardMessageCodec implements MessageCodec<dynamic> {
         final int length = readSize(buffer);
         result = buffer.getInt64List(length);
         break;
-      case _valueFloat64List:
+      case _valueFloat32List:
         final int length = readSize(buffer);
-        result = buffer.getFloat64List(length);
+        result = buffer.getFloat32List(length);
         break;
       case _valueList:
         final int length = readSize(buffer);

--- a/lib/web_ui/lib/src/engine/services/serialization.dart
+++ b/lib/web_ui/lib/src/engine/services/serialization.dart
@@ -78,8 +78,8 @@ class WriteBuffer {
         .addAll(list.buffer.asUint8List(list.offsetInBytes, 8 * list.length));
   }
 
-  /// Write all the values from a [Float32List] into the buffer.
-  void putFloat32List(Float32List list) {
+  /// Write all the values from a [Float64List] into the buffer.
+  void putFloat64List(Float64List list) {
     _alignTo(8);
     _buffer
         .addAll(list.buffer.asUint8List(list.offsetInBytes, 8 * list.length));
@@ -186,10 +186,10 @@ class ReadBuffer {
   }
 
   /// Reads the given number of Float64s from the buffer.
-  Float32List getFloat32List(int length) {
+  Float64List getFloat64List(int length) {
     _alignTo(8);
-    final Float32List list =
-        data.buffer.asFloat32List(data.offsetInBytes + _position, length);
+    final Float64List list =
+        data.buffer.asFloat64List(data.offsetInBytes + _position, length);
     _position += 8 * length;
     return list;
   }

--- a/lib/web_ui/lib/src/engine/services/serialization.dart
+++ b/lib/web_ui/lib/src/engine/services/serialization.dart
@@ -78,8 +78,8 @@ class WriteBuffer {
         .addAll(list.buffer.asUint8List(list.offsetInBytes, 8 * list.length));
   }
 
-  /// Write all the values from a [Float64List] into the buffer.
-  void putFloat64List(Float64List list) {
+  /// Write all the values from a [Float32List] into the buffer.
+  void putFloat32List(Float32List list) {
     _alignTo(8);
     _buffer
         .addAll(list.buffer.asUint8List(list.offsetInBytes, 8 * list.length));
@@ -186,10 +186,10 @@ class ReadBuffer {
   }
 
   /// Reads the given number of Float64s from the buffer.
-  Float64List getFloat64List(int length) {
+  Float32List getFloat32List(int length) {
     _alignTo(8);
-    final Float64List list =
-        data.buffer.asFloat64List(data.offsetInBytes + _position, length);
+    final Float32List list =
+        data.buffer.asFloat32List(data.offsetInBytes + _position, length);
     _position += 8 * length;
     return list;
   }

--- a/lib/web_ui/lib/src/engine/shader.dart
+++ b/lib/web_ui/lib/src/engine/shader.dart
@@ -12,7 +12,7 @@ bool _offsetIsValid(ui.Offset offset) {
   return true;
 }
 
-bool _matrix4IsValid(Float64List matrix4) {
+bool _matrix4IsValid(Float32List matrix4) {
   assert(matrix4 != null, 'Matrix4 argument was null.');
   assert(matrix4.length == 16, 'Matrix4 must have 16 entries.');
   return true;
@@ -58,7 +58,7 @@ class GradientSweep extends EngineGradient {
   final ui.TileMode tileMode;
   final double startAngle;
   final double endAngle;
-  final Float64List matrix4;
+  final Float32List matrix4;
 
   @override
   js.JsObject createSkiaShader() {
@@ -165,13 +165,13 @@ class GradientRadial extends EngineGradient {
   final List<ui.Color> colors;
   final List<double> colorStops;
   final ui.TileMode tileMode;
-  final Float64List matrix4;
+  final Float32List matrix4;
 
   @override
   Object createPaintStyle(html.CanvasRenderingContext2D ctx) {
     if (!experimentalUseSkia) {
       // The DOM backend does not (yet) support all parameters.
-      if (matrix4 != null && !Matrix4.fromFloat64List(matrix4).isIdentity()) {
+      if (matrix4 != null && !Matrix4.fromFloat32List(matrix4).isIdentity()) {
         throw UnimplementedError(
             'matrix4 not supported in GradientRadial shader');
       }
@@ -211,7 +211,7 @@ class GradientRadial extends EngineGradient {
       jsColors,
       makeSkiaColorStops(colorStops),
       tileMode.index,
-      matrix4 != null ? makeSkMatrix(matrix4) : null,
+      matrix4 != null ? makeSkMatrixFromFloat32(matrix4) : null,
       0,
     ]);
   }
@@ -229,7 +229,7 @@ class GradientConical extends EngineGradient {
   final List<ui.Color> colors;
   final List<double> colorStops;
   final ui.TileMode tileMode;
-  final Float64List matrix4;
+  final Float32List matrix4;
 
   @override
   Object createPaintStyle(html.CanvasRenderingContext2D ctx) {
@@ -254,7 +254,7 @@ class GradientConical extends EngineGradient {
       jsColors,
       makeSkiaColorStops(colorStops),
       tileMode.index,
-      matrix4 != null ? makeSkMatrix(matrix4) : null,
+      matrix4 != null ? makeSkMatrixFromFloat32(matrix4) : null,
       0,
     ]);
   }

--- a/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
@@ -231,7 +231,7 @@ class RecordingCanvas {
     _commands.add(PaintRotate(radians));
   }
 
-  void transform(Float64List matrix4) {
+  void transform(Float32List matrix4) {
     assert(!_debugRecordingEnded);
     _paintBounds.transform(matrix4);
     _commands.add(PaintTransform(matrix4));
@@ -744,7 +744,7 @@ class PaintRotate extends PaintCommand {
 }
 
 class PaintTransform extends PaintCommand {
-  final Float64List matrix4;
+  final Float32List matrix4;
 
   PaintTransform(this.matrix4);
 
@@ -756,7 +756,7 @@ class PaintTransform extends PaintCommand {
   @override
   String toString() {
     if (assertionsEnabled) {
-      return 'transform(Matrix4.fromFloat64List(Float64List.fromList(<double>[${matrix4.join(', ')}])))';
+      return 'transform(Matrix4.fromFloat32List(Float32List.fromList(<double>[${matrix4.join(', ')}])))';
     } else {
       return super.toString();
     }
@@ -1426,10 +1426,10 @@ abstract class PathCommand {
   List<dynamic> serializeToCssPaint();
 
   /// Transform the command and add to targetPath.
-  void transform(Float64List matrix4, ui.Path targetPath);
+  void transform(Float32List matrix4, SurfacePath targetPath);
 
   /// Helper method for implementing transforms.
-  static ui.Offset _transformOffset(double x, double y, Float64List matrix4) =>
+  static ui.Offset _transformOffset(double x, double y, Float32List matrix4) =>
       ui.Offset((matrix4[0] * x) + (matrix4[4] * y) + matrix4[12],
           (matrix4[1] * x) + (matrix4[5] * y) + matrix4[13]);
 }
@@ -1451,7 +1451,7 @@ class MoveTo extends PathCommand {
   }
 
   @override
-  void transform(Float64List matrix4, ui.Path targetPath) {
+  void transform(Float32List matrix4, ui.Path targetPath) {
     final ui.Offset offset = PathCommand._transformOffset(x, y, matrix4);
     targetPath.moveTo(offset.dx, offset.dy);
   }
@@ -1483,7 +1483,7 @@ class LineTo extends PathCommand {
   }
 
   @override
-  void transform(Float64List matrix4, ui.Path targetPath) {
+  void transform(Float32List matrix4, ui.Path targetPath) {
     final ui.Offset offset = PathCommand._transformOffset(x, y, matrix4);
     targetPath.lineTo(offset.dx, offset.dy);
   }
@@ -1534,7 +1534,7 @@ class Ellipse extends PathCommand {
   }
 
   @override
-  void transform(Float64List matrix4, ui.Path targetPath) {
+  void transform(Float32List matrix4, SurfacePath targetPath) {
     final ui.Path bezierPath = ui.Path();
     _drawArcWithBezier(
         x,
@@ -1546,7 +1546,11 @@ class Ellipse extends PathCommand {
         anticlockwise ? startAngle - endAngle : endAngle - startAngle,
         matrix4,
         bezierPath);
-    targetPath.addPath(bezierPath, ui.Offset.zero, matrix4: matrix4);
+    if (matrix4 != null) {
+      targetPath._addPathWithMatrix(bezierPath, 0, 0, matrix4);
+    } else {
+      targetPath._addPath(bezierPath, 0, 0);
+    }
   }
 
   void _drawArcWithBezier(
@@ -1557,7 +1561,7 @@ class Ellipse extends PathCommand {
       double rotation,
       double startAngle,
       double sweep,
-      Float64List matrix4,
+      Float32List matrix4,
       ui.Path targetPath) {
     double ratio = sweep.abs() / (math.pi / 2.0);
     if ((1.0 - ratio).abs() < 0.0000001) {
@@ -1583,7 +1587,7 @@ class Ellipse extends PathCommand {
       double startAngle,
       double sweep,
       bool startPath,
-      Float64List matrix4) {
+      Float32List matrix4) {
     final double s = 4 / 3 * math.tan(sweep / 4);
 
     // Rotate unit vector to startAngle and endAngle to use for computing start
@@ -1667,7 +1671,7 @@ class QuadraticCurveTo extends PathCommand {
   }
 
   @override
-  void transform(Float64List matrix4, ui.Path targetPath) {
+  void transform(Float32List matrix4, ui.Path targetPath) {
     final double m0 = matrix4[0];
     final double m1 = matrix4[1];
     final double m4 = matrix4[4];
@@ -1715,7 +1719,7 @@ class BezierCurveTo extends PathCommand {
   }
 
   @override
-  void transform(Float64List matrix4, ui.Path targetPath) {
+  void transform(Float32List matrix4, ui.Path targetPath) {
     final double s0 = matrix4[0];
     final double s1 = matrix4[1];
     final double s4 = matrix4[4];
@@ -1757,7 +1761,7 @@ class RectCommand extends PathCommand {
   }
 
   @override
-  void transform(Float64List matrix4, ui.Path targetPath) {
+  void transform(Float32List matrix4, ui.Path targetPath) {
     final double s0 = matrix4[0];
     final double s1 = matrix4[1];
     final double s4 = matrix4[4];
@@ -1821,10 +1825,14 @@ class RRectCommand extends PathCommand {
   }
 
   @override
-  void transform(Float64List matrix4, ui.Path targetPath) {
+  void transform(Float32List matrix4, SurfacePath targetPath) {
     final ui.Path roundRectPath = ui.Path();
     _RRectToPathRenderer(roundRectPath).render(rrect);
-    targetPath.addPath(roundRectPath, ui.Offset.zero, matrix4: matrix4);
+    if (matrix4 != null) {
+      targetPath._addPathWithMatrix(roundRectPath, 0, 0, matrix4);
+    } else {
+      targetPath._addPath(roundRectPath, 0, 0);
+    }
   }
 
   @override
@@ -1851,7 +1859,7 @@ class CloseCommand extends PathCommand {
   }
 
   @override
-  void transform(Float64List matrix4, ui.Path targetPath) {
+  void transform(Float32List matrix4, ui.Path targetPath) {
     targetPath.close();
   }
 
@@ -1909,8 +1917,8 @@ class _PaintBounds {
     _currentMatrix.rotateZ(radians);
   }
 
-  void transform(Float64List matrix4) {
-    final Matrix4 m4 = Matrix4.fromFloat64List(matrix4);
+  void transform(Float32List matrix4) {
+    final Matrix4 m4 = Matrix4.fromFloat32List(matrix4);
     _currentMatrix.multiply(m4);
     _currentMatrixIsIdentity = _currentMatrix.isIdentity();
   }
@@ -1921,13 +1929,13 @@ class _PaintBounds {
     // DO NOT USE Matrix4.skew(sx, sy)! It treats sx and sy values as radians,
     // but in our case they are transform matrix values.
     final Matrix4 skewMatrix = Matrix4.identity();
-    final Float64List storage = skewMatrix.storage;
+    final Float32List storage = skewMatrix.storage;
     storage[1] = sy;
     storage[4] = sx;
     _currentMatrix.multiply(skewMatrix);
   }
 
-  static final Float64List _tempRectData = Float64List(4);
+  static final Float32List _tempRectData = Float32List(4);
 
   void clipRect(final ui.Rect rect, DrawCommand command) {
     double left = rect.left;

--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -108,8 +108,8 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
       // scene to devicepixelratio. Use identity instead since CSS uses
       // logical device pixels.
       if (!ui.debugEmulateFlutterTesterEnvironment) {
-        assert(matrix[0] == window.devicePixelRatio &&
-           matrix[5] == window.devicePixelRatio);
+        assert(matrix4[0] == window.devicePixelRatio &&
+           matrix4[5] == window.devicePixelRatio);
       }
       matrix = Matrix4.identity().storage;
     } else {

--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -100,17 +100,22 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     if (matrix4.length != 16) {
       throw ArgumentError('"matrix4" must have 16 entries.');
     }
+
+    // TODO(yjbanov): make this final after NNBD ships definite assignment.
+    /*final*/ Float32List matrix;
     if (_surfaceStack.length == 1) {
       // Top level transform contains view configuration to scale
       // scene to devicepixelratio. Use identity instead since CSS uses
       // logical device pixels.
       if (!ui.debugEmulateFlutterTesterEnvironment) {
-        assert(matrix4[0] == window.devicePixelRatio &&
-           matrix4[5] == window.devicePixelRatio);
+        assert(matrix[0] == window.devicePixelRatio &&
+           matrix[5] == window.devicePixelRatio);
       }
-      matrix4 = Matrix4.identity().storage;
+      matrix = Matrix4.identity().storage;
+    } else {
+      matrix = toMatrix32(matrix4);
     }
-    return _pushSurface(PersistedTransform(oldLayer, matrix4));
+    return _pushSurface(PersistedTransform(oldLayer, matrix));
   }
 
   /// Pushes a rectangular clip operation onto the operation stack.

--- a/lib/web_ui/lib/src/engine/surface/transform.dart
+++ b/lib/web_ui/lib/src/engine/surface/transform.dart
@@ -11,11 +11,11 @@ class PersistedTransform extends PersistedContainerSurface
   PersistedTransform(PersistedTransform oldLayer, this.matrix4)
       : super(oldLayer);
 
-  final Float64List matrix4;
+  final Float32List matrix4;
 
   @override
   void recomputeTransformAndClip() {
-    _transform = parent._transform.multiplied(Matrix4.fromFloat64List(matrix4));
+    _transform = parent._transform.multiplied(Matrix4.fromFloat32List(matrix4));
     _localTransformInverse = null;
     _projectedClip = null;
   }
@@ -23,7 +23,7 @@ class PersistedTransform extends PersistedContainerSurface
   @override
   Matrix4 get localTransformInverse {
     _localTransformInverse ??=
-        Matrix4.tryInvert(Matrix4.fromFloat64List(matrix4));
+        Matrix4.tryInvert(Matrix4.fromFloat32List(matrix4));
     return _localTransformInverse;
   }
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1121,7 +1121,7 @@ class EditableTextGeometry {
     return EditableTextGeometry(
       width: encodedGeometry['width'],
       height: encodedGeometry['height'],
-      globalTransform: Float64List.fromList(transformList),
+      globalTransform: Float32List.fromList(transformList),
     );
   }
 
@@ -1136,7 +1136,7 @@ class EditableTextGeometry {
   ///
   /// For correct sizing this transform must be applied to the [width] and
   /// [height] fields.
-  final Float64List globalTransform;
+  final Float32List globalTransform;
 
   /// Applies this geometry to the DOM element.
   ///

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -58,7 +58,7 @@ String matrix4ToCssTransform(Matrix4 matrix) {
 /// Applies a transform to the [element].
 ///
 /// See [float64ListToCssTransform] for details on how the CSS value is chosen.
-void setElementTransform(html.Element element, Float64List matrix4) {
+void setElementTransform(html.Element element, Float32List matrix4) {
   element.style
     ..transformOrigin = '0 0 0'
     ..transform = float64ListToCssTransform(matrix4);
@@ -73,7 +73,7 @@ void setElementTransform(html.Element element, Float64List matrix4) {
 /// See also:
 ///  * https://github.com/flutter/flutter/issues/32274
 ///  * https://bugs.chromium.org/p/chromium/issues/detail?id=1040222
-String float64ListToCssTransform(Float64List matrix) {
+String float64ListToCssTransform(Float32List matrix) {
   assert(matrix.length == 16);
   final TransformKind transformKind = transformKindOf(matrix);
   if (transformKind == TransformKind.transform2d) {
@@ -105,9 +105,9 @@ enum TransformKind {
 }
 
 /// Detects the kind of transform the [matrix] performs.
-TransformKind transformKindOf(Float64List matrix) {
+TransformKind transformKindOf(Float32List matrix) {
   assert(matrix.length == 16);
-  final Float64List m = matrix;
+  final Float32List m = matrix;
 
   // If matrix contains scaling, rotation, z translation or
   // perspective transform, it is not considered simple.
@@ -152,7 +152,7 @@ TransformKind transformKindOf(Float64List matrix) {
 }
 
 /// Returns `true` is the [matrix] describes an identity transformation.
-bool isIdentityFloat64ListTransform(Float64List matrix) {
+bool isIdentityFloat32ListTransform(Float32List matrix) {
   assert(matrix.length == 16);
   return transformKindOf(matrix) == TransformKind.identity;
 }
@@ -164,15 +164,15 @@ bool isIdentityFloat64ListTransform(Float64List matrix) {
 /// permitted. However, it is inefficient to construct a matrix for an identity
 /// transform. Consider removing the CSS `transform` property from elements
 /// that apply identity transform.
-String float64ListToCssTransform2d(Float64List matrix) {
+String float64ListToCssTransform2d(Float32List matrix) {
   assert (transformKindOf(matrix) != TransformKind.complex);
   return 'matrix(${matrix[0]},${matrix[1]},${matrix[4]},${matrix[5]},${matrix[12]},${matrix[13]})';
 }
 
 /// Converts [matrix] to a 3D CSS transform value.
-String float64ListToCssTransform3d(Float64List matrix) {
+String float64ListToCssTransform3d(Float32List matrix) {
   assert(matrix.length == 16);
-  final Float64List m = matrix;
+  final Float32List m = matrix;
   if (m[0] == 1.0 &&
       m[1] == 0.0 &&
       m[2] == 0.0 &&
@@ -203,7 +203,7 @@ bool get assertionsEnabled {
   return k;
 }
 
-final Float64List _tempRectData = Float64List(4);
+final Float32List _tempRectData = Float32List(4);
 
 /// Transforms a [ui.Rect] given the effective [transform].
 ///
@@ -228,14 +228,14 @@ ui.Rect transformRect(Matrix4 transform, ui.Rect rect) {
 ///
 /// WARNING: do not use this outside [transformLTRB]. Sharing this variable in
 /// other contexts will lead to bugs.
-final Float64List _tempPointData = Float64List(16);
-final Matrix4 _tempPointMatrix = Matrix4.fromFloat64List(_tempPointData);
+final Float32List _tempPointData = Float32List(16);
+final Matrix4 _tempPointMatrix = Matrix4.fromFloat32List(_tempPointData);
 
 /// Transforms a rectangle given the effective [transform].
 ///
 /// This is the same as [transformRect], except that the rect is specified
 /// in terms of left, top, right, and bottom edge offsets.
-void transformLTRB(Matrix4 transform, Float64List ltrb) {
+void transformLTRB(Matrix4 transform, Float32List ltrb) {
   // Construct a matrix where each row represents a vector pointing at
   // one of the four corners of the (left, top, right, bottom) rectangle.
   // Using the row-major order allows us to multiply the matrix in-place
@@ -243,14 +243,14 @@ void transformLTRB(Matrix4 transform, Float64List ltrb) {
   // library has a convenience function `multiplyTranspose` that performs
   // the multiplication without copying. This way we compute the positions
   // of all four points in a single matrix-by-matrix multiplication at the
-  // cost of one `Matrix4` instance and one `Float64List` instance.
+  // cost of one `Matrix4` instance and one `Float32List` instance.
   //
   // The rejected alternative was to use `Vector3` for each point and
   // multiply by the current transform. However, that would cost us four
-  // `Vector3` instances, four `Float64List` instances, and four
+  // `Vector3` instances, four `Float32List` instances, and four
   // matrix-by-vector multiplications.
   //
-  // `Float64List` initializes the array with zeros, so we do not have to
+  // `Float32List` initializes the array with zeros, so we do not have to
   // fill in every single element.
 
   // Row 0: top-left

--- a/lib/web_ui/lib/src/engine/validators.dart
+++ b/lib/web_ui/lib/src/engine/validators.dart
@@ -34,7 +34,7 @@ bool offsetIsValid(ui.Offset offset) {
   return true;
 }
 
-bool matrix4IsValid(Float64List matrix4) {
+bool matrix4IsValid(Float32List matrix4) {
   assert(matrix4 != null, 'Matrix4 argument was null.');
   assert(matrix4.length == 16, 'Matrix4 must have 16 entries.');
   return true;

--- a/lib/web_ui/lib/src/engine/vector_math.dart
+++ b/lib/web_ui/lib/src/engine/vector_math.dart
@@ -1045,6 +1045,18 @@ class Matrix4 {
     _m4storage[1] = array[i + 1];
     _m4storage[0] = array[i + 0];
   }
+
+  /// Converts this matrix to a [Float64List].
+  ///
+  /// Generally we try to stick with 32-bit floats inside the engine code
+  /// because it's faster (see [toMatrix32]). However, this method is handy
+  /// in tests that use the public `dart:ui` surface.
+  ///
+  /// This method is not optimized, but also is not meant to be fast, only
+  /// convenient.
+  Float64List toFloat64() {
+    return Float64List.fromList(_m4storage);
+  }
 }
 
 /// 3D column vector.

--- a/lib/web_ui/lib/src/engine/vector_math.dart
+++ b/lib/web_ui/lib/src/engine/vector_math.dart
@@ -6,10 +6,10 @@
 part of engine;
 
 class Matrix4 {
-  final Float64List _m4storage;
+  final Float32List _m4storage;
 
   /// The components of the matrix.
-  Float64List get storage => _m4storage;
+  Float32List get storage => _m4storage;
 
   /// Returns a matrix that is the inverse of [other] if [other] is invertible,
   /// otherwise `null`.
@@ -63,28 +63,8 @@ class Matrix4 {
         ..setValues(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9,
             arg10, arg11, arg12, arg13, arg14, arg15);
 
-  /// New matrix from [values].
-  factory Matrix4.fromList(List<double> values) => Matrix4.zero()
-    ..setValues(
-        values[0],
-        values[1],
-        values[2],
-        values[3],
-        values[4],
-        values[5],
-        values[6],
-        values[7],
-        values[8],
-        values[9],
-        values[10],
-        values[11],
-        values[12],
-        values[13],
-        values[14],
-        values[15]);
-
   /// Zero matrix.
-  Matrix4.zero() : _m4storage = Float64List(16);
+  Matrix4.zero() : _m4storage = Float32List(16);
 
   /// Identity matrix.
   factory Matrix4.identity() => Matrix4.zero()..setIdentity();
@@ -136,13 +116,13 @@ class Matrix4 {
         .._m4storage[5] = y
         .._m4storage[0] = x;
 
-  /// Constructs Matrix4 with given [Float64List] as [storage].
-  Matrix4.fromFloat64List(this._m4storage);
+  /// Constructs Matrix4 with given [Float32List] as [storage].
+  Matrix4.fromFloat32List(this._m4storage);
 
   /// Constructs Matrix4 with a [storage] that views given [buffer] starting at
-  /// [offset]. [offset] has to be multiple of [Float64List.bytesPerElement].
+  /// [offset]. [offset] has to be multiple of [Float32List.bytesPerElement].
   Matrix4.fromBuffer(ByteBuffer buffer, int offset)
-      : _m4storage = Float64List.view(buffer, offset, 16);
+      : _m4storage = Float32List.view(buffer, offset, 16);
 
   /// Sets the matrix with specified values.
   void setValues(
@@ -182,7 +162,7 @@ class Matrix4 {
 
   /// Sets the entire matrix to the matrix in [arg].
   void setFrom(Matrix4 arg) {
-    final Float64List argStorage = arg._m4storage;
+    final Float32List argStorage = arg._m4storage;
     _m4storage[15] = argStorage[15];
     _m4storage[14] = argStorage[14];
     _m4storage[13] = argStorage[13];
@@ -217,7 +197,7 @@ class Matrix4 {
 
   /// Copy into [arg].
   Matrix4 copyInto(Matrix4 arg) {
-    final Float64List argStorage = arg._m4storage;
+    final Float32List argStorage = arg._m4storage;
     argStorage[0] = _m4storage[0];
     argStorage[1] = _m4storage[1];
     argStorage[2] = _m4storage[2];
@@ -404,7 +384,7 @@ class Matrix4 {
   /// Transform [arg] of type [Vector3] using the perspective transformation
   /// defined by [this].
   Vector3 perspectiveTransform(Vector3 arg) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     final double x = (_m4storage[0] * argStorage[0]) +
         (_m4storage[4] * argStorage[1]) +
         (_m4storage[8] * argStorage[2]) +
@@ -460,7 +440,7 @@ class Matrix4 {
 
   void rotate(Vector3 axis, double angle) {
     final double len = axis.length;
-    final Float64List axisStorage = axis._v3storage;
+    final Float32List axisStorage = axis._v3storage;
     final double x = axisStorage[0] / len;
     final double y = axisStorage[1] / len;
     final double z = axisStorage[2] / len;
@@ -537,7 +517,7 @@ class Matrix4 {
 
   /// Sets the translation vector in this homogeneous transformation matrix.
   void setTranslation(Vector3 t) {
-    final Float64List tStorage = t._v3storage;
+    final Float32List tStorage = t._v3storage;
     final double z = tStorage[2];
     final double y = tStorage[1];
     final double x = tStorage[0];
@@ -581,7 +561,7 @@ class Matrix4 {
 
   /// Set this matrix to be the inverse of [arg]
   double copyInverse(Matrix4 arg) {
-    final Float64List argStorage = arg._m4storage;
+    final Float32List argStorage = arg._m4storage;
     final double a00 = argStorage[0];
     final double a01 = argStorage[1];
     final double a02 = argStorage[2];
@@ -753,7 +733,7 @@ class Matrix4 {
     final double m31 = _m4storage[7];
     final double m32 = _m4storage[11];
     final double m33 = _m4storage[15];
-    final Float64List argStorage = arg._m4storage;
+    final Float32List argStorage = arg._m4storage;
     final double n00 = argStorage[0];
     final double n01 = argStorage[4];
     final double n02 = argStorage[8];
@@ -809,7 +789,7 @@ class Matrix4 {
     final double m31 = _m4storage[13];
     final double m32 = _m4storage[14];
     final double m33 = _m4storage[15];
-    final Float64List argStorage = arg._m4storage;
+    final Float32List argStorage = arg._m4storage;
     _m4storage[0] = (m00 * argStorage[0]) +
         (m01 * argStorage[1]) +
         (m02 * argStorage[2]) +
@@ -894,7 +874,7 @@ class Matrix4 {
     final double m31 = _m4storage[7];
     final double m32 = _m4storage[11];
     final double m33 = _m4storage[15];
-    final Float64List argStorage = arg._m4storage;
+    final Float32List argStorage = arg._m4storage;
     _m4storage[0] = (m00 * argStorage[0]) +
         (m01 * argStorage[4]) +
         (m02 * argStorage[8]) +
@@ -963,7 +943,7 @@ class Matrix4 {
 
   /// Rotate [arg] of type [Vector3] using the rotation defined by [this].
   Vector3 rotate3(Vector3 arg) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     final double x = (_m4storage[0] * argStorage[0]) +
         (_m4storage[4] * argStorage[1]) +
         (_m4storage[8] * argStorage[2]);
@@ -993,7 +973,7 @@ class Matrix4 {
   /// Transform [arg] of type [Vector3] using the transformation defined by
   /// [this].
   Vector3 transform3(Vector3 arg) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     final double x = (_m4storage[0] * argStorage[0]) +
         (_m4storage[4] * argStorage[1]) +
         (_m4storage[8] * argStorage[2]) +
@@ -1069,10 +1049,10 @@ class Matrix4 {
 
 /// 3D column vector.
 class Vector3 {
-  final Float64List _v3storage;
+  final Float32List _v3storage;
 
   /// The components of the vector.
-  Float64List get storage => _v3storage;
+  Float32List get storage => _v3storage;
 
   /// Set the values of [result] to the minimum of [a] and [b] for each line.
   static void min(Vector3 a, Vector3 b, Vector3 result) {
@@ -1104,7 +1084,7 @@ class Vector3 {
       Vector3.zero()..setValues(x, y, z);
 
   /// Zero vector.
-  Vector3.zero() : _v3storage = Float64List(3);
+  Vector3.zero() : _v3storage = Float32List(3);
 
   /// Splat [value] into all lanes of the vector.
   factory Vector3.all(double value) => Vector3.zero()..splat(value);
@@ -1112,13 +1092,13 @@ class Vector3 {
   /// Copy of [other].
   factory Vector3.copy(Vector3 other) => Vector3.zero()..setFrom(other);
 
-  /// Constructs Vector3 with given Float64List as [storage].
-  Vector3.fromFloat64List(this._v3storage);
+  /// Constructs Vector3 with given Float32List as [storage].
+  Vector3.fromFloat32List(this._v3storage);
 
   /// Constructs Vector3 with a [storage] that views given [buffer] starting at
-  /// [offset]. [offset] has to be multiple of [Float64List.bytesPerElement].
+  /// [offset]. [offset] has to be multiple of [Float32List.bytesPerElement].
   Vector3.fromBuffer(ByteBuffer buffer, int offset)
-      : _v3storage = Float64List.view(buffer, offset, 3);
+      : _v3storage = Float32List.view(buffer, offset, 3);
 
   /// Generate random vector in the range (0, 0, 0) to (1, 1, 1). You can
   /// optionally pass your own random number generator.
@@ -1143,7 +1123,7 @@ class Vector3 {
 
   /// Set the values by copying them from [other].
   void setFrom(Vector3 other) {
-    final Float64List otherStorage = other._v3storage;
+    final Float32List otherStorage = other._v3storage;
     _v3storage[0] = otherStorage[0];
     _v3storage[1] = otherStorage[1];
     _v3storage[2] = otherStorage[2];
@@ -1222,7 +1202,7 @@ class Vector3 {
 
   /// Squared distance from [this] to [arg]
   double distanceToSquared(Vector3 arg) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     final double dx = _v3storage[0] - argStorage[0];
     final double dy = _v3storage[1] - argStorage[1];
     final double dz = _v3storage[2] - argStorage[2];
@@ -1232,7 +1212,7 @@ class Vector3 {
 
   /// Returns the angle between [this] vector and [other] in radians.
   double angleTo(Vector3 other) {
-    final Float64List otherStorage = other._v3storage;
+    final Float32List otherStorage = other._v3storage;
     if (_v3storage[0] == otherStorage[0] &&
         _v3storage[1] == otherStorage[1] &&
         _v3storage[2] == otherStorage[2]) {
@@ -1246,7 +1226,7 @@ class Vector3 {
 
   /// Inner product.
   double dot(Vector3 other) {
-    final Float64List otherStorage = other._v3storage;
+    final Float32List otherStorage = other._v3storage;
     double sum;
     sum = _v3storage[0] * otherStorage[0];
     sum += _v3storage[1] * otherStorage[1];
@@ -1256,7 +1236,7 @@ class Vector3 {
 
   /// Projects [this] using the projection matrix [arg]
   void applyProjection(Matrix4 arg) {
-    final Float64List argStorage = arg.storage;
+    final Float32List argStorage = arg.storage;
     final double x = _v3storage[0];
     final double y = _v3storage[1];
     final double z = _v3storage[2];
@@ -1302,7 +1282,7 @@ class Vector3 {
 
   /// Add [arg] to [this].
   void add(Vector3 arg) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] + argStorage[0];
     _v3storage[1] = _v3storage[1] + argStorage[1];
     _v3storage[2] = _v3storage[2] + argStorage[2];
@@ -1310,7 +1290,7 @@ class Vector3 {
 
   /// Add [arg] scaled by [factor] to [this].
   void addScaled(Vector3 arg, double factor) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] + argStorage[0] * factor;
     _v3storage[1] = _v3storage[1] + argStorage[1] * factor;
     _v3storage[2] = _v3storage[2] + argStorage[2] * factor;
@@ -1318,7 +1298,7 @@ class Vector3 {
 
   /// Subtract [arg] from [this].
   void sub(Vector3 arg) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] - argStorage[0];
     _v3storage[1] = _v3storage[1] - argStorage[1];
     _v3storage[2] = _v3storage[2] - argStorage[2];
@@ -1326,7 +1306,7 @@ class Vector3 {
 
   /// Multiply entries in [this] with entries in [arg].
   void multiply(Vector3 arg) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] * argStorage[0];
     _v3storage[1] = _v3storage[1] * argStorage[1];
     _v3storage[2] = _v3storage[2] * argStorage[2];
@@ -1334,7 +1314,7 @@ class Vector3 {
 
   /// Divide entries in [this] with entries in [arg].
   void divide(Vector3 arg) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     _v3storage[0] = _v3storage[0] / argStorage[0];
     _v3storage[1] = _v3storage[1] / argStorage[1];
     _v3storage[2] = _v3storage[2] / argStorage[2];
@@ -1355,7 +1335,7 @@ class Vector3 {
 
   /// Copy [this] into [arg].
   Vector3 copyInto(Vector3 arg) {
-    final Float64List argStorage = arg._v3storage;
+    final Float32List argStorage = arg._v3storage;
     argStorage[0] = _v3storage[0];
     argStorage[1] = _v3storage[1];
     argStorage[2] = _v3storage[2];

--- a/lib/web_ui/lib/src/ui/canvas.dart
+++ b/lib/web_ui/lib/src/ui/canvas.dart
@@ -460,10 +460,10 @@ class Canvas {
     if (matrix4.length != 16) {
       throw ArgumentError('"matrix4" must have 16 entries.');
     }
-    _transform(matrix4);
+    _transform(engine.toMatrix32(matrix4));
   }
 
-  void _transform(Float64List matrix4) {
+  void _transform(Float32List matrix4) {
     _canvas.transform(matrix4);
   }
 

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -1136,14 +1136,15 @@ abstract class Gradient extends Shader {
     _validateColorStops(colors, colorStops);
     // If focal is null or focal radius is null, this should be treated as a regular radial gradient
     // If focal == center and the focal radius is 0.0, it's still a regular radial gradient
+    final Float32List matrix32 = matrix4 != null ? engine.toMatrix32(matrix4) : null;
     if (focal == null || (focal == center && focalRadius == 0.0)) {
       return engine.GradientRadial(
-          center, radius, colors, colorStops, tileMode, engine.toMatrix32(matrix4));
+          center, radius, colors, colorStops, tileMode, matrix32);
     } else {
       assert(center != Offset.zero ||
           focal != Offset.zero); // will result in exception(s) in Skia side
       return engine.GradientConical(focal, focalRadius, center, radius, colors,
-          colorStops, tileMode, engine.toMatrix32(matrix4));
+          colorStops, tileMode, matrix32);
     }
   }
 

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -14,7 +14,7 @@ bool _offsetIsValid(Offset offset) {
 }
 
 // ignore: unused_element, Used in Shader assert.
-bool _matrix4IsValid(Float64List matrix4) {
+bool _matrix4IsValid(Float32List matrix4) {
   assert(matrix4 != null, 'Matrix4 argument was null.');
   assert(matrix4.length == 16, 'Matrix4 must have 16 entries.');
   return true;
@@ -1092,8 +1092,8 @@ abstract class Gradient extends Shader {
     List<Color> colors, [
     List<double> colorStops,
     TileMode tileMode = TileMode.clamp,
-    Float64List
-        matrix4, // TODO(flutter_web): see https://github.com/flutter/flutter/issues/32819
+    // TODO(flutter_web): see https://github.com/flutter/flutter/issues/32819
+    Float64List matrix4,
   ]) =>
       engine.GradientLinear(from, to, colors, colorStops, tileMode);
 
@@ -1138,12 +1138,12 @@ abstract class Gradient extends Shader {
     // If focal == center and the focal radius is 0.0, it's still a regular radial gradient
     if (focal == null || (focal == center && focalRadius == 0.0)) {
       return engine.GradientRadial(
-          center, radius, colors, colorStops, tileMode, matrix4);
+          center, radius, colors, colorStops, tileMode, engine.toMatrix32(matrix4));
     } else {
       assert(center != Offset.zero ||
           focal != Offset.zero); // will result in exception(s) in Skia side
       return engine.GradientConical(focal, focalRadius, center, radius, colors,
-          colorStops, tileMode, matrix4);
+          colorStops, tileMode, engine.toMatrix32(matrix4));
     }
   }
 
@@ -1183,7 +1183,7 @@ abstract class Gradient extends Shader {
     Float64List matrix4,
   ]) =>
       engine.GradientSweep(
-          center, colors, colorStops, tileMode, startAngle, endAngle, matrix4);
+          center, colors, colorStops, tileMode, startAngle, endAngle, engine.toMatrix32(matrix4));
 }
 
 /// Opaque handle to raw decoded image data (pixels).

--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -714,7 +714,7 @@ class SemanticsUpdateBuilder {
       increasedValue: increasedValue,
       decreasedValue: decreasedValue,
       textDirection: textDirection,
-      transform: transform,
+      transform: engine.toMatrix32(transform),
       elevation: elevation,
       thickness: thickness,
       childrenInTraversalOrder: childrenInTraversalOrder,

--- a/lib/web_ui/test/compositing_test.dart
+++ b/lib/web_ui/test/compositing_test.dart
@@ -25,7 +25,7 @@ void main() {
     test('pushTransform implements surface lifecycle', () {
       testLayerLifeCycle((SceneBuilder sceneBuilder, EngineLayer oldLayer) {
         return sceneBuilder.pushTransform(
-            Matrix4.translationValues(10, 20, 0).storage,
+            Matrix4.translationValues(10, 20, 0).toFloat64(),
             oldLayer: oldLayer);
       }, () {
         return '''<s><flt-transform></flt-transform></s>''';

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -104,7 +104,7 @@ void _testEngineSemanticsOwner() {
       id: 0,
       actions: 0,
       flags: 0,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 20, 20),
       childrenInHitTestOrder: Int32List.fromList(<int>[1]),
       childrenInTraversalOrder: Int32List.fromList(<int>[1]),
@@ -114,7 +114,7 @@ void _testEngineSemanticsOwner() {
       actions: 0,
       flags: 0,
       label: label,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 20, 20),
     );
     semantics().updateSemantics(builder.build());
@@ -233,7 +233,7 @@ void _testHeader() {
       actions: 0,
       flags: 0 | ui.SemanticsFlag.isHeader.index,
       label: 'Header of the page',
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -308,7 +308,7 @@ void _testContainer() {
       id: 0,
       actions: 0,
       flags: 0,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: zeroOffsetRect,
       childrenInHitTestOrder: Int32List.fromList(<int>[1]),
       childrenInTraversalOrder: Int32List.fromList(<int>[1]),
@@ -347,7 +347,7 @@ void _testContainer() {
       id: 0,
       actions: 0,
       flags: 0,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(10, 10, 20, 20),
       childrenInHitTestOrder: Int32List.fromList(<int>[1]),
       childrenInTraversalOrder: Int32List.fromList(<int>[1]),
@@ -388,7 +388,7 @@ void _testVerticalScrolling() {
       id: 0,
       actions: 0 | ui.SemanticsAction.scrollUp.index,
       flags: 0,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 50, 100),
     );
 
@@ -414,7 +414,7 @@ void _testVerticalScrolling() {
       id: 0,
       actions: 0 | ui.SemanticsAction.scrollUp.index,
       flags: 0,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 50, 100),
       childrenInHitTestOrder: Int32List.fromList(<int>[1]),
       childrenInTraversalOrder: Int32List.fromList(<int>[1]),
@@ -474,7 +474,7 @@ void _testVerticalScrolling() {
           ui.SemanticsAction.scrollUp.index |
           ui.SemanticsAction.scrollDown.index,
       flags: 0,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 50, 100),
       childrenInHitTestOrder: Int32List.fromList(<int>[1, 2, 3]),
       childrenInTraversalOrder: Int32List.fromList(<int>[1, 2, 3]),
@@ -485,7 +485,7 @@ void _testVerticalScrolling() {
         id: id,
         actions: 0,
         flags: 0,
-        transform: Matrix4.translationValues(0, 50.0 * id, 0).storage,
+        transform: Matrix4.translationValues(0, 50.0 * id, 0).toFloat64(),
         rect: const ui.Rect.fromLTRB(0, 0, 50, 50),
       );
     }
@@ -540,7 +540,7 @@ void _testHorizontalScrolling() {
       id: 0,
       actions: 0 | ui.SemanticsAction.scrollLeft.index,
       flags: 0,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -566,7 +566,7 @@ void _testHorizontalScrolling() {
       id: 0,
       actions: 0 | ui.SemanticsAction.scrollLeft.index,
       flags: 0,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
       childrenInHitTestOrder: Int32List.fromList(<int>[1]),
       childrenInTraversalOrder: Int32List.fromList(<int>[1]),
@@ -607,7 +607,7 @@ void _testHorizontalScrolling() {
           ui.SemanticsAction.scrollLeft.index |
           ui.SemanticsAction.scrollRight.index,
       flags: 0,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
       childrenInHitTestOrder: Int32List.fromList(<int>[1, 2, 3]),
       childrenInTraversalOrder: Int32List.fromList(<int>[1, 2, 3]),
@@ -618,7 +618,7 @@ void _testHorizontalScrolling() {
         id: id,
         actions: 0,
         flags: 0,
-        transform: Matrix4.translationValues(50.0 * id, 0, 0).storage,
+        transform: Matrix4.translationValues(50.0 * id, 0, 0).toFloat64(),
         rect: const ui.Rect.fromLTRB(0, 0, 50, 50),
       );
     }
@@ -674,7 +674,7 @@ void _testIncrementables() {
       actions: 0 | ui.SemanticsAction.increase.index,
       flags: 0,
       value: 'd',
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -702,7 +702,7 @@ void _testIncrementables() {
       flags: 0,
       value: 'd',
       increasedValue: 'e',
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -738,7 +738,7 @@ void _testIncrementables() {
       flags: 0,
       value: 'd',
       decreasedValue: 'c',
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -776,7 +776,7 @@ void _testIncrementables() {
       value: 'd',
       increasedValue: 'e',
       decreasedValue: 'c',
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -804,7 +804,7 @@ void _testTextField() {
       actions: 0 | ui.SemanticsAction.tap.index,
       flags: 0 | ui.SemanticsFlag.isTextField.index,
       value: 'hello',
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -833,7 +833,7 @@ void _testTextField() {
       actions: 0 | ui.SemanticsAction.tap.index,
       flags: 0 | ui.SemanticsFlag.isTextField.index,
       value: 'hello',
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -872,7 +872,7 @@ void _testCheckables() {
           ui.SemanticsFlag.isEnabled.index |
           ui.SemanticsFlag.hasToggledState.index |
           ui.SemanticsFlag.isToggled.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -898,7 +898,7 @@ void _testCheckables() {
       flags: 0 |
           ui.SemanticsFlag.hasToggledState.index |
           ui.SemanticsFlag.isToggled.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -924,7 +924,7 @@ void _testCheckables() {
       flags: 0 |
           ui.SemanticsFlag.hasToggledState.index |
           ui.SemanticsFlag.isEnabled.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -951,7 +951,7 @@ void _testCheckables() {
           ui.SemanticsFlag.isEnabled.index |
           ui.SemanticsFlag.hasCheckedState.index |
           ui.SemanticsFlag.isChecked.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -977,7 +977,7 @@ void _testCheckables() {
       flags: 0 |
           ui.SemanticsFlag.hasCheckedState.index |
           ui.SemanticsFlag.isChecked.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -1003,7 +1003,7 @@ void _testCheckables() {
       flags: 0 |
           ui.SemanticsFlag.hasCheckedState.index |
           ui.SemanticsFlag.isEnabled.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -1031,7 +1031,7 @@ void _testCheckables() {
           ui.SemanticsFlag.hasCheckedState.index |
           ui.SemanticsFlag.isInMutuallyExclusiveGroup.index |
           ui.SemanticsFlag.isChecked.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -1058,7 +1058,7 @@ void _testCheckables() {
           ui.SemanticsFlag.hasCheckedState.index |
           ui.SemanticsFlag.isInMutuallyExclusiveGroup.index |
           ui.SemanticsFlag.isChecked.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -1085,7 +1085,7 @@ void _testCheckables() {
           ui.SemanticsFlag.isEnabled.index |
           ui.SemanticsFlag.hasCheckedState.index |
           ui.SemanticsFlag.isInMutuallyExclusiveGroup.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -1114,7 +1114,7 @@ void _testTappable() {
           ui.SemanticsFlag.hasEnabledState.index |
           ui.SemanticsFlag.isEnabled.index |
           ui.SemanticsFlag.isButton.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -1140,7 +1140,7 @@ void _testTappable() {
       flags: 0 |
           ui.SemanticsFlag.hasEnabledState.index |
           ui.SemanticsFlag.isButton.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -1169,7 +1169,7 @@ void _testImage() {
       actions: 0,
       flags: 0 | ui.SemanticsFlag.isImage.index,
       label: 'Test Image Label',
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -1194,7 +1194,7 @@ void _testImage() {
       actions: 0,
       flags: 0 | ui.SemanticsFlag.isImage.index,
       label: 'Test Image Label',
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
       childrenInHitTestOrder: Int32List.fromList(<int>[1]),
       childrenInTraversalOrder: Int32List.fromList(<int>[1]),
@@ -1225,7 +1225,7 @@ void _testImage() {
       id: 0,
       actions: 0,
       flags: 0 | ui.SemanticsFlag.isImage.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
 
@@ -1248,7 +1248,7 @@ void _testImage() {
       id: 0,
       actions: 0,
       flags: 0 | ui.SemanticsFlag.isImage.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
       childrenInHitTestOrder: Int32List.fromList(<int>[1]),
       childrenInTraversalOrder: Int32List.fromList(<int>[1]),
@@ -1282,7 +1282,7 @@ void _testLiveRegion() {
       actions: 0,
       label: 'This is a snackbar',
       flags: 0 | ui.SemanticsFlag.isLiveRegion.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
     semantics().updateSemantics(builder.build());
@@ -1306,7 +1306,7 @@ void _testLiveRegion() {
       id: 0,
       actions: 0,
       flags: 0 | ui.SemanticsFlag.isLiveRegion.index,
-      transform: Matrix4.identity().storage,
+      transform: Matrix4.identity().toFloat64(),
       rect: const ui.Rect.fromLTRB(0, 0, 100, 50),
     );
     semantics().updateSemantics(builder.build());

--- a/lib/web_ui/test/engine/surface/surface_test.dart
+++ b/lib/web_ui/test/engine/surface/surface_test.dart
@@ -63,7 +63,7 @@ void main() {
       final SceneBuilder builder1 = SceneBuilder();
       final PersistedOpacity opacityLayer = builder1.pushOpacity(100);
       final PersistedTransform transformLayer =
-          builder1.pushTransform(Matrix4.identity().storage);
+          builder1.pushTransform(Matrix4.identity().toFloat64());
       builder1.pop();
       builder1.pop();
       builder1.build();
@@ -154,10 +154,10 @@ void main() {
       final _LoggingTestSurface logger = _LoggingTestSurface();
       final SurfaceSceneBuilder builder1 = SurfaceSceneBuilder();
       final PersistedTransform a1 =
-          builder1.pushTransform(Matrix4.identity().storage);
+          builder1.pushTransform(Matrix4.identity().toFloat64());
       final PersistedOpacity b1 = builder1.pushOpacity(100);
       final PersistedTransform c1 =
-          builder1.pushTransform(Matrix4.identity().storage);
+          builder1.pushTransform(Matrix4.identity().toFloat64());
       builder1.debugAddSurface(logger);
       builder1.pop();
       builder1.pop();
@@ -174,9 +174,9 @@ void main() {
 
       final SurfaceSceneBuilder builder2 = SurfaceSceneBuilder();
       final PersistedTransform a2 =
-          builder2.pushTransform(Matrix4.identity().storage, oldLayer: a1);
+          builder2.pushTransform(Matrix4.identity().toFloat64(), oldLayer: a1);
       final PersistedTransform c2 =
-          builder2.pushTransform(Matrix4.identity().storage, oldLayer: c1);
+          builder2.pushTransform(Matrix4.identity().toFloat64(), oldLayer: c1);
       builder2.addRetained(logger);
       builder2.pop();
       builder2.pop();
@@ -245,7 +245,7 @@ void main() {
       final SceneBuilder builder1 = SceneBuilder();
       final PersistedOpacity opacityLayer = builder1.pushOpacity(100);
       final PersistedTransform transformLayer =
-          builder1.pushTransform(Matrix4.identity().storage);
+          builder1.pushTransform(Matrix4.identity().toFloat64());
       builder1.pop();
       builder1.pop();
       builder1.build();

--- a/lib/web_ui/test/engine/util_test.dart
+++ b/lib/web_ui/test/engine/util_test.dart
@@ -9,31 +9,31 @@ import 'package:ui/src/engine.dart';
 
 import 'package:test/test.dart';
 
-final Float64List identityTransform = Matrix4.identity().storage;
-final Float64List xTranslation = (Matrix4.identity()..translate(10)).storage;
-final Float64List yTranslation = (Matrix4.identity()..translate(0, 10)).storage;
-final Float64List zTranslation = (Matrix4.identity()..translate(0, 0, 10)).storage;
-final Float64List scaleAndTranslate2d = (Matrix4.identity()..scale(2, 3, 1)..translate(4, 5, 0)).storage;
-final Float64List rotation2d = (Matrix4.identity()..rotateZ(0.2)).storage;
+final Float32List identityTransform = Matrix4.identity().storage;
+final Float32List xTranslation = (Matrix4.identity()..translate(10)).storage;
+final Float32List yTranslation = (Matrix4.identity()..translate(0, 10)).storage;
+final Float32List zTranslation = (Matrix4.identity()..translate(0, 0, 10)).storage;
+final Float32List scaleAndTranslate2d = (Matrix4.identity()..scale(2, 3, 1)..translate(4, 5, 0)).storage;
+final Float32List rotation2d = (Matrix4.identity()..rotateZ(0.2)).storage;
 
 void main() {
-  test('transformKindOf and isIdentityFloat64ListTransform identify matrix kind', () {
+  test('transformKindOf and isIdentityFloat32ListTransform identify matrix kind', () {
     expect(transformKindOf(identityTransform), TransformKind.identity);
-    expect(isIdentityFloat64ListTransform(identityTransform), isTrue);
+    expect(isIdentityFloat32ListTransform(identityTransform), isTrue);
 
     expect(transformKindOf(zTranslation), TransformKind.complex);
-    expect(isIdentityFloat64ListTransform(zTranslation), isFalse);
+    expect(isIdentityFloat32ListTransform(zTranslation), isFalse);
 
     expect(transformKindOf(xTranslation), TransformKind.transform2d);
-    expect(isIdentityFloat64ListTransform(xTranslation), isFalse);
+    expect(isIdentityFloat32ListTransform(xTranslation), isFalse);
 
     expect(transformKindOf(yTranslation), TransformKind.transform2d);
-    expect(isIdentityFloat64ListTransform(yTranslation), isFalse);
+    expect(isIdentityFloat32ListTransform(yTranslation), isFalse);
 
     expect(transformKindOf(scaleAndTranslate2d), TransformKind.transform2d);
-    expect(isIdentityFloat64ListTransform(scaleAndTranslate2d), isFalse);
+    expect(isIdentityFloat32ListTransform(scaleAndTranslate2d), isFalse);
 
     expect(transformKindOf(rotation2d), TransformKind.transform2d);
-    expect(isIdentityFloat64ListTransform(rotation2d), isFalse);
+    expect(isIdentityFloat32ListTransform(rotation2d), isFalse);
   });
 }

--- a/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
@@ -223,8 +223,8 @@ void main() async {
 
     final SceneBuilder sb = SceneBuilder();
     sb.pushTransform(Matrix4.diagonal3Values(EngineWindow.browserDevicePixelRatio,
-        EngineWindow.browserDevicePixelRatio, 1.0).storage);
-    sb.pushTransform(Matrix4.rotationZ(math.pi / 2).storage);
+        EngineWindow.browserDevicePixelRatio, 1.0).toFloat64());
+    sb.pushTransform(Matrix4.rotationZ(math.pi / 2).toFloat64());
     sb.pushOffset(0, -500);
     sb.pushClipRect(canvasSize);
     sb.pop();

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -46,7 +46,7 @@ void main() async {
 
     builder.pushOffset(0, 60);
     builder.pushTransform(
-      Matrix4.diagonal3Values(1, -1, 1).storage,
+      Matrix4.diagonal3Values(1, -1, 1).toFloat64(),
     );
     builder.pushClipRect(
       const Rect.fromLTRB(10, 10, 60, 60),
@@ -347,7 +347,7 @@ void _testCullRectComputation() {
     builder.pushOffset(80, 50);
 
     builder.pushTransform(
-      Matrix4.rotationZ(-math.pi / 4).storage,
+      Matrix4.rotationZ(-math.pi / 4).toFloat64(),
     );
 
     builder.pushClipRect(
@@ -355,7 +355,7 @@ void _testCullRectComputation() {
     );
 
     builder.pushTransform(
-      Matrix4.rotationZ(math.pi / 4).storage,
+      Matrix4.rotationZ(math.pi / 4).toFloat64(),
     );
 
     drawWithBitmapCanvas(builder, (RecordingCanvas canvas) {
@@ -408,7 +408,7 @@ void _testCullRectComputation() {
 
     builder.pushTransform(Matrix4.diagonal3Values(
         EngineWindow.browserDevicePixelRatio,
-        EngineWindow.browserDevicePixelRatio, 1.0).storage);
+        EngineWindow.browserDevicePixelRatio, 1.0).toFloat64());
 
     // TODO(yjbanov): see the TODO below.
     // final double screenWidth = html.window.innerWidth.toDouble();
@@ -416,7 +416,7 @@ void _testCullRectComputation() {
 
     final Matrix4 scaleTransform = Matrix4.identity().scaled(0.5, 0.2);
     builder.pushTransform(
-      scaleTransform.storage,
+      scaleTransform.toFloat64(),
     );
 
     builder.pushOffset(400, 200);
@@ -426,14 +426,14 @@ void _testCullRectComputation() {
     );
 
     builder.pushTransform(
-      Matrix4.rotationY(45.0 * math.pi / 180.0).storage,
+      Matrix4.rotationY(45.0 * math.pi / 180.0).toFloat64()
     );
 
     builder.pushClipRect(
       const Rect.fromLTRB(-140, -140, 140, 140),
     );
 
-    builder.pushTransform(Matrix4.translationValues(0, 0, -50).storage);
+    builder.pushTransform(Matrix4.translationValues(0, 0, -50).toFloat64());
 
     drawWithBitmapCanvas(builder, (RecordingCanvas canvas) {
       canvas.drawPaint(Paint()

--- a/lib/web_ui/test/golden_tests/engine/path_transform_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/path_transform_test.dart
@@ -61,7 +61,7 @@ void main() async {
     final Matrix4 testMatrixTranslateRotate =
         Matrix4.rotationZ(math.pi * 30.0 / 180.0)..translate(100, 20);
     transformedPath.addPath(path, Offset.zero,
-        matrix4: testMatrixTranslateRotate.storage);
+        matrix4: testMatrixTranslateRotate.toFloat64());
     rc.drawPath(
         transformedPath,
         Paint()
@@ -86,7 +86,7 @@ void main() async {
     final Matrix4 testMatrixTranslateRotate =
         Matrix4.rotationZ(math.pi * 30.0 / 180.0)..translate(100, 20);
     transformedPath.addPath(path, Offset.zero,
-        matrix4: testMatrixTranslateRotate.storage);
+        matrix4: testMatrixTranslateRotate.toFloat64());
     rc.drawPath(
         transformedPath,
         Paint()
@@ -112,7 +112,7 @@ void main() async {
     final Matrix4 testMatrixTranslateRotate =
         Matrix4.rotationZ(math.pi * 30.0 / 180.0)..translate(100, -80);
     transformedPath.addPath(path, Offset.zero,
-        matrix4: testMatrixTranslateRotate.storage);
+        matrix4: testMatrixTranslateRotate.toFloat64());
     rc.drawPath(
         transformedPath,
         Paint()
@@ -149,7 +149,7 @@ void main() async {
     final Matrix4 testMatrixTranslateRotate =
         Matrix4.rotationZ(math.pi * 30.0 / 180.0)..translate(100, -80);
     transformedPath.addPath(path, Offset.zero,
-        matrix4: testMatrixTranslateRotate.storage);
+        matrix4: testMatrixTranslateRotate.toFloat64());
     rc.drawPath(
         transformedPath,
         Paint()
@@ -183,7 +183,7 @@ void main() async {
     final Matrix4 testMatrixTranslateRotate =
         Matrix4.rotationZ(math.pi * 30.0 / 180.0)..translate(100, 10);
     transformedPath.addPath(path, Offset.zero,
-        matrix4: testMatrixTranslateRotate.storage);
+        matrix4: testMatrixTranslateRotate.toFloat64());
     rc.drawPath(
         transformedPath,
         Paint()
@@ -211,7 +211,7 @@ void main() async {
     final Matrix4 testMatrixTranslateRotate =
         Matrix4.rotationZ(math.pi * 30.0 / 180.0)..translate(100, -80);
     transformedPath.addPath(path, Offset.zero,
-        matrix4: testMatrixTranslateRotate.storage);
+        matrix4: testMatrixTranslateRotate.toFloat64());
     rc.drawPath(
         transformedPath,
         Paint()

--- a/lib/web_ui/test/golden_tests/engine/recording_canvas_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/recording_canvas_golden_test.dart
@@ -193,7 +193,7 @@ void main() async {
     rc.drawRect(const Rect.fromLTRB(10, 20, 30, 40), testPaint);
     rc.endRecording();
     expect(rc.pictureBounds,
-        const Rect.fromLTRB(168.0, 283.6, 224.0, 368.4));
+        within(distance: 0.001, from: const Rect.fromLTRB(168.0, 283.6, 224.0, 368.4)));
     await _checkScreenshot(rc, 'complex_transform');
   });
 
@@ -422,7 +422,7 @@ void main() async {
 
     expect(
       rc.pictureBounds,
-      Rect.fromCircle(center: const Offset(50, 50), radius: 20 * math.sqrt(2)),
+      within(distance: 0.001, from: Rect.fromCircle(center: const Offset(50, 50), radius: 20 * math.sqrt(2))),
     );
     await _checkScreenshot(rc, 'clip_rect_rotated');
   });

--- a/lib/web_ui/test/golden_tests/engine/recording_canvas_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/recording_canvas_golden_test.dart
@@ -171,7 +171,7 @@ void main() async {
 
   test('Computes paint bounds for a complex transform', () async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
-    final Float64List matrix = Float64List(16);
+    final Float32List matrix = Float32List(16);
     // translate(210, 220) , scale(2, 3), rotate(math.pi / 4.0)
     matrix[0] = 1.4;
     matrix[1] = 2.12;

--- a/lib/web_ui/test/mock_engine_canvas.dart
+++ b/lib/web_ui/test/mock_engine_canvas.dart
@@ -94,7 +94,7 @@ class MockEngineCanvas implements EngineCanvas {
   }
 
   @override
-  void transform(Float64List matrix4) {
+  void transform(Float32List matrix4) {
     _called('transform', arguments: matrix4);
   }
 


### PR DESCRIPTION
This change converts all `Float64List` matrices to `Float32List` at the `dart:ui` interface boundary. Internally, it only uses `Float32List`. `Float32List` requires less memory and is orders of magnitude faster to allocate, and it has sufficient precision as Flutter mobile engine and Skia use 32-bit floats anyway.

This change speeds up frame preroll by **50%** on the [bench_card_infinite_scroll](https://github.com/flutter/flutter/blob/master/dev/benchmarks/macrobenchmarks/lib/src/web/bench_card_infinite_scroll.dart) benchmark.

For more details on `Float64Array` allocation in JS (which backs `Float64List` in Dart) see the following:

 * https://bugs.chromium.org/p/v8/issues/detail?id=9199
 * https://bugs.chromium.org/p/v8/issues/detail?id=2022
