### PR TITLE
Hand off presentation properly in VirtualDisplayController.resize()

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -16,6 +16,7 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewTreeObserver;
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.view.TextureRegistry;
 
 @TargetApi(Build.VERSION_CODES.KITKAT_WATCH)
@@ -62,7 +63,7 @@ class VirtualDisplayController {
   private final TextureRegistry.SurfaceTextureEntry textureEntry;
   private final OnFocusChangeListener focusChangeListener;
   private VirtualDisplay virtualDisplay;
-  private SingleViewPresentation presentation;
+  @VisibleForTesting SingleViewPresentation presentation;
   private Surface surface;
 
   private VirtualDisplayController(

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -146,11 +146,10 @@ class VirtualDisplayController {
           public void onViewDetachedFromWindow(View v) {}
         });
 
-    // Initialize a new presentation. We don't want to cancel
-    // the old one before we can properly show the new one to
-    // take over where it left off. Cancelling before the show()
-    // of the new presentation causes the contents to stop, eg,
-    // video stops playing.
+    // Create a new SingleViewPresentation and show() it before we cancel() the existing
+    // presentation. Calling show() and cancel() in this order fixes
+    // https://github.com/flutter/flutter/issues/26345 and maintains seamless transition
+    // of the contents of the presentation.
     SingleViewPresentation newPresentation =
         new SingleViewPresentation(
             context,
@@ -160,8 +159,6 @@ class VirtualDisplayController {
             focusChangeListener,
             isFocused);
     newPresentation.show();
-    // Stop the old presentation to prevent it from triggering callbacks
-    // after it is outdated. This prevents a NPE crash.
     presentation.cancel();
     presentation = newPresentation;
   }

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -145,7 +145,10 @@ class VirtualDisplayController {
           public void onViewDetachedFromWindow(View v) {}
         });
 
-    presentation =
+    // Initialize a new presentation. We don't want to cancel
+    // the old one before we can properly show the new one to
+    // take over where it left off.
+    SingleViewPresentation newPresentation =
         new SingleViewPresentation(
             context,
             virtualDisplay.getDisplay(),
@@ -153,7 +156,11 @@ class VirtualDisplayController {
             presentationState,
             focusChangeListener,
             isFocused);
-    presentation.show();
+    newPresentation.show();
+    // Stop the old presentation to prevent it from triggering callbacks
+    // after it is outdated.
+    presentation.cancel();
+    presentation = newPresentation;
   }
 
   public void dispose() {

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -148,7 +148,9 @@ class VirtualDisplayController {
 
     // Initialize a new presentation. We don't want to cancel
     // the old one before we can properly show the new one to
-    // take over where it left off.
+    // take over where it left off. Cancelling before the show()
+    // of the new presentation causes the contents to stop, eg,
+    // video stops playing.
     SingleViewPresentation newPresentation =
         new SingleViewPresentation(
             context,
@@ -159,7 +161,7 @@ class VirtualDisplayController {
             isFocused);
     newPresentation.show();
     // Stop the old presentation to prevent it from triggering callbacks
-    // after it is outdated.
+    // after it is outdated. This prevents a NPE crash.
     presentation.cancel();
     presentation = newPresentation;
   }

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -57,4 +57,26 @@ public class PlatformViewsControllerTest {
     verify(fakeVdController2, times(1)).onFlutterViewAttached(eq(fakeFlutterView));
     verify(fakeVdController2, times(1)).onFlutterViewDetached();
   }
+
+  @Test
+  public void itCancelsOldPresentationOnResize() {
+    // Setup test structure.
+    // Create a fake View that represents the View that renders a Flutter UI.
+    View fakeFlutterView = new View(RuntimeEnvironment.systemContext);
+
+    // Create fake VirtualDisplayControllers. This requires internal knowledge of
+    // PlatformViewsController. We know that all PlatformViewsController does is
+    // forward view attachment/detachment calls to it's VirtualDisplayControllers.
+    //
+    // TODO(mattcarroll): once PlatformViewsController is refactored into testable
+    // pieces, remove this test and avoid verifying private behavior.
+    VirtualDisplayController fakeVdController1 = mock(VirtualDisplayController.class);
+
+    SingleViewPresentation presentation = fakeVdController1.presentation;
+
+    fakeVdController1.resize(10, 10, null);
+
+    assertEquals(fakeVdController1.presentation != presentation, true);
+    assertEquals(presentation.isShowing(), false);
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/26345 and https://github.com/flutter/flutter/issues/47154

Previously, we were overwriting the presentation variable with an instance of a new SingleViewPresentation. This caused the old one to remain in memory and crash when callbacks were triggered before GC

This patch creates the new SingleViewPresentation without overwriting the old presentation, shows the new one to maintain smooth transition (without this ordering of calls, content like videos stop playing) and then when the old presentation is no longer needed, calls cancel() and sets the reference to the new presentation.