### PR TITLE
 future:  support engine create shell with aysnc mode

### DIFF
--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -48,6 +48,7 @@ enum class DartErrorCode {
   /// The Dart error code for an unkonwn error.
   UnknownError = 255
 };
+struct ShellCreateParams;
 
 //------------------------------------------------------------------------------
 /// Perhaps the single most important class in the Flutter engine repository.
@@ -95,6 +96,46 @@ class Shell final : public PlatformView::Delegate,
  public:
   template <class T>
   using CreateCallback = std::function<std::unique_ptr<T>(Shell&)>;
+
+  ///----------------------------------------------------------------------------
+  /// Used by method `CreateShellHolder`,Provide synchronous and asynchronous
+  /// initialization methods.
+  ///   auto shell_holder_future = Shell::CreateShellHolder(...);
+  /// 1.synchronous
+  ///   auto shell_holder = shell_holder_future.get();
+  ///   //must run in platformThread
+  ///   auto shell = Shell::MakeShellFromHolder(std::move(shell_holder));
+  /// 2.asynchronous
+  ///   std::async(std::launch::async,[](){
+  ///     auto shell_holder = shell_holder_future.get();
+  ///     fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),[](){
+  ///           auto shell =
+  ///           Shell::MakeShellFromHolder(std::move(shell_holder));
+  ///      });
+  ///   });
+  ///
+  class ShellHolder {
+   public:
+    ShellHolder(std::unique_ptr<Shell> shell_ref,
+                std::unique_ptr<PlatformView> platform_view_ref,
+                std::unique_ptr<Engine> engine_ref,
+                std::unique_ptr<Rasterizer> rasterizer_ref,
+                std::unique_ptr<ShellIOManager> io_manager_ref)
+        : shell(std::move(shell_ref)),
+          platform_view(std::move(platform_view_ref)),
+          engine(std::move(engine_ref)),
+          rasterizer(std::move(rasterizer_ref)),
+          io_manager(std::move(io_manager_ref)) {}
+
+   private:
+    /// shell has not been Setup.
+    std::unique_ptr<Shell> shell;
+    std::unique_ptr<PlatformView> platform_view;
+    std::unique_ptr<Engine> engine;
+    std::unique_ptr<Rasterizer> rasterizer;
+    std::unique_ptr<ShellIOManager> io_manager;
+    friend Shell;
+  };
 
   //----------------------------------------------------------------------------
   /// @brief      Creates a shell instance using the provided settings. The
@@ -209,6 +250,25 @@ class Shell final : public PlatformView::Delegate,
       const CreateCallback<PlatformView>& on_create_platform_view,
       const CreateCallback<Rasterizer>& on_create_rasterizer,
       DartVMRef vm);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Creates a shell instance asynchronously using the provided
+  /// params.
+  ///
+  /// @param[in]  params                   shell init params
+  ///
+  /// @return future with shell which is full initialized  or null if the params
+  /// are valid
+
+  static std::future<std::unique_ptr<Shell::ShellHolder>> CreateShellHolder(
+      std::unique_ptr<ShellCreateParams> params);
+
+  //----------------------------------------------------------------------------
+  /// @brief      return full init shell. (call `shell.setup` on
+  /// platformThread)
+  /// must run in platfromThread , else abort
+  static std::unique_ptr<Shell> MakeShellFromHolder(
+      std::unique_ptr<ShellHolder> holder);
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys the shell. This is a synchronous operation and
@@ -423,7 +483,8 @@ class Shell final : public PlatformView::Delegate,
 
   Shell(DartVMRef vm, TaskRunners task_runners, Settings settings);
 
