### PR TITLE
Roll buildroot to flutter/buildroot@a4f3c4d5023e080ee50596e6623d179e9c5f839b

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -138,7 +138,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e32b5c320d36bdb7a21ecfc7a2f86787f63e8dd6',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'a4f3c4d5023e080ee50596e6623d179e9c5f839b',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
More discussion at flutter/buildroot#369

This is expected to reduce the flutter_runner artifact sizes on arm64 release by ~1.75 megabytes.

It is also expected to result in at least some performance regressions.  /cc @nathanrogersgoogle @fmeawad

If we can land https://dart-review.googlesource.com/c/sdk/+/135791 we should be able to reduce Fuchsia size even further.