### PR TITLE
Fix error renderSurface , enderSurface maybe will null.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -208,7 +208,12 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
     }
 
     flutterRenderer.stopRenderingToSurface();
-    renderSurface.release();
-    renderSurface = null;
+    // in some devices go to background will invoke onSurfaceTextureDestroyed before detachFromFlutterEngine
+    // so disconnectSurfaceFromRenderer will be invoked twice
+    // renderSurface will be null make crash NullPointerException
+    if(renderSurface != null){
+      renderSurface.release();
+      renderSurface = null;
+    }
   }
 }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -264,7 +264,7 @@ public class FlutterView extends FrameLayout {
     super(context, attrs);
 
     this.flutterTextureView = flutterTextureView;
-    this.renderSurface = flutterSurfaceView;
+    this.renderSurface = flutterTextureView;
 
     init();
   }


### PR DESCRIPTION
fix FlutterTextureView set error renderSurface and in some cases renderSurface will be null before invoke detachFromFlutterEngine. 
