### PR TITLE
Add new FlutterEngineAOTData argument to FlutterProjectArgs

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -71,6 +71,7 @@ template("embedder_source_set") {
       "//flutter/shell/common",
       "//flutter/third_party/tonic",
       "//third_party/dart/runtime/bin:dart_io_api",
+      "//third_party/dart/runtime/bin:elf_loader",
       "//third_party/skia",
     ]
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -591,7 +591,7 @@ FlutterEngineResult FlutterEngineCreateAOTData(
 
       *data_out = aot_data.release();
       return kSuccess;
-    } break;
+    }
   }
 
   return LOG_EMBEDDER_ERROR(

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -557,10 +557,10 @@ FlutterEngineResult FlutterEngineCreateAOTData(
                                   "Invalid ELF path specified.");
       }
 
-      auto aot_data = new _FlutterEngineAOTData();
+      auto aot_data = std::make_unique<_FlutterEngineAOTData>();
       const char* error = nullptr;
 
-      auto loaded_elf = Dart_LoadELF(
+      Dart_LoadedElf* loaded_elf = Dart_LoadELF(
           source->elf_path,               // file path
           0,                              // file offset
           &error,                         // error (out)
@@ -571,21 +571,19 @@ FlutterEngineResult FlutterEngineCreateAOTData(
       );
 
       if (loaded_elf == nullptr) {
-        delete aot_data;
         return LOG_EMBEDDER_ERROR(kInvalidArguments, error);
       }
 
       aot_data->loaded_elf.reset(loaded_elf);
 
-      *data_out = aot_data;
+      *data_out = aot_data.release();
+      return kSuccess;
     } break;
-    default:
-      return LOG_EMBEDDER_ERROR(
-          kInvalidArguments,
-          "Invalid FlutterEngineAOTDataSourceType type specified.");
   }
 
