### PR TITLE
adding more tests for text form fields

### DIFF
--- a/e2etests/web/regular_integration_tests/lib/text_editing_main.dart
+++ b/e2etests/web/regular_integration_tests/lib/text_editing_main.dart
@@ -29,6 +29,9 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   String infoText = 'no-enter';
 
+  // Controller with no inital value;
+  final TextEditingController _emptyController = TextEditingController();
+
   final TextEditingController _controller =
       TextEditingController(text: 'Text1');
 
@@ -46,7 +49,18 @@ class _MyHomePageState extends State<MyHomePage> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
             const Text(
-              'Text Editing Test',
+              'Text Editing Test 1',
+            ),
+            TextFormField(
+              key: const Key('empty-input'),
+              enabled: true,
+              controller: _emptyController,
+              decoration: const InputDecoration(
+                labelText: 'Empty Input Field:',
+              ),
+            ),
+            const Text(
+              'Text Editing Test 2',
             ),
             TextFormField(
               key: const Key('input'),
@@ -57,7 +71,7 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
             ),
             const Text(
-              'Text Editing Test 2',
+              'Text Editing Test 3',
             ),
             TextFormField(
               key: const Key('input2'),

--- a/e2etests/web/regular_integration_tests/lib/text_editing_main.dart
+++ b/e2etests/web/regular_integration_tests/lib/text_editing_main.dart
@@ -27,8 +27,13 @@ class MyHomePage extends StatefulWidget {
 }
 
 class _MyHomePageState extends State<MyHomePage> {
+  String infoText = 'no-enter';
+
   final TextEditingController _controller =
       TextEditingController(text: 'Text1');
+
+  final TextEditingController _controller2 =
+      TextEditingController(text: 'Text2');
 
   @override
   Widget build(BuildContext context) {
@@ -47,10 +52,28 @@ class _MyHomePageState extends State<MyHomePage> {
               key: const Key('input'),
               enabled: true,
               controller: _controller,
-              //initialValue: 'Text1',
               decoration: const InputDecoration(
                 labelText: 'Text Input Field:',
               ),
+            ),
+            const Text(
+              'Text Editing Test 2',
+            ),
+            TextFormField(
+              key: const Key('input2'),
+              enabled: true,
+              controller: _controller2,
+              decoration: const InputDecoration(
+                labelText: 'Text Input Field 2:',
+              ),
+              onFieldSubmitted: (String str) {
+                print('event received');
+                setState(() => infoText = 'enter pressed');
+              },
+            ),
+            Text(
+              infoText,
+              key: const Key('text'),
             ),
           ],
         ),

--- a/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:html';
+import 'dart:js_util' as js_util;
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/text_editing_main.dart' as app;
@@ -40,4 +41,92 @@ void main() {
     // DOM element's value also changes.
     expect(input.value, 'New Value');
   });