-  static std::unique_ptr<Shell> CreateShellOnPlatformThread(
+  static void CreateShellOnPlatformThread(
+      std::promise<std::unique_ptr<Shell::ShellHolder>> shell_holder_promise,
       DartVMRef vm,
       TaskRunners task_runners,
       const WindowData window_data,
@@ -431,6 +492,15 @@ class Shell final : public PlatformView::Delegate,
       fml::RefPtr<const DartSnapshot> isolate_snapshot,
       const Shell::CreateCallback<PlatformView>& on_create_platform_view,
       const Shell::CreateCallback<Rasterizer>& on_create_rasterizer);
+
+  static std::future<std::unique_ptr<Shell::ShellHolder>> InitShellEnv(
+      TaskRunners task_runners,
+      const WindowData window_data,
+      Settings settings,
+      fml::RefPtr<const DartSnapshot> isolate_snapshot,
+      const CreateCallback<PlatformView>& on_create_platform_view,
+      const CreateCallback<Rasterizer>& on_create_rasterizer,
+      DartVMRef vm);
 
   bool Setup(std::unique_ptr<PlatformView> platform_view,
              std::unique_ptr<Engine> engine,
@@ -593,6 +663,36 @@ class Shell final : public PlatformView::Delegate,
   friend class testing::ShellTest;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Shell);
+};
+
+//----------------------------------------------------------------------------
+/// @brief     shell init params, used by create method
+struct ShellCreateParams {
+  // The task runners
+  TaskRunners task_runners;
+  // The default data for setting up ui.Window that attached to this intance.
+  WindowData window_data;
+  // The settings
+  Settings settings;
+  // The callback that must return a  platform view. This will be called on the
+  // platform task runner before this method returns
+  Shell::CreateCallback<flutter::PlatformView> on_create_platform_view;
+  // valid rasterizer. This will be called  on the render task runner before
+  // thismethod returns.
+  Shell::CreateCallback<flutter::Rasterizer> on_create_rasterizer;
+
+  ShellCreateParams(
+      flutter::TaskRunners task_runners,
+      flutter::WindowData window_data,
+      flutter::Settings settings,
+      flutter::Shell::CreateCallback<flutter::PlatformView>
+          on_create_platform_view,
+      flutter::Shell::CreateCallback<flutter::Rasterizer> on_create_rasterizer)
+      : task_runners(std::move(task_runners)),
+        window_data(window_data),
+        settings(settings),
+        on_create_platform_view(std::move(on_create_platform_view)),
+        on_create_rasterizer(std::move(on_create_rasterizer)) {}
 };
 
 }  // namespace flutter

--- a/shell/common/shell_benchmarks.cc
+++ b/shell/common/shell_benchmarks.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/benchmarking/benchmarking.h"
 #include "flutter/fml/logging.h"
+#include "flutter/fml/make_copyable.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/thread_host.h"
@@ -98,6 +99,89 @@ static void StartupAndShutdownShell(benchmark::State& state,
   FML_CHECK(!shell);
 }
 
+static void StartupAsync(benchmark::State& state, bool mesure_async_total) {
+  auto assets_dir = fml::OpenDirectory(testing::GetFixturesPath(), false,
+                                       fml::FilePermission::kRead);
+  std::unique_ptr<Shell> shell_res;
+  std::unique_ptr<ThreadHost> thread_host;
+  testing::ELFAOTSymbols aot_symbols;
+  {
+    Settings settings = {};
+    settings.task_observer_add = [](intptr_t, fml::closure) {};
+    settings.task_observer_remove = [](intptr_t) {};
+
+    if (DartVM::IsRunningPrecompiledCode()) {
+      aot_symbols = testing::LoadELFSymbolFromFixturesIfNeccessary();
+      FML_CHECK(
+          testing::PrepareSettingsForAOTWithSymbols(settings, aot_symbols))
+          << "Could not setup settings with AOT symbols.";
+    } else {
+      settings.application_kernels = [&]() {
+        std::vector<std::unique_ptr<const fml::Mapping>> kernel_mappings;
+        kernel_mappings.emplace_back(
+            fml::FileMapping::CreateReadOnly(assets_dir, "kernel_blob.bin"));
+        return kernel_mappings;
+      };
+    }
+
+    thread_host = std::make_unique<ThreadHost>(
+        "io.flutter.bench.", ThreadHost::Type::Platform |
+                                 ThreadHost::Type::GPU | ThreadHost::Type::IO |
+                                 ThreadHost::Type::UI);
+
+    TaskRunners task_runners("test",
+                             thread_host->platform_thread->GetTaskRunner(),
+                             thread_host->raster_thread->GetTaskRunner(),
+                             thread_host->ui_thread->GetTaskRunner(),
+                             thread_host->io_thread->GetTaskRunner());
+
+    auto shell_holder_future =
+        Shell::CreateShellHolder(std::make_unique<ShellCreateParams>(
+            std::move(task_runners), WindowData{/* default window data */},
+            settings,
+            [](Shell& shell) {
+              return std::make_unique<PlatformView>(shell,
+                                                    shell.GetTaskRunners());
+            },
+            [](Shell& shell) {
+              return std::make_unique<Rasterizer>(
+                  shell, shell.GetTaskRunners(),
+                  shell.GetIsGpuDisabledSyncSwitch());
+            }));
+    std::unique_ptr<Shell::ShellHolder> shell_holder;
+    {
+      benchmarking::ScopedPauseTiming pause(state, !mesure_async_total);
+      shell_holder = shell_holder_future.get();
+    }
+    fml::AutoResetWaitableEvent latch;
+
+    fml::TaskRunner::RunNowOrPostTask(
+        task_runners.GetPlatformTaskRunner(),
+        fml::MakeCopyable([&latch, &shell_res, &shell_holder]() mutable {
+          shell_res = Shell::MakeShellFromHolder(std::move(shell_holder));
+          latch.Signal();
+        }));
+    latch.Wait();
+
+    FML_CHECK(shell_res);
+  }
+  {
+    // don't care shutdown time here
+    benchmarking::ScopedPauseTiming pause(state, true);
+    // Shutdown must occur synchronously on the platform thread.
+    fml::AutoResetWaitableEvent latch;
+    fml::TaskRunner::RunNowOrPostTask(
+        thread_host->platform_thread->GetTaskRunner(),
+        [&shell_res, &latch]() mutable {
+          shell_res.reset();
+          latch.Signal();
+        });
+    latch.Wait();
+    thread_host.reset();
+  }
+  FML_CHECK(!shell_res);
+}
+
 static void BM_ShellInitialization(benchmark::State& state) {
   while (state.KeepRunning()) {
     StartupAndShutdownShell(state, true, false);
@@ -121,5 +205,19 @@ static void BM_ShellInitializationAndShutdown(benchmark::State& state) {
 }
 
 BENCHMARK(BM_ShellInitializationAndShutdown);
+
+static void BM_ShellInitializationAsyncbBLockTime(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    StartupAsync(state, false);
+  }
+}
+BENCHMARK(BM_ShellInitializationAsyncbBLockTime);
+
+static void BM_ShellInitializationAsyncTotalTime(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    StartupAsync(state, true);
+  }
+}
+BENCHMARK(BM_ShellInitializationAsyncTotalTime);
 
 }  // namespace flutter

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -187,7 +187,7 @@ TEST_F(ShellTest,
           }));
 
   fml::AutoResetWaitableEvent latch;
