### PR TITLE
Add fullscreen padding workarounds to v2 android embedding

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -6,6 +6,7 @@ package io.flutter.embedding.android;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Insets;
@@ -25,6 +26,7 @@ import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.autofill.AutofillValue;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
+import android.view.Surface;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -381,6 +383,68 @@ public class FlutterView extends FrameLayout {
     sendViewportMetricsToFlutter();
   }
 
+  // TODO(garyq): Add support for notch cutout API
+  // Decide if we want to zero the padding of the sides. When in Landscape orientation,
+  // android may decide to place the software navigation bars on the side. When the nav
+  // bar is hidden, the reported insets should be removed to prevent extra useless space
+  // on the sides.
+  enum ZeroSides {
+    NONE,
+    LEFT,
+    RIGHT,
+    BOTH
+  }
+
+  ZeroSides calculateShouldZeroSides() {
+    // We get both orientation and rotation because rotation is all 4
+    // rotations relative to default rotation while orientation is portrait
+    // or landscape. By combining both, we can obtain a more precise measure
+    // of the rotation.
+    Activity activity = (Activity) getContext();
+    int orientation = activity.getResources().getConfiguration().orientation;
+    int rotation = activity.getWindowManager().getDefaultDisplay().getRotation();
+
+    if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+      if (rotation == Surface.ROTATION_90) {
+        return ZeroSides.RIGHT;
+      } else if (rotation == Surface.ROTATION_270) {
+        // In android API >= 23, the nav bar always appears on the "bottom" (USB) side.
+        return Build.VERSION.SDK_INT >= 23 ? ZeroSides.LEFT : ZeroSides.RIGHT;
+      }
+      // Ambiguous orientation due to landscape left/right default. Zero both sides.
+      else if (rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180) {
+        return ZeroSides.BOTH;
+      }
+    }
+    // Square orientation deprecated in API 16, we will not check for it and return false
+    // to be safe and not remove any unique padding for the devices that do use it.
+    return ZeroSides.NONE;
+  }
+
+  // TODO(garyq): Use clean ways to detect keyboard instead of heuristics if possible
+  // TODO(garyq): The keyboard detection may interact strangely with
+  //   https://github.com/flutter/flutter/issues/22061
+
+  // Uses inset heights and screen heights as a heuristic to determine if the insets should
+  // be padded. When the on-screen keyboard is detected, we want to include the full inset
+  // but when the inset is just the hidden nav bar, we want to provide a zero inset so the space
+  // can be used.
+  @TargetApi(20)
+  @RequiresApi(20)
+  int calculateBottomKeyboardInset(WindowInsets insets) {
+    int screenHeight = getRootView().getHeight();
+    // Magic number due to this being a heuristic. This should be replaced, but we have not
+    // found a clean way to do it yet (Sept. 2018)
+    final double keyboardHeightRatioHeuristic = 0.18;
+    if (insets.getSystemWindowInsetBottom() < screenHeight * keyboardHeightRatioHeuristic) {
+      // Is not a keyboard, so return zero as inset.
+      return 0;
+    } else {
+      // Is a keyboard, so return the full inset.
+      return insets.getSystemWindowInsetBottom();
+    }
+  }
+
   /**
    * Invoked when Android's desired window insets change, i.e., padding.
    *
@@ -401,18 +465,40 @@ public class FlutterView extends FrameLayout {
   @NonNull
   public final WindowInsets onApplyWindowInsets(@NonNull WindowInsets insets) {
     boolean statusBarHidden = (SYSTEM_UI_FLAG_FULLSCREEN & getWindowSystemUiVisibility()) != 0;
+    boolean navigationBarHidden =
+        (SYSTEM_UI_FLAG_HIDE_NAVIGATION & getWindowSystemUiVisibility()) != 0;
+    // We zero the left and/or right sides to prevent the padding the
+    // navigation bar would have caused.
+    ZeroSides zeroSides = ZeroSides.NONE;
+    if (navigationBarHidden) {
+      zeroSides = calculateShouldZeroSides();
+    }
+
     WindowInsets newInsets = super.onApplyWindowInsets(insets);
+
 
     // Status bar (top) and left/right system insets should partially obscure the content (padding).
     viewportMetrics.paddingTop = statusBarHidden ? 0 : insets.getSystemWindowInsetTop();
-    viewportMetrics.paddingRight = insets.getSystemWindowInsetRight();
+    // viewportMetrics.paddingRight = insets.getSystemWindowInsetRight();
+    viewportMetrics.paddingRight =
+        zeroSides == ZeroSides.RIGHT || zeroSides == ZeroSides.BOTH
+            ? 0
+            : insets.getSystemWindowInsetRight();
     viewportMetrics.paddingBottom = 0;
-    viewportMetrics.paddingLeft = insets.getSystemWindowInsetLeft();
+    // viewportMetrics.paddingLeft = insets.getSystemWindowInsetLeft();
+    viewportMetrics.paddingLeft =
+        zeroSides == ZeroSides.LEFT || zeroSides == ZeroSides.BOTH
+            ? 0
+            : insets.getSystemWindowInsetLeft();
 
     // Bottom system inset (keyboard) should adjust scrollable bottom edge (inset).
     viewportMetrics.viewInsetTop = 0;
     viewportMetrics.viewInsetRight = 0;
-    viewportMetrics.viewInsetBottom = insets.getSystemWindowInsetBottom();
+    // viewportMetrics.viewInsetBottom = insets.getSystemWindowInsetBottom();
+    viewportMetrics.viewInsetBottom =
+        navigationBarHidden
+            ? calculateBottomKeyboardInset(insets)
+            : insets.getSystemWindowInsetBottom();
     viewportMetrics.viewInsetLeft = 0;
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -402,7 +402,10 @@ public class FlutterView extends FrameLayout {
     // of the rotation.
     Context context = getContext();
     int orientation = context.getResources().getConfiguration().orientation;
-    int rotation = ((WindowManager)context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
+    int rotation =
+        ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE))
+            .getDefaultDisplay()
+            .getRotation();
 
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
       if (rotation == Surface.ROTATION_90) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -431,7 +431,7 @@ public class FlutterView extends FrameLayout {
   // can be used.
   @TargetApi(20)
   @RequiresApi(20)
-  private int calculateBottomKeyboardInset(WindowInsets insets) {
+  private int guessBottomKeyboardInset(WindowInsets insets) {
     int screenHeight = getRootView().getHeight();
     // Magic number due to this being a heuristic. This should be replaced, but we have not
     // found a clean way to do it yet (Sept. 2018)
@@ -493,7 +493,7 @@ public class FlutterView extends FrameLayout {
     viewportMetrics.viewInsetRight = 0;
     viewportMetrics.viewInsetBottom =
         navigationBarHidden
-            ? calculateBottomKeyboardInset(insets)
+            ? guessBottomKeyboardInset(insets)
             : insets.getSystemWindowInsetBottom();
     viewportMetrics.viewInsetLeft = 0;
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -479,13 +479,11 @@ public class FlutterView extends FrameLayout {
 
     // Status bar (top) and left/right system insets should partially obscure the content (padding).
     viewportMetrics.paddingTop = statusBarHidden ? 0 : insets.getSystemWindowInsetTop();
-    // viewportMetrics.paddingRight = insets.getSystemWindowInsetRight();
     viewportMetrics.paddingRight =
         zeroSides == ZeroSides.RIGHT || zeroSides == ZeroSides.BOTH
             ? 0
             : insets.getSystemWindowInsetRight();
     viewportMetrics.paddingBottom = 0;
-    // viewportMetrics.paddingLeft = insets.getSystemWindowInsetLeft();
     viewportMetrics.paddingLeft =
         zeroSides == ZeroSides.LEFT || zeroSides == ZeroSides.BOTH
             ? 0
@@ -494,7 +492,6 @@ public class FlutterView extends FrameLayout {
     // Bottom system inset (keyboard) should adjust scrollable bottom edge (inset).
     viewportMetrics.viewInsetTop = 0;
     viewportMetrics.viewInsetRight = 0;
-    // viewportMetrics.viewInsetBottom = insets.getSystemWindowInsetBottom();
     viewportMetrics.viewInsetBottom =
         navigationBarHidden
             ? calculateBottomKeyboardInset(insets)

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -22,6 +22,7 @@ import android.view.Surface;
 import android.view.View;
 import android.view.ViewStructure;
 import android.view.WindowInsets;
+import android.view.WindowManager;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.autofill.AutofillValue;
@@ -400,9 +401,9 @@ public class FlutterView extends FrameLayout {
     // rotations relative to default rotation while orientation is portrait
     // or landscape. By combining both, we can obtain a more precise measure
     // of the rotation.
-    Activity activity = (Activity) getContext();
-    int orientation = activity.getResources().getConfiguration().orientation;
-    int rotation = activity.getWindowManager().getDefaultDisplay().getRotation();
+    Context context = getContext();
+    int orientation = context.getResources().getConfiguration().orientation;
+    int rotation = ((WindowManager)context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
 
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
       if (rotation == Surface.ROTATION_90) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -18,6 +18,7 @@ import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
+import android.view.Surface;
 import android.view.View;
 import android.view.ViewStructure;
 import android.view.WindowInsets;
@@ -26,7 +27,6 @@ import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.autofill.AutofillValue;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
-import android.view.Surface;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -464,6 +464,8 @@ public class FlutterView extends FrameLayout {
   @SuppressLint({"InlinedApi", "NewApi"})
   @NonNull
   public final WindowInsets onApplyWindowInsets(@NonNull WindowInsets insets) {
+    WindowInsets newInsets = super.onApplyWindowInsets(insets);
+
     boolean statusBarHidden = (SYSTEM_UI_FLAG_FULLSCREEN & getWindowSystemUiVisibility()) != 0;
     boolean navigationBarHidden =
         (SYSTEM_UI_FLAG_HIDE_NAVIGATION & getWindowSystemUiVisibility()) != 0;
@@ -473,9 +475,6 @@ public class FlutterView extends FrameLayout {
     if (navigationBarHidden) {
       zeroSides = calculateShouldZeroSides();
     }
-
-    WindowInsets newInsets = super.onApplyWindowInsets(insets);
-
 
     // Status bar (top) and left/right system insets should partially obscure the content (padding).
     viewportMetrics.paddingTop = statusBarHidden ? 0 : insets.getSystemWindowInsetTop();

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -388,14 +388,14 @@ public class FlutterView extends FrameLayout {
   // android may decide to place the software navigation bars on the side. When the nav
   // bar is hidden, the reported insets should be removed to prevent extra useless space
   // on the sides.
-  enum ZeroSides {
+  private enum ZeroSides {
     NONE,
     LEFT,
     RIGHT,
     BOTH
   }
 
-  ZeroSides calculateShouldZeroSides() {
+  private ZeroSides calculateShouldZeroSides() {
     // We get both orientation and rotation because rotation is all 4
     // rotations relative to default rotation while orientation is portrait
     // or landscape. By combining both, we can obtain a more precise measure
@@ -431,7 +431,7 @@ public class FlutterView extends FrameLayout {
   // can be used.
   @TargetApi(20)
   @RequiresApi(20)
-  int calculateBottomKeyboardInset(WindowInsets insets) {
+  private int calculateBottomKeyboardInset(WindowInsets insets) {
     int screenHeight = getRootView().getHeight();
     // Magic number due to this being a heuristic. This should be replaced, but we have not
     // found a clean way to do it yet (Sept. 2018)

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -383,7 +383,7 @@ public class FlutterView extends FrameLayout {
     sendViewportMetricsToFlutter();
   }
 
-  // TODO(garyq): Add support for notch cutout API
+  // TODO(garyq): Add support for notch cutout API: https://github.com/flutter/flutter/issues/56592
   // Decide if we want to zero the padding of the sides. When in Landscape orientation,
   // android may decide to place the software navigation bars on the side. When the nav
   // bar is hidden, the reported insets should be removed to prevent extra useless space

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -6,7 +6,6 @@ package io.flutter.embedding.android;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Insets;
@@ -422,7 +421,7 @@ public class FlutterView extends FrameLayout {
     return ZeroSides.NONE;
   }
 
-  // TODO(garyq): Use clean ways to detect keyboard instead of heuristics if possible
+  // TODO(garyq): Use new Android R getInsets API
   // TODO(garyq): The keyboard detection may interact strangely with
   //   https://github.com/flutter/flutter/issues/22061
 

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -29,8 +29,8 @@ import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewStructure;
-import android.view.WindowManager;
 import android.view.WindowInsets;
+import android.view.WindowManager;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.autofill.AutofillValue;
@@ -550,7 +550,10 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     // of the rotation.
     Context context = getContext();
     int orientation = context.getResources().getConfiguration().orientation;
-    int rotation = ((WindowManager)context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
+    int rotation =
+        ((WindowManager) context.getSystemService(Context.WINDOW_SERVICE))
+            .getDefaultDisplay()
+            .getRotation();
 
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
       if (rotation == Surface.ROTATION_90) {

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -535,14 +535,14 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
   // android may decide to place the software navigation bars on the side. When the nav
   // bar is hidden, the reported insets should be removed to prevent extra useless space
   // on the sides.
-  enum ZeroSides {
+  private enum ZeroSides {
     NONE,
     LEFT,
     RIGHT,
     BOTH
   }
 
-  ZeroSides calculateShouldZeroSides() {
+  private ZeroSides calculateShouldZeroSides() {
     // We get both orientation and rotation because rotation is all 4
     // rotations relative to default rotation while orientation is portrait
     // or landscape. By combining both, we can obtain a more precise measure
@@ -578,7 +578,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
   // can be used.
   @TargetApi(20)
   @RequiresApi(20)
-  int calculateBottomKeyboardInset(WindowInsets insets) {
+  private int calculateBottomKeyboardInset(WindowInsets insets) {
     int screenHeight = getRootView().getHeight();
     // Magic number due to this being a heuristic. This should be replaced, but we have not
     // found a clean way to do it yet (Sept. 2018)

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -578,7 +578,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
   // can be used.
   @TargetApi(20)
   @RequiresApi(20)
-  private int calculateBottomKeyboardInset(WindowInsets insets) {
+  private int guessBottomKeyboardInset(WindowInsets insets) {
     int screenHeight = getRootView().getHeight();
     // Magic number due to this being a heuristic. This should be replaced, but we have not
     // found a clean way to do it yet (Sept. 2018)
@@ -632,7 +632,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     // the navbar padding should always be provided.
     mMetrics.physicalViewInsetBottom =
         navigationBarHidden
-            ? calculateBottomKeyboardInset(insets)
+            ? guessBottomKeyboardInset(insets)
             : insets.getSystemWindowInsetBottom();
     mMetrics.physicalViewInsetLeft = 0;
 

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -569,7 +569,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     return ZeroSides.NONE;
   }
 
-  // TODO(garyq): Use clean ways to detect keyboard instead of heuristics if possible
+  // TODO(garyq): Use new Android R getInsets API
   // TODO(garyq): The keyboard detection may interact strangely with
   //   https://github.com/flutter/flutter/issues/22061
 

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -29,6 +29,7 @@ import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewStructure;
+import android.view.WindowManager;
 import android.view.WindowInsets;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeProvider;
@@ -547,9 +548,9 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     // rotations relative to default rotation while orientation is portrait
     // or landscape. By combining both, we can obtain a more precise measure
     // of the rotation.
-    Activity activity = (Activity) getContext();
-    int orientation = activity.getResources().getConfiguration().orientation;
-    int rotation = activity.getWindowManager().getDefaultDisplay().getRotation();
+    Context context = getContext();
+    int orientation = context.getResources().getConfiguration().orientation;
+    int rotation = ((WindowManager)context.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay().getRotation();
 
     if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
       if (rotation == Surface.ROTATION_90) {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -324,7 +324,7 @@ public class FlutterViewTest {
     // Padding bottom is always 0.
     assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
     assertEquals(100, viewportMetricsCaptor.getValue().paddingLeft);
-    // Right paddiong is zero because the rotation is 270deg
+    // Right padding is zero because the rotation is 270deg
     assertEquals(0, viewportMetricsCaptor.getValue().paddingRight);
   }
 
@@ -367,7 +367,7 @@ public class FlutterViewTest {
     assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
     // Padding bottom is always 0.
     assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
-    // Left paddiong is zero because the rotation is 270deg
+    // Left padding is zero because the rotation is 270deg
     assertEquals(0, viewportMetricsCaptor.getValue().paddingLeft);
     assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -387,12 +387,4 @@ public class FlutterViewTest {
   // production classes' view hierarchy.
   @Implements(ViewGroup.class)
   public static class ShadowFullscreenViewGroup extends ShadowFullscreenView {}
-
-  // @Implements(Display.class)
-  // public static class ShadowFlutterDisplay {
-  //   @Implementation
-  //   public int getRotation() {
-  //     return 90;
-  //   }
-  // }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -9,12 +9,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.annotation.TargetApi;
+import android.app.Activity;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.util.Log;
+import android.view.Display;
+import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
+import android.view.WindowManager;
+import android.hardware.display.DisplayManager;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.FlutterLoader;
@@ -36,6 +42,10 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowDisplay;
+import org.robolectric.Shadows;
+
+import java.io.*;
 
 // TODO(xster): we have 2 versions of robolectric Android shadows in
 // shell/platform/android/embedding_bundle/build.gradle. Remove the older
@@ -276,6 +286,62 @@ public class FlutterViewTest {
     assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
     assertEquals(100, viewportMetricsCaptor.getValue().paddingLeft);
     assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
+  }
+
+  @Test
+  public void systemInsetHandlesFullscreenNavbar() {
+    RuntimeEnvironment.setQualifiers("+land");
+    FlutterView flutterView = new FlutterView(RuntimeEnvironment.systemContext);
+    ShadowDisplay display = Shadows.shadowOf(((DisplayManager)RuntimeEnvironment.systemContext.getSystemService(Context.DISPLAY_SERVICE)).getDisplays()[0]);
+    display.setRotation(90);
+    assert(display.getDefaultDisplay().getRotation() == Surface.ROTATION_90);
+    assert(((DisplayManager)RuntimeEnvironment.systemContext.getSystemService(Context.DISPLAY_SERVICE)).getDisplays().length == 1);
+    assertEquals(0, flutterView.getSystemUiVisibility());
+
+    FlutterEngine flutterEngine =
+        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
+    when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
+
+    // When we attach a new FlutterView to the engine without any system insets, the viewport
+    // metrics
+    // default to 0.
+    flutterView.attachToFlutterEngine(flutterEngine);
+    ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
+        ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
+    verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
+    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+
+    // Then we simulate the system applying a window inset.
+    WindowInsets windowInsets = mock(WindowInsets.class);
+    when(windowInsets.getSystemWindowInsetTop()).thenReturn(100);
+    when(windowInsets.getSystemWindowInsetBottom()).thenReturn(100);
+    when(windowInsets.getSystemWindowInsetLeft()).thenReturn(100);
+    when(windowInsets.getSystemWindowInsetRight()).thenReturn(100);
+
+    flutterView.onApplyWindowInsets(windowInsets);
+
+    // Verify.
+    verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
+    // Top padding is reported as-is.
+    assertEquals(100, viewportMetricsCaptor.getValue().paddingTop);
+    // Padding bottom is always 0.
+    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
+    assertEquals(100, viewportMetricsCaptor.getValue().paddingLeft);
+    assertEquals(0, viewportMetricsCaptor.getValue().paddingRight);
+
+    display.setRotation(270);
+    flutterView.onApplyWindowInsets(windowInsets);
+
+    // Verify.
+    verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
+    // Top padding is reported as-is.
+    assertEquals(100, viewportMetricsCaptor.getValue().paddingTop);
+    // Padding bottom is always 0.
+    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
+    assertEquals(0, viewportMetricsCaptor.getValue().paddingLeft);
+    assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
+
   }
 
   /*

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -12,13 +12,10 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.view.Display;
-import android.view.Surface;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
 import android.view.WindowManager;
-import android.hardware.display.DisplayManager;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.FlutterLoader;
@@ -299,15 +296,13 @@ public class FlutterViewTest {
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
-
     FlutterEngine flutterEngine =
         spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
-    // When we attach a new FlutterView to the engine without any system insets, the viewport
-    // metrics
-    // default to 0.
+    // When we attach a new FlutterView to the engine without any system insets,
+    // the viewport metrics default to 0.
     flutterView.attachToFlutterEngine(flutterEngine);
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
@@ -348,15 +343,13 @@ public class FlutterViewTest {
         .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
-
     FlutterEngine flutterEngine =
         spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
-    // When we attach a new FlutterView to the engine without any system insets, the viewport
-    // metrics
-    // default to 0.
+    // When we attach a new FlutterView to the engine without any system insets,
+    // the viewport metrics default to 0.
     flutterView.attachToFlutterEngine(flutterEngine);
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -37,11 +37,11 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowDisplay;
-import org.robolectric.Shadows;
 
 // TODO(xster): we have 2 versions of robolectric Android shadows in
 // shell/platform/android/embedding_bundle/build.gradle. Remove the older
@@ -288,10 +288,15 @@ public class FlutterViewTest {
   public void systemInsetHandlesFullscreenNavbarRight() {
     RuntimeEnvironment.setQualifiers("+land");
     FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.systemContext));
-    ShadowDisplay display = Shadows.shadowOf(((WindowManager)RuntimeEnvironment.systemContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay());
+    ShadowDisplay display =
+        Shadows.shadowOf(
+            ((WindowManager)
+                    RuntimeEnvironment.systemContext.getSystemService(Context.WINDOW_SERVICE))
+                .getDefaultDisplay());
     display.setRotation(1);
     assertEquals(0, flutterView.getSystemUiVisibility());
-    when(flutterView.getWindowSystemUiVisibility()).thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+    when(flutterView.getWindowSystemUiVisibility())
+        .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
 
@@ -332,10 +337,15 @@ public class FlutterViewTest {
   public void systemInsetHandlesFullscreenNavbarLeft() {
     RuntimeEnvironment.setQualifiers("+land");
     FlutterView flutterView = spy(new FlutterView(RuntimeEnvironment.systemContext));
-    ShadowDisplay display = Shadows.shadowOf(((WindowManager)RuntimeEnvironment.systemContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay());
+    ShadowDisplay display =
+        Shadows.shadowOf(
+            ((WindowManager)
+                    RuntimeEnvironment.systemContext.getSystemService(Context.WINDOW_SERVICE))
+                .getDefaultDisplay());
     display.setRotation(3);
     assertEquals(0, flutterView.getSystemUiVisibility());
-    when(flutterView.getWindowSystemUiVisibility()).thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
+    when(flutterView.getWindowSystemUiVisibility())
+        .thenReturn(View.SYSTEM_UI_FLAG_FULLSCREEN | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
 
 


### PR DESCRIPTION
These workarounds are necessary to maintain the correct behavior for padding when fullscreen.

The v1 embedding had it, but the workarounds were not moved to the v2 embedding. This PR restores the workarounds to the v2 embedding to fix the regression.

Fixes https://github.com/flutter/flutter/issues/56449