### PR TITLE
Run the rasterizer on the platform thread 

### DIFF
--- a/fml/message_loop.h
+++ b/fml/message_loop.h
@@ -15,6 +15,7 @@ class MessageLoopImpl;
 
 class MessageLoop {
  public:
+  FML_EMBEDDER_ONLY
   static MessageLoop& GetCurrent();
 
   bool IsValid() const;

--- a/fml/message_loop.h
+++ b/fml/message_loop.h
@@ -15,7 +15,6 @@ class MessageLoopImpl;
 
 class MessageLoop {
  public:
-  FML_EMBEDDER_ONLY
   static MessageLoop& GetCurrent();
 
   bool IsValid() const;

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -61,14 +61,14 @@ bool AndroidExternalViewEmbedder::SubmitFrame(
 // |ExternalViewEmbedder|
 PostPrerollResult AndroidExternalViewEmbedder::PostPrerollAction(
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
-  // This frame may remove existing platform views that aren't contained 
+  // This frame may remove existing platform views that aren't contained
   // in `composition_order_`.
   //
   // If this frame doesn't have platform views, it's still required to keep
-  // the rasterizer running on the platform thread for at least one more 
+  // the rasterizer running on the platform thread for at least one more
   // frame.
   //
-  // To keep the rasterizer running on the platform thread one more frame, 
+  // To keep the rasterizer running on the platform thread one more frame,
   // `kDefaultMergedLeaseDuration` must be at least `1`.
   bool has_platform_views = composition_order_.size() > 0;
   if (has_platform_views) {

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -61,6 +61,15 @@ bool AndroidExternalViewEmbedder::SubmitFrame(
 // |ExternalViewEmbedder|
 PostPrerollResult AndroidExternalViewEmbedder::PostPrerollAction(
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
+  // This frame may remove existing platform views that aren't contained 
+  // in `composition_order_`.
+  //
+  // If this frame doesn't have platform views, it's still required to keep
+  // the rasterizer running on the platform thread for at least one more 
+  // frame.
+  //
+  // To keep the rasterizer running on the platform thread one more frame, 
+  // `kDefaultMergedLeaseDuration` must be at least `1`.
   bool has_platform_views = composition_order_.size() > 0;
   if (has_platform_views) {
     if (raster_thread_merger->IsMerged()) {

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -46,6 +46,10 @@ bool AndroidExternalViewEmbedder::SubmitFrame(
   // TODO(egarciad): Implement hybrid composition.
   // https://github.com/flutter/flutter/issues/55270
   TRACE_EVENT0("flutter", "AndroidExternalViewEmbedder::SubmitFrame");
+  if (should_run_rasterizer_on_platform_thread_) {
+    // Don't submit the current frame if the frame will be resubmitted.
+    return false;
+  }
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t view_id = composition_order_[i];
     frame->SkiaCanvas()->drawPicture(
@@ -57,6 +61,17 @@ bool AndroidExternalViewEmbedder::SubmitFrame(
 // |ExternalViewEmbedder|
 PostPrerollResult AndroidExternalViewEmbedder::PostPrerollAction(
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
+  bool has_platform_views = composition_order_.size() > 0;
+  if (has_platform_views) {
+    if (raster_thread_merger->IsMerged()) {
+      raster_thread_merger->ExtendLeaseTo(kDefaultMergedLeaseDuration);
+    } else {
+      // Merge the raster and platform threads in `EndFrame`.
+      should_run_rasterizer_on_platform_thread_ = true;
+      CancelFrame();
+      return PostPrerollResult::kResubmitFrame;
+    }
+  }
   return PostPrerollResult::kSuccess;
 }
 
@@ -86,6 +101,11 @@ void AndroidExternalViewEmbedder::CancelFrame() {
 
 // |ExternalViewEmbedder|
 void AndroidExternalViewEmbedder::EndFrame(
-    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {}
+    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
+  if (should_run_rasterizer_on_platform_thread_) {
+    raster_thread_merger->MergeWithLease(kDefaultMergedLeaseDuration);
+    should_run_rasterizer_on_platform_thread_ = false;
+  }
+}
 
 }  // namespace flutter

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -48,7 +48,7 @@ bool AndroidExternalViewEmbedder::SubmitFrame(
   TRACE_EVENT0("flutter", "AndroidExternalViewEmbedder::SubmitFrame");
   if (should_run_rasterizer_on_platform_thread_) {
     // Don't submit the current frame if the frame will be resubmitted.
-    return false;
+    return true;
   }
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t view_id = composition_order_[i];

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -48,6 +48,17 @@ class AndroidExternalViewEmbedder : public ExternalViewEmbedder {
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
  private:
+  // The number of frames the rasterizer task runner will continue
+  // to run on the platform thread after no platform view is rendered.
+  //
+  // Note: this is an arbitrary number that attempts to account for cases
+  // where the platform view might be momentarily off the screen.
+  static const int kDefaultMergedLeaseDuration = 10;
+
+  // Whether the rasterizer task runner should run on the platform thread.
+  // When this is true, the current frame is cancelled and resubmitted.
+  bool should_run_rasterizer_on_platform_thread_ = false;
+
   // The size of the background canvas.
   SkISize frame_size_;
 

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -2,9 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "gtest/gtest.h"
+#include <thread>
 
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/raster_thread_merger.h"
+#include "flutter/fml/synchronization/count_down_latch.h"
+#include "flutter/fml/task_runner.h"
 #include "flutter/shell/platform/android/external_view_embedder/external_view_embedder.h"
+#include "gtest/gtest.h"
 
 namespace flutter {
 namespace testing {
@@ -46,6 +51,111 @@ TEST(AndroidExternalViewEmbedder, CancelFrame) {
 
   auto canvases = embedder->GetCurrentCanvases();
   ASSERT_EQ(0UL, canvases.size());
+}
+
+TEST(AndroidExternalViewEmbedder, RasterizerRunsOnPlatformThread) {
+  auto embedder = new AndroidExternalViewEmbedder();
+
+  embedder->BeginFrame(SkISize::Make(10, 20), nullptr, 1.0);
+
+  // Push a platform view.
+  embedder->PrerollCompositeEmbeddedView(
+      0, std::make_unique<EmbeddedViewParams>());
+
+  fml::MessageLoop* loop1 = nullptr;
+  fml::AutoResetWaitableEvent latch1;
+  fml::AutoResetWaitableEvent term1;
+  std::thread thread1([&loop1, &latch1, &term1]() {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop1 = &fml::MessageLoop::GetCurrent();
+    latch1.Signal();
+    term1.Wait();
+  });
+
+  fml::MessageLoop* loop2 = nullptr;
+  fml::AutoResetWaitableEvent latch2;
+  fml::AutoResetWaitableEvent term2;
+  std::thread thread2([&loop2, &latch2, &term2]() {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop2 = &fml::MessageLoop::GetCurrent();
+    latch2.Signal();
+    term2.Wait();
+  });
+
+  latch1.Wait();
+  latch2.Wait();
+
+  fml::TaskQueueId qid1 = loop1->GetTaskRunner()->GetTaskQueueId();
+  fml::TaskQueueId qid2 = loop2->GetTaskRunner()->GetTaskQueueId();
+
+  const auto raster_thread_merger =
+      fml::MakeRefCounted<fml::RasterThreadMerger>(qid1, qid2);
+  ASSERT_FALSE(raster_thread_merger->IsMerged());
+
+  const auto postpreroll_result =
+      embedder->PostPrerollAction(raster_thread_merger);
+  ASSERT_EQ(PostPrerollResult::kResubmitFrame, postpreroll_result);
+  ASSERT_FALSE(embedder->SubmitFrame(nullptr, nullptr));
+
+  embedder->EndFrame(raster_thread_merger);
+  ASSERT_TRUE(raster_thread_merger->IsMerged());
+
+  int pending_frames = 0;
+  while (raster_thread_merger->IsMerged()) {
+    raster_thread_merger->DecrementLease();
+    pending_frames++;
+  }
+  ASSERT_EQ(10, pending_frames);  // kDefaultMergedLeaseDuration
+
+  term1.Signal();
+  term2.Signal();
+  thread1.join();
+  thread2.join();
+}
+
+TEST(AndroidExternalViewEmbedder, RasterizerRunsOnRasterizerThread) {
+  auto embedder = new AndroidExternalViewEmbedder();
+
+  fml::MessageLoop* loop1 = nullptr;
+  fml::AutoResetWaitableEvent latch1;
+  fml::AutoResetWaitableEvent term1;
+  std::thread thread1([&loop1, &latch1, &term1]() {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop1 = &fml::MessageLoop::GetCurrent();
+    latch1.Signal();
+    term1.Wait();
+  });
+
+  fml::MessageLoop* loop2 = nullptr;
+  fml::AutoResetWaitableEvent latch2;
+  fml::AutoResetWaitableEvent term2;
+  std::thread thread2([&loop2, &latch2, &term2]() {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop2 = &fml::MessageLoop::GetCurrent();
+    latch2.Signal();
+    term2.Wait();
+  });
+
+  latch1.Wait();
+  latch2.Wait();
+
+  fml::TaskQueueId qid1 = loop1->GetTaskRunner()->GetTaskQueueId();
+  fml::TaskQueueId qid2 = loop2->GetTaskRunner()->GetTaskQueueId();
+
+  const auto raster_thread_merger =
+      fml::MakeRefCounted<fml::RasterThreadMerger>(qid1, qid2);
+  ASSERT_FALSE(raster_thread_merger->IsMerged());
+
+  PostPrerollResult result = embedder->PostPrerollAction(raster_thread_merger);
+  ASSERT_EQ(PostPrerollResult::kSuccess, result);
+
+  embedder->EndFrame(raster_thread_merger);
+  ASSERT_FALSE(raster_thread_merger->IsMerged());
+
+  term1.Signal();
+  term2.Signal();
+  thread1.join();
+  thread2.join();
 }
 
 }  // namespace testing

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -53,11 +53,12 @@ TEST(AndroidExternalViewEmbedder, RasterizerRunsOnPlatformThread) {
   auto embedder = new AndroidExternalViewEmbedder();
   auto platform_thread = new fml::Thread("platform");
   auto rasterizer_thread = new fml::Thread("rasterizer");
-  auto qid1 = platform_thread->GetTaskRunner()->GetTaskQueueId();
-  auto qid2 = rasterizer_thread->GetTaskRunner()->GetTaskQueueId();
+  auto platform_queue_id = platform_thread->GetTaskRunner()->GetTaskQueueId();
+  auto rasterizer_queue_id =
+      rasterizer_thread->GetTaskRunner()->GetTaskQueueId();
 
-  auto raster_thread_merger =
-      fml::MakeRefCounted<fml::RasterThreadMerger>(qid1, qid2);
+  auto raster_thread_merger = fml::MakeRefCounted<fml::RasterThreadMerger>(
+      platform_queue_id, rasterizer_queue_id);
   ASSERT_FALSE(raster_thread_merger->IsMerged());
 
   embedder->BeginFrame(SkISize::Make(10, 20), nullptr, 1.0);
@@ -84,11 +85,12 @@ TEST(AndroidExternalViewEmbedder, RasterizerRunsOnRasterizerThread) {
   auto embedder = new AndroidExternalViewEmbedder();
   auto platform_thread = new fml::Thread("platform");
   auto rasterizer_thread = new fml::Thread("rasterizer");
-  auto qid1 = platform_thread->GetTaskRunner()->GetTaskQueueId();
-  auto qid2 = rasterizer_thread->GetTaskRunner()->GetTaskQueueId();
+  auto platform_queue_id = platform_thread->GetTaskRunner()->GetTaskQueueId();
+  auto rasterizer_queue_id =
+      rasterizer_thread->GetTaskRunner()->GetTaskQueueId();
 
-  auto raster_thread_merger =
-      fml::MakeRefCounted<fml::RasterThreadMerger>(qid1, qid2);
+  auto raster_thread_merger = fml::MakeRefCounted<fml::RasterThreadMerger>(
+      platform_queue_id, rasterizer_queue_id);
   ASSERT_FALSE(raster_thread_merger->IsMerged());
 
   PostPrerollResult result = embedder->PostPrerollAction(raster_thread_merger);

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -68,7 +68,7 @@ TEST(AndroidExternalViewEmbedder, RasterizerRunsOnPlatformThread) {
 
   auto postpreroll_result = embedder->PostPrerollAction(raster_thread_merger);
   ASSERT_EQ(PostPrerollResult::kResubmitFrame, postpreroll_result);
-  ASSERT_FALSE(embedder->SubmitFrame(nullptr, nullptr));
+  ASSERT_TRUE(embedder->SubmitFrame(nullptr, nullptr));
 
   embedder->EndFrame(raster_thread_merger);
   ASSERT_TRUE(raster_thread_merger->IsMerged());

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -209,12 +209,11 @@ class FlutterPlatformViewsController {
   std::map<int64_t, int64_t> clip_count_;
   SkISize frame_size_;
 
-  // This is the number of frames the task runners will stay
-  // merged after a frame where we see a mutation to the embedded views.
-  // Note: This number was arbitrarily picked. The rationale being
-  // merge-unmerge are not zero cost operations. To account for cases
-  // like animating platform views, we picked it to be > 2, as we would
-  // want to avoid merge-unmerge during each frame with a mutation.
+  // The number of frames the rasterizer task runner will continue
+  // to run on the platform thread after no platform view is rendered.
+  //
+  // Note: this is an arbitrary number that attempts to account for cases
+  // where the platform view might be momentarily off the screen.
   static const int kDefaultMergedLeaseDuration = 10;
 
   // Method channel `OnDispose` calls adds the views to be disposed to this set to be disposed on


### PR DESCRIPTION
## Description

Runs the rasterizer on the platform thread if a platform view is in the current frame.

## Related Issues

https://github.com/flutter/flutter/issues/58292

## Tests

I added the following tests: Unit tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
