### PR TITLE
[web] Prevent unnecessary DOM append call when canvas is reused

### DIFF
--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -130,7 +130,12 @@ class _CanvasPool extends _SaveStackTracking {
     if (isFirstChildElement) {
       _canvas.style.zIndex = '-1';
     }
-    _rootElement.append(_canvas);
+    // Before appending canvas, check if canvas is already on rootElement. This
+    // optimization prevents DOM .append call when a PersistentSurface is
+    // reused. Reading lastChild is faster than append call.
+    if (_rootElement.lastChild != _canvas) {
+      _rootElement.append(_canvas);
+    }
     _context = _canvas.context2D;
     _contextHandle = ContextStateHandle(_context);
     _initializeViewport(requiresClearRect);


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/issues/54507.

Before:
![unnamed-1](https://user-images.githubusercontent.com/5061034/79938927-b8a01c80-8412-11ea-875b-852936b6251e.png)

After:
![unnamed](https://user-images.githubusercontent.com/5061034/79938914-b0e07800-8412-11ea-8b9a-925ef48e13d7.png)
