### PR TITLE
Revert "Remove the global engine entry timestamp"

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -559,6 +559,8 @@ FILE: ../../../flutter/runtime/service_protocol.cc
 FILE: ../../../flutter/runtime/service_protocol.h
 FILE: ../../../flutter/runtime/skia_concurrent_executor.cc
 FILE: ../../../flutter/runtime/skia_concurrent_executor.h
+FILE: ../../../flutter/runtime/start_up.cc
+FILE: ../../../flutter/runtime/start_up.h
 FILE: ../../../flutter/runtime/test_font_data.cc
 FILE: ../../../flutter/runtime/test_font_data.h
 FILE: ../../../flutter/runtime/window_data.cc

--- a/common/settings.h
+++ b/common/settings.h
@@ -8,7 +8,6 @@
 #include <fcntl.h>
 #include <stdint.h>
 
-#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -207,11 +206,6 @@ struct Settings {
   /// See also:
   /// https://github.com/dart-lang/sdk/blob/ca64509108b3e7219c50d6c52877c85ab6a35ff2/runtime/vm/flag_list.h#L150
   int64_t old_gen_heap_size = -1;
-
-  /// A timestamp representing when the engine started. The value is based
-  /// on the clock used by the Dart timeline APIs. This timestamp is used
-  /// to log a timeline event that tracks the latency of engine startup.
-  std::chrono::microseconds engine_start_timestamp = {};
 
   std::string ToString() const;
 };

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -70,6 +70,8 @@ source_set("runtime") {
     "service_protocol.h",
     "skia_concurrent_executor.cc",
     "skia_concurrent_executor.h",
+    "start_up.cc",
+    "start_up.h",
     "window_data.cc",
     "window_data.h",
   ]

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -25,6 +25,7 @@
 #include "flutter/runtime/dart_isolate.h"
 #include "flutter/runtime/dart_service_isolate.h"
 #include "flutter/runtime/ptrace_ios.h"
+#include "flutter/runtime/start_up.h"
 #include "third_party/dart/runtime/include/bin/dart_io_api.h"
 #include "third_party/skia/include/core/SkExecutor.h"
 #include "third_party/tonic/converter/dart_converter.h"
@@ -425,15 +426,14 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     // the very first frame gives us a good idea about Flutter's startup time.
     // Use a duration event so about:tracing will consider this event when
     // deciding the earliest event to use as time 0.
-    if (settings_.engine_start_timestamp.count()) {
-      Dart_TimelineEvent(
-          "FlutterEngineMainEnter",                  // label
-          settings_.engine_start_timestamp.count(),  // timestamp0
-          Dart_TimelineGetMicros(),                  // timestamp1_or_async_id
-          Dart_Timeline_Event_Duration,              // event type
-          0,                                         // argument_count
-          nullptr,                                   // argument_names
-          nullptr                                    // argument_values
+    if (engine_main_enter_ts != 0) {
+      Dart_TimelineEvent("FlutterEngineMainEnter",  // label
+                         engine_main_enter_ts,      // timestamp0
+                         Dart_TimelineGetMicros(),  // timestamp1_or_async_id
+                         Dart_Timeline_Event_Duration,  // event type
+                         0,                             // argument_count
+                         nullptr,                       // argument_names
+                         nullptr                        // argument_values
       );
     }
   }

--- a/runtime/start_up.cc
+++ b/runtime/start_up.cc
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/runtime/start_up.h"
+
+namespace flutter {
+
+int64_t engine_main_enter_ts = 0;
+
+}  // namespace flutter

--- a/runtime/start_up.h
+++ b/runtime/start_up.h
@@ -1,0 +1,24 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_RUNTIME_START_UP_H_
+#define FLUTTER_RUNTIME_START_UP_H_
+
+#include <stdint.h>
+
+namespace flutter {
+
+// The earliest available timestamp in the application's lifecycle. The
+// difference between this timestamp and the time we render the very first
+// frame gives us a good idea about Flutter's startup time.
+//
+// This timestamp only covers Flutter's own startup. In an upside-down model
+// it is possible that the first Flutter view is not initialized until some
+// time later. In this case the timestamp may not cover the time spent in the
+// user code prior to initializing Flutter.
+extern int64_t engine_main_enter_ts;
+
+}  // namespace flutter
+
+#endif  // FLUTTER_RUNTIME_START_UP_H_

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -20,6 +20,7 @@
 #include "flutter/fml/trace_event.h"
 #include "flutter/fml/unique_fd.h"
 #include "flutter/runtime/dart_vm.h"
+#include "flutter/runtime/start_up.h"
 #include "flutter/shell/common/engine.h"
 #include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/skia_event_tracer_impl.h"
@@ -174,6 +175,12 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
   return shell;
 }
 
