### PR TITLE
Fix timeline events lost before dart init

### DIFF
--- a/fml/trace_event.cc
+++ b/fml/trace_event.cc
@@ -47,7 +47,7 @@ struct CachedTimelineEvent {
 std::vector<std::unique_ptr<CachedTimelineEvent>> gCachedTimelineEvents;
 std::mutex gCachedTimelineEventsMutex;
 
-inline void CacheTimelineEvent(const char* label,
+static void CacheTimelineEvent(const char* label,
                                int64_t timestamp0,
                                int64_t timestamp1_or_async_id,
                                Dart_Timeline_Event_Type type,
@@ -62,9 +62,6 @@ inline void CacheTimelineEvent(const char* label,
   gCachedTimelineEvents.push_back(std::move(event));
 }
 
-// Before DartVM has initialized, |Dart_TimelineEvent| is not able to record
-// timeline events but drop them. Thus we need to cache these previous events,
-// and flush them once DartVM init.
 typedef void (*TimelineEventFunction)(const char* label,
                                       int64_t timestamp0,
                                       int64_t timestamp1_or_async_id,

--- a/fml/trace_event.cc
+++ b/fml/trace_event.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <mutex>
 #include <utility>
 
 #include "flutter/fml/ascii_trie.h"
@@ -26,8 +27,7 @@ namespace tracing {
 namespace {
 AsciiTrie gWhitelist;
 
-struct CachedTimelineEvent
-{
+struct CachedTimelineEvent {
   const char* label_;
   int64_t timestamp0_;
   int64_t timestamp1_or_async_id_;
@@ -57,8 +57,8 @@ inline void CacheTimelineEvent(const char* label,
   const std::lock_guard<std::mutex> lock(gCachedTimelineEventsMutex);
   // TODO(chenjianguang): Cache events with arguments.
   std::unique_ptr<CachedTimelineEvent> event =
-      std::make_unique<CachedTimelineEvent>(
-          label, timestamp0, timestamp1_or_async_id, type);
+      std::make_unique<CachedTimelineEvent>(label, timestamp0,
+                                            timestamp1_or_async_id, type);
   gCachedTimelineEvents.push_back(std::move(event));
 }
 
@@ -93,8 +93,8 @@ void FlushCachedTimelineEvents() {
   const std::lock_guard<std::mutex> lock(gCachedTimelineEventsMutex);
   for (const auto& event : gCachedTimelineEvents) {
     Dart_TimelineEvent(event->label_, event->timestamp0_,
-                       event->timestamp1_or_async_id_, event->type_,
-                       0, nullptr, nullptr);
+                       event->timestamp1_or_async_id_, event->type_, 0, nullptr,
+                       nullptr);
   }
   gCachedTimelineEvents.clear();
 

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -351,6 +351,8 @@ class TraceFlow {
   FML_DISALLOW_COPY_AND_ASSIGN(TraceFlow);
 };
 
+void FlushCachedTimelineEvents();
+
 }  // namespace tracing
 }  // namespace fml
 

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -351,6 +351,13 @@ class TraceFlow {
   FML_DISALLOW_COPY_AND_ASSIGN(TraceFlow);
 };
 
+//------------------------------------------------------------------------------
+/// @brief      Before DartVM has initialized, |Dart_TimelineEvent| is not able
+///             to record events but drop them since |TimelineRecorder| not yet
+///             created. To resolve this issue, we need to cache these early
+///             events, then call this method after |Dart_Initialize| to flush
+///             the cached events.
+///
 void FlushCachedTimelineEvents();
 
 }  // namespace tracing

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -436,6 +436,7 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
           nullptr                                    // argument_values
       );
     }
+    fml::tracing::FlushCachedTimelineEvents();
   }
 
   Dart_SetFileModifiedCallback(&DartFileModifiedCallback);


### PR DESCRIPTION
Before DartVM has initialized, |Dart_TimelineEvent| is not able to record timeline events but drop them. 
For example, we have TRACE_EVENT0("flutter", "Dart_Initialize") inside DartVM::DartVM() which calls Dart_Initialize(), but actually the |begin| event is discarded since Dart not yeah init, Timeline not yeah init, TimelineRecorder not yeah created, leaving a single |end| event.

before this PR,
![image](https://user-images.githubusercontent.com/62057376/80595392-3d181e00-8a57-11ea-8c8a-8db78624a403.png)
![image](https://user-images.githubusercontent.com/62057376/80595953-232b0b00-8a58-11ea-83f5-d245d0e0d670.png)

after this PR,
![image](https://user-images.githubusercontent.com/62057376/80595994-3938cb80-8a58-11ea-8757-f2d0485ca49e.png)
![image](https://user-images.githubusercontent.com/62057376/80596335-cda32e00-8a58-11ea-950a-32c57fe7b109.png)

The solution is to cache timeline events before Dart init, and flush them once Dart has initialized.