### PR TITLE
Fix units used in Linux shell timestamps.

### DIFF
--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -66,7 +66,7 @@ void fl_engine_send_window_metrics_event(FlEngine* engine,
  * fl_engine_send_mouse_pointer_event:
  * @engine: a #FlEngine
  * @phase: mouse phase.
- * @timestamp: time when event occurred in nanoseconds.
+ * @timestamp: time when event occurred in microseconds.
  * @x: x location of mouse cursor.
  * @y: y location of mouse cursor.
  * @buttons: buttons that are pressed.

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -10,7 +10,7 @@
 
 #include <gdk/gdkx.h>
 
-#define NSEC_PER_MSEC 1000000
+static constexpr int kMicrosecondsPerMillisecond = 1000;
 
 struct _FlView {
   GtkWidget parent_instance;
@@ -63,8 +63,8 @@ static gboolean fl_view_send_pointer_button_event(FlView* self,
     return FALSE;
 
   fl_engine_send_mouse_pointer_event(self->engine, phase,
-                                     event->time * NSEC_PER_MSEC, event->x,
-                                     event->y, self->button_state);
+                                     event->time * kMicrosecondsPerMillisecond,
+                                     event->x, event->y, self->button_state);
   return TRUE;
 }
 
@@ -188,9 +188,10 @@ static gboolean fl_view_motion_notify_event(GtkWidget* widget,
   if (self->engine == nullptr)
     return FALSE;
 
-  fl_engine_send_mouse_pointer_event(
-      self->engine, self->button_state != 0 ? kMove : kHover,
-      event->time * NSEC_PER_MSEC, event->x, event->y, self->button_state);
+  fl_engine_send_mouse_pointer_event(self->engine,
+                                     self->button_state != 0 ? kMove : kHover,
+                                     event->time * kMicrosecondsPerMillisecond,
+                                     event->x, event->y, self->button_state);
 
   return TRUE;
 }


### PR DESCRIPTION
GTK uses timestamps in milliseconds, Flutter wants them in microseconds.