### PR TITLE
use a different flag to detect release branch for post submit tests

### DIFF
--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -17,8 +17,18 @@ fi
 # Go to the engine git repo to get the date of the latest commit.
 cd $ENGINE_PATH/src/flutter
 
-# Special handling of release branches.
+# Special handling of release branches. We would like to run the tests against
+# the release branch of flutter.
+#
+# On presubmit, we can get the branch name from the `CIRRUS_BASE_BRANCH` flag.
+# During the commit tests the base branch value is empty, instead
+# `CIRRUS_BRANCH` has the correct branch name.
 ENGINE_BRANCH_NAME=$CIRRUS_BASE_BRANCH
+if [[ -z $CIRRUS_BASE_BRANCH ]]
+then
+  echo "Running post commit tests use CIRRUS_BRANCH instead."
+  ENGINE_BRANCH_NAME=$CIRRUS_BRANCH
+fi
 versionregex="^v[[:digit:]]+\."
 releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
 ON_RELEASE_BRANCH=false


### PR DESCRIPTION
Using CIRRUS_BRANCH flag for getting the engine branch, for post-submit tests. (CIRRUS_BASE_FLAG is empty on post-submit. it is used for testing PRs presubmits though)