### PR TITLE
gpu_metal_surface `submitframe` return false when canvas is null

### DIFF
--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -80,6 +80,10 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetal::AcquireFrame(const SkISize& frame
 
   auto submit_callback = [this](const SurfaceFrame& surface_frame, SkCanvas* canvas) -> bool {
     TRACE_EVENT0("flutter", "GPUSurfaceMetal::Submit");
+    if (canvas == nullptr) {
+      return false;
+    }
+
     canvas->flush();
 
     if (next_drawable_ == nullptr) {

--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -81,6 +81,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetal::AcquireFrame(const SkISize& frame
   auto submit_callback = [this](const SurfaceFrame& surface_frame, SkCanvas* canvas) -> bool {
     TRACE_EVENT0("flutter", "GPUSurfaceMetal::Submit");
     if (canvas == nullptr) {
+      FML_DLOG(ERROR) << "Canvas not available.";
       return false;
     }
 


### PR DESCRIPTION
At the frame when we dynamically change thread config, the canvas is null. Let submit frame return false directly when it happens.

I'm not sure how to test this, any suggestion would be appreciated!