### PR TITLE
Run integration tests on luci, use cipd package for Chrome

### DIFF
--- a/lib/web_ui/dev/browser_lock.yaml
+++ b/lib/web_ui/dev/browser_lock.yaml
@@ -1,7 +1,7 @@
 chrome:
   # It seems Chrome can't always release from the same build for all operating
   # systems, so we specify per-OS build number.
-  Linux: 753189
+  Linux: 741412
   Mac: 735194
   Win: 735105
 firefox:

--- a/lib/web_ui/dev/browser_lock.yaml
+++ b/lib/web_ui/dev/browser_lock.yaml
@@ -1,6 +1,8 @@
 chrome:
   # It seems Chrome can't always release from the same build for all operating
   # systems, so we specify per-OS build number.
+  # Note: 741412 binary is for Chrome Version 82. Driver for Chrome version 83
+  # is not working with chrome.binary option.
   Linux: 741412
   Mac: 735194
   Win: 735105

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -12,7 +12,6 @@ import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
 import 'common.dart';
-import 'utils.dart';
 import 'environment.dart';
 import 'exceptions.dart';
 
@@ -166,17 +165,6 @@ class ChromeInstaller {
   final io.Directory versionDir;
 
   bool get isInstalled {
-    if (versionDir.existsSync()) {
-      print('version dir exits: ${versionDir.path.toString()}');
-      final String chromeexecutable =
-          PlatformBinding.instance.getChromeExecutablePath(versionDir);
-      print('chromeexecutable dir : ${chromeexecutable}');
-      io.File chrome = io.File(chromeexecutable);
-      if (chrome.existsSync()) {
-        print('chrome found');
-      }
-    }
-
     return versionDir.existsSync();
   }
 
@@ -205,7 +193,6 @@ class ChromeInstaller {
 
     versionDir.createSync(recursive: true);
     final String url = PlatformBinding.instance.getChromeDownloadUrl(version);
-    print('urlchromedownload: $url');
     final StreamedResponse download = await client.send(Request(
       'GET',
       Uri.parse(url),
@@ -276,7 +263,8 @@ String chromeExecutableForLUCI() {
   final ChromeInstaller chromeInstaller = ChromeInstaller(version: buildNumber);
   if (chromeInstaller.isInstalled) {
     print(
-        'Found exabutable in LUCI: ${chromeInstaller.getInstallation().executable}');
+        'INFO: Found chrome executable for LUCI: '
+        '${chromeInstaller.getInstallation().executable}');
     return chromeInstaller.getInstallation().executable;
   } else {
     throw StateError(

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -260,7 +260,7 @@ Future<String> queryChromeDriverVersion() async {
 /// We are using CIPD packages in LUCI. The pinned chrome version from the
 /// `browser_lock.yaml` file will already be installed in the LUCI bot.
 /// Verify if Chrome is installed and use it for the integration tests.
-String chromeExecutableForLUCI() {
+String preinstalledChromeExecutable() {
   // Note that build number and major version is different for Chrome.
   // For example for a build number `753189`, major version is 83.
   final String buildNumber = ChromeArgParser.instance.pinnedChromeBuildNumber;
@@ -277,9 +277,9 @@ String chromeExecutableForLUCI() {
 
 Future<int> _querySystemChromeMajorVersion() async {
   String chromeExecutable = '';
-  // LUCI used the Chrome from CIPD packages.
+  // LUCI uses the Chrome from CIPD packages.
   if (isLuci) {
-    chromeExecutable = chromeExecutableForLUCI();
+    chromeExecutable = preinstalledChromeExecutable();
   } else if (io.Platform.isLinux) {
     chromeExecutable = 'google-chrome';
   } else if (io.Platform.isMacOS) {

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -162,6 +162,16 @@ class ChromeInstaller {
   final io.Directory versionDir;
 
   bool get isInstalled {
+    if (versionDir.existsSync()) {
+      print('version dir exits: ${versionDir.path.toString()}');
+      final String chromeexecutable = PlatformBinding.instance.getChromeExecutablePath(versionDir);
+      print('chromeexecutable dir : ${chromeexecutable}');
+      io.File chrome = io.File(chromeexecutable);
+      if(chrome.existsSync()) {
+        print('chrome found');
+      }
+    }
+
     return versionDir.existsSync();
   }
 
@@ -178,11 +188,18 @@ class ChromeInstaller {
 
   Future<void> install() async {
     if (versionDir.existsSync()) {
-      versionDir.deleteSync(recursive: true);
+      print('version dir exits: ${versionDir.path.toString()}'); 
+      final String chromeexecutable = PlatformBinding.instance.getChromeExecutablePath(versionDir); 
+      print('chromeexecutable dir : ${chromeexecutable}'); 
+      io.File chrome = io.File(chromeexecutable); 
+      if(chrome.existsSync()) { 
+        print('chrome found'); 
+      }
     }
 
     versionDir.createSync(recursive: true);
     final String url = PlatformBinding.instance.getChromeDownloadUrl(version);
+    print('urlchromedownload: $url');
     final StreamedResponse download = await client.send(Request(
       'GET',
       Uri.parse(url),

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -279,7 +279,7 @@ String chromeExecutableForLUCI() {
         'Found exabutable in LUCI: ${chromeInstaller.getInstallation().executable}');
     return chromeInstaller.getInstallation().executable;
   } else {
-    throw BrowserInstallerException(
+    throw StateError(
         'Failed to locate pinned Chrome build: $buildNumber on LUCI.');
   }
 }

--- a/lib/web_ui/dev/driver_version.yaml
+++ b/lib/web_ui/dev/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  83: '83.0.4103.39'
   81: '81.0.4044.69'
   80: '80.0.3987.106'
   79: '79.0.3945.36'

--- a/lib/web_ui/dev/driver_version.yaml
+++ b/lib/web_ui/dev/driver_version.yaml
@@ -2,7 +2,6 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
-  83: '83.0.4103.39'
   81: '81.0.4044.69'
   80: '80.0.3987.106'
   79: '79.0.3945.36'

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -96,15 +96,15 @@ class IntegrationTestsManager {
         useSystemFlutter: _useSystemFlutter);
   }
 
-  /// Start the Chrome Driver on LUCI/
+  /// Start the Chrome Driver on LUCI.
   ///
   /// Driver should already exist on LUCI as a CIPD package. No need to install.
   ///
   /// Throw an error if directory does not exists.
   void runDriverOnLUCI() {
-    print('INFO: Checking driver on path: ${_browserDriverDir.path}');
     if (!_browserDriverDir.existsSync()) {
-      throw StateError('Failed to locate Chrome driver on LUCI.');
+      throw StateError('Failed to locate Chrome driver on LUCI on path:'
+          '${_browserDriverDir.path}');
     }
     print('INFO: Starting the driver on path: ${_browserDriverDir.path}');
     _runDriver(_browserDriverDir.path);
@@ -190,7 +190,7 @@ class IntegrationTestsManager {
         if (!blackList.contains(basename)) {
           e2eTestsToRun.add(basename);
         } else {
-          print('Test $basename is skipped since it is blacklisted for '
+          print('INFO: Test $basename is skipped since it is blacklisted for '
               '${getBlackListMapKey(_browser)}');
         }
       }

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -235,9 +235,13 @@ class IntegrationTestsManager {
     );
 
     if (exitCode != 0) {
-      final String statementToRun = 'flutter drive '
+      String statementToRun = 'flutter drive '
           '--target=test_driver/${testName} -d web-server --profile '
           '--browser-name=$_browser --local-engine=host_debug_unopt';
+      if (isLuci) {
+        statementToRun = '$statementToRun --chrome-binary='
+            '${preinstalledChromeExecutable()}';
+      }
       io.stderr
           .writeln('ERROR: Failed to run test. Exited with exit code $exitCode'
               '. Statement to run $testName locally use the following '

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -9,6 +9,7 @@ import 'package:web_driver_installer/chrome_driver_installer.dart';
 import 'chrome_installer.dart';
 import 'environment.dart';
 import 'exceptions.dart';
+import 'common.dart';
 import 'utils.dart';
 
 class IntegrationTestsManager {
@@ -200,6 +201,8 @@ class IntegrationTestsManager {
         'web-server',
         '--profile',
         '--browser-name=$_browser',
+        if (isLuci) '--chrome-binary=${chromeExecutableForLUCI()}',
+        if (isLuci) '--no-headless',
         '--local-engine=host_debug_unopt',
       ],
       workingDirectory: directory.path,

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -21,7 +21,8 @@ class IntegrationTestsManager {
   /// It usually changes with each the browser version changes.
   /// A better solution would be installing the browser and the driver at the
   /// same time.
-  // TODO(nurhan): https://github.com/flutter/flutter/issues/53179.
+  // TODO(nurhan): https://github.com/flutter/flutter/issues/53179. Partly
+  // solved. Remaining local integration tests using the locked Chrome version.
   final io.Directory _browserDriverDir;
 
   /// This is the parent directory for all drivers.

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -360,6 +360,16 @@ class IntegrationTestsManager {
 String getBlackListMapKey(String browser) =>
     '${browser}-${io.Platform.operatingSystem}';
 
+/// Tests that should be skipped run for a specific platform-browser
+/// combination.
+///
+/// These tests might be failing or might have been implemented for a specific
+/// configuration.
+///
+/// For example a mobile browser only tests will be added to blacklist for
+/// `chrome-linux`, `safari-macos` and `chrome-macos`.
+///
+/// Note that integration tests are only running on chrome for now.
 const Map<String, List<String>> blackListsMap = <String, List<String>>{
   'chrome-linux': [
     'target_platform_ios_e2e.dart',

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -75,7 +75,7 @@ class IntegrationTestsManager {
   Future<void> _cloneFlutterRepo() async {
     // Delete directory if exists.
     if (environment.engineDartToolDir.existsSync()) {
-      environment.engineDartToolDir.deleteSync();
+      environment.engineDartToolDir.deleteSync(recursive: true);
     }
     environment.engineDartToolDir.createSync();
 

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -34,7 +34,10 @@ class IntegrationTestsManager {
 
   IntegrationTestsManager(this._browser, this._useSystemFlutter)
       : this._browserDriverDir = io.Directory(pathlib.join(
-            environment.webUiDartToolDir.path, 'drivers', _browser)),
+            environment.webUiDartToolDir.path,
+            'drivers',
+            _browser,
+            '${_browser}driver-${io.Platform.operatingSystem.toString()}')),
         this._drivers = io.Directory(
             pathlib.join(environment.webUiDartToolDir.path, 'drivers'));
 

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -202,7 +202,7 @@ class IntegrationTestsManager {
         '--profile',
         '--browser-name=$_browser',
         if (isLuci) '--chrome-binary=${chromeExecutableForLUCI()}',
-        if (isLuci) '--no-headless',
+        if (isLuci) '--headless',
         '--local-engine=host_debug_unopt',
       ],
       workingDirectory: directory.path,

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -147,9 +147,9 @@ class TestCommand extends Command<bool> with ArgUtils {
 
   Future<bool> runIntegrationTests() async {
     // TODO(nurhan): https://github.com/flutter/flutter/issues/52983
-    if (io.Platform.environment['LUCI_CONTEXT'] != null) {
-      return true;
-    }
+    //if (io.Platform.environment['LUCI_CONTEXT'] != null) {
+    //  return true;
+    //}
 
     return IntegrationTestsManager(browser, useSystemFlutter).runTests();
   }

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -131,8 +131,8 @@ class TestCommand extends Command<bool> with ArgUtils {
         // TODO(nurhan): https://github.com/flutter/flutter/issues/53322
         // TODO(nurhan): Expand browser matrix for felt integration tests.
         if (runAllTests && isChrome) {
-          bool integrationTestResult = await runIntegrationTests();
           bool unitTestResult = await runUnitTests();
+          bool integrationTestResult = await runIntegrationTests();
           if (integrationTestResult != unitTestResult) {
             print('Tests run. Integration tests passed: $integrationTestResult '
                 'unit tests passed: $unitTestResult');

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -146,11 +146,6 @@ class TestCommand extends Command<bool> with ArgUtils {
   }
 
   Future<bool> runIntegrationTests() async {
-    // TODO(nurhan): https://github.com/flutter/flutter/issues/52983
-    //if (io.Platform.environment['LUCI_CONTEXT'] != null) {
-    //  return true;
-    //}
-
     return IntegrationTestsManager(browser, useSystemFlutter).runTests();
   }
 


### PR DESCRIPTION
(1) Run Integration tests on LUCI
(2) Using Chrome from CIPD package both for Integration and Unit tests.
(3) Adds blacklist for failing tests and tests should not be run on Linux.

Related recipe change(MERGED): https://flutter-review.googlesource.com/c/recipes/+/2700

Fixes: https://github.com/flutter/flutter/issues/52983
Contributes to: https://github.com/flutter/flutter/issues/53179

This PR combined with the recipe change:https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/nurhan_google.com/258f50b81fc7d4e704effa8dadc1c8ae94637b402726cbbf03a83d205e397376/+/annotations?server=chromium-swarm.appspot.com