### PR TITLE
Populate window.locale in Dart

### DIFF
--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
@@ -12,13 +12,13 @@ import androidx.test.internal.runner.junit4.statement.UiThreadStatement;
 import androidx.test.runner.AndroidJUnit4;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.dart.DartExecutor;
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.Arrays;
-import java.util.Locale;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,10 +40,7 @@ public class EngineLaunchE2ETest {
     // This is required, so `window.locale` in populated in dart.
     UiThreadStatement.runOnUiThread(
         () ->
-            engine
-                .get()
-                .getLocalizationChannel()
-                .sendLocales(Arrays.asList(Locale.US), Locale.US));
+            engine.get().getLocalizationChannel().sendLocales(Arrays.asList(Locale.US), Locale.US));
 
     // The default Dart main entrypoint sends back a platform message on the "waiting_for_status"
     // channel. That will be our launch success assertion condition.

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
@@ -17,6 +17,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.Arrays;
+import java.util.Locale;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -33,6 +35,15 @@ public class EngineLaunchE2ETest {
     // on the same thread will create deadlocks.
     UiThreadStatement.runOnUiThread(() -> engine.set(new FlutterEngine(applicationContext)));
     CompletableFuture<Boolean> statusReceived = new CompletableFuture<>();
+
+    // Resolve locale to `en_US`.
+    // This is required, so `window.locale` in populated in dart.
+    UiThreadStatement.runOnUiThread(
+        () ->
+            engine
+                .get()
+                .getLocalizationChannel()
+                .sendLocales(Arrays.asList(Locale.US), Locale.US));
 
     // The default Dart main entrypoint sends back a platform message on the "waiting_for_status"
     // channel. That will be our launch success assertion condition.

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
@@ -38,6 +38,8 @@ public class EngineLaunchE2ETest {
 
     // Resolve locale to `en_US`.
     // This is required, so `window.locale` in populated in dart.
+    // TODO: Fix race condition between sending this over the channel and starting the entrypoint.
+    // https://github.com/flutter/flutter/issues/55999
     UiThreadStatement.runOnUiThread(
         () ->
             engine.get().getLocalizationChannel().sendLocales(Arrays.asList(Locale.US), Locale.US));


### PR DESCRIPTION
This makes the test green again.  This is required after https://github.com/flutter/engine/pull/17473, since `lib/main.dart` asserts that `window.locale` is defined: https://github.com/flutter/engine/blob/43b88eca0348dabf918c8b0adab0742fa689feb4/testing/scenario_app/lib/main.dart#L48