### PR TITLE
use $CIRRUS_BASE_BRANCH for the branch name

### DIFF
--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -17,7 +17,7 @@ fi
 cd $ENGINE_PATH/src/flutter
 
 # Special handling of release branches.
-ENGINE_BRANCH_NAME=`git branch | grep '*' | cut -d ' ' -f2`
+ENGINE_BRANCH_NAME=$CIRRUS_BASE_BRANCH
 versionregex="^v[[:digit:]]+\."
 releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
 ON_RELEASE_BRANCH=false


### PR DESCRIPTION
use $CIRRUS_BASE_BRANCH for getting the branch name when cloning the flutter repo.

Successful run for the failing integration test: https://cirrus-ci.com/task/6347234272870400

Fixes flutter/flutter#55884