### PR TITLE
[web] Running integration tests on Safari on Local

### DIFF
--- a/lib/web_ui/dev/driver_manager.dart
+++ b/lib/web_ui/dev/driver_manager.dart
@@ -131,4 +131,15 @@ abstract class DriverManager {
 
   @protected
   Future<void> _startDriver(String driverPath);
+
+  static DriverManager chooseDriver(String browser) {
+    if (browser == 'chrome') {
+      return ChromeDriverManager(browser);
+    } else if (browser == 'safari' && io.Platform.isMacOS) {
+      return SafariDriverManager(browser);
+    } else {
+      throw StateError('Integration tests are only supported on Chrome or '
+          'on Safari (running on MacOS)');
+    }
+  }
 }

--- a/lib/web_ui/dev/driver_manager.dart
+++ b/lib/web_ui/dev/driver_manager.dart
@@ -1,0 +1,107 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io' as io;
+
+import 'package:path/path.dart' as pathlib;
+import 'package:web_driver_installer/chrome_driver_installer.dart';
+
+import 'chrome_installer.dart';
+import 'common.dart';
+import 'environment.dart';
+import 'utils.dart';
+
+class ChromeDriverManager extends DriverManager {
+  ChromeDriverManager(String browser) : super(browser);
+
+  Future<void> _installDriver() async {
+    if (_browserDriverDir.existsSync()) {
+      _browserDriverDir.deleteSync(recursive: true);
+    }
+
+    _browserDriverDir.createSync(recursive: true);
+    temporaryDirectories.add(_drivers);
+
+    io.Directory temp = io.Directory.current;
+    io.Directory.current = _browserDriverDir;
+
+    // TODO(nurhan): https://github.com/flutter/flutter/issues/53179
+    final String chromeDriverVersion = await queryChromeDriverVersion();
+    ChromeDriverInstaller chromeDriverInstaller =
+        ChromeDriverInstaller.withVersion(chromeDriverVersion);
+    await chromeDriverInstaller.install(alwaysInstall: true);
+    io.Directory.current = temp;
+  }
+
+  /// Driver should already exist on LUCI as a CIPD package.
+  ///
+  /// Throw an error if directory does not exists.
+  void _verifyDriverForLUCI() {
+    if (!_browserDriverDir.existsSync()) {
+      throw StateError('Failed to locate Chrome driver on LUCI on path:'
+          '${_browserDriverDir.path}');
+    }
+  }
+
+  Future<void> _startDriver(String driverPath) async {
+    await startProcess('./chromedriver/chromedriver', ['--port=4444'],
+        workingDirectory: driverPath);
+    print('INFO: Driver started');
+  }
+}
+
+// class SafariDriverManager extends DriverManager {
+//   SafariDriverManager(String browser) : super(browser);
+
+//   Future<void> _installDriver() {}
+
+//   Future<void> _verifyDriverForLUCI() {}
+
+//   Future<void> _startDriver(String driverPath) {}
+// }
+
+abstract class DriverManager {
+  /// Installation directory for browser's driver.
+  ///
+  /// Always re-install since driver can change frequently.
+  /// It usually changes with each the browser version changes.
+  /// A better solution would be installing the browser and the driver at the
+  /// same time.
+  // TODO(nurhan): https://github.com/flutter/flutter/issues/53179. Partly
+  // solved. Remaining local integration tests using the locked Chrome version.
+  final io.Directory _browserDriverDir;
+
+  /// This is the parent directory for all drivers.
+  ///
+  /// This directory is saved to [temporaryDirectories] and deleted before
+  /// tests shutdown.
+  final io.Directory _drivers;
+
+  final String _browser;
+
+  DriverManager(this._browser)
+      : this._browserDriverDir = io.Directory(pathlib.join(
+            environment.webUiDartToolDir.path,
+            'drivers',
+            _browser,
+            '${_browser}driver-${io.Platform.operatingSystem.toString()}')),
+        this._drivers = io.Directory(
+            pathlib.join(environment.webUiDartToolDir.path, 'drivers'));
+
+  Future<void> prepareDriver() async {
+    if (!isLuci) {
+      // LUCI installs driver from CIPD, so we skip installing it on LUCI.
+      await _installDriver();
+    } else {
+      await _verifyDriverForLUCI();
+    }
+    await _startDriver(_browserDriverDir.path);
+  }
+
+  Future<void> _installDriver();
+
+  void _verifyDriverForLUCI();
+
+  Future<void> _startDriver(String driverPath);
+}

