### PR TITLE
delete opengl texture  when it detatch from surfacetexture.

### DIFF
--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -103,6 +103,7 @@ void AndroidExternalTextureGL::UpdateTransform() {
 void AndroidExternalTextureGL::OnGrContextDestroyed() {
   if (state_ == AttachmentState::attached) {
     Detach();
+    glDeleteTextures(1, &texture_name_);
   }
   state_ = AttachmentState::detached;
 }


### PR DESCRIPTION
We use [flutter_boost](https://github.com/alibaba/flutter_boost) as our hybrid integration of Flutter for our existing native apps, and use [video_player](https://github.com/flutter/plugins/tree/master/packages/video_player) for video playing.

We found  that  when user switch between difference Flutter pages，the GPU memory will keep increasing  continuously.

The reason is that the external_texture used by video_player  create a OpenGL texture by calling glGenTextures，and this texture will be deleted when external_texture object destructed under normal conditions.

But we find that the external_texture's  onGrContextDestroyed method will first be called when we leave a flutter page. So  the external_texture state  is  changed  to   detached:
`void AndroidExternalTextureGL::OnGrContextDestroyed() {
  if (state_ == AttachmentState::attached) {
    Detach();
  }
  state_ = AttachmentState::detached;
}
`

Then the external_texture's destruct function is called:
`AndroidExternalTextureGL::~AndroidExternalTextureGL() {
  if (state_ == AttachmentState::attached) {
    glDeleteTextures(1, &texture_name_);
  }
}
`
Because of the state is not attached any more,  the OpenGL texture will be never deleted.

In this case, we should  add the glDeleteTextures function to OnGrContextDestroyed.namely:
`void AndroidExternalTextureGL::OnGrContextDestroyed() {
  if (state_ == AttachmentState::attached) {
    Detach();
    glDeleteTextures(1, &texture_name_);
  }
  state_ = AttachmentState::detached;
}
`