+static void RecordStartupTimestamp() {
+  if (engine_main_enter_ts == 0) {
+    engine_main_enter_ts = Dart_TimelineGetMicros();
+  }
+}
+
 static void Tokenize(const std::string& input,
                      std::vector<std::string>* results,
                      char delimiter) {
@@ -190,7 +197,7 @@ static void Tokenize(const std::string& input,
 // TODO(chinmaygarde): The unfortunate side effect of this call is that settings
 // that cause shell initialization failures will still lead to some of their
 // settings being applied.
-static void PerformInitializationTasks(Settings& settings) {
+static void PerformInitializationTasks(const Settings& settings) {
   {
     fml::LogSettings log_settings;
     log_settings.min_log_level =
@@ -200,10 +207,7 @@ static void PerformInitializationTasks(Settings& settings) {
 
   static std::once_flag gShellSettingsInitialization = {};
   std::call_once(gShellSettingsInitialization, [&settings] {
-    if (settings.engine_start_timestamp.count() == 0) {
-      settings.engine_start_timestamp =
-          std::chrono::microseconds(Dart_TimelineGetMicros());
-    }
+    RecordStartupTimestamp();
 
     tonic::SetLogHandler(
         [](const char* message) { FML_LOG(ERROR) << message; });

--- a/shell/platform/android/flutter_main.h
+++ b/shell/platform/android/flutter_main.h
@@ -35,8 +35,7 @@ class FlutterMain {
                    jobjectArray jargs,
                    jstring kernelPath,
                    jstring appStoragePath,
-                   jstring engineCachesPath,
-                   jlong initTimeMillis);
+                   jstring engineCachesPath);
 
   void SetupObservatoryUriCallback(JNIEnv* env);
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -103,8 +103,10 @@ public class FlutterJNI {
       @NonNull String[] args,
       @Nullable String bundlePath,
       @NonNull String appStoragePath,
-      @NonNull String engineCachesPath,
-      long initTimeMillis);
+      @NonNull String engineCachesPath);
+
+  // TODO(mattcarroll): add javadocs
+  public static native void nativeRecordStartTimestamp(long initTimeMillis);
 
   // TODO(mattcarroll): add javadocs
   @UiThread

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -78,7 +78,6 @@ public class FlutterLoader {
   private boolean initialized = false;
   @Nullable private ResourceExtractor resourceExtractor;
   @Nullable private Settings settings;
-  private long initStartTimestampMillis;
 
   /**
    * Starts initialization of the native system.
@@ -114,7 +113,8 @@ public class FlutterLoader {
 
     this.settings = settings;
 
-    initStartTimestampMillis = SystemClock.uptimeMillis();
+    long initStartTimestampMillis = SystemClock.uptimeMillis();
+    initConfig(applicationContext);
     initResources(applicationContext);
 
     System.loadLibrary("flutter");
@@ -122,6 +122,14 @@ public class FlutterLoader {
     VsyncWaiter.getInstance(
             (WindowManager) applicationContext.getSystemService(Context.WINDOW_SERVICE))
         .init();
+
+    // We record the initialization time using SystemClock because at the start of the
+    // initialization we have not yet loaded the native library to call into dart_tools_api.h.
+    // To get Timeline timestamp of the start of initialization we simply subtract the delta
+    // from the Timeline timestamp at the current moment (the assumption is that the overhead
+    // of the JNI call is negligible).
+    long initTimeMillis = SystemClock.uptimeMillis() - initStartTimestampMillis;
+    FlutterJNI.nativeRecordStartTimestamp(initTimeMillis);
   }
 
   /**
@@ -194,14 +202,12 @@ public class FlutterLoader {
 
       String appStoragePath = PathUtils.getFilesDir(applicationContext);
       String engineCachesPath = PathUtils.getCacheDirectory(applicationContext);
-      long initTimeMillis = SystemClock.uptimeMillis() - initStartTimestampMillis;
       FlutterJNI.nativeInit(
           applicationContext,
           shellArgs.toArray(new String[0]),
           kernelPath,
           appStoragePath,
-          engineCachesPath,
-          initTimeMillis);
+          engineCachesPath);
 
       initialized = true;
     } catch (Exception e) {


### PR DESCRIPTION
Reverts flutter/engine#18182

Detailed discussion around g3 test failures are in the roller's chat room.