### PR TITLE
Moved memory management code from scoped_nsobject from the header to the binary

### DIFF
--- a/fml/platform/darwin/scoped_nsobject.h
+++ b/fml/platform/darwin/scoped_nsobject.h
@@ -38,26 +38,28 @@ namespace fml {
 // time with a template specialization (see below).
 
 #if __has_feature(objc_arc)
+template <typename NST>
 class scoped_nsprotocol_memory_management {
  public:
-  static id Retain(__unsafe_unretained id object) { return object; }
-  static id Autorelease(__unsafe_unretained id object) { return object; }
-  static void Release(__unsafe_unretained id object) {}
-  static id InvalidValue() { return nil; }
+  static NST Retain(NST object) { return object; }
+  static NST Autorelease(NST object) { return object; }
+  static void Release(NST object) {}
+  static NST InvalidValue() { return nil; }
 };
 #else
+template <typename NST>
 class scoped_nsprotocol_memory_management {
  public:
-  static id Retain(id object) { return [object retain]; }
-  static id Autorelease(id object) { return [object autorelease]; }
-  static void Release(id object) { [object release]; }
-  static id InvalidValue() { return nil; }
+  static NST Retain(NST object) { return [object retain]; }
+  static NST Autorelease(NST object) { return [object autorelease]; }
+  static void Release(NST object) { [object release]; }
+  static NST InvalidValue() { return nil; }
 };
 #endif
 
 template <typename NST>
 class scoped_nsprotocol {
-  using Memory = scoped_nsprotocol_memory_management;
+  using Memory = scoped_nsprotocol_memory_management<NST>;
 
  public:
   explicit scoped_nsprotocol(NST object = Memory::InvalidValue()) : object_(object) {}

--- a/fml/platform/darwin/scoped_nsobject.h
+++ b/fml/platform/darwin/scoped_nsobject.h
@@ -46,21 +46,7 @@ class scoped_nsprotocol_arc_memory_management {
 };
 
 template <typename NST>
-class scoped_nsprotocol_mrc_memory_management {
- public:
-  static NST Retain(NST object) { return [object retain]; }
-  static NST Autorelease(NST object) { return [object autorelease]; }
-  static void Release(NST object) { [object release]; }
-  static NST InvalidValue() { return nil; }
-};
-
-#if __has_feature(objc_arc)
-template <typename NST>
 using scoped_nsprotocol_memory_management = scoped_nsprotocol_arc_memory_management;
-#else
-template <typename NST>
-using scoped_nsprotocol_memory_management = scoped_nsprotocol_mrc_memory_management<NST>;
-#endif
 
 template <typename NST>
 class scoped_nsprotocol {

--- a/fml/platform/darwin/scoped_nsobject.h
+++ b/fml/platform/darwin/scoped_nsobject.h
@@ -63,6 +63,7 @@ using scoped_nsprotocol_memory_management = scoped_nsprotocol_mrc_memory_managem
 template <typename NST>
 class scoped_nsprotocol {
   using Memory = scoped_nsprotocol_memory_management<NST>;
+
  public:
   explicit scoped_nsprotocol(NST object = nil) : object_(object) {}
 

--- a/fml/platform/darwin/scoped_nsobject.mm
+++ b/fml/platform/darwin/scoped_nsobject.mm
@@ -6,15 +6,15 @@
 
 namespace fml {
 
-id ObjcRetain(id object) {
+id scoped_nsprotocol_arc_memory_management::Retain(id object) {
   return [object retain];
 }
 
-id ObjcAutorelease(id object) {
+id scoped_nsprotocol_arc_memory_management::Autorelease(id object) {
   return [object autorelease];
 }
 
-void ObjcRelease(id object) {
+void scoped_nsprotocol_arc_memory_management::Release(id object) {
   [object release];
 }
 

--- a/fml/platform/darwin/scoped_nsobject.mm
+++ b/fml/platform/darwin/scoped_nsobject.mm
@@ -3,19 +3,3 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
-
-namespace fml {
-
-id scoped_nsprotocol_arc_memory_management::Retain(id object) {
-  return [object retain];
-}
-
-id scoped_nsprotocol_arc_memory_management::Autorelease(id object) {
-  return [object autorelease];
-}
-
-void scoped_nsprotocol_arc_memory_management::Release(id object) {
-  [object release];
-}
-
-}  // namespace fml

--- a/fml/platform/darwin/scoped_nsobject.mm
+++ b/fml/platform/darwin/scoped_nsobject.mm
@@ -6,6 +6,16 @@
 
 namespace fml {
 
-//
+id ObjcRetain(id object) {
+  return [object retain];
+}
+
+id ObjcAutorelease(id object) {
+  return [object autorelease];
+}
+
+void ObjcRelease(id object) {
+  [object release];
+}
 
 }  // namespace fml

--- a/shell/gpu/gpu_surface_metal.h
+++ b/shell/gpu/gpu_surface_metal.h
@@ -20,7 +20,7 @@ namespace flutter {
 class GPUSurfaceMetal : public Surface {
  public:
   GPUSurfaceMetal(GPUSurfaceDelegate* delegate,
-                  fml::scoped_nsobject<CAMetalLayer> layer,
+                  fml::scoped_nsobject<CAMetalLayer*> layer,
                   sk_sp<GrDirectContext> context,
                   fml::scoped_nsprotocol<id<MTLCommandQueue>> command_queue);
 
@@ -29,7 +29,7 @@ class GPUSurfaceMetal : public Surface {
 
  private:
   GPUSurfaceDelegate* delegate_;
-  fml::scoped_nsobject<CAMetalLayer> layer_;
+  fml::scoped_nsobject<CAMetalLayer*> layer_;
   sk_sp<GrDirectContext> context_;
   fml::scoped_nsprotocol<id<MTLCommandQueue>> command_queue_;
   GrMTLHandle next_drawable_ = nullptr;

--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -17,7 +17,7 @@ static_assert(!__has_feature(objc_arc), "ARC must be disabled.");
 namespace flutter {
 
 GPUSurfaceMetal::GPUSurfaceMetal(GPUSurfaceDelegate* delegate,
-                                 fml::scoped_nsobject<CAMetalLayer> layer,
+                                 fml::scoped_nsobject<CAMetalLayer*> layer,
                                  sk_sp<GrDirectContext> context,
                                  fml::scoped_nsprotocol<id<MTLCommandQueue>> command_queue)
     : delegate_(delegate),

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -54,30 +54,30 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 @end
 
 @implementation FlutterEngine {
-  fml::scoped_nsobject<FlutterDartProject> _dartProject;
+  fml::scoped_nsobject<FlutterDartProject*> _dartProject;
   flutter::ThreadHost _threadHost;
   std::unique_ptr<flutter::Shell> _shell;
   NSString* _labelPrefix;
   std::unique_ptr<fml::WeakPtrFactory<FlutterEngine>> _weakFactory;
 
   fml::WeakPtr<FlutterViewController> _viewController;
-  fml::scoped_nsobject<FlutterObservatoryPublisher> _publisher;
+  fml::scoped_nsobject<FlutterObservatoryPublisher*> _publisher;
 
   std::unique_ptr<flutter::FlutterPlatformViewsController> _platformViewsController;
   std::unique_ptr<flutter::ProfilerMetricsIOS> _profiler_metrics;
   std::unique_ptr<flutter::SamplingProfiler> _profiler;
 
   // Channels
-  fml::scoped_nsobject<FlutterPlatformPlugin> _platformPlugin;
-  fml::scoped_nsobject<FlutterTextInputPlugin> _textInputPlugin;
-  fml::scoped_nsobject<FlutterMethodChannel> _localizationChannel;
-  fml::scoped_nsobject<FlutterMethodChannel> _navigationChannel;
-  fml::scoped_nsobject<FlutterMethodChannel> _platformChannel;
-  fml::scoped_nsobject<FlutterMethodChannel> _platformViewsChannel;
-  fml::scoped_nsobject<FlutterMethodChannel> _textInputChannel;
-  fml::scoped_nsobject<FlutterBasicMessageChannel> _lifecycleChannel;
-  fml::scoped_nsobject<FlutterBasicMessageChannel> _systemChannel;
-  fml::scoped_nsobject<FlutterBasicMessageChannel> _settingsChannel;
+  fml::scoped_nsobject<FlutterPlatformPlugin*> _platformPlugin;
+  fml::scoped_nsobject<FlutterTextInputPlugin*> _textInputPlugin;
+  fml::scoped_nsobject<FlutterMethodChannel*> _localizationChannel;
+  fml::scoped_nsobject<FlutterMethodChannel*> _navigationChannel;
+  fml::scoped_nsobject<FlutterMethodChannel*> _platformChannel;
+  fml::scoped_nsobject<FlutterMethodChannel*> _platformViewsChannel;
+  fml::scoped_nsobject<FlutterMethodChannel*> _textInputChannel;
+  fml::scoped_nsobject<FlutterBasicMessageChannel*> _lifecycleChannel;
+  fml::scoped_nsobject<FlutterBasicMessageChannel*> _systemChannel;
+  fml::scoped_nsobject<FlutterBasicMessageChannel*> _settingsChannel;
 
   int64_t _nextTextureId;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -49,14 +49,14 @@
 - (void)publishServiceProtocolPort:(NSString*)uri;
 - (void)stopService;
 
-@property(readonly) fml::scoped_nsobject<NSURL> url;
+@property(readonly) fml::scoped_nsobject<NSURL*> url;
 @end
 
 @interface FlutterObservatoryPublisher ()
 - (NSData*)createTxtData:(NSURL*)url;
 
 @property(readonly) NSString* serviceName;
-@property(readonly) fml::scoped_nsobject<NSObject<FlutterObservatoryPublisherDelegate>> delegate;
+@property(readonly) fml::scoped_nsobject<NSObject<FlutterObservatoryPublisherDelegate>*> delegate;
 
 @end
 
@@ -68,7 +68,7 @@
 @end
 
 @implementation ObservatoryDNSServiceDelegate {
-  fml::scoped_nsobject<FlutterObservatoryPublisher> _owner;
+  fml::scoped_nsobject<FlutterObservatoryPublisher*> _owner;
   DNSServiceRef _dnsServiceRef;
 }
 
@@ -165,8 +165,8 @@ static void DNSSD_API registrationCallback(DNSServiceRef sdRef,
 @end
 
 @implementation ObservatoryNSNetServiceDelegate {
-  fml::scoped_nsobject<FlutterObservatoryPublisher> _owner;
-  fml::scoped_nsobject<NSNetService> _netService;
+  fml::scoped_nsobject<FlutterObservatoryPublisher*> _owner;
+  fml::scoped_nsobject<NSNetService*> _netService;
 }
 
 @synthesize url;

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -64,8 +64,8 @@
 
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
     (std::shared_ptr<flutter::IOSContext>)ios_context {
-  return flutter::IOSSurface::Create(std::move(ios_context),                              // context
-                                     fml::scoped_nsobject<CALayer>{[self.layer retain]},  // layer
+  return flutter::IOSSurface::Create(std::move(ios_context),  // context
+                                     fml::scoped_nsobject<CALayer*>{[self.layer retain]},  // layer
                                      nullptr  // platform views controller
   );
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -26,8 +26,8 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewLayerPool::GetLayer
     std::shared_ptr<IOSContext> ios_context) {
   if (available_layer_index_ >= layers_.size()) {
     std::shared_ptr<FlutterPlatformViewLayer> layer;
-    fml::scoped_nsobject<FlutterOverlayView> overlay_view;
-    fml::scoped_nsobject<FlutterOverlayView> overlay_view_wrapper;
+    fml::scoped_nsobject<FlutterOverlayView*> overlay_view;
+    fml::scoped_nsobject<FlutterOverlayView*> overlay_view_wrapper;
 
     if (!gr_context) {
       overlay_view.reset([[FlutterOverlayView alloc] init]);
@@ -161,7 +161,7 @@ void FlutterPlatformViewsController::OnCreate(FlutterMethodCall* call, FlutterRe
   // Set a unique view identifier, so the platform view can be identified in unit tests.
   [embedded_view view].accessibilityIdentifier =
       [NSString stringWithFormat:@"platform_view[%ld]", viewId];
-  views_[viewId] = fml::scoped_nsobject<NSObject<FlutterPlatformView>>([embedded_view retain]);
+  views_[viewId] = fml::scoped_nsobject<NSObject<FlutterPlatformView>*>([embedded_view retain]);
 
   FlutterTouchInterceptingView* touch_interceptor = [[[FlutterTouchInterceptingView alloc]
                   initWithEmbeddedView:embedded_view.view
@@ -170,12 +170,12 @@ void FlutterPlatformViewsController::OnCreate(FlutterMethodCall* call, FlutterRe
       autorelease];
 
   touch_interceptors_[viewId] =
-      fml::scoped_nsobject<FlutterTouchInterceptingView>([touch_interceptor retain]);
+      fml::scoped_nsobject<FlutterTouchInterceptingView*>([touch_interceptor retain]);
 
   ChildClippingView* clipping_view =
       [[[ChildClippingView alloc] initWithFrame:CGRectZero] autorelease];
   [clipping_view addSubview:touch_interceptor];
-  root_views_[viewId] = fml::scoped_nsobject<UIView>([clipping_view retain]);
+  root_views_[viewId] = fml::scoped_nsobject<UIView*>([clipping_view retain]);
 
   result(nil);
 }
@@ -238,7 +238,7 @@ void FlutterPlatformViewsController::RegisterViewFactory(
   std::string idString([factoryId UTF8String]);
   FML_CHECK(factories_.count(idString) == 0);
   factories_[idString] =
-      fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>([factory retain]);
+      fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>*>([factory retain]);
   gesture_recognizers_blocking_policies[idString] = gestureRecognizerBlockingPolicy;
 }
 
@@ -703,7 +703,7 @@ void FlutterPlatformViewsController::DisposeViews() {
 @end
 
 @implementation FlutterTouchInterceptingView {
-  fml::scoped_nsobject<DelayingGestureRecognizer> _delayingRecognizer;
+  fml::scoped_nsobject<DelayingGestureRecognizer*> _delayingRecognizer;
   FlutterPlatformViewGestureRecognizersBlockingPolicy _blockingPolicy;
 }
 - (instancetype)initWithEmbeddedView:(UIView*)embeddedView
@@ -781,7 +781,7 @@ void FlutterPlatformViewsController::DisposeViews() {
 @end
 
 @implementation DelayingGestureRecognizer {
-  fml::scoped_nsobject<UIGestureRecognizer> _forwardingRecognizer;
+  fml::scoped_nsobject<UIGestureRecognizer*> _forwardingRecognizer;
 }
 
 - (instancetype)initWithTarget:(id)target

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -63,15 +63,15 @@ class IOSContextGL;
 class IOSSurface;
 
 struct FlutterPlatformViewLayer {
-  FlutterPlatformViewLayer(fml::scoped_nsobject<UIView> overlay_view,
-                           fml::scoped_nsobject<UIView> overlay_view_wrapper,
+  FlutterPlatformViewLayer(fml::scoped_nsobject<UIView*> overlay_view,
+                           fml::scoped_nsobject<UIView*> overlay_view_wrapper,
                            std::unique_ptr<IOSSurface> ios_surface,
                            std::unique_ptr<Surface> surface);
 
   ~FlutterPlatformViewLayer();
 
-  fml::scoped_nsobject<UIView> overlay_view;
-  fml::scoped_nsobject<UIView> overlay_view_wrapper;
+  fml::scoped_nsobject<UIView*> overlay_view;
+  fml::scoped_nsobject<UIView*> overlay_view_wrapper;
   std::unique_ptr<IOSSurface> ios_surface;
   std::unique_ptr<Surface> surface;
 
@@ -199,18 +199,18 @@ class FlutterPlatformViewsController {
   // operation until the next platform view or the end of the last leaf node in the layer tree.
   std::map<int64_t, std::unique_ptr<SkPictureRecorder>> picture_recorders_;
 
-  fml::scoped_nsobject<FlutterMethodChannel> channel_;
-  fml::scoped_nsobject<UIView> flutter_view_;
-  fml::scoped_nsobject<UIViewController> flutter_view_controller_;
-  std::map<std::string, fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>> factories_;
-  std::map<int64_t, fml::scoped_nsobject<NSObject<FlutterPlatformView>>> views_;
-  std::map<int64_t, fml::scoped_nsobject<FlutterTouchInterceptingView>> touch_interceptors_;
+  fml::scoped_nsobject<FlutterMethodChannel*> channel_;
+  fml::scoped_nsobject<UIView*> flutter_view_;
+  fml::scoped_nsobject<UIViewController*> flutter_view_controller_;
+  std::map<std::string, fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>*>> factories_;
+  std::map<int64_t, fml::scoped_nsobject<NSObject<FlutterPlatformView>*>> views_;
+  std::map<int64_t, fml::scoped_nsobject<FlutterTouchInterceptingView*>> touch_interceptors_;
   // Mapping a platform view ID to the top most parent view (root_view) who is a direct child to
   // the `flutter_view_`.
   //
   // The platform view with the view ID is a child of the root view; If the platform view is not
   // clipped, and no clipping view is added, the root view will be the intercepting view.
-  std::map<int64_t, fml::scoped_nsobject<UIView>> root_views_;
+  std::map<int64_t, fml::scoped_nsobject<UIView*>> root_views_;
   // Mapping a platform view ID to its latest composition params.
   std::map<int64_t, EmbeddedViewParams> current_composition_params_;
   // Mapping a platform view ID to the count of the clipping operations that were applied to the

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -12,8 +12,8 @@ static int kMaxPointsInVerb = 4;
 namespace flutter {
 
 FlutterPlatformViewLayer::FlutterPlatformViewLayer(
-    fml::scoped_nsobject<UIView> overlay_view,
-    fml::scoped_nsobject<UIView> overlay_view_wrapper,
+    fml::scoped_nsobject<UIView*> overlay_view,
+    fml::scoped_nsobject<UIView*> overlay_view_wrapper,
     std::unique_ptr<IOSSurface> ios_surface,
     std::unique_ptr<Surface> surface)
     : overlay_view(std::move(overlay_view)),

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -75,9 +75,9 @@
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
     (std::shared_ptr<flutter::IOSContext>)ios_context {
   return flutter::IOSSurface::Create(
-      std::move(ios_context),                              // context
-      fml::scoped_nsobject<CALayer>{[self.layer retain]},  // layer
-      [_delegate platformViewsController]                  // platform views controller
+      std::move(ios_context),                               // context
+      fml::scoped_nsobject<CALayer*>{[self.layer retain]},  // layer
+      [_delegate platformViewsController]                   // platform views controller
   );
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -59,12 +59,12 @@ typedef enum UIAccessibilityContrast : NSInteger {
 
 @implementation FlutterViewController {
   std::unique_ptr<fml::WeakPtrFactory<FlutterViewController>> _weakFactory;
-  fml::scoped_nsobject<FlutterEngine> _engine;
+  fml::scoped_nsobject<FlutterEngine*> _engine;
 
   // We keep a separate reference to this and create it ahead of time because we want to be able to
   // setup a shell along with its platform view before the view has to appear.
-  fml::scoped_nsobject<FlutterView> _flutterView;
-  fml::scoped_nsobject<UIView> _splashScreenView;
+  fml::scoped_nsobject<FlutterView*> _flutterView;
+  fml::scoped_nsobject<UIView*> _splashScreenView;
   fml::ScopedBlock<void (^)(void)> _flutterViewRenderedCallback;
   UIInterfaceOrientationMask _orientationPreferences;
   UIStatusBarStyle _statusBarStyle;
@@ -72,12 +72,12 @@ typedef enum UIAccessibilityContrast : NSInteger {
   BOOL _initialized;
   BOOL _viewOpaque;
   BOOL _engineNeedsLaunch;
-  fml::scoped_nsobject<NSMutableSet<NSNumber*>> _ongoingTouches;
+  fml::scoped_nsobject<NSMutableSet<NSNumber*>*> _ongoingTouches;
   // This scroll view is a workaround to accomodate iOS 13 and higher.  There isn't a way to get
   // touches on the status bar to trigger scrolling to the top of a scroll view.  We place a
   // UIScrollView with height zero and a content offset so we can get those events. See also:
   // https://github.com/flutter/flutter/issues/35050
-  fml::scoped_nsobject<UIScrollView> _scrollView;
+  fml::scoped_nsobject<UIScrollView*> _scrollView;
 }
 
 @synthesize displayingFlutterUI = _displayingFlutterUI;
@@ -157,7 +157,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
 
 - (void)sharedSetupWithProject:(nullable FlutterDartProject*)project
                   initialRoute:(nullable NSString*)initialRoute {
-  auto engine = fml::scoped_nsobject<FlutterEngine>{[[FlutterEngine alloc]
+  auto engine = fml::scoped_nsobject<FlutterEngine*>{[[FlutterEngine alloc]
                 initWithName:@"io.flutter"
                      project:project
       allowHeadlessExecution:self.engineAllowHeadlessExecution]};
@@ -471,7 +471,7 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
     FML_DCHECK(RasterTaskRunner->RunsTasksOnCurrentThread());
     // Get callback on raster thread and jump back to platform thread.
     platformTaskRunner->PostTask([weakSelf]() {
-      fml::scoped_nsobject<FlutterViewController> flutterViewController(
+      fml::scoped_nsobject<FlutterViewController*> flutterViewController(
           [(FlutterViewController*)weakSelf.get() retain]);
       if (flutterViewController) {
         if (flutterViewController.get()->_splashScreenView) {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -109,7 +109,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 @end
 
 @implementation SemanticsObject {
-  fml::scoped_nsobject<SemanticsObjectContainer> _container;
+  fml::scoped_nsobject<SemanticsObjectContainer*> _container;
   NSMutableArray<SemanticsObject*>* _children;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -90,7 +90,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   // been focused or the focus is currently outside of the flutter application
   // (i.e. the status bar or keyboard)
   int32_t last_focused_semantics_object_id_;
-  fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
+  fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>*> objects_;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;
   fml::WeakPtrFactory<AccessibilityBridge> weak_factory_;
   int32_t previous_route_id_;

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -21,7 +21,7 @@ class VsyncWaiterIOS final : public VsyncWaiter {
   ~VsyncWaiterIOS() override;
 
  private:
-  fml::scoped_nsobject<VSyncClient> client_;
+  fml::scoped_nsobject<VSyncClient*> client_;
 
   // |VsyncWaiter|
   void AwaitVSync() override;

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -66,7 +66,7 @@ float VsyncWaiterIOS::GetDisplayRefreshRate() const {
 
 @implementation VSyncClient {
   flutter::VsyncWaiter::Callback callback_;
-  fml::scoped_nsobject<CADisplayLink> display_link_;
+  fml::scoped_nsobject<CADisplayLink*> display_link_;
 }
 
 - (instancetype)initWithTaskRunner:(fml::RefPtr<fml::TaskRunner>)task_runner
@@ -75,7 +75,7 @@ float VsyncWaiterIOS::GetDisplayRefreshRate() const {
 
   if (self) {
     callback_ = std::move(callback);
-    display_link_ = fml::scoped_nsobject<CADisplayLink> {
+    display_link_ = fml::scoped_nsobject<CADisplayLink*> {
       [[CADisplayLink displayLinkWithTarget:self selector:@selector(onDisplayLink:)] retain]
     };
     display_link_.get().paused = YES;

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -104,7 +104,7 @@ class IOSContext {
   ///
   virtual std::unique_ptr<Texture> CreateExternalTexture(
       int64_t texture_id,
-      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) = 0;
+      fml::scoped_nsobject<NSObject<FlutterTexture>*> texture) = 0;
 
  protected:
   IOSContext();

--- a/shell/platform/darwin/ios/ios_context_gl.h
+++ b/shell/platform/darwin/ios/ios_context_gl.h
@@ -23,11 +23,11 @@ class IOSContextGL final : public IOSContext {
   // |IOSContext|
   ~IOSContextGL() override;
 
-  std::unique_ptr<IOSRenderTargetGL> CreateRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer);
+  std::unique_ptr<IOSRenderTargetGL> CreateRenderTarget(fml::scoped_nsobject<CAEAGLLayer*> layer);
 
  private:
-  fml::scoped_nsobject<EAGLContext> context_;
-  fml::scoped_nsobject<EAGLContext> resource_context_;
+  fml::scoped_nsobject<EAGLContext*> context_;
+  fml::scoped_nsobject<EAGLContext*> resource_context_;
 
   // |IOSContext|
   sk_sp<GrDirectContext> CreateResourceContext() override;
@@ -38,7 +38,7 @@ class IOSContextGL final : public IOSContext {
   // |IOSContext|
   std::unique_ptr<Texture> CreateExternalTexture(
       int64_t texture_id,
-      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;
+      fml::scoped_nsobject<NSObject<FlutterTexture>*> texture) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSContextGL);
 };

--- a/shell/platform/darwin/ios/ios_context_gl.mm
+++ b/shell/platform/darwin/ios/ios_context_gl.mm
@@ -27,7 +27,7 @@ IOSContextGL::IOSContextGL() {
 IOSContextGL::~IOSContextGL() = default;
 
 std::unique_ptr<IOSRenderTargetGL> IOSContextGL::CreateRenderTarget(
-    fml::scoped_nsobject<CAEAGLLayer> layer) {
+    fml::scoped_nsobject<CAEAGLLayer*> layer) {
   return std::make_unique<IOSRenderTargetGL>(std::move(layer), context_);
 }
 
@@ -52,7 +52,7 @@ std::unique_ptr<GLContextResult> IOSContextGL::MakeCurrent() {
 // |IOSContext|
 std::unique_ptr<Texture> IOSContextGL::CreateExternalTexture(
     int64_t texture_id,
-    fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {
+    fml::scoped_nsobject<NSObject<FlutterTexture>*> texture) {
   return std::make_unique<IOSExternalTextureGL>(texture_id, std::move(texture));
 }
 

--- a/shell/platform/darwin/ios/ios_context_metal.h
+++ b/shell/platform/darwin/ios/ios_context_metal.h
@@ -48,7 +48,7 @@ class IOSContextMetal final : public IOSContext {
   // |IOSContext|
   std::unique_ptr<Texture> CreateExternalTexture(
       int64_t texture_id,
-      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;
+      fml::scoped_nsobject<NSObject<FlutterTexture>*> texture) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSContextMetal);
 };

--- a/shell/platform/darwin/ios/ios_context_metal.mm
+++ b/shell/platform/darwin/ios/ios_context_metal.mm
@@ -106,7 +106,7 @@ std::unique_ptr<GLContextResult> IOSContextMetal::MakeCurrent() {
 // |IOSContext|
 std::unique_ptr<Texture> IOSContextMetal::CreateExternalTexture(
     int64_t texture_id,
-    fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {
+    fml::scoped_nsobject<NSObject<FlutterTexture>*> texture) {
   return std::make_unique<IOSExternalTextureMetal>(texture_id, texture_cache_, std::move(texture));
 }
 

--- a/shell/platform/darwin/ios/ios_context_software.h
+++ b/shell/platform/darwin/ios/ios_context_software.h
@@ -26,7 +26,7 @@ class IOSContextSoftware final : public IOSContext {
   // |IOSContext|
   std::unique_ptr<Texture> CreateExternalTexture(
       int64_t texture_id,
-      fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;
+      fml::scoped_nsobject<NSObject<FlutterTexture>*> texture) override;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(IOSContextSoftware);

--- a/shell/platform/darwin/ios/ios_context_software.mm
+++ b/shell/platform/darwin/ios/ios_context_software.mm
@@ -25,7 +25,7 @@ std::unique_ptr<GLContextResult> IOSContextSoftware::MakeCurrent() {
 // |IOSContext|
 std::unique_ptr<Texture> IOSContextSoftware::CreateExternalTexture(
     int64_t texture_id,
-    fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {
+    fml::scoped_nsobject<NSObject<FlutterTexture>*> texture) {
   // Don't use FML for logging as it will contain engine specific details. This is a user facing
   // message.
   NSLog(@"Flutter: Attempted to composite external texture sources using the software backend. "

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -21,7 +21,7 @@ class IOSExternalTextureGL final : public Texture {
 
  private:
   bool new_frame_ready_ = false;
-  fml::scoped_nsobject<NSObject<FlutterTexture>> external_texture_;
+  fml::scoped_nsobject<NSObject<FlutterTexture>*> external_texture_;
   fml::CFRef<CVOpenGLESTextureCacheRef> cache_ref_;
   fml::CFRef<CVOpenGLESTextureRef> texture_ref_;
   fml::CFRef<CVPixelBufferRef> buffer_ref_;

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -20,7 +20,7 @@ namespace flutter {
 IOSExternalTextureGL::IOSExternalTextureGL(int64_t textureId,
                                            NSObject<FlutterTexture>* externalTexture)
     : Texture(textureId),
-      external_texture_(fml::scoped_nsobject<NSObject<FlutterTexture>>([externalTexture retain])) {
+      external_texture_(fml::scoped_nsobject<NSObject<FlutterTexture>*>([externalTexture retain])) {
   FML_DCHECK(external_texture_);
 }
 

--- a/shell/platform/darwin/ios/ios_external_texture_metal.h
+++ b/shell/platform/darwin/ios/ios_external_texture_metal.h
@@ -22,14 +22,14 @@ class IOSExternalTextureMetal final : public Texture {
  public:
   IOSExternalTextureMetal(int64_t texture_id,
                           fml::CFRef<CVMetalTextureCacheRef> texture_cache,
-                          fml::scoped_nsobject<NSObject<FlutterTexture>> external_texture);
+                          fml::scoped_nsobject<NSObject<FlutterTexture>*> external_texture);
 
   // |Texture|
   ~IOSExternalTextureMetal();
 
  private:
   fml::CFRef<CVMetalTextureCacheRef> texture_cache_;
-  fml::scoped_nsobject<NSObject<FlutterTexture>> external_texture_;
+  fml::scoped_nsobject<NSObject<FlutterTexture>*> external_texture_;
   std::atomic_bool texture_frame_available_;
   fml::CFRef<CVPixelBufferRef> last_pixel_buffer_;
   sk_sp<SkImage> external_image_;

--- a/shell/platform/darwin/ios/ios_external_texture_metal.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_metal.mm
@@ -15,7 +15,7 @@ namespace flutter {
 IOSExternalTextureMetal::IOSExternalTextureMetal(
     int64_t texture_id,
     fml::CFRef<CVMetalTextureCacheRef> texture_cache,
-    fml::scoped_nsobject<NSObject<FlutterTexture>> external_texture)
+    fml::scoped_nsobject<NSObject<FlutterTexture>*> external_texture)
     : Texture(texture_id),
       texture_cache_(std::move(texture_cache)),
       external_texture_(std::move(external_texture)) {

--- a/shell/platform/darwin/ios/ios_render_target_gl.h
+++ b/shell/platform/darwin/ios/ios_render_target_gl.h
@@ -19,8 +19,8 @@ namespace flutter {
 
 class IOSRenderTargetGL {
  public:
-  IOSRenderTargetGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-                    fml::scoped_nsobject<EAGLContext> context_);
+  IOSRenderTargetGL(fml::scoped_nsobject<CAEAGLLayer*> layer,
+                    fml::scoped_nsobject<EAGLContext*> context_);
 
   ~IOSRenderTargetGL();
 
@@ -33,8 +33,8 @@ class IOSRenderTargetGL {
   bool UpdateStorageSizeIfNecessary();
 
  private:
-  fml::scoped_nsobject<CAEAGLLayer> layer_;
-  fml::scoped_nsobject<EAGLContext> context_;
+  fml::scoped_nsobject<CAEAGLLayer*> layer_;
+  fml::scoped_nsobject<EAGLContext*> context_;
   GLuint framebuffer_ = GL_NONE;
   GLuint colorbuffer_ = GL_NONE;
   GLint storage_size_width_ = GL_NONE;

--- a/shell/platform/darwin/ios/ios_render_target_gl.mm
+++ b/shell/platform/darwin/ios/ios_render_target_gl.mm
@@ -12,8 +12,8 @@
 
 namespace flutter {
 
-IOSRenderTargetGL::IOSRenderTargetGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-                                     fml::scoped_nsobject<EAGLContext> context)
+IOSRenderTargetGL::IOSRenderTargetGL(fml::scoped_nsobject<CAEAGLLayer*> layer,
+                                     fml::scoped_nsobject<EAGLContext*> context)
     : layer_(std::move(layer)), context_(context) {
   FML_DCHECK(layer_ != nullptr);
   FML_DCHECK(context_ != nullptr);

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -26,7 +26,7 @@ class IOSSurface : public ExternalViewEmbedder {
  public:
   static std::unique_ptr<IOSSurface> Create(
       std::shared_ptr<IOSContext> context,
-      fml::scoped_nsobject<CALayer> layer,
+      fml::scoped_nsobject<CALayer*> layer,
       FlutterPlatformViewsController* platform_views_controller);
 
   // |ExternalViewEmbedder|

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -15,14 +15,14 @@ namespace flutter {
 
 std::unique_ptr<IOSSurface> IOSSurface::Create(
     std::shared_ptr<IOSContext> context,
-    fml::scoped_nsobject<CALayer> layer,
+    fml::scoped_nsobject<CALayer*> layer,
     FlutterPlatformViewsController* platform_views_controller) {
   FML_DCHECK(layer);
   FML_DCHECK(context);
 
   if ([layer.get() isKindOfClass:[CAEAGLLayer class]]) {
     return std::make_unique<IOSSurfaceGL>(
-        fml::scoped_nsobject<CAEAGLLayer>(
+        fml::scoped_nsobject<CAEAGLLayer*>(
             reinterpret_cast<CAEAGLLayer*>([layer.get() retain])),  // EAGL layer
         std::move(context),                                         // context
         platform_views_controller                                   // platform views controller
@@ -32,7 +32,7 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(
 #if FLUTTER_SHELL_ENABLE_METAL
   if ([layer.get() isKindOfClass:[CAMetalLayer class]]) {
     return std::make_unique<IOSSurfaceMetal>(
-        fml::scoped_nsobject<CAMetalLayer>(
+        fml::scoped_nsobject<CAMetalLayer*>(
             reinterpret_cast<CAMetalLayer*>([layer.get() retain])),  // Metal layer
         std::move(context),                                          // context
         platform_views_controller                                    // platform views controller

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -18,7 +18,7 @@ namespace flutter {
 
 class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
  public:
-  IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
+  IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer*> layer,
                std::shared_ptr<IOSContext> context,
                FlutterPlatformViewsController* platform_views_controller = nullptr);
 

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -14,7 +14,7 @@ static IOSContextGL* CastToGLContext(const std::shared_ptr<IOSContext>& context)
   return reinterpret_cast<IOSContextGL*>(context.get());
 }
 
-IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
+IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer*> layer,
                            std::shared_ptr<IOSContext> context,
                            FlutterPlatformViewsController* platform_views_controller)
     : IOSSurface(context, platform_views_controller) {

--- a/shell/platform/darwin/ios/ios_surface_metal.h
+++ b/shell/platform/darwin/ios/ios_surface_metal.h
@@ -15,7 +15,7 @@ namespace flutter {
 
 class IOSSurfaceMetal final : public IOSSurface, public GPUSurfaceDelegate {
  public:
-  IOSSurfaceMetal(fml::scoped_nsobject<CAMetalLayer> layer,
+  IOSSurfaceMetal(fml::scoped_nsobject<CAMetalLayer*> layer,
                   std::shared_ptr<IOSContext> context,
                   FlutterPlatformViewsController* platform_views_controller);
 
@@ -23,7 +23,7 @@ class IOSSurfaceMetal final : public IOSSurface, public GPUSurfaceDelegate {
   ~IOSSurfaceMetal() override;
 
  private:
-  fml::scoped_nsobject<CAMetalLayer> layer_;
+  fml::scoped_nsobject<CAMetalLayer*> layer_;
   bool is_valid_ = false;
 
   // |IOSSurface|

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -13,7 +13,7 @@ static IOSContextMetal* CastToMetalContext(const std::shared_ptr<IOSContext>& co
   return reinterpret_cast<IOSContextMetal*>(context.get());
 }
 
-IOSSurfaceMetal::IOSSurfaceMetal(fml::scoped_nsobject<CAMetalLayer> layer,
+IOSSurfaceMetal::IOSSurfaceMetal(fml::scoped_nsobject<CAMetalLayer*> layer,
                                  std::shared_ptr<IOSContext> context,
                                  FlutterPlatformViewsController* platform_views_controller)
     : IOSSurface(std::move(context), platform_views_controller), layer_(std::move(layer)) {

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -18,7 +18,7 @@ namespace flutter {
 
 class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDelegate {
  public:
-  IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
+  IOSSurfaceSoftware(fml::scoped_nsobject<CALayer*> layer,
                      std::shared_ptr<IOSContext> context,
                      FlutterPlatformViewsController* platform_views_controller);
 
@@ -43,7 +43,7 @@ class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDel
   ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
  private:
-  fml::scoped_nsobject<CALayer> layer_;
+  fml::scoped_nsobject<CALayer*> layer_;
   sk_sp<SkSurface> sk_surface_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceSoftware);

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -15,7 +15,7 @@
 
 namespace flutter {
 
-IOSSurfaceSoftware::IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
+IOSSurfaceSoftware::IOSSurfaceSoftware(fml::scoped_nsobject<CALayer*> layer,
                                        std::shared_ptr<IOSContext> context,
                                        FlutterPlatformViewsController* platform_views_controller)
     : IOSSurface(std::move(context), platform_views_controller), layer_(std::move(layer)) {}

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -121,7 +121,7 @@ PointerDataDispatcherMaker PlatformViewIOS::GetDispatcherMaker() {
 void PlatformViewIOS::RegisterExternalTexture(int64_t texture_id,
                                               NSObject<FlutterTexture>* texture) {
   RegisterTexture(ios_context_->CreateExternalTexture(
-      texture_id, fml::scoped_nsobject<NSObject<FlutterTexture>>{[texture retain]}));
+      texture_id, fml::scoped_nsobject<NSObject<FlutterTexture>*>{[texture retain]}));
 }
 
 // |PlatformView|


### PR DESCRIPTION
All of our unit tests are written with ARC.  In order for us to write those tests, non-ARC code must live in the binary, not in the headers to avoid `clang++ -fobjc-arc` from attempting to compile them when including the headers of the classes it wants to test.

Related PR: https://github.com/flutter/engine/pull/18281