### PR TITLE
Delete unused decode UTF-8, JSON functions

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -7,16 +7,6 @@
 // @dart = 2.6
 part of dart.ui;
 
-// ignore: unused_element
-String _decodeUTF8(ByteData message) {
-  return message != null ? utf8.decoder.convert(message.buffer.asUint8List()) : null;
-}
-
-// ignore: unused_element
-dynamic _decodeJSON(String message) {
-  return message != null ? json.decode(message) : null;
-}
-
 @pragma('vm:entry-point')
 // ignore: unused_element
 void _updateWindowMetrics(


### PR DESCRIPTION
These were added in 7e5d63513a7ae854605dbd38582cead55594e9f0 for use in
_handleNavigationMessage. That function was deleted in
f37aafd456fc6a1c2dba5bc1b63123b0e665e6cd, but the support methods were
left in the code. `// ignore: unused` annotations were added to all
private native entry points by dnfield (to work around what is arguably
a bug) in 6179ac637724e8f93b7f3c8dcfda93a6b9b7995e, and were applied to
these two methods, I suspect unintentionally.

In any case, they appear entirely unused at present.