### PR TITLE
Fix intent builder visibility

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -428,6 +428,7 @@ action("robolectric_tests") {
     "test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java",
     "test/io/flutter/embedding/android/FlutterActivityTest.java",
     "test/io/flutter/embedding/android/FlutterAndroidComponentTest.java",
+    "test/io/flutter/embedding/android/FlutterFragmentActivityTest.java",
     "test/io/flutter/embedding/android/FlutterFragmentTest.java",
     "test/io/flutter/embedding/android/FlutterViewTest.java",
     "test/io/flutter/embedding/android/RobolectricFlutterActivity.java",

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -241,7 +241,7 @@ public class FlutterActivity extends Activity
      *
      * <p>{@code return new NewEngineIntentBuilder(MyFlutterActivity.class); }
      */
-    protected NewEngineIntentBuilder(@NonNull Class<? extends FlutterActivity> activityClass) {
+    public NewEngineIntentBuilder(@NonNull Class<? extends FlutterActivity> activityClass) {
       this.activityClass = activityClass;
     }
 
@@ -314,12 +314,12 @@ public class FlutterActivity extends Activity
      * {@code FlutterActivity}.
      *
      * <p>Subclasses of {@code FlutterActivity} should provide their own static version of {@link
-     * #withNewEngine()}, which returns an instance of {@code CachedEngineIntentBuilder} constructed
-     * with a {@code Class} reference to the {@code FlutterActivity} subclass, e.g.:
+     * #withCachedEngine()}, which returns an instance of {@code CachedEngineIntentBuilder}
+     * constructed with a {@code Class} reference to the {@code FlutterActivity} subclass, e.g.:
      *
      * <p>{@code return new CachedEngineIntentBuilder(MyFlutterActivity.class, engineId); }
      */
-    protected CachedEngineIntentBuilder(
+    public CachedEngineIntentBuilder(
         @NonNull Class<? extends FlutterActivity> activityClass, @NonNull String engineId) {
       this.activityClass = activityClass;
       this.cachedEngineId = engineId;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -101,8 +101,7 @@ public class FlutterFragmentActivity extends FragmentActivity
      *
      * <p>{@code return new NewEngineIntentBuilder(MyFlutterActivity.class); }
      */
-    public NewEngineIntentBuilder(
-        @NonNull Class<? extends FlutterFragmentActivity> activityClass) {
+    public NewEngineIntentBuilder(@NonNull Class<? extends FlutterFragmentActivity> activityClass) {
       this.activityClass = activityClass;
     }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -101,7 +101,7 @@ public class FlutterFragmentActivity extends FragmentActivity
      *
      * <p>{@code return new NewEngineIntentBuilder(MyFlutterActivity.class); }
      */
-    protected NewEngineIntentBuilder(
+    public NewEngineIntentBuilder(
         @NonNull Class<? extends FlutterFragmentActivity> activityClass) {
       this.activityClass = activityClass;
     }
@@ -177,13 +177,13 @@ public class FlutterFragmentActivity extends FragmentActivity
      * {@code FlutterFragmentActivity}.
      *
      * <p>Subclasses of {@code FlutterFragmentActivity} should provide their own static version of
-     * {@link #withNewEngine()}, which returns an instance of {@code CachedEngineIntentBuilder}
+     * {@link #withCachedEngine()}, which returns an instance of {@code CachedEngineIntentBuilder}
      * constructed with a {@code Class} reference to the {@code FlutterFragmentActivity} subclass,
      * e.g.:
      *
      * <p>{@code return new CachedEngineIntentBuilder(MyFlutterActivity.class, engineId); }
      */
-    protected CachedEngineIntentBuilder(
+    public CachedEngineIntentBuilder(
         @NonNull Class<? extends FlutterFragmentActivity> activityClass, @NonNull String engineId) {
       this.activityClass = activityClass;
       this.cachedEngineId = engineId;

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -7,6 +7,7 @@ package io.flutter;
 import io.flutter.embedding.android.FlutterActivityAndFragmentDelegateTest;
 import io.flutter.embedding.android.FlutterActivityTest;
 import io.flutter.embedding.android.FlutterAndroidComponentTest;
+import io.flutter.embedding.android.FlutterFragmentActivityTest;
 import io.flutter.embedding.android.FlutterFragmentTest;
 import io.flutter.embedding.android.FlutterViewTest;
 import io.flutter.embedding.engine.FlutterEngineCacheTest;
@@ -42,6 +43,7 @@ import test.io.flutter.embedding.engine.dart.DartExecutorTest;
   FlutterEngineCacheTest.class,
   FlutterEnginePluginRegistryTest.class,
   FlutterEngineTest.class,
+  FlutterFragmentActivityTest.class,
   FlutterFragmentTest.class,
   FlutterJNITest.class,
   FlutterLaunchTests.class,

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -181,7 +181,7 @@ public class FlutterActivityTest {
   // to provide their own intent builders which builds their own runtime types.
   static class FlutterActivityWithIntentBuilders extends FlutterActivity {
     public static NewEngineIntentBuilder withNewEngine() {
-      return new NewEngineIntentBuilder(FlutterActivity.class);
+      return new NewEngineIntentBuilder(FlutterActivityWithIntentBuilders.class);
     }
 
     public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -13,7 +13,6 @@ import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterJNI;

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -13,6 +13,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterJNI;
@@ -173,6 +174,18 @@ public class FlutterActivityTest {
 
       return new FlutterEngine(
           context, mock(FlutterLoader.class), flutterJNI, new String[] {}, false);
+    }
+  }
+
+  // This is just a compile time check to ensure that it's possible for FlutterActivity subclasses
+  // to provide their own intent builders which builds their own runtime types.
+  static class FlutterActivityWithIntentBuilders extends FlutterActivity {
+    public static NewEngineIntentBuilder withNewEngine() {
+      return new NewEngineIntentBuilder(FlutterActivity.class);
+    }
+
+    public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {
+      return new CachedEngineIntentBuilder(FlutterActivityWithIntentBuilders.class, cachedEngineId);
     }
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -1,31 +1,11 @@
 package io.flutter.embedding.android;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import android.content.Context;
-import android.content.Intent;
-import android.os.Bundle;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
-import io.flutter.embedding.engine.FlutterEngine;
-import io.flutter.embedding.engine.FlutterJNI;
-import io.flutter.embedding.engine.loader.FlutterLoader;
-import java.util.List;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
-import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -38,7 +18,8 @@ public class FlutterFragmentActivityTest {
     assertTrue(true);
   }
 
-  // This is just a compile time check to ensure that it's possible for FlutterFragmentActivity subclasses
+  // This is just a compile time check to ensure that it's possible for FlutterFragmentActivity
+  // subclasses
   // to provide their own intent builders which builds their own runtime types.
   static class FlutterFragmentActivityWithIntentBuilders extends FlutterFragmentActivity {
     public static NewEngineIntentBuilder withNewEngine() {
@@ -46,7 +27,8 @@ public class FlutterFragmentActivityTest {
     }
 
     public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {
-      return new CachedEngineIntentBuilder(FlutterFragmentActivityWithIntentBuilders.class, cachedEngineId);
+      return new CachedEngineIntentBuilder(
+          FlutterFragmentActivityWithIntentBuilders.class, cachedEngineId);
     }
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -1,0 +1,52 @@
+package io.flutter.embedding.android;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.loader.FlutterLoader;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class FlutterFragmentActivityTest {
+  @Test
+  public void placeholder() {
+    // This is just a placeholder since this file only has a compile check currently.
+    // Delete when adding the first real test.
+    assertTrue(true);
+  }
+
+  // This is just a compile time check to ensure that it's possible for FlutterFragmentActivity subclasses
+  // to provide their own intent builders which builds their own runtime types.
+  static class FlutterFragmentActivityWithIntentBuilders extends FlutterFragmentActivity {
+    public static NewEngineIntentBuilder withNewEngine() {
+      return new NewEngineIntentBuilder(FlutterFragmentActivityWithIntentBuilders.class);
+    }
+
+    public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {
+      return new CachedEngineIntentBuilder(FlutterFragmentActivityWithIntentBuilders.class, cachedEngineId);
+    }
+  }
+}


### PR DESCRIPTION
This code doesn't do what it seems to intend to do. I think the intent is to let people subclass FlutterActivity then override an intent builder factory where the intent builder is parametrized to the subclass's type. 

The intent builder's constructor is protected for use by the subclass only. Except the intent builder is itself an (inner) class. The FlutterActivity subclass is not a subclass of the inner intent builder class and can't access its constructor to factory a parametrized instance of it. 