### PR TITLE
Setup default font manager after engine created, to improve startup performance

### DIFF
--- a/lib/ui/text/font_collection.cc
+++ b/lib/ui/text/font_collection.cc
@@ -47,8 +47,6 @@ void _LoadFontFromList(Dart_NativeArguments args) {
 
 FontCollection::FontCollection()
     : collection_(std::make_shared<txt::FontCollection>()) {
-  collection_->SetupDefaultFontManager();
-
   dynamic_font_manager_ = sk_make_sp<txt::DynamicFontManager>();
   collection_->SetDynamicFontManager(dynamic_font_manager_);
 }
@@ -66,6 +64,10 @@ void FontCollection::RegisterNatives(tonic::DartLibraryNatives* natives) {
 
 std::shared_ptr<txt::FontCollection> FontCollection::GetFontCollection() const {
   return collection_;
+}
+
+void FontCollection::SetupDefaultFontManager() {
+  collection_->SetupDefaultFontManager();
 }
 
 void FontCollection::RegisterFonts(

--- a/lib/ui/text/font_collection.h
+++ b/lib/ui/text/font_collection.h
@@ -29,6 +29,8 @@ class FontCollection {
 
   std::shared_ptr<txt::FontCollection> GetFontCollection() const;
 
+  void SetupDefaultFontManager();
+
   void RegisterFonts(std::shared_ptr<AssetManager> asset_manager);
 
   void RegisterTestFonts();

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -90,6 +90,11 @@ fml::WeakPtr<Engine> Engine::GetWeakPtr() const {
   return weak_factory_.GetWeakPtr();
 }
 
+void Engine::SetupDefaultFontManager() {
+  TRACE_EVENT0("flutter", "Engine::SetupDefaultFontManager");
+  font_collection_.SetupDefaultFontManager();
+}
+
 bool Engine::UpdateAssetManager(
     std::shared_ptr<AssetManager> new_asset_manager) {
   if (asset_manager_ == new_asset_manager) {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -366,8 +366,6 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   //----------------------------------------------------------------------------
   /// @brief      Setup default font manager according to specific platform.
   ///
-  /// @attention  This operation calls `SkFontMgr::RefDefault` which is
-  ///             time-consuming except running at linux and windows.
   void SetupDefaultFontManager();
 
   //----------------------------------------------------------------------------

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -364,6 +364,13 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   [[nodiscard]] bool Restart(RunConfiguration configuration);
 
   //----------------------------------------------------------------------------
+  /// @brief      Setup default font manager according to specific platform.
+  ///
+  /// @attention  This operation calls `SkFontMgr::RefDefault` which is
+  ///             time-consuming except running at linux and windows.
+  void SetupDefaultFontManager();
+
+  //----------------------------------------------------------------------------
   /// @brief      Updates the asset manager referenced by the root isolate of a
   ///             Flutter application. This happens implicitly in the call to
   ///             `Engine::Run` and `Engine::Restart` as the asset manager is

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -542,6 +542,14 @@ bool Shell::Setup(std::unique_ptr<PlatformView> platform_view,
   weak_rasterizer_ = rasterizer_->GetWeakPtr();
   weak_platform_view_ = platform_view_->GetWeakPtr();
 
+  // Setup the time-consuming default font manager right after engine created.
+  fml::TaskRunner::RunNowOrPostTask(task_runners_.GetUITaskRunner(),
+                                    [engine = weak_engine_] {
+                                      if (engine) {
+                                        engine->SetupDefaultFontManager();
+                                      }
+                                    });
+
   is_setup_ = true;
 
   vm_->GetServiceProtocol()->AddHandler(this, GetServiceProtocolDescription());

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -21,6 +21,7 @@
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/switches.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
+#include "third_party/skia/include/core/SkFontMgr.h"
 
 namespace flutter {
 
@@ -155,6 +156,10 @@ void FlutterMain::SetupObservatoryUriCallback(JNIEnv* env) {
       });
 }
 
+static void CreateDefaultFontManager(JNIEnv* env, jclass jcaller) {
+  sk_sp<SkFontMgr> font_mgr(SkFontMgr::RefDefault());
+}
+
 bool FlutterMain::Register(JNIEnv* env) {
   static const JNINativeMethod methods[] = {
       {
@@ -162,6 +167,11 @@ bool FlutterMain::Register(JNIEnv* env) {
           .signature = "(Landroid/content/Context;[Ljava/lang/String;Ljava/"
                        "lang/String;Ljava/lang/String;Ljava/lang/String;J)V",
           .fnPtr = reinterpret_cast<void*>(&Init),
+      },
+      {
+          .name = "nativeCreateDefaultFontManager",
+          .signature = "()V",
+          .fnPtr = reinterpret_cast<void*>(&CreateDefaultFontManager),
       },
   };
 

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -156,8 +156,9 @@ void FlutterMain::SetupObservatoryUriCallback(JNIEnv* env) {
       });
 }
 
-static void CreateDefaultFontManager(JNIEnv* env, jclass jcaller) {
-  sk_sp<SkFontMgr> font_mgr(SkFontMgr::RefDefault());
+static void PrefetchDefaultFontManager(JNIEnv* env, jclass jcaller) {
+  // Initialize a singleton owned by Skia.
+  SkFontMgr::RefDefault();
 }
 
 bool FlutterMain::Register(JNIEnv* env) {
@@ -169,9 +170,9 @@ bool FlutterMain::Register(JNIEnv* env) {
           .fnPtr = reinterpret_cast<void*>(&Init),
       },
       {
-          .name = "nativeCreateDefaultFontManager",
+          .name = "nativePrefetchDefaultFontManager",
           .signature = "()V",
-          .fnPtr = reinterpret_cast<void*>(&CreateDefaultFontManager),
+          .fnPtr = reinterpret_cast<void*>(&PrefetchDefaultFontManager),
       },
   };
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -106,6 +106,13 @@ public class FlutterJNI {
       @NonNull String engineCachesPath,
       long initTimeMillis);
 
+  /**
+   * Create the default font manager provided by SkFontMgr::RefDefault() which is a process-wide
+   * singleton owned by Skia. Note that, the first call to SkFontMgr::RefDefault() will take
+   * noticeable time, but later calls will return a reference to the preexisting font manager.
+   */
+  public static native void nativeCreateDefaultFontManager();
+
   // TODO(mattcarroll): add javadocs
   @UiThread
   public native boolean nativeGetIsSoftwareRenderingEnabled();

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -107,11 +107,11 @@ public class FlutterJNI {
       long initTimeMillis);
 
   /**
-   * Create the default font manager provided by SkFontMgr::RefDefault() which is a process-wide
+   * Prefetch the default font manager provided by SkFontMgr::RefDefault() which is a process-wide
    * singleton owned by Skia. Note that, the first call to SkFontMgr::RefDefault() will take
    * noticeable time, but later calls will return a reference to the preexisting font manager.
    */
-  public static native void nativeCreateDefaultFontManager();
+  public static native void nativePrefetchDefaultFontManager();
 
   // TODO(mattcarroll): add javadocs
   @UiThread

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -144,16 +144,16 @@ public class FlutterLoader {
 
             System.loadLibrary("flutter");
 
-            // Pre-warm the default font manager as soon as possible on a background thread.
+            // Prefetch the default font manager as soon as possible on a background thread.
             // It helps to reduce time cost of engine setup that blocks the platform thread.
-            new Thread(
+            Executors.newSingleThreadExecutor()
+                .execute(
                     new Runnable() {
                       @Override
                       public void run() {
-                        FlutterJNI.nativeCreateDefaultFontManager();
+                        FlutterJNI.nativePrefetchDefaultFontManager();
                       }
-                    })
-                .start();
+                    });
 
             if (resourceExtractor != null) {
               resourceExtractor.waitForCompletion();

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -144,6 +144,17 @@ public class FlutterLoader {
 
             System.loadLibrary("flutter");
 
+            // Pre-warm the default font manager as soon as possible on a background thread.
+            // It helps to reduce time cost of engine setup that blocks the platform thread.
+            new Thread(
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        FlutterJNI.nativeCreateDefaultFontManager();
+                      }
+                    })
+                .start();
+
             if (resourceExtractor != null) {
               resourceExtractor.waitForCompletion();
             }


### PR DESCRIPTION
`Shell::Create` may gain 25~50% performance improvement by this pr ^_^

`SkFontMgr::RefDefault` is time-consuming, about 15ms in Pixel2, which is blocking Android's main thread during engine initialization. It is called by `FontCollection` while creating `Engine`, and I think we can just make that happen right after initialization instead of initializing.

before this pr: 
![image](https://user-images.githubusercontent.com/62057376/81392016-9d424a80-9150-11ea-8974-39339dbb09c8.png)

after this pr:
![image](https://user-images.githubusercontent.com/62057376/81392190-ded2f580-9150-11ea-996a-f85edd542bee.png)

Shown as the above figures,
Shell::Create    ~60ms ==> ~30ms
ShellSetupUISubsystem    ~25ms ==> ~10ms
