### PR TITLE
Synchronize Shell:OnPlatformViewDestoryed with thread merging.

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -132,6 +132,7 @@ void Rasterizer::Draw(std::shared_ptr<LayerTreeHolder> layer_tree_holder) {
         << "kResubmit is an invalid raster status without external view "
            "embedder.";
     external_view_embedder->EndFrame(raster_thread_merger_);
+    delegate_.OnTaskRunnerWillMerge();
   }
 
   // Consume as many layer trees as possible. But yield the event loop

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -73,6 +73,15 @@ class Rasterizer final : public SnapshotDelegate {
     /// Target time for the latest frame. See also `Shell::OnAnimatorBeginFrame`
     /// for when this time gets updated.
     virtual fml::TimePoint GetLatestFrameTargetTime() const = 0;
+
+    //--------------------------------------------------------------------------
+    /// @brief      Notifies the delegate that the raster_task_runner will be
+    /// merged
+    ///             into the platform_task_runner at the next frame.
+    ///             This is triggered at the end of the current `Draw` and it is
+    ///             always called on the raster thread.
+    ///
+    virtual void OnTaskRunnerWillMerge() const = 0;
   };
 
   // TODO(dnfield): remove once embedders have caught up.
@@ -86,6 +95,7 @@ class Rasterizer final : public SnapshotDelegate {
     fml::TimePoint GetLatestFrameTargetTime() const override {
       return fml::TimePoint::FromEpochDelta(fml::TimeDelta::Zero());
     }
+    void OnTaskRunnerWillMerge() const override {}
   };
 
   //----------------------------------------------------------------------------

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -419,6 +419,9 @@ class Shell final : public PlatformView::Delegate,
   // and read from the raster thread.
   std::atomic<float> display_refresh_rate_ = 0.0f;
 
+  std::unique_ptr<fml::AutoResetWaitableEvent>
+      platform_view_destroy_raster_task_latch;
+
   // How many frames have been timed since last report.
   size_t UnreportedFramesCount() const;
 
@@ -525,6 +528,9 @@ class Shell final : public PlatformView::Delegate,
 
   // |Rasterizer::Delegate|
   fml::TimePoint GetLatestFrameTargetTime() const override;
+
+  // |Rasterizer::Delegate|
+  void OnTaskRunnerWillMerge() const override;
 
   // |ServiceProtocol::Handler|
   fml::RefPtr<fml::TaskRunner> GetServiceProtocolHandlerTaskRunner(

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -75,6 +75,16 @@ void ShellTest::PlatformViewNotifyCreated(Shell* shell) {
   latch.Wait();
 }
 
+void ShellTest::PlatformViewNotifyDestroyed(Shell* shell) {
+  fml::AutoResetWaitableEvent latch;
+  fml::TaskRunner::RunNowOrPostTask(
+      shell->GetTaskRunners().GetPlatformTaskRunner(), [shell, &latch]() {
+        shell->GetPlatformView()->NotifyDestroyed();
+        latch.Signal();
+      });
+  latch.Wait();
+}
+
 void ShellTest::RunEngine(Shell* shell, RunConfiguration configuration) {
   fml::AutoResetWaitableEvent latch;
   fml::TaskRunner::RunNowOrPostTask(

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -52,6 +52,7 @@ class ShellTest : public ThreadTest {
 
   static void PlatformViewNotifyCreated(
       Shell* shell);  // This creates the surface
+  static void PlatformViewNotifyDestroyed(Shell* shell);
   static void RunEngine(Shell* shell, RunConfiguration configuration);
   static void RestartEngine(Shell* shell, RunConfiguration configuration);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -482,43 +482,19 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     [self startProfiler];
   }
 
-  if (flutter::IsIosEmbeddedViewsPreviewEnabled()) {
-    // Embedded views requires the gpu and the platform views to be the same.
-    // The plan is to eventually dynamically merge the threads when there's a
-    // platform view in the layer tree.
-    // For now we use a fixed thread configuration with the same thread used as the
-    // gpu and platform task runner.
-    // TODO(amirh/chinmaygarde): remove this, and dynamically change the thread configuration.
-    // https://github.com/flutter/flutter/issues/23975
-
-    flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
-                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
-                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // raster
-                                      _threadHost.ui_thread->GetTaskRunner(),          // ui
-                                      _threadHost.io_thread->GetTaskRunner()           // io
-    );
-    // Create the shell. This is a blocking operation.
-    _shell = flutter::Shell::Create(std::move(task_runners),  // task runners
-                                    std::move(windowData),    // window data
-                                    std::move(settings),      // settings
-                                    on_create_platform_view,  // platform view creation
-                                    on_create_rasterizer      // rasterzier creation
-    );
-  } else {
-    flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
-                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
-                                      _threadHost.raster_thread->GetTaskRunner(),      // raster
-                                      _threadHost.ui_thread->GetTaskRunner(),          // ui
-                                      _threadHost.io_thread->GetTaskRunner()           // io
-    );
-    // Create the shell. This is a blocking operation.
-    _shell = flutter::Shell::Create(std::move(task_runners),  // task runners
-                                    std::move(windowData),    // window data
-                                    std::move(settings),      // settings
-                                    on_create_platform_view,  // platform view creation
-                                    on_create_rasterizer      // rasterzier creation
-    );
-  }
+  flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
+                                    fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
+                                    _threadHost.raster_thread->GetTaskRunner(),      // raster
+                                    _threadHost.ui_thread->GetTaskRunner(),          // ui
+                                    _threadHost.io_thread->GetTaskRunner()           // io
+  );
+  // Create the shell. This is a blocking operation.
+  _shell = flutter::Shell::Create(std::move(task_runners),  // task runners
+                                  std::move(windowData),    // window data
+                                  std::move(settings),      // settings
+                                  on_create_platform_view,  // platform view creation
+                                  on_create_rasterizer      // rasterzier creation
+  );
 
   if (_shell == nullptr) {
     FML_LOG(ERROR) << "Could not start a shell FlutterEngine with entrypoint: "


### PR DESCRIPTION
This PR tries to resolve a synchronization issue between `Shell:OnPlatformViewDestoryed` and thread merging. It also updated Shell:OnPlatformViewCreated` to use correct method to determine if threads are merged.

Issue details explained here: https://github.com/flutter/flutter/issues/57067

This PR depends on https://github.com/flutter/engine/pull/18346 to be landed. Because `Shell:OnPlatformViewDestoryed` while thread merging will destroy the surface objects on a different thread that they are created on (but the same task runner)