### PR TITLE
[fuchsia] Avoid unnecessary layout transition.

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -214,7 +214,7 @@ bool VulkanSurfaceProducer::TransitionSurfacesToExternal(
         .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
         .dstAccessMask = 0,
         .oldLayout = imageInfo.fImageLayout,
-        .newLayout = VK_IMAGE_LAYOUT_GENERAL,
+        .newLayout = imageInfo.fImageLayout,
         .srcQueueFamilyIndex = 0,
         .dstQueueFamilyIndex = VK_QUEUE_FAMILY_EXTERNAL_KHR,
         .image = vk_surface->GetVkImage(),


### PR DESCRIPTION
See https://github.com/KhronosGroup/Vulkan-Samples/blob/master/samples/performance/layout_transitions/layout_transitions_tutorial.md#transaction-elimination-on-mali-gpus
for an explanation of why transitioning the layout hurts performance
on Mali drivers.