### PR TITLE
Add an API for resyncing output streams

### DIFF
--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 
 #include <assert.h>
+#include <io.h>
 
 #include <algorithm>
 #include <chrono>
@@ -222,6 +223,17 @@ UINT FlutterDesktopGetDpiForHWND(HWND hwnd) {
 
 UINT FlutterDesktopGetDpiForMonitor(HMONITOR monitor) {
   return flutter::GetDpiForMonitor(monitor);
+}
+
+void FlutterDesktopResyncOutputStreams() {
+  FILE* unused;
+  if (freopen_s(&unused, "CONOUT$", "w", stdout)) {
+    _dup2(_fileno(stdout), 1);
+  }
+  if (freopen_s(&unused, "CONOUT$", "w", stderr)) {
+    _dup2(_fileno(stdout), 2);
+  }
+  std::ios::sync_with_stdio();
 }
 
 FlutterDesktopEngineRef FlutterDesktopRunEngine(

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -110,6 +110,11 @@ FLUTTER_EXPORT UINT FlutterDesktopGetDpiForHWND(HWND hwnd);
 // DPI of 96 is returned.
 FLUTTER_EXPORT UINT FlutterDesktopGetDpiForMonitor(HMONITOR monitor);
 
+// Reopens stdout and stderr and resysncs the standard library output streams.
+// Should be called if output is being directed somewhere in the runner process
+// (e.g., after an AllocConsole call).
+FLUTTER_EXPORT void FlutterDesktopResyncOutputStreams();
+
 // Runs an instance of a headless Flutter engine.
 //
 // Returns a null pointer in the event of an error.


### PR DESCRIPTION
When creating a console on Windows, stdout/stderr aren't wired up to it.
They need to be re-opened afeter the console is created, and that needs
to be done separately in the engine due to the use of static runtime
linking. This provides a helper method that the runner can call when
creating a console so that output will work as expected.

Part of https://github.com/flutter/flutter/issues/53169