### PR TITLE
Disable the import_internal_library analyzer check for dart:ui

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,6 +28,8 @@ analyzer:
     native_function_body_in_non_sdk_code: ignore
     # allow having TODOs in the code
     todo: ignore
+    # allow dart:ui to import dart:_internal
+    import_internal_library: ignore
   # `flutter analyze` (without `--watch`) just ignores directories
   # that contain a .dartignore file, and this file does not have any
   # effect on what files are actually analyzed.

--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -12,7 +12,7 @@
 // @dart = 2.6
 library dart.ui;
 
-import 'dart:_internal' hide Symbol; // ignore: import_internal_library, unused_import
+import 'dart:_internal' hide Symbol; // ignore: unused_import
 import 'dart:async';
 import 'dart:collection' as collection;
 import 'dart:convert';


### PR DESCRIPTION
The latest version of dartanalyzer does not support disabling this for a
specific line of code.