### PR TITLE
Add GDestroyNotify callbacks on handlers

### DIFF
--- a/shell/platform/linux/fl_binary_messenger.cc
+++ b/shell/platform/linux/fl_binary_messenger.cc
@@ -76,26 +76,34 @@ static FlBinaryMessengerResponseHandle* fl_binary_messenger_response_handle_new(
 typedef struct {
   FlBinaryMessengerMessageHandler message_handler;
   gpointer message_handler_data;
+  GDestroyNotify message_handler_destroy_notify;
 } PlatformMessageHandler;
 
 static PlatformMessageHandler* platform_message_handler_new(
     FlBinaryMessengerMessageHandler handler,
-    gpointer user_data) {
+    gpointer user_data,
+    GDestroyNotify destroy_notify) {
   PlatformMessageHandler* self = static_cast<PlatformMessageHandler*>(
       g_malloc0(sizeof(PlatformMessageHandler)));
   self->message_handler = handler;
   self->message_handler_data = user_data;
+  self->message_handler_destroy_notify = destroy_notify;
   return self;
 }
 
 static void platform_message_handler_free(gpointer data) {
   PlatformMessageHandler* self = static_cast<PlatformMessageHandler*>(data);
+  if (self->message_handler_destroy_notify)
+    self->message_handler_destroy_notify(self->message_handler_data);
   g_free(self);
 }
 
 static void engine_weak_notify_cb(gpointer user_data, GObject* object) {
   FlBinaryMessenger* self = FL_BINARY_MESSENGER(user_data);
   self->engine = nullptr;
+
+  // Disconnect any handlers
+  g_hash_table_remove_all(self->platform_message_handlers);
 }
 
 static gboolean fl_binary_messenger_platform_message_cb(
@@ -151,7 +159,7 @@ FlBinaryMessenger* fl_binary_messenger_new(FlEngine* engine) {
   g_object_weak_ref(G_OBJECT(engine), engine_weak_notify_cb, self);
 
   fl_engine_set_platform_message_handler(
-      engine, fl_binary_messenger_platform_message_cb, self);
+      engine, fl_binary_messenger_platform_message_cb, self, NULL);
 
   return self;
 }
@@ -160,13 +168,25 @@ G_MODULE_EXPORT void fl_binary_messenger_set_message_handler_on_channel(
     FlBinaryMessenger* self,
     const gchar* channel,
     FlBinaryMessengerMessageHandler handler,
-    gpointer user_data) {
+    gpointer user_data,
+    GDestroyNotify destroy_notify) {
   g_return_if_fail(FL_IS_BINARY_MESSENGER(self));
   g_return_if_fail(channel != nullptr);
 
+  // Don't set handlers if engine already gone
+  if (self->engine == nullptr) {
+    g_warning(
+        "Attempted to set message handler on closed FlBinaryMessenger without "
+        "engine");
+    if (destroy_notify != nullptr)
+      destroy_notify(user_data);
+    return;
+  }
+
   if (handler != nullptr)
-    g_hash_table_replace(self->platform_message_handlers, g_strdup(channel),
-                         platform_message_handler_new(handler, user_data));
+    g_hash_table_replace(
+        self->platform_message_handlers, g_strdup(channel),
+        platform_message_handler_new(handler, user_data, destroy_notify));
   else
     g_hash_table_remove(self->platform_message_handlers, channel);
 }

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -60,6 +60,8 @@ FlEngine* fl_engine_new(FlDartProject* project, FlRenderer* renderer);
  * @engine: an #FlEngine.
  * @handler: function to call when a platform message is received.
  * @user_data: (closure): user data to pass to @handler.
+ * @destroy_notify: (allow-none): a function which gets called to free
+ * @user_data, or %NULL.
  *
  * Registers the function called when a platform message is reveived. Call
  * fl_engine_send_platform_message_response() with the response to this message.
@@ -70,7 +72,8 @@ FlEngine* fl_engine_new(FlDartProject* project, FlRenderer* renderer);
 void fl_engine_set_platform_message_handler(
     FlEngine* engine,
     FlEnginePlatformMessageHandler handler,
-    gpointer user_data);
+    gpointer user_data,
+    GDestroyNotify destroy_notify);
 
 /**
  * fl_engine_start:

--- a/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h
+++ b/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h
@@ -70,7 +70,8 @@ G_DECLARE_FINAL_TYPE(FlBasicMessageChannelResponseHandle,
  *   g_autoptr(FlStandardMessageCodec) codec = fl_standard_message_codec_new ();
  *   channel = fl_basic_message_channel_new (messenger, "flutter/foo",
  *                                           FL_MESSAGE_CODEC (codec));
- *   fl_basic_message_channel_set_message_handler (channel, message_cb, NULL);
+ *   fl_basic_message_channel_set_message_handler (channel, message_cb, NULL,
+ * NULL);
  *
  *   g_autoptr(FlValue) message = fl_value_new_string ("Hello World");
  *   fl_basic_message_channel_send (channel, message, NULL,
@@ -131,13 +132,21 @@ FlBasicMessageChannel* fl_basic_message_channel_new(
  * @handler: (allow-none): function to call when a message is received on this
  * channel or %NULL to disable the handler.
  * @user_data: (closure): user data to pass to @handler.
+ * @destroy_notify: (allow-none): a function which gets called to free
+ * @user_data, or %NULL.
  *
- * Sets the function called when a message is received.
+ * Sets the function called when a message is received from the Dart side of the
+ * channel. See #FlBasicMessageChannelMessageHandler for details on how to
+ * respond to messages.
+ *
+ * The handler is removed if the channel is closed or is replaced by another
+ * handler, set @destroy_notify if you want to detect this.
  */
 void fl_basic_message_channel_set_message_handler(
     FlBasicMessageChannel* channel,
     FlBasicMessageChannelMessageHandler handler,
-    gpointer user_data);
+    gpointer user_data,
+    GDestroyNotify destroy_notify);
 
 /**
  * fl_basic_message_channel_respond:

--- a/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
+++ b/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
@@ -83,17 +83,22 @@ typedef void (*FlBinaryMessengerMessageHandler)(
  * @handler: (allow-none): function to call when a message is received on this
  * channel or %NULL to disable a handler
  * @user_data: (closure): user data to pass to @handler.
+ * @destroy_notify: (allow-none): a function which gets called to free
+ * @user_data, or %NULL.
  *
  * Sets the function called when a platform message is received on the given
- * channel. Call fl_binary_messenger_send_response() when the message is
- * handled. Ownership of #FlBinaryMessengerResponseHandle is transferred to the
- * caller, and the call must be responded to to avoid memory leaks.
+ * channel. See #FlBinaryMessengerMessageHandler for details on how to respond
+ * to messages.
+ *
+ * The handler is removed if the channel is closed or is replaced by another
+ * handler, set @destroy_notify if you want to detect this.
  */
 void fl_binary_messenger_set_message_handler_on_channel(
     FlBinaryMessenger* messenger,
     const gchar* channel,
     FlBinaryMessengerMessageHandler handler,
-    gpointer user_data);
+    gpointer user_data,
+    GDestroyNotify destroy_notify);
 
 /**
  * fl_binary_messenger_send_response:

--- a/shell/platform/linux/public/flutter_linux/fl_method_channel.h
+++ b/shell/platform/linux/public/flutter_linux/fl_method_channel.h
@@ -84,7 +84,8 @@ G_DECLARE_FINAL_TYPE(FlMethodChannel,
  *   g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new ();
  *   channel =
  *     fl_method_channel_new(messenger, "flutter/foo", FL_METHOD_CODEC (codec));
- *   fl_method_channel_set_method_call_handler (channel, method_call_cb, NULL);
+ *   fl_method_channel_set_method_call_handler (channel, method_call_cb, NULL,
+ * NULL);
  *
  *   g_autoptr(FlValue) args = fl_value_new_string ("Hello World");
  *   fl_method_channel_invoke_method (channel, "Foo.foo", args,
@@ -105,7 +106,7 @@ G_DECLARE_FINAL_TYPE(FlMethodChannel,
  * Function called when a method call is received. Respond to the method call
  * with fl_method_call_respond(). If the response is not occurring in this
  * callback take a reference to @method_call and release that once it has been
- * responded to.Failing to respond before the last reference to @method_call is
+ * responded to. Failing to respond before the last reference to @method_call is
  * dropped is a programming error.
  */
 typedef void (*FlMethodChannelMethodCallHandler)(FlMethodChannel* channel,
@@ -132,14 +133,21 @@ FlMethodChannel* fl_method_channel_new(FlBinaryMessenger* messenger,
  * @channel: an #FlMethodChannel.
  * @handler: function to call when a method call is received on this channel.
  * @user_data: (closure): user data to pass to @handler.
+ * @destroy_notify: (allow-none): a function which gets called to free
+ * @user_data, or %NULL.
  *
- * Sets the function called when a method is called. Call
- * fl_method_call_respond() when the method completes.
+ * Sets the function called when a method call is received from the Dart side of
+ * the channel. See #FlMethodChannelMethodCallHandler for details on how to
+ * respond to method calls.
+ *
+ * The handler is removed if the channel is closed or is replaced by another
+ * handler, set @destroy_notify if you want to detect this.
  */
 void fl_method_channel_set_method_call_handler(
     FlMethodChannel* channel,
     FlMethodChannelMethodCallHandler handler,
-    gpointer user_data);
+    gpointer user_data,
+    GDestroyNotify destroy_notify);
 
 /**
  * fl_method_channel_invoke_method:


### PR DESCRIPTION
Using a destroy notify we can make plugins destroy themselves when the engine is destroyed, i.e.
```c
void some_plugin_init(SomePlugin *self) {
  self->channel = fl_method_channel_new(messenger, "flutter/some-plugin", codec);
  fl_method_channel_set_method_call_handler(self->channel, method_call_cb, g_object_ref(self), g_object_unref);
}

void setup_plugin() {
  g_autoptr(SomePlugin) plugin = some_plugin_new();
  // Reference is dropped but one remains in the callback handler
}
```