### PR TITLE
Change the repo fetch script used in integration tests

### DIFF
--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -19,7 +19,7 @@ cd $ENGINE_PATH/src/flutter
 # Special handling of release branches.
 ENGINE_BRANCH_NAME=`git branch | grep '*' | cut -d ' ' -f2`
 versionregex="^v[[:digit:]]+\."
-releasecandidateregex="^flutter-[[:digit:]]+\."
+releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
 ON_RELEASE_BRANCH=false
 echo "Engine on branch $ENGINE_BRANCH_NAME"
 if [[ $ENGINE_BRANCH_NAME =~ $versionregex || $ENGINE_BRANCH_NAME =~ $releasecandidateregex ]]

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -19,9 +19,10 @@ cd $ENGINE_PATH/src/flutter
 # Special handling of release branches.
 ENGINE_BRANCH_NAME=`git branch | grep '*' | cut -d ' ' -f2`
 versionregex="^v[[:digit:]]+\."
+releasecandidateregex="^flutter-[[:digit:]]+\."
 ON_RELEASE_BRANCH=false
 echo "Engine on branch $ENGINE_BRANCH_NAME"
-if [[ $ENGINE_BRANCH_NAME =~ $versionregex ]]
+if [[ $ENGINE_BRANCH_NAME =~ $versionregex || $ENGINE_BRANCH_NAME =~ $releasecandidateregex ]]
 then
   echo "release branch $ENGINE_BRANCH_NAME"
   ON_RELEASE_BRANCH=true


### PR DESCRIPTION
change the repo fetch script to recognize candidate versions such as flutter-1.17-candidate.3. Originally the script only accepted branches such as v0.7.3 as valid engine branches.

This will fix test breakages such as: https://github.com/flutter/engine/pull/17931

