### PR TITLE
Fix BM_ShellShutdown regression

### DIFF
--- a/shell/common/shell_benchmarks.cc
+++ b/shell/common/shell_benchmarks.cc
@@ -67,6 +67,17 @@ static void StartupAndShutdownShell(benchmark::State& state,
   FML_CHECK(shell);
 
   {
+    // The ui thread could be busy processing tasks after shell created, e.g.,
+    // default font manager setup. The measurement of shell shutdown should be
+    // considered after those ui tasks have been done.
+    benchmarking::ScopedPauseTiming pause(state, true);
+    fml::AutoResetWaitableEvent latch;
+    fml::TaskRunner::RunNowOrPostTask(thread_host->ui_thread->GetTaskRunner(),
+                                      [&latch]() { latch.Signal(); });
+    latch.Wait();
+  }
+
+  {
     benchmarking::ScopedPauseTiming pause(state, !measure_shutdown);
     // Shutdown must occur synchronously on the platform thread.
     fml::AutoResetWaitableEvent latch;


### PR DESCRIPTION
#18225 shifts the work of font manager setup out of `Shell::Create` and into an ui thread task.
`BM_ShellShutdown` measures the time of `Shell::~Shell` which queues a task the ui thread to reset engine and waits for its completion. Now the time spent by font manager setup is counted into `BM_ShellShutdown`.
This pr fix the regression.