### PR TITLE
Refactor Accessibility bridge to have a  FlutterViewController

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -18,6 +18,7 @@
 #include "flutter/lib/ui/semantics/custom_accessibility_action.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
+#include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.h"
@@ -42,12 +43,13 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
     virtual ~IosDelegate() = default;
     /// Returns true when the FlutterViewController associated with the `view`
     /// is presenting a modal view controller.
-    virtual bool IsFlutterViewControllerPresentingModalViewController(UIView* view) = 0;
+    virtual bool IsFlutterViewControllerPresentingModalViewController(
+        FlutterViewController* view_controller) = 0;
     virtual void PostAccessibilityNotification(UIAccessibilityNotifications notification,
                                                id argument) = 0;
   };
 
-  AccessibilityBridge(UIView* view,
+  AccessibilityBridge(FlutterViewController* view_controller,
                       PlatformViewIOS* platform_view,
                       FlutterPlatformViewsController* platform_views_controller,
                       std::unique_ptr<IosDelegate> ios_delegate = nullptr);
@@ -62,7 +64,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
 
   UIView<UITextInput>* textInputView() override;
 
-  UIView* view() const override { return view_; }
+  UIView* view() const override { return view_controller_.view; }
 
   fml::WeakPtr<AccessibilityBridge> GetWeakPtr();
 
@@ -78,7 +80,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
                                         NSMutableArray<NSNumber*>* doomed_uids);
   void HandleEvent(NSDictionary<NSString*, id>* annotatedEvent);
 
-  UIView* view_;
+  FlutterViewController* view_controller_;
   PlatformViewIOS* platform_view_;
   FlutterPlatformViewsController* platform_views_controller_;
   fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -96,7 +96,8 @@ class MockDelegate : public PlatformView::Delegate {
 
 class MockIosDelegate : public AccessibilityBridge::IosDelegate {
  public:
-  bool IsFlutterViewControllerPresentingModalViewController(UIView* view) override {
+  bool IsFlutterViewControllerPresentingModalViewController(
+      FlutterViewController* view_controller) override {
     return result_IsFlutterViewControllerPresentingModalViewController_;
   };
 
@@ -157,9 +158,11 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
+  id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
   OCMExpect([mockFlutterView setAccessibilityElements:[OCMArg isNil]]);
   auto bridge =
-      std::make_unique<flutter::AccessibilityBridge>(/*view=*/mockFlutterView,
+      std::make_unique<flutter::AccessibilityBridge>(/*view_controller=*/mockFlutterViewController,
                                                      /*platform_view=*/platform_view.get(),
                                                      /*platform_views_controller=*/nil);
   flutter::SemanticsNodeUpdates nodes;
@@ -181,10 +184,12 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
+  id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
   std::string label = "some label";
 
   __block auto bridge =
-      std::make_unique<flutter::AccessibilityBridge>(/*view=*/mockFlutterView,
+      std::make_unique<flutter::AccessibilityBridge>(/*view_controller=*/mockFlutterViewController,
                                                      /*platform_view=*/platform_view.get(),
                                                      /*platform_views_controller=*/nil);
 
@@ -224,6 +229,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
         /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
         /*task_runners=*/runners);
     id mockFlutterView = OCMClassMock([FlutterView class]);
+    id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+    OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
     std::string label = "some label";
 
     auto flutterPlatformViewsController =
@@ -243,7 +250,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
         result);
 
     auto bridge = std::make_unique<flutter::AccessibilityBridge>(
-        /*view=*/mockFlutterView,
+        /*view_controller=*/mockFlutterViewController,
         /*platform_view=*/platform_view.get(),
         /*platform_views_controller=*/flutterPlatformViewsController.get());
 
@@ -274,6 +281,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
+  id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
   std::string label = "some label";
 
   NSMutableArray<NSDictionary<NSString*, id>*>* accessibility_notifications =
@@ -287,7 +296,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
         }];
       };
   __block auto bridge =
-      std::make_unique<flutter::AccessibilityBridge>(/*view=*/mockFlutterView,
+      std::make_unique<flutter::AccessibilityBridge>(/*view_controller=*/mockFlutterViewController,
                                                      /*platform_view=*/platform_view.get(),
                                                      /*platform_views_controller=*/nil,
                                                      /*ios_delegate=*/std::move(ios_delegate));
@@ -331,6 +340,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
+  id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
   std::string label = "some label";
 
   NSMutableArray<NSDictionary<NSString*, id>*>* accessibility_notifications =
@@ -345,7 +356,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       };
   ios_delegate->result_IsFlutterViewControllerPresentingModalViewController_ = true;
   __block auto bridge =
-      std::make_unique<flutter::AccessibilityBridge>(/*view=*/mockFlutterView,
+      std::make_unique<flutter::AccessibilityBridge>(/*view_controller=*/mockFlutterViewController,
                                                      /*platform_view=*/platform_view.get(),
                                                      /*platform_views_controller=*/nil,
                                                      /*ios_delegate=*/std::move(ios_delegate));

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -107,9 +107,8 @@ void PlatformViewIOS::attachView() {
   FML_DCHECK(ios_surface_ != nullptr);
 
   if (accessibility_bridge_) {
-    accessibility_bridge_.reset(
-        new AccessibilityBridge(static_cast<FlutterView*>(owner_controller_.get().view), this,
-                                [owner_controller_.get() platformViewsController]));
+    accessibility_bridge_.reset(new AccessibilityBridge(
+        owner_controller_.get(), this, [owner_controller_.get() platformViewsController]));
   }
 }
 
@@ -150,9 +149,8 @@ void PlatformViewIOS::SetSemanticsEnabled(bool enabled) {
     return;
   }
   if (enabled && !accessibility_bridge_) {
-    accessibility_bridge_.reset(
-        new AccessibilityBridge(static_cast<FlutterView*>(owner_controller_.get().view), this,
-                                [owner_controller_.get() platformViewsController]));
+    accessibility_bridge_.reset(new AccessibilityBridge(
+        owner_controller_.get(), this, [owner_controller_.get() platformViewsController]));
   } else if (!enabled && accessibility_bridge_) {
     accessibility_bridge_.reset();
   } else {


### PR DESCRIPTION
## Description

Refactor the accessibility bridge to hold on to a FlutterViewController instead of a UIView.

## Related Issues

spawn from https://github.com/flutter/engine/pull/18544

## Tests

I added the following tests:

none, refactor

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
