### PR TITLE
Make fl_value_get return appropriate things for null values.

### DIFF
--- a/shell/platform/linux/fl_value.cc
+++ b/shell/platform/linux/fl_value.cc
@@ -452,42 +452,63 @@ G_MODULE_EXPORT double fl_value_get_float(FlValue* self) {
 
 G_MODULE_EXPORT const gchar* fl_value_get_string(FlValue* self) {
   g_return_val_if_fail(self != nullptr, nullptr);
-  g_return_val_if_fail(self->type == FL_VALUE_TYPE_STRING, nullptr);
+  g_return_val_if_fail(
+      self->type == FL_VALUE_TYPE_STRING || self->type == FL_VALUE_TYPE_NULL,
+      nullptr);
+  if (self->type == FL_VALUE_TYPE_NULL)
+    return nullptr;
   FlValueString* v = reinterpret_cast<FlValueString*>(self);
   return v->value;
 }
 
 G_MODULE_EXPORT const uint8_t* fl_value_get_uint8_list(FlValue* self) {
   g_return_val_if_fail(self != nullptr, nullptr);
-  g_return_val_if_fail(self->type == FL_VALUE_TYPE_UINT8_LIST, nullptr);
+  g_return_val_if_fail(self->type == FL_VALUE_TYPE_UINT8_LIST ||
+                           self->type == FL_VALUE_TYPE_NULL,
+                       nullptr);
+  if (self->type == FL_VALUE_TYPE_NULL)
+    return nullptr;
   FlValueUint8List* v = reinterpret_cast<FlValueUint8List*>(self);
   return v->values;
 }
 
 G_MODULE_EXPORT const int32_t* fl_value_get_int32_list(FlValue* self) {
   g_return_val_if_fail(self != nullptr, nullptr);
-  g_return_val_if_fail(self->type == FL_VALUE_TYPE_INT32_LIST, nullptr);
+  g_return_val_if_fail(self->type == FL_VALUE_TYPE_INT32_LIST ||
+                           self->type == FL_VALUE_TYPE_NULL,
+                       nullptr);
+  if (self->type == FL_VALUE_TYPE_NULL)
+    return nullptr;
   FlValueInt32List* v = reinterpret_cast<FlValueInt32List*>(self);
   return v->values;
 }
 
 G_MODULE_EXPORT const int64_t* fl_value_get_int64_list(FlValue* self) {
   g_return_val_if_fail(self != nullptr, nullptr);
-  g_return_val_if_fail(self->type == FL_VALUE_TYPE_INT64_LIST, nullptr);
+  g_return_val_if_fail(self->type == FL_VALUE_TYPE_INT64_LIST ||
+                           self->type == FL_VALUE_TYPE_NULL,
+                       nullptr);
+  if (self->type == FL_VALUE_TYPE_NULL)
+    return nullptr;
   FlValueInt64List* v = reinterpret_cast<FlValueInt64List*>(self);
   return v->values;
 }
 
 G_MODULE_EXPORT const double* fl_value_get_float_list(FlValue* self) {
   g_return_val_if_fail(self != nullptr, nullptr);
-  g_return_val_if_fail(self->type == FL_VALUE_TYPE_FLOAT_LIST, nullptr);
+  g_return_val_if_fail(self->type == FL_VALUE_TYPE_FLOAT_LIST ||
+                           self->type == FL_VALUE_TYPE_NULL,
+                       nullptr);
+  if (self->type == FL_VALUE_TYPE_NULL)
+    return nullptr;
   FlValueFloatList* v = reinterpret_cast<FlValueFloatList*>(self);
   return v->values;
 }
 
 G_MODULE_EXPORT size_t fl_value_get_length(FlValue* self) {
   g_return_val_if_fail(self != nullptr, 0);
-  g_return_val_if_fail(self->type == FL_VALUE_TYPE_UINT8_LIST ||
+  g_return_val_if_fail(self->type == FL_VALUE_TYPE_NULL ||
+                           self->type == FL_VALUE_TYPE_UINT8_LIST ||
                            self->type == FL_VALUE_TYPE_INT32_LIST ||
                            self->type == FL_VALUE_TYPE_INT64_LIST ||
                            self->type == FL_VALUE_TYPE_FLOAT_LIST ||
@@ -496,6 +517,8 @@ G_MODULE_EXPORT size_t fl_value_get_length(FlValue* self) {
                        0);
 
   switch (self->type) {
+    case FL_VALUE_TYPE_NULL:
+      return 0;
     case FL_VALUE_TYPE_UINT8_LIST: {
       FlValueUint8List* v = reinterpret_cast<FlValueUint8List*>(self);
       return v->values_length;
@@ -520,7 +543,6 @@ G_MODULE_EXPORT size_t fl_value_get_length(FlValue* self) {
       FlValueMap* v = reinterpret_cast<FlValueMap*>(self);
       return v->keys->len;
     }
-    case FL_VALUE_TYPE_NULL:
     case FL_VALUE_TYPE_BOOL:
     case FL_VALUE_TYPE_INT:
     case FL_VALUE_TYPE_FLOAT:
@@ -557,7 +579,12 @@ G_MODULE_EXPORT FlValue* fl_value_get_map_value(FlValue* self, size_t index) {
 
 G_MODULE_EXPORT FlValue* fl_value_lookup(FlValue* self, FlValue* key) {
   g_return_val_if_fail(self != nullptr, nullptr);
-  g_return_val_if_fail(self->type == FL_VALUE_TYPE_MAP, nullptr);
+  g_return_val_if_fail(
+      self->type == FL_VALUE_TYPE_MAP || self->type == FL_VALUE_TYPE_NULL,
+      nullptr);
+
+  if (self->type == FL_VALUE_TYPE_NULL)
+    return nullptr;
 
   ssize_t index = fl_value_lookup_index(self, key);
   if (index < 0)
@@ -567,6 +594,13 @@ G_MODULE_EXPORT FlValue* fl_value_lookup(FlValue* self, FlValue* key) {
 
 FlValue* fl_value_lookup_string(FlValue* self, const gchar* key) {
   g_return_val_if_fail(self != nullptr, nullptr);
+  g_return_val_if_fail(
+      self->type == FL_VALUE_TYPE_MAP || self->type == FL_VALUE_TYPE_NULL,
+      nullptr);
+
+  if (self->type == FL_VALUE_TYPE_NULL)
+    return nullptr;
+
   g_autoptr(FlValue) string_key = fl_value_new_string(key);
   return fl_value_lookup(self, string_key);
 }

--- a/shell/platform/linux/fl_value_test.cc
+++ b/shell/platform/linux/fl_value_test.cc
@@ -150,6 +150,11 @@ TEST(FlValueTest, StringSizedZeroLength) {
   EXPECT_STREQ(fl_value_get_string(value), "");
 }
 
+TEST(FlValueTest, StringNull) {
+  g_autoptr(FlValue) value = fl_value_new_null();
+  EXPECT_EQ(fl_value_get_string(value), nullptr);
+}
+
 TEST(FlValueTest, StringEqual) {
   g_autoptr(FlValue) value1 = fl_value_new_string("hello");
   g_autoptr(FlValue) value2 = fl_value_new_string("hello");
@@ -177,6 +182,12 @@ TEST(FlValueTest, Uint8ListNullptr) {
   g_autoptr(FlValue) value = fl_value_new_uint8_list(nullptr, 0);
   ASSERT_EQ(fl_value_get_type(value), FL_VALUE_TYPE_UINT8_LIST);
   ASSERT_EQ(fl_value_get_length(value), static_cast<size_t>(0));
+}
+
+TEST(FlValueTest, Uint8ListNull) {
+  g_autoptr(FlValue) value = fl_value_new_null();
+  EXPECT_EQ(fl_value_get_length(value), static_cast<size_t>(0));
+  EXPECT_EQ(fl_value_get_uint8_list(value), nullptr);
 }
 
 TEST(FlValueTest, Uint8ListEqual) {
@@ -233,6 +244,12 @@ TEST(FlValueTest, Int32ListNullptr) {
   ASSERT_EQ(fl_value_get_length(value), static_cast<size_t>(0));
 }
 
+TEST(FlValueTest, Int32ListNull) {
+  g_autoptr(FlValue) value = fl_value_new_null();
+  EXPECT_EQ(fl_value_get_length(value), static_cast<size_t>(0));
+  EXPECT_EQ(fl_value_get_int32_list(value), nullptr);
+}
+
 TEST(FlValueTest, Int32ListEqual) {
   int32_t data1[] = {0, G_MAXINT32, G_MININT32};
   g_autoptr(FlValue) value1 = fl_value_new_int32_list(data1, 3);
@@ -287,6 +304,12 @@ TEST(FlValueTest, Int64ListNullptr) {
   ASSERT_EQ(fl_value_get_length(value), static_cast<size_t>(0));
 }
 
+TEST(FlValueTest, Int64ListNull) {
+  g_autoptr(FlValue) value = fl_value_new_null();
+  EXPECT_EQ(fl_value_get_length(value), static_cast<size_t>(0));
+  EXPECT_EQ(fl_value_get_int64_list(value), nullptr);
+}
+
 TEST(FlValueTest, Int64ListEqual) {
   int64_t data1[] = {0, G_MAXINT64, G_MININT64};
   g_autoptr(FlValue) value1 = fl_value_new_int64_list(data1, 3);
@@ -338,6 +361,12 @@ TEST(FlValueTest, FloatListNullptr) {
   g_autoptr(FlValue) value = fl_value_new_float_list(nullptr, 0);
   ASSERT_EQ(fl_value_get_type(value), FL_VALUE_TYPE_FLOAT_LIST);
   ASSERT_EQ(fl_value_get_length(value), static_cast<size_t>(0));
+}
+
+TEST(FlValueTest, FloatListNull) {
+  g_autoptr(FlValue) value = fl_value_new_null();
+  EXPECT_EQ(fl_value_get_length(value), static_cast<size_t>(0));
+  EXPECT_EQ(fl_value_get_float_list(value), nullptr);
 }
 
 TEST(FlValueTest, FloatListEqual) {
@@ -598,6 +627,13 @@ TEST(FlValueTest, MapLookupString) {
   EXPECT_EQ(fl_value_get_int(v), 2);
   v = fl_value_lookup_string(value, "four");
   ASSERT_EQ(v, nullptr);
+}
+
+TEST(FlValueTest, MapNull) {
+  g_autoptr(FlValue) value = fl_value_new_null();
+  g_autoptr(FlValue) two_key = fl_value_new_string("two");
+  EXPECT_EQ(fl_value_lookup(value, two_key), nullptr);
+  EXPECT_EQ(fl_value_lookup_string(value, nullptr), nullptr);
 }
 
 TEST(FlValueTest, MapEqual) {

--- a/shell/platform/linux/public/flutter_linux/fl_value.h
+++ b/shell/platform/linux/public/flutter_linux/fl_value.h
@@ -363,12 +363,13 @@ double fl_value_get_float(FlValue* value);
 
 /**
  * fl_value_get_string:
- * @value: an #FlValue of type #FL_VALUE_TYPE_STRING
+ * @value: an #FlValue of type #FL_VALUE_TYPE_STRING or #FL_VALUE_TYPE_NULL.
  *
  * Gets the UTF-8 text contained in @value. Calling this with an #FlValue
- * that is not of type #FL_VALUE_TYPE_STRING is a programming error.
+ * that is not of type #FL_VALUE_TYPE_STRING or #FL_VALUE_TYPE_NULL is a
+ * programming error.
  *
- * Returns: a UTF-8 encoded string.
+ * Returns: a UTF-8 encoded string or %NULL if the type is #FL_VALUE_TYPE_NULL.
  */
 const gchar* fl_value_get_string(FlValue* value);
 
@@ -376,18 +377,21 @@ const gchar* fl_value_get_string(FlValue* value);
  * fl_value_get_length:
  * @value: an #FlValue of type #FL_VALUE_TYPE_UINT8_LIST,
  * #FL_VALUE_TYPE_INT32_LIST, #FL_VALUE_TYPE_INT64_LIST,
- * #FL_VALUE_TYPE_FLOAT_LIST, #FL_VALUE_TYPE_LIST or #FL_VALUE_TYPE_MAP.
+ * #FL_VALUE_TYPE_FLOAT_LIST, #FL_VALUE_TYPE_LIST, #FL_VALUE_TYPE_MAP or
+ * #FL_VALUE_TYPE_NULL.
  *
- * Gets the number of elements @value contains. This is only valid for list
- * and map types. Calling this with other types is a programming error.
+ * Gets the number of elements @value contains. This is only valid for the
+ * list/map types and the #FL_VALUE_TYPE_NULL. Calling this with other types is
+ * a programming error.
  *
- * Returns: the number of elements inside @value.
+ * Returns: the number of elements inside @value or zero for
+ * #FL_VALUE_TYPE_NULL.
  */
 size_t fl_value_get_length(FlValue* value);
 
 /**
  * fl_value_get_uint8_list:
- * @value: an #FlValue of type #FL_VALUE_TYPE_UINT8_LIST
+ * @value: an #FlValue of type #FL_VALUE_TYPE_UINT8_LIST or #FL_VALUE_TYPE_NULL.
  *
  * Gets the array of unisigned 8 bit integers @value contains. The data
  * contains fl_get_length() elements. Calling this with an #FlValue that is
@@ -399,7 +403,7 @@ const uint8_t* fl_value_get_uint8_list(FlValue* value);
 
 /**
  * fl_value_get_int32_list:
- * @value: an #FlValue of type #FL_VALUE_TYPE_INT32_LIST
+ * @value: an #FlValue of type #FL_VALUE_TYPE_INT32_LIST or #FL_VALUE_TYPE_NULL.
  *
  * Gets the array of 32 bit integers @value contains. The data contains
  * fl_get_length() elements. Calling this with an #FlValue that is not of
@@ -411,7 +415,7 @@ const int32_t* fl_value_get_int32_list(FlValue* value);
 
 /**
  * fl_value_get_int64_list:
- * @value: an #FlValue of type #FL_VALUE_TYPE_INT64_LIST
+ * @value: an #FlValue of type #FL_VALUE_TYPE_INT64_LIST or #FL_VALUE_TYPE_NULL.
  *
  * Gets the array of 64 bit integers @value contains. The data contains
  * fl_get_length() elements. Calling this with an #FlValue that is not of
@@ -423,7 +427,7 @@ const int64_t* fl_value_get_int64_list(FlValue* value);
 
 /**
  * fl_value_get_float_list:
- * @value: an #FlValue of type #FL_VALUE_TYPE_FLOAT_LIST
+ * @value: an #FlValue of type #FL_VALUE_TYPE_FLOAT_LIST or #FL_VALUE_TYPE_NULL.
  *
  * Gets the array of floating point numbers @value contains. The data
  * contains fl_get_length() elements. Calling this with an #FlValue that is
@@ -440,7 +444,8 @@ const double* fl_value_get_float_list(FlValue* value);
  *
  * Gets a child element of the list. It is a programming error to request an
  * index that is outside the size of the list as returned from
- * fl_value_get_length().
+ * fl_value_get_length(). Calling this with an #FlValue that is
+ * not of type #FL_VALUE_TYPE_LIST is a programming error.
  *
  * Returns: an #FlValue
  */
@@ -453,6 +458,8 @@ FlValue* fl_value_get_list_value(FlValue* value, size_t index);
  *
  * Gets an key from the map. It is a programming error to request an index that
  * is outside the size of the list as returned from fl_value_get_length().
+ * Calling this with an #FlValue that is not of type #FL_VALUE_TYPE_MAP is a
+ * programming error.
  *
  * Returns: an #FlValue
  */
@@ -464,7 +471,9 @@ FlValue* fl_value_get_map_key(FlValue* value, size_t index);
  * @index: an index in the map.
  *
  * Gets a value from the map. It is a programming error to request an index that
- * is outside the size of the list as returned from fl_value_get_length().
+ * is outside the size of the map as returned from fl_value_get_length().
+ * Calling this with an #FlValue that is not of type #FL_VALUE_TYPE_MAP is a
+ * programming error.
  *
  * Returns: an #FlValue
  */
@@ -472,11 +481,12 @@ FlValue* fl_value_get_map_value(FlValue* value, size_t index);
 
 /**
  * fl_value_lookup:
- * @value: an #FlValue of type #FL_VALUE_TYPE_MAP
+ * @value: an #FlValue of type #FL_VALUE_TYPE_MAP or #FL_VALUE_TYPE_NULL.
  * @key: a key value
  *
  * Gets the map entry that matches @key. Keys are checked using
- * fl_value_equal().
+ * fl_value_equal(). Calling this with an #FlValue that is
+ * not of type #FL_VALUE_TYPE_MAP or #FL_VALUE_TYPE_NULL is a programming error.
  *
  * Map lookups are not optimised for performance - if have a large map or need
  * frequent access you should copy the data into another structure, e.g.
@@ -488,11 +498,12 @@ FlValue* fl_value_lookup(FlValue* value, FlValue* key);
 
 /**
  * fl_value_lookup_string:
- * @value: an #FlValue of type #FL_VALUE_TYPE_MAP
+ * @value: an #FlValue of type #FL_VALUE_TYPE_MAP or #FL_VALUE_TYPE_NULL.
  * @key: a key value
  *
  * Gets the map entry that matches @key. Keys are checked using
- * fl_value_equal().
+ * fl_value_equal(). Calling this with an #FlValue that is
+ * not of type #FL_VALUE_TYPE_MAP or #FL_VALUE_TYPE_NULL is a programming error.
  *
  * Map lookups are not optimised for performance - if have a large map or need
  * frequent access you should copy the data into another structure, e.g.


### PR DESCRIPTION
This allows the user to access strings, lists and maps without having to check
if they are null.