### PR TITLE
Fix child caching in opacity_layer

### DIFF
--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -55,7 +55,7 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
     child_matrix = RasterCache::GetIntegralTransCTM(child_matrix);
 #endif
-    TryToPrepareRasterCache(context, container, child_matrix);
+    TryToPrepareRasterCache(context, GetCacheableChild(), child_matrix);
   }
 
   // Restore cull_rect
@@ -78,7 +78,7 @@ void OpacityLayer::Paint(PaintContext& context) const {
 #endif
 
   if (context.raster_cache &&
-      context.raster_cache->Draw(GetChildContainer(),
+      context.raster_cache->Draw(GetCacheableChild(),
                                  *context.leaf_nodes_canvas, &paint)) {
     return;
   }
@@ -116,6 +116,15 @@ ContainerLayer* OpacityLayer::GetChildContainer() const {
   FML_DCHECK(layers().size() == 1);
 
   return static_cast<ContainerLayer*>(layers()[0].get());
+}
+
+Layer* OpacityLayer::GetCacheableChild() const {
+  ContainerLayer* child_container = GetChildContainer();
+  if (child_container->layers().size() == 1) {
+    return child_container->layers()[0].get();
+  }
+
+  return child_container;
 }
 
 }  // namespace flutter

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -76,6 +76,15 @@ class OpacityLayer : public ContainerLayer {
    * and this method will return that single child if possible to improve
    * the performance of caching the children.
    *
+   * Note that if GetCacheableChild() does not find a single stable child of
+   * the child container it will return the child container as a fallback.
+   * Even though that child is new in each frame of an animation and thus we
+   * cannot reuse the cached layer raster between animation frames, the single
+   * container child will allow us to paint the child onto an offscreen buffer
+   * during Preroll() which reduces one render target switch compared to
+   * painting the child on the fly via an AutoSaveLayer in Paint() and thus
+   * still improves our performance.
+   *
    * @see GetChildContainer()
    * @return the best candidate Layer for caching the children
    */

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -39,6 +39,7 @@ class OpacityLayer : public ContainerLayer {
 
  private:
   ContainerLayer* GetChildContainer() const;
+  Layer* GetCacheableChild() const;
 
   SkAlpha alpha_;
   SkPoint offset_;

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -38,7 +38,27 @@ class OpacityLayer : public ContainerLayer {
 #endif  // defined(OS_FUCHSIA)
 
  private:
+  // Returns the |ContainerLayer| used to hold all of the children of the
+  // |OpacityLayer|. Typically these layers should only have a single child
+  // according to the contract of the associated Flutter widget, but the
+  // engine API cannot enforce that contract and must be prepared to support
+  // the possibility of adding more than one child. In either case, the
+  // child container will hold all children. Note that since the child
+  // container is created fresh with each new |OpacityLayer|, it may not
+  // be the best choice to cache to speed up rendering during an animation.
+  //
+  // @see |GetCacheableChild()|
   ContainerLayer* GetChildContainer() const;
+
+  // Returns the best choice for a |Layer| object that can represent all
+  // children and remain stable if the |OpacityLayer| is reconstructed in
+  // new scenes. The |OpacityLayer| needs to be recreated on frames where
+  // its opacity values change, but it often contains the same child on
+  // each such frame. Since the child container is created fresh when
+  // each |OpacityLayer| is constructed, that |Layer| will not be stable
+  // even if the same child is used. This method will determine if there
+  // is a stable child and return that |Layer| so that caching will be
+  // more successful.
   Layer* GetCacheableChild() const;
 
   SkAlpha alpha_;

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -38,27 +38,40 @@ class OpacityLayer : public ContainerLayer {
 #endif  // defined(OS_FUCHSIA)
 
  private:
-  // Returns the |ContainerLayer| used to hold all of the children of the
-  // |OpacityLayer|. Typically these layers should only have a single child
-  // according to the contract of the associated Flutter widget, but the
-  // engine API cannot enforce that contract and must be prepared to support
-  // the possibility of adding more than one child. In either case, the
-  // child container will hold all children. Note that since the child
-  // container is created fresh with each new |OpacityLayer|, it may not
-  // be the best choice to cache to speed up rendering during an animation.
-  //
-  // @see |GetCacheableChild()|
+  /**
+   * @brief Returns the ContainerLayer used to hold all of the children
+   * of the OpacityLayer.
+   *
+   * Typically these layers should only have a single child according to
+   * the contract of the associated Flutter widget, but the engine API
+   * cannot enforce that contract and must be prepared to support the
+   * possibility of adding more than one child. In either case, the
+   * child container will hold all children. Note that since the child
+   * container is created fresh with each new OpacityLayer, it may not
+   * be the best choice to cache to speed up rendering during an animation.
+   *
+   * @see GetCacheableChild()
+   * @return the ContainerLayer child used to hold the children
+   */
   ContainerLayer* GetChildContainer() const;
 
-  // Returns the best choice for a |Layer| object that can represent all
-  // children and remain stable if the |OpacityLayer| is reconstructed in
-  // new scenes. The |OpacityLayer| needs to be recreated on frames where
-  // its opacity values change, but it often contains the same child on
-  // each such frame. Since the child container is created fresh when
-  // each |OpacityLayer| is constructed, that |Layer| will not be stable
-  // even if the same child is used. This method will determine if there
-  // is a stable child and return that |Layer| so that caching will be
-  // more successful.
+  /**
+   * @brief Returns the best choice for a Layer object that can be used
+   * in RasterCache operations to cache the children of the OpacityLayer.
+   *
+   * The returned Layer must represent all children and try to remain stable
+   * if the OpacityLayer is reconstructed in subsequent frames of the scene.
+   * The OpacityLayer needs to be recreated on frames where its opacity
+   * values change, but it often contains the same child on each such frame.
+   * Since the child container is created fresh each time the OpacityLayer
+   * is constructed, the return value from GetChildContainer will be different
+   * on each such frame even if the same child is used. This method will
+   * determine if there is a (single) stable child and return that Layer
+   * so that caching will be more successful.
+   *
+   * @see GetChildContainer()
+   * @return the best candidate Layer for caching the children
+   */
   Layer* GetCacheableChild() const;
 
   SkAlpha alpha_;

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -64,21 +64,20 @@ TEST_F(OpacityLayerTest, ChildIsCached) {
   layer->Add(mock_layer);
 
   SkMatrix cache_ctm = initial_transform;
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  cache_ctm = RasterCache::GetIntegralTransCTM(cache_ctm);
-#endif
   SkCanvas cache_canvas;
   cache_canvas.setMatrix(cache_ctm);
   SkCanvas other_canvas;
   other_canvas.setMatrix(other_transform);
 
-  EXPECT_EQ(raster_cache()->LayerCacheCount(), 0);
+  use_mock_raster_cache();
+
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
   EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), other_canvas));
   EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
 
   layer->Preroll(preroll_context(), initial_transform);
 
-  EXPECT_EQ(raster_cache()->LayerCacheCount(), 1);
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
   EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), other_canvas));
   EXPECT_TRUE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
 }
