### PR TITLE
Use the main bundle if the App bundle is not found

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -47,7 +47,7 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
   if (flutterAssetsName == nil) {
     flutterAssetsName = @"flutter_assets";
   }
-  NSString* path = [_dartBundle pathForResource:flutterAssetsName ofType:@""];
+  NSString* path = [assetBundle pathForResource:flutterAssetsName ofType:@""];
   if (!path) {
     NSLog(@"Failed to find path for \"%@\"", flutterAssetsName);
   }


### PR DESCRIPTION
## Description

It looks like half the code in this function was updated to use the
main bundle but this one line was still only using the _dartBundle. I am
pretty sure that is a mistake and instead we want to use the mainBundle
as a backup both to find the plist and to find the assets.

## Related Issues

I didn't create an issue for this yet.

## Tests

?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
