### PR TITLE
Add new keyboard types and missing ios UITextContentType.newPassword

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -544,6 +544,8 @@ public class TextInputChannel {
   public enum TextInputType {
     TEXT("TextInputType.text"),
     DATETIME("TextInputType.datetime"),
+    NAME("TextInputType.name"),
+    POSTAL_ADDRESS("TextInputType.address"),
     NUMBER("TextInputType.number"),
     PHONE("TextInputType.phone"),
     MULTILINE("TextInputType.multiline"),

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -194,6 +194,10 @@ public class TextInputPlugin {
       textType |= InputType.TYPE_TEXT_VARIATION_URI;
     } else if (type.type == TextInputChannel.TextInputType.VISIBLE_PASSWORD) {
       textType |= InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
+    } else if (type.type == TextInputChannel.TextInputType.NAME) {
+      textType |= InputType.TYPE_TEXT_VARIATION_PERSON_NAME;
+    } else if (type.type == TextInputChannel.TextInputType.POSTAL_ADDRESS) {
+      textType |= InputType.TYPE_TEXT_VARIATION_POSTAL_ADDRESS;
     }
 
     if (obscureText) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -13,10 +13,16 @@ static const char _kTextAffinityUpstream[] = "TextAffinity.upstream";
 
 static UIKeyboardType ToUIKeyboardType(NSDictionary* type) {
   NSString* inputType = type[@"name"];
-  if ([inputType isEqualToString:@"TextInputType.text"])
+  if ([inputType isEqualToString:@"TextInputType.address"])
     return UIKeyboardTypeDefault;
+  if ([inputType isEqualToString:@"TextInputType.datetime"])
+    return UIKeyboardTypeNumbersAndPunctuation;
+  if ([inputType isEqualToString:@"TextInputType.emailAddress"])
+    return UIKeyboardTypeEmailAddress;
   if ([inputType isEqualToString:@"TextInputType.multiline"])
     return UIKeyboardTypeDefault;
+  if ([inputType isEqualToString:@"TextInputType.name"])
+    return UIKeyboardTypeNamePhonePad;
   if ([inputType isEqualToString:@"TextInputType.number"]) {
     if ([type[@"signed"] boolValue])
       return UIKeyboardTypeNumbersAndPunctuation;
@@ -26,8 +32,8 @@ static UIKeyboardType ToUIKeyboardType(NSDictionary* type) {
   }
   if ([inputType isEqualToString:@"TextInputType.phone"])
     return UIKeyboardTypePhonePad;
-  if ([inputType isEqualToString:@"TextInputType.emailAddress"])
-    return UIKeyboardTypeEmailAddress;
+  if ([inputType isEqualToString:@"TextInputType.text"])
+    return UIKeyboardTypeDefault;
   if ([inputType isEqualToString:@"TextInputType.url"])
     return UIKeyboardTypeURL;
   return UIKeyboardTypeDefault;
@@ -193,6 +199,10 @@ static UITextContentType ToUITextContentType(NSArray<NSString*>* hints) {
   if (@available(iOS 12.0, *)) {
     if ([hint isEqualToString:@"oneTimeCode"]) {
       return UITextContentTypeOneTimeCode;
+    }
+
+    if ([hint isEqualToString:@"newPassword"]) {
+      return UITextContentTypeNewPassword;
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/41508

`UIKeyboardTypeNamePhonePad` seems to be required in order to trigger name/address autofill.