### PR TITLE
[fuchsia] Use dart::ComponentContext()

### DIFF
--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -127,7 +127,7 @@ bool EntropySource(uint8_t* buffer, intptr_t count) {
 
 }  // namespace
 
-DartRunner::DartRunner() : context_(sys::ComponentContext::Create()) {
+DartRunner::DartRunner(sys::ComponentContext* context) : context_(context) {
   context_->outgoing()->AddPublicService<fuchsia::sys::Runner>(
       [this](fidl::InterfaceRequest<fuchsia::sys::Runner> request) {
         bindings_.AddBinding(this, std::move(request));

--- a/shell/platform/fuchsia/dart_runner/dart_runner.h
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.h
@@ -15,7 +15,7 @@ namespace dart_runner {
 
 class DartRunner : public fuchsia::sys::Runner {
  public:
-  explicit DartRunner();
+  explicit DartRunner(sys::ComponentContext* context);
   ~DartRunner() override;
 
  private:
@@ -26,7 +26,8 @@ class DartRunner : public fuchsia::sys::Runner {
       ::fidl::InterfaceRequest<fuchsia::sys::ComponentController> controller)
       override;
 
-  std::unique_ptr<sys::ComponentContext> context_;
+  // Not owned by DartRunner.
+  sys::ComponentContext* context_;
   fidl::BindingSet<fuchsia::sys::Runner> bindings_;
 
 #if !defined(AOT_RUNTIME)

--- a/shell/platform/fuchsia/dart_runner/main.cc
+++ b/shell/platform/fuchsia/dart_runner/main.cc
@@ -12,6 +12,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
 #include "logging.h"
+#include "platform/utils.h"
 #include "runtime/dart/utils/files.h"
 #include "runtime/dart/utils/tempfs.h"
 #include "third_party/dart/runtime/include/dart_api.h"
@@ -50,7 +51,7 @@ int main(int argc, const char** argv) {
 #endif  // !defined(DART_PRODUCT)
 
   dart_utils::RunnerTemp runner_temp;
-  dart_runner::DartRunner runner;
+  dart_runner::DartRunner runner(dart::ComponentContext());
   loop.Run();
   return 0;
 }

--- a/shell/platform/fuchsia/flutter/main.cc
+++ b/shell/platform/fuchsia/flutter/main.cc
@@ -9,6 +9,7 @@
 #include <cstdlib>
 
 #include "loop.h"
+#include "platform/utils.h"
 #include "runner.h"
 #include "runtime/dart/utils/tempfs.h"
 
@@ -28,10 +29,9 @@ int main(int argc, char const* argv[]) {
 
   FML_DLOG(INFO) << "Flutter application services initialized.";
 
-  flutter_runner::Runner runner(loop.get());
+  flutter_runner::Runner runner(loop.get(), dart::ComponentContext());
 
   loop->Run();
-
   FML_DLOG(INFO) << "Flutter application services terminated.";
 
   return EXIT_SUCCESS;

--- a/shell/platform/fuchsia/flutter/runner.cc
+++ b/shell/platform/fuchsia/flutter/runner.cc
@@ -146,8 +146,8 @@ static void RegisterProfilerSymbols(const char* symbols_path,
 }
 #endif  // !defined(DART_PRODUCT)
 
-Runner::Runner(async::Loop* loop)
-    : loop_(loop), context_(sys::ComponentContext::Create()) {
+Runner::Runner(async::Loop* loop, sys::ComponentContext* context)
+    : loop_(loop), context_(context) {
 #if !defined(DART_PRODUCT)
   // The VM service isolate uses the process-wide namespace. It writes the
   // vm service protocol port under /tmp. The VMServiceObject exposes that

--- a/shell/platform/fuchsia/flutter/runner.h
+++ b/shell/platform/fuchsia/flutter/runner.h
@@ -25,14 +25,15 @@ namespace flutter_runner {
 // their own threads.
 class Runner final : public fuchsia::sys::Runner {
  public:
-  explicit Runner(async::Loop* loop);
+  // Does not take ownership of loop or context.
+  Runner(async::Loop* loop, sys::ComponentContext* context);
 
   ~Runner();
 
  private:
   async::Loop* loop_;
 
-  std::unique_ptr<sys::ComponentContext> context_;
+  sys::ComponentContext* context_;
   fidl::BindingSet<fuchsia::sys::Runner> active_applications_bindings_;
   std::unordered_map<const Application*, ActiveApplication>
       active_applications_;


### PR DESCRIPTION
This functionality is added in dart-lang/sdk#41523.  Allows runners to request
the singleton instance of `sys::ComponentContext`, while it remains also
accessible to component-specific code that does not have direct access
to top-level objects.

Fixes dart-lang/sdk#41523