### PR TITLE
Restore the call to initConfig in FlutterLoader

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -115,6 +115,7 @@ public class FlutterLoader {
     this.settings = settings;
 
     initStartTimestampMillis = SystemClock.uptimeMillis();
+    initConfig(applicationContext);
     initResources(applicationContext);
 
     System.loadLibrary("flutter");


### PR DESCRIPTION
This was accidentally removed in https://github.com/flutter/engine/pull/18182