--- a/lib/web_ui/dev/driver_manager.dart
+++ b/lib/web_ui/dev/driver_manager.dart
@@ -6,12 +6,16 @@ import 'dart:io' as io;
 
 import 'package:path/path.dart' as pathlib;
 import 'package:web_driver_installer/chrome_driver_installer.dart';
+import 'package:web_driver_installer/safari_driver_runner.dart';
 
 import 'chrome_installer.dart';
 import 'common.dart';
 import 'environment.dart';
 import 'utils.dart';
 
+/// [DriverManager] implementation for Chrome.
+///
+/// This manager can be used for both MacOS and Linux.
 class ChromeDriverManager extends DriverManager {
   ChromeDriverManager(String browser) : super(browser);
 
@@ -51,16 +55,35 @@ class ChromeDriverManager extends DriverManager {
   }
 }
 
-// class SafariDriverManager extends DriverManager {
-//   SafariDriverManager(String browser) : super(browser);
+/// [DriverManager] implementation for Safari.
+///
+/// This manager is will only be created/used for MacOS.
+class SafariDriverManager extends DriverManager {
+  SafariDriverManager(String browser) : super(browser);
 
-//   Future<void> _installDriver() {}
+  Future<void> _installDriver() {
+    // No-op.
+    // macOS comes with Safari Driver installed.
+    return new Future<void>.value();
+  }
 
-//   Future<void> _verifyDriverForLUCI() {}
+  void _verifyDriverForLUCI() {
+    // No-op.
+    // macOS comes with Safari Driver installed.
+  }
 
-//   Future<void> _startDriver(String driverPath) {}
-// }
+  Future<void> _startDriver(String driverPath) async {
+    final SafariDriverRunner safariDriverRunner = SafariDriverRunner();
 
+    final io.Process process =
+        await safariDriverRunner.runDriver(version: 'system');
+
+    processesToCleanUp.add(process);
+  }
+}
+
+/// Interface for preparing the browser driver before running the integration
+/// tests.
 abstract class DriverManager {
   /// Installation directory for browser's driver.
   ///
@@ -78,14 +101,12 @@ abstract class DriverManager {
   /// tests shutdown.
   final io.Directory _drivers;
 
-  final String _browser;
-
-  DriverManager(this._browser)
+  DriverManager(String browser)
       : this._browserDriverDir = io.Directory(pathlib.join(
             environment.webUiDartToolDir.path,
             'drivers',
-            _browser,
-            '${_browser}driver-${io.Platform.operatingSystem.toString()}')),
+            browser,
+            '${browser}driver-${io.Platform.operatingSystem.toString()}')),
         this._drivers = io.Directory(
             pathlib.join(environment.webUiDartToolDir.path, 'drivers'));
 

--- a/lib/web_ui/dev/driver_manager.dart
+++ b/lib/web_ui/dev/driver_manager.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io' as io;
 
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as pathlib;
 import 'package:web_driver_installer/chrome_driver_installer.dart';
 import 'package:web_driver_installer/safari_driver_runner.dart';
