### PR TITLE
add driver for chrome 83

### DIFF
--- a/lib/web_ui/dev/driver_version.yaml
+++ b/lib/web_ui/dev/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  83: '83.0.4103.39'
   81: '81.0.4044.69'
   80: '80.0.3987.106'
   79: '79.0.3945.36'


### PR DESCRIPTION
Add chrome driver version to be used with chrome 83.

It is the suggested version from the chrome driver page: https://chromedriver.chromium.org/downloads