### PR TITLE
Fix include paths to help building flutter runner for Fuchsia

### DIFF
--- a/flow/layers/child_scene_layer.h
+++ b/flow/layers/child_scene_layer.h
@@ -5,9 +5,9 @@
 #ifndef FLUTTER_FLOW_LAYERS_CHILD_SCENE_LAYER_H_
 #define FLUTTER_FLOW_LAYERS_CHILD_SCENE_LAYER_H_
 
-#include <third_party/skia/include/core/SkMatrix.h>
-#include <third_party/skia/include/core/SkPoint.h>
-#include <third_party/skia/include/core/SkSize.h>
+#include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkPoint.h"
+#include "third_party/skia/include/core/SkSize.h"
 
 #include "flutter/flow/layers/layer.h"
 #include "flutter/flow/scene_update_context.h"

--- a/flow/view_holder.h
+++ b/flow/view_holder.h
@@ -9,10 +9,10 @@
 #include <fuchsia/ui/views/cpp/fidl.h>
 #include <lib/ui/scenic/cpp/id.h>
 #include <lib/ui/scenic/cpp/resources.h>
-#include <third_party/skia/include/core/SkMatrix.h>
-#include <third_party/skia/include/core/SkPoint.h>
-#include <third_party/skia/include/core/SkSize.h>
 #include <zircon/types.h>
+#include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkPoint.h"
+#include "third_party/skia/include/core/SkSize.h"
 
 #include <memory>
 

--- a/shell/platform/fuchsia/runtime/dart/utils/files.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/files.cc
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "runtime/dart/utils/files.h"
+#include "files.h"
 
 #include <fcntl.h>
 #include <stdint.h>
 
