### PR TITLE
soften shadows even more; fix shadow alpha

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 263d816b73df47fca2fdc0fbce7ad09f17aa30b6
+revision: 15cd7bcdf55ec9047c30adbcaba1991c6531e4da

--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 15cd7bcdf55ec9047c30adbcaba1991c6531e4da
+revision: f64d8957ae281d1558647f0591ff9742e6135385

--- a/lib/web_ui/lib/src/engine/shadow.dart
+++ b/lib/web_ui/lib/src/engine/shadow.dart
@@ -133,9 +133,24 @@ void applyCssShadow(
   if (shadow == null) {
     element.style.boxShadow = 'none';
   } else {
-    // Multiply by 0.4 to make shadows less aggressive (https://github.com/flutter/flutter/issues/52734)
-    final double alpha = 0.4 * color.alpha / 255;
+    color = toShadowColor(color);
     element.style.boxShadow = '${shadow.offset.dx}px ${shadow.offset.dy}px '
-        '${shadow.blurWidth}px 0px rgba(${color.red}, ${color.green}, ${color.blue}, $alpha)';
+        '${shadow.blurWidth}px 0px rgba(${color.red}, ${color.green}, ${color.blue}, ${color.alpha / 255})';
   }
+}
+
+/// Converts a shadow color specified by the framework to the color that should
+/// actually be applied when rendering the shadow.
+///
+/// Flutter shadows look softer than the color specified by the developer. For
+/// example, it is common to get a solid black for a shadow and see a very soft
+/// shadow. This function softens the color by reducing its alpha by a constant
+/// factor.
+ui.Color toShadowColor(ui.Color color) {
+  // Reduce alpha to make shadows less aggressive:
+  //
+  // - https://github.com/flutter/flutter/issues/52734
+  // - https://github.com/flutter/gallery/issues/118
+  final int reducedAlpha = (0.3 * color.alpha).round();
+  return ui.Color((reducedAlpha & 0xff) << 24 | (color.value & 0x00ffffff));
 }

--- a/lib/web_ui/test/golden_tests/engine/shadow_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/shadow_golden_test.dart
@@ -69,7 +69,7 @@ void main() async {
     builder.pop(); // offset
   }
 
-  void _paintBitmapCanvasShadow(double elevation, Offset offset) {
+  void _paintBitmapCanvasShadow(double elevation, Offset offset, bool transparentOccluder) {
     final SurfacePath path = SurfacePath()
       ..addRect(const Rect.fromLTRB(0, 0, 20, 20));
     builder.pushOffset(offset.dx, offset.dy);
@@ -82,7 +82,7 @@ void main() async {
       path,
       _kShadowColor,
       elevation,
-      false,
+      transparentOccluder,
     );
     builder.addPicture(Offset.zero, recorder.endRecording());
     _paintShapeOutline();
@@ -136,12 +136,16 @@ void main() async {
       }
 
       for (int i = 0; i < 10; i++) {
-        _paintBitmapCanvasShadow(i.toDouble(), Offset(50.0 * i, 60));
+        _paintBitmapCanvasShadow(i.toDouble(), Offset(50.0 * i, 60), false);
+      }
+
+      for (int i = 0; i < 10; i++) {
+        _paintBitmapCanvasShadow(i.toDouble(), Offset(50.0 * i, 120), true);
       }
 
       for (int i = 0; i < 10; i++) {
         _paintBitmapCanvasComplexPathShadow(
-            i.toDouble(), Offset(50.0 * i, 120));
+            i.toDouble(), Offset(50.0 * i, 180));
       }
 
       builder.pop();


### PR DESCRIPTION
* Soften shadows even more; fix shadow alpha. This change uses `globalAlpha` to make the shadow transparent rather than using `rgba` on `shadowColor`, which is not supported as of today.
* Add a test for transparent occluder.

This requires a golden update: https://github.com/flutter/goldens/pull/90

Fixes https://github.com/flutter/flutter/issues/55786
Fixes https://github.com/flutter/gallery/issues/118

Examples:

Slider before:

![slider-before](https://user-images.githubusercontent.com/211513/80658004-db958680-8a39-11ea-8ff7-329af13e29b9.png)

Slider after:

![slider-after](https://user-images.githubusercontent.com/211513/80658019-e4865800-8a39-11ea-90d6-8363ddbdda3b.png)

Appbar before:

![appbar-before](https://user-images.githubusercontent.com/211513/80658034-e94b0c00-8a39-11ea-8c23-01c8362ca2c0.png)

Appbar after:

![appbar-after](https://user-images.githubusercontent.com/211513/80658042-eea85680-8a39-11ea-9056-c248480451db.png)

Gallery before:

![gallery-before](https://user-images.githubusercontent.com/211513/80658052-f2d47400-8a39-11ea-84a0-15226347d08f.png)

Gallery after:

![gallery-after](https://user-images.githubusercontent.com/211513/80658062-f7009180-8a39-11ea-86a5-a0109134c650.png)

Shrine demo before:

![shrine-before](https://user-images.githubusercontent.com/211513/80658076-fd8f0900-8a39-11ea-9ea6-2f87f7014993.png)

Shrine demo after:

![shrine-after](https://user-images.githubusercontent.com/211513/80658084-02ec5380-8a3a-11ea-8b4c-0567998e48f6.png)
