### PR TITLE
[web] Line break algorithm using unicode properties

### DIFF
--- a/lib/web_ui/lib/src/engine/text/line_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/line_breaker.dart
@@ -20,27 +20,32 @@ enum LineBreakType {
   endOfText,
 }
 
-class CharCode {
-  // New line characters.
-  static const int lf = 0x0A;
-  static const int bk1 = 0x0B;
-  static const int bk2 = 0x0C;
-  static const int cr = 0x0D;
-  static const int nl = 0x85;
-
-  // Space characters.
-  static const int tab = 0x09;
-  static const int space = 0x20;
-
-  static const int hyphen = 0x2D;
-}
-
 /// Acts as a tuple that encapsulates information about a line break.
 class LineBreakResult {
   LineBreakResult(this.index, this.type);
 
   final int index;
   final LineBreakType type;
+}
+
+/// Normalizes properties that behave the same way into one common property.
+LineCharProperty _normalizeLineProperty(LineCharProperty prop) {
+  // LF and NL behave exactly the same as BK.
+  // See: https://www.unicode.org/reports/tr14/tr14-22.html#ExplicitBreaks
+  if (prop == LineCharProperty.LF || prop == LineCharProperty.NL) {
+    return LineCharProperty.BK;
+  }
+  // In the absence of extra data (ICU data and language dictionaries), the
+  // following properties will be treated as AL (alphabetic): AI, SA, SG and XX.
+  // See LB1: https://www.unicode.org/reports/tr14/tr14-22.html#LB1
+  if (prop == LineCharProperty.AI ||
+      prop == LineCharProperty.SA ||
+      prop == LineCharProperty.SG ||
+      prop == LineCharProperty.XX) {
+    return LineCharProperty.AL;
+  }
+
+  return prop;
 }
 
 /// Finds the next line break in the given [text] starting from [index].
