### PR TITLE
[web] running ios unit tests from felt …

### DIFF
--- a/lib/web_ui/dev/README.md
+++ b/lib/web_ui/dev/README.md
@@ -89,6 +89,28 @@ To run tests on Safari use the following command. It works on MacOS devices and 
 felt test --browser=safari
 ```
 
+One can also use Ios Safari for running unit tests. It works on MacOS devices. There are few prerequisite steps:
+
+1. Please make sure that you installed XCode.
+
+2. The default version used in the tests are in browser_lock.yaml file. Install the ios version to use for simulators: XCode > Preferences > Components
+
+3. run `xcrun simctl list devices`. If the simulator you want is not installed use step 4.
+
+4. Use felt to create a simulator:
+
+```
+felt create --majorVersion=11 --minorVersion=1 --device='iPhone.11.Pro'
+```
+
+To run tests on ios-safari use the one of the following commands:
+
+```
+felt test --browser=ios-safari
+felt test --browser=ios-safari --majorVersion=13 --minorVersion=1 --device='iPhone.11.Pro'
+felt test --browser=ios-safari test/alarm_clock_test.dart
+```
+
 To run tests on Windows Edge use the following command. It works on Windows devices and it uses the Edge installed on the OS.
 
 ```

--- a/lib/web_ui/dev/browser_lock.yaml
+++ b/lib/web_ui/dev/browser_lock.yaml
@@ -10,3 +10,7 @@ firefox:
   version: '72.0'
 edge:
   launcher_version: '1.2.0.0'
+ios-safari:
+  majorVersion: 13
+  minorVersion: 5
+  device: 'iPhone 11'

--- a/lib/web_ui/dev/create_simulator.dart
+++ b/lib/web_ui/dev/create_simulator.dart
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.6
+import 'dart:async';
+
+import 'package:args/command_runner.dart';
+import 'package:simulators/simulator_manager.dart';
+
+import 'safari_installation.dart';
+import 'utils.dart';
+
+class CreateCommand extends Command<bool> with ArgUtils {
+  CreateCommand() {
+    IosSafariArgParser.instance.populateOptions(argParser);
+  }
+
+  @override
+  String get name => 'create';
+
+  @override
+  String get description => 'Creates mobile simulators.';
+
+  @override
+  FutureOr<bool> run() async {
+    IosSafariArgParser.instance.parseOptions(argResults);
+    final IosSimulatorManager iosSimulatorManager = IosSimulatorManager();
+    try {
+    final IosSimulator simulator = await iosSimulatorManager.createSimulator(
+        IosSafariArgParser.instance.iosMajorVersion,
+        IosSafariArgParser.instance.iosMinorVersion,
+        IosSafariArgParser.instance.iosDevice);
+    print('INFO: Simulator created ${simulator.toString()}');
+    } catch (e) {
+      throw Exception('Error creating requested simulator. You can use Xcode '
+            'to install more versions: XCode > Preferences > Components.'
+            ' Exception: $e');
+    }
+    return true;
+  }
+}

--- a/lib/web_ui/dev/felt.dart
+++ b/lib/web_ui/dev/felt.dart
@@ -9,6 +9,7 @@ import 'package:args/command_runner.dart';
 
 import 'build.dart';
 import 'clean.dart';
+import 'create_simulator.dart';
 import 'licenses.dart';
 import 'exceptions.dart';
 import 'test_runner.dart';
@@ -19,6 +20,7 @@ CommandRunner runner = CommandRunner<bool>(
   'Command-line utility for building and testing Flutter web engine.',
 )
   ..addCommand(CleanCommand())
+  ..addCommand(CreateCommand())
   ..addCommand(LicensesCommand())
   ..addCommand(TestCommand())
   ..addCommand(BuildCommand());

--- a/lib/web_ui/dev/safari_installation.dart
+++ b/lib/web_ui/dev/safari_installation.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:args/args.dart';
+import 'package:yaml/yaml.dart';
 
 import 'common.dart';
 
@@ -31,6 +32,9 @@ class SafariArgParser extends BrowserArgParser {
             'Soon we will add support for using different versions using the '
             'tech previews.',
       );
+
+      // Populate options for Ios Safari.
+      IosSafariArgParser.instance.populateOptions(argParser);
   }
 
   @override
