### PR TITLE
[web] Add TargetPlatform tests

### DIFF
--- a/e2etests/web/regular_integration_tests/lib/target_platform_main.dart
+++ b/e2etests/web/regular_integration_tests/lib/target_platform_main.dart
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+void main() => runApp(MyApp());
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      key: const Key('mainapp'),
+      title: 'Platform Test',
+      home: MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            if (defaultTargetPlatform == TargetPlatform.macOS)
+              const Text(
+                'I am running on MacOS',
+                key: Key('macOSKey'),
+              ),
+            if (defaultTargetPlatform == TargetPlatform.iOS)
+              const Text(
+                'I am running on MacOS',
+                key: Key('iOSKey'),
+              ),
+            if (defaultTargetPlatform == TargetPlatform.android)
+              const Text(
+                'I am running on Android',
+                key: Key('androidKey'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e.dart
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:regular_integration_tests/text_editing_main.dart' as app;
+import 'package:flutter/material.dart';
+
+import 'package:e2e/e2e.dart';
+
+void main() {
+  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+
+  testWidgets('Focused text field creates a native input element',
+          (WidgetTester tester) async {
+        app.main();
+        await tester.pumpAndSettle();
+
+        final Finder macOSFinder = find.byKey(const Key('macOSKey'));
+        expect(macOSFinder, findsNothing);
+
+        final Finder iOSFinder = find.byKey(const Key('iOSKey'));
+        expect(iOSFinder, findsNothing);
+
+        final Finder androidFinder = find.byKey(const Key('androidKey'));
+        expect(androidFinder, findsOneWidget);
+      });
+}

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e.dart
@@ -13,7 +13,7 @@ import 'package:e2e/e2e.dart';
 void main() {
   E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
 
-  testWidgets('Focused text field creates a native input element',
+  testWidgets('Should detect android platform when running on android device',
           (WidgetTester tester) async {
         app.main();
         await tester.pumpAndSettle();

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:e2e/e2e_driver.dart' as e2e;
+
+Future<void> main() async => e2e.main();

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
@@ -13,7 +13,7 @@ import 'package:e2e/e2e.dart';
 void main() {
   E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
 
-  testWidgets('Focused text field creates a native input element',
+  testWidgets('Should detect iOS platform when running on iOS device',
           (WidgetTester tester) async {
         app.main();
         await tester.pumpAndSettle();

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:regular_integration_tests/text_editing_main.dart' as app;
+import 'package:flutter/material.dart';
+
+import 'package:e2e/e2e.dart';
+
+void main() {
+  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+
+  testWidgets('Focused text field creates a native input element',
+          (WidgetTester tester) async {
+        app.main();
+        await tester.pumpAndSettle();
+
+        final Finder macOSFinder = find.byKey(const Key('macOSKey'));
+        expect(macOSFinder, findsNothing);
+
+        final Finder iOSFinder = find.byKey(const Key('iOSKey'));
+        expect(iOSFinder, findsOneWidget);
+
+        final Finder androidFinder = find.byKey(const Key('androidKey'));
+        expect(androidFinder, findsNothing);
+      });
+}

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:e2e/e2e_driver.dart' as e2e;
+
+Future<void> main() async => e2e.main();

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
@@ -13,7 +13,7 @@ import 'package:e2e/e2e.dart';
 void main() {
   E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
 
-  testWidgets('Focused text field creates a native input element',
+  testWidgets('Should detect MacOS platform when running on MacOS',
           (WidgetTester tester) async {
         app.main();
         await tester.pumpAndSettle();

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:regular_integration_tests/text_editing_main.dart' as app;
+import 'package:flutter/material.dart';
+
+import 'package:e2e/e2e.dart';
+
+void main() {
+  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+
+  testWidgets('Focused text field creates a native input element',
+          (WidgetTester tester) async {
+        app.main();
+        await tester.pumpAndSettle();
+
+        final Finder macOSFinder = find.byKey(const Key('macOSKey'));
+        expect(macOSFinder, findsOneWidget);
+
+        final Finder iOSFinder = find.byKey(const Key('iOSKey'));
+        expect(iOSFinder, findsNothing);
+
+        final Finder androidFinder = find.byKey(const Key('androidKey'));
+        expect(androidFinder, findsNothing);
+      });
+}

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:e2e/e2e_driver.dart' as e2e;
+
+Future<void> main() async => e2e.main();


### PR DESCRIPTION
Adds target platform tests to be enabled when infra is ready.
These tests are for framework PR that will address issue : https://github.com/flutter/flutter/issues/43633