### PR TITLE
Update renderer_context_manager

### DIFF
--- a/shell/common/renderer_context_manager.h
+++ b/shell/common/renderer_context_manager.h
@@ -44,13 +44,14 @@ class RendererContextSwitch;
 //------------------------------------------------------------------------------
 /// Manages the renderer context.
 ///
-/// Initially, the |RendererContextManager| doesn't know any context that is
-/// set by other programs (e.g. a plugin). To make sure not to pollute the
-/// other context, use `MakeCurrent` to set other context, so
-/// |RendererContextManager| has a reference of the other context. Ideally,
-/// this process has to be done everytime before a context used by Flutter
-/// is set, if the current context at the moment is not null or used by
-/// Flutter.
+/// Use this manager to manage flutter's gl context. All the contexts managed by
+/// this are not shared between threads.
+///
+/// We want to return the exact context state before we set our context, after
+/// we are done with our contexts. One way to do it is to cache any current
+/// context (if any) in the `SetCurrent` of your `ContextRenderer`
+/// implementation. Then in the `RemoveCurrent`, reset the cached context to
+/// current using the platform specific gl method.
 class RendererContextManager {
  public:
   RendererContextManager(std::shared_ptr<RendererContext> context,
@@ -60,9 +61,9 @@ class RendererContextManager {
 
   //----------------------------------------------------------------------------
   /// @brief      Make the `context` to be the current context. It can be used
-  /// to set a context set by other programs to be the current context in
-  /// |RendererContextManager|. Which make sure Flutter doesn't pollute other
-  /// contexts.
+  /// to set a context other than the flutter context or the flutter resource
+  /// context. We can manage a context this way only if we know the life cycle
+  /// of it.
   ///
   /// @return     A `RendererContextSwitch` which ensures the `context` is the
   /// current context.
@@ -98,6 +99,9 @@ class RendererContextManager {
   FML_DISALLOW_COPY_AND_ASSIGN(RendererContextManager);
 };
 
+/// The result of a set context operation.
+///
+/// Used by platforms that don't need the |RendererContextManager|.
 class RendererContextResult {
  public:
   //----------------------------------------------------------------------------

--- a/shell/common/renderer_context_manager.h
+++ b/shell/common/renderer_context_manager.h
@@ -30,7 +30,7 @@ class RendererContext {
   //------------------------------------------------------------------------------
   /// Implement this to remove the context wrapped by this |RendererContext|
   /// object from current context;
-  virtual void RemoveCurrent() = 0;
+  virtual bool RemoveCurrent() = 0;
 
   RendererContext();
 
@@ -39,50 +39,22 @@ class RendererContext {
   FML_DISALLOW_COPY_AND_ASSIGN(RendererContext);
 };
 
+class RendererContextSwitch;
+
 //------------------------------------------------------------------------------
 /// Manages the renderer context.
 ///
-/// Initially, the |RendererContextManager| doesn't know any context that is set
-/// by other programs (e.g. a plugin). To make sure not to pollute the other
-/// context, use `MakeCurrent` to set other context, so |RendererContextManager|
-/// has a reference of the other context. Ideally, this process has to be done
-/// everytime before a context used by Flutter is set, if the current context at
-/// the moment is not null or used by Flutter.
+/// Initially, the |RendererContextManager| doesn't know any context that is
+/// set by other programs (e.g. a plugin). To make sure not to pollute the
+/// other context, use `MakeCurrent` to set other context, so
+/// |RendererContextManager| has a reference of the other context. Ideally,
+/// this process has to be done everytime before a context used by Flutter
+/// is set, if the current context at the moment is not null or used by
+/// Flutter.
 class RendererContextManager {
  public:
-  //------------------------------------------------------------------------------
-  /// Switches the renderer context to the a context that is passed in the
-  /// constructor.
-  ///
-  /// In destruction, it should reset the current context back to what was
-  /// before the construction of this switch.
-  ///
-  class RendererContextSwitch {
-   public:
-    //----------------------------------------------------------------------------
-    /// Constructs a |RendererContextSwitch|.
-    ///
-    /// @param  manager A reference to the manager.
-    /// @param  context The context that is going to be set as the current
-    /// context.
-    RendererContextSwitch(RendererContextManager& manager,
-                          std::unique_ptr<RendererContext> context);
-
-    ~RendererContextSwitch();
-
-    //----------------------------------------------------------------------------
-    // Returns true if the context switching was successful.
-    bool GetResult();
-
-   private:
-    RendererContextManager& manager_;
-    bool result_;
-
-    FML_DISALLOW_COPY_AND_ASSIGN(RendererContextSwitch);
-  };
-
-  RendererContextManager(std::unique_ptr<RendererContext> context,
-                         std::unique_ptr<RendererContext> resource_context);
+  RendererContextManager(std::shared_ptr<RendererContext> context,
+                         std::shared_ptr<RendererContext> resource_context);
 
   ~RendererContextManager();
 
@@ -94,7 +66,8 @@ class RendererContextManager {
   ///
   /// @return     A `RendererContextSwitch` which ensures the `context` is the
   /// current context.
-  RendererContextSwitch MakeCurrent(std::unique_ptr<RendererContext> context);
+  std::unique_ptr<RendererContextSwitch> MakeCurrent(
+      std::shared_ptr<RendererContext> context);
 
   //----------------------------------------------------------------------------
   /// @brief      Make the context Flutter uses on the raster thread for
@@ -102,7 +75,7 @@ class RendererContextManager {
   ///
   /// @return     A `RendererContextSwitch` which ensures the current context is
   /// the `context` that used in the constructor.
-  RendererContextSwitch FlutterMakeCurrent();
+  std::unique_ptr<RendererContextSwitch> FlutterMakeCurrent();
 
   //----------------------------------------------------------------------------
   /// @brief      Make the context Flutter uses for performing texture upload on
@@ -110,20 +83,69 @@ class RendererContextManager {
   ///
   /// @return     A `RendererContextSwitch` which ensures the current context is
   /// the `resource_context` that used in the constructor.
-  RendererContextSwitch FlutterResourceMakeCurrent();
+  std::unique_ptr<RendererContextSwitch> FlutterResourceMakeCurrent();
 
  private:
-  std::unique_ptr<RendererContext> context_;
-  std::unique_ptr<RendererContext> resource_context_;
+  friend RendererContextSwitch;
 
-  std::unique_ptr<RendererContext> current_;
+  std::shared_ptr<RendererContext> context_;
+  std::shared_ptr<RendererContext> resource_context_;
 
-  std::vector<std::unique_ptr<RendererContext>> stored_;
-
-  bool PushContext(std::unique_ptr<RendererContext> context);
-  void PopContext();
+  bool PushContext(std::shared_ptr<RendererContext> context);
+  bool PopContext();
+  void EnsureStackInitialized();
 
   FML_DISALLOW_COPY_AND_ASSIGN(RendererContextManager);
+};
+
+class RendererContextResult {
+ public:
+  //----------------------------------------------------------------------------
+  /// Constructs a |RendererContextResult| with a static result.
+  ///
+  /// Used in embeders that doesn't require renderer context switching. (For
+  /// example, metal on iOS)
+  ///
+  /// @param  static_result a static value that will be returned from
+  /// |GetResult|
+  RendererContextResult(bool static_result);
+
+  RendererContextResult();
+  ~RendererContextResult();
+
+  //----------------------------------------------------------------------------
+  // Returns true if the context switching was successful.
+  bool GetResult();
+
+ protected:
+  bool result_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(RendererContextResult);
+};
+//------------------------------------------------------------------------------
+/// Switches the renderer context to the a context that is passed in the
+/// constructor.
+///
+/// In destruction, it should reset the current context back to what was
+/// before the construction of this switch.
+///
+class RendererContextSwitch final : public RendererContextResult {
+ public:
+  //----------------------------------------------------------------------------
+  /// Constructs a |RendererContextSwitch|.
+  ///
+  /// @param  manager A reference to the manager.
+  /// @param  context The context that is going to be set as the current
+  /// context.
+  RendererContextSwitch(RendererContextManager& manager,
+                        std::shared_ptr<RendererContext> context);
+
+  ~RendererContextSwitch();
+
+ private:
+  RendererContextManager& manager_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(RendererContextSwitch);
 };
 
 }  // namespace flutter

--- a/shell/common/renderer_context_manager_unittests.cc
+++ b/shell/common/renderer_context_manager_unittests.cc
@@ -15,11 +15,10 @@ namespace flutter {
 namespace testing {
 
 TEST_F(RendererContextTest, StartWithNoContextFlutterMakeCurrent) {
-  auto flutter_context = std::make_unique<TestRendererContext>(0);
-  auto flutter_resource_context = std::make_unique<TestRendererContext>(1);
+  auto flutter_context = std::make_shared<TestRendererContext>(0);
+  auto flutter_resource_context = std::make_shared<TestRendererContext>(1);
 
-  RendererContextManager manager(std::move(flutter_context),
-                                 std::move(flutter_resource_context));
+  RendererContextManager manager(flutter_context, flutter_resource_context);
   // started with current_context as -1
   TestRendererContext::SetCurrentContext(-1);
   ASSERT_EQ(TestRendererContext::GetCurrentContext(), -1);
@@ -33,11 +32,10 @@ TEST_F(RendererContextTest, StartWithNoContextFlutterMakeCurrent) {
 }
 
 TEST_F(RendererContextTest, StartWithNoContextFlutterResourceMakeCurrent) {
-  auto flutter_context = std::make_unique<TestRendererContext>(0);
-  auto flutter_resource_context = std::make_unique<TestRendererContext>(1);
+  auto flutter_context = std::make_shared<TestRendererContext>(0);
+  auto flutter_resource_context = std::make_shared<TestRendererContext>(1);
 
-  RendererContextManager manager(std::move(flutter_context),
-                                 std::move(flutter_resource_context));
+  RendererContextManager manager(flutter_context, flutter_resource_context);
   // started with current_context as -1
   TestRendererContext::SetCurrentContext(-1);
   ASSERT_EQ(TestRendererContext::GetCurrentContext(), -1);
@@ -51,14 +49,13 @@ TEST_F(RendererContextTest, StartWithNoContextFlutterResourceMakeCurrent) {
 }
 
 TEST_F(RendererContextTest, StartWithSomeContextFlutterMakeCurrent) {
-  auto flutter_context = std::make_unique<TestRendererContext>(0);
-  auto flutter_resource_context = std::make_unique<TestRendererContext>(1);
-  auto some_context = std::make_unique<TestRendererContext>(2);
+  auto flutter_context = std::make_shared<TestRendererContext>(0);
+  auto flutter_resource_context = std::make_shared<TestRendererContext>(1);
+  auto some_context = std::make_shared<TestRendererContext>(2);
 
-  RendererContextManager manager(std::move(flutter_context),
-                                 std::move(flutter_resource_context));
+  RendererContextManager manager(flutter_context, flutter_resource_context);
   // started with some_context
-  auto context_switch = manager.MakeCurrent(std::move(some_context));
+  auto context_switch = manager.MakeCurrent(some_context);
   ASSERT_EQ(TestRendererContext::GetCurrentContext(), 2);
   {
     // made flutter context to be the current
@@ -70,14 +67,13 @@ TEST_F(RendererContextTest, StartWithSomeContextFlutterMakeCurrent) {
 }
 
 TEST_F(RendererContextTest, StartWithSomeContextFlutterResourceMakeCurrent) {
-  auto flutter_context = std::make_unique<TestRendererContext>(0);
-  auto flutter_resource_context = std::make_unique<TestRendererContext>(1);
-  auto some_context = std::make_unique<TestRendererContext>(2);
+  auto flutter_context = std::make_shared<TestRendererContext>(0);
+  auto flutter_resource_context = std::make_shared<TestRendererContext>(1);
+  auto some_context = std::make_shared<TestRendererContext>(2);
 
-  RendererContextManager manager(std::move(flutter_context),
-                                 std::move(flutter_resource_context));
+  RendererContextManager manager(flutter_context, flutter_resource_context);
   // started with some_context
-  auto context_switch = manager.MakeCurrent(std::move(some_context));
+  auto context_switch = manager.MakeCurrent(some_context);
   ASSERT_EQ(TestRendererContext::GetCurrentContext(), 2);
   {
     // made resource context to be the current
@@ -89,15 +85,14 @@ TEST_F(RendererContextTest, StartWithSomeContextFlutterResourceMakeCurrent) {
 }
 
 TEST_F(RendererContextTest, Nested) {
-  auto flutter_context = std::make_unique<TestRendererContext>(0);
-  auto flutter_resource_context = std::make_unique<TestRendererContext>(1);
-  auto some_context = std::make_unique<TestRendererContext>(2);
+  auto flutter_context = std::make_shared<TestRendererContext>(0);
+  auto flutter_resource_context = std::make_shared<TestRendererContext>(1);
+  auto some_context = std::make_shared<TestRendererContext>(2);
 
-  RendererContextManager manager(std::move(flutter_context),
-                                 std::move(flutter_resource_context));
+  RendererContextManager manager(flutter_context, flutter_resource_context);
 
   // started with some_context
-  auto context_switch = manager.MakeCurrent(std::move(some_context));
+  auto context_switch = manager.MakeCurrent(some_context);
   ASSERT_EQ(TestRendererContext::GetCurrentContext(), 2);
   {
     // made flutter context to be the current

--- a/shell/common/renderer_context_test.cc
+++ b/shell/common/renderer_context_test.cc
@@ -20,8 +20,9 @@ bool TestRendererContext::SetCurrent() {
   return true;
 };
 
-void TestRendererContext::RemoveCurrent() {
+bool TestRendererContext::RemoveCurrent() {
   SetCurrentContext(-1);
+  return true;
 };
 
 int TestRendererContext::GetContext() {

--- a/shell/common/renderer_context_test.h
+++ b/shell/common/renderer_context_test.h
@@ -27,7 +27,7 @@ class TestRendererContext : public RendererContext {
 
   bool SetCurrent() override;
 
-  void RemoveCurrent() override;
+  bool RemoveCurrent() override;
 
   int GetContext();
 


### PR DESCRIPTION
Includes in this PR:
1.  Make the stack in `RendererContextManager` a thread local to make it thread safe
1. Make the stored pointers in the stack shared_ptr, because both `context_` and `resource_context_` also need to own the pointer.
1. Remove the `current_` field as the stack can be the single source of truth.
1. Make the returned value of `FlutterMakeCurrent` and  `FlutterResourceMakeCurrent` unique_ptr as in practice, they need to be sent up from a function return, for example, https://github.com/flutter/engine/blob/master/shell/platform/darwin/ios/ios_surface_gl.mm#L62-L66 will eventually return the `Switch` object and we can't use Object type here as it will call the destructor at the end of the scope before returning.
1. Introduced a `RendererContextResult`, which will be a base class of `RendererContextSwitch`. It is used in the platforms that doesn't require gl context switching. (metal, software surface, etc)
1. Make `RemoveCurrent` method in `RendererContext`, indicating if removal was successful.
1. Update the documentation, as a non-flutter context cannot actually be managed in our stack because we don't know when is the end of the life of the other context. It has to be done in a different way.