### PR TITLE
[web] Remap cupertino fonts to -apple-system

### DIFF
--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -17,6 +17,16 @@ void main() async {
 
   await webOnlyInitializeTestDomRenderer();
 
+  String fallback;
+  setUp(() {
+    if (operatingSystem == OperatingSystem.macOs ||
+        operatingSystem == OperatingSystem.iOs) {
+      fallback = '-apple-system, BlinkMacSystemFont';
+    } else {
+      fallback = 'Arial';
+    }
+  });
+
   test('predictably lays out a single-line paragraph', () {
     for (double fontSize in <double>[10.0, 20.0, 30.0, 40.0]) {
       final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
@@ -361,9 +371,9 @@ void main() async {
     expect(paragraph.plainText, isNull);
     final List<SpanElement> spans =
         paragraph.paragraphElement.querySelectorAll('span');
-    expect(spans[0].style.fontFamily, 'Ahem, Arial, sans-serif');
+    expect(spans[0].style.fontFamily, 'Ahem, $fallback, sans-serif');
     // The nested span here should not set it's family to default sans-serif.
-    expect(spans[1].style.fontFamily, 'Ahem, Arial, sans-serif');
+    expect(spans[1].style.fontFamily, 'Ahem, $fallback, sans-serif');
   },
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50771
       // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
@@ -383,7 +393,7 @@ void main() async {
 
     final EngineParagraph paragraph = builder.build();
     expect(paragraph.paragraphElement.style.fontFamily,
-        'SomeFont, Arial, sans-serif');
+        'SomeFont, $fallback, sans-serif');
 
     debugEmulateFlutterTesterEnvironment = true;
   },
@@ -422,7 +432,7 @@ void main() async {
 
     final EngineParagraph paragraph = builder.build();
     expect(paragraph.paragraphElement.style.fontFamily,
-        '"MyFont 2000", Arial, sans-serif');
+        '"MyFont 2000", $fallback, sans-serif');
 
     debugEmulateFlutterTesterEnvironment = true;
   },


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/55989

Test screenshot Chrome on iOS:
![Screen Shot 2020-05-14 at 11 30 12 AM](https://user-images.githubusercontent.com/5061034/81971930-b591e980-95d6-11ea-881f-afddcb69f04d.png)
