### PR TITLE
Include dart2native in the vended Dart SDK

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -254,7 +254,9 @@ def to_gn_args(args):
     if args.target_os is None:
       # dart_platform_sdk is not declared for Android targets.
       gn_args['dart_platform_sdk'] = not args.full_dart_sdk
-    gn_args['full_dart_sdk'] = args.full_dart_sdk
+    if args.full_dart_sdk:
+      gn_args['include_dart2native'] = True
+      gn_args['full_dart_sdk'] = True
 
     # Desktop embeddings can have more dependencies than the engine library,
     # which can be problematic in some build environments (e.g., building on


### PR DESCRIPTION
## Description

The Dart SDK is now exposed to Flutter users through `FLUTTER_TOOT/bin/dart`. This PR adds the `dart2native` tool to the Dart SDK vended by the engine builders so that it has all the tools expected by Dart SDK users.

This increases the size of the zip file from 206MB to 224MB primarily due to `bin/snapshots/gen_kernel.dart.snapshot`.

## Related Issues

https://github.com/flutter/flutter/issues/43968

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