@@ -97,15 +96,14 @@ TEST_F(OpacityLayerTest, ChildrenNotCached) {
   layer->Add(mock_layer2);
 
   SkMatrix cache_ctm = initial_transform;
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  cache_ctm = RasterCache::GetIntegralTransCTM(cache_ctm);
-#endif
   SkCanvas cache_canvas;
   cache_canvas.setMatrix(cache_ctm);
   SkCanvas other_canvas;
   other_canvas.setMatrix(other_transform);
 
-  EXPECT_EQ(raster_cache()->LayerCacheCount(), 0);
+  use_mock_raster_cache();
+
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
   EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), other_canvas));
   EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), cache_canvas));
   EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), other_canvas));
@@ -113,7 +111,7 @@ TEST_F(OpacityLayerTest, ChildrenNotCached) {
 
   layer->Preroll(preroll_context(), initial_transform);
 
-  EXPECT_EQ(raster_cache()->LayerCacheCount(), 1);
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
   EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), other_canvas));
   EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), cache_canvas));
   EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), other_canvas));

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -67,16 +67,20 @@ TEST_F(OpacityLayerTest, ChildIsCached) {
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
   cache_ctm = RasterCache::GetIntegralTransCTM(cache_ctm);
 #endif
+  SkCanvas cache_canvas;
+  cache_canvas.setMatrix(cache_ctm);
+  SkCanvas other_canvas;
+  other_canvas.setMatrix(other_transform);
 
   EXPECT_EQ(raster_cache()->LayerCacheCount(), 0);
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer.get(), other_transform));
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer.get(), cache_ctm));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
 
   layer->Preroll(preroll_context(), initial_transform);
 
   EXPECT_EQ(raster_cache()->LayerCacheCount(), 1);
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer.get(), other_transform));
-  EXPECT_TRUE(raster_cache()->WasPrepared(mock_layer.get(), cache_ctm));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), other_canvas));
+  EXPECT_TRUE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
 }
 
 TEST_F(OpacityLayerTest, ChildrenNotCached) {
@@ -96,20 +100,24 @@ TEST_F(OpacityLayerTest, ChildrenNotCached) {
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
   cache_ctm = RasterCache::GetIntegralTransCTM(cache_ctm);
 #endif
+  SkCanvas cache_canvas;
+  cache_canvas.setMatrix(cache_ctm);
+  SkCanvas other_canvas;
+  other_canvas.setMatrix(other_transform);
 
   EXPECT_EQ(raster_cache()->LayerCacheCount(), 0);
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer1.get(), other_transform));
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer1.get(), cache_ctm));
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer2.get(), other_transform));
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer2.get(), cache_ctm));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), cache_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), cache_canvas));
 
   layer->Preroll(preroll_context(), initial_transform);
 
   EXPECT_EQ(raster_cache()->LayerCacheCount(), 1);
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer1.get(), other_transform));
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer1.get(), cache_ctm));
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer2.get(), other_transform));
-  EXPECT_FALSE(raster_cache()->WasPrepared(mock_layer2.get(), cache_ctm));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), cache_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), cache_canvas));
 }
 
 TEST_F(OpacityLayerTest, FullyOpaque) {

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -122,10 +122,10 @@ static RasterCacheResult Rasterize(
 }
 
 static RasterCacheResult RasterizePicture(SkPicture* picture,
-                                   GrContext* context,
-                                   const SkMatrix& ctm,
-                                   SkColorSpace* dst_color_space,
-                                   bool checkerboard) {
+                                          GrContext* context,
+                                          const SkMatrix& ctm,
+                                          SkColorSpace* dst_color_space,
+                                          bool checkerboard) {
   return Rasterize(context, ctm, dst_color_space, checkerboard,
                    picture->cullRect(),
                    [=](SkCanvas* canvas) { canvas->drawPicture(picture); });

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -121,7 +121,7 @@ static RasterCacheResult Rasterize(
   return {surface->makeImageSnapshot(), logical_rect};
 }
 
-RasterCacheResult RasterizePicture(SkPicture* picture,
+static RasterCacheResult RasterizePicture(SkPicture* picture,
                                    GrContext* context,
                                    const SkMatrix& ctm,
                                    SkColorSpace* dst_color_space,

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -92,18 +92,20 @@ class RasterCache {
   // 4. There are too many pictures to be cached in the current frame.
   //    (See also kDefaultPictureCacheLimitPerFrame.)
   virtual bool Prepare(GrContext* context,
-               SkPicture* picture,
-               const SkMatrix& transformation_matrix,
-               SkColorSpace* dst_color_space,
-               bool is_complex,
-               bool will_change);
+                       SkPicture* picture,
+                       const SkMatrix& transformation_matrix,
+                       SkColorSpace* dst_color_space,
+                       bool is_complex,
+                       bool will_change);
 
-  virtual void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
+  virtual void Prepare(PrerollContext* context,
+                       Layer* layer,
+                       const SkMatrix& ctm);
 
   // Find the raster cache for the picture and draw it to the canvas.
   //
   // Return true if it's found and drawn.
-  bool Draw(const SkPicture& picture, SkCanvas& canvas) const;
+  virtual bool Draw(const SkPicture& picture, SkCanvas& canvas) const;
 
   // Find the raster cache for the layer and draw it to the canvas.
   //
@@ -111,9 +113,9 @@ class RasterCache {
   // draw the raster cache with some opacity).
   //
   // Return true if the layer raster cache is found and drawn.
-  bool Draw(const Layer* layer,
-            SkCanvas& canvas,
-            SkPaint* paint = nullptr) const;
+  virtual bool Draw(const Layer* layer,
+                    SkCanvas& canvas,
+                    SkPaint* paint = nullptr) const;
 
   void SweepAfterFrame();
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -91,14 +91,14 @@ class RasterCache {
   // 3. The picture is accessed too few times
   // 4. There are too many pictures to be cached in the current frame.
   //    (See also kDefaultPictureCacheLimitPerFrame.)
-  bool Prepare(GrContext* context,
+  virtual bool Prepare(GrContext* context,
                SkPicture* picture,
                const SkMatrix& transformation_matrix,
                SkColorSpace* dst_color_space,
                bool is_complex,
                bool will_change);
 
-  void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
+  virtual void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
 
   // Find the raster cache for the picture and draw it to the canvas.
   //

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -13,6 +13,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/testing/canvas_test.h"
 #include "flutter/testing/mock_canvas.h"
+#include "flutter/testing/mock_raster_cache.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/utils/SkNWayCanvas.h"
@@ -32,9 +33,9 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
  public:
   LayerTestBase()
       : preroll_context_({
-            nullptr, /* raster_cache */
-            nullptr, /* gr_context */
-            nullptr, /* external_view_embedder */
+            raster_cache(), /* raster_cache */
+            nullptr,        /* gr_context */
+            nullptr,        /* external_view_embedder */
             mutators_stack_, TestT::mock_canvas().imageInfo().colorSpace(),
             kGiantRect, /* cull_rect */
             false,      /* layer reads from surface */
@@ -58,6 +59,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
         }) {}
 
   TextureRegistry& texture_regitry() { return texture_registry_; }
+  MockRasterCache* raster_cache() { return &raster_cache_; }
   PrerollContext* preroll_context() { return &preroll_context_; }
   Layer::PaintContext& paint_context() { return paint_context_; }
 
@@ -67,6 +69,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
   MutatorsStack mutators_stack_;
   TextureRegistry texture_registry_;
 
+  MockRasterCache raster_cache_;
   PrerollContext preroll_context_;
   Layer::PaintContext paint_context_;
 

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -71,10 +71,13 @@ source_set("skia") {
     "canvas_test.h",
     "mock_canvas.cc",
     "mock_canvas.h",
+    "mock_raster_cache.cc",
+    "mock_raster_cache.h",
   ]
 
   public_deps = [
     ":testing_lib",
+    "//flutter/flow",
     "//third_party/skia",
   ]
 }

--- a/testing/mock_raster_cache.cc
+++ b/testing/mock_raster_cache.cc
@@ -8,138 +8,33 @@
 namespace flutter {
 namespace testing {
 
-MockRasterCache::MockRasterCache() : RasterCache::RasterCache(1, 1000000) {}
+MockRasterCacheResult::MockRasterCacheResult(SkIRect device_rect)
+    : device_rect_(device_rect) {}
 
-static bool CanRasterizePicture(SkPicture* picture) {
-  if (picture == nullptr) {
-    return false;
-  }
+std::unique_ptr<RasterCacheResult>
+MockRasterCacheImageDelegate::RasterizePicture(SkPicture* picture,
+                                               GrContext* context,
+                                               const SkMatrix& ctm,
+                                               SkColorSpace* dst_color_space,
+                                               bool checkerboard) const {
+  SkRect logical_rect = picture->cullRect();
+  SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
 
-  const SkRect cull_rect = picture->cullRect();
-
-  if (cull_rect.isEmpty()) {
-    // No point in ever rasterizing an empty picture.
-    return false;
-  }
-
-  if (!cull_rect.isFinite()) {
-    // Cannot attempt to rasterize into an infinitely large surface.
-    return false;
-  }
-
-  return true;
+  return std::make_unique<MockRasterCacheResult>(cache_rect);
 }
 
-static bool IsPictureWorthRasterizing(SkPicture* picture,
-                                      bool will_change,
-                                      bool is_complex) {
-  if (will_change) {
-    // If the picture is going to change in the future, there is no point in
-    // doing to extra work to rasterize.
-    return false;
-  }
+std::unique_ptr<RasterCacheResult> MockRasterCacheImageDelegate::RasterizeLayer(
+    PrerollContext* context,
+    Layer* layer,
+    const SkMatrix& ctm,
+    bool checkerboard) const {
+  SkRect logical_rect = layer->paint_bounds();
+  SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
 
-  if (!CanRasterizePicture(picture)) {
-    // No point in deciding whether the picture is worth rasterizing if it
-    // cannot be rasterized at all.
-    return false;
-  }
-
-  if (is_complex) {
-    // The caller seems to have extra information about the picture and thinks
-    // the picture is always worth rasterizing.
-    return true;
-  }
-
-  // TODO(abarth): We should find a better heuristic here that lets us avoid
-  // wasting memory on trivial layers that are easy to re-rasterize every frame.
-  return picture->approximateOpCount() > 5;
+  return std::make_unique<MockRasterCacheResult>(cache_rect);
 }
 
-void MockRasterCache::Prepare(PrerollContext* context,
-                              Layer* layer,
-                              const SkMatrix& ctm) {
-  LayerRasterCacheKey cache_key(layer->unique_id(), ctm);
-  MockEntry& entry = layer_cache_[cache_key];
-  entry.access_count++;
-  entry.used_this_frame = true;
-  entry.rasterized = true;
-}
-
-bool MockRasterCache::Prepare(GrContext* context,
-                              SkPicture* picture,
-                              const SkMatrix& transformation_matrix,
-                              SkColorSpace* dst_color_space,
-                              bool is_complex,
-                              bool will_change) {
-  if (!IsPictureWorthRasterizing(picture, will_change, is_complex)) {
-    // We only deal with pictures that are worthy of rasterization.
-    return false;
-  }
-
-  // Decompose the matrix (once) for all subsequent operations. We want to make
-  // sure to avoid volumetric distortions while accounting for scaling.
-  const MatrixDecomposition matrix(transformation_matrix);
-
-  if (!matrix.IsValid()) {
-    // The matrix was singular. No point in going further.
-    return false;
-  }
-
-  PictureRasterCacheKey cache_key(picture->uniqueID(), transformation_matrix);
-
-  // Creates an entry, if not present prior.
-  MockEntry& entry = picture_cache_[cache_key];
-  entry.rasterized = true;
-
-  return true;
-}
-
-bool MockRasterCache::Draw(const SkPicture& picture, SkCanvas& canvas) const {
-  PictureRasterCacheKey cache_key(picture.uniqueID(), canvas.getTotalMatrix());
-  auto it = picture_cache_.find(cache_key);
-  if (it == picture_cache_.end()) {
-    return false;
-  }
-
-  MockEntry& entry = it->second;
-  entry.access_count++;
-  entry.used_this_frame = true;
-
-  return entry.rasterized;
-}
-
-bool MockRasterCache::Draw(const Layer* layer,
-                           SkCanvas& canvas,
-                           SkPaint* paint) const {
-  LayerRasterCacheKey cache_key(layer->unique_id(), canvas.getTotalMatrix());
-  auto it = layer_cache_.find(cache_key);
-  if (it == layer_cache_.end()) {
-    return false;
-  }
-
-  MockEntry& entry = it->second;
-  entry.access_count++;
-  entry.used_this_frame = true;
-
-  return entry.rasterized;
-}
-
-void MockRasterCache::SweepAfterFrame() {
-  SweepOneCacheAfterFrame(picture_cache_);
-  SweepOneCacheAfterFrame(layer_cache_);
-}
-
-void MockRasterCache::Clear() {
-  picture_cache_.clear();
-  layer_cache_.clear();
-}
-
-size_t MockRasterCache::GetCachedEntriesCount() const {
-  return layer_cache_.size() + picture_cache_.size();
-}
-
-void MockRasterCache::SetCheckboardCacheImages(bool checkerboard) {}
+MockRasterCacheImageDelegate MockRasterCacheImageDelegate::instance;
 
 }  // namespace testing
 }  // namespace flutter

--- a/testing/mock_raster_cache.cc
+++ b/testing/mock_raster_cache.cc
@@ -9,21 +9,22 @@ namespace flutter {
 namespace testing {
 
 MockRasterCacheResult::MockRasterCacheResult(SkIRect device_rect)
-    : device_rect_(device_rect) {}
+    : RasterCacheResult(nullptr, SkRect::MakeEmpty()),
+      device_rect_(device_rect) {}
 
-std::unique_ptr<RasterCacheResult>
-MockRasterCacheImageDelegate::RasterizePicture(SkPicture* picture,
-                                               GrContext* context,
-                                               const SkMatrix& ctm,
-                                               SkColorSpace* dst_color_space,
-                                               bool checkerboard) const {
+std::unique_ptr<RasterCacheResult> MockRasterCache::RasterizePicture(
+    SkPicture* picture,
+    GrContext* context,
+    const SkMatrix& ctm,
+    SkColorSpace* dst_color_space,
+    bool checkerboard) const {
   SkRect logical_rect = picture->cullRect();
   SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
 
   return std::make_unique<MockRasterCacheResult>(cache_rect);
 }
 
-std::unique_ptr<RasterCacheResult> MockRasterCacheImageDelegate::RasterizeLayer(
+std::unique_ptr<RasterCacheResult> MockRasterCache::RasterizeLayer(
     PrerollContext* context,
     Layer* layer,
     const SkMatrix& ctm,
@@ -33,8 +34,6 @@ std::unique_ptr<RasterCacheResult> MockRasterCacheImageDelegate::RasterizeLayer(
 
   return std::make_unique<MockRasterCacheResult>(cache_rect);
 }
-
-MockRasterCacheImageDelegate MockRasterCacheImageDelegate::instance;
 
 }  // namespace testing
 }  // namespace flutter

--- a/testing/mock_raster_cache.cc
+++ b/testing/mock_raster_cache.cc
@@ -1,0 +1,198 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/layers/layer.h"
+#include "flutter/testing/mock_raster_cache.h"
+
+namespace flutter {
+namespace testing {
+
+// RasterCacheResult::RasterCacheResult(sk_sp<SkImage> image,
+//                                      const SkRect& logical_rect)
+//     : image_(std::move(image)), logical_rect_(logical_rect) {}
+
+// void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
+//   TRACE_EVENT0("flutter", "RasterCacheResult::draw");
+//   SkAutoCanvasRestore auto_restore(&canvas, true);
+//   SkIRect bounds =
+//       RasterCache::GetDeviceBounds(logical_rect_, canvas.getTotalMatrix());
+//   FML_DCHECK(
+//       std::abs(bounds.size().width() - image_->dimensions().width()) <= 1 &&
+//       std::abs(bounds.size().height() - image_->dimensions().height()) <= 1);
+//   canvas.resetMatrix();
+//   canvas.drawImage(image_, bounds.fLeft, bounds.fTop, paint);
+// }
+
+MockRasterCache::MockRasterCache()
+    : RasterCache::RasterCache(1, 1000000) { }
+
+static bool CanRasterizePicture(SkPicture* picture) {
+  if (picture == nullptr) {
+    return false;
+  }
+
+  const SkRect cull_rect = picture->cullRect();
+
+  if (cull_rect.isEmpty()) {
+    // No point in ever rasterizing an empty picture.
+    return false;
+  }
+
+  if (!cull_rect.isFinite()) {
+    // Cannot attempt to rasterize into an infinitely large surface.
+    return false;
+  }
+
+  return true;
+}
+
+static bool IsPictureWorthRasterizing(SkPicture* picture,
+                                      bool will_change,
+                                      bool is_complex) {
+  if (will_change) {
+    // If the picture is going to change in the future, there is no point in
+    // doing to extra work to rasterize.
+    return false;
+  }
+
+  if (!CanRasterizePicture(picture)) {
+    // No point in deciding whether the picture is worth rasterizing if it
+    // cannot be rasterized at all.
+    return false;
+  }
+
+  if (is_complex) {
+    // The caller seems to have extra information about the picture and thinks
+    // the picture is always worth rasterizing.
+    return true;
+  }
+
+  // TODO(abarth): We should find a better heuristic here that lets us avoid
+  // wasting memory on trivial layers that are easy to re-rasterize every frame.
+  return picture->approximateOpCount() > 5;
+}
+
+/// @note Procedure doesn't copy all closures.
+static RasterCacheResult Rasterize(
+    const SkMatrix& ctm,
+    SkColorSpace* dst_color_space,
+    const SkRect& logical_rect) {
+  TRACE_EVENT0("flutter", "RasterCachePopulate");
+  SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
+
+  const SkImageInfo image_info = SkImageInfo::MakeN32Premul(
+      cache_rect.width(), cache_rect.height(), sk_ref_sp(dst_color_space));
+
+  sk_sp<SkData> data = SkData::MakeUninitialized(image_info.computeMinByteSize());
+  sk_sp<SkImage> image = SkImage::MakeRasterData(image_info, data, image_info.minRowBytes());
+
+  return {image, logical_rect};
+}
+
+static RasterCacheResult RasterizePicture(SkPicture* picture,
+                                   const SkMatrix& ctm,
+                                   SkColorSpace* dst_color_space) {
+  return Rasterize(ctm, dst_color_space, picture->cullRect());
+}
+
+void MockRasterCache::Prepare(PrerollContext* context,
+                              Layer* layer,
+                              const SkMatrix& ctm) {
+  LayerRasterCacheKey cache_key(layer->unique_id(), ctm);
+  Entry& entry = layer_cache_[cache_key];
+  entry.access_count++;
+  entry.used_this_frame = true;
+  if (!entry.image.is_valid()) {
+    entry.image = Rasterize(
+        ctm, context->dst_color_space,
+        layer->paint_bounds());
+  }
+}
+
+bool MockRasterCache::WasPrepared(Layer* layer, const SkMatrix& ctm) {
+  LayerRasterCacheKey cache_key(layer->unique_id(), ctm);
+  // return layer_cache_.contains(cache_key); - Requires STD_VER > 17, C++20
+  return layer_cache_.find(cache_key) != layer_cache_.end();
+}
+
+bool MockRasterCache::Prepare(GrContext* context,
+                          SkPicture* picture,
+                          const SkMatrix& transformation_matrix,
+                          SkColorSpace* dst_color_space,
+                          bool is_complex,
+                          bool will_change) {
+  if (!IsPictureWorthRasterizing(picture, will_change, is_complex)) {
+    // We only deal with pictures that are worthy of rasterization.
+    return false;
+  }
+
+  // Decompose the matrix (once) for all subsequent operations. We want to make
+  // sure to avoid volumetric distortions while accounting for scaling.
+  const MatrixDecomposition matrix(transformation_matrix);
+
+  if (!matrix.IsValid()) {
+    // The matrix was singular. No point in going further.
+    return false;
+  }
+
+  PictureRasterCacheKey cache_key(picture->uniqueID(), transformation_matrix);
+
+  // Creates an entry, if not present prior.
+  Entry& entry = picture_cache_[cache_key];
+
+  if (!entry.image.is_valid()) {
+    entry.image = RasterizePicture(picture, transformation_matrix,
+                                   dst_color_space);
+  }
+  return true;
+}
+
+RasterCacheResult MockRasterCache::Get(const SkPicture& picture,
+                                   const SkMatrix& ctm) const {
+  PictureRasterCacheKey cache_key(picture.uniqueID(), ctm);
+  auto it = picture_cache_.find(cache_key);
+  if (it == picture_cache_.end()) {
+    return RasterCacheResult();
+  }
+
+  Entry& entry = it->second;
+  entry.access_count++;
+  entry.used_this_frame = true;
+
+  return entry.image;
+}
+
+RasterCacheResult MockRasterCache::Get(Layer* layer, const SkMatrix& ctm) const {
+  LayerRasterCacheKey cache_key(layer->unique_id(), ctm);
+  auto it = layer_cache_.find(cache_key);
+  if (it == layer_cache_.end()) {
+    return RasterCacheResult();
+  }
+
+  Entry& entry = it->second;
+  entry.access_count++;
+  entry.used_this_frame = true;
+
+  return entry.image;
+}
+
+void MockRasterCache::SweepAfterFrame() {
+  SweepOneCacheAfterFrame(picture_cache_);
+  SweepOneCacheAfterFrame(layer_cache_);
+}
+
+void MockRasterCache::Clear() {
+  picture_cache_.clear();
+  layer_cache_.clear();
+}
+
+size_t MockRasterCache::GetCachedEntriesCount() const {
+  return layer_cache_.size() + picture_cache_.size();
+}
+
+void MockRasterCache::SetCheckboardCacheImages(bool checkerboard) {
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/testing/mock_raster_cache.h
+++ b/testing/mock_raster_cache.h
@@ -1,0 +1,92 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TESTING_MOCK_RASTER_CACHE_H_
+#define TESTING_MOCK_RASTER_CACHE_H_
+
+#include "flutter/flow/raster_cache.h"
+#include "third_party/skia/include/core/SkPicture.h"
+#include "third_party/skia/include/core/SkImage.h"
+
+namespace flutter {
+namespace testing {
+
+// Mock |RasterCache|, useful for writing tests that impact the Flutter engine
+// raster_cache without requiring a GPU.
+//
+// The |MockCanvas| stores a list of Engine Layers and Pictures that have been
+// inserted into the cache that the test can later verify against the expected
+// list of cached objects.
+class MockRasterCache : public RasterCache {
+ public:
+  // Return true if the cache is generated.
+  //
+  // We may return false and not generate the cache if
+  // 1. The picture is not worth rasterizing
+  // 2. The matrix is singular
+  // 3. The picture is accessed too few times
+  // 4. There are too many pictures to be cached in the current frame.
+  //    (See also kDefaultPictureCacheLimitPerFrame.)
+  bool Prepare(GrContext* context,
+               SkPicture* picture,
+               const SkMatrix& transformation_matrix,
+               SkColorSpace* dst_color_space,
+               bool is_complex,
+               bool will_change) override;
+
+  void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm) override;
+
+  RasterCacheResult Get(const SkPicture& picture, const SkMatrix& ctm) const override;
+
+  RasterCacheResult Get(Layer* layer, const SkMatrix& ctm) const override;
+
+  bool WasPrepared(Layer* layer, const SkMatrix& ctm);
+
+  void SweepAfterFrame();
+
+  void Clear();
+
+  int PictureCacheCount() { return picture_cache_.size(); }
+  int LayerCacheCount() { return layer_cache_.size(); }
+
+  void SetCheckboardCacheImages(bool checkerboard);
+
+  size_t GetCachedEntriesCount() const;
+
+  MockRasterCache();
+
+ protected:
+
+ private:
+  struct Entry {
+    bool used_this_frame = false;
+    size_t access_count = 0;
+    RasterCacheResult image;
+  };
+
+  template <class Cache>
+  static void SweepOneCacheAfterFrame(Cache& cache) {
+    std::vector<typename Cache::iterator> dead;
+
+    for (auto it = cache.begin(); it != cache.end(); ++it) {
+      Entry& entry = it->second;
+      if (!entry.used_this_frame) {
+        dead.push_back(it);
+      }
+      entry.used_this_frame = false;
+    }
+
+    for (auto it : dead) {
+      cache.erase(it);
+    }
+  }
+
+  mutable PictureRasterCacheKey::Map<Entry> picture_cache_;
+  mutable LayerRasterCacheKey::Map<Entry> layer_cache_;
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // TESTING_MOCK_RASTER_CACHE_H_

--- a/testing/mock_raster_cache.h
+++ b/testing/mock_raster_cache.h
@@ -6,8 +6,8 @@
 #define TESTING_MOCK_RASTER_CACHE_H_
 
 #include "flutter/flow/raster_cache.h"
-#include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/core/SkPicture.h"
 
 namespace flutter {
 namespace testing {
@@ -35,13 +35,15 @@ class MockRasterCache : public RasterCache {
                bool is_complex,
                bool will_change) override;
 
-  void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm) override;
+  void Prepare(PrerollContext* context,
+               Layer* layer,
+               const SkMatrix& ctm) override;
 
-  RasterCacheResult Get(const SkPicture& picture, const SkMatrix& ctm) const override;
+  bool Draw(const SkPicture& picture, SkCanvas& canvas) const override;
 
-  RasterCacheResult Get(Layer* layer, const SkMatrix& ctm) const override;
-
-  bool WasPrepared(Layer* layer, const SkMatrix& ctm);
+  bool Draw(const Layer* layer,
+            SkCanvas& canvas,
+            SkPaint* paint = nullptr) const override;
 
   void SweepAfterFrame();
 
@@ -56,13 +58,11 @@ class MockRasterCache : public RasterCache {
 
   MockRasterCache();
 
- protected:
-
  private:
-  struct Entry {
+  struct MockEntry {
     bool used_this_frame = false;
     size_t access_count = 0;
-    RasterCacheResult image;
+    bool rasterized;
   };
 
   template <class Cache>
@@ -70,7 +70,7 @@ class MockRasterCache : public RasterCache {
     std::vector<typename Cache::iterator> dead;
 
     for (auto it = cache.begin(); it != cache.end(); ++it) {
-      Entry& entry = it->second;
+      MockEntry& entry = it->second;
       if (!entry.used_this_frame) {
         dead.push_back(it);
       }
@@ -82,8 +82,8 @@ class MockRasterCache : public RasterCache {
     }
   }
 
-  mutable PictureRasterCacheKey::Map<Entry> picture_cache_;
-  mutable LayerRasterCacheKey::Map<Entry> layer_cache_;
+  mutable PictureRasterCacheKey::Map<MockEntry> picture_cache_;
+  mutable LayerRasterCacheKey::Map<MockEntry> layer_cache_;
 };
 
 }  // namespace testing

--- a/testing/mock_raster_cache.h
+++ b/testing/mock_raster_cache.h
@@ -12,10 +12,13 @@
 namespace flutter {
 namespace testing {
 
-// A |RasterCacheResult| implementation that represents a cached |Layer| or
-// |SkPicture| without the overhead of storage. This implementation is used
-// by |MockRasterCacheImageDelegate| only for testing proper usage of the
-// |RasterCache| in layer unit tests.
+/**
+ * @brief A RasterCacheResult implementation that represents a cached Layer or
+ * SkPicture without the overhead of storage.
+ *
+ * This implementation is used by MockRasterCache only for testing proper usage
+ * of the RasterCache in layer unit tests.
+ */
 class MockRasterCacheResult : public RasterCacheResult {
  public:
   MockRasterCacheResult(SkIRect device_rect);
@@ -24,15 +27,22 @@ class MockRasterCacheResult : public RasterCacheResult {
 
   SkISize image_dimensions() const override { return device_rect_.size(); };
 
+  int64_t image_bytes() const override {
+    return image_dimensions().area() *
+           SkColorTypeBytesPerPixel(kBGRA_8888_SkColorType);
+  }
+
  private:
   SkIRect device_rect_;
 };
 
-// A |RasterCacheImageDelegate| implementation that simulates the act of
-// rendering a |Layer| or |SkPicture| without the overhead of rasterization
-// or storage. This implementation is used only for testing proper usage of
-// the |RasterCache| in layer unit tests.
-class MockRasterCacheImageDelegate : public RasterCacheImageDelegate {
+/**
+ * @brief A RasterCache implementation that simulates the act of rendering a
+ * Layer or SkPicture without the overhead of rasterization or pixel storage.
+ * This implementation is used only for testing proper usage of the RasterCache
+ * in layer unit tests.
+ */
+class MockRasterCache : public RasterCache {
  public:
   std::unique_ptr<RasterCacheResult> RasterizePicture(
       SkPicture* picture,
@@ -46,8 +56,6 @@ class MockRasterCacheImageDelegate : public RasterCacheImageDelegate {
       Layer* layer,
       const SkMatrix& ctm,
       bool checkerboard) const override;
-
-  static MockRasterCacheImageDelegate instance;
 };
 
 }  // namespace testing


### PR DESCRIPTION
A recent change to how OpacityLayer manages its single child for caching purposes (see https://github.com/flutter/engine/pull/14559) actually broke the caching of the single child. This fix not only restores the caching for the OpacityLayer, it adds tests that will detect if it successfully caches its child in practice (as long as there is only one).