### PR TITLE
Pin the analyzer version as a temporary workaround for https://github.com/dart-lang/sdk/issues/42163

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -8,6 +8,8 @@ dependencies:
   meta: 1.1.8
 
 dev_dependencies:
+  # Pin the analyzer version as a temporary workaround for https://github.com/dart-lang/sdk/issues/42163
+  analyzer: 0.39.8
   http: 0.12.0+4
   image: 2.1.4
   mockito: 4.1.1


### PR DESCRIPTION
A recent change to the analyzer package introduced an API incompatibility with
the build_resolvers package.  The analyzer package needs to be pinned to an
older version until this is resolved.
