### PR TITLE
Started allowing setting message handlers to nil for dead engines

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -678,9 +678,12 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (void)setMessageHandlerOnChannel:(NSString*)channel
               binaryMessageHandler:(FlutterBinaryMessageHandler)handler {
   NSParameterAssert(channel);
-  NSAssert(_shell && _shell->IsSetup(),
-           @"Setting a message handler before the FlutterEngine has been run.");
-  self.iosPlatformView->GetPlatformMessageRouter().SetMessageHandler(channel.UTF8String, handler);
+  if (_shell && _shell->IsSetup()) {
+    self.iosPlatformView->GetPlatformMessageRouter().SetMessageHandler(channel.UTF8String, handler);
+  } else {
+    NSAssert(!handler, @"Setting a message handler before the FlutterEngine has been run.");
+    // Setting a handler to nil for a not setup channel is a noop.
+  }
 }
 
 #pragma mark - FlutterTextureRegistry

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -47,6 +47,13 @@ FLUTTER_ASSERT_ARC
             }]);
 }
 
+- (void)testNilSetMessageHandlerBeforeRun {
+  id project = OCMClassMock([FlutterDartProject class]);
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
+  XCTAssertNotNil(engine);
+  XCTAssertNoThrow([engine.binaryMessenger setMessageHandlerOnChannel:@"foo" binaryMessageHandler:nil]);
+}
+
 - (void)testNotifyPluginOfDealloc {
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   OCMStub([plugin detachFromEngineForRegistrar:[OCMArg any]]);

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -51,7 +51,8 @@ FLUTTER_ASSERT_ARC
   id project = OCMClassMock([FlutterDartProject class]);
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
   XCTAssertNotNil(engine);
-  XCTAssertNoThrow([engine.binaryMessenger setMessageHandlerOnChannel:@"foo" binaryMessageHandler:nil]);
+  XCTAssertNoThrow([engine.binaryMessenger setMessageHandlerOnChannel:@"foo"
+                                                 binaryMessageHandler:nil]);
 }
 
 - (void)testNotifyPluginOfDealloc {


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/57151
related issue: https://github.com/flutter/flutter/issues/56996

Plugins who attempt to nil out their channels when getting detached from a dying engine are running afoul of this assert.  We can make this acceptable or find someway to pass the context to a plugin to know wether it is detaching from a dying engine or a running engine.  I opted for the former.