### PR TITLE
Wire up channel for restoration data

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -736,6 +736,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/system
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/SettingsChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/SystemChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -444,6 +444,7 @@ action("robolectric_tests") {
     "test/io/flutter/embedding/engine/dart/DartExecutorTest.java",
     "test/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistryTest.java",
     "test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java",
+    "test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java",
     "test/io/flutter/external/FlutterLaunchTests.java",
     "test/io/flutter/plugin/common/StandardMessageCodecTest.java",
     "test/io/flutter/plugin/common/StandardMethodCodecTest.java",

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -184,6 +184,7 @@ android_java_sources = [
   "io/flutter/embedding/engine/systemchannels/NavigationChannel.java",
   "io/flutter/embedding/engine/systemchannels/PlatformChannel.java",
   "io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java",
+  "io/flutter/embedding/engine/systemchannels/RestorationChannel.java",
   "io/flutter/embedding/engine/systemchannels/SettingsChannel.java",
   "io/flutter/embedding/engine/systemchannels/SystemChannel.java",
   "io/flutter/embedding/engine/systemchannels/TextInputChannel.java",

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -11,6 +11,7 @@ import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DEFAULT_
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_BACKGROUND_MODE;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_CACHED_ENGINE_ID;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_DESTROY_ENGINE_WITH_ACTIVITY;
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_ENABLE_STATE_RESTORATION;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_INITIAL_ROUTE;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.INITIAL_ROUTE_META_DATA_KEY;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.NORMAL_THEME_META_DATA_KEY;
@@ -947,6 +948,17 @@ public class FlutterActivity extends Activity
   @Override
   public void onFlutterUiNoLongerDisplayed() {
     // no-op
+  }
+
+  @Override
+  public boolean shouldRestoreAndSaveState() {
+    if (getIntent().hasExtra(EXTRA_ENABLE_STATE_RESTORATION)) {
+      return getIntent().getBooleanExtra(EXTRA_ENABLE_STATE_RESTORATION, false);
+    }
+    if (getCachedEngineId() != null) {
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -64,7 +64,7 @@ import java.lang.reflect.Method;
  *   <li>Chooses Flutter's initial route.
  *   <li>Renders {@code Activity} transparently, if desired.
  *   <li>Offers hooks for subclasses to provide and configure a {@link FlutterEngine}.
- *   <li>Save and restore instance state, see {@code shouldRestoreAndSaveState()};
+ *   <li>Save and restore instance state, see {@code #shouldRestoreAndSaveState()};
  * </ul>
  *
  * <p><strong>Dart entrypoint, initial route, and app bundle path</strong>

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -64,6 +64,7 @@ import java.lang.reflect.Method;
  *   <li>Chooses Flutter's initial route.
  *   <li>Renders {@code Activity} transparently, if desired.
  *   <li>Offers hooks for subclasses to provide and configure a {@link FlutterEngine}.
+     <li>Save and restore instance state, see {@code shouldRestoreAndSaveState()};
  * </ul>
  *
  * <p><strong>Dart entrypoint, initial route, and app bundle path</strong>
@@ -956,6 +957,7 @@ public class FlutterActivity extends Activity
       return getIntent().getBooleanExtra(EXTRA_ENABLE_STATE_RESTORATION, false);
     }
     if (getCachedEngineId() != null) {
+      // Prevent overwriting the existing state in a cached engine with restoration state.
       return false;
     }
     return true;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -64,7 +64,7 @@ import java.lang.reflect.Method;
  *   <li>Chooses Flutter's initial route.
  *   <li>Renders {@code Activity} transparently, if desired.
  *   <li>Offers hooks for subclasses to provide and configure a {@link FlutterEngine}.
-     <li>Save and restore instance state, see {@code shouldRestoreAndSaveState()};
+ *   <li>Save and restore instance state, see {@code shouldRestoreAndSaveState()};
  * </ul>
  *
  * <p><strong>Dart entrypoint, initial route, and app bundle path</strong>

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -299,19 +299,19 @@ import java.util.Arrays;
     Log.v(TAG, "onActivityCreated. Giving framework and plugins an opportunity to restore state.");
     ensureAlive();
 
-    Bundle pluginsBundle = null;
-    byte[] frameworkBundle = null;
+    Bundle pluginState = null;
+    byte[] frameworkState = null;
     if (bundle != null) {
-      pluginsBundle = bundle.getBundle(PLUGINS_RESTORATION_BUNDLE_KEY);
-      frameworkBundle = bundle.getByteArray(FRAMEWORK_RESTORATION_BUNDLE_KEY);
+      pluginState = bundle.getBundle(PLUGINS_RESTORATION_BUNDLE_KEY);
+      frameworkState = bundle.getByteArray(FRAMEWORK_RESTORATION_BUNDLE_KEY);
     }
 
     if (host.shouldRestoreAndSaveState()) {
-      flutterEngine.getRestorationChannel().setRestorationData(frameworkBundle);
+      flutterEngine.getRestorationChannel().setRestorationData(frameworkState);
     }
 
     if (host.shouldAttachEngineToActivity()) {
-      flutterEngine.getActivityControlSurface().onRestoreInstanceState(pluginsBundle);
+      flutterEngine.getActivityControlSurface().onRestoreInstanceState(pluginState);
     }
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -25,7 +25,6 @@ import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
-import io.flutter.embedding.engine.systemchannels.RestorationChannel;
 import io.flutter.plugin.platform.PlatformPlugin;
 import java.util.Arrays;
 
@@ -307,9 +306,8 @@ import java.util.Arrays;
       frameworkBundle = bundle.getByteArray(FRAMEWORK_RESTORATION_BUNDLE_KEY);
     }
 
-    final RestorationChannel restorationChannel = flutterEngine.getRestorationChannel();
-    if (host.shouldRestoreAndSaveState() && !restorationChannel.hasRestorationDataBeenSet()) {
-      restorationChannel.setRestorationData(frameworkBundle);
+    if (host.shouldRestoreAndSaveState()) {
+      flutterEngine.getRestorationChannel().setRestorationData(frameworkBundle);
     }
 
     if (host.shouldAttachEngineToActivity()) {
@@ -465,7 +463,8 @@ import java.util.Arrays;
 
     if (host.shouldRestoreAndSaveState()) {
       bundle.putByteArray(
-          FRAMEWORK_RESTORATION_BUNDLE_KEY, flutterEngine.getRestorationChannel().getRestorationData());
+          FRAMEWORK_RESTORATION_BUNDLE_KEY,
+          flutterEngine.getRestorationChannel().getRestorationData());
     }
 
     if (host.shouldAttachEngineToActivity()) {
@@ -835,9 +834,6 @@ import java.util.Arrays;
      * will be forwarded to the framework via the {@code RestorationChannel} and during {@code
      * onSaveInstanceState(Bundle)} the current framework instance state obtained from {@code
      * RestorationChannel} will be stored in the provided bundle.
-     *
-     * <p>This may only be set to true if the engine in used has the
-     * {@code FlutterEngine.willProvideRestorationData} flag set to true.
      *
      * <p>This defaults to true, unless a cached engine is used.
      */

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -465,8 +465,7 @@ import java.util.Arrays;
 
     if (host.shouldRestoreAndSaveState()) {
       bundle.putByteArray(
-          FRAMEWORK_BUNDLE_KEY,
-          flutterEngine.getRestorationChannel().getRestorationData());
+          FRAMEWORK_BUNDLE_KEY, flutterEngine.getRestorationChannel().getRestorationData());
     }
 
     if (host.shouldAttachEngineToActivity()) {
@@ -830,12 +829,12 @@ import java.util.Arrays;
     void onFlutterUiNoLongerDisplayed();
 
     /**
-     * Whether instance state saving and restoration is enabled.
+     * Whether state restoration is enabled.
      *
      * <p>When this returns true, the instance state provided to {@code onActivityCreated(Bundle)}
-     * will be forwarded to the framework via the {@code RestorationChannel} and during
-     * @{@code onSaveInstanceState(Bundle)} the current framework instance state obtained from
-     * {@code RestorationChannel} will be stored in the provided bundle.
+     * will be forwarded to the framework via the {@code RestorationChannel} and during {@code
+     * onSaveInstanceState(Bundle)} the current framework instance state obtained from {@code
+     * RestorationChannel} will be stored in the provided bundle.
      */
     boolean shouldRestoreAndSaveState();
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -64,8 +64,8 @@ import java.util.Arrays;
  */
 /* package */ final class FlutterActivityAndFragmentDelegate {
   private static final String TAG = "FlutterActivityAndFragmentDelegate";
-  private static final String FRAMEWORK_BUNDLE_KEY = "framework";
-  private static final String PLUGINS_BUNDLE_KEY = "plugins";
+  private static final String FRAMEWORK_RESTORATION_BUNDLE_KEY = "framework";
+  private static final String PLUGINS_RESTORATION_BUNDLE_KEY = "plugins";
 
   // The FlutterActivity or FlutterFragment that is delegating most of its calls
   // to this FlutterActivityAndFragmentDelegate.
@@ -303,8 +303,8 @@ import java.util.Arrays;
     Bundle pluginsBundle = null;
     byte[] frameworkBundle = null;
     if (bundle != null) {
-      pluginsBundle = bundle.getBundle(PLUGINS_BUNDLE_KEY);
-      frameworkBundle = bundle.getByteArray(FRAMEWORK_BUNDLE_KEY);
+      pluginsBundle = bundle.getBundle(PLUGINS_RESTORATION_BUNDLE_KEY);
+      frameworkBundle = bundle.getByteArray(FRAMEWORK_RESTORATION_BUNDLE_KEY);
     }
 
     final RestorationChannel restorationChannel = flutterEngine.getRestorationChannel();
@@ -465,13 +465,13 @@ import java.util.Arrays;
 
     if (host.shouldRestoreAndSaveState()) {
       bundle.putByteArray(
-          FRAMEWORK_BUNDLE_KEY, flutterEngine.getRestorationChannel().getRestorationData());
+          FRAMEWORK_RESTORATION_BUNDLE_KEY, flutterEngine.getRestorationChannel().getRestorationData());
     }
 
     if (host.shouldAttachEngineToActivity()) {
       final Bundle plugins = new Bundle();
       flutterEngine.getActivityControlSurface().onSaveInstanceState(plugins);
-      bundle.putBundle(PLUGINS_BUNDLE_KEY, plugins);
+      bundle.putBundle(PLUGINS_RESTORATION_BUNDLE_KEY, plugins);
     }
   }
 
@@ -835,6 +835,11 @@ import java.util.Arrays;
      * will be forwarded to the framework via the {@code RestorationChannel} and during {@code
      * onSaveInstanceState(Bundle)} the current framework instance state obtained from {@code
      * RestorationChannel} will be stored in the provided bundle.
+     *
+     * <p>This may only be set to true if the engine in used has the
+     * {@code FlutterEngine.willProvideRestorationData} flag set to true.
+     *
+     * <p>This defaults to true, unless a cached engine is used.
      */
     boolean shouldRestoreAndSaveState();
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -63,6 +63,8 @@ import java.util.Arrays;
  */
 /* package */ final class FlutterActivityAndFragmentDelegate {
   private static final String TAG = "FlutterActivityAndFragmentDelegate";
+  private static final String FRAMEWORK_BUNDLE_KEY = "framework";
+  private static final String PLUGINS_BUNDLE_KEY = "plugins";
 
   // The FlutterActivity or FlutterFragment that is delegating most of its calls
   // to this FlutterActivityAndFragmentDelegate.
@@ -293,11 +295,18 @@ import java.util.Arrays;
   }
 
   void onActivityCreated(@Nullable Bundle bundle) {
-    Log.v(TAG, "onActivityCreated. Giving plugins an opportunity to restore state.");
+    Log.v(TAG, "onActivityCreated. Giving framework and plugins an opportunity to restore state.");
     ensureAlive();
 
+    Bundle pluginsBundle = null;
+    if (bundle != null) {
+      flutterEngine.getRestorationChannel()
+          .setRestorationDataForFramework(bundle.getByteArray(FRAMEWORK_BUNDLE_KEY));
+      pluginsBundle = bundle.getBundle(PLUGINS_BUNDLE_KEY);
+    }
+
     if (host.shouldAttachEngineToActivity()) {
-      flutterEngine.getActivityControlSurface().onRestoreInstanceState(bundle);
+      flutterEngine.getActivityControlSurface().onRestoreInstanceState(pluginsBundle);
     }
   }
 
@@ -444,11 +453,15 @@ import java.util.Arrays;
   }
 
   void onSaveInstanceState(@Nullable Bundle bundle) {
-    Log.v(TAG, "onSaveInstanceState. Giving plugins an opportunity to save state.");
+    Log.v(TAG, "onSaveInstanceState. Giving framework and plugins an opportunity to save state.");
     ensureAlive();
 
+    bundle.putByteArray(FRAMEWORK_BUNDLE_KEY, flutterEngine.getRestorationChannel().getRestorationDataFromFramework());
+
     if (host.shouldAttachEngineToActivity()) {
-      flutterEngine.getActivityControlSurface().onSaveInstanceState(bundle);
+      final Bundle plugins = new Bundle();
+      flutterEngine.getActivityControlSurface().onSaveInstanceState(plugins);
+      bundle.putBundle(PLUGINS_BUNDLE_KEY, plugins);
     }
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -300,7 +300,8 @@ import java.util.Arrays;
 
     Bundle pluginsBundle = null;
     if (bundle != null) {
-      flutterEngine.getRestorationChannel()
+      flutterEngine
+          .getRestorationChannel()
           .setRestorationDataForFramework(bundle.getByteArray(FRAMEWORK_BUNDLE_KEY));
       pluginsBundle = bundle.getBundle(PLUGINS_BUNDLE_KEY);
     }
@@ -456,7 +457,9 @@ import java.util.Arrays;
     Log.v(TAG, "onSaveInstanceState. Giving framework and plugins an opportunity to save state.");
     ensureAlive();
 
-    bundle.putByteArray(FRAMEWORK_BUNDLE_KEY, flutterEngine.getRestorationChannel().getRestorationDataFromFramework());
+    bundle.putByteArray(
+        FRAMEWORK_BUNDLE_KEY,
+        flutterEngine.getRestorationChannel().getRestorationDataFromFramework());
 
     if (host.shouldAttachEngineToActivity()) {
       final Bundle plugins = new Bundle();

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
@@ -23,6 +23,7 @@ public class FlutterActivityLaunchConfigs {
   /* package */ static final String EXTRA_CACHED_ENGINE_ID = "cached_engine_id";
   /* package */ static final String EXTRA_DESTROY_ENGINE_WITH_ACTIVITY =
       "destroy_engine_with_activity";
+  /* package */ static final String EXTRA_ENABLE_STATE_RESTORATION = "enable_state_restoration";
 
   // Default configuration.
   /* package */ static final String DEFAULT_DART_ENTRYPOINT = "main";

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -113,6 +113,11 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
    * outlive the {@code FlutterFragment}.
    */
   protected static final String ARG_DESTROY_ENGINE_WITH_FRAGMENT = "destroy_engine_with_fragment";
+  /**
+   * True if the framework state in the engine attached to this engine should be stored and restored
+   * when this fragment is created and destroyed.
+   */
+  protected static final String ARG_ENABLE_STATE_RESTORATION = "enable_state_restoration";
 
   /**
    * Creates a {@code FlutterFragment} with a default configuration.
@@ -1016,6 +1021,17 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
     if (attachedActivity instanceof FlutterUiDisplayListener) {
       ((FlutterUiDisplayListener) attachedActivity).onFlutterUiNoLongerDisplayed();
     }
+  }
+
+  @Override
+  public boolean shouldRestoreAndSaveState() {
+    if (getArguments().containsKey(ARG_ENABLE_STATE_RESTORATION)) {
+      return getArguments().getBoolean(ARG_ENABLE_STATE_RESTORATION);
+    }
+    if (getCachedEngineId() != null) {
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -386,8 +386,8 @@ public class FlutterEngine {
   /**
    * System channel to exchange restoration data between framework and engine.
    *
-   * <p> The engine can obtain the current restoration data from the framework via this channel
-   * to store it on disk and - when the app is relaunched - provide the stored data back to the
+   * <p>The engine can obtain the current restoration data from the framework via this channel to
+   * store it on disk and - when the app is relaunched - provide the stored data back to the
    * framework to recreate the original state of the app.
    */
   @NonNull

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -174,9 +174,9 @@ public class FlutterEngine {
    * this extra work by delaying initialization until the data is available.
    *
    * <p>When {@code waitForRestorationData} is set, {@code
-   * RestorationChannel.setRestorationData(byte[] data)} must be called at a later point in time.
-   * If it later turns out that no restoration data is available to restore the framework from,
-   * that method must still be called with null as an argument to indicate "no data".
+   * RestorationChannel.setRestorationData(byte[] data)} must be called at a later point in time. If
+   * it later turns out that no restoration data is available to restore the framework from, that
+   * method must still be called with null as an argument to indicate "no data".
    *
    * <p>If the framework never requests the restoration data, this flag has no effect.
    */

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -104,6 +104,7 @@ public class FlutterEngine {
           }
 
           platformViewsController.onPreEngineRestart();
+          restorationChannel.clearData();
         }
       };
 
@@ -162,6 +163,25 @@ public class FlutterEngine {
   }
 
   /**
+   * Same as {@link #FlutterEngine(Context, String[], boolean)} with added support for configuring
+   * whether the engine will receive restoration data.
+   */
+  public FlutterEngine(
+      @NonNull Context context,
+      @Nullable String[] dartVmArgs,
+      boolean automaticallyRegisterPlugins,
+      boolean willProvideRestorationData) {
+    this(
+        context,
+        FlutterLoader.getInstance(),
+        new FlutterJNI(),
+        new PlatformViewsController(),
+        dartVmArgs,
+        automaticallyRegisterPlugins,
+        willProvideRestorationData);
+  }
+
+  /**
    * Same as {@link #FlutterEngine(Context, FlutterLoader, FlutterJNI, String[])} but with no Dart
    * VM flags.
    *
@@ -196,6 +216,27 @@ public class FlutterEngine {
         automaticallyRegisterPlugins);
   }
 
+  /**
+   * Same as {@link #FlutterEngine(Context, FlutterLoader, FlutterJNI, String[], boolean)}, plus
+   * the ability to provide a custom {@code PlatformViewsController}.
+   */
+  public FlutterEngine(
+    @NonNull Context context,
+    @NonNull FlutterLoader flutterLoader,
+    @NonNull FlutterJNI flutterJNI,
+    @NonNull PlatformViewsController platformViewsController,
+    @Nullable String[] dartVmArgs,
+    boolean automaticallyRegisterPlugins) {
+    this(
+      context,
+      flutterLoader,
+      flutterJNI,
+      platformViewsController,
+      dartVmArgs,
+      automaticallyRegisterPlugins,
+      false);
+  }
+
   /** Fully configurable {@code FlutterEngine} constructor. */
   public FlutterEngine(
       @NonNull Context context,
@@ -203,7 +244,8 @@ public class FlutterEngine {
       @NonNull FlutterJNI flutterJNI,
       @NonNull PlatformViewsController platformViewsController,
       @Nullable String[] dartVmArgs,
-      boolean automaticallyRegisterPlugins) {
+      boolean automaticallyRegisterPlugins,
+      boolean willProvideRestorationData) {
     this.flutterJNI = flutterJNI;
     flutterLoader.startInitialization(context.getApplicationContext());
     flutterLoader.ensureInitializationComplete(context, dartVmArgs);
@@ -226,7 +268,7 @@ public class FlutterEngine {
     mouseCursorChannel = new MouseCursorChannel(dartExecutor);
     navigationChannel = new NavigationChannel(dartExecutor);
     platformChannel = new PlatformChannel(dartExecutor);
-    restorationChannel = new RestorationChannel(dartExecutor);
+    restorationChannel = new RestorationChannel(dartExecutor, willProvideRestorationData);
     settingsChannel = new SettingsChannel(dartExecutor);
     systemChannel = new SystemChannel(dartExecutor);
     textInputChannel = new TextInputChannel(dartExecutor);

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -24,6 +24,7 @@ import io.flutter.embedding.engine.systemchannels.LocalizationChannel;
 import io.flutter.embedding.engine.systemchannels.MouseCursorChannel;
 import io.flutter.embedding.engine.systemchannels.NavigationChannel;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
+import io.flutter.embedding.engine.systemchannels.RestorationChannel;
 import io.flutter.embedding.engine.systemchannels.SettingsChannel;
 import io.flutter.embedding.engine.systemchannels.SystemChannel;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
@@ -80,6 +81,7 @@ public class FlutterEngine {
   @NonNull private final LocalizationChannel localizationChannel;
   @NonNull private final MouseCursorChannel mouseCursorChannel;
   @NonNull private final NavigationChannel navigationChannel;
+  @NonNull private final RestorationChannel restorationChannel;
   @NonNull private final PlatformChannel platformChannel;
   @NonNull private final SettingsChannel settingsChannel;
   @NonNull private final SystemChannel systemChannel;
@@ -224,6 +226,7 @@ public class FlutterEngine {
     mouseCursorChannel = new MouseCursorChannel(dartExecutor);
     navigationChannel = new NavigationChannel(dartExecutor);
     platformChannel = new PlatformChannel(dartExecutor);
+    restorationChannel = new RestorationChannel(dartExecutor);
     settingsChannel = new SettingsChannel(dartExecutor);
     systemChannel = new SystemChannel(dartExecutor);
     textInputChannel = new TextInputChannel(dartExecutor);
@@ -378,6 +381,18 @@ public class FlutterEngine {
   @NonNull
   public PlatformChannel getPlatformChannel() {
     return platformChannel;
+  }
+
+  /**
+   * System channel to exchange restoration data between framework and engine.
+   *
+   * <p> The engine can obtain the current restoration data from the framework via this channel
+   * to store it on disk and - when the app is relaunched - provide the stored data back to the
+   * framework to recreate the original state of the app.
+   */
+  @NonNull
+  public RestorationChannel getRestorationChannel() {
+    return restorationChannel;
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -165,6 +165,13 @@ public class FlutterEngine {
   /**
    * Same as {@link #FlutterEngine(Context, String[], boolean)} with added support for configuring
    * whether the engine will receive restoration data.
+   *
+   * <p>When the engine is configured to receive restoration data {@code
+   * RestorationChannel.setRestorationData(byte[] data)} must be called to provide the restoration
+   * data. All requests to get restoration data from the framework will be blocked until that method
+   * is called. If the engine is configured to wait for restoration data, but it turns out later
+   * that no restoration data has been provided by the operating system, that method must still be
+   * called with null as an argument to indicate "no data".
    */
   public FlutterEngine(
       @NonNull Context context,

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -166,18 +166,25 @@ public class FlutterEngine {
    * Same as {@link #FlutterEngine(Context, String[], boolean)} with added support for configuring
    * whether the engine will receive restoration data.
    *
-   * <p>When the engine is configured to receive restoration data {@code
-   * RestorationChannel.setRestorationData(byte[] data)} must be called to provide the restoration
-   * data. All requests to get restoration data from the framework will be blocked until that method
-   * is called. If the engine is configured to wait for restoration data, but it turns out later
-   * that no restoration data has been provided by the operating system, that method must still be
-   * called with null as an argument to indicate "no data".
+   * <p>The {@code waitForRestorationData} flag controls whether the engine delays responding to
+   * requests from the framework for restoration data until that data has been provided to the
+   * engine via {@code RestorationChannel.setRestorationData(byte[] data)}. If the flag is false,
+   * the framework may temporarily initialize itself to default values before the restoration data
+   * has been made available to the engine. Setting {@code waitForRestorationData} to true avoids
+   * this extra work by delaying initialization until the data is available.
+   *
+   * <p>When {@code waitForRestorationData} is set, {@code
+   * RestorationChannel.setRestorationData(byte[] data)} must be called at a later point in time.
+   * If it later turns out that no restoration data is available to restore the framework from,
+   * that method must still be called with null as an argument to indicate "no data".
+   *
+   * <p>If the framework never requests the restoration data, this flag has no effect.
    */
   public FlutterEngine(
       @NonNull Context context,
       @Nullable String[] dartVmArgs,
       boolean automaticallyRegisterPlugins,
-      boolean willProvideRestorationData) {
+      boolean waitForRestorationData) {
     this(
         context,
         FlutterLoader.getInstance(),
@@ -185,7 +192,7 @@ public class FlutterEngine {
         new PlatformViewsController(),
         dartVmArgs,
         automaticallyRegisterPlugins,
-        willProvideRestorationData);
+        waitForRestorationData);
   }
 
   /**
@@ -252,7 +259,7 @@ public class FlutterEngine {
       @NonNull PlatformViewsController platformViewsController,
       @Nullable String[] dartVmArgs,
       boolean automaticallyRegisterPlugins,
-      boolean willProvideRestorationData) {
+      boolean waitForRestorationData) {
     this.flutterJNI = flutterJNI;
     flutterLoader.startInitialization(context.getApplicationContext());
     flutterLoader.ensureInitializationComplete(context, dartVmArgs);
@@ -275,7 +282,7 @@ public class FlutterEngine {
     mouseCursorChannel = new MouseCursorChannel(dartExecutor);
     navigationChannel = new NavigationChannel(dartExecutor);
     platformChannel = new PlatformChannel(dartExecutor);
-    restorationChannel = new RestorationChannel(dartExecutor, willProvideRestorationData);
+    restorationChannel = new RestorationChannel(dartExecutor, waitForRestorationData);
     settingsChannel = new SettingsChannel(dartExecutor);
     systemChannel = new SystemChannel(dartExecutor);
     textInputChannel = new TextInputChannel(dartExecutor);

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -217,24 +217,24 @@ public class FlutterEngine {
   }
 
   /**
-   * Same as {@link #FlutterEngine(Context, FlutterLoader, FlutterJNI, String[], boolean)}, plus
-   * the ability to provide a custom {@code PlatformViewsController}.
+   * Same as {@link #FlutterEngine(Context, FlutterLoader, FlutterJNI, String[], boolean)}, plus the
+   * ability to provide a custom {@code PlatformViewsController}.
    */
   public FlutterEngine(
-    @NonNull Context context,
-    @NonNull FlutterLoader flutterLoader,
-    @NonNull FlutterJNI flutterJNI,
-    @NonNull PlatformViewsController platformViewsController,
-    @Nullable String[] dartVmArgs,
-    boolean automaticallyRegisterPlugins) {
+      @NonNull Context context,
+      @NonNull FlutterLoader flutterLoader,
+      @NonNull FlutterJNI flutterJNI,
+      @NonNull PlatformViewsController platformViewsController,
+      @Nullable String[] dartVmArgs,
+      boolean automaticallyRegisterPlugins) {
     this(
-      context,
-      flutterLoader,
-      flutterJNI,
-      platformViewsController,
-      dartVmArgs,
-      automaticallyRegisterPlugins,
-      false);
+        context,
+        flutterLoader,
+        flutterJNI,
+        platformViewsController,
+        dartVmArgs,
+        automaticallyRegisterPlugins,
+        false);
   }
 
   /** Fully configurable {@code FlutterEngine} constructor. */

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
@@ -143,6 +143,10 @@ public class RestorationChannel {
               frameworkHasRequestedData = true;
               if (engineHasProvidedData || !waitForRestorationData) {
                 result.success(restorationData);
+                // Do not delete the restoration data on the engine side after sending it to the
+                // framework. We may need to hand this data back to the operating system if the
+                // framework never modifies the data (and thus doesn't send us any
+                // data back).
               } else {
                 pendingFrameworkRestorationChannelRequest = result;
               }

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
@@ -1,0 +1,65 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.embedding.engine.systemchannels;
+
+import android.support.annotation.NonNull;
+import io.flutter.Log;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.StandardMethodCodec;
+
+/**
+ * System channel to exchange restoration data between framework and engine.
+ *
+ * <p>The engine can obtain the current restoration data from the framework via this channel to
+ * store it on disk and - when the app is relaunched - provide the stored data back to the framework
+ * to recreate the original state of the app.
+ */
+public class RestorationChannel {
+  private static final String TAG = "RestorationChannel";
+
+  public RestorationChannel(@NonNull DartExecutor dartExecutor) {
+    MethodChannel channel =
+        new MethodChannel(dartExecutor, "flutter/restoration", StandardMethodCodec.INSTANCE);
+    channel.setMethodCallHandler(handler);
+  }
+
+  private byte[] dataForFramework;
+  private byte[] dataFromFramework;
+
+  /** Obtain the most current restoration data that the framework has provided. */
+  public byte[] getRestorationDataFromFramework() {
+    return dataFromFramework;
+  }
+
+  /** Set the restoration data that will be sent to the framework when the framework requests it. */
+  public void setRestorationDataForFramework(byte[] data) {
+    dataForFramework = data;
+  }
+
+  private final MethodChannel.MethodCallHandler handler =
+      new MethodChannel.MethodCallHandler() {
+        @Override
+        public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+          final String method = call.method;
+          final Object args = call.arguments;
+          Log.v(TAG, "Received '" + method + "' message.");
+          switch (method) {
+            case "put":
+              dataFromFramework = (byte[]) args;
+              result.success(null);
+              break;
+            case "get":
+              result.success(dataForFramework);
+              dataForFramework = null;
+              break;
+            default:
+              result.notImplemented();
+              break;
+          }
+        }
+      };
+}

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
@@ -49,9 +49,9 @@ public class RestorationChannel {
    * Whether the channel delays responding to the framework's initial request for restoration data
    * until {@code setRestorationData} has been called.
    *
-   * <p>If the engine never calls {@code setRestorationData} this flag must be set to false.
-   * If set to true, the engine must call {@code setRestorationData} either with the actual
-   * restoration data as argument or null if it turns out that there is no restoration data.
+   * <p>If the engine never calls {@code setRestorationData} this flag must be set to false. If set
+   * to true, the engine must call {@code setRestorationData} either with the actual restoration
+   * data as argument or null if it turns out that there is no restoration data.
    *
    * <p>If the response to the framework's request for restoration data is not delayed until the
    * data has been set via {@code setRestorationData}, the framework may intermittently initialize

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
@@ -21,7 +21,8 @@ import io.flutter.plugin.common.StandardMethodCodec;
 public class RestorationChannel {
   private static final String TAG = "RestorationChannel";
 
-  public RestorationChannel(@NonNull DartExecutor dartExecutor, @NonNull boolean waitForRestorationData) {
+  public RestorationChannel(
+      @NonNull DartExecutor dartExecutor, @NonNull boolean waitForRestorationData) {
     this.waitForRestorationData = waitForRestorationData;
     MethodChannel channel =
         new MethodChannel(dartExecutor, "flutter/restoration", StandardMethodCodec.INSTANCE);
@@ -29,14 +30,14 @@ public class RestorationChannel {
   }
 
   /**
-   * Whether {@code setRestorationData} will be called to provide restoration data for
-   * the framework.
+   * Whether {@code setRestorationData} will be called to provide restoration data for the
+   * framework.
    *
    * <p>When this is set to true, the channel will delay answering any requests for restoration data
-   * by the framework until {@code setRestorationData} has been called. It must be set
-   * to false if the engine never calls {@code setRestorationData}. If it has been set
-   * to true, but it later turns out that there is no restoration data,
-   * {@code setRestorationData} must be called with null.
+   * by the framework until {@code setRestorationData} has been called. It must be set to false if
+   * the engine never calls {@code setRestorationData}. If it has been set to true, but it later
+   * turns out that there is no restoration data, {@code setRestorationData} must be called with
+   * null.
    */
   public final boolean waitForRestorationData;
 
@@ -45,9 +46,7 @@ public class RestorationChannel {
   private boolean engineHasProvidedData = false;
   private boolean frameworkHasRequestedData = false;
 
-  /**
-   * Whether {@code setRestorationData} has been called.
-   */
+  /** Whether {@code setRestorationData} has been called. */
   public boolean hasRestorationDataBeenSet() {
     return engineHasProvidedData;
   }
@@ -60,7 +59,9 @@ public class RestorationChannel {
   /** Set the restoration data that will be sent to the framework when the framework requests it. */
   public void setRestorationData(byte[] data) {
     if (!waitForRestorationData || engineHasProvidedData) {
-      Log.e(TAG, "Channel has not been configured to wait for restoration data or data has already been provided.");
+      Log.e(
+          TAG,
+          "Channel has not been configured to wait for restoration data or data has already been provided.");
       return;
     }
     engineHasProvidedData = true;
@@ -72,8 +73,8 @@ public class RestorationChannel {
     }
   }
 
-
-  /** Clears the current restoration data.
+  /**
+   * Clears the current restoration data.
    *
    * <p>This should be called just prior to a hot restart. Otherwise, after the hot restart the
    * state prior to the hot restart will get restored.

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
@@ -33,8 +33,15 @@ public class RestorationChannel {
 
   public RestorationChannel(
       @NonNull DartExecutor dartExecutor, @NonNull boolean waitForRestorationData) {
+    this(
+        new MethodChannel(dartExecutor, "flutter/restoration", StandardMethodCodec.INSTANCE),
+        waitForRestorationData);
+  }
+
+  RestorationChannel(MethodChannel channel, @NonNull boolean waitForRestorationData) {
+    this.channel = channel;
     this.waitForRestorationData = waitForRestorationData;
-    channel = new MethodChannel(dartExecutor, "flutter/restoration", StandardMethodCodec.INSTANCE);
+
     channel.setMethodCallHandler(handler);
   }
 
@@ -67,6 +74,7 @@ public class RestorationChannel {
     if (pendingResult != null) {
       pendingResult.success(data);
       pendingResult = null;
+      restorationData = data;
     } else if (frameworkHasRequestedData) {
       channel.invokeMethod(
           "push",

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/RestorationChannel.java
@@ -17,6 +17,18 @@ import io.flutter.plugin.common.StandardMethodCodec;
  * <p>The engine can obtain the current restoration data from the framework via this channel to
  * store it on disk and - when the app is relaunched - provide the stored data back to the framework
  * to recreate the original state of the app.
+ *
+ * <p>The channel only accepts restoration data for the engine when {@code waitForRestorationData}
+ * is set to true. If it is not set, it will send null to the framework as initial restoration data.
+ * When it is set to true, it will wait until {@code setRestorationData(byte[])} has been called
+ * before responding to restoration data requests from the framework. In other words, if
+ * {@code waitForRestorationData} is true, {@code setRestorationData(byte[])} must be called
+ * (possibly with null as argument if no restoration data is available).
+ *
+ * <p>Restoration data for the framework can only be set once via
+ * {@code setRestorationData(byte[])}. The current restoration data provided by the framework can be
+ * read via {@code getRestorationData()}.
+ *
  */
 public class RestorationChannel {
   private static final String TAG = "RestorationChannel";
@@ -38,6 +50,9 @@ public class RestorationChannel {
    * the engine never calls {@code setRestorationData}. If it has been set to true, but it later
    * turns out that there is no restoration data, {@code setRestorationData} must be called with
    * null.
+   *
+   * <p>When constructing an engine set this to true if you want to provide restoration data to
+   * the framework by calling {@code setRestorationData(byte[])}.
    */
   public final boolean waitForRestorationData;
 
@@ -46,7 +61,7 @@ public class RestorationChannel {
   private boolean engineHasProvidedData = false;
   private boolean frameworkHasRequestedData = false;
 
-  /** Whether {@code setRestorationData} has been called. */
+  /** Whether {@code setRestorationData(byte[])} has been called. */
   public boolean hasRestorationDataBeenSet() {
     return engineHasProvidedData;
   }

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -26,7 +26,7 @@ import java.nio.ByteBuffer;
  * <p>The logical identity of the channel is given by its name. Identically named channels will
  * interfere with each other's communication.
  */
-public final class MethodChannel {
+public class MethodChannel {
   private static final String TAG = "MethodChannel#";
 
   private final BinaryMessenger messenger;

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -16,6 +16,7 @@ import io.flutter.embedding.engine.FlutterJNITest;
 import io.flutter.embedding.engine.RenderingComponentTest;
 import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistryTest;
 import io.flutter.embedding.engine.renderer.FlutterRendererTest;
+import io.flutter.embedding.engine.systemchannels.RestorationChannelTest;
 import io.flutter.external.FlutterLaunchTests;
 import io.flutter.plugin.common.StandardMessageCodecTest;
 import io.flutter.plugin.common.StandardMethodCodecTest;
@@ -63,6 +64,7 @@ import test.io.flutter.embedding.engine.dart.DartExecutorTest;
   TextInputPluginTest.class,
   MouseCursorPluginTest.class,
   AccessibilityBridgeTest.class,
+  RestorationChannelTest.class,
 })
 /** Runs all of the unit tests listed in the {@code @SuiteClasses} annotation. */
 public class FlutterTestSuite {}

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -273,6 +273,11 @@ public class FlutterAndroidComponentTest {
     }
 
     @Override
+    public boolean shouldRestoreAndSaveState() {
+      return true;
+    }
+
+    @Override
     public void onFlutterSurfaceViewCreated(@NonNull FlutterSurfaceView flutterSurfaceView) {}
 
     @Override

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
@@ -4,32 +4,19 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 import android.annotation.TargetApi;
-import android.view.PointerIcon;
-import io.flutter.embedding.android.FlutterView;
-import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.embedding.engine.systemchannels.RestorationChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
-import java.util.HashMap;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
-import android.support.annotation.NonNull;
-import io.flutter.Log;
-import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.StandardMethodCodec;
 import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 @Config(
     manifest = Config.NONE,
@@ -38,9 +25,11 @@ import org.mockito.ArgumentCaptor;
 @TargetApi(24)
 public class RestorationChannelTest {
   @Test
-  public void itDoesNotDoAnythingWhenRestorationDataIsSetBeforeFrameworkAsks() throws JSONException {
+  public void itDoesNotDoAnythingWhenRestorationDataIsSetBeforeFrameworkAsks()
+      throws JSONException {
     MethodChannel rawChannel = mock(MethodChannel.class);
-    RestorationChannel restorationChannel = new RestorationChannel(rawChannel, /*waitForRestorationData=*/ false);
+    RestorationChannel restorationChannel =
+        new RestorationChannel(rawChannel, /*waitForRestorationData=*/ false);
     restorationChannel.setRestorationData("Any String you want".getBytes());
     verify(rawChannel, times(0)).invokeMethod(any(), any());
   }
@@ -50,8 +39,10 @@ public class RestorationChannelTest {
     byte[] data = "Any String you want".getBytes();
 
     MethodChannel rawChannel = mock(MethodChannel.class);
-    RestorationChannel restorationChannel = new RestorationChannel(rawChannel, /*waitForRestorationData=*/ true);
-    ArgumentCaptor<MethodChannel.MethodCallHandler> argumentCaptor = ArgumentCaptor.forClass(MethodChannel.MethodCallHandler.class);
+    RestorationChannel restorationChannel =
+        new RestorationChannel(rawChannel, /*waitForRestorationData=*/ true);
+    ArgumentCaptor<MethodChannel.MethodCallHandler> argumentCaptor =
+        ArgumentCaptor.forClass(MethodChannel.MethodCallHandler.class);
     verify(rawChannel).setMethodCallHandler(argumentCaptor.capture());
 
     MethodChannel.Result result = mock(MethodChannel.Result.class);
@@ -73,8 +64,10 @@ public class RestorationChannelTest {
     byte[] data = "Any String you want".getBytes();
 
     MethodChannel rawChannel = mock(MethodChannel.class);
-    RestorationChannel restorationChannel = new RestorationChannel(rawChannel, /*waitForRestorationData=*/ false);
-    ArgumentCaptor<MethodChannel.MethodCallHandler> argumentCaptor = ArgumentCaptor.forClass(MethodChannel.MethodCallHandler.class);
+    RestorationChannel restorationChannel =
+        new RestorationChannel(rawChannel, /*waitForRestorationData=*/ false);
+    ArgumentCaptor<MethodChannel.MethodCallHandler> argumentCaptor =
+        ArgumentCaptor.forClass(MethodChannel.MethodCallHandler.class);
     verify(rawChannel).setMethodCallHandler(argumentCaptor.capture());
 
     MethodChannel.Result result = mock(MethodChannel.Result.class);
@@ -84,7 +77,8 @@ public class RestorationChannelTest {
     restorationChannel.setRestorationData(data);
     assertEquals(restorationChannel.getRestorationData(), null);
 
-    ArgumentCaptor<MethodChannel.Result> resultCapture = ArgumentCaptor.forClass(MethodChannel.Result.class);
+    ArgumentCaptor<MethodChannel.Result> resultCapture =
+        ArgumentCaptor.forClass(MethodChannel.Result.class);
     verify(rawChannel).invokeMethod(eq("push"), eq(data), resultCapture.capture());
     resultCapture.getValue().success(null);
     assertEquals(restorationChannel.getRestorationData(), data);
@@ -95,8 +89,10 @@ public class RestorationChannelTest {
     byte[] data = "Any String you want".getBytes();
 
     MethodChannel rawChannel = mock(MethodChannel.class);
-    RestorationChannel restorationChannel = new RestorationChannel(rawChannel, /*waitForRestorationData=*/ false);
-    ArgumentCaptor<MethodChannel.MethodCallHandler> argumentCaptor = ArgumentCaptor.forClass(MethodChannel.MethodCallHandler.class);
+    RestorationChannel restorationChannel =
+        new RestorationChannel(rawChannel, /*waitForRestorationData=*/ false);
+    ArgumentCaptor<MethodChannel.MethodCallHandler> argumentCaptor =
+        ArgumentCaptor.forClass(MethodChannel.MethodCallHandler.class);
     verify(rawChannel).setMethodCallHandler(argumentCaptor.capture());
 
     MethodChannel.Result result = mock(MethodChannel.Result.class);
@@ -104,4 +100,3 @@ public class RestorationChannelTest {
     assertEquals(restorationChannel.getRestorationData(), data);
   }
 }
-

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
@@ -1,0 +1,107 @@
+package io.flutter.embedding.engine.systemchannels;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+import android.annotation.TargetApi;
+import android.view.PointerIcon;
+import io.flutter.embedding.android.FlutterView;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.systemchannels.RestorationChannel;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import java.util.HashMap;
+import org.json.JSONException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import android.support.annotation.NonNull;
+import io.flutter.Log;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.StandardMethodCodec;
+import org.mockito.ArgumentCaptor;
+
+@Config(
+    manifest = Config.NONE,
+    shadows = {})
+@RunWith(RobolectricTestRunner.class)
+@TargetApi(24)
+public class RestorationChannelTest {
+  @Test
+  public void itDoesNotDoAnythingWhenRestorationDataIsSetBeforeFrameworkAsks() throws JSONException {
+    MethodChannel rawChannel = mock(MethodChannel.class);
+    RestorationChannel restorationChannel = new RestorationChannel(rawChannel, /*waitForRestorationData=*/ false);
+    restorationChannel.setRestorationData("Any String you want".getBytes());
+    verify(rawChannel, times(0)).invokeMethod(any(), any());
+  }
+
+  @Test
+  public void itSendsDataOverWhenRequestIsPending() throws JSONException {
+    byte[] data = "Any String you want".getBytes();
+
+    MethodChannel rawChannel = mock(MethodChannel.class);
+    RestorationChannel restorationChannel = new RestorationChannel(rawChannel, /*waitForRestorationData=*/ true);
+    ArgumentCaptor<MethodChannel.MethodCallHandler> argumentCaptor = ArgumentCaptor.forClass(MethodChannel.MethodCallHandler.class);
+    verify(rawChannel).setMethodCallHandler(argumentCaptor.capture());
+
+    MethodChannel.Result result = mock(MethodChannel.Result.class);
+    argumentCaptor.getValue().onMethodCall(new MethodCall("get", null), result);
+    verifyZeroInteractions(result);
+
+    restorationChannel.setRestorationData(data);
+    verify(rawChannel, times(0)).invokeMethod(any(), any());
+    verify(result).success(data);
+
+    // Next get request is answered right away.
+    MethodChannel.Result result2 = mock(MethodChannel.Result.class);
+    argumentCaptor.getValue().onMethodCall(new MethodCall("get", null), result2);
+    verify(result2).success(data);
+  }
+
+  @Test
+  public void itPushesNewData() throws JSONException {
+    byte[] data = "Any String you want".getBytes();
+
+    MethodChannel rawChannel = mock(MethodChannel.class);
+    RestorationChannel restorationChannel = new RestorationChannel(rawChannel, /*waitForRestorationData=*/ false);
+    ArgumentCaptor<MethodChannel.MethodCallHandler> argumentCaptor = ArgumentCaptor.forClass(MethodChannel.MethodCallHandler.class);
+    verify(rawChannel).setMethodCallHandler(argumentCaptor.capture());
+
+    MethodChannel.Result result = mock(MethodChannel.Result.class);
+    argumentCaptor.getValue().onMethodCall(new MethodCall("get", null), result);
+    verify(result).success(null);
+
+    restorationChannel.setRestorationData(data);
+    assertEquals(restorationChannel.getRestorationData(), null);
+
+    ArgumentCaptor<MethodChannel.Result> resultCapture = ArgumentCaptor.forClass(MethodChannel.Result.class);
+    verify(rawChannel).invokeMethod(eq("push"), eq(data), resultCapture.capture());
+    resultCapture.getValue().success(null);
+    assertEquals(restorationChannel.getRestorationData(), data);
+  }
+
+  @Test
+  public void itHoldsOnToDataFromFramework() throws JSONException {
+    byte[] data = "Any String you want".getBytes();
+
+    MethodChannel rawChannel = mock(MethodChannel.class);
+    RestorationChannel restorationChannel = new RestorationChannel(rawChannel, /*waitForRestorationData=*/ false);
+    ArgumentCaptor<MethodChannel.MethodCallHandler> argumentCaptor = ArgumentCaptor.forClass(MethodChannel.MethodCallHandler.class);
+    verify(rawChannel).setMethodCallHandler(argumentCaptor.capture());
+
+    MethodChannel.Result result = mock(MethodChannel.Result.class);
+    argumentCaptor.getValue().onMethodCall(new MethodCall("put", data), result);
+    assertEquals(restorationChannel.getRestorationData(), data);
+  }
+}
+

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -320,7 +320,7 @@ def EnsureIosTestsAreBuilt(ios_out_dir):
 
 def AssertExpectedJavaVersion():
   """Checks that the user has Java 8 which is the supported Java version for Android"""
-  EXPECTED_VERSION = '1.8'
+  EXPECTED_VERSION = '11.0'
   # `java -version` is output to stderr. https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4380614
   version_output = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
   match = bool(re.compile('version "%s' % EXPECTED_VERSION).search(version_output))

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -320,7 +320,7 @@ def EnsureIosTestsAreBuilt(ios_out_dir):
 
 def AssertExpectedJavaVersion():
   """Checks that the user has Java 8 which is the supported Java version for Android"""
-  EXPECTED_VERSION = '11.0'
+  EXPECTED_VERSION = '1.8'
   # `java -version` is output to stderr. https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4380614
   version_output = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
   match = bool(re.compile('version "%s' % EXPECTED_VERSION).search(version_output))


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/6827.

Android provides the engine with the restoration data in the Bundle given to the onCreate callback. The framework can retrieve this data via the new channel. When the framework has new restoration data to store it can send it over the channel to the engine. The engine will hold onto it until Android asks for the data by invoking the onSaveInstanceState callback.