### PR TITLE
Coordinate surfaceUpdated&scheduleFrame with UIApplication lifecycle. Rendering can only happens when UIApplicationStateActive.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -485,11 +485,11 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 #pragma mark - Surface creation and teardown updates
 
 - (void)surfaceUpdated:(BOOL)appeared {
-    UIApplicationState appState = [UIApplication sharedApplication].applicationState;
-    // Update surface only when application is active.
-    if (appState == UIApplicationStateActive) {
-        [self _innerSurfaceUpdated:appeared];
-    }
+  UIApplicationState appState = [UIApplication sharedApplication].applicationState;
+  // Update surface only when application is active.
+  if (appState == UIApplicationStateActive) {
+    [self _innerSurfaceUpdated:appeared];
+  }
 }
 
 - (void)_innerSurfaceUpdated:(BOOL)appeared {
@@ -641,12 +641,13 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
   // Accessing self.view will create the view. Check whether the view is organically loaded
   // first before checking whether the view is attached to window.
   if (self.isViewLoaded && self.view.window) {
-      UIApplicationState appState = [UIApplication sharedApplication].applicationState;
-      if (([state isEqualToString:@"AppLifecycleState.resumed"] || [state isEqualToString:@"AppLifecycleState.inactive"])
-          && (appState != UIApplicationStateActive)) {
-          // Schedule frame only when application is active.
-          return;
-      }
+    UIApplicationState appState = [UIApplication sharedApplication].applicationState;
+    if (([state isEqualToString:@"AppLifecycleState.resumed"] ||
+         [state isEqualToString:@"AppLifecycleState.inactive"]) &&
+        (appState != UIApplicationStateActive)) {
+      // Schedule frame only when application is active.
+      return;
+    }
     [[_engine.get() lifecycleChannel] sendMessage:state];
   }
 }


### PR DESCRIPTION
This pr will fix https://github.com/flutter/flutter/issues/57973
Let me give more details.
First, though this fix works in flutter v1.12.13.hotfix.8, I believe it will also work for master as the related logic remains.

Several days ago, one application in alibaba begins to use flutter in their homepage, the first tab for a UITabController. After the app is released for beta testing using testflight. We received a lot of libgpu related crash, see https://github.com/flutter/flutter/issues/57973 for more.
The crashes occurs on iPhone6&6Plus, iOS11&iOS12.
![1](https://user-images.githubusercontent.com/817851/83591483-a32e1e80-a58a-11ea-8cb8-7c793d9be20b.png)

In the very beginning, I guess it might crash because the user enter the background without consuming all the gpu related task. However, after some digging, the guess seems not the real situation in the user side.

We have several clues to believe that the user's application crashes when launching.
1. We contact the users, they says that it crashes when launching without any actions to enter background.
2. We have a crash sdk which will catch Application Lifecycle information when crashed.
All the crashes has the similar application state when crashed.
![1](https://user-images.githubusercontent.com/817851/83591602-e5576000-a58a-11ea-8090-9b8c15e11bc5.png)

It means that when the app crashes it has received the UIApplicationWillEnterForegroundNotification notification(application_in_foreground: true), but hasn't received UIApplicationDidBecomeActiveNotification(application_active: false) and it has never been in the background(background_time_since_launch: 0).
3. What's more, I add more logs to Flutter related logic to determine the application state when certain rendering related calls.
```shell
E2020-06-01 14:22:52.052699ALIFLUTTER{
  "ApplicationState" : "UIApplicationStateBackground",
  "curTime" : "2020年6月1日 14:22:52",
  "message" : "LTaoHomeFlutterViewController:viewWillAppear:"
}
E2020-06-01 14:22:52.442727ALIFLUTTER{
  "ApplicationState" : "UIApplicationStateBackground",
  "curTime" : "2020年6月1日 14:22:52",
  "message" : "LTaoHomeFlutterViewController:surfaceUpdated:"
}
E2020-06-01 14:23:18.499525ALIFLUTTER{
  "ApplicationState" : "UIApplicationStateBackground",
  "curTime" : "2020年6月1日 14:23:18",
  "message" : "LTaoHomeFlutterViewController:viewDidAppear:"
}
```

Based on those informations above, I think it's better to  guarantee that the GL related operations in FlutterViewController, including LifeCycle change and surfaceUpdate, should be called in the right appstate.
Besides, I talked to some iOS developers who's familiar with this, they say the strange UIViewController and UIApplication lifecycle is reasonable on some devices.

Today, we did another beta testing with this pr, the crash disappears and the application works fine in our devices.
![3](https://user-images.githubusercontent.com/817851/83591844-80e8d080-a58b-11ea-84f8-c802efe37d82.png)
![4](https://user-images.githubusercontent.com/817851/83591851-834b2a80-a58b-11ea-8383-5fc492841dec.png)

Version 3.20.999.2 is the bad one where almost all the crashes are the one shown in https://github.com/flutter/flutter/issues/57973.
Version 3.20.999.3 is the right one with my pr. The only crash reported is not related to flutter.
