### PR TITLE
Refactor GLFW embedding to support headless mode

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1154,9 +1154,12 @@ FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
 FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/vmo.h
 FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
 FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.h
+FILE: ../../../flutter/shell/platform/glfw/client_wrapper/flutter_engine.cc
+FILE: ../../../flutter/shell/platform/glfw/client_wrapper/flutter_engine_unittests.cc
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/flutter_window_controller_unittests.cc
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/flutter_window_unittests.cc
+FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/flutter_engine.h
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/plugin_registrar_glfw.h

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1160,9 +1160,13 @@ FILE: ../../../flutter/shell/platform/glfw/client_wrapper/flutter_window_unittes
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/plugin_registrar_glfw.h
+FILE: ../../../flutter/shell/platform/glfw/event_loop.cc
+FILE: ../../../flutter/shell/platform/glfw/event_loop.h
 FILE: ../../../flutter/shell/platform/glfw/flutter_glfw.cc
 FILE: ../../../flutter/shell/platform/glfw/glfw_event_loop.cc
 FILE: ../../../flutter/shell/platform/glfw/glfw_event_loop.h
+FILE: ../../../flutter/shell/platform/glfw/headless_event_loop.cc
+FILE: ../../../flutter/shell/platform/glfw/headless_event_loop.h
 FILE: ../../../flutter/shell/platform/glfw/key_event_handler.cc
 FILE: ../../../flutter/shell/platform/glfw/key_event_handler.h
 FILE: ../../../flutter/shell/platform/glfw/keyboard_hook_handler.h

