### PR TITLE
remove unused IOSContext::ResourceMakeCurrent and IOS:Context::ClearCurrent

### DIFF
--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -89,31 +89,6 @@ class IOSContext {
   virtual bool MakeCurrent() = 0;
 
   //----------------------------------------------------------------------------
-  /// @brief      When using client rendering APIs whose contexts need to be
-  ///             bound to a specific thread, the engine will call this method
-  ///             to give the off-screen context a chance to bind to the current
-  ///             thread.
-  ///
-  /// @attention  Client rendering APIs that have no-concept of thread local
-  ///             bindings (anything that is not OpenGL) will always return
-  ///             `true`.
-  ///
-  /// @attention  Client rendering APIs for which a GrContext cannot be created
-  ///             (software rendering) will always return `false`.
-  ///
-  /// @attention  This binds the off-screen context to the current thread. To
-  ///             bind the on-screen context to the thread, use the
-  ///             `MakeCurrent` method instead.
-  ///
-  /// @attention  Only one context may be bound to a thread at any given time.
-  ///             Making a binding on a thread, clears the old binding.
-  ///
-  /// @return     If the off-screen context could be bound to the current
-  ///             thread.
-  ///
-  virtual bool ResourceMakeCurrent() = 0;
-
-  //----------------------------------------------------------------------------
   /// @brief      Clears the context binding of the current thread if one is
   ///             present. Does noting otherwise.
   ///

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -89,14 +89,6 @@ class IOSContext {
   virtual bool MakeCurrent() = 0;
 
   //----------------------------------------------------------------------------
-  /// @brief      Clears the context binding of the current thread if one is
-  ///             present. Does noting otherwise.
-  ///
-  /// @return     `true` is the current context bound to the thread is cleared.
-  ///
-  virtual bool ClearCurrent() = 0;
-
-  //----------------------------------------------------------------------------
   /// @brief      Creates an external texture proxy of the appropriate client
   ///             rendering API.
   ///

--- a/shell/platform/darwin/ios/ios_context_gl.h
+++ b/shell/platform/darwin/ios/ios_context_gl.h
@@ -35,9 +35,6 @@ class IOSContextGL final : public IOSContext {
   bool MakeCurrent() override;
 
   // |IOSContext|
-  bool ClearCurrent() override;
-
-  // |IOSContext|
   std::unique_ptr<Texture> CreateExternalTexture(
       int64_t texture_id,
       fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;

--- a/shell/platform/darwin/ios/ios_context_gl.h
+++ b/shell/platform/darwin/ios/ios_context_gl.h
@@ -38,9 +38,6 @@ class IOSContextGL final : public IOSContext {
   bool ClearCurrent() override;
 
   // |IOSContext|
-  bool ResourceMakeCurrent() override;
-
-  // |IOSContext|
   std::unique_ptr<Texture> CreateExternalTexture(
       int64_t texture_id,
       fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;

--- a/shell/platform/darwin/ios/ios_context_gl.mm
+++ b/shell/platform/darwin/ios/ios_context_gl.mm
@@ -33,7 +33,6 @@ std::unique_ptr<IOSRenderTargetGL> IOSContextGL::CreateRenderTarget(
 
 // |IOSContext|
 sk_sp<GrContext> IOSContextGL::CreateResourceContext() {
-  // TODO(chinmaygarde): Now that this is here, can ResourceMakeCurrent be removed?
   if (![EAGLContext setCurrentContext:resource_context_.get()]) {
     FML_DLOG(INFO) << "Could not make resource context current on IO thread. Async texture uploads "
                       "will be disabled. On Simulators, this is expected.";
@@ -47,11 +46,6 @@ sk_sp<GrContext> IOSContextGL::CreateResourceContext() {
 // |IOSContext|
 bool IOSContextGL::MakeCurrent() {
   return [EAGLContext setCurrentContext:context_.get()];
-}
-
-// |IOSContext|
-bool IOSContextGL::ResourceMakeCurrent() {
-  return [EAGLContext setCurrentContext:resource_context_.get()];
 }
 
 // |IOSContext|

--- a/shell/platform/darwin/ios/ios_context_gl.mm
+++ b/shell/platform/darwin/ios/ios_context_gl.mm
@@ -49,11 +49,6 @@ bool IOSContextGL::MakeCurrent() {
 }
 
 // |IOSContext|
-bool IOSContextGL::ClearCurrent() {
-  return [EAGLContext setCurrentContext:nil];
-}
-
-// |IOSContext|
 std::unique_ptr<Texture> IOSContextGL::CreateExternalTexture(
     int64_t texture_id,
     fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {

--- a/shell/platform/darwin/ios/ios_context_metal.h
+++ b/shell/platform/darwin/ios/ios_context_metal.h
@@ -46,9 +46,6 @@ class IOSContextMetal final : public IOSContext {
   bool MakeCurrent() override;
 
   // |IOSContext|
-  bool ClearCurrent() override;
-
-  // |IOSContext|
   std::unique_ptr<Texture> CreateExternalTexture(
       int64_t texture_id,
       fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;

--- a/shell/platform/darwin/ios/ios_context_metal.h
+++ b/shell/platform/darwin/ios/ios_context_metal.h
@@ -46,9 +46,6 @@ class IOSContextMetal final : public IOSContext {
   bool MakeCurrent() override;
 
   // |IOSContext|
-  bool ResourceMakeCurrent() override;
-
-  // |IOSContext|
   bool ClearCurrent() override;
 
   // |IOSContext|

--- a/shell/platform/darwin/ios/ios_context_metal.mm
+++ b/shell/platform/darwin/ios/ios_context_metal.mm
@@ -102,12 +102,6 @@ bool IOSContextMetal::MakeCurrent() {
 }
 
 // |IOSContext|
-bool IOSContextMetal::ClearCurrent() {
-  // This only makes sense for context that need to be bound to a specific thread.
-  return true;
-}
-
-// |IOSContext|
 std::unique_ptr<Texture> IOSContextMetal::CreateExternalTexture(
     int64_t texture_id,
     fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {

--- a/shell/platform/darwin/ios/ios_context_metal.mm
+++ b/shell/platform/darwin/ios/ios_context_metal.mm
@@ -102,12 +102,6 @@ bool IOSContextMetal::MakeCurrent() {
 }
 
 // |IOSContext|
-bool IOSContextMetal::ResourceMakeCurrent() {
-  // This only makes sense for context that need to be bound to a specific thread.
-  return true;
-}
-
-// |IOSContext|
 bool IOSContextMetal::ClearCurrent() {
   // This only makes sense for context that need to be bound to a specific thread.
   return true;

--- a/shell/platform/darwin/ios/ios_context_software.h
+++ b/shell/platform/darwin/ios/ios_context_software.h
@@ -24,9 +24,6 @@ class IOSContextSoftware final : public IOSContext {
   bool MakeCurrent() override;
 
   // |IOSContext|
-  bool ClearCurrent() override;
-
-  // |IOSContext|
   std::unique_ptr<Texture> CreateExternalTexture(
       int64_t texture_id,
       fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;

--- a/shell/platform/darwin/ios/ios_context_software.h
+++ b/shell/platform/darwin/ios/ios_context_software.h
@@ -24,9 +24,6 @@ class IOSContextSoftware final : public IOSContext {
   bool MakeCurrent() override;
 
   // |IOSContext|
-  bool ResourceMakeCurrent() override;
-
-  // |IOSContext|
   bool ClearCurrent() override;
 
   // |IOSContext|

--- a/shell/platform/darwin/ios/ios_context_software.mm
+++ b/shell/platform/darwin/ios/ios_context_software.mm
@@ -22,11 +22,6 @@ bool IOSContextSoftware::MakeCurrent() {
 }
 
 // |IOSContext|
-bool IOSContextSoftware::ClearCurrent() {
-  return false;
-}
-
-// |IOSContext|
 std::unique_ptr<Texture> IOSContextSoftware::CreateExternalTexture(
     int64_t texture_id,
     fml::scoped_nsobject<NSObject<FlutterTexture>> texture) {

--- a/shell/platform/darwin/ios/ios_context_software.mm
+++ b/shell/platform/darwin/ios/ios_context_software.mm
@@ -22,11 +22,6 @@ bool IOSContextSoftware::MakeCurrent() {
 }
 
 // |IOSContext|
-bool IOSContextSoftware::ResourceMakeCurrent() {
-  return false;
-}
-
-// |IOSContext|
 bool IOSContextSoftware::ClearCurrent() {
   return false;
 }


### PR DESCRIPTION
`IOSContext::ResourceMakeCurrent` and `IOS:Context::ClearCurrent` not used in engine anywhere.