@@ -50,55 +55,90 @@ class LineBreakResult {
 /// * http://www.unicode.org/reports/tr14/#Algorithm
 /// * https://www.unicode.org/Public/11.0.0/ucd/LineBreak.txt
 LineBreakResult nextLineBreak(String text, int index) {
-  // TODO(flutter_web): https://github.com/flutter/flutter/issues/33523
-  // This is a hacky/temporary/throw-away implementation to enable us to move fast
-  // with the rest of the line-splitting project.
+  // "raw" refers to the property before normalization.
+  LineCharProperty rawCurr = lineLookup.find(text, index);
+  LineCharProperty curr = _normalizeLineProperty(rawCurr);
+
+  LineCharProperty rawPrev;
+  LineCharProperty prev;
+
+  bool hasSpaces = false;
+
+  // When the text/line starts with SP, we should treat the begining of text/line
+  // as if it were a WJ (word joiner).
+  // See: https://www.unicode.org/reports/tr14/tr14-22.html#SampleCode
+  if (curr == LineCharProperty.SP) {
+    hasSpaces = true;
+    rawCurr = LineCharProperty.WJ;
+    curr = LineCharProperty.WJ;
+  }
 
   // Always break at the end of text.
-  // LB3: ÷ eot
-  while (index++ < text.length) {
-    final int curr = index < text.length ? text.codeUnitAt(index) : null;
-    final int prev = index > 0 ? text.codeUnitAt(index - 1) : null;
+  // LB3: ! eot
+  while (index < text.length) {
+    index++;
+    rawPrev = rawCurr;
+    prev = curr;
+
+    rawCurr = lineLookup.find(text, index);
+    curr = _normalizeLineProperty(rawCurr);
 
     // Always break after hard line breaks.
     // LB4: BK !
-    if (prev == CharCode.bk1 || prev == CharCode.bk2) {
-      return LineBreakResult(index, LineBreakType.mandatory);
-    }
-
+    //
     // Treat CR followed by LF, as well as CR, LF, and NL as hard line breaks.
     // LB5: CR × LF
     //      CR !
     //      LF !
     //      NL !
-    if (prev == CharCode.cr && curr == CharCode.lf) {
-      continue;
-    }
-    if (prev == CharCode.cr || prev == CharCode.lf || prev == CharCode.nl) {
+    if (prev == LineCharProperty.BK) {
       return LineBreakResult(index, LineBreakType.mandatory);
+    }
+
+    if (prev == LineCharProperty.CR) {
+      if (rawCurr == LineCharProperty.LF) {
+        // LB5: CR × LF
+        continue;
+      } else {
+        // LB5: CR !
+        return LineBreakResult(index, LineBreakType.mandatory);
+      }
     }
 
     // Do not break before hard line breaks.
     // LB6: × ( BK | CR | LF | NL )
-    if (curr == CharCode.bk1 ||
-        curr == CharCode.bk2 ||
-        curr == CharCode.cr ||
-        curr == CharCode.lf ||
-        curr == CharCode.nl) {
+    if (curr == LineCharProperty.BK || curr == LineCharProperty.CR) {
       continue;
     }
 
+    // Always break at the end of text.
+    // LB3: ! eot
     if (index >= text.length) {
       return LineBreakResult(text.length, LineBreakType.endOfText);
     }
 
-    if (curr == CharCode.space || curr == CharCode.tab) {
+    // Break before and after unresolved CB.
+    // LB20: ÷ CB
+    //       CB ÷
+    if (prev == LineCharProperty.CB || curr == LineCharProperty.CB) {
+      return LineBreakResult(index, LineBreakType.opportunity);
+    }
+
+    if (curr == LineCharProperty.SP) {
+      hasSpaces = true;
+      // When we encounter SP, we preserve the property of the previous character.
+      rawCurr = rawPrev;
+      curr = prev;
       continue;
     }
 
-    if (prev == CharCode.space ||
-        prev == CharCode.tab ||
-        prev == CharCode.hyphen) {
+    // At this point, we've handled new lines, and consumed all spaces (if any).
+    // TODO: Use the 2d table now. See https://www.unicode.org/reports/tr14/tr14-22.html#ExampleTable
+
+    // TODO: After using the 2d table, do:
+    // hasSpaces = false;
+
+    if (hasSpaces) {
       return LineBreakResult(index, LineBreakType.opportunity);
     }
   }

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -16,10 +16,19 @@ const double _baselineRatioHack = 1.1662499904632568;
 /// Signature of a function that takes a character and returns true or false.
 typedef CharPredicate = bool Function(int char);
 
-bool _whitespacePredicate(int char) =>
-    char == CharCode.space || char == CharCode.tab || _newlinePredicate(char);
-bool _newlinePredicate(int char) =>
-    char == CharCode.cr || char == CharCode.lf || char == CharCode.nl;
+bool _whitespacePredicate(int char) {
+  final LineCharProperty prop =
+      _normalizeLineProperty(lineLookup.findForChar(char));
+  return prop == LineCharProperty.SP ||
+      prop == LineCharProperty.BK ||
+      prop == LineCharProperty.CR;
+}
+
+bool _newlinePredicate(int char) {
+  final LineCharProperty prop =
+      _normalizeLineProperty(lineLookup.findForChar(char));
+  return prop == LineCharProperty.BK || prop == LineCharProperty.CR;
+}
 
 /// Manages [ParagraphRuler] instances and caches them per unique
 /// [ParagraphGeometricStyle].

--- a/lib/web_ui/lib/src/engine/text/unicode_range.dart
+++ b/lib/web_ui/lib/src/engine/text/unicode_range.dart
@@ -92,7 +92,15 @@ class UnicodePropertyLookup<P> {
     if (index < 0 || index >= text.length) {
       return null;
     }
-    final int rangeIndex = _binarySearch(text.codeUnitAt(index));
+    return findForChar(text.codeUnitAt(index));
+  }
+
+  /// Takes one character as an integer code unit and returns its property.
+  ///
+  /// If a property can't be found for the given character, null will be
+  /// returned.
+  P findForChar(int char) {
+    final int rangeIndex = _binarySearch(char);
     return rangeIndex == -1 ? null : ranges[rangeIndex].property;
   }
 


### PR DESCRIPTION
Switch to using the unicode data instead of checking manually for new lines and whitespace.

Note: this PR uses minimal parts of the unicode data just to cover the main things (e.g. whitespace, NL, BK, LF, CR, etc). There's another PR coming that will implement the full algorithm that'll take advantage of the entire unicode data.

Didn't add any tests because I'm relying on existing tests to verify that the switch to unicode data doesn't break existing behavior.

TODO:
- [ ] Check if there are any performance implications.