### PR TITLE
Remove simulator build mode restrictions

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -65,9 +65,6 @@ def to_gn_args(args):
     if args.simulator:
         if args.target_os == 'android':
             raise Exception('--simulator is not supported on Android')
-        elif args.target_os == 'ios':
-            if args.runtime_mode != 'debug':
-                raise Exception('iOS simulator only supports the debug runtime mode')
 
     if args.target_os != 'android' and args.enable_vulkan:
       raise Exception('--enable-vulkan is only supported on Android')


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/issues/58988

Along with https://github.com/flutter/flutter/issues/58988#issuecomment-640789287 , allows a release/profile build to be created for iOS simulators.