### PR TITLE
[fuchsia] Update the error message to reference the right asset

### DIFF
--- a/shell/common/isolate_configuration.cc
+++ b/shell/common/isolate_configuration.cc
@@ -179,7 +179,8 @@ std::unique_ptr<IsolateConfiguration> IsolateConfiguration::InferFromSettings(
     std::unique_ptr<fml::Mapping> kernel_list =
         asset_manager->GetAsMapping(settings.application_kernel_list_asset);
     if (!kernel_list) {
-      FML_LOG(ERROR) << "Failed to load: " << settings.application_kernel_asset;
+      FML_LOG(ERROR) << "Failed to load: "
+                     << settings.application_kernel_list_asset;
       return nullptr;
     }
     auto kernel_pieces_paths = ParseKernelListPaths(std::move(kernel_list));


### PR DESCRIPTION
When trying to map kernel list (`app.dilp`) files and failing
we need to log `application_kernel_list_asset` not `application_kernel_asset`.