### PR TITLE
[web] runs ios unit tests

### DIFF
--- a/lib/web_ui/dev/safari.dart
+++ b/lib/web_ui/dev/safari.dart
@@ -53,18 +53,19 @@ class Safari extends Browser {
           infoLog: DevNull(),
         );
 
-        // In the latest versions of MacOs opening Safari browser with a file brings
+        // In the macOS Catalina opening Safari browser with a file brings
         // a popup which halts the test.
-        // The following list of arguments needs to be provided to the `open` command
-        // to open Safari for a given URL. In summary they provide a new instance
-        // to open, that instance to wait for opening the url until Safari launches,
-        // provide Safari bundles identifier.
-        // The details copied from `man open` on MacOS.
+        // The following list of arguments needs to be provided to the `open`
+        // command to open Safari for a given URL. In summary, `open` tool opens
+        // a new Safari browser (even if one is already open), opens it with no
+        // persistent state and wait until it opens.
+        // The details copied from `man open` on macOS.
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50809
         var process = await Process.start(installation.executable, [
-          '-F', // Open a fresh application with no persistant state.
-          '-W', // Open to wait until the applications it opens.
-          '-n', // Open a new instance of the application.
+          // These are flags for `open` command line tool.
+          '-F', // Open a fresh Safari with no persistant state.
+          '-W', // Wait until the Safari opens.
+          '-n', // Open a new instance of the Safari even another one is open.
           '-b', // Specifies the bundle identifier for the application to use.
           'com.apple.Safari', // Bundle identifier for Safari.
           '${url.toString()}'

--- a/lib/web_ui/dev/safari.dart
+++ b/lib/web_ui/dev/safari.dart
@@ -23,16 +23,16 @@ class Safari extends Browser {
 
   static String version;
 
-  static bool mobileBrowser;
+  static bool isMobileBrowser;
 
   /// Starts a new instance of Safari open to the given [url], which may be a
   /// [Uri] or a [String].
   factory Safari(Uri url, {bool debug = false}) {
     version = SafariArgParser.instance.version;
-    mobileBrowser = SafariArgParser.instance.isMobileBrowser;
+    isMobileBrowser = SafariArgParser.instance.isMobileBrowser;
     assert(version != null);
     return Safari._(() async {
-      if (mobileBrowser) {
+      if (isMobileBrowser) {
         // iOS-Safari
         // Uses `xcrun simctl`. It is a command line utility to control the
         // Simulator. For more details on interacting with the simulator:

--- a/lib/web_ui/dev/safari.dart
+++ b/lib/web_ui/dev/safari.dart
@@ -29,19 +29,24 @@ class Safari extends Browser {
   /// [Uri] or a [String].
   factory Safari(Uri url, {bool debug = false}) {
     version = SafariArgParser.instance.version;
-    mobileBrowser = SafariArgParser.instance.mobileBrowser;
+    mobileBrowser = SafariArgParser.instance.isMobileBrowser;
     assert(version != null);
     return Safari._(() async {
-      if (mobileBrowser) { // iOS-Safari
+      if (mobileBrowser) {
+        // iOS-Safari
+        // Uses `xcrun simctl`. It is a command line utility to control the
+        // Simulator. For more details on interacting with the simulator:
+        // https://developer.apple.com/library/archive/documentation/IDEs/Conceptual/iOS_Simulator_Guide/InteractingwiththeiOSSimulator/InteractingwiththeiOSSimulator.html
         var process = await Process.start('xcrun', [
-          'simctl', // Open a fresh application with no persistant state.
-          'openurl', // Open to wait until the applications it opens.
-          'booted', // Open a new instance of the application.
+          'simctl',
+          'openurl', // Opens the url on Safari installed on the simulator.
+          'booted', // The simulator is already booted.
           '${url.toString()}'
         ]);
 
         return process;
-      } else { // Desktop-Safari
+      } else {
+        // Desktop-Safari
         // TODO(nurhan): Configure info log for LUCI.
         final BrowserInstallation installation = await getOrInstallSafari(
           version,

--- a/lib/web_ui/dev/safari_installation.dart
+++ b/lib/web_ui/dev/safari_installation.dart
@@ -63,16 +63,16 @@ Future<BrowserInstallation> getOrInstallSafari(
   StringSink infoLog,
 }) async {
 
-  // These tests are aimed to run only on MacOs machines local or on LUCI.
+  // These tests are aimed to run only on macOS machines local or on LUCI.
   if (!io.Platform.isMacOS) {
     throw UnimplementedError('Safari on ${io.Platform.operatingSystem} is'
-        ' not supported. Safari is only supported on MacOS.');
+        ' not supported. Safari is only supported on macOS.');
   }
 
   infoLog ??= io.stdout;
 
   if (requestedVersion == 'system') {
-    // Since Safari is included in MacOS, always assume there will be one on the
+    // Since Safari is included in macOS, always assume there will be one on the
     // system.
     infoLog.writeln('Using the system version that is already installed.');
     return BrowserInstallation(

--- a/lib/web_ui/dev/safari_installation.dart
+++ b/lib/web_ui/dev/safari_installation.dart
@@ -38,15 +38,15 @@ class SafariArgParser extends BrowserArgParser {
     _version = argResults['safari-version'] as String;
     assert(_version == 'system');
     final String browser = argResults['browser'] as String;
-    _mobileBrowser = browser == 'ios-safari' ? true : false;
+    _isMobileBrowser = browser == 'ios-safari' ? true : false;
   }
 
   @override
   String get version => _version;
 
-  bool _mobileBrowser;
+  bool _isMobileBrowser;
 
-  bool get mobileBrowser => _mobileBrowser;
+  bool get isMobileBrowser => _isMobileBrowser;
 }
 
 /// Returns the installation of Safari.

--- a/lib/web_ui/dev/safari_installation.dart
+++ b/lib/web_ui/dev/safari_installation.dart
@@ -37,10 +37,16 @@ class SafariArgParser extends BrowserArgParser {
   void parseOptions(ArgResults argResults) {
     _version = argResults['safari-version'] as String;
     assert(_version == 'system');
+    final String browser = argResults['browser'] as String;
+    _mobileBrowser = browser == 'ios-safari' ? true : false;
   }
 
   @override
   String get version => _version;
+
+  bool _mobileBrowser;
+
+  bool get mobileBrowser => _mobileBrowser;
 }
 
 /// Returns the installation of Safari.

--- a/lib/web_ui/dev/supported_browsers.dart
+++ b/lib/web_ui/dev/supported_browsers.dart
@@ -45,6 +45,7 @@ class SupportedBrowsers {
     'edge': Runtime.internetExplorer,
     'firefox': Runtime.firefox,
     'safari': Runtime.safari,
+    'ios-safari': Runtime.safari,
   };
 
   final Map<String, String> supportedBrowserToPlatform = {
@@ -52,6 +53,7 @@ class SupportedBrowsers {
     'edge': 'ie',
     'firefox': 'firefox',
     'safari': 'safari',
+    'ios-safari': 'safari',
   };
 
   final Map<String, String> browserToConfiguration = {
@@ -62,6 +64,8 @@ class SupportedBrowsers {
     'firefox':
         '--configuration=${environment.webUiRootDir.path}/dart_test_firefox.yaml',
     'safari':
+        '--configuration=${environment.webUiRootDir.path}/dart_test_safari.yaml',
+    'ios-safari':
         '--configuration=${environment.webUiRootDir.path}/dart_test_safari.yaml',
   };
 

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -688,14 +688,12 @@ class BrowserManager {
 
     var completer = Completer<BrowserManager>();
 
-    browser.onExit.then((_) {
-      // For the cases where we use a delegator such as `adb` (for Android) or
-      // `xcrun` (for IOS), these delegator processes can shut down before the
-      // websocket is available. Therefore do not throw an error if proccess
-      // exits.
-      // Note that `browser` will throw and error if the exit code was not 0,
-      // which will be processed by the next callback.
-    }).catchError((dynamic error, StackTrace stackTrace) {
+    // For the cases where we use a delegator such as `adb` (for Android) or
+    // `xcrun` (for IOS), these delegator processes can shut down before the
+    // websocket is available. Therefore do not throw an error if proccess
+    // exits with exitCode 0. Note that `browser` will throw and error if the
+    // exit code was not 0, which will be processed by the next callback.
+    browser.onExit.catchError((dynamic error, StackTrace stackTrace) {
       if (completer.isCompleted) {
         return;
       }


### PR DESCRIPTION
This only works if the simulator is already created/booted.
(1) For this to work in local, I'll edit web_installers and add code to create/boot simulators.
(2) For this to work on LUCI, I'll change the recipe and the bot configurations.

Usage
```
felt test --browser=ios-safari

felt test --browser=ios-safari test/alarm_clock_test.dart
```

note: I closed the previous PR:https://github.com/flutter/engine/pull/17454 since this approach is better. 