### PR TITLE
[ios] Allow for iOS version slack for scenarios tests

### DIFF
--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -19,7 +19,7 @@ pushd ios/Scenarios
 
 set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme Scenarios \
-  -destination 'platform=iOS Simulator,OS=13.0,name=iPhone 8' \
+  -destination 'platform=iOS Simulator,name=iPhone 8' \
   test \
   FLUTTER_ENGINE=$FLUTTER_ENGINE | $PRETTY
 


### PR DESCRIPTION
This is equivalent to having OS=latest which allows one
to pick the latest available OS version on the host system
rather than enforcing a strict match of 13.0