### PR TITLE
CP fix for web_engine_integration_test_linux to 1.17 engine 

### DIFF
--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -18,7 +18,7 @@ fi
 cd $ENGINE_PATH/src/flutter
 
 # Special handling of release branches.
-ENGINE_BRANCH_NAME=`git branch | grep '*' | cut -d ' ' -f2`
+ENGINE_BRANCH_NAME=$CIRRUS_BASE_BRANCH
 versionregex="^v[[:digit:]]+\."
 ON_RELEASE_BRANCH=false
 echo "Engine on branch $ENGINE_BRANCH_NAME"

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -20,9 +20,10 @@ cd $ENGINE_PATH/src/flutter
 # Special handling of release branches.
 ENGINE_BRANCH_NAME=$CIRRUS_BASE_BRANCH
 versionregex="^v[[:digit:]]+\."
+releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
 ON_RELEASE_BRANCH=false
 echo "Engine on branch $ENGINE_BRANCH_NAME"
-if [[ $ENGINE_BRANCH_NAME =~ $versionregex ]]
+if [[ $ENGINE_BRANCH_NAME =~ $versionregex || $ENGINE_BRANCH_NAME =~ $releasecandidateregex ]]
 then
   echo "release branch $ENGINE_BRANCH_NAME"
   ON_RELEASE_BRANCH=true


### PR DESCRIPTION
use $CIRRUS_BASE_BRANCH for getting the branch name when cloning the flutter repo.