### PR TITLE
Re-enable Fuchsia tests

### DIFF
--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -16,10 +16,11 @@
 
 set -Ee
 
+test_timeout_seconds=300
 
-echo "These tests have been temporarily disabled."
-echo "See: https://github.com/flutter/flutter/issues/57061"
-exit 0
+# This is longer than the test timeout as dumping the
+# logs can sometimes take longer.
+ssh_timeout_seconds=360
 
 # The nodes are named blah-blah--four-word-fuchsia-id
 device_name=${SWARMING_BOT_ID#*--}
@@ -40,6 +41,7 @@ reboot() {
 
   ./fuchsia_ctl -d $device_name ssh \
       -c "log_listener --dump_logs yes" \
+      --timeout-seconds $ssh_timeout_seconds \
       --identity-file $pkey
 
   echo "$(date) START:REBOOT ------------------------------------------"
@@ -71,54 +73,57 @@ tar -xvzf $2 -C packages 1> /dev/null
 echo "$(date) END:EXTRACT_PACKAGES  -----------------------------------"
 
 
-# TODO (kaushikiska): Re-enable these tests.
-# see: https://github.com/flutter/flutter/issues/57061
 # TODO(gw280): Enable tests using JIT runner
 
-# echo "$(date) START:flutter_runner_tests ----------------------------"
-# ./fuchsia_ctl -d $device_name test \
-#     -f flutter_aot_runner-0.far    \
-#     -f flutter_runner_tests-0.far  \
-#     -t flutter_runner_tests        \
-#     --identity-file $pkey \
-#     --timeout-seconds 300 \
-#     --packages-directory packages
+echo "$(date) START:flutter_runner_tests ----------------------------"
+./fuchsia_ctl -d $device_name test \
+    -f flutter_aot_runner-0.far    \
+    -f flutter_runner_tests-0.far  \
+    -t flutter_runner_tests        \
+    --identity-file $pkey \
+    --timeout-seconds $test_timeout_seconds \
+    --packages-directory packages
 
-# ./fuchsia_ctl -d $device_name test \
-#     -f flutter_aot_runner-0.far    \
-#     -f flutter_runner_scenic_tests-0.far  \
-#     -t flutter_runner_scenic_tests \
-#     --identity-file $pkey \
-#     --timeout-seconds 300 \
-#     --packages-directory packages
+./fuchsia_ctl -d $device_name test \
+    -f flutter_aot_runner-0.far    \
+    -f flutter_runner_scenic_tests-0.far  \
+    -t flutter_runner_scenic_tests \
+    --identity-file $pkey \
+    --timeout-seconds $test_timeout_seconds \
+    --packages-directory packages
 
 # TODO(https://github.com/flutter/flutter/issues/50032) Enable after the
 # Fuchsia message loop migration is complete.
-# echo "$(date) START:fml_tests ---------------------------------------"
-# ./fuchsia_ctl -d $device_name test \
-#     -f fml_tests-0.far  \
-#     -t fml_tests \
-#     -a "--gtest_filter=-MessageLoop*:Message*:FileTest*" \
-#     --identity-file $pkey \
-#     --timeout-seconds 300 \
-#     --packages-directory packages
+echo "$(date) START:fml_tests ---------------------------------------"
+./fuchsia_ctl -d $device_name test \
+    -f fml_tests-0.far  \
+    -t fml_tests \
+    -a "--gtest_filter=-MessageLoop*:Message*:FileTest*" \
+    --identity-file $pkey \
+    --timeout-seconds $test_timeout_seconds \
+    --packages-directory packages
 
 
-# echo "$(date) START:flow_tests --------------------------------------"
-# ./fuchsia_ctl -d $device_name test \
-#     -f flow_tests-0.far  \
-#     -t flow_tests \
-#     --identity-file $pkey \
-#     --timeout-seconds 300 \
-#     --packages-directory packages
+echo "$(date) START:flow_tests --------------------------------------"
+./fuchsia_ctl -d $device_name test \
+    -f flow_tests-0.far  \
+    -t flow_tests \
+    --identity-file $pkey \
+    --timeout-seconds $test_timeout_seconds \
+    --packages-directory packages
+
+
+# TODO(kaushikiska): Runtime and shell tests are failing with
+# async_dispatcher failures. Re-enable them once this gets fixed.
 
 # echo "$(date) START:runtime_tests -----------------------------------"
 # ./fuchsia_ctl -d $device_name test \
 #     -f runtime_tests-0.far  \
 #     -t runtime_tests \
 #     --identity-file $pkey \
-#     --timeout-seconds 300 \
+#     --timeout-seconds $test_timeout_seconds \
 #     --packages-directory packages
+
 
 # TODO(https://github.com/flutter/flutter/issues/53399): Re-enable
 # OnServiceProtocolGetSkSLsWorks and CanLoadSkSLsFromAsset once they pass on
@@ -129,5 +134,5 @@ echo "$(date) END:EXTRACT_PACKAGES  -----------------------------------"
 #     -t shell_tests \
 #     -a "--gtest_filter=-ShellTest.CacheSkSLWorks:ShellTest.SetResourceCacheSize*:ShellTest.OnServiceProtocolGetSkSLsWorks:ShellTest.CanLoadSkSLsFromAsset" \
 #     --identity-file $pkey \
-#     --timeout-seconds 300 \
+#     --timeout-seconds $test_timeout_seconds \
 #     --packages-directory packages


### PR DESCRIPTION
Per my analysis [here](https://docs.google.com/spreadsheets/d/1BB0O4ti6dOY3EkBuBMLkImUB3vxYfPSFvvvPapRzgNQ/edit#gid=0), most of the failures seem to be test timeouts. I'm attempting to enable the tests again.