### PR TITLE
Let run_tests.py just stream output

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -462,7 +462,7 @@ action("robolectric_tests") {
                         embedding_jar_path,
                       ] + embedding_dependencies_jars
 
-  inputs = _jar_dependencies
+  inputs = _jar_dependencies + additional_jar_files
 
   _rebased_current_path = rebase_path(".")
   _rebased_jar_path = rebase_path(jar_path, root_build_dir)

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -38,13 +38,9 @@ def RunCmd(cmd, **kwargs):
   print 'Running command "%s"' % command_string
 
   start_time = time.time()
-  process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs)
-  (output, _) = process.communicate()
+  process = subprocess.Popen(cmd, stdout=sys.stdout, stderr=sys.stderr, **kwargs)
+  process.communicate()
   end_time = time.time()
-
-  # Print the result no matter what.
-  for line in output.splitlines():
-    print line
 
   if process.returncode != 0:
     PrintDivider('!')


### PR DESCRIPTION
1- Let run_tests just stream output as they come instead of buffering them to show at the end. Makes it easier to just look at the test (and especially long builds) and know what's going on when running locally. 
2- Add java resource files to `inputs` to fix caching.