@@ -45,8 +49,73 @@ class SafariArgParser extends BrowserArgParser {
   String get version => _version;
 
   bool _isMobileBrowser;
-
   bool get isMobileBrowser => _isMobileBrowser;
+}
+
+class IosSafariArgParser extends BrowserArgParser {
+  static final IosSafariArgParser _singletonInstance = IosSafariArgParser._();
+
+  /// The [IosSafariArgParser] singleton.
+  static IosSafariArgParser get instance => _singletonInstance;
+
+  String get version => 'iOS ${iosMajorVersion}.${iosMinorVersion}';
+
+  int _pinnedIosMajorVersion;
+  int _iosMajorVersion;
+  int get iosMajorVersion => _iosMajorVersion ?? _pinnedIosMajorVersion;
+
+  int _pinnedIosMinorVersion;
+  int _iosMinorVersion;
+  int get iosMinorVersion => _iosMinorVersion ?? _pinnedIosMinorVersion;
+
+  String _pinnedIosDevice;
+  String _iosDevice;
+  String get iosDevice => _iosDevice ?? _pinnedIosDevice;
+
+  IosSafariArgParser._();
+
+  @override
+  void populateOptions(ArgParser argParser) {
+    final YamlMap browserLock = BrowserLock.instance.configuration;
+    _pinnedIosMajorVersion = browserLock['ios-safari']['majorVersion'] as int;
+    _pinnedIosMinorVersion = browserLock['ios-safari']['minorVersion'] as int;
+    _pinnedIosDevice = browserLock['ios-safari']['device'] as String;
+    argParser
+      ..addOption('majorVersion',
+          defaultsTo: '$_pinnedIosMajorVersion',
+          help: 'The major version for the iOS operating system the iOS '
+              'Simulator will use for tests. For example for testing with '
+              'iOS 13.2, use major version as 13. Use command: '
+              '`xcrun simctl list runtimes` to list available versions. Use '
+              'XCode to install more versions: XCode > Preferences > Components'
+              'If this value is not filled version locked in the '
+              'browser_lock.yaml file will be user.')
+      ..addOption('minorVersion',
+          defaultsTo: '$_pinnedIosMinorVersion',
+          help: 'The minor version for the iOS operating system the iOS '
+              'Simulator will use for tests. For example for testing with '
+              'iOS 13.2, use minor version as 2. Use command: '
+              '`xcrun simctl list runtimes` to list available versions. Use '
+              'XCode to install more versions: XCode > Preferences > Components'
+              'If this value is not filled version locked in the '
+              'browser_lock.yaml file will be user.')
+      ..addOption('device',
+          defaultsTo: '$_pinnedIosDevice',
+          help: 'The device to be used for the iOS Simulator during the tests. '
+              'Use `.` instead of space for seperating the words. '
+              'Common examples: iPhone.8, iPhone.8.Plus, iPhone.11, '
+              'iPhone 11 Pro. Use command: '
+              '`xcrun simctl list devices` for listing the available '
+              'devices. If this value is not filled device locked in the '
+              'browser_lock.yaml file will be user.');
+  }
+
+  @override
+  void parseOptions(ArgResults argResults) {
+    _iosMajorVersion = int.parse(argResults['majorVersion'] as String);
+    _iosMinorVersion = int.parse(argResults['minorVersion'] as String);
+    _iosDevice = (argResults['device'] as String).replaceAll('.', ' ');
+  }
 }
 
 /// Returns the installation of Safari.
@@ -62,7 +131,6 @@ Future<BrowserInstallation> getOrInstallSafari(
   String requestedVersion, {
   StringSink infoLog,
 }) async {
-
   // These tests are aimed to run only on macOS machines local or on LUCI.
   if (!io.Platform.isMacOS) {
     throw UnimplementedError('Safari on ${io.Platform.operatingSystem} is'

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -219,7 +219,7 @@ void cleanup() async {
     }
   }
 
-  cleanupCallbacks.forEach((element) {
-    element.call();
+  cleanupCallbacks.forEach((element) async {
+    await element.call();
   });
 }

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -23,6 +23,11 @@ dev_dependencies:
   watcher: 0.9.7+12
   web_engine_tester:
     path: ../../web_sdk/web_engine_tester
+  simulators:
+    git:
+      url: git://github.com/flutter/web_installers.git
+      path: packages/simulators/
+      ref: 9ede7e3c069180b28322bb3f0d0307c824071fb5
   web_driver_installer:
     git:
       url: git://github.com/flutter/web_installers.git


### PR DESCRIPTION
running ios unit tests from felt by booting/shutingdown simulators. create simulator with felt.
updating the readme.

Enabled felt commands:
```
felt create --majorVersion=11 --minorVersion=1 --device='iPhone.11.Pro'
```

```
felt test --browser=ios-safari --majorVersion=13 --minorVersion=1 --device='iPhone.11.Pro'
```

Contributes to https://github.com/flutter/flutter/issues/53690