### PR TITLE
handling branches in ci

### DIFF
--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -2,27 +2,31 @@
 set -e
 set -x
 
-if [[ "$CIRRUS_CI" = false || -z $CIRRUS_CI ]]
-then
-  echo "This script is aimed to be run on CI environments. Do not run locally."
-  exit 1
-fi
+# if [[ "$CIRRUS_CI" = false || -z $CIRRUS_CI ]]
+# then
+#   echo "This script is aimed to be run on CI environments. Do not run locally."
+#   exit 1
+# fi
 
-if [[ -z $ENGINE_PATH ]]
-then
-  echo "Engine path should be set to run the script."
-  exit 1
-fi
+# if [[ -z $ENGINE_PATH ]]
+# then
+#   echo "Engine path should be set to run the script."
+#   exit 1
+# fi
 
 # Go to the engine git repo to get the date of the latest commit.
 cd $ENGINE_PATH/src/flutter
 
 # Special handling of release branches.
+BRANCH=`git branch`
+echo "git branches $BRANCH"
+
 ENGINE_BRANCH_NAME=`git branch | grep '*' | cut -d ' ' -f2`
 versionregex="^v[[:digit:]]+\."
+releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
 ON_RELEASE_BRANCH=false
 echo "Engine on branch $ENGINE_BRANCH_NAME"
-if [[ $ENGINE_BRANCH_NAME =~ $versionregex ]]
+if [[ $ENGINE_BRANCH_NAME =~ $versionregex || $ENGINE_BRANCH_NAME =~ $releasecandidateregex ]]
 then
   echo "release branch $ENGINE_BRANCH_NAME"
   ON_RELEASE_BRANCH=true

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -18,10 +18,7 @@ set -x
 cd $ENGINE_PATH/src/flutter
 
 # Special handling of release branches.
-echo "cirrus branch: $CIRRUS_BRANCH"
-echo "cirrus base branch: $CIRRUS_BASE_BRANCH"
-
-ENGINE_BRANCH_NAME=`git branch | grep '*' | cut -d ' ' -f2`
+ENGINE_BRANCH_NAME=$CIRRUS_BASE_BRANCH
 versionregex="^v[[:digit:]]+\."
 releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
 ON_RELEASE_BRANCH=false

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -2,17 +2,17 @@
 set -e
 set -x
 
-# if [[ "$CIRRUS_CI" = false || -z $CIRRUS_CI ]]
-# then
-#   echo "This script is aimed to be run on CI environments. Do not run locally."
-#   exit 1
-# fi
+if [[ "$CIRRUS_CI" = false || -z $CIRRUS_CI ]]
+then
+  echo "This script is aimed to be run on CI environments. Do not run locally."
+  exit 1
+fi
 
-# if [[ -z $ENGINE_PATH ]]
-# then
-#   echo "Engine path should be set to run the script."
-#   exit 1
-# fi
+if [[ -z $ENGINE_PATH ]]
+then
+  echo "Engine path should be set to run the script."
+  exit 1
+fi
 
 # Go to the engine git repo to get the date of the latest commit.
 cd $ENGINE_PATH/src/flutter

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -18,8 +18,8 @@ set -x
 cd $ENGINE_PATH/src/flutter
 
 # Special handling of release branches.
-BRANCH=`git branch`
-echo "git branches $BRANCH"
+echo "cirrus branch: $CIRRUS_BRANCH"
+echo "cirrus base branch: $CIRRUS_BASE_BRANCH"
 
 ENGINE_BRANCH_NAME=`git branch | grep '*' | cut -d ' ' -f2`
 versionregex="^v[[:digit:]]+\."


### PR DESCRIPTION
print the git branch output

found result: BRANCH='* (no branch)'. Therefore using the clone_flutter.sh we are not able to get the engine branch.

Solution: $CIRRUS_BASE_BRANCH can be used for branch name: https://cirrus-ci.com/task/6753845336342528?command=fetch_framework#L5 

Successful run: https://cirrus-ci.com/task/6347234272870400

Fixes https://github.com/flutter/flutter/issues/55884