### PR TITLE
1.17 CP: Change the repo fetch script used in integration tests (#17943)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -87,6 +87,9 @@ task:
         mkdir -p $FRAMEWORK_PATH
         cd $FRAMEWORK_PATH
         git clone https://github.com/flutter/flutter.git
+        # following lines only for hotfix branch!
+        cd $FRAMEWORK_PATH/flutter
+        git checkout flutter-1.17-candidate.3
       test_web_script: |
         cd $FRAMEWORK_PATH/flutter/dev/integration_tests/web
         ../../../bin/flutter config --local-engine=host_debug_unopt --no-analytics --enable-web

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -20,9 +20,10 @@ cd $ENGINE_PATH/src/flutter
 # Special handling of release branches.
 ENGINE_BRANCH_NAME=`git branch | grep '*' | cut -d ' ' -f2`
 versionregex="^v[[:digit:]]+\."
+releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
 ON_RELEASE_BRANCH=false
 echo "Engine on branch $ENGINE_BRANCH_NAME"
-if [[ $ENGINE_BRANCH_NAME =~ $versionregex ]]
+if [[ $ENGINE_BRANCH_NAME =~ $versionregex || $ENGINE_BRANCH_NAME =~ $releasecandidateregex ]]
 then
   echo "release branch $ENGINE_BRANCH_NAME"
   ON_RELEASE_BRANCH=true


### PR DESCRIPTION
fixes failing test from https://github.com/flutter/flutter/issues/55575

original comment:

* change the repo fetch script to recognize candidate versions such as flutter-1.17-candidate.3. Originally the script only accepted branches such as v0.7.3 as valid engine branches.

* addressing reviewer comments: changing the release regular expression

