### PR TITLE
[iOS platform view] fix active_composition_order_ never cleared

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -563,7 +563,6 @@ bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
   // If a layer was allocated in the previous frame, but it's not used in the current frame,
   // then it can be removed from the scene.
   RemoveUnusedLayers();
-
   // Organize the layers by their z indexes.
   BringLayersIntoView(platform_view_layers);
   // Mark all layers as available, so they can be used in the next frame.

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -563,6 +563,7 @@ bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
   // If a layer was allocated in the previous frame, but it's not used in the current frame,
   // then it can be removed from the scene.
   RemoveUnusedLayers();
+
   // Organize the layers by their z indexes.
   BringLayersIntoView(platform_view_layers);
   // Mark all layers as available, so they can be used in the next frame.
@@ -576,6 +577,7 @@ bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
 void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
   UIView* flutter_view = flutter_view_.get();
   auto zIndex = 0;
+  active_composition_order_.clear();
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t platform_view_id = composition_order_[i];
     std::vector<std::shared_ptr<FlutterPlatformViewLayer>> layers = layer_map[platform_view_id];

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -576,6 +576,7 @@ bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
 void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
   UIView* flutter_view = flutter_view_.get();
   auto zIndex = 0;
+  // Clear the `active_composition_order_`, which will be populated down below.
   active_composition_order_.clear();
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t platform_view_id = composition_order_[i];


### PR DESCRIPTION
The `active_composition_order_.clear();` was removed accidentally in a previous PR. https://github.com/flutter/engine/pull/17049/
This PR brings the code back.

I'm not sure how to test this, any suggestion would be appreciated!