### PR TITLE
Minimize child DOM node moves in many-to-many update

### DIFF
--- a/lib/web_ui/lib/src/engine/surface/surface.dart
+++ b/lib/web_ui/lib/src/engine/surface/surface.dart
@@ -184,7 +184,27 @@ bool debugAssertSurfaceState(
 /// compute the fewest amount of mutations necessary to update the browser DOM.
 abstract class PersistedSurface implements ui.EngineLayer {
   /// Creates a persisted surface.
-  PersistedSurface();
+  PersistedSurface(PersistedSurface oldLayer)
+    : _oldLayer = FrameReference<PersistedSurface>(
+            oldLayer != null && oldLayer.isActive ? oldLayer : null);
+
+  /// The surface that is being updated using this surface.
+  ///
+  /// If not null this surface will reuse the old surface's HTML [element].
+  ///
+  /// This value is set to null at the end of the frame.
+  PersistedSurface get oldLayer => _oldLayer.value;
+  final FrameReference<PersistedSurface> _oldLayer;
+
+  /// The index of this surface in its parent's [PersistedContainerSurface._children]
+  /// list.
+  ///
+  /// This index is used to detect whether any child nodes moved within a
+  /// container layer. The index is cached by the child to avoid a linear
+  /// look-up in the parent's child list.
+  ///
+  /// This index is updated by [PersistedContainerSurface.update].
+  int _index = -1;
 
   /// Controls the algorithm that reuses the DOM resources owned by this
   /// surface.
@@ -584,7 +604,7 @@ abstract class PersistedSurface implements ui.EngineLayer {
 
 /// A surface that doesn't have child surfaces.
 abstract class PersistedLeafSurface extends PersistedSurface {
-  PersistedLeafSurface();
+  PersistedLeafSurface() : super(null);
 
   @override
   void visitChildren(PersistedSurfaceVisitor visitor) {
@@ -598,19 +618,9 @@ abstract class PersistedContainerSurface extends PersistedSurface {
   ///
   /// `oldLayer` points to the surface rendered in the previous frame that's
   /// being updated by this layer.
-  PersistedContainerSurface(PersistedSurface oldLayer)
-      : _oldLayer = FrameReference<PersistedSurface>(
-            oldLayer != null && oldLayer.isActive ? oldLayer : null) {
+  PersistedContainerSurface(PersistedSurface oldLayer) : super(oldLayer) {
     assert(oldLayer == null || runtimeType == oldLayer.runtimeType);
   }
-
-  /// The surface that is being updated using this surface.
-  ///
-  /// If not null this surface will reuse the old surface's HTML [element].
-  ///
-  /// This value is set to null at the end of the frame.
-  PersistedSurface get oldLayer => _oldLayer.value;
-  final FrameReference<PersistedSurface> _oldLayer;
 
   final List<PersistedSurface> _children = <PersistedSurface>[];
 
@@ -671,7 +681,9 @@ abstract class PersistedContainerSurface extends PersistedSurface {
         child.build();
       }
       containerElement.append(child.rootElement);
+      child._index = i;
     }
+    _debugValidateContainerNewState();
   }
 
   @override
@@ -729,8 +741,16 @@ abstract class PersistedContainerSurface extends PersistedSurface {
           assert(oldChild.childContainer == null);
         }
       }
+      _debugValidateContainerNewState();
+      return true;
+    }());
+  }
+
+  void _debugValidateContainerNewState() {
+    assert(() {
       for (int i = 0; i < _children.length; i++) {
         final PersistedSurface newChild = _children[i];
+        assert(newChild._index == i);
         assert(debugAssertSurfaceState(newChild, PersistedSurfaceState.active,
             PersistedSurfaceState.pendingRetention));
         assert(newChild.rootElement != null);
@@ -770,6 +790,7 @@ abstract class PersistedContainerSurface extends PersistedSurface {
         newChild.build();
         assert(debugAssertSurfaceState(newChild, PersistedSurfaceState.active));
       }
+      newChild._index = i;
       assert(newChild.rootElement != null);
       containerElement.append(newChild.rootElement);
     }
@@ -794,6 +815,7 @@ abstract class PersistedContainerSurface extends PersistedSurface {
   void _updateManyToOne(PersistedContainerSurface oldSurface) {
     assert(_children.length == 1);
     final PersistedSurface newChild = _children[0];
+    newChild._index = 0;
 
     // Retained child is moved to the correct location in the tree; all others
     // are released.
@@ -890,8 +912,10 @@ abstract class PersistedContainerSurface extends PersistedSurface {
         _matchChildren(oldSurface);
 
     // This pair of lists maps from _children indices to oldSurface._children indices.
-    final List<int> indexMapNew = <int>[];
-    final List<int> indexMapOld = <int>[];
+    // These lists are initialized lazily, only when we discover that we will need to
+    // move nodes around. Otherwise, these lists remain null.
+    List<int> indexMapNew;
+    List<int> indexMapOld;
 
     // Whether children need to move around the DOM. It is common for children
     // to be updated/retained but never move. Knowing this allows us to bypass
@@ -946,20 +970,36 @@ abstract class PersistedContainerSurface extends PersistedSurface {
       }
 
       int indexInOld = -1;
-      if (matchedOldChild != null) {
-        if (!isReparenting) {
-          // TODO(yjbanov): this causes a O(N^2) search. Can we avoid it?
-          indexInOld = matchedOldChild.parent._children.indexOf(matchedOldChild);
-          if (indexInOld != -1) {
-            indexMapNew.add(topInNew);
-            indexMapOld.add(indexInOld);
-          }
-        }
-      }
-      if (indexInOld != topInNew) {
-        requiresDomInserts = true;
+      if (matchedOldChild != null && !isReparenting) {
+        assert(
+          matchedOldChild._index != -1,
+          'Invalid index ${matchedOldChild._index} of child layer ${matchedOldChild.runtimeType}',
+        );
+        indexInOld = matchedOldChild._index;
       }
 
+      // indexInOld != topInNew indicates that at least one child has moved and
+      // therefore we'll need to find the minimum moves necessary to update the
+      // child list.
+      if (!requiresDomInserts && indexInOld != topInNew) {
+        requiresDomInserts = true;
+        indexMapNew = <int>[];
+        indexMapOld = <int>[];
+
+        // Because up until this moment we haven't been populating the
+        // indexMapNew and indexMapOld, we backfill them with indices up until
+        // the current index.
+        for (int backfill = 0; backfill < topInNew; backfill++) {
+          indexMapNew.add(backfill);
+          indexMapOld.add(backfill);
+        }
+      }
+      if (requiresDomInserts && indexInOld != -1) {
+        indexMapNew.add(topInNew);
+        indexMapOld.add(indexInOld);
+      }
+
+      newChild._index = topInNew;
       assert(newChild.rootElement != null);
       assert(debugAssertSurfaceState(newChild, PersistedSurfaceState.active,
           PersistedSurfaceState.pendingRetention));
@@ -968,7 +1008,13 @@ abstract class PersistedContainerSurface extends PersistedSurface {
     // Avoid calling `_insertChildDomNodes` unnecessarily. Only call it if we
     // actually need to move DOM nodes around.
     if (requiresDomInserts) {
+      assert(indexMapNew.length == indexMapOld.length);
       _insertChildDomNodes(indexMapNew, indexMapOld);
+    } else {
+      // The fast path, where nothing needs to move, should not intialize the
+      // mapping lists at all.
+      assert(indexMapNew == null);
+      assert(indexMapOld == null);
     }
 
     // Remove elements that were not reused this frame.
@@ -1014,7 +1060,9 @@ abstract class PersistedContainerSurface extends PersistedSurface {
     final List<PersistedSurface> newChildren = <PersistedSurface>[];
     for (int i = 0; i < newUnfilteredChildCount; i++) {
       final PersistedSurface child = _children[i];
-      if (child.isCreated && !(child is PersistedContainerSurface && child.oldLayer != null)) {
+      // If child has an old layer, it means it's scheduled for an explicit
+      // update, and therefore there's no need to try to match it.
+      if (child.isCreated && child.oldLayer == null) {
         newChildren.add(child);
       }
     }

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
-@TestOn('vm && linux')
+@TestOn('chrome')
 // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
 
 import 'dart:async';

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -3,16 +3,21 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
+import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 import 'package:ui/src/engine.dart';
-import 'package:ui/ui.dart';
+import 'package:ui/ui.dart' hide window;
 
 import 'package:test/test.dart';
 
 import '../../matchers.dart';
 
 void main() {
+  setUpAll(() async {
+    await webOnlyInitializeEngine();
+  });
+
   group('SceneBuilder', () {
     test('pushOffset implements surface lifecycle', () {
       testLayerLifeCycle((SceneBuilder sceneBuilder, EngineLayer oldLayer) {
@@ -342,6 +347,133 @@ void main() {
     // Expect as many layers as we pushed (not popped).
     html.HtmlElement content = builder.build().webOnlyRootElement;
     expect(content.querySelectorAll('flt-offset'), hasLength(5));
+  });
+
+  test('updates child lists efficiently', () async {
+    // Pushes a single child that renders one character.
+    //
+    // If the character is a number, pushes an offset layer. Otherwise, pushes
+    // an offset layer. Test cases use this to control how layers are reused.
+    // Layers of the same type can be reused even if they are not explicitly
+    // updated. Conversely, layers of different types are never reused.
+    EngineLayer pushChild(SurfaceSceneBuilder builder, String char, {EngineLayer oldLayer}) {
+      // Numbers use opacity layers, letters use offset layers. This is used to
+      // control DOM reuse. Layers of the same type can reuse DOM nodes from other
+      // dropped layers.
+      final bool useOffset = int.tryParse(char) == null;
+      final EnginePictureRecorder recorder = PictureRecorder();
+      final RecordingCanvas canvas = recorder.beginRecording(const Rect.fromLTRB(0, 0, 400, 400));
+      final Paragraph paragraph = (ParagraphBuilder(ParagraphStyle())..addText(char)).build();
+      paragraph.layout(ParagraphConstraints(width: 1000));
+      canvas.drawParagraph(paragraph, Offset.zero);
+      final EngineLayer newLayer = useOffset
+        ? builder.pushOffset(0, 0, oldLayer: oldLayer)
+        : builder.pushOpacity(100, oldLayer: oldLayer);
+      builder.addPicture(Offset.zero, recorder.endRecording());
+      builder.pop();
+      return newLayer;
+    }
+
+    // Maps letters to layers used to render them in the last frame, used to
+    // supply `oldLayer` to guarantee update.
+    final Map<String, EngineLayer> renderedLayers = <String, EngineLayer>{};
+
+    // Pump an empty scene to reset it, otherwise the first frame will attempt
+    // to diff left-overs from a previous test, which results in unpredictable
+    // DOM mutations.
+    window.render(SurfaceSceneBuilder().build());
+
+    // Renders a `string` by breaking it up into individual characters and
+    // rendering each character into its own layer.
+    Future<void> testCase(String string, String description, { int deletions = 0, int additions = 0, int moves = 0 }) {
+      print('Testing "$string" - $description');
+      final Set<html.Node> actualDeletions = <html.Node>{};
+      final Set<html.Node> actualAdditions = <html.Node>{};
+
+      // Watches DOM mutations and counts deletions and additions to the child
+      // list of the `<flt-scene>` element.
+      final html.MutationObserver observer = html.MutationObserver((List mutations, _) {
+        for (html.MutationRecord record in mutations.cast<html.MutationRecord>()) {
+          actualDeletions.addAll(record.removedNodes);
+          actualAdditions.addAll(record.addedNodes);
+        }
+      });
+      observer.observe(SurfaceSceneBuilder.debugLastFrameScene.rootElement, childList: true);
+
+      final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
+      for (int i = 0; i < string.length; i++) {
+        final String char = string[i];
+        renderedLayers[char] = pushChild(builder, char, oldLayer: renderedLayers[char]);
+      }
+      final SurfaceScene scene = builder.build();
+      final List<html.HtmlElement> pTags = scene.webOnlyRootElement.querySelectorAll('p');
+      expect(pTags, hasLength(string.length));
+      expect(
+        scene.webOnlyRootElement.querySelectorAll('p').map((p) => p.innerText).join(''),
+        string,
+      );
+      renderedLayers.removeWhere((key, value) => !string.contains(key));
+
+      // Inject a zero-duration timer to allow mutation observers to receive notification.
+      return Future<void>.delayed(Duration.zero).then((_) {
+        observer.disconnect();
+
+        // Nodes that are removed then added are classified as "moves".
+        final int actualMoves = actualAdditions.intersection(actualDeletions).length;
+        // Compare all at once instead of one by one because when it fails, it's
+        // much more useful to see all numbers, not just the one that failed to
+        // match.
+        expect(
+          <String, int>{
+            'additions': actualAdditions.length - actualMoves,
+            'deletions': actualDeletions.length - actualMoves,
+            'moves': actualMoves,
+          },
+          <String, int>{
+            'additions': additions,
+            'deletions': deletions,
+            'moves': moves,
+          },
+        );
+      });
+    }
+
+    // Adding
+    await testCase('', 'noop');
+    await testCase('', 'noop');
+    await testCase('be', 'zero-to-many', additions: 2);
+    await testCase('bcde', 'insert in the middle', additions: 2);
+    await testCase('abcde', 'prepend', additions: 1);
+    await testCase('abcdef', 'append', additions: 1);
+
+    // Moving
+    await testCase('fbcdea', 'swap at ends', moves: 2);
+    await testCase('fecdba', 'swap in the middle', moves: 2);
+    await testCase('fedcba', 'swap adjacent in one move', moves: 1);
+    await testCase('fedcba', 'non-empty noop');
+    await testCase('afedcb', 'shift right by 1', moves: 1);
+    await testCase('fedcba', 'shift left by 1', moves: 1);
+    await testCase('abcdef', 'reverse', moves: 5);
+    await testCase('efabcd', 'shift right by 2', moves: 2);
+    await testCase('abcdef', 'shift left by 2', moves: 2);
+
+    // Scrolling without DOM reuse (numbers and letters use different types of layers)
+    await testCase('9abcde', 'scroll right by 1', additions: 1, deletions: 1);
+    await testCase('789abc', 'scroll right by 2', additions: 2, deletions: 2);
+    await testCase('89abcd', 'scroll left by 1', additions: 1, deletions: 1);
+    await testCase('abcdef', 'scroll left by 2', additions: 2, deletions: 2);
+
+    // Scrolling with DOM reuse
+    await testCase('zabcde', 'scroll right by 1', moves: 1);
+    await testCase('xyzabc', 'scroll right by 2', moves: 2);
+    await testCase('yzabcd', 'scroll left by 1', moves: 1);
+    await testCase('abcdef', 'scroll left by 2', moves: 2);
+
+    // Removing
+    await testCase('bcdef', 'remove as start', deletions: 1);
+    await testCase('bcde', 'remove as end', deletions: 1);
+    await testCase('be', 'remove in the middle', deletions: 2);
+    await testCase('', 'remove all', deletions: 2);
   });
 }
 


### PR DESCRIPTION
Change many-to-many child node update to move as few elements as possible. This captures many more cases than the previous naive implementation did. In particular it improves backwards scrolling by 15%-25% (see e.g. https://github.com/flutter/flutter/issues/55922).

Below are A/B benchmark results from our infinite scrolling benchmark (I'm adding the backwards scrolling variant in https://github.com/flutter/flutter/pull/58140).

I will consider that this fixes https://github.com/flutter/flutter/issues/55922, as backwards scrolling was the single biggest issue I've seen in that case. We can open more specific issues for the remaining work.

```
Score	Average A (noise)	Average B (noise)	Speed-up
bench_card_infinite_scroll.html.drawFrameDuration.average	907.66 (5.34%)	815.24 (11.33%)	1.11x	
bench_card_infinite_scroll.html.drawFrameDuration.outlierRatio	2.80 (6.91%)	2.60 (3.33%)	1.08x	
bench_card_infinite_scroll.html.totalUiFrame.average	2191.67 (6.03%)	2064.50 (10.16%)	1.06x	
bench_card_infinite_scroll_backward.html.drawFrameDuration.average	880.83 (5.51%)	730.35 (10.17%)	1.21x	
bench_card_infinite_scroll_backward.html.drawFrameDuration.outlierRatio	3.01 (2.44%)	3.51 (4.57%)	0.86x	
bench_card_infinite_scroll_backward.html.totalUiFrame.average	2493.50 (5.28%)	2137.67 (6.63%)	1.17x	
```