### PR TITLE
[web] also hide scrollbars in text_editing

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -36,6 +36,7 @@ void _setStaticStyleAttributes(html.HtmlElement domElement) {
     ..border = 'none'
     ..resize = 'none'
     ..textShadow = 'transparent'
+    ..overflow = 'hidden'
     ..transformOrigin = '0 0 0';
 
   /// This property makes the input's blinking cursor transparent.


### PR DESCRIPTION
When using https://github.com/memspace/zefyr on the web in Chromium under Linux, a scrollbar appears at the top left of the screen, it belongs to the hidden text_area from DefaultTextEditingStrategy used to receive input in Zefyr)

This patch hides the scrollbar.

This may not be visible with a regular TextField. With a regular TextField the hidden text editing is superposed to the TextField, while in Zefyr it appears at the top left corner of the page.
