### PR TITLE
Revert "Update CanvasKit to 0.15.0 (#18570)"

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/initialization.dart
+++ b/lib/web_ui/lib/src/engine/compositor/initialization.dart
@@ -14,7 +14,7 @@ const bool experimentalUseSkia =
 /// When CanvasKit pushes a new release to NPM, update this URL to reflect the
 /// most recent version. For example, if CanvasKit releases version 0.34.0 to
 /// NPM, update this URL to `https://unpkg.com/canvaskit-wasm@0.34.0/bin/`.
-const String canvasKitBaseUrl = 'https://unpkg.com/canvaskit-wasm@0.15.0/bin/';
+const String canvasKitBaseUrl = 'https://unpkg.com/canvaskit-wasm@0.14.0/bin/';
 
 /// Initialize the Skia backend.
 ///


### PR DESCRIPTION
This reverts commit 1166a3543c86ce7ebc68b455feb0a3d927bf6583.

Reason: breaks dashboard