### PR TITLE
auto-pop pushed layers

### DIFF
--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -17,22 +17,6 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// This getter should only be called after all surfaces are built.
   PersistedScene get _persistedScene {
-    assert(() {
-      if (_surfaceStack.length != 1) {
-        final String surfacePrintout = _surfaceStack
-            .map<Type>(
-                (PersistedContainerSurface surface) => surface.runtimeType)
-            .toList()
-            .join(', ');
-        throw Exception('Incorrect sequence of push/pop operations while '
-            'building scene surfaces. After building the scene the persisted '
-            'surface stack must contain a single element which corresponds '
-            'to the scene itself (_PersistedScene). All other surfaces '
-            'should have been popped off the stack. Found the following '
-            'surfaces in the stack:\n$surfacePrintout');
-      }
-      return true;
-    }());
     return _surfaceStack.first;
   }
 
@@ -547,6 +531,10 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   @override
   SurfaceScene build() {
     timeAction<void>(kProfilePrerollFrame, () {
+      while (_surfaceStack.length > 1) {
+        // Auto-pop layers that were pushed without a corresponding pop.
+        pop();
+      }
       _persistedScene.preroll();
     });
     return timeAction<SurfaceScene>(kProfileApplyFrame, () {

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -323,6 +323,26 @@ void main() {
     expect(content.querySelectorAll('flt-picture').single.children, isEmpty);
     expect(findPictureSurfaceChild(subOffset1).debugCanvas, isNull);
   });
+
+  test('auto-pops pushed layers', () async {
+    final Picture picture = _drawPicture();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
+    builder.pushOffset(0, 0);
+    builder.pushOffset(0, 0);
+    builder.pushOffset(0, 0);
+    builder.pushOffset(0, 0);
+    builder.pushOffset(0, 0);
+    builder.addPicture(Offset.zero, picture);
+
+    // Intentionally pop fewer layers than we pushed
+    builder.pop();
+    builder.pop();
+    builder.pop();
+
+    // Expect as many layers as we pushed (not popped).
+    html.HtmlElement content = builder.build().webOnlyRootElement;
+    expect(content.querySelectorAll('flt-offset'), hasLength(5));
+  });
 }
 
 typedef TestLayerBuilder = EngineLayer Function(


### PR DESCRIPTION
Auto-pop pushed layers instead of complaining about the missing pops. This matches Flutter mobile.

Fixes https://github.com/flutter/flutter/issues/52856