+
+  testWidgets('Pressing enter on the text field works',
+      (WidgetTester tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    // TODO(nurhan): https://github.com/flutter/flutter/issues/51885
+    SystemChannels.textInput.setMockMethodCallHandler(null);
+
+    // This text will show no-enter initially. It will have 'enter-pressed'
+    // after `onFieldSubmitted` of TextField is triggered.
+    final Finder textFinder = find.byKey(const Key('text'));
+    expect(textFinder, findsOneWidget);
+    final Text text = tester.widget(textFinder);
+    expect(text.data, 'no-enter');
+
+    // Focus on a TextFormField.
+    final Finder textFormFielsFinder = find.byKey(const Key('input2'));
+    expect(textFormFielsFinder, findsOneWidget);
+    await tester.tap(find.byKey(const Key('input2')));
+
+    // // Press Tab. This should trigger `onFieldSubmitted` of TextField.
+    final InputElement input =
+        document.getElementsByTagName('input')[0] as InputElement;
+    dispatchKeyboardEvent(input, 'keydown', <String, dynamic>{
+      'keyCode': 13, // Enter.
+      'cancelable': true,
+    });
+
+    await tester.pumpAndSettle();
+
+    final Finder textFinder2 = find.byKey(const Key('text'));
+    expect(textFinder2, findsOneWidget);
+    final Text text2 = tester.widget(textFinder2);
+    expect(text2.data, 'enter pressed');
+  });
+
+  testWidgets('Jump between TextFormFields with tab key',
+      (WidgetTester tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    // TODO(nurhan): https://github.com/flutter/flutter/issues/51885
+    SystemChannels.textInput.setMockMethodCallHandler(null);
+
+    // Focus on a TextFormField.
+    final Finder finder = find.byKey(const Key('input'));
+    expect(finder, findsOneWidget);
+    await tester.tap(find.byKey(const Key('input')));
+
+    // A native input element will be appended to the DOM.
+    final List<Node> nodeList = document.getElementsByTagName('input');
+    expect(nodeList.length, equals(1));
+    final InputElement input =
+        document.getElementsByTagName('input')[0] as InputElement;
+
+    // Press Tab. The focus should move to the next TextFormField.
+    dispatchKeyboardEvent(input, 'keydown', <String, dynamic>{
+      'key': 'Tab',
+      'code': 'Tab',
+      'bubbles': true,
+      'cancelable': true,
+    });
+
+    await tester.pumpAndSettle();
+
+    // A native input element for the next TextField should be attached to the
+    // DOM.
+    final InputElement input2 =
+        document.getElementsByTagName('input')[0] as InputElement;
+    expect(input2.value, 'Text2');
+  });
+}
+
+KeyboardEvent dispatchKeyboardEvent(
+    EventTarget target, String type, Map<String, dynamic> args) {
+  final dynamic jsKeyboardEvent = js_util.getProperty(window, 'KeyboardEvent');
+  final List<dynamic> eventArgs = <dynamic>[
+    type,
+    args,
+  ];
+
+  final KeyboardEvent event = js_util.callConstructor(
+          jsKeyboardEvent, js_util.jsify(eventArgs) as List<dynamic>)
+      as KeyboardEvent;
+  target.dispatchEvent(event);
+
+  return event;
 }

--- a/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e.dart
@@ -42,7 +42,35 @@ void main() {
     expect(input.value, 'New Value');
   });
 
-  testWidgets('Pressing enter on the text field works',
+  testWidgets('Input field with no initial value works',
+      (WidgetTester tester) async {
+    app.main();
+    await tester.pumpAndSettle();
+
+    // TODO(nurhan): https://github.com/flutter/flutter/issues/51885
+    SystemChannels.textInput.setMockMethodCallHandler(null);
+
+    // Focus on a TextFormField.
+    final Finder finder = find.byKey(const Key('empty-input'));
+    expect(finder, findsOneWidget);
+    await tester.tap(find.byKey(const Key('empty-input')));
+
+    // A native input element will be appended to the DOM.
+    final List<Node> nodeList = document.getElementsByTagName('input');
+    expect(nodeList.length, equals(1));
+    final InputElement input =
+        document.getElementsByTagName('input')[0] as InputElement;
+    // The element's value will be empty.
+    expect(input.value, '');
+
+    // Change the value of the TextFormField.
+    final TextFormField textFormField = tester.widget(finder);
+    textFormField.controller.text = 'New Value';
+    // DOM element's value also changes.
+    expect(input.value, 'New Value');
+  });
+
+  testWidgets('Pressing enter on the text field triggers submit',
       (WidgetTester tester) async {
     app.main();
     await tester.pumpAndSettle();


### PR DESCRIPTION
Looks like this test is very useful, last week it prevented a breakage. I thought it would be better to cover more areas.

Testing more cases for text editing:
- Pressing enter will trigger onFieldSubmit
- Pressing tab will go to the next TextFormField.

Note: this is also a good example for showing keyboard events. I will add it to the codelab.