### PR TITLE
Set GL context in PresentSurface instead of AcquireFrame

### DIFF
--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -230,12 +230,6 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGL::AcquireFrame(const SkISize& size) {
     return nullptr;
   }
 
-  if (!delegate_->GLContextMakeCurrent()) {
-    FML_LOG(ERROR)
-        << "Could not make the context current to acquire the frame.";
-    return nullptr;
-  }
-
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an
   // external view embedder may want to render to the root surface.
   if (!render_to_surface_) {
@@ -268,6 +262,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGL::AcquireFrame(const SkISize& size) {
 
 bool GPUSurfaceGL::PresentSurface(SkCanvas* canvas) {
   if (delegate_ == nullptr || canvas == nullptr || context_ == nullptr) {
+    return false;
+  }
+
+  if (!delegate_->GLContextMakeCurrent()) {
+    FML_LOG(ERROR)
+        << "Could not make the context current to present the surface.";
     return false;
   }
 


### PR DESCRIPTION
This should be set in `PresentSurface`, which is called when the frame is submitted. Otherwise, the GL context is incorrect in hybrid composition (Multiple surfaces).