### PR TITLE
Handle Throwable in StandardMethodCodec

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -165,7 +165,9 @@ public final class MethodChannel {
     /**
      * Handles a successful result.
      *
-     * @param result The result, possibly null.
+     * @param result The result, possibly null. The result must be an Object type supported by the codec.
+     * For instance, if you are using StandardCodec (default), please see {@link StandardMessageCodec}
+     * documentation on what types are supported.
      */
     @UiThread
     void success(@Nullable Object result);
@@ -175,7 +177,9 @@ public final class MethodChannel {
      *
      * @param errorCode An error code String.
      * @param errorMessage A human-readable error message String, possibly null.
-     * @param errorDetails Error details, possibly null
+     * @param errorDetails Error details, possibly null. The details must be an Object type supported
+     * by the codec. For instance, if you are using StandardCodec (default), please see
+     * {@link StandardMessageCodec} documentation on what types are supported.
      */
     @UiThread
     void error(String errorCode, @Nullable String errorMessage, @Nullable Object errorDetails);

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -165,9 +165,9 @@ public final class MethodChannel {
     /**
      * Handles a successful result.
      *
-     * @param result The result, possibly null. The result must be an Object type supported by the codec.
-     * For instance, if you are using StandardCodec (default), please see {@link StandardMessageCodec}
-     * documentation on what types are supported.
+     * @param result The result, possibly null. The result must be an Object type supported by the
+     *     codec. For instance, if you are using StandardCodec (default), please see {@link
+     *     StandardMessageCodec} documentation on what types are supported.
      */
     @UiThread
     void success(@Nullable Object result);
@@ -177,9 +177,9 @@ public final class MethodChannel {
      *
      * @param errorCode An error code String.
      * @param errorMessage A human-readable error message String, possibly null.
-     * @param errorDetails Error details, possibly null. The details must be an Object type supported
-     * by the codec. For instance, if you are using StandardCodec (default), please see
-     * {@link StandardMessageCodec} documentation on what types are supported.
+     * @param errorDetails Error details, possibly null. The details must be an Object type
+     *     supported by the codec. For instance, if you are using StandardCodec (default), please
+     *     see {@link StandardMessageCodec} documentation on what types are supported.
      */
     @UiThread
     void error(String errorCode, @Nullable String errorMessage, @Nullable Object errorDetails);

--- a/shell/platform/android/io/flutter/plugin/common/StandardMethodCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMethodCodec.java
@@ -7,6 +7,9 @@ package io.flutter.plugin.common;
 import io.flutter.plugin.common.StandardMessageCodec.ExposedByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
 
 /**
  * A {@link MethodCodec} using the Flutter standard binary encoding.
@@ -66,7 +69,11 @@ public final class StandardMethodCodec implements MethodCodec {
     stream.write(1);
     messageCodec.writeValue(stream, errorCode);
     messageCodec.writeValue(stream, errorMessage);
-    messageCodec.writeValue(stream, errorDetails);
+    if (errorDetails instanceof Throwable) {
+      messageCodec.writeValue(stream, getStackTrace((Throwable) errorDetails));
+    } else {
+      messageCodec.writeValue(stream, errorDetails);
+    }
     final ByteBuffer buffer = ByteBuffer.allocateDirect(stream.size());
     buffer.put(stream.buffer(), 0, stream.size());
     return buffer;
@@ -98,5 +105,11 @@ public final class StandardMethodCodec implements MethodCodec {
         }
     }
     throw new IllegalArgumentException("Envelope corrupted");
+  }
+
+  private static String getStackTrace(Throwable t) {
+    Writer result = new StringWriter();
+    t.printStackTrace(new PrintWriter(result));
+    return result.toString();
   }
 }

--- a/shell/platform/android/io/flutter/plugin/common/StandardMethodCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMethodCodec.java
@@ -5,11 +5,11 @@
 package io.flutter.plugin.common;
 
 import io.flutter.plugin.common.StandardMessageCodec.ExposedByteArrayOutputStream;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
  * A {@link MethodCodec} using the Flutter standard binary encoding.


### PR DESCRIPTION
It seems like a common mistake in plugins to assume that `errorDetails` can be of type `Throwable`. This PR does two things:

- Enhance documentation on reply so that `success` and `failure` indicate that only objects that are supported by the codec are supported. Also links to `StandardMessageCodec` since that is the default codec used by many plugins.

- Handle `Throwable` type in errorDetails which some plugins inadvertently pass to the codec. This is almost always the wrong thing to do for `success` case so I did not want to generically handle this in `StandardMessageCodec`. However, it is a reasonable thing to do from error handlers.