### PR TITLE
[fuchsia] set vsync_offset to 13.2ms for performance gains

### DIFF
--- a/shell/platform/fuchsia/flutter/vsync_waiter.h
+++ b/shell/platform/fuchsia/flutter/vsync_waiter.h
@@ -34,8 +34,9 @@ class VsyncWaiter final : public flutter::VsyncWaiter {
   async::Wait session_wait_;
   fml::WeakPtrFactory<VsyncWaiter> weak_factory_;
 
+  // You can check how this impacts performance at go/flutter-fuchsia-fps.
   static constexpr fml::TimeDelta vsync_offset =
-      fml::TimeDelta::FromNanoseconds(0);
+      fml::TimeDelta::FromMicroseconds(13200);
 
   // For accessing the VsyncWaiter via the UI thread, necessary for the callback
   // for AwaitVSync()


### PR DESCRIPTION
Following the use of the raster cache, we found that Flutter work could
potentially finish a latch point too early - which would cause jank by
being too efficient, ironically.

To prevent this, we use the `vsync_offset` field to have Flutter begin
its work immediately following Scenic CPU work. This ensures they don't
compete for CPU and GPU resources, while giving both plenty of time to
complete their work.

See Astro performance gains here (Google-internal link):
https://screenshot.googleplex.com/ZHq3abR6UmQ