### PR TITLE
Stop clang code formatter checker breaking if local files match glob

### DIFF
--- a/ci/format.sh
+++ b/ci/format.sh
@@ -42,7 +42,12 @@ fi;
 
 BASE_SHA="$(git fetch $UPSTREAM master > /dev/null 2>&1 && \
            (git merge-base --fork-point FETCH_HEAD HEAD || git merge-base FETCH_HEAD HEAD))"
+# Disable glob matching otherwise a file in the current directory that matches
+# $CLANG_FILETYPES will cause git to query for that exact file instead of doing
+# a match.
+set -f
 CLANG_FILES_TO_CHECK="$(git ls-files $CLANG_FILETYPES)"
+set +f
 FAILED_CHECKS=0
 for f in $CLANG_FILES_TO_CHECK; do
   set +e


### PR DESCRIPTION
To reproduce:
$ touch foo.c foo.cc foo.cpp foo.h foo.m foo.mm
$ ./ci/format.sh

This will not check any file with clang, as the following command will do a
shell expansion and not find anything in git that matches:
$ git ls-files *.c *.cc *.cpp *.h *.m *.mm