### PR TITLE
Revert "check the branch flags"

### DIFF
--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -18,8 +18,6 @@ fi
 cd $ENGINE_PATH/src/flutter
 
 # Special handling of release branches.
-echo "CIRRUS_BASE_BRANCH $CIRRUS_BASE_BRANCH and CIRRUS_BRANCH $CIRRUS_BRANCH and CIRRUS_DEFAULT_BRANCH $CIRRUS_DEFAULT_BRANCH"
-
 ENGINE_BRANCH_NAME=$CIRRUS_BASE_BRANCH
 versionregex="^v[[:digit:]]+\."
 releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"


### PR DESCRIPTION
Reverts flutter/engine#18649

I collected the necessary information, looks like we should use CIRRUS_BASE_BRANCH for pre-submit tests and CIRRUS_BRANCH for post submit tests.

https://cirrus-ci.com/task/4687465485172736?command=fetch_framework#L7

Let's revert this PR, I'll send a change with new code (and a lot of documentation).

Thanks,