### PR TITLE
Implement WriteAtomically using write/fsync on all platforms, and enable file unittests on Fuchsia

### DIFF
--- a/testing/fuchsia/meta/fuchsia_test.cmx
+++ b/testing/fuchsia/meta/fuchsia_test.cmx
@@ -6,7 +6,8 @@
     "features": [
       "vulkan",
       "deprecated-ambient-replace-as-executable",
-      "isolated-cache-storage"
+      "isolated-cache-storage",
+      "isolated-temp"
     ],
     "services": [
       "fuchsia.accessibility.semantics.SemanticsManager",

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -100,7 +100,7 @@ echo "$(date) START:fml_tests ---------------------------------------"
 ./fuchsia_ctl -d $device_name test \
     -f fml_tests-0.far  \
     -t fml_tests \
-    -a "--gtest_filter=-FileTest*" \
+    -a "--gtest_filter=-FileTest.CanTruncateAndWrite:FileTest.CreateDirectoryStructure" \
     --identity-file $pkey \
     --timeout-seconds $test_timeout_seconds \
     --packages-directory packages


### PR DESCRIPTION
This is because the existing mmap/memcpy codepath doesn't work on Fuchsia.