### PR TITLE
Handle backspace on Android by using the engine's ICU grapheme breaker

### DIFF
--- a/fml/platform/android/jni_util.cc
+++ b/fml/platform/android/jni_util.cc
@@ -165,5 +165,21 @@ std::string GetJavaExceptionInfo(JNIEnv* env, jthrowable java_throwable) {
   return JavaStringToString(env, exception_string.obj());
 }
 
+void ThrowException(JNIEnv* env, const char* class_name, const char* message) {
+  jclass clazz = env->FindClass(class_name);
+  FML_DCHECK(clazz);
+  env->ThrowNew(clazz, message);
+}
+
+ScopedJavaStringChars::ScopedJavaStringChars(JNIEnv* env, jstring str)
+    : env_(env), str_(str) {
+  chars_ = env_->GetStringChars(str_, nullptr);
+  FML_DCHECK(chars_);
+}
+
+ScopedJavaStringChars::~ScopedJavaStringChars() {
+  env_->ReleaseStringChars(str_, chars_);
+}
+
 }  // namespace jni
 }  // namespace fml

--- a/fml/platform/android/jni_util.h
+++ b/fml/platform/android/jni_util.h
@@ -38,6 +38,21 @@ bool ClearException(JNIEnv* env);
 
 std::string GetJavaExceptionInfo(JNIEnv* env, jthrowable java_throwable);
 
+void ThrowException(JNIEnv* env, const char* class_name, const char* message);
+
+class ScopedJavaStringChars {
+ public:
+  ScopedJavaStringChars(JNIEnv* env, jstring str);
+  ~ScopedJavaStringChars();
+
+  const jchar* chars() { return chars_; }
+
+ private:
+  JNIEnv* env_;
+  jstring str_;
+  const jchar* chars_;
+};
+
 }  // namespace jni
 }  // namespace fml
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -146,6 +146,15 @@ public class FlutterJNI {
   @NonNull
   public static native FlutterCallbackInformation nativeLookupCallbackInformation(long handle);
 
+  /**
+   * Return the index of the first grapheme cluster preceding {@code offset} in {@code text}.
+   *
+   * <p>This is similar to {@link android.text.TextUtils#getOffsetBefore(CharSequence, int, int)}
+   * but it uses the engine's ICU library which is up to date and acts consistently on all versions
+   * of Android.
+   */
+  public static native int nativeGetTextOffsetBefore(String text, int offset);
+
   @Nullable private Long nativePlatformViewId;
   @Nullable private AccessibilityDelegate accessibilityDelegate;
   @Nullable private PlatformMessageHandler platformMessageHandler;

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -16,6 +16,7 @@ import android.text.Editable;
 import android.text.InputType;
 import android.text.Selection;
 import android.text.SpannableStringBuilder;
+import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
@@ -318,6 +319,13 @@ public class InputConnectionAdaptorTest {
     int selStart = 29;
     Editable editable = sampleRtlEditable(selStart, selStart);
     InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+    adaptor.setGetOffsetBefore(
+        new InputConnectionAdaptor.GetOffsetBefore() {
+          @Override
+          public int getOffsetBefore(String text, int offset) {
+            return TextUtils.getOffsetBefore(text, offset);
+          }
+        });
 
     KeyEvent downKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL);
 


### PR DESCRIPTION
The backspace key handler in the Android text input plugin needs to
identify the logical character preceding the cursor and remove it
from the editable.  Older versions of Android may not provide APIs
that can do this with accurate handling of current emojis.  This
implementation handles it by invoking the icu::BreakIterator via JNI.