### PR TITLE
do not lock petitparser

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -17,8 +17,6 @@ dev_dependencies:
   build_runner: 1.7.2
   build_test: 1.0.0
   build_web_compilers: 2.7.1
-  # TODO(yjbanov): the Dart SDK complains about nonVirtual for some reason.
-  petitparser: 3.0.2
   yaml: 2.2.0
   watcher: 0.9.7+12
   web_engine_tester:


### PR DESCRIPTION
@jason-simmons fixed the meta dependency in https://github.com/flutter/engine/commit/175a92b467e988649d642193e864189f88430524, so we don't need to lock it.