### PR TITLE
Use the term 'handler' for registering callbacks.

### DIFF
--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -26,18 +26,18 @@ typedef enum {
 GQuark fl_engine_error_quark(void) G_GNUC_CONST;
 
 /**
- * FlEnginePlatformMessageCallback:
+ * FlEnginePlatformMessageHandler:
  * @engine: a #FlEngine
  * @channel: channel message received on.
  * @message: message content received from Dart
  * @response_handle: a handle to respond to the message with
- * @user_data: (closure): data provided when registering this callback
+ * @user_data: (closure): data provided when registering this handler
  *
  * Function called when platform messages are received.
  *
  * Returns: %TRUE if message has been accepted.
  */
-typedef gboolean (*FlEnginePlatformMessageCallback)(
+typedef gboolean (*FlEnginePlatformMessageHandler)(
     FlEngine* engine,
     const gchar* channel,
     GBytes* message,
@@ -58,10 +58,10 @@ FlEngine* fl_engine_new(FlDartProject* project, FlRenderer* renderer);
 /**
  * fl_engine_set_platform_message_handler:
  * @engine: a #FlEngine
- * @callback: function to call when a platform message is received
- * @user_data: (closure): user data to pass to @callback
+ * @handler: function to call when a platform message is received
+ * @user_data: (closure): user data to pass to @handler
  *
- * Register a callback to handle platform messages. Call
+ * Register a handler to handle platform messages. Call
  * fl_engine_send_platform_message_response() when this message should be
  * responded to. Ownership of #FlutterPlatformMessageResponseHandle is
  * transferred to the caller, and the call must be responded to to avoid
@@ -69,7 +69,7 @@ FlEngine* fl_engine_new(FlDartProject* project, FlRenderer* renderer);
  */
 void fl_engine_set_platform_message_handler(
     FlEngine* engine,
-    FlEnginePlatformMessageCallback callback,
+    FlEnginePlatformMessageHandler handler,
     gpointer user_data);
 
 /**
@@ -119,7 +119,7 @@ void fl_engine_send_mouse_pointer_event(FlEngine* engine,
 /**
  * fl_engine_send_platform_message_response:
  * @engine: a #FlEngine
- * @response_handle: handle that was provided in the callback.
+ * @handle: handle that was provided in #FlEnginePlatformMessageHandler
  * @response: (allow-none): response to send or %NULL for an empty response.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  * to ignore.

--- a/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
+++ b/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
@@ -35,18 +35,17 @@ G_DECLARE_FINAL_TYPE(FlBinaryMessenger,
 typedef struct _FlBinaryMessengerResponseHandle FlBinaryMessengerResponseHandle;
 
 /**
- * FlBinaryMessengerCallback:
+ * FlBinaryMessengerMessageHandler:
  * @messenger: a #FlBinaryMessenger
  * @channel: channel message received on
  * @message: message content received from Dart
  * @response_handle: (transfer full): a handle to respond to the message with
- * @user_data: (closure): data provided when registering this callback
+ * @user_data: (closure): data provided when registering this handler
  *
  * Function called when platform messages are received. The receiver must
- * respond to the message to avoid leaking the handle, see the documentation on
- * the code that generated the callback as to which function to call.
+ * call fl_binary_messenger_send_response() to avoid leaking the handle.
  */
-typedef void (*FlBinaryMessengerCallback)(
+typedef void (*FlBinaryMessengerMessageHandler)(
     FlBinaryMessenger* messenger,
     const gchar* channel,
     GBytes* message,
@@ -57,8 +56,9 @@ typedef void (*FlBinaryMessengerCallback)(
  * fl_binary_messenger_set_platform_message_handler:
  * @binary_messenger: a #FlBinaryMessenger
  * @channel: channel to listen on
- * @callback: function to call when a message is received on this channel
- * @user_data: (closure): user data to pass to @callback
+ * @handler: (allow-none): function to call when a message is received on this
+ * channel or %NULL to disable a handler
+ * @user_data: (closure): user data to pass to @handler
  *
  * Set the function called when a platform message is received on the given
  * channel. Call fl_binary_messenger_send_response() when the message is
@@ -68,14 +68,14 @@ typedef void (*FlBinaryMessengerCallback)(
 void fl_binary_messenger_set_message_handler_on_channel(
     FlBinaryMessenger* messenger,
     const gchar* channel,
-    FlBinaryMessengerCallback callback,
+    FlBinaryMessengerMessageHandler handler,
     gpointer user_data);
 
 /**
  * fl_binary_messenger_send_response:
  * @binary_messenger: a #FlBinaryMessenger
  * @response_handle: (transfer full): handle that was provided in a
- * #FlBinaryMessengerCallback
+ * #FlBinaryMessengerMessageHandler
  * @response: (allow-none): response to send or %NULL for an empty response
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  * to ignore


### PR DESCRIPTION
This is the term used in the Dart code and which callback is more commonly used
in GLib matching the Dart code will make developers life easier.