### PR TITLE
Update Fuchsia ComponentContext constructor call to renamed, but equvalent, method

### DIFF
--- a/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
@@ -22,7 +22,7 @@ namespace flutter_runner_test {
 class SessionConnectionTest : public ::testing::Test {
  public:
   void SetUp() override {
-    context_ = sys::ComponentContext::Create();
+    context_ = sys::ComponentContext::CreateAndServeOutgoingDirectory();
     scenic_ = context_->svc()->Connect<fuchsia::ui::scenic::Scenic>();
     presenter_ = context_->svc()->Connect<fuchsia::ui::policy::Presenter>();
 


### PR DESCRIPTION
This change is part of an LSC in Fuchsia, and is a functionality no-op.

Fixes fxbug.dev/50759