-  return kSuccess;
+  return LOG_EMBEDDER_ERROR(
+      kInvalidArguments,
+      "Invalid FlutterEngineAOTDataSourceType type specified.");
 }
 
 FlutterEngineResult FlutterEngineCollectAOTData(FlutterEngineAOTData data) {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -553,23 +553,22 @@ FlutterEngineResult FlutterEngineCreateAOTData(
   switch (source->type) {
     case kFlutterEngineAOTDataSourceTypeElfPath: {
       if (!source->elf_path || !fml::IsFile(source->elf_path)) {
-        return LOG_EMBEDDER_ERROR(
-          kInvalidArguments,
-          "Invalid ELF path specified.");
+        return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                                  "Invalid ELF path specified.");
       }
 
       auto aot_data = new _FlutterEngineAOTData();
       const char* error = nullptr;
 
-      auto loaded_elf =
-        Dart_LoadELF(source->elf_path,              // file path
-                     0,                             // file offset
-                     &error,                        // error (out)
-                     &aot_data->vm_snapshot_data,   // vm snapshot data (out)
-                     &aot_data->vm_snapshot_instrs, // vm snapshot instr (out)
-                     &aot_data->vm_isolate_data,    // vm isolate data (out)
-                     &aot_data->vm_isolate_instrs   // vm isolate instr (out)
-        );
+      auto loaded_elf = Dart_LoadELF(
+          source->elf_path,               // file path
+          0,                              // file offset
+          &error,                         // error (out)
+          &aot_data->vm_snapshot_data,    // vm snapshot data (out)
+          &aot_data->vm_snapshot_instrs,  // vm snapshot instr (out)
+          &aot_data->vm_isolate_data,     // vm isolate data (out)
+          &aot_data->vm_isolate_instrs    // vm isolate instr (out)
+      );
 
       if (loaded_elf == nullptr) {
         delete aot_data;
@@ -579,7 +578,7 @@ FlutterEngineResult FlutterEngineCreateAOTData(
       aot_data->loaded_elf.reset(loaded_elf);
 
       *data_out = aot_data;
-    }  break;
+    } break;
     default:
       return LOG_EMBEDDER_ERROR(
           kInvalidArguments,
@@ -610,17 +609,17 @@ void PopulateSnapshotMappingCallbacks(const FlutterProjectArgs* args,
 
   if (flutter::DartVM::IsRunningPrecompiledCode()) {
     if (SAFE_ACCESS(args, aot_data, nullptr) != nullptr) {
-      settings.vm_snapshot_data = make_mapping_callback(
-          args->aot_data->vm_snapshot_data, 0);
+      settings.vm_snapshot_data =
+          make_mapping_callback(args->aot_data->vm_snapshot_data, 0);
 
-      settings.vm_snapshot_instr = make_mapping_callback(
-          args->aot_data->vm_snapshot_instrs, 0);
+      settings.vm_snapshot_instr =
+          make_mapping_callback(args->aot_data->vm_snapshot_instrs, 0);
 
-      settings.isolate_snapshot_data = make_mapping_callback(
-          args->aot_data->vm_isolate_data, 0);
+      settings.isolate_snapshot_data =
+          make_mapping_callback(args->aot_data->vm_isolate_data, 0);
 
-      settings.isolate_snapshot_instr = make_mapping_callback(
-          args->aot_data->vm_isolate_instrs, 0);
+      settings.isolate_snapshot_instr =
+          make_mapping_callback(args->aot_data->vm_isolate_instrs, 0);
     }
 
     if (SAFE_ACCESS(args, vm_snapshot_data, nullptr) != nullptr) {
@@ -744,8 +743,8 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         SAFE_ACCESS(args, vm_snapshot_instructions, nullptr) ||
         SAFE_ACCESS(args, isolate_snapshot_data, nullptr) ||
         SAFE_ACCESS(args, isolate_snapshot_instructions, nullptr)) {
-          return LOG_EMBEDDER_ERROR(kInvalidArguments,
-                                    "Multiple AOT sources specified.");
+      return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                                "Multiple AOT sources specified.");
     }
   }
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -533,7 +533,7 @@ struct _FlutterPlatformMessageResponseHandle {
   fml::RefPtr<flutter::PlatformMessage> message;
 };
 
-struct LoadedELFDeleter {
+struct LoadedElfDeleter {
   void operator()(Dart_LoadedElf* elf) {
     if (elf) {
       ::Dart_UnloadELF(elf);
@@ -541,10 +541,10 @@ struct LoadedELFDeleter {
   }
 };
 
-using UniqueLoadedELF = std::unique_ptr<Dart_LoadedElf, LoadedELFDeleter>;
+using UniqueLoadedElf = std::unique_ptr<Dart_LoadedElf, LoadedElfDeleter>;
 
 struct _FlutterEngineAOTData {
-  UniqueLoadedELF loaded_elf = nullptr;
+  UniqueLoadedElf loaded_elf = nullptr;
   const uint8_t* vm_snapshot_data = nullptr;
   const uint8_t* vm_snapshot_instrs = nullptr;
   const uint8_t* vm_isolate_data = nullptr;

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -997,9 +997,8 @@ FlutterEngineResult FlutterEngineCreateAOTData(
 //------------------------------------------------------------------------------
 /// @brief      Collects the AOT data.
 ///
-/// @warning    The embedder must ensure that this call is made only after all
-///             FlutterEngine instance launched using this data have been shut
-///             down.
+/// @warning    The embedder must ensure that this call is made only after the
+///             FlutterEngine instance launched using this data is shut down.
 ///
 /// @param[in]  data   The data to collect.
 ///
@@ -1200,6 +1199,8 @@ typedef struct {
   ///
   /// Embedders should instantiate and destroy this object via the
   /// FlutterEngineCreateAOTData and FlutterEngineCollectAOTData methods.
+  ///
+  /// Embedders can provide either snapshot buffers or aot_data, but not both.
   FlutterEngineAOTData aot_data;
 } FlutterProjectArgs;
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -969,7 +969,7 @@ typedef enum {
 typedef struct {
   FlutterEngineAOTDataSourceType type;
   union {
-    /// Path to an ELF library file
+    /// Absolute path to an ELF library file
     const char* elf_path;
   };
 } FlutterEngineAOTDataSource;

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -969,7 +969,7 @@ typedef enum {
 typedef struct {
   FlutterEngineAOTDataSourceType type;
   union {
-    /// Absolute path to an ELF library file
+    /// Absolute path to an ELF library file.
     const char* elf_path;
   };
 } FlutterEngineAOTDataSource;

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1196,8 +1196,10 @@ typedef struct {
   /// https://github.com/dart-lang/sdk/blob/ca64509108b3e7219c50d6c52877c85ab6a35ff2/runtime/vm/flag_list.h#L150
   int64_t dart_old_gen_heap_size;
 
-  /// The AOT data to be used in AOT operation. This object should be obtained
-  /// via the `FlutterEngineCreateAOTData` method.
+  /// The AOT data to be used in AOT operation.
+  ///
+  /// Embedders should instantiate and destroy this object via the
+  /// FlutterEngineCreateAOTData and FlutterEngineCollectAOTData methods.
   FlutterEngineAOTData aot_data;
 } FlutterProjectArgs;
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -981,8 +981,8 @@ typedef struct _FlutterEngineAOTData* FlutterEngineAOTData;
 //------------------------------------------------------------------------------
 /// @brief      Creates the necessary data structures to launch a Flutter Dart
 ///             application in AOT mode. The data may only be collected after
-///             the FlutterEngine instance launched using this data is shut
-///             down.
+///             all FlutterEngine instances launched using this data have been
+///             terminated.
 ///
 /// @param[in]  source    The source of the AOT data.
 /// @param[out] data_out  The AOT data on success. Unchanged on failure.
@@ -997,8 +997,11 @@ FlutterEngineResult FlutterEngineCreateAOTData(
 //------------------------------------------------------------------------------
 /// @brief      Collects the AOT data.
 ///
-/// @warning    The embedder must ensure that this call is made only after the
-///             FlutterEngine instance launched using this data is shut down.
+/// @warning    The embedder must ensure that this call is made only after all
+///             FlutterEngine instances launched using this data have been
+///             terminated, and that all of those instances were launched with
+///             the FlutterProjectArgs::shutdown_dart_vm_when_done flag set to
+///             true.
 ///
 /// @param[in]  data   The data to collect.
 ///

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -959,6 +959,55 @@ typedef enum {
 typedef void (*FlutterNativeThreadCallback)(FlutterNativeThreadType type,
                                             void* user_data);
 
+/// AOT data source type.
+typedef enum {
+  kFlutterEngineAOTDataSourceTypeElfPath
+} FlutterEngineAOTDataSourceType;
+
+/// This struct specifies one of the various locations the engine can look for
+/// AOT data sources.
+typedef struct {
+  FlutterEngineAOTDataSourceType type;
+  union {
+    /// Path to an ELF library file
+    const char* elf_path;
+  };
+} FlutterEngineAOTDataSource;
+
+/// An opaque object that describes the AOT data that can be used to launch a
+/// FlutterEngine instance in AOT mode.
+typedef struct _FlutterEngineAOTData* FlutterEngineAOTData;
+
+//------------------------------------------------------------------------------
+/// @brief      Creates the necessary data structures to launch a Flutter Dart
+///             application in AOT mode. The data may only be collected after
+///             the FlutterEngine instance launched using this data is shut
+///             down.
+///
+/// @param[in]  source    The source of the AOT data.
+/// @param[out] data_out  The AOT data on success. Unchanged on failure.
+///
+/// @return     Returns if the AOT data could be successfully resolved.
+///
+FLUTTER_EXPORT
+FlutterEngineResult FlutterEngineCreateAOTData(
+    const FlutterEngineAOTDataSource* source,
+    FlutterEngineAOTData* data_out);
+
+//------------------------------------------------------------------------------
+/// @brief      Collects the AOT data.
+///
+/// @warning    The embedder must ensure that this call is made only after all
+///             FlutterEngine instance launched using this data have been shut
+///             down.
+///
+/// @param[in]  data   The data to collect.
+///
+/// @return     Returns if the AOT data was successfully collected.
+///
+FLUTTER_EXPORT
+FlutterEngineResult FlutterEngineCollectAOTData(FlutterEngineAOTData data);
+
 typedef struct {
   /// The size of this struct. Must be sizeof(FlutterProjectArgs).
   size_t struct_size;
@@ -1146,6 +1195,10 @@ typedef struct {
   /// See also:
   /// https://github.com/dart-lang/sdk/blob/ca64509108b3e7219c50d6c52877c85ab6a35ff2/runtime/vm/flag_list.h#L150
   int64_t dart_old_gen_heap_size;
+
+  /// The AOT data to be used in AOT operation. This object should be obtained
+  /// via the `FlutterEngineCreateAOTData` method.
+  FlutterEngineAOTData aot_data;
 } FlutterProjectArgs;
 
 //------------------------------------------------------------------------------

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -82,14 +82,13 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
     SetSemanticsCallbackHooks();
     AddCommandLineArgument("--disable-observatory");
   }
-  
+
   if (preference == InitializationPreference::kSnapshotsInitialize) {
     SetSnapshots();
-  }
-  else if (preference == InitializationPreference::kElfInitialize) {
+  } else if (preference == InitializationPreference::kElfInitialize) {
     SetAotDataElf();
-  }
-  else if (preference == InitializationPreference::kSnapshotsAndElfInitialize) {
+  } else if (preference ==
+             InitializationPreference::kSnapshotsAndElfInitialize) {
     SetSnapshots();
     SetAotDataElf();
   }

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -82,12 +82,13 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
     SetSemanticsCallbackHooks();
     AddCommandLineArgument("--disable-observatory");
 
-    if (DartVM::IsRunningPrecompiledCode()) {
-      SetAotDataElf();
-    }
-    if (!DartVM::IsRunningPrecompiledCode() ||
+    if (preference == InitializationPreference::kSnapshotsInitialize ||
         preference == InitializationPreference::kMultiAOTInitialize) {
       SetSnapshots();
+    }
+    if (preference == InitializationPreference::kAOTDataInitialize ||
+        preference == InitializationPreference::kMultiAOTInitialize) {
+      SetAotDataElf();
     }
   }
 }

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -88,7 +88,7 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
     }
     if (preference == InitializationPreference::kAOTDataInitialize ||
         preference == InitializationPreference::kMultiAOTInitialize) {
-      SetAotDataElf();
+      SetAOTDataElf();
     }
   }
 }
@@ -141,7 +141,7 @@ void EmbedderConfigBuilder::SetSnapshots() {
   }
 }
 
-void EmbedderConfigBuilder::SetAotDataElf() {
+void EmbedderConfigBuilder::SetAOTDataElf() {
   project_args_.aot_data = context_.GetAOTData();
 }
 

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -4,7 +4,6 @@
 
 #include "flutter/shell/platform/embedder/tests/embedder_config_builder.h"
 
-#include "flutter/fml/paths.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "third_party/skia/include/core/SkBitmap.h"
@@ -142,19 +141,7 @@ void EmbedderConfigBuilder::SetSnapshots() {
 }
 
 void EmbedderConfigBuilder::SetAotDataElf() {
-  FlutterEngineAOTDataSource data_in = {};
-  FlutterEngineAOTData data_out = nullptr;
-
-  const auto elf_path =
-      fml::paths::JoinPaths({GetFixturesPath(), kAOTAppELFFileName});
-
-  data_in.type = kFlutterEngineAOTDataSourceTypeElfPath;
-  data_in.elf_path = elf_path.c_str();
-
-  ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kSuccess);
-
-  aot_data_.reset(data_out);
-  project_args_.aot_data = data_out;
+  project_args_.aot_data = context_.GetAOTData();
 }
 
 void EmbedderConfigBuilder::SetIsolateCreateCallbackHook() {

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -28,16 +28,6 @@ struct UniqueEngineTraits {
 
 using UniqueEngine = fml::UniqueObject<FlutterEngine, UniqueEngineTraits>;
 
-struct AOTDataDeleter {
-  void operator()(FlutterEngineAOTData aot_data) {
-    if (aot_data) {
-      FlutterEngineCollectAOTData(aot_data);
-    }
-  }
-};
-
-using UniqueAOTData = std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter>;
-
 class EmbedderConfigBuilder {
  public:
   enum class InitializationPreference {
@@ -97,7 +87,6 @@ class EmbedderConfigBuilder {
   FlutterCustomTaskRunners custom_task_runners_ = {};
   FlutterCompositor compositor_ = {};
   std::vector<std::string> command_line_arguments_;
-  UniqueAOTData aot_data_;
 
   UniqueEngine SetupEngine(bool run) const;
 

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -31,13 +31,15 @@ using UniqueEngine = fml::UniqueObject<FlutterEngine, UniqueEngineTraits>;
 class EmbedderConfigBuilder {
  public:
   enum class InitializationPreference {
-    kInitialize,
+    kSnapshotsInitialize,
+    kElfInitialize,
+    kSnapshotsAndElfInitialize,
     kNoInitialize,
   };
 
   EmbedderConfigBuilder(EmbedderTestContext& context,
                         InitializationPreference preference =
-                            InitializationPreference::kInitialize);
+                            InitializationPreference::kSnapshotsInitialize);
 
   ~EmbedderConfigBuilder();
 
@@ -50,6 +52,8 @@ class EmbedderConfigBuilder {
   void SetAssetsPath();
 
   void SetSnapshots();
+
+  void SetAotDataElf();
 
   void SetIsolateCreateCallbackHook();
 

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -31,14 +31,15 @@ using UniqueEngine = fml::UniqueObject<FlutterEngine, UniqueEngineTraits>;
 class EmbedderConfigBuilder {
  public:
   enum class InitializationPreference {
-    kInitialize,
+    kSnapshotsInitialize,
+    kAOTDataInitialize,
     kMultiAOTInitialize,
     kNoInitialize,
   };
 
   EmbedderConfigBuilder(EmbedderTestContext& context,
                         InitializationPreference preference =
-                            InitializationPreference::kInitialize);
+                            InitializationPreference::kSnapshotsInitialize);
 
   ~EmbedderConfigBuilder();
 

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -28,18 +28,27 @@ struct UniqueEngineTraits {
 
 using UniqueEngine = fml::UniqueObject<FlutterEngine, UniqueEngineTraits>;
 
+struct AOTDataDeleter {
+  void operator()(FlutterEngineAOTData aot_data) {
+    if (aot_data) {
+      FlutterEngineCollectAOTData(aot_data);
+    }
+  }
+};
+
+using UniqueAOTData = std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter>;
+
 class EmbedderConfigBuilder {
  public:
   enum class InitializationPreference {
-    kSnapshotsInitialize,
-    kElfInitialize,
-    kSnapshotsAndElfInitialize,
+    kInitialize,
+    kMultiAOTInitialize,
     kNoInitialize,
   };
 
   EmbedderConfigBuilder(EmbedderTestContext& context,
                         InitializationPreference preference =
-                            InitializationPreference::kSnapshotsInitialize);
+                            InitializationPreference::kInitialize);
 
   ~EmbedderConfigBuilder();
 
@@ -88,6 +97,7 @@ class EmbedderConfigBuilder {
   FlutterCustomTaskRunners custom_task_runners_ = {};
   FlutterCompositor compositor_ = {};
   std::vector<std::string> command_line_arguments_;
+  UniqueAOTData aot_data_;
 
   UniqueEngine SetupEngine(bool run) const;
 

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -53,7 +53,7 @@ class EmbedderConfigBuilder {
 
   void SetSnapshots();
 
-  void SetAotDataElf();
+  void SetAOTDataElf();
 
   void SetIsolateCreateCallbackHook();
 

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -28,6 +28,16 @@ using SemanticsNodeCallback = std::function<void(const FlutterSemanticsNode*)>;
 using SemanticsActionCallback =
     std::function<void(const FlutterSemanticsCustomAction*)>;
 
+struct AOTDataDeleter {
+  void operator()(FlutterEngineAOTData aot_data) {
+    if (aot_data) {
+      FlutterEngineCollectAOTData(aot_data);
+    }
+  }
+};
+
+using UniqueAOTData = std::unique_ptr<_FlutterEngineAOTData, AOTDataDeleter>;
+
 class EmbedderTestContext {
  public:
   EmbedderTestContext(std::string assets_path = "");
@@ -43,6 +53,8 @@ class EmbedderTestContext {
   const fml::Mapping* GetIsolateSnapshotData() const;
 
   const fml::Mapping* GetIsolateSnapshotInstructions() const;
+
+  FlutterEngineAOTData GetAOTData() const;
 
   void SetRootSurfaceTransformation(SkMatrix matrix);
 
@@ -79,6 +91,7 @@ class EmbedderTestContext {
   std::unique_ptr<fml::Mapping> vm_snapshot_instructions_;
   std::unique_ptr<fml::Mapping> isolate_snapshot_data_;
   std::unique_ptr<fml::Mapping> isolate_snapshot_instructions_;
+  UniqueAOTData aot_data_;
   std::vector<fml::closure> isolate_create_callbacks_;
   std::shared_ptr<TestDartNativeResolver> native_resolver_;
   SemanticsNodeCallback update_semantics_node_callback_;
@@ -100,6 +113,8 @@ class EmbedderTestContext {
   GetUpdateSemanticsCustomActionCallbackHook();
 
   void SetupAOTMappingsIfNecessary();
+
+  void SetupAOTDataIfNecessary();
 
   void SetupCompositor();
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4235,6 +4235,10 @@ TEST_F(EmbedderTest, InvalidAOTDataSourcesMustReturnError) {
 }
 
 TEST_F(EmbedderTest, MustNotRunWithMultipleAotSources) {
+  if (!DartVM::IsRunningPrecompiledCode()) {
+    GTEST_SKIP();
+    return;
+  }
   auto& context = GetEmbedderContext();
 
   EmbedderConfigBuilder builder(
@@ -4247,6 +4251,10 @@ TEST_F(EmbedderTest, MustNotRunWithMultipleAotSources) {
 }
 
 TEST_F(EmbedderTest, CanLaunchAndShutdownWithValidElfSource) {
+  if (!DartVM::IsRunningPrecompiledCode()) {
+    GTEST_SKIP();
+    return;
+  }
   auto& context = GetEmbedderContext();
 
   fml::AutoResetWaitableEvent latch;

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4301,7 +4301,9 @@ TEST_F(EmbedderTest, CanLaunchAndShutdownWithAValidElfSource) {
   fml::AutoResetWaitableEvent latch;
   context.AddIsolateCreateCallback([&latch]() { latch.Signal(); });
 
-  EmbedderConfigBuilder builder(context);
+  EmbedderConfigBuilder builder(
+      context,
+      EmbedderConfigBuilder::InitializationPreference::kAOTDataInitialize);
 
   builder.SetSoftwareRendererConfig();
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4241,11 +4241,11 @@ TEST_F(EmbedderTest, InvalidAOTDataSourcesMustReturnError) {
   ASSERT_EQ(data_in.elf_path, "");
   ASSERT_EQ(data_out, nullptr);
 
-  // Could not read ELF file.
-  data_in.elf_path = "/dev/null";
+  // Could not find VM snapshot data.
+  data_in.elf_path = "/bin/true";
   ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);
   ASSERT_EQ(data_in.type, kFlutterEngineAOTDataSourceTypeElfPath);
-  ASSERT_EQ(data_in.elf_path, "/dev/null");
+  ASSERT_EQ(data_in.elf_path, "/bin/true");
   ASSERT_EQ(data_out, nullptr);
 }
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4212,26 +4212,22 @@ TEST_F(EmbedderTest, InvalidAOTDataSourcesMustReturnError) {
   FlutterEngineAOTData data_out;
 
   // Invalid FlutterEngineAOTDataSourceType type specified.
-  ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out),
-            kInvalidArguments);
+  ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);
 
   data_in.type = kFlutterEngineAOTDataSourceTypeElfPath;
 
   // Invalid ELF path specified.
-  ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out),
-            kInvalidArguments);
+  ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);
 
   data_in.elf_path = "";
 
   // Invalid ELF path specified.
-  ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out),
-            kInvalidArguments);
+  ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);
 
   data_in.elf_path = "/dev/null";
 
   // Could not read ELF file.
-  ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out),
-            kInvalidArguments);
+  ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);
 }
 
 TEST_F(EmbedderTest, MustNotRunWithMultipleAotSources) {
@@ -4242,10 +4238,11 @@ TEST_F(EmbedderTest, MustNotRunWithMultipleAotSources) {
   auto& context = GetEmbedderContext();
 
   EmbedderConfigBuilder builder(
-      context, EmbedderConfigBuilder::InitializationPreference::kSnapshotsAndElfInitialize);
-  
+      context, EmbedderConfigBuilder::InitializationPreference::
+                   kSnapshotsAndElfInitialize);
+
   builder.SetSoftwareRendererConfig();
-  
+
   auto engine = builder.LaunchEngine();
   ASSERT_FALSE(engine.is_valid());
 }

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4223,6 +4223,7 @@ TEST_F(EmbedderTest, InvalidAOTDataSourcesMustReturnError) {
   ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, nullptr), kInvalidArguments);
 
   // Invalid FlutterEngineAOTDataSourceType type specified.
+  data_in.type = FlutterEngineAOTDataSourceType(-1);
   ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);
   ASSERT_EQ(data_out, nullptr);
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4215,6 +4215,7 @@ TEST_F(EmbedderTest, InvalidAOTDataSourcesMustReturnError) {
   ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);
 
   data_in.type = kFlutterEngineAOTDataSourceTypeElfPath;
+  data_in.elf_path = nullptr;
 
   // Invalid ELF path specified.
   ASSERT_EQ(FlutterEngineCreateAOTData(&data_in, &data_out), kInvalidArguments);

--- a/testing/elf_loader.cc
+++ b/testing/elf_loader.cc
@@ -12,8 +12,6 @@
 namespace flutter {
 namespace testing {
 
-static constexpr const char* kAOTAppELFFileName = "app_elf_snapshot.so";
-
 ELFAOTSymbols LoadELFSymbolFromFixturesIfNeccessary() {
   if (!DartVM::IsRunningPrecompiledCode()) {
     return {};

--- a/testing/elf_loader.h
+++ b/testing/elf_loader.h
@@ -14,6 +14,8 @@
 namespace flutter {
 namespace testing {
 
+static constexpr const char* kAOTAppELFFileName = "app_elf_snapshot.so";
+
 struct LoadedELFDeleter {
   void operator()(Dart_LoadedElf* elf) { ::Dart_UnloadELF(elf); }
 };

--- a/testing/elf_loader.h
+++ b/testing/elf_loader.h
@@ -14,7 +14,7 @@
 namespace flutter {
 namespace testing {
 
-static constexpr const char* kAOTAppELFFileName = "app_elf_snapshot.so";
+inline constexpr const char* kAOTAppELFFileName = "app_elf_snapshot.so";
 
 struct LoadedELFDeleter {
   void operator()(Dart_LoadedElf* elf) { ::Dart_UnloadELF(elf); }


### PR DESCRIPTION
Added a new `FlutterEngineAOTData` argument to `FlutterProjectArgs`. Embedders can instantiate and destroy this object via the new `FlutterEngineCreateAOTData` and `FlutterEngineCollectAOTData` methods provided.

If an embedder provides more than one source of AOT data to `FlutterEngineInitialize` or `FlutterEngineRun` (e.g. snapshots as well as `FlutterEngineAOTData`), the engine will error out.

Resolves: https://github.com/flutter/flutter/issues/50778