### PR TITLE
fix AttachCurrentThread override thread name issue

### DIFF
--- a/fml/platform/android/jni_util.cc
+++ b/fml/platform/android/jni_util.cc
@@ -4,9 +4,9 @@
 
 #include "flutter/fml/platform/android/jni_util.h"
 
+#include <sys/prctl.h>
 #include <codecvt>
 #include <string>
-#include <sys/prctl.h>
 
 #include "flutter/fml/logging.h"
 


### PR DESCRIPTION
## Description
On Android platform, if thread attach to JVM use AttachCurrentThread, but not pass the current thread name, android will use default java thread name. So should as chromium: https://chromium.googlesource.com/chromium/src/+/HEAD/base/android/jni_android.cc#50

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue
database]. Indicate, which of these issues are resolved or fixed by this PR.
There should be at least one issue listed here.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
