### PR TITLE
null-annotate native calls in lib/ui/window.dart

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -981,7 +981,7 @@ class Window {
   }
 
   _SetNeedsReportTimingsFunc _setNeedsReportTimings;
-  void _nativeSetNeedsReportTimings(bool value) native 'Window_setNeedsReportTimings';
+  void _nativeSetNeedsReportTimings(bool/*!*/ value) native 'Window_setNeedsReportTimings';
 
   /// A callback that is invoked when pointer data is available.
   ///
@@ -1030,8 +1030,8 @@ class Window {
   ///  * [Navigator], a widget that handles routing.
   ///  * [SystemChannels.navigation], which handles subsequent navigation
   ///    requests from the embedder.
-  String get defaultRouteName => _defaultRouteName();
-  String _defaultRouteName() native 'Window_defaultRouteName';
+  String/*!*/ get defaultRouteName => _defaultRouteName();
+  String/*!*/ _defaultRouteName() native 'Window_defaultRouteName';
 
   /// Requests that, at the next appropriate opportunity, the [onBeginFrame]
   /// and [onDrawFrame] callbacks be invoked.
@@ -1066,7 +1066,7 @@ class Window {
   ///    scheduling of frames.
   ///  * [RendererBinding], the Flutter framework class which manages layout and
   ///    painting.
-  void render(Scene scene) native 'Window_render';
+  void render(Scene/*!*/ scene) native 'Window_render';
 
   /// Whether the user has requested that [updateSemantics] be called when
   /// the semantic contents of window changes.
@@ -1127,7 +1127,7 @@ class Window {
   ///
   /// In either case, this function disposes the given update, which means the
   /// semantics update cannot be used further.
-  void updateSemantics(SemanticsUpdate update) native 'Window_updateSemantics';
+  void updateSemantics(SemanticsUpdate/*!*/ update) native 'Window_updateSemantics';
 
   /// Set the debug name associated with this window's root isolate.
   ///
@@ -1137,7 +1137,7 @@ class Window {
   /// This can be combined with flutter tools `--isolate-filter` flag to debug
   /// specific root isolates. For example: `flutter attach --isolate-filter=[name]`.
   /// Note that this does not rename any child isolates of the root.
-  void setIsolateDebugName(String name) native 'Window_setIsolateDebugName';
+  void setIsolateDebugName(String/*!*/ name) native 'Window_setIsolateDebugName';
 
   /// Sends a message to a platform-specific plugin.
   ///
@@ -1148,17 +1148,17 @@ class Window {
   ///
   /// The framework invokes [callback] in the same zone in which this method
   /// was called.
-  void sendPlatformMessage(String name,
-                           ByteData data,
-                           PlatformMessageResponseCallback callback) {
+  void sendPlatformMessage(String/*!*/ name,
+                           ByteData/*?*/ data,
+                           PlatformMessageResponseCallback/*?*/ callback) {
     final String error =
         _sendPlatformMessage(name, _zonedPlatformMessageResponseCallback(callback), data);
     if (error != null)
       throw Exception(error);
   }
-  String _sendPlatformMessage(String name,
-                              PlatformMessageResponseCallback callback,
-                              ByteData data) native 'Window_sendPlatformMessage';
+  String _sendPlatformMessage(String/*!*/ name,
+                              PlatformMessageResponseCallback/*?*/ callback,
+                              ByteData/*?*/ data) native 'Window_sendPlatformMessage';
 
   /// Called whenever this window receives a message from a platform-specific
   /// plugin.
@@ -1182,12 +1182,12 @@ class Window {
   }
 
   /// Called by [_dispatchPlatformMessage].
-  void _respondToPlatformMessage(int responseId, ByteData data)
+  void _respondToPlatformMessage(int/*!*/ responseId, ByteData/*?*/ data)
       native 'Window_respondToPlatformMessage';
 
   /// Wraps the given [callback] in another callback that ensures that the
   /// original callback is called in the zone it was registered in.
-  static PlatformMessageResponseCallback _zonedPlatformMessageResponseCallback(PlatformMessageResponseCallback callback) {
+  static PlatformMessageResponseCallback/*?*/ _zonedPlatformMessageResponseCallback(PlatformMessageResponseCallback/*?*/ callback) {
     if (callback == null)
       return null;
 
@@ -1209,7 +1209,7 @@ class Window {
   ///
   /// For asynchronous communication between the embedder and isolate, a
   /// platform channel may be used.
-  ByteData getPersistentIsolateData() native 'Window_getPersistentIsolateData';
+  ByteData/*?*/ getPersistentIsolateData() native 'Window_getPersistentIsolateData';
 }
 
 /// Additional accessibility features that may be enabled by the platform.

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -1422,7 +1422,7 @@ class EngineSemanticsOwner {
   }
 
   /// Updates the semantics tree from data in the [uiUpdate].
-  void updateSemantics(ui.SemanticsUpdate uiUpdate) {
+  void updateSemantics(ui.SemanticsUpdate/*!*/ uiUpdate) {
     if (!_semanticsEnabled) {
       return;
     }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -154,7 +154,7 @@ class EngineWindow extends ui.Window {
   String _defaultRouteName;
 
   @override
-  String get defaultRouteName => _defaultRouteName ??= _browserHistory.currentPath;
+  String/*!*/ get defaultRouteName => _defaultRouteName ??= _browserHistory.currentPath;
 
   /// Change the strategy to use for handling browser history location.
   /// Setting this member will automatically update [_browserHistory].
@@ -367,16 +367,16 @@ class EngineWindow extends ui.Window {
 
   @override
   void sendPlatformMessage(
-    String name,
-    ByteData data,
-    ui.PlatformMessageResponseCallback callback,
+    String/*!*/ name,
+    ByteData/*?*/ data,
+    ui.PlatformMessageResponseCallback/*?*/ callback,
   ) {
     _sendPlatformMessage(name, data, _zonedPlatformMessageResponseCallback(callback));
   }
 
   /// Wraps the given [callback] in another callback that ensures that the
   /// original callback is called in the zone it was registered in.
-  static ui.PlatformMessageResponseCallback _zonedPlatformMessageResponseCallback(ui.PlatformMessageResponseCallback callback) {
+  static ui.PlatformMessageResponseCallback/*?*/ _zonedPlatformMessageResponseCallback(ui.PlatformMessageResponseCallback/*?*/ callback) {
     if (callback == null)
       return null;
 
@@ -389,9 +389,9 @@ class EngineWindow extends ui.Window {
   }
 
   void _sendPlatformMessage(
-    String name,
-    ByteData data,
-    ui.PlatformMessageResponseCallback callback,
+    String/*!*/ name,
+    ByteData/*?*/ data,
+    ui.PlatformMessageResponseCallback/*?*/ callback,
   ) {
     // In widget tests we want to bypass processing of platform messages.
     if (assertionsEnabled && ui.debugEmulateFlutterTesterEnvironment) {
@@ -597,7 +597,7 @@ class EngineWindow extends ui.Window {
   }
 
   @override
-  void render(ui.Scene scene) {
+  void render(ui.Scene/*!*/ scene) {
     if (experimentalUseSkia) {
       final LayerScene layerScene = scene;
       rasterizer.draw(layerScene.layerTree);

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -846,7 +846,7 @@ abstract class Window {
   ///  * [Navigator], a widget that handles routing.
   ///  * [SystemChannels.navigation], which handles subsequent navigation
   ///    requests from the embedder.
-  String get defaultRouteName;
+  String/*!*/ get defaultRouteName;
 
   /// Whether the user has requested that [updateSemantics] be called when
   /// the semantic contents of window changes.
@@ -907,7 +907,7 @@ abstract class Window {
   ///
   /// In either case, this function disposes the given update, which means the
   /// semantics update cannot be used further.
-  void updateSemantics(SemanticsUpdate update) {
+  void updateSemantics(SemanticsUpdate/*!*/ update) {
     engine.EngineSemanticsOwner.instance.updateSemantics(update);
   }
 
@@ -921,9 +921,9 @@ abstract class Window {
   /// The framework invokes [callback] in the same zone in which this method
   /// was called.
   void sendPlatformMessage(
-    String name,
-    ByteData data,
-    PlatformMessageResponseCallback callback,
+    String/*!*/ name,
+    ByteData/*?*/ data,
+    PlatformMessageResponseCallback/*?*/ callback,
   );
 
   /// Additional accessibility features that may be enabled by the platform.
@@ -954,15 +954,15 @@ abstract class Window {
   ///    scheduling of frames.
   ///  * [RendererBinding], the Flutter framework class which manages layout and
   ///    painting.
-  void render(Scene scene);
+  void render(Scene/*!*/ scene);
 
   String get initialLifecycleState => _initialLifecycleState;
 
   String _initialLifecycleState;
 
-  void setIsolateDebugName(String name) {}
+  void setIsolateDebugName(String/*!*/ name) {}
 
-  ByteData getPersistentIsolateData() => null;
+  ByteData/*?*/ getPersistentIsolateData() => null;
 }
 
 VoidCallback webOnlyScheduleFrameCallback;


### PR DESCRIPTION
Migrates just the native calls and their immediate wrappers within
window.dart, as well as their web_ui counterparts.