--- a/shell/platform/glfw/BUILD.gn
+++ b/shell/platform/glfw/BUILD.gn
@@ -30,9 +30,13 @@ source_set("flutter_glfw_headers") {
 
 source_set("flutter_glfw") {
   sources = [
+    "event_loop.cc",
+    "event_loop.h",
     "flutter_glfw.cc",
     "glfw_event_loop.cc",
     "glfw_event_loop.h",
+    "headless_event_loop.cc",
+    "headless_event_loop.h",
     "key_event_handler.cc",
     "key_event_handler.h",
     "keyboard_hook_handler.h",

--- a/shell/platform/glfw/client_wrapper/BUILD.gn
+++ b/shell/platform/glfw/client_wrapper/BUILD.gn
@@ -6,12 +6,16 @@ import("//flutter/shell/platform/common/cpp/client_wrapper/publish.gni")
 import("//flutter/testing/testing.gni")
 
 _wrapper_includes = [
+  "include/flutter/flutter_engine.h",
   "include/flutter/flutter_window.h",
   "include/flutter/flutter_window_controller.h",
   "include/flutter/plugin_registrar_glfw.h",
 ]
 
-_wrapper_sources = [ "flutter_window_controller.cc" ]
+_wrapper_sources = [
+  "flutter_engine.cc",
+  "flutter_window_controller.cc",
+]
 
 # This code will be merged into .../common/cpp/client_wrapper for client use,
 # so uses header paths that assume the merged state. Include the header
@@ -70,8 +74,8 @@ test_fixtures("client_wrapper_glfw_fixtures") {
 executable("client_wrapper_glfw_unittests") {
   testonly = true
 
-  # TODO: Add more unit tests.
   sources = [
+    "flutter_engine_unittests.cc",
     "flutter_window_controller_unittests.cc",
     "flutter_window_unittests.cc",
   ]

--- a/shell/platform/glfw/client_wrapper/flutter_engine.cc
+++ b/shell/platform/glfw/client_wrapper/flutter_engine.cc
@@ -1,0 +1,85 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "include/flutter/flutter_engine.h"
+
+#include <algorithm>
+#include <iostream>
+
+namespace flutter {
+
+FlutterEngine::FlutterEngine() {}
+
+FlutterEngine::~FlutterEngine() {
+  ShutDown();
+}
+
+bool FlutterEngine::Start(const std::string& icu_data_path,
+                          const std::string& assets_path,
+                          const std::vector<std::string>& arguments) {
+  if (engine_) {
+    std::cerr << "Cannot run an already running engine. Create a new instance "
+                 "or call ShutDown first."
+              << std::endl;
+    return false;
+  }
+
+  FlutterDesktopEngineProperties c_engine_properties = {};
+  c_engine_properties.assets_path = assets_path.c_str();
+  c_engine_properties.icu_data_path = icu_data_path.c_str();
+  std::vector<const char*> engine_switches;
+  std::transform(
+      arguments.begin(), arguments.end(), std::back_inserter(engine_switches),
+      [](const std::string& arg) -> const char* { return arg.c_str(); });
+  if (engine_switches.size() > 0) {
+    c_engine_properties.switches = &engine_switches[0];
+    c_engine_properties.switches_count = engine_switches.size();
+  }
+
+  engine_ = FlutterDesktopRunEngine(c_engine_properties);
+  if (!engine_) {
+    std::cerr << "Failed to start engine." << std::endl;
+    return false;
+  }
+  return true;
+}
+
+void FlutterEngine::ShutDown() {
+  if (engine_) {
+    FlutterDesktopShutDownEngine(engine_);
+    engine_ = nullptr;
+  }
+}
+
+FlutterDesktopPluginRegistrarRef FlutterEngine::GetRegistrarForPlugin(
+    const std::string& plugin_name) {
+  if (!engine_) {
+    std::cerr << "Cannot get plugin registrar on an engine that isn't running; "
+                 "call Run first."
+              << std::endl;
+    return nullptr;
+  }
+  return FlutterDesktopGetPluginRegistrar(engine_, plugin_name.c_str());
+}
+
+void FlutterEngine::RunEventLoopWithTimeout(std::chrono::milliseconds timeout) {
+  if (!engine_) {
+    std::cerr << "Cannot run event loop without a running engine; call "
+                 "Run first."
+              << std::endl;
+    return;
+  }
+  uint32_t timeout_milliseconds;
+  if (timeout == std::chrono::milliseconds::max()) {
+    // The C API uses 0 to represent no timeout, so convert |max| to 0.
+    timeout_milliseconds = 0;
+  } else if (timeout.count() > UINT32_MAX) {
+    timeout_milliseconds = UINT32_MAX;
+  } else {
+    timeout_milliseconds = static_cast<uint32_t>(timeout.count());
+  }
+  FlutterDesktopRunEngineEventLoopWithTimeout(engine_, timeout_milliseconds);
+}
+
+}  // namespace flutter

--- a/shell/platform/glfw/client_wrapper/flutter_engine_unittests.cc
+++ b/shell/platform/glfw/client_wrapper/flutter_engine_unittests.cc
@@ -1,0 +1,103 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <memory>
+#include <string>
+
+#include "flutter/shell/platform/glfw/client_wrapper/include/flutter/flutter_engine.h"
+#include "flutter/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+
+namespace {
+
+// Stub implementation to validate calls to the API.
+class TestGlfwApi : public testing::StubFlutterGlfwApi {
+ public:
+  // |flutter::testing::StubFlutterGlfwApi|
+  FlutterDesktopEngineRef RunEngine(
+      const FlutterDesktopEngineProperties& properties) override {
+    run_called_ = true;
+    return reinterpret_cast<FlutterDesktopEngineRef>(1);
+  }
+
+  // |flutter::testing::StubFlutterGlfwApi|
+  void RunEngineEventLoopWithTimeout(uint32_t millisecond_timeout) override {
+    last_run_loop_timeout_ = millisecond_timeout;
+  }
+
+  // |flutter::testing::StubFlutterGlfwApi|
+  bool ShutDownEngine() override {
+    shut_down_called_ = true;
+    return true;
+  }
+
+  bool run_called() { return run_called_; }
+
+  bool shut_down_called() { return shut_down_called_; }
+
+  uint32_t last_run_loop_timeout() { return last_run_loop_timeout_; }
+
+ private:
+  bool run_called_ = false;
+  bool shut_down_called_ = false;
+  uint32_t last_run_loop_timeout_ = 0;
+};
+
+}  // namespace
+
+TEST(FlutterEngineTest, CreateDestroy) {
+  const std::string icu_data_path = "fake/path/to/icu";
+  const std::string assets_path = "fake/path/to/assets";
+  testing::ScopedStubFlutterGlfwApi scoped_api_stub(
+      std::make_unique<TestGlfwApi>());
+  auto test_api = static_cast<TestGlfwApi*>(scoped_api_stub.stub());
+  {
+    FlutterEngine engine;
+    engine.Start(icu_data_path, assets_path, {});
+    EXPECT_EQ(test_api->run_called(), true);
+    EXPECT_EQ(test_api->shut_down_called(), false);
+  }
+  // Destroying should implicitly shut down if it hasn't been done manually.
+  EXPECT_EQ(test_api->shut_down_called(), true);
+}
+
+TEST(FlutterEngineTest, ExplicitShutDown) {
+  const std::string icu_data_path = "fake/path/to/icu";
+  const std::string assets_path = "fake/path/to/assets";
+  testing::ScopedStubFlutterGlfwApi scoped_api_stub(
+      std::make_unique<TestGlfwApi>());
+  auto test_api = static_cast<TestGlfwApi*>(scoped_api_stub.stub());
+
+  FlutterEngine engine;
+  engine.Start(icu_data_path, assets_path, {});
+  EXPECT_EQ(test_api->run_called(), true);
+  EXPECT_EQ(test_api->shut_down_called(), false);
+  engine.ShutDown();
+  EXPECT_EQ(test_api->shut_down_called(), true);
+}
+
+TEST(FlutterEngineTest, RunloopTimeoutTranslation) {
+  const std::string icu_data_path = "fake/path/to/icu";
+  const std::string assets_path = "fake/path/to/assets";
+  testing::ScopedStubFlutterGlfwApi scoped_api_stub(
+      std::make_unique<TestGlfwApi>());
+  auto test_api = static_cast<TestGlfwApi*>(scoped_api_stub.stub());
+
+  FlutterEngine engine;
+  engine.Start(icu_data_path, assets_path, {});
+
+  engine.RunEventLoopWithTimeout(std::chrono::milliseconds(100));
+  EXPECT_EQ(test_api->last_run_loop_timeout(), 100U);
+
+  engine.RunEventLoopWithTimeout(std::chrono::milliseconds::max() -
+                                 std::chrono::milliseconds(1));
+  EXPECT_EQ(test_api->last_run_loop_timeout(), UINT32_MAX);
+
+  engine.RunEventLoopWithTimeout(std::chrono::milliseconds::max());
+  EXPECT_EQ(test_api->last_run_loop_timeout(), 0U);
+}
+
+}  // namespace flutter

--- a/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
+++ b/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
@@ -84,7 +84,8 @@ FlutterDesktopPluginRegistrarRef FlutterWindowController::GetRegistrarForPlugin(
               << std::endl;
     return nullptr;
   }
-  return FlutterDesktopGetPluginRegistrar(controller_, plugin_name.c_str());
+  return FlutterDesktopGetPluginRegistrar(FlutterDesktopGetEngine(controller_),
+                                          plugin_name.c_str());
 }
 
 bool FlutterWindowController::RunEventLoopWithTimeout(

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_engine.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_engine.h
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_GLFW_CLIENT_WRAPPER_INCLUDE_FLUTTER_FLUTTER_ENGINE_H_
+#define FLUTTER_SHELL_PLATFORM_GLFW_CLIENT_WRAPPER_INCLUDE_FLUTTER_FLUTTER_ENGINE_H_
+
+#include <flutter_glfw.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "plugin_registrar.h"
+#include "plugin_registry.h"
+
+namespace flutter {
+
+// An engine for running a headless Flutter application.
+class FlutterEngine : public PluginRegistry {
+ public:
+  explicit FlutterEngine();
+
+  virtual ~FlutterEngine();
+
+  // Prevent copying.
+  FlutterEngine(FlutterEngine const&) = delete;
+  FlutterEngine& operator=(FlutterEngine const&) = delete;
+
+  // Starts running the engine with the given parameters, returning true if
+  // successful.
+  bool Start(const std::string& icu_data_path,
+             const std::string& assets_path,
+             const std::vector<std::string>& arguments);
+
+  // Terminates the running engine.
+  void ShutDown();
+
+  // Processes the next event for the engine, or returns early if |timeout| is
+  // reached before the next event.
+  void RunEventLoopWithTimeout(
+      std::chrono::milliseconds timeout = std::chrono::milliseconds::max());
+
+  // flutter::PluginRegistry:
+  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
+      const std::string& plugin_name) override;
+
+ private:
+  // Handle for interacting with the C API's engine reference.
+  FlutterDesktopEngineRef engine_ = nullptr;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_GLFW_CLIENT_WRAPPER_INCLUDE_FLUTTER_FLUTTER_ENGINE_H_

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_engine.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_engine.h
@@ -47,8 +47,12 @@ class FlutterEngine : public PluginRegistry {
       const std::string& plugin_name) override;
 
  private:
+  using UniqueEnginePtr = std::unique_ptr<FlutterDesktopEngineState,
+                                          bool (*)(FlutterDesktopEngineState*)>;
+
   // Handle for interacting with the C API's engine reference.
-  FlutterDesktopEngineRef engine_ = nullptr;
+  UniqueEnginePtr engine_ =
+      UniqueEnginePtr(nullptr, FlutterDesktopShutDownEngine);
 };
 
 }  // namespace flutter

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -149,6 +149,14 @@ FlutterDesktopEngineRef FlutterDesktopRunEngine(
   return nullptr;
 }
 
+void FlutterDesktopRunEngineEventLoopWithTimeout(
+    FlutterDesktopEngineRef engine,
+    uint32_t timeout_milliseconds) {
+  if (s_stub_implementation) {
+    s_stub_implementation->RunEngineEventLoopWithTimeout(timeout_milliseconds);
+  }
+}
+
 bool FlutterDesktopShutDownEngine(FlutterDesktopEngineRef engine_ref) {
   if (s_stub_implementation) {
     return s_stub_implementation->ShutDownEngine();

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -162,8 +162,14 @@ FlutterDesktopWindowRef FlutterDesktopGetWindow(
   return reinterpret_cast<FlutterDesktopWindowRef>(1);
 }
 
+FlutterDesktopEngineRef FlutterDesktopGetEngine(
+    FlutterDesktopWindowControllerRef controller) {
+  // The stub ignores this, so just return an arbitrary non-zero value.
+  return reinterpret_cast<FlutterDesktopEngineRef>(3);
+}
+
 FlutterDesktopPluginRegistrarRef FlutterDesktopGetPluginRegistrar(
-    FlutterDesktopWindowControllerRef controller,
+    FlutterDesktopEngineRef engine,
     const char* plugin_name) {
   // The stub ignores this, so just return an arbitrary non-zero value.
   return reinterpret_cast<FlutterDesktopPluginRegistrarRef>(2);

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
@@ -83,6 +83,9 @@ class StubFlutterGlfwApi {
     return nullptr;
   }
 
+  // Called for FlutterDesktopRunEngineEventLoopWithTimeout.
+  virtual void RunEngineEventLoopWithTimeout(uint32_t millisecond_timeout) {}
+
   // Called for FlutterDesktopShutDownEngine.
   virtual bool ShutDownEngine() { return true; }
 };

--- a/shell/platform/glfw/event_loop.cc
+++ b/shell/platform/glfw/event_loop.cc
@@ -1,0 +1,104 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/glfw/event_loop.h"
+
+#include <atomic>
+#include <utility>
+
+namespace flutter {
+
+EventLoop::EventLoop(std::thread::id main_thread_id,
+                     const TaskExpiredCallback& on_task_expired)
+    : main_thread_id_(main_thread_id),
+      on_task_expired_(std::move(on_task_expired)) {}
+
+EventLoop::~EventLoop() = default;
+
+bool EventLoop::RunsTasksOnCurrentThread() const {
+  return std::this_thread::get_id() == main_thread_id_;
+}
+
+void EventLoop::WaitForEvents(std::chrono::nanoseconds max_wait) {
+  const auto now = TaskTimePoint::clock::now();
+  std::vector<FlutterTask> expired_tasks;
+
+  // Process expired tasks.
+  {
+    std::lock_guard<std::mutex> lock(task_queue_mutex_);
+    while (!task_queue_.empty()) {
+      const auto& top = task_queue_.top();
+      // If this task (and all tasks after this) has not yet expired, there is
+      // nothing more to do. Quit iterating.
+      if (top.fire_time > now) {
+        break;
+      }
+
+      // Make a record of the expired task. Do NOT service the task here
+      // because we are still holding onto the task queue mutex. We don't want
+      // other threads to block on posting tasks onto this thread till we are
+      // done processing expired tasks.
+      expired_tasks.push_back(task_queue_.top().task);
+
+      // Remove the tasks from the delayed tasks queue.
+      task_queue_.pop();
+    }
+  }
+
+  // Fire expired tasks.
+  {
+    // Flushing tasks here without holing onto the task queue mutex.
+    for (const auto& task : expired_tasks) {
+      on_task_expired_(&task);
+    }
+  }
+
+  // Sleep till the next task needs to be processed. If a new task comes
+  // along, the wait will be resolved early because PostTask calls Wake().
+  {
+    TaskTimePoint next_wake;
+    {
+      std::lock_guard<std::mutex> lock(task_queue_mutex_);
+      TaskTimePoint max_wake_timepoint =
+          max_wait == std::chrono::nanoseconds::max() ? TaskTimePoint::max()
+                                                      : now + max_wait;
+      TaskTimePoint next_event_timepoint = task_queue_.empty()
+                                               ? TaskTimePoint::max()
+                                               : task_queue_.top().fire_time;
+      next_wake = std::min(max_wake_timepoint, next_event_timepoint);
+    }
+    WaitUntil(next_wake);
+  }
+}
+
+EventLoop::TaskTimePoint EventLoop::TimePointFromFlutterTime(
+    uint64_t flutter_target_time_nanos) {
+  const auto now = TaskTimePoint::clock::now();
+  const int64_t flutter_duration =
+      flutter_target_time_nanos - FlutterEngineGetCurrentTime();
+  return now + std::chrono::nanoseconds(flutter_duration);
+}
+
+void EventLoop::PostTask(FlutterTask flutter_task,
+                         uint64_t flutter_target_time_nanos) {
+  static std::atomic_uint64_t sGlobalTaskOrder(0);
+
+  Task task;
+  task.order = ++sGlobalTaskOrder;
+  task.fire_time = TimePointFromFlutterTime(flutter_target_time_nanos);
+  task.task = flutter_task;
+
+  {
+    std::lock_guard<std::mutex> lock(task_queue_mutex_);
+    task_queue_.push(task);
+
+    // Make sure the queue mutex is unlocked before waking up the loop. In case
+    // the wake causes this thread to be descheduled for the primary thread to
+    // process tasks, the acquisition of the lock on that thread while holding
+    // the lock here momentarily till the end of the scope is a pessimization.
+  }
+  Wake();
+}
+
+}  // namespace flutter

--- a/shell/platform/glfw/event_loop.h
+++ b/shell/platform/glfw/event_loop.h
@@ -1,0 +1,88 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_GLFW_EVENT_LOOP_H_
+#define FLUTTER_SHELL_PLATFORM_GLFW_EVENT_LOOP_H_
+
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+
+#include "flutter/shell/platform/embedder/embedder.h"
+
+namespace flutter {
+
+// An abstract event loop.
+class EventLoop {
+ public:
+  using TaskExpiredCallback = std::function<void(const FlutterTask*)>;
+
+  // Creates an event loop running on the given thread, calling
+  // |on_task_expired| to run tasks.
+  EventLoop(std::thread::id main_thread_id,
+            const TaskExpiredCallback& on_task_expired);
+
+  virtual ~EventLoop();
+
+  // Disallow copy.
+  EventLoop(const EventLoop&) = delete;
+  EventLoop& operator=(const EventLoop&) = delete;
+
+  // Returns if the current thread is the thread used by this event loop.
+  bool RunsTasksOnCurrentThread() const;
+
+  // Waits for the next event, processes it, and returns.
+  //
+  // Expired engine events, if any, are processed as well. The optional
+  // timeout should only be used when events not managed by this loop need to be
+  // processed in a polling manner.
+  void WaitForEvents(
+      std::chrono::nanoseconds max_wait = std::chrono::nanoseconds::max());
+
+  // Posts a Flutter engine task to the event loop for delayed execution.
+  void PostTask(FlutterTask flutter_task, uint64_t flutter_target_time_nanos);
+
+ protected:
+  using TaskTimePoint = std::chrono::steady_clock::time_point;
+
+  // Returns the timepoint corresponding to a Flutter task time.
+  static TaskTimePoint TimePointFromFlutterTime(
+      uint64_t flutter_target_time_nanos);
+
+  // Returns the mutex used to control the task queue. Subclasses may safely
+  // lock this mutex in the abstract methods below.
+  std::mutex& GetTaskQueueMutex() { return task_queue_mutex_; }
+
+  // Waits until the given time, or a Wake() call.
+  virtual void WaitUntil(const TaskTimePoint& time) = 0;
+
+  // Wakes the main thread from a WaitUntil call.
+  virtual void Wake() = 0;
+
+  struct Task {
+    uint64_t order;
+    TaskTimePoint fire_time;
+    FlutterTask task;
+
+    struct Comparer {
+      bool operator()(const Task& a, const Task& b) {
+        if (a.fire_time == b.fire_time) {
+          return a.order > b.order;
+        }
+        return a.fire_time > b.fire_time;
+      }
+    };
+  };
+  std::thread::id main_thread_id_;
+  TaskExpiredCallback on_task_expired_;
+  std::mutex task_queue_mutex_;
+  std::priority_queue<Task, std::deque<Task>, Task::Comparer> task_queue_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_GLFW_EVENT_LOOP_H_

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -857,12 +857,12 @@ FlutterDesktopEngineRef FlutterDesktopGetEngine(
 }
 
 FlutterDesktopPluginRegistrarRef FlutterDesktopGetPluginRegistrar(
-    FlutterDesktopWindowControllerRef controller,
+    FlutterDesktopEngineRef engine,
     const char* plugin_name) {
   // Currently, one registrar acts as the registrar for all plugins, so the
   // name is ignored. It is part of the API to reduce churn in the future when
   // aligning more closely with the Flutter registrar system.
-  return controller->engine->plugin_registrar.get();
+  return engine->plugin_registrar.get();
 }
 
 FlutterDesktopEngineRef FlutterDesktopRunEngine(

--- a/shell/platform/glfw/glfw_event_loop.cc
+++ b/shell/platform/glfw/glfw_event_loop.cc
@@ -13,104 +13,28 @@ namespace flutter {
 
 GLFWEventLoop::GLFWEventLoop(std::thread::id main_thread_id,
                              const TaskExpiredCallback& on_task_expired)
-    : main_thread_id_(main_thread_id),
-      on_task_expired_(std::move(on_task_expired)) {}
+    : EventLoop(main_thread_id, std::move(on_task_expired)) {}
 
 GLFWEventLoop::~GLFWEventLoop() = default;
 
-bool GLFWEventLoop::RunsTasksOnCurrentThread() const {
-  return std::this_thread::get_id() == main_thread_id_;
-}
-
-void GLFWEventLoop::WaitForEvents(std::chrono::nanoseconds max_wait) {
+void GLFWEventLoop::WaitUntil(const TaskTimePoint& time) {
   const auto now = TaskTimePoint::clock::now();
-  std::vector<FlutterTask> expired_tasks;
 
-  // Process expired tasks.
-  {
-    std::lock_guard<std::mutex> lock(task_queue_mutex_);
-    while (!task_queue_.empty()) {
-      const auto& top = task_queue_.top();
-      // If this task (and all tasks after this) has not yet expired, there is
-      // nothing more to do. Quit iterating.
-      if (top.fire_time > now) {
-        break;
-      }
+  // Make sure the seconds are not integral.
+  using Seconds = std::chrono::duration<double, std::ratio<1>>;
+  const auto duration_to_wait = std::chrono::duration_cast<Seconds>(time - now);
 
-      // Make a record of the expired task. Do NOT service the task here
-      // because we are still holding onto the task queue mutex. We don't want
-      // other threads to block on posting tasks onto this thread till we are
-      // done processing expired tasks.
-      expired_tasks.push_back(task_queue_.top().task);
-
-      // Remove the tasks from the delayed tasks queue.
-      task_queue_.pop();
-    }
-  }
-
-  // Fire expired tasks.
-  {
-    // Flushing tasks here without holing onto the task queue mutex.
-    for (const auto& task : expired_tasks) {
-      on_task_expired_(&task);
-    }
-  }
-
-  // Sleep till the next task needs to be processed. If a new task comes
-  // along, the wait in GLFW will be resolved early because PostTask posts an
-  // empty event.
-  {
-    // Make sure the seconds are not integral.
-    using Seconds = std::chrono::duration<double, std::ratio<1>>;
-
-    TaskTimePoint next_wake;
-    {
-      std::lock_guard<std::mutex> lock(task_queue_mutex_);
-      next_wake = task_queue_.empty() ? TaskTimePoint::max()
-                                      : task_queue_.top().fire_time;
-    }
-
-    const auto duration_to_wait = std::chrono::duration_cast<Seconds>(
-        std::min(next_wake - now, max_wait));
-
-    if (duration_to_wait.count() > 0.0) {
-      ::glfwWaitEventsTimeout(duration_to_wait.count());
-    } else {
-      // Avoid engine task priority inversion by making sure GLFW events are
-      // always processed even when there is no need to wait for pending engine
-      // tasks.
-      ::glfwPollEvents();
-    }
+  if (duration_to_wait.count() > 0.0) {
+    ::glfwWaitEventsTimeout(duration_to_wait.count());
+  } else {
+    // Avoid engine task priority inversion by making sure GLFW events are
+    // always processed even when there is no need to wait for pending engine
+    // tasks.
+    ::glfwPollEvents();
   }
 }
 
-GLFWEventLoop::TaskTimePoint GLFWEventLoop::TimePointFromFlutterTime(
-    uint64_t flutter_target_time_nanos) {
-  const auto now = TaskTimePoint::clock::now();
-  const int64_t flutter_duration =
-      flutter_target_time_nanos - FlutterEngineGetCurrentTime();
-  return now + std::chrono::nanoseconds(flutter_duration);
-}
-
-void GLFWEventLoop::PostTask(FlutterTask flutter_task,
-                             uint64_t flutter_target_time_nanos) {
-  static std::atomic_uint64_t sGlobalTaskOrder(0);
-
-  Task task;
-  task.order = ++sGlobalTaskOrder;
-  task.fire_time = TimePointFromFlutterTime(flutter_target_time_nanos);
-  task.task = flutter_task;
-
-  {
-    std::lock_guard<std::mutex> lock(task_queue_mutex_);
-    task_queue_.push(task);
-
-    // Make sure the queue mutex is unlocked before waking up the loop. In case
-    // the wake causes this thread to be descheduled for the primary thread to
-    // process tasks, the acquisition of the lock on that thread while holding
-    // the lock here momentarily till the end of the scope is a pessimization.
-  }
-
+void GLFWEventLoop::Wake() {
   ::glfwPostEmptyEvent();
 }
 

--- a/shell/platform/glfw/glfw_event_loop.h
+++ b/shell/platform/glfw/glfw_event_loop.h
@@ -5,68 +5,29 @@
 #ifndef FLUTTER_SHELL_PLATFORM_GLFW_GLFW_EVENT_LOOP_H_
 #define FLUTTER_SHELL_PLATFORM_GLFW_GLFW_EVENT_LOOP_H_
 
-#include <chrono>
-#include <deque>
-#include <functional>
-#include <mutex>
-#include <queue>
-#include <thread>
-
-#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/glfw/event_loop.h"
 
 namespace flutter {
 
 // An event loop implementation that supports Flutter Engine tasks scheduling in
 // the GLFW event loop.
-class GLFWEventLoop {
+class GLFWEventLoop : public EventLoop {
  public:
-  using TaskExpiredCallback = std::function<void(const FlutterTask*)>;
   GLFWEventLoop(std::thread::id main_thread_id,
                 const TaskExpiredCallback& on_task_expired);
 
-  ~GLFWEventLoop();
+  virtual ~GLFWEventLoop();
 
-  // Returns if the current thread is the thread used by the GLFW event loop.
-  bool RunsTasksOnCurrentThread() const;
-
-  // Wait for an any GLFW or pending Flutter Engine events and returns when
-  // either is encountered. Expired engine events are processed. The optional
-  // timeout should only be used when non-GLFW or engine events need to be
-  // processed in a polling manner.
-  void WaitForEvents(
-      std::chrono::nanoseconds max_wait = std::chrono::nanoseconds::max());
-
-  // Post a Flutter engine tasks to the event loop for delayed execution.
-  void PostTask(FlutterTask flutter_task, uint64_t flutter_target_time_nanos);
-
- private:
-  using TaskTimePoint = std::chrono::steady_clock::time_point;
-  struct Task {
-    uint64_t order;
-    TaskTimePoint fire_time;
-    FlutterTask task;
-
-    struct Comparer {
-      bool operator()(const Task& a, const Task& b) {
-        if (a.fire_time == b.fire_time) {
-          return a.order > b.order;
-        }
-        return a.fire_time > b.fire_time;
-      }
-    };
-  };
-  std::thread::id main_thread_id_;
-  TaskExpiredCallback on_task_expired_;
-  std::mutex task_queue_mutex_;
-  std::priority_queue<Task, std::deque<Task>, Task::Comparer> task_queue_;
-  std::condition_variable task_queue_cv_;
-
+  // Prevent copying.
   GLFWEventLoop(const GLFWEventLoop&) = delete;
-
   GLFWEventLoop& operator=(const GLFWEventLoop&) = delete;
 
-  static TaskTimePoint TimePointFromFlutterTime(
-      uint64_t flutter_target_time_nanos);
+ private:
+  // |EventLoop|
+  void WaitUntil(const TaskTimePoint& time) override;
+
+  // |EventLoop|
+  void Wake() override;
 };
 
 }  // namespace flutter

--- a/shell/platform/glfw/headless_event_loop.cc
+++ b/shell/platform/glfw/headless_event_loop.cc
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/glfw/headless_event_loop.h"
+
+#include <atomic>
+#include <utility>
+
+namespace flutter {
+
+HeadlessEventLoop::HeadlessEventLoop(std::thread::id main_thread_id,
+                                     const TaskExpiredCallback& on_task_expired)
+    : EventLoop(main_thread_id, std::move(on_task_expired)) {}
+
+HeadlessEventLoop::~HeadlessEventLoop() = default;
+
+void HeadlessEventLoop::WaitUntil(const TaskTimePoint& time) {
+  std::mutex& mutex = GetTaskQueueMutex();
+  std::unique_lock<std::mutex> lock(mutex);
+  task_queue_condition_.wait_until(lock, time);
+}
+
+void HeadlessEventLoop::Wake() {
+  task_queue_condition_.notify_one();
+}
+
+}  // namespace flutter

--- a/shell/platform/glfw/headless_event_loop.h
+++ b/shell/platform/glfw/headless_event_loop.h
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_GLFW_HEADLESS_EVENT_LOOP_H_
+#define FLUTTER_SHELL_PLATFORM_GLFW_HEADLESS_EVENT_LOOP_H_
+
+#include <condition_variable>
+
+#include "flutter/shell/platform/glfw/event_loop.h"
+
+namespace flutter {
+
+// An event loop implementation that only handles Flutter Engine task
+// scheduling.
+class HeadlessEventLoop : public EventLoop {
+ public:
+  using TaskExpiredCallback = std::function<void(const FlutterTask*)>;
+  HeadlessEventLoop(std::thread::id main_thread_id,
+                    const TaskExpiredCallback& on_task_expired);
+
+  ~HeadlessEventLoop();
+
+  // Disallow copy.
+  HeadlessEventLoop(const HeadlessEventLoop&) = delete;
+  HeadlessEventLoop& operator=(const HeadlessEventLoop&) = delete;
+
+ private:
+  // |EventLoop|
+  void WaitUntil(const TaskTimePoint& time) override;
+
+  // |EventLoop|
+  void Wake() override;
+
+  std::condition_variable task_queue_condition_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_GLFW_HEADLESS_EVENT_LOOP_H_

--- a/shell/platform/glfw/platform_handler.cc
+++ b/shell/platform/glfw/platform_handler.cc
@@ -17,6 +17,7 @@ static constexpr char kSystemNavigatorPopMethod[] = "SystemNavigator.pop";
 static constexpr char kTextPlainFormat[] = "text/plain";
 static constexpr char kTextKey[] = "text";
 
+static constexpr char kNoWindowError[] = "Missing window error";
 static constexpr char kUnknownClipboardFormatError[] =
     "Unknown clipboard format error";
 
@@ -43,6 +44,11 @@ void PlatformHandler::HandleMethodCall(
   const std::string& method = method_call.method_name();
 
   if (method.compare(kGetClipboardDataMethod) == 0) {
+    if (!window_) {
+      result->Error(kNoWindowError,
+                    "Clipboard is not available in GLFW headless mode.");
+      return;
+    }
     // Only one string argument is expected.
     const rapidjson::Value& format = method_call.arguments()[0];
 
@@ -65,6 +71,11 @@ void PlatformHandler::HandleMethodCall(
                        rapidjson::Value(clipboardData, allocator), allocator);
     result->Success(&document);
   } else if (method.compare(kSetClipboardDataMethod) == 0) {
+    if (!window_) {
+      result->Error(kNoWindowError,
+                    "Clipboard is not available in GLFW headless mode.");
+      return;
+    }
     const rapidjson::Value& document = *method_call.arguments();
     rapidjson::Value::ConstMemberIterator itr = document.FindMember(kTextKey);
     if (itr == document.MemberEnd()) {

--- a/shell/platform/glfw/platform_handler.h
+++ b/shell/platform/glfw/platform_handler.h
@@ -29,7 +29,7 @@ class PlatformHandler {
   // The MethodChannel used for communication with the Flutter engine.
   std::unique_ptr<flutter::MethodChannel<rapidjson::Document>> channel_;
 
-  // A reference to the GLFW window.
+  // A reference to the GLFW window, if any. Null in headless mode.
   GLFWwindow* window_;
 };
 

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -212,7 +212,7 @@ FLUTTER_EXPORT void FlutterDesktopRunEngineEventLoopWithTimeout(
 // Shuts down the given engine instance. Returns true if the shutdown was
 // successful. |engine_ref| is no longer valid after this call.
 FLUTTER_EXPORT bool FlutterDesktopShutDownEngine(
-    FlutterDesktopEngineRef engine_ref);
+    FlutterDesktopEngineRef engine);
 
 // Returns the window associated with this registrar's engine instance.
 // This is a GLFW shell-specific extension to flutter_plugin_registrar.h

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -119,6 +119,13 @@ FLUTTER_EXPORT bool FlutterDesktopRunWindowEventLoopWithTimeout(
 FLUTTER_EXPORT FlutterDesktopWindowRef
 FlutterDesktopGetWindow(FlutterDesktopWindowControllerRef controller);
 
+// Returns the handle for the engine running in
+// FlutterDesktopWindowControllerRef.
+//
+// Its lifetime is the same as the |controller|'s.
+FLUTTER_EXPORT FlutterDesktopEngineRef
+FlutterDesktopGetEngine(FlutterDesktopWindowControllerRef controller);
+
 // Returns the plugin registrar handle for the plugin with the given name.
 //
 // The name must be unique across the application.

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -200,6 +200,15 @@ FLUTTER_EXPORT void FlutterDesktopWindowSetSizeLimits(
 FLUTTER_EXPORT FlutterDesktopEngineRef
 FlutterDesktopRunEngine(const FlutterDesktopEngineProperties& properties);
 
+// Waits for and processes the next event before |timeout_milliseconds|.
+//
+// If |timeout_milliseconds| is zero, it will wait for the next event
+// indefinitely. A non-zero timeout is needed only if processing unrelated to
+// the event loop is necessary (e.g., to handle events from another source).
+FLUTTER_EXPORT void FlutterDesktopRunEngineEventLoopWithTimeout(
+    FlutterDesktopEngineRef engine,
+    uint32_t timeout_milliseconds);
+
 // Shuts down the given engine instance. Returns true if the shutdown was
 // successful. |engine_ref| is no longer valid after this call.
 FLUTTER_EXPORT bool FlutterDesktopShutDownEngine(

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -130,7 +130,7 @@ FlutterDesktopGetEngine(FlutterDesktopWindowControllerRef controller);
 //
 // The name must be unique across the application.
 FLUTTER_EXPORT FlutterDesktopPluginRegistrarRef
-FlutterDesktopGetPluginRegistrar(FlutterDesktopWindowControllerRef controller,
+FlutterDesktopGetPluginRegistrar(FlutterDesktopEngineRef engine,
                                  const char* plugin_name);
 
 // Enables or disables hover tracking.

--- a/shell/platform/windows/win32_task_runner.h
+++ b/shell/platform/windows/win32_task_runner.h
@@ -57,7 +57,6 @@ class Win32TaskRunner {
   TaskExpiredCallback on_task_expired_;
   std::mutex task_queue_mutex_;
   std::priority_queue<Task, std::deque<Task>, Task::Comparer> task_queue_;
-  std::condition_variable task_queue_cv_;
 
   Win32TaskRunner(const Win32TaskRunner&) = delete;
 


### PR DESCRIPTION
This does some long-overdue refactoring of the spaghetti code that grew in the GLFW embedding to begin providing a clearer separation between the engine and the window. It is now possible to register plugins, and run the runloop, on a headless engine, which makes headless mode much more usable. This is useful in some automated testing environments.

There is more refactoring that should be done in the future, but this is a good incremental point to stop as the PR is already large, and it provides useful new functionality as-is.