@@ -41,11 +42,12 @@ class ChromeDriverManager extends DriverManager {
   /// Driver should already exist on LUCI as a CIPD package.
   ///
   /// Throw an error if directory does not exists.
-  void _verifyDriverForLUCI() {
+  Future<void> _verifyDriverForLUCI() {
     if (!_browserDriverDir.existsSync()) {
       throw StateError('Failed to locate Chrome driver on LUCI on path:'
           '${_browserDriverDir.path}');
     }
+    return Future<void>.value();
   }
 
   Future<void> _startDriver(String driverPath) async {
@@ -67,9 +69,10 @@ class SafariDriverManager extends DriverManager {
     return new Future<void>.value();
   }
 
-  void _verifyDriverForLUCI() {
+  Future<void> _verifyDriverForLUCI() {
     // No-op.
     // macOS comes with Safari Driver installed.
+    return Future<void>.value();
   }
 
   Future<void> _startDriver(String driverPath) async {
@@ -82,7 +85,7 @@ class SafariDriverManager extends DriverManager {
   }
 }
 
-/// Interface for preparing the browser driver before running the integration
+/// Abstract class for preparing the browser driver before running the integration
 /// tests.
 abstract class DriverManager {
   /// Installation directory for browser's driver.
@@ -93,12 +96,14 @@ abstract class DriverManager {
   /// same time.
   // TODO(nurhan): https://github.com/flutter/flutter/issues/53179. Partly
   // solved. Remaining local integration tests using the locked Chrome version.
+  @protected
   final io.Directory _browserDriverDir;
 
   /// This is the parent directory for all drivers.
   ///
   /// This directory is saved to [temporaryDirectories] and deleted before
   /// tests shutdown.
+  @protected
   final io.Directory _drivers;
 
   DriverManager(String browser)
@@ -122,7 +127,8 @@ abstract class DriverManager {
 
   Future<void> _installDriver();
 
-  void _verifyDriverForLUCI();
+  Future<void> _verifyDriverForLUCI();
 
+  @protected
   Future<void> _startDriver(String driverPath);
 }

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -329,7 +329,7 @@ class ChromeIntegrationArguments extends IntegrationArguments {
       '--$mode',
       '--browser-name=chrome',
       if (isLuci) '--chrome-binary=${preinstalledChromeExecutable()}',
-      '--headless',
+      if (isLuci) '--headless',
       '--local-engine=host_debug_unopt',
     ];
   }

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -106,7 +106,7 @@ class TestCommand extends Command<bool> with ArgUtils {
       print('Running the unit tests only');
       return TestTypesRequested.unit;
     } else if (boolArg('integration-tests-only')) {
-      if (!isChrome) {
+      if (!isChrome && !isSafariOnMacOS) {
         throw UnimplementedError(
             'Integration tests are only available on Chrome Desktop for now');
       }
@@ -132,7 +132,7 @@ class TestCommand extends Command<bool> with ArgUtils {
       case TestTypesRequested.all:
         // TODO(nurhan): https://github.com/flutter/flutter/issues/53322
         // TODO(nurhan): Expand browser matrix for felt integration tests.
-        if (runAllTests && isChrome) {
+        if (runAllTests && (isChrome || isSafariOnMacOS)) {
           bool unitTestResult = await runUnitTests();
           bool integrationTestResult = await runIntegrationTests();
           if (integrationTestResult != unitTestResult) {
@@ -262,6 +262,10 @@ class TestCommand extends Command<bool> with ArgUtils {
 
   /// Whether [browser] is set to "chrome".
   bool get isChrome => browser == 'chrome';
+
+  /// Whether [browser] is set to "safari".
+  bool get isSafariOnMacOS => browser == 'safari'
+      && io.Platform.isMacOS;
 
   /// Use system flutter instead of cloning the repository.
   ///

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -32,4 +32,4 @@ dev_dependencies:
     git:
       url: git://github.com/flutter/web_installers.git
       path: packages/web_drivers/
-      ref: e8a99a2fec12b723524977a7f5590d1c11b08540
+      ref: 41f96bb55d2f064dac3c9fc727ebdf4b0cdf79c4

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -32,4 +32,4 @@ dev_dependencies:
     git:
       url: git://github.com/flutter/web_installers.git
       path: packages/web_drivers/
-      ref: 90c69a79b2764c93875dc8ed4f4932c27a6f3a86
+      ref: e8a99a2fec12b723524977a7f5590d1c11b08540


### PR DESCRIPTION
Changes to felt to be able to run integration tests on Safari both on LUCI and on local MacOs machines.

fixes: https://github.com/flutter/flutter/issues/57348

currently blocked on: https://github.com/flutter/flutter/issues/57758