### PR TITLE
Add fl_binary_messenger_unset_message_handler_on_channel

### DIFF
--- a/shell/platform/linux/fl_basic_message_channel.cc
+++ b/shell/platform/linux/fl_basic_message_channel.cc
@@ -128,8 +128,8 @@ static void fl_basic_message_channel_dispose(GObject* object) {
   FlBasicMessageChannel* self = FL_BASIC_MESSAGE_CHANNEL(object);
 
   if (self->messenger != nullptr)
-    fl_binary_messenger_set_message_handler_on_channel(
-        self->messenger, self->name, nullptr, nullptr, nullptr);
+    fl_binary_messenger_unset_message_handler_on_channel(
+        self->messenger, self->name, message_cb, self);
 
   g_clear_object(&self->messenger);
   g_clear_pointer(&self->name, g_free);
@@ -179,6 +179,7 @@ G_MODULE_EXPORT void fl_basic_message_channel_set_message_handler(
     gpointer user_data,
     GDestroyNotify destroy_notify) {
   g_return_if_fail(FL_IS_BASIC_MESSAGE_CHANNEL(self));
+  g_return_if_fail(handler != nullptr);
 
   // Don't set handler if channel closed
   if (self->channel_closed) {

--- a/shell/platform/linux/fl_method_channel.cc
+++ b/shell/platform/linux/fl_method_channel.cc
@@ -87,8 +87,8 @@ static void fl_method_channel_dispose(GObject* object) {
   FlMethodChannel* self = FL_METHOD_CHANNEL(object);
 
   if (self->messenger != nullptr)
-    fl_binary_messenger_set_message_handler_on_channel(
-        self->messenger, self->name, nullptr, nullptr, nullptr);
+    fl_binary_messenger_unset_message_handler_on_channel(
+        self->messenger, self->name, message_cb, self);
 
   g_clear_object(&self->messenger);
   g_clear_pointer(&self->name, g_free);
@@ -137,6 +137,7 @@ G_MODULE_EXPORT void fl_method_channel_set_method_call_handler(
     gpointer user_data,
     GDestroyNotify destroy_notify) {
   g_return_if_fail(FL_IS_METHOD_CHANNEL(self));
+  g_return_if_fail(handler != nullptr);
 
   // Don't set handler if channel closed
   if (self->channel_closed) {

--- a/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h
+++ b/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h
@@ -129,8 +129,7 @@ FlBasicMessageChannel* fl_basic_message_channel_new(
 /**
  * fl_basic_message_channel_set_message_handler:
  * @channel: an #FlBasicMessageChannel.
- * @handler: (allow-none): function to call when a message is received on this
- * channel or %NULL to disable the handler.
+ * @handler: function to call when a message is received on this channel.
  * @user_data: (closure): user data to pass to @handler.
  * @destroy_notify: (allow-none): a function which gets called to free
  * @user_data, or %NULL.

--- a/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
+++ b/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h
@@ -77,11 +77,10 @@ typedef void (*FlBinaryMessengerMessageHandler)(
     gpointer user_data);
 
 /**
- * fl_binary_messenger_set_platform_message_handler:
+ * fl_binary_messenger_set_message_handler_on_channel:
  * @binary_messenger: an #FlBinaryMessenger.
  * @channel: channel to listen on.
- * @handler: (allow-none): function to call when a message is received on this
- * channel or %NULL to disable a handler
+ * @handler: function to call when a message is received on this channel.
  * @user_data: (closure): user data to pass to @handler.
  * @destroy_notify: (allow-none): a function which gets called to free
  * @user_data, or %NULL.
@@ -99,6 +98,23 @@ void fl_binary_messenger_set_message_handler_on_channel(
     FlBinaryMessengerMessageHandler handler,
     gpointer user_data,
     GDestroyNotify destroy_notify);
+
+/**
+ * fl_binary_messenger_unset_message_handler_on_channel:
+ * @binary_messenger: an #FlBinaryMessenger.
+ * @channel: channel handler is registered on.
+ * @handler: (allow-none): .
+ * @user_data: (closure): user data provided in.
+ *
+ * Clears the handler set in
+ * fl_binary_messenger_set_message_handler_on_channel() if the provided details
+ * match the current handler. If they do not, this function has no effect.
+ */
+void fl_binary_messenger_unset_message_handler_on_channel(
+    FlBinaryMessenger* messenger,
+    const gchar* channel,
+    FlBinaryMessengerMessageHandler handler,
+    gpointer user_data);
 
 /**
  * fl_binary_messenger_send_response:


### PR DESCRIPTION
This is safer than setting an nullptr handler, as the current handler may not be
the one that was first registered.

This also fixes warnings when cleaning up about setting and handler when the
engine is gone.