### PR TITLE
Add ImageFilter.blur to Paint for web

### DIFF
--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -1106,7 +1106,7 @@ String _blurImageFilterToSvg(EngineImageFilter filter) {
 }
 
 /// Returns an SVG filter element with `filters` as children.
-/// 
+///
 /// `filters` must not be null and must contain valid SVG HTML elements.
 html.Element _buildSvgFilterElement(String filters) {
   assert(filters != null);

--- a/lib/web_ui/lib/src/engine/surface/painting.dart
+++ b/lib/web_ui/lib/src/engine/surface/painting.dart
@@ -164,14 +164,15 @@ class SurfacePaint implements ui.Paint {
   }
 
   @override
-  ui.ImageFilter get imageFilter {
-    // TODO(flutter/flutter#35156): Implement ImageFilter.
-    return null;
-  }
+  ui.ImageFilter get imageFilter => _paintData.imageFilter;
 
   @override
   set imageFilter(ui.ImageFilter value) {
-    // TODO(flutter/flutter#35156): Implement ImageFilter.
+    if (_frozen) {
+      _paintData = _paintData.clone();
+      _frozen = false;
+    }
+    _paintData.imageFilter = value;
   }
 
   // True if Paint instance has used in RecordingCanvas.
@@ -230,6 +231,7 @@ class SurfacePaintData {
   ui.MaskFilter maskFilter;
   ui.FilterQuality filterQuality;
   ui.ColorFilter colorFilter;
+  ui.ImageFilter imageFilter;
 
   // Internal for recording canvas use.
   SurfacePaintData clone() {
@@ -237,6 +239,7 @@ class SurfacePaintData {
       ..blendMode = blendMode
       ..filterQuality = filterQuality
       ..maskFilter = maskFilter
+      ..imageFilter = imageFilter
       ..shader = shader
       ..isAntiAlias = isAntiAlias
       ..color = color

--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -577,9 +577,10 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   }
 }
 
-// TODO(yjbanov): in HTML the blur looks too aggressive. The current
-//                implementation was copied from the existing backdrop-filter
-//                but probably needs a revision.
+// TODO(krista-koivisto): migrate backdrop-filter over to SVG filters to achieve
+//                        closer to a one-to-one blur filter result with
+//                        Flutter. Current implementation is too aggressive and
+//                        does not allow for directional blur.
 String _imageFilterToCss(EngineImageFilter filter) {
   return 'blur(${math.max(filter.sigmaX, filter.sigmaY) * 2}px)';
 }

--- a/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
@@ -147,6 +147,19 @@ void main() async {
     await _checkScreenshot(rc, 'draw_image_rect_with_transform_source');
   });
 
+  test('Paints image with blur', () async {
+    final RecordingCanvas rc =
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+    rc.save();
+    Image testImage = createTestImage(width: 120, height: 80,
+        offset: Offset(12, 12));
+    final paint = Paint()
+        ..imageFilter = ImageFilter.blur(sigmaX: 2.0, sigmaY: 6.0);
+    rc.drawImage(testImage, Offset(0, 0), paint);
+    rc.restore();
+    await _checkScreenshot(rc, 'draw_image_with_blur');
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/44845
   // Circle should draw on top of image not below.
   test('Paints on top of image', () async {
@@ -348,18 +361,19 @@ void main() async {
   });
 }
 
-HtmlImage createTestImage({int width = 100, int height = 50}) {
+HtmlImage createTestImage({int width = 100, int height = 50,
+    Offset offset = const Offset(0, 0)}) {
   html.CanvasElement canvas =
       new html.CanvasElement(width: width, height: height);
   html.CanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#E04040';
-  ctx.fillRect(0, 0, 33, 50);
+  ctx.fillRect(offset.dx, offset.dy, 33, 50);
   ctx.fill();
   ctx.fillStyle = '#40E080';
-  ctx.fillRect(33, 0, 33, 50);
+  ctx.fillRect(offset.dx + 33, offset.dy, 33, 50);
   ctx.fill();
   ctx.fillStyle = '#2040E0';
-  ctx.fillRect(66, 0, 33, 50);
+  ctx.fillRect(offset.dy + 66, offset.dy, 33, 50);
   ctx.fill();
   html.ImageElement imageElement = html.ImageElement();
   imageElement.src = js_util.callMethod(canvas, 'toDataURL', <dynamic>[]);


### PR DESCRIPTION
Implements `ImageFilter.blur` on Flutter Web when applied to `Paint`. Blur was previously only supported through use of a `BackdropFilter`.

Issues related to this pull request are:

 * [#35156](https://github.com/flutter/flutter/issues/35156) - Partially solves this issue. Support for `ImageFilter.matrix` has not yet been implemented.
 * [#35141](https://github.com/flutter/flutter/issues/35141) - This issue was closed, but support was not yet added for web.

@Piinks This is my first time contributing to Flutter and I have added a golden file test. The test in question is `draw_image_with_blur` in `canvas_draw_image_golden_test.dart`.
