### PR TITLE
[fuchsia] add robust scheduling for flutter_runner

### DIFF
--- a/shell/platform/fuchsia/flutter/session_connection.cc
+++ b/shell/platform/fuchsia/flutter/session_connection.cc
@@ -153,7 +153,6 @@ fml::TimePoint SessionConnection::CalculateNextLatchPoint(
     if (latch_point >= minimum_latch_point_to_target) {
       return latch_point;
     }
-
   }
 
   // We could not find a suitable latch point in the list given to us from

--- a/shell/platform/fuchsia/flutter/session_connection.cc
+++ b/shell/platform/fuchsia/flutter/session_connection.cc
@@ -140,9 +140,9 @@ fml::TimePoint SessionConnection::CalculateNextLatchPoint(
     std::deque<std::pair<fml::TimePoint, fml::TimePoint>>&
         future_presentation_infos) {
   // The minimum latch point is the largest of:
-  // * Now
-  // * The beginning of the frame + frame build time
-  // * The last latch point
+  // Now
+  // When we expect the Flutter work for the frame to be completed
+  // The last latch point targeted
   fml::TimePoint minimum_latch_point_to_target =
       std::max(std::max(now, present_requested_time + flutter_frame_build_time),
                last_latch_point_targeted);

--- a/shell/platform/fuchsia/flutter/session_connection.cc
+++ b/shell/platform/fuchsia/flutter/session_connection.cc
@@ -147,18 +147,14 @@ fml::TimePoint SessionConnection::CalculateNextLatchPoint(
       std::max(std::max(now, present_requested_time + flutter_frame_build_time),
                last_latch_point_targeted);
 
-  auto it = future_presentation_infos.begin();
-  while (it != future_presentation_infos.end()) {
-    fml::TimePoint latch_point = it->first;
+  for (auto& info : future_presentation_infos) {
+    fml::TimePoint latch_point = info.first;
 
     if (latch_point >= minimum_latch_point_to_target) {
       return latch_point;
     }
 
-    it++;
   }
-
-  FML_DCHECK(it == future_presentation_infos.end());
 
   // We could not find a suitable latch point in the list given to us from
   // Scenic, so aim for the smallest safe value.

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -75,7 +75,7 @@ class SessionConnection final {
   static fml::TimePoint CalculateNextLatchPoint(
       fml::TimePoint present_requested_time,
       fml::TimePoint now,
-      fml::TimePoint last_vsync_targeted,
+      fml::TimePoint last_latch_point_targeted,
       fml::TimeDelta flutter_frame_build_time,
       fml::TimeDelta vsync_interval,
       std::deque<std::pair<fml::TimePoint, fml::TimePoint>>&
@@ -93,6 +93,12 @@ class SessionConnection final {
   on_frame_presented_event on_frame_presented_callback_;
 
   zx_handle_t vsync_event_handle_;
+
+  fml::TimePoint last_latch_point_targeted_ = fml::TimePoint::Min();
+  fml::TimePoint present_requested_time_ = fml::TimePoint::Min();
+
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos_ = {};
 
   bool initialized_ = false;
 

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -94,8 +94,10 @@ class SessionConnection final {
 
   zx_handle_t vsync_event_handle_;
 
-  fml::TimePoint last_latch_point_targeted_ = fml::TimePoint::Min();
-  fml::TimePoint present_requested_time_ = fml::TimePoint::Min();
+  fml::TimePoint last_latch_point_targeted_ =
+      fml::TimePoint::FromEpochDelta(fml::TimeDelta::Zero());
+  fml::TimePoint present_requested_time_ =
+      fml::TimePoint::FromEpochDelta(fml::TimeDelta::Zero());
 
   std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
       future_presentation_infos_ = {};

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -78,7 +78,6 @@ class SessionConnection final {
       fml::TimePoint last_latch_point_targeted,
       fml::TimeDelta flutter_frame_build_time,
       fml::TimeDelta vsync_interval,
-      fml::TimeDelta max_e2e_latency,
       std::deque<std::pair<fml::TimePoint, fml::TimePoint>>&
           future_presentation_infos);
 

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -78,6 +78,7 @@ class SessionConnection final {
       fml::TimePoint last_latch_point_targeted,
       fml::TimeDelta flutter_frame_build_time,
       fml::TimeDelta vsync_interval,
+      fml::TimeDelta max_e2e_latency,
       std::deque<std::pair<fml::TimePoint, fml::TimePoint>>&
           future_presentation_infos);
 

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -72,6 +72,15 @@ class SessionConnection final {
     return surface_producer_.get();
   }
 
+  static fml::TimePoint CalculateNextLatchPoint(
+      fml::TimePoint present_requested_time,
+      fml::TimePoint now,
+      fml::TimePoint last_vsync_targeted,
+      fml::TimeDelta flutter_frame_build_time,
+      fml::TimeDelta vsync_interval,
+      std::deque<std::pair<fml::TimePoint, fml::TimePoint>>&
+          future_presentation_infos);
+
  private:
   const std::string debug_label_;
   scenic::Session session_wrapper_;

--- a/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
@@ -207,7 +207,7 @@ TEST(CalculateNextLatchPointTest, DelayedPresentRequestWithLongFrameBuildTime) {
             TimePointToInt(last_latch_point_targeted));
 }
 
-TEST(CalculateNextLatchPointTest, LastLastPointTargettedLate) {
+TEST(CalculateNextLatchPointTest, LastLastPointTargetedLate) {
   fml::TimePoint present_requested_time = TimePointFromInt(2000);
   fml::TimePoint now = TimePointFromInt(2000);
   fml::TimePoint last_latch_point_targeted = TimePointFromInt(2600);

--- a/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
@@ -101,4 +101,336 @@ TEST_F(SessionConnectionTest, BatchedPresentTest) {
   EXPECT_GT(num_presents_handled, 0u);
 }
 
+static fml::TimePoint TimePointFromInt(int i) {
+  return fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromNanoseconds(i));
+}
+static fml::TimeDelta TimeDeltaFromInt(int i) {
+  return fml::TimeDelta::FromNanoseconds(i);
+}
+static int TimePointToInt(fml::TimePoint time) {
+  return time.ToEpochDelta().ToNanoseconds();
+}
+
+// The first set of tests has an empty |future_presentation_infos| passed in.
+// Therefore these tests are to ensure that on startup and after not presenting
+// for some time that we have correct, reasonable behavior.
+TEST(CalculateNextLatchPointTest, PresentAsSoonAsPossible) {
+  fml::TimePoint present_requested_time = TimePointFromInt(0);
+  fml::TimePoint now = TimePointFromInt(0);
+  fml::TimePoint last_latch_point_targeted = TimePointFromInt(0);
+  fml::TimeDelta flutter_frame_build_time = TimeDeltaFromInt(0);
+  fml::TimeDelta vsync_interval = TimeDeltaFromInt(1000);
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos = {};
+
+  // Assertions about given values.
+  EXPECT_GE(now, present_requested_time);
+  EXPECT_GE(flutter_frame_build_time, TimeDeltaFromInt(0));
+  EXPECT_GT(vsync_interval, TimeDeltaFromInt(0));
+
+  fml::TimePoint calculated_latch_point =
+      SessionConnection::CalculateNextLatchPoint(
+          present_requested_time, now, last_latch_point_targeted,
+          flutter_frame_build_time, vsync_interval, future_presentation_infos);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point), TimePointToInt(now));
+  EXPECT_LE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + vsync_interval));
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(present_requested_time + flutter_frame_build_time));
+  EXPECT_GT(TimePointToInt(calculated_latch_point),
+            TimePointToInt(last_latch_point_targeted));
+}
+
+TEST(CalculateNextLatchPointTest, LongFrameBuildTime) {
+  fml::TimePoint present_requested_time = TimePointFromInt(500);
+  fml::TimePoint now = TimePointFromInt(600);
+  fml::TimePoint last_latch_point_targeted = TimePointFromInt(0);
+  fml::TimeDelta flutter_frame_build_time = TimeDeltaFromInt(2500);
+  fml::TimeDelta vsync_interval = TimeDeltaFromInt(1000);
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos = {};
+
+  // Assertions about given values.
+  EXPECT_GE(now, present_requested_time);
+  EXPECT_GE(flutter_frame_build_time, TimeDeltaFromInt(0));
+  EXPECT_GT(vsync_interval, TimeDeltaFromInt(0));
+
+  EXPECT_GT(flutter_frame_build_time, vsync_interval);
+
+  fml::TimePoint calculated_latch_point =
+      SessionConnection::CalculateNextLatchPoint(
+          present_requested_time, now, last_latch_point_targeted,
+          flutter_frame_build_time, vsync_interval, future_presentation_infos);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 2)));
+  EXPECT_LE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 3)));
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(present_requested_time + flutter_frame_build_time));
+  EXPECT_GT(TimePointToInt(calculated_latch_point),
+            TimePointToInt(last_latch_point_targeted));
+}
+
+TEST(CalculateNextLatchPointTest, DelayedPresentRequestWithLongFrameBuildTime) {
+  fml::TimePoint present_requested_time = TimePointFromInt(0);
+  fml::TimePoint now = TimePointFromInt(1500);
+  fml::TimePoint last_latch_point_targeted = TimePointFromInt(0);
+  fml::TimeDelta flutter_frame_build_time = TimeDeltaFromInt(2000);
+  fml::TimeDelta vsync_interval = TimeDeltaFromInt(1000);
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos = {};
+
+  // Assertions about given values.
+  EXPECT_GE(now, present_requested_time);
+  EXPECT_GE(flutter_frame_build_time, TimeDeltaFromInt(0));
+  EXPECT_GT(vsync_interval, TimeDeltaFromInt(0));
+
+  EXPECT_GT(flutter_frame_build_time, vsync_interval);
+  EXPECT_GT(now, present_requested_time + vsync_interval);
+
+  fml::TimePoint calculated_latch_point =
+      SessionConnection::CalculateNextLatchPoint(
+          present_requested_time, now, last_latch_point_targeted,
+          flutter_frame_build_time, vsync_interval, future_presentation_infos);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point), TimePointToInt(now));
+  EXPECT_LE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + vsync_interval));
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(present_requested_time + flutter_frame_build_time));
+  EXPECT_GT(TimePointToInt(calculated_latch_point),
+            TimePointToInt(last_latch_point_targeted));
+}
+
+TEST(CalculateNextLatchPointTest, LastLastPointTargettedLate) {
+  fml::TimePoint present_requested_time = TimePointFromInt(2000);
+  fml::TimePoint now = TimePointFromInt(2000);
+  fml::TimePoint last_latch_point_targeted = TimePointFromInt(2600);
+  fml::TimeDelta flutter_frame_build_time = TimeDeltaFromInt(1000);
+  fml::TimeDelta vsync_interval = TimeDeltaFromInt(1000);
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos = {};
+
+  // Assertions about given values.
+  EXPECT_GE(now, present_requested_time);
+  EXPECT_GE(flutter_frame_build_time, TimeDeltaFromInt(0));
+  EXPECT_GT(vsync_interval, TimeDeltaFromInt(0));
+
+  EXPECT_GT(last_latch_point_targeted, present_requested_time);
+
+  fml::TimePoint calculated_latch_point =
+      SessionConnection::CalculateNextLatchPoint(
+          present_requested_time, now, last_latch_point_targeted,
+          flutter_frame_build_time, vsync_interval, future_presentation_infos);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + vsync_interval));
+  EXPECT_LE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 2)));
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(present_requested_time + flutter_frame_build_time));
+  EXPECT_GT(TimePointToInt(calculated_latch_point),
+            TimePointToInt(last_latch_point_targeted));
+}
+
+// This set of tests provides (latch_point, vsync_time) pairs in
+// |future_presentation_infos|. This tests steady state behavior where we're
+// presenting frames virtually every vsync interval.
+
+TEST(CalculateNextLatchPointTest, SteadyState_OnTimeFrames) {
+  fml::TimePoint present_requested_time = TimePointFromInt(5000);
+  fml::TimePoint now = TimePointFromInt(5000);
+  fml::TimePoint last_latch_point_targeted = TimePointFromInt(4500);
+  fml::TimeDelta flutter_frame_build_time = TimeDeltaFromInt(1000);
+  fml::TimeDelta vsync_interval = TimeDeltaFromInt(1000);
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos = {
+          {TimePointFromInt(3500), TimePointFromInt(4000)},
+          {TimePointFromInt(4500), TimePointFromInt(5000)},
+          {TimePointFromInt(5500), TimePointFromInt(6000)},
+          {TimePointFromInt(6500), TimePointFromInt(7000)},
+          {TimePointFromInt(7500), TimePointFromInt(8000)},
+      };
+
+  // Assertions about given values.
+  EXPECT_GE(now, present_requested_time);
+  EXPECT_GE(flutter_frame_build_time, TimeDeltaFromInt(0));
+  EXPECT_GT(vsync_interval, TimeDeltaFromInt(0));
+
+  fml::TimePoint calculated_latch_point =
+      SessionConnection::CalculateNextLatchPoint(
+          present_requested_time, now, last_latch_point_targeted,
+          flutter_frame_build_time, vsync_interval, future_presentation_infos);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + vsync_interval));
+  EXPECT_LE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 2)));
+  EXPECT_EQ(TimePointToInt(calculated_latch_point), 6500);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(present_requested_time + flutter_frame_build_time));
+  EXPECT_GT(TimePointToInt(calculated_latch_point),
+            TimePointToInt(last_latch_point_targeted));
+}
+
+TEST(CalculateNextLatchPointTest, SteadyState_LongFrameBuildTimes) {
+  fml::TimePoint present_requested_time = TimePointFromInt(5000);
+  fml::TimePoint now = TimePointFromInt(5000);
+  fml::TimePoint last_latch_point_targeted = TimePointFromInt(4500);
+  fml::TimeDelta flutter_frame_build_time = TimeDeltaFromInt(2000);
+  fml::TimeDelta vsync_interval = TimeDeltaFromInt(1000);
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos = {
+          {TimePointFromInt(3500), TimePointFromInt(4000)},
+          {TimePointFromInt(4500), TimePointFromInt(5000)},
+          {TimePointFromInt(5500), TimePointFromInt(6000)},
+          {TimePointFromInt(6500), TimePointFromInt(7000)},
+          {TimePointFromInt(7500), TimePointFromInt(8000)},
+      };
+
+  // Assertions about given values.
+  EXPECT_GE(now, present_requested_time);
+  EXPECT_GE(flutter_frame_build_time, TimeDeltaFromInt(0));
+  EXPECT_GT(vsync_interval, TimeDeltaFromInt(0));
+
+  EXPECT_GT(flutter_frame_build_time, vsync_interval);
+
+  fml::TimePoint calculated_latch_point =
+      SessionConnection::CalculateNextLatchPoint(
+          present_requested_time, now, last_latch_point_targeted,
+          flutter_frame_build_time, vsync_interval, future_presentation_infos);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 2)));
+  EXPECT_LE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 3)));
+  EXPECT_EQ(TimePointToInt(calculated_latch_point), 7500);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(present_requested_time + flutter_frame_build_time));
+  EXPECT_GT(TimePointToInt(calculated_latch_point),
+            TimePointToInt(last_latch_point_targeted));
+}
+
+TEST(CalculateNextLatchPointTest, SteadyState_LateLastLatchPointTargeted) {
+  fml::TimePoint present_requested_time = TimePointFromInt(5000);
+  fml::TimePoint now = TimePointFromInt(5000);
+  fml::TimePoint last_latch_point_targeted = TimePointFromInt(6500);
+  fml::TimeDelta flutter_frame_build_time = TimeDeltaFromInt(1000);
+  fml::TimeDelta vsync_interval = TimeDeltaFromInt(1000);
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos = {
+          {TimePointFromInt(4500), TimePointFromInt(5000)},
+          {TimePointFromInt(5500), TimePointFromInt(6000)},
+          {TimePointFromInt(6500), TimePointFromInt(7000)},
+          {TimePointFromInt(7500), TimePointFromInt(8000)},
+          {TimePointFromInt(8500), TimePointFromInt(9000)},
+      };
+
+  // Assertions about given values.
+  EXPECT_GE(now, present_requested_time);
+  EXPECT_GE(flutter_frame_build_time, TimeDeltaFromInt(0));
+  EXPECT_GT(vsync_interval, TimeDeltaFromInt(0));
+
+  EXPECT_GT(last_latch_point_targeted, now + vsync_interval);
+
+  fml::TimePoint calculated_latch_point =
+      SessionConnection::CalculateNextLatchPoint(
+          present_requested_time, now, last_latch_point_targeted,
+          flutter_frame_build_time, vsync_interval, future_presentation_infos);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 2)));
+  EXPECT_LE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 3)));
+  EXPECT_EQ(TimePointToInt(calculated_latch_point), 7500);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(present_requested_time + flutter_frame_build_time));
+  EXPECT_GT(TimePointToInt(calculated_latch_point),
+            TimePointToInt(last_latch_point_targeted));
+}
+
+TEST(CalculateNextLatchPointTest,
+     SteadyState_DelayedPresentRequestWithLongFrameBuildTime) {
+  fml::TimePoint present_requested_time = TimePointFromInt(4000);
+  fml::TimePoint now = TimePointFromInt(5500);
+  fml::TimePoint last_latch_point_targeted = TimePointFromInt(3500);
+  fml::TimeDelta flutter_frame_build_time = TimeDeltaFromInt(2000);
+  fml::TimeDelta vsync_interval = TimeDeltaFromInt(1000);
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos = {
+          {TimePointFromInt(4500), TimePointFromInt(5000)},
+          {TimePointFromInt(5500), TimePointFromInt(6000)},
+          {TimePointFromInt(6500), TimePointFromInt(7000)},
+      };
+
+  // Assertions about given values.
+  EXPECT_GE(now, present_requested_time);
+  EXPECT_GE(flutter_frame_build_time, TimeDeltaFromInt(0));
+  EXPECT_GT(vsync_interval, TimeDeltaFromInt(0));
+
+  EXPECT_GT(flutter_frame_build_time, vsync_interval);
+  EXPECT_GT(now, present_requested_time + vsync_interval);
+
+  fml::TimePoint calculated_latch_point =
+      SessionConnection::CalculateNextLatchPoint(
+          present_requested_time, now, last_latch_point_targeted,
+          flutter_frame_build_time, vsync_interval, future_presentation_infos);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + vsync_interval));
+  EXPECT_LE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 2)));
+  EXPECT_EQ(TimePointToInt(calculated_latch_point), 6500);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(present_requested_time + flutter_frame_build_time));
+  EXPECT_GT(TimePointToInt(calculated_latch_point),
+            TimePointToInt(last_latch_point_targeted));
+}
+
+TEST(CalculateNextLatchPointTest, SteadyState_FuzzyLatchpoints) {
+  fml::TimePoint present_requested_time = TimePointFromInt(4000);
+  fml::TimePoint now = TimePointFromInt(4000);
+  fml::TimePoint last_latch_point_targeted = TimePointFromInt(5490);
+  fml::TimeDelta flutter_frame_build_time = TimeDeltaFromInt(1000);
+  fml::TimeDelta vsync_interval = TimeDeltaFromInt(1000);
+  std::deque<std::pair<fml::TimePoint, fml::TimePoint>>
+      future_presentation_infos = {
+          {TimePointFromInt(4510), TimePointFromInt(5000)},
+          {TimePointFromInt(5557), TimePointFromInt(6000)},
+          {TimePointFromInt(6490), TimePointFromInt(7000)},
+          {TimePointFromInt(7356), TimePointFromInt(8000)},
+      };
+
+  // Assertions about given values.
+  EXPECT_GE(now, present_requested_time);
+  EXPECT_GE(flutter_frame_build_time, TimeDeltaFromInt(0));
+  EXPECT_GT(vsync_interval, TimeDeltaFromInt(0));
+
+  fml::TimePoint calculated_latch_point =
+      SessionConnection::CalculateNextLatchPoint(
+          present_requested_time, now, last_latch_point_targeted,
+          flutter_frame_build_time, vsync_interval, future_presentation_infos);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 2)));
+  EXPECT_LE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(now + (vsync_interval * 3)));
+  EXPECT_EQ(TimePointToInt(calculated_latch_point), 6490);
+
+  EXPECT_GE(TimePointToInt(calculated_latch_point),
+            TimePointToInt(present_requested_time + flutter_frame_build_time));
+  EXPECT_GT(TimePointToInt(calculated_latch_point),
+            TimePointToInt(last_latch_point_targeted));
+}
+
 }  // namespace flutter_runner_test

