### PR TITLE
Fix copy/paste in the Linux embedding

### DIFF
--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -652,7 +652,7 @@ static void SetUpCommonEngineState(FlutterDesktopEngineState* state,
 
   // System channel handler.
   state->platform_handler = std::make_unique<flutter::PlatformHandler>(
-      state->internal_plugin_registrar->messenger(), nullptr);
+      state->internal_plugin_registrar->messenger(), window);
 }
 
 bool FlutterDesktopInit() {


### PR DESCRIPTION
The recent refactoring to support headless mode accidentally passed
nullptr instead of the window (if any) to the platform handler that
manages clipboard interactions, causing it to be broken.

Fixes https://github.com/flutter/flutter/issues/58035