### PR TITLE
Move robolectric tests to sdk 28

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -502,7 +502,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/embedding_bundle',
-        'version': 'last_updated:2020-03-13T15:42:26-0700'
+        'version': 'last_updated:2020-05-20T01:36:16-0700'
        }
      ],
      'condition': 'download_android_deps',

--- a/shell/platform/android/embedding_bundle/build.gradle
+++ b/shell/platform/android/embedding_bundle/build.gradle
@@ -37,7 +37,7 @@ configurations {
 }
 
 android {
-  compileSdkVersion 28
+  compileSdkVersion 29
 
   dependencies {
     embedding "androidx.annotation:annotation:1.1.0"
@@ -52,7 +52,7 @@ android {
     // TODO(xster): remove these android-all compile time dependencies.
     // Use https://github.com/robolectric/robolectric/blob/master/robolectric/src/main/java/org/robolectric/plugins/LegacyDependencyResolver.java#L24
     // and specify them as runtime dependencies.
-    embeddingTesting "org.robolectric:android-all:8.1.0-robolectric-4611349"
+    embeddingTesting "org.robolectric:android-all:9-robolectric-4913185-2"
     // Get robolectric shadows for SDK=16 used by PlatformPluginTest.
     embeddingTesting_v16 "org.robolectric:android-all:4.1.2_r1-robolectric-r1"
     embeddingTesting "androidx.fragment:fragment-testing:1.1.0"

--- a/shell/platform/android/robolectric.properties
+++ b/shell/platform/android/robolectric.properties
@@ -1,2 +1,4 @@
 # Match the value at shell/platform/android/embedding_bundle/build.gradle.
-sdk=29
+# TODO(https://github.com/flutter/flutter/issues/57655): figure out
+# what's wrong with sdk=29.
+sdk=28

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -42,7 +41,6 @@ import org.robolectric.shadows.ShadowDisplay;
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
-@TargetApi(29)
 public class FlutterViewTest {
   @Mock FlutterJNI mockFlutterJni;
   @Mock FlutterLoader mockFlutterLoader;

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -41,6 +42,7 @@ import org.robolectric.shadows.ShadowDisplay;
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
+@TargetApi(28)
 public class FlutterViewTest {
   @Mock FlutterJNI mockFlutterJni;
   @Mock FlutterLoader mockFlutterLoader;

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -34,7 +34,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowClipboardManager;
 
-@Config(manifest = Config.NONE, sdk = 27, shadows = ShadowClipboardManager.class)
+@Config(manifest = Config.NONE, shadows = ShadowClipboardManager.class)
 @RunWith(RobolectricTestRunner.class)
 public class InputConnectionAdaptorTest {
   @Test

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -52,7 +52,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowBuild;
 import org.robolectric.shadows.ShadowInputMethodManager;
 
-@Config(manifest = Config.NONE, shadows = TextInputPluginTest.TestImm.class, sdk = 27)
+@Config(manifest = Config.NONE, shadows = TextInputPluginTest.TestImm.class)
 @RunWith(RobolectricTestRunner.class)
 public class TextInputPluginTest {
   // Verifies the method and arguments for a captured method call.

--- a/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -22,7 +22,6 @@ import org.robolectric.shadows.ShadowInputMethodManager;
 @Config(
     manifest = Config.NONE,
     shadows = {ShadowInputMethodManager.class, ShadowDisplayManager.class, ShadowDisplay.class})
-
 @RunWith(RobolectricTestRunner.class)
 @TargetApi(28)
 public class SingleViewPresentationTest {

--- a/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.hardware.display.DisplayManager;
 import android.view.Display;
@@ -21,7 +22,9 @@ import org.robolectric.shadows.ShadowInputMethodManager;
 @Config(
     manifest = Config.NONE,
     shadows = {ShadowInputMethodManager.class, ShadowDisplayManager.class, ShadowDisplay.class})
+
 @RunWith(RobolectricTestRunner.class)
+@TargetApi(28)
 public class SingleViewPresentationTest {
   @Test
   public void returnsOuterContextInputMethodManager() {

--- a/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.hardware.display.DisplayManager;
 import android.view.Display;
@@ -21,10 +20,8 @@ import org.robolectric.shadows.ShadowInputMethodManager;
 
 @Config(
     manifest = Config.NONE,
-    shadows = {ShadowInputMethodManager.class, ShadowDisplayManager.class, ShadowDisplay.class},
-    sdk = 27)
+    shadows = {ShadowInputMethodManager.class, ShadowDisplayManager.class, ShadowDisplay.class})
 @RunWith(RobolectricTestRunner.class)
-@TargetApi(27)
 public class SingleViewPresentationTest {
   @Test
   public void returnsOuterContextInputMethodManager() {


### PR DESCRIPTION
Things were terribly broken after https://github.com/flutter/engine/pull/17996. 

For some reason I haven't figured out yet, robolectric sdk v29 is silently skipping tests targeting sdk 29 despite enumerating them. https://github.com/flutter/flutter/issues/57655

Moving to 28 for the time being. 