### PR TITLE
[web] Remove left/top/transform reset since all code paths now set ltwh

### DIFF
--- a/lib/web_ui/lib/src/engine/surface/clip.dart
+++ b/lib/web_ui/lib/src/engine/surface/clip.dart
@@ -328,6 +328,8 @@ class PersistedPhysicalShape extends PersistedContainerSurface
       domRenderer.setElementStyle(rootElement, 'clip-path', '');
       domRenderer.setElementStyle(rootElement, '-webkit-clip-path', '');
       _applyShape();
+      // This null check is in update since we don't want to unnecessarily
+      // clear style in apply on first build.
       if (path == null) {
         // Reset style on prior element when path becomes null.
         final html.CssStyleDeclaration style = rootElement.style;

--- a/lib/web_ui/lib/src/engine/surface/clip.dart
+++ b/lib/web_ui/lib/src/engine/surface/clip.dart
@@ -327,7 +327,6 @@ class PersistedPhysicalShape extends PersistedContainerSurface
       oldSurface._clipElement?.remove();
       // Reset style on prior element since we may have switched between
       // rect/rrect and arbitrary path.
-      final html.CssStyleDeclaration style = rootElement.style;
       domRenderer.setElementStyle(rootElement, 'clip-path', '');
       domRenderer.setElementStyle(rootElement, '-webkit-clip-path', '');
       _applyShape();

--- a/lib/web_ui/lib/src/engine/surface/clip.dart
+++ b/lib/web_ui/lib/src/engine/surface/clip.dart
@@ -325,11 +325,16 @@ class PersistedPhysicalShape extends PersistedContainerSurface
     }
     if (oldSurface.path != path) {
       oldSurface._clipElement?.remove();
-      // Reset style on prior element since we may have switched between
-      // rect/rrect and arbitrary path.
       domRenderer.setElementStyle(rootElement, 'clip-path', '');
       domRenderer.setElementStyle(rootElement, '-webkit-clip-path', '');
       _applyShape();
+      if (path == null) {
+        // Reset style on prior element when path becomes null.
+        final html.CssStyleDeclaration style = rootElement.style;
+        style.left = '';
+        style.top = '';
+        style.borderRadius = '';
+      }
     } else {
       _clipElement = oldSurface._clipElement;
     }

--- a/lib/web_ui/lib/src/engine/surface/clip.dart
+++ b/lib/web_ui/lib/src/engine/surface/clip.dart
@@ -328,10 +328,6 @@ class PersistedPhysicalShape extends PersistedContainerSurface
       // Reset style on prior element since we may have switched between
       // rect/rrect and arbitrary path.
       final html.CssStyleDeclaration style = rootElement.style;
-      style.transform = '';
-      style.left = '';
-      style.top = '';
-      style.borderRadius = '';
       domRenderer.setElementStyle(rootElement, 'clip-path', '');
       domRenderer.setElementStyle(rootElement, '-webkit-clip-path', '');
       _applyShape();


### PR DESCRIPTION
Related issue flutter/flutter#54507.

Since PersistedPhysicalShape is reused, the update code path was causing 20ms loss in resetting these values during update in issue referenced above.