### PR TITLE
[web] remove linux-chrome unit tests from cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -86,17 +86,6 @@ task:
       test_host_script: |
         cd $ENGINE_PATH/src
         ./flutter/testing/run_tests.sh host_debug_unopt
-      test_web_engine_script: |
-        cd $ENGINE_PATH/src/flutter/web_sdk/web_engine_tester
-        $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/pub get
-        cd $ENGINE_PATH/src/flutter/lib/web_ui
-        $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/pub get
-        export FELT="$ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/dart dev/felt.dart"
-        $FELT check-licenses
-        CHROME_NO_SANDBOX=true $FELT test
-      always:
-        web_engine_test_artifacts:
-          path: test_results/*
       fetch_framework_script: |
         mkdir -p $FRAMEWORK_PATH
         cd $FRAMEWORK_PATH


### PR DESCRIPTION
Removing linux-chrome unit tests from cirrus CI. These tasks already run in Lunix Web Build LUCI task:
- felt test: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8881727102719613472/+/steps/felt_test/0/logs/execution_details/0
- felt check-licenses: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8881727102719613472/+/steps/felt_licenses/0/logs/execution_details/0

One of the steps for the Cirrus to CI migration project. Fixes https://github.com/flutter/flutter/issues/55901 