-#include "runtime/dart/utils/inlines.h"
-#include "runtime/dart/utils/logging.h"
+#include "inlines.h"
+#include "logging.h"
 
 namespace dart_utils {
 

--- a/shell/platform/fuchsia/runtime/dart/utils/handle_exception.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/handle_exception.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "runtime/dart/utils/handle_exception.h"
+#include "handle_exception.h"
 
 #include <fuchsia/feedback/cpp/fidl.h>
 #include <fuchsia/mem/cpp/fidl.h>
@@ -14,7 +14,7 @@
 
 #include <string>
 
-#include "runtime/dart/utils/logging.h"
+#include "logging.h"
 
 namespace {
 static bool SetStackTrace(const std::string& data,

--- a/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
@@ -18,11 +18,10 @@
 #include <zircon/dlfcn.h>
 #include <zircon/status.h>
 
+#include "inlines.h"
 #include "logging.h"
-#include "runtime/dart/utils/inlines.h"
-#include "runtime/dart/utils/logging.h"
-#include "runtime/dart/utils/vmo.h"
 #include "third_party/dart/runtime/include/dart_api.h"
+#include "vmo.h"
 
 namespace dart_utils {
 

--- a/shell/platform/fuchsia/runtime/dart/utils/tempfs.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/tempfs.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "runtime/dart/utils/tempfs.h"
+#include "tempfs.h"
 
 #include <future>
 #include <string>
@@ -18,7 +18,7 @@
 #include <zircon/status.h>
 #include <zircon/syscalls.h>
 
-#include "runtime/dart/utils/logging.h"
+#include "logging.h"
 
 namespace {
 

--- a/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "runtime/dart/utils/vmo.h"
+#include "vmo.h"
 
 #include <fcntl.h>
 #include <sys/stat.h>
@@ -14,7 +14,7 @@
 #include <lib/syslog/global.h>
 #include <zircon/status.h>
 
-#include "runtime/dart/utils/logging.h"
+#include "logging.h"
 
 namespace {
 

--- a/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "runtime/dart/utils/vmservice_object.h"
+#include "vmservice_object.h"
 
 #include <dirent.h>
 #include <errno.h>
@@ -12,7 +12,7 @@
 #include <lib/syslog/global.h>
 #include <zircon/status.h>
 
-#include "runtime/dart/utils/logging.h"
+#include "logging.h"
 
 namespace {
 

--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -2,14 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_application.h"
+#include "vulkan_application.h"
 
 #include <utility>
 #include <vector>
 
-#include "flutter/vulkan/vulkan_device.h"
-#include "flutter/vulkan/vulkan_proc_table.h"
-#include "flutter/vulkan/vulkan_utilities.h"
+#include "vulkan_device.h"
+#include "vulkan_proc_table.h"
+#include "vulkan_utilities.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_application.h
+++ b/vulkan/vulkan_application.h
@@ -9,8 +9,8 @@
 #include <string>
 #include <vector>
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_debug_report.h"
-#include "flutter/vulkan/vulkan_handle.h"
+#include "vulkan_debug_report.h"
+#include "vulkan_handle.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_backbuffer.cc
+++ b/vulkan/vulkan_backbuffer.cc
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_backbuffer.h"
+#include "vulkan_backbuffer.h"
 
 #include <limits>
 
-#include "flutter/vulkan/vulkan_proc_table.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 #include "vulkan/vulkan.h"
+#include "vulkan_proc_table.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_backbuffer.h
+++ b/vulkan/vulkan_backbuffer.h
@@ -9,10 +9,10 @@
 
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_command_buffer.h"
-#include "flutter/vulkan/vulkan_handle.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "vulkan_command_buffer.h"
+#include "vulkan_handle.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_command_buffer.cc
+++ b/vulkan/vulkan_command_buffer.cc
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_command_buffer.h"
+#include "vulkan_command_buffer.h"
 
-#include "flutter/vulkan/vulkan_proc_table.h"
+#include "vulkan_proc_table.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_command_buffer.h
+++ b/vulkan/vulkan_command_buffer.h
@@ -7,7 +7,7 @@
 
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_handle.h"
+#include "vulkan_handle.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_debug_report.cc
+++ b/vulkan/vulkan_debug_report.cc
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_debug_report.h"
+#include "vulkan_debug_report.h"
 
 #include <iomanip>
 #include <vector>
 
 #include "flutter/fml/compiler_specific.h"
-#include "flutter/vulkan/vulkan_utilities.h"
+#include "vulkan_utilities.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_debug_report.h
+++ b/vulkan/vulkan_debug_report.h
@@ -6,9 +6,9 @@
 #define FLUTTER_VULKAN_VULKAN_DEBUG_REPORT_H_
 
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_handle.h"
-#include "flutter/vulkan/vulkan_interface.h"
-#include "flutter/vulkan/vulkan_proc_table.h"
+#include "vulkan_handle.h"
+#include "vulkan_interface.h"
+#include "vulkan_proc_table.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_device.cc
+++ b/vulkan/vulkan_device.cc
@@ -2,16 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_device.h"
+#include "vulkan_device.h"
 
 #include <limits>
 #include <map>
 #include <vector>
 
-#include "flutter/vulkan/vulkan_proc_table.h"
-#include "flutter/vulkan/vulkan_surface.h"
-#include "flutter/vulkan/vulkan_utilities.h"
 #include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
+#include "vulkan_proc_table.h"
+#include "vulkan_surface.h"
+#include "vulkan_utilities.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_device.h
+++ b/vulkan/vulkan_device.h
@@ -9,7 +9,7 @@
 
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_handle.h"
+#include "vulkan_handle.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_image.cc
+++ b/vulkan/vulkan_image.cc
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_image.h"
+#include "vulkan_image.h"
 
-#include "flutter/vulkan/vulkan_command_buffer.h"
-#include "flutter/vulkan/vulkan_proc_table.h"
+#include "vulkan_command_buffer.h"
+#include "vulkan_proc_table.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_image.h
+++ b/vulkan/vulkan_image.h
@@ -7,7 +7,7 @@
 
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_handle.h"
+#include "vulkan_handle.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_interface.cc
+++ b/vulkan/vulkan_interface.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_interface.h"
+#include "vulkan_interface.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_native_surface.cc
+++ b/vulkan/vulkan_native_surface.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_native_surface.h"
+#include "vulkan_native_surface.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_native_surface_android.cc
+++ b/vulkan/vulkan_native_surface_android.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_native_surface_android.h"
+#include "vulkan_native_surface_android.h"
 
 #include <android/native_window.h>
 

--- a/vulkan/vulkan_native_surface_android.h
+++ b/vulkan/vulkan_native_surface_android.h
@@ -6,7 +6,7 @@
 #define FLUTTER_VULKAN_VULKAN_NATIVE_SURFACE_ANDROID_H_
 
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_native_surface.h"
+#include "vulkan_native_surface.h"
 
 struct ANativeWindow;
 typedef struct ANativeWindow ANativeWindow;

--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_proc_table.h"
+#include "vulkan_proc_table.h"
 
 #include <dlfcn.h>
 

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -8,10 +8,10 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/memory/ref_ptr.h"
-#include "flutter/vulkan/vulkan_handle.h"
-#include "flutter/vulkan/vulkan_interface.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
 #include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
+#include "vulkan_handle.h"
+#include "vulkan_interface.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_provider.cc
+++ b/vulkan/vulkan_provider.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_provider.h"
+#include "vulkan_provider.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_provider.h
+++ b/vulkan/vulkan_provider.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_VULKAN_VULKAN_PROVIDER_H_
 #define FLUTTER_VULKAN_VULKAN_PROVIDER_H_
 
-#include "flutter/vulkan/vulkan_handle.h"
+#include "vulkan_handle.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_surface.cc
+++ b/vulkan/vulkan_surface.cc
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_surface.h"
+#include "vulkan_surface.h"
 
-#include "flutter/vulkan/vulkan_application.h"
-#include "flutter/vulkan/vulkan_native_surface.h"
+#include "vulkan_application.h"
+#include "vulkan_native_surface.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_surface.h
+++ b/vulkan/vulkan_surface.h
@@ -6,8 +6,8 @@
 #define FLUTTER_VULKAN_VULKAN_SURFACE_H_
 
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_handle.h"
 #include "third_party/skia/include/core/SkSize.h"
+#include "vulkan_handle.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -2,16 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_swapchain.h"
+#include "vulkan_swapchain.h"
 
-#include "flutter/vulkan/vulkan_backbuffer.h"
-#include "flutter/vulkan/vulkan_device.h"
-#include "flutter/vulkan/vulkan_image.h"
-#include "flutter/vulkan/vulkan_proc_table.h"
-#include "flutter/vulkan/vulkan_surface.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
+#include "vulkan_backbuffer.h"
+#include "vulkan_device.h"
+#include "vulkan_image.h"
+#include "vulkan_proc_table.h"
+#include "vulkan_surface.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_swapchain.h
+++ b/vulkan/vulkan_swapchain.h
@@ -11,9 +11,9 @@
 
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_handle.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "vulkan_handle.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_swapchain_stub.cc
+++ b/vulkan/vulkan_swapchain_stub.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_swapchain.h"
+#include "vulkan_swapchain.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_utilities.cc
+++ b/vulkan/vulkan_utilities.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_utilities.h"
+#include "vulkan_utilities.h"
 #include "flutter/fml/build_config.h"
 
 #include <algorithm>

--- a/vulkan/vulkan_utilities.h
+++ b/vulkan/vulkan_utilities.h
@@ -9,8 +9,8 @@
 #include <vector>
 
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_handle.h"
-#include "flutter/vulkan/vulkan_proc_table.h"
+#include "vulkan_handle.h"
+#include "vulkan_proc_table.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -2,17 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/vulkan/vulkan_window.h"
+#include "vulkan_window.h"
 
 #include <memory>
 #include <string>
 
-#include "flutter/vulkan/vulkan_application.h"
-#include "flutter/vulkan/vulkan_device.h"
-#include "flutter/vulkan/vulkan_native_surface.h"
-#include "flutter/vulkan/vulkan_surface.h"
-#include "flutter/vulkan/vulkan_swapchain.h"
 #include "third_party/skia/include/gpu/GrContext.h"
+#include "vulkan_application.h"
+#include "vulkan_device.h"
+#include "vulkan_native_surface.h"
+#include "vulkan_surface.h"
+#include "vulkan_swapchain.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_window.h
+++ b/vulkan/vulkan_window.h
@@ -12,12 +12,12 @@
 
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
-#include "flutter/vulkan/vulkan_proc_table.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
+#include "vulkan_proc_table.h"
 
 namespace vulkan {
 


### PR DESCRIPTION
Fix include paths to help building flutter runner for Fuchsia in Google3.

Include header file without absolute path if the header file belongs to
the same directory as source file.




