### PR TITLE
Avoid creating a vector when constructing Dart typed data objects for platform messages

### DIFF
--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -166,24 +166,11 @@ void GetPersistentIsolateData(Dart_NativeArguments args) {
                                         persistent_isolate_data->GetSize()));
 }
 
-}  // namespace
-
 Dart_Handle ToByteData(const std::vector<uint8_t>& buffer) {
-  Dart_Handle data_handle =
-      Dart_NewTypedData(Dart_TypedData_kByteData, buffer.size());
-  if (Dart_IsError(data_handle))
-    return data_handle;
-
-  Dart_TypedData_Type type;
-  void* data = nullptr;
-  intptr_t num_bytes = 0;
-  FML_CHECK(!Dart_IsError(
-      Dart_TypedDataAcquireData(data_handle, &type, &data, &num_bytes)));
-
-  memcpy(data, buffer.data(), num_bytes);
-  Dart_TypedDataReleaseData(data_handle);
-  return data_handle;
+  return tonic::DartByteData::Create(buffer.data(), buffer.size());
 }
+
+}  // namespace
 
 WindowClient::~WindowClient() {}
 

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -35,8 +35,6 @@ namespace flutter {
 class FontCollection;
 class Scene;
 
-Dart_Handle ToByteData(const std::vector<uint8_t>& buffer);
-
 // Must match the AccessibilityFeatureFlag enum in window.dart.
 enum class AccessibilityFeatureFlag : int32_t {
   kAccessibleNavigation = 1 << 0,


### PR DESCRIPTION
PlatformMessageResponseDart creates an external typed data object to
hold the contents of large platform messages such as loaded assets.
The implementation was using a std::vector to hold the message data
extracted from an fml::Mapping.  The vector is initialized during
construction, which is unnecessary given that the data will be
immediately overwritten.

This change centralizes creation of these typed data objects into
Tonic's DartByteData::Create.  DartByteData::Create will allocate an
external typed data based on a malloc buffer if the size exceeds a
threshold.

Fixes https://github.com/flutter/flutter/issues/58572
