### PR TITLE
Set the max vulkan API version

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -125,6 +125,11 @@ bool VulkanSurfaceProducer::Initialize(scenic::Session* scenic_session) {
 
   context_ = GrContext::MakeVulkan(backend_context);
 
+  if (context_ == nullptr) {
+    FML_LOG(ERROR) << "Failed to create GrContext.";
+    return false;
+  }
+
   // Use local limits specified in this file above instead of flutter defaults.
   context_->setResourceCacheLimits(kGrCacheMaxCount, kGrCacheMaxByteSize);
 

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -118,6 +118,7 @@ bool VulkanSurfaceProducer::Initialize(scenic::Session* scenic_session) {
   backend_context.fGraphicsQueueIndex =
       logical_device_->GetGraphicsQueueIndex();
   backend_context.fMinAPIVersion = application_->GetAPIVersion();
+  backend_context.fMaxAPIVersion = application_->GetAPIVersion();
   backend_context.fFeatures = skia_features;
   backend_context.fGetProc = std::move(getProc);
   backend_context.fOwnsInstanceAndDevice = false;


### PR DESCRIPTION
We need to pass in the max API version to Skia otherwise sometimes null is returned from `GrContext::MakeVulkan()` (in particular, I've found this when validation layers are enabled).