-  std::async(std::launch::async,
+  auto handle = std::async(std::launch::async,
              fml::MakeCopyable([shell_test_point = this, &latch, task_runners,
                                 shell_holder_future =
                                     std::move(shell_holder_future)]() mutable {
@@ -212,6 +212,7 @@ TEST_F(ShellTest,
              }));
 
   latch.Wait();
+  handle.get();
 }
 
 TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -187,29 +187,29 @@ TEST_F(ShellTest,
           }));
 
   fml::AutoResetWaitableEvent latch;
-  auto handle = std::async(std::launch::async,
-             fml::MakeCopyable([shell_test_point = this, &latch, task_runners,
-                                shell_holder_future =
-                                    std::move(shell_holder_future)]() mutable {
-               // wait
-               auto shell_holder = shell_holder_future.get();
-               // check shell_res on platformthread
-               auto lambda_shell_res = fml::MakeCopyable(
-                   [shell_test_point, &latch, task_runners,
-                    shell_holder = std::move(shell_holder)]() mutable {
-                     auto shell_res =
-                         Shell::MakeShellFromHolder(std::move(shell_holder));
-                     ASSERT_TRUE(ValidateShell(shell_res.get()));
-                     ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-                     shell_test_point->DestroyShell(std::move(shell_res),
-                                                    std::move(task_runners));
-                     ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-                     latch.Signal();
-                   });
-               fml::TaskRunner::RunNowOrPostTask(
-                   task_runners.GetPlatformTaskRunner(),
-                   std::move(lambda_shell_res));
-             }));
+  auto handle = std::async(
+      std::launch::async,
+      fml::MakeCopyable([shell_test_point = this, &latch, task_runners,
+                         shell_holder_future =
+                             std::move(shell_holder_future)]() mutable {
+        // wait
+        auto shell_holder = shell_holder_future.get();
+        // check shell_res on platformthread
+        auto lambda_shell_res = fml::MakeCopyable(
+            [shell_test_point, &latch, task_runners,
+             shell_holder = std::move(shell_holder)]() mutable {
+              auto shell_res =
+                  Shell::MakeShellFromHolder(std::move(shell_holder));
+              ASSERT_TRUE(ValidateShell(shell_res.get()));
+              ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+              shell_test_point->DestroyShell(std::move(shell_res),
+                                             std::move(task_runners));
+              ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+              latch.Signal();
+            });
+        fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
+                                          std::move(lambda_shell_res));
+      }));
 
   latch.Wait();
   handle.get();


### PR DESCRIPTION
this is a split PR, __supprot create shell with aysnc mode__ , you can see full contex on https://github.com/flutter/engine/pull/17192

> Now create shell will block platform thread. The cost of blocking the main thread is very expensive on android/ios  platform. 

core modify method is `CreateShellOnPlatformThread `. Other code are
- new async api for create shell
- compatible with existing APIs
- unittests 
-  benchmark

@chinmaygarde 