--- a/shell/platform/fuchsia/flutter/vsync_waiter.cc
+++ b/shell/platform/fuchsia/flutter/vsync_waiter.cc
@@ -140,8 +140,14 @@ void VsyncWaiter::AwaitVSync() {
   fml::TimePoint now = fml::TimePoint::Now();
   fml::TimePoint last_presentation_time =
       VsyncRecorder::GetInstance().GetLastPresentationTime();
-  fml::TimePoint next_vsync = SnapToNextPhase(now, last_presentation_time,
-                                              vsync_info.presentation_interval);
+
+  fml::TimePoint next_vsync =
+      VsyncRecorder::GetInstance().GetCurrentVsyncInfo().presentation_time;
+
+  if (next_vsync <= now) {
+    next_vsync = SnapToNextPhase(now, last_presentation_time,
+                                 vsync_info.presentation_interval);
+  }
 
   auto next_vsync_start_time = next_vsync - vsync_offset_;
 
@@ -182,8 +188,13 @@ void VsyncWaiter::FireCallbackNow() {
   fml::TimePoint now = fml::TimePoint::Now();
   fml::TimePoint last_presentation_time =
       VsyncRecorder::GetInstance().GetLastPresentationTime();
-  fml::TimePoint next_vsync = SnapToNextPhase(now, last_presentation_time,
-                                              vsync_info.presentation_interval);
+  fml::TimePoint next_vsync =
+      VsyncRecorder::GetInstance().GetCurrentVsyncInfo().presentation_time;
+
+  if (next_vsync <= now) {
+    next_vsync = SnapToNextPhase(now, last_presentation_time,
+                                 vsync_info.presentation_interval);
+  }
   fml::TimePoint previous_vsync = next_vsync - vsync_info.presentation_interval;
 
   FireCallback(previous_vsync, next_vsync);


### PR DESCRIPTION
Currently, we request a presentation time of 0 for all frames, thus relying on wakeup ordering between Flutter and Scenic to have reasonable behavior. This is unreliable at best, and necessitates coordination between Flutter and Scenic code changes in order to not regress performance.

This PR enables Flutter to instead target frame times based on information returned every vsync interval from Scenic. No change in performance is expected, as we're still targeting the same vsyncs, only now we're doing so explicitly.