### PR TITLE
Track scene size through rasterization

### DIFF
--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -30,17 +30,21 @@ void Scene::create(Dart_Handle scene_handle,
                    std::shared_ptr<flutter::Layer> rootLayer,
                    uint32_t rasterizerTracingThreshold,
                    bool checkerboardRasterCacheImages,
-                   bool checkerboardOffscreenLayers) {
+                   bool checkerboardOffscreenLayers,
+                   size_t external_size_bytes) {
   auto scene = fml::MakeRefCounted<Scene>(
       std::move(rootLayer), rasterizerTracingThreshold,
-      checkerboardRasterCacheImages, checkerboardOffscreenLayers);
+      checkerboardRasterCacheImages, checkerboardOffscreenLayers,
+      external_size_bytes);
   scene->AssociateWithDartWrapper(scene_handle);
 }
 
 Scene::Scene(std::shared_ptr<flutter::Layer> rootLayer,
              uint32_t rasterizerTracingThreshold,
              bool checkerboardRasterCacheImages,
-             bool checkerboardOffscreenLayers) {
+             bool checkerboardOffscreenLayers,
+             size_t external_size_bytes)
+    : external_size_bytes_(external_size_bytes) {
   auto viewport_metrics = UIDartState::Current()->window()->viewport_metrics();
 
   layer_tree_ = std::make_unique<LayerTree>(
@@ -80,6 +84,10 @@ Dart_Handle Scene::toImage(uint32_t width,
 
 std::unique_ptr<flutter::LayerTree> Scene::takeLayerTree() {
   return std::move(layer_tree_);
+}
+
+size_t Scene::GetAllocationSize() const {
+  return sizeof(Scene) + sizeof(layer_tree_) + external_size_bytes_;
 }
 
 }  // namespace flutter

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -28,7 +28,8 @@ class Scene : public RefCountedDartWrappable<Scene> {
                      std::shared_ptr<flutter::Layer> rootLayer,
                      uint32_t rasterizerTracingThreshold,
                      bool checkerboardRasterCacheImages,
-                     bool checkerboardOffscreenLayers);
+                     bool checkerboardOffscreenLayers,
+                     size_t external_size_bytes);
 
   std::unique_ptr<flutter::LayerTree> takeLayerTree();
 
@@ -40,12 +41,18 @@ class Scene : public RefCountedDartWrappable<Scene> {
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
- private:
-  explicit Scene(std::shared_ptr<flutter::Layer> rootLayer,
-                 uint32_t rasterizerTracingThreshold,
-                 bool checkerboardRasterCacheImages,
-                 bool checkerboardOffscreenLayers);
+  size_t GetAllocationSize() const override;
 
+  size_t external_size_bytes() const { return external_size_bytes_; }
+
+ private:
+  Scene(std::shared_ptr<flutter::Layer> rootLayer,
+        uint32_t rasterizerTracingThreshold,
+        bool checkerboardRasterCacheImages,
+        bool checkerboardOffscreenLayers,
+        size_t external_size_bytes);
+
+  size_t external_size_bytes_;
   std::unique_ptr<flutter::LayerTree> layer_tree_;
 };
 

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -221,6 +221,7 @@ void SceneBuilder::addPicture(double dx,
   auto layer = std::make_unique<flutter::PictureLayer>(
       offset, UIDartState::CreateGPUObject(picture->picture()), !!(hints & 1),
       !!(hints & 2));
+  external_size_bytes_ += picture->GetAllocationSize();
   AddLayer(std::move(layer));
 }
 
@@ -288,7 +289,7 @@ void SceneBuilder::build(Dart_Handle scene_handle) {
 
   Scene::create(scene_handle, layer_stack_[0], rasterizer_tracing_threshold_,
                 checkerboard_raster_cache_images_,
-                checkerboard_offscreen_layers_);
+                checkerboard_offscreen_layers_, external_size_bytes_);
   ClearDartWrapper();  // may delete this object.
 }
 

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -124,6 +124,7 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   void PushLayer(std::shared_ptr<ContainerLayer> layer);
   void PopLayer();
 
+  size_t external_size_bytes_ = 0;
   std::vector<std::shared_ptr<ContainerLayer>> layer_stack_;
   int rasterizer_tracing_threshold_ = 0;
   bool checkerboard_raster_cache_images_ = false;

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -302,7 +302,7 @@ void RuntimeController::ScheduleFrame() {
 
 // |WindowClient|
 void RuntimeController::Render(Scene* scene) {
-  client_.Render(scene->takeLayerTree());
+  client_.Render(scene->takeLayerTree(), scene->external_size_bytes());
 }
 
 // |WindowClient|

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -23,7 +23,8 @@ class RuntimeDelegate {
 
   virtual void ScheduleFrame(bool regenerate_layer_tree = true) = 0;
 
-  virtual void Render(std::unique_ptr<flutter::LayerTree> layer_tree) = 0;
+  virtual void Render(std::unique_ptr<flutter::LayerTree> layer_tree,
+                      size_t external_size_bytes) = 0;
 
   virtual void UpdateSemantics(SemanticsNodeUpdates update,
                                CustomAccessibilityActionUpdates actions) = 0;

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -171,7 +171,8 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
   }
 }
 
-void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
+void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree,
+                      size_t external_size_bytes) {
   if (dimension_change_pending_ &&
       layer_tree->frame_size() != last_layer_tree_size_) {
     dimension_change_pending_ = false;
@@ -190,7 +191,8 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
     FML_DLOG(INFO) << "No pending continuation to commit";
   }
 
-  delegate_.OnAnimatorDraw(layer_tree_pipeline_, last_frame_target_time_);
+  delegate_.OnAnimatorDraw(layer_tree_pipeline_, last_frame_target_time_,
+                           external_size_bytes);
 }
 
 bool Animator::CanReuseLastLayerTree() {

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -36,7 +36,8 @@ class Animator final {
 
     virtual void OnAnimatorDraw(
         fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline,
-        fml::TimePoint frame_target_time) = 0;
+        fml::TimePoint frame_target_time,
+        size_t external_size_bytes) = 0;
 
     virtual void OnAnimatorDrawLastLayerTree() = 0;
   };
@@ -51,7 +52,8 @@ class Animator final {
 
   void RequestFrame(bool regenerate_layer_tree = true);
 
-  void Render(std::unique_ptr<flutter::LayerTree> layer_tree);
+  void Render(std::unique_ptr<flutter::LayerTree> layer_tree,
+              size_t external_size_bytes);
 
   //--------------------------------------------------------------------------
   /// @brief    Schedule a secondary callback to be executed right after the

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -461,7 +461,8 @@ void Engine::ScheduleFrame(bool regenerate_layer_tree) {
   animator_->RequestFrame(regenerate_layer_tree);
 }
 
-void Engine::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
+void Engine::Render(std::unique_ptr<flutter::LayerTree> layer_tree,
+                    size_t external_size_bytes) {
   if (!layer_tree)
     return;
 
@@ -471,7 +472,7 @@ void Engine::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
       layer_tree->frame_device_pixel_ratio() <= 0.0f)
     return;
 
-  animator_->Render(std::move(layer_tree));
+  animator_->Render(std::move(layer_tree), external_size_bytes);
 }
 
 void Engine::UpdateSemantics(SemanticsNodeUpdates update,

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -759,7 +759,8 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   std::string DefaultRouteName() override;
 
   // |RuntimeDelegate|
-  void Render(std::unique_ptr<flutter::LayerTree> layer_tree) override;
+  void Render(std::unique_ptr<flutter::LayerTree> layer_tree,
+              size_t external_size_bytes) override;
 
   // |RuntimeDelegate|
   void UpdateSemantics(SemanticsNodeUpdates update,

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -961,7 +961,8 @@ void Shell::OnAnimatorNotifyIdle(int64_t deadline) {
 
 // |Animator::Delegate|
 void Shell::OnAnimatorDraw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline,
-                           fml::TimePoint frame_target_time) {
+                           fml::TimePoint frame_target_time,
+                           size_t external_size_bytes) {
   FML_DCHECK(is_setup_);
 
   // record the target time for use by rasterizer.
@@ -977,8 +978,8 @@ void Shell::OnAnimatorDraw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline,
   task_runners_.GetRasterTaskRunner()->PostTask(
       [&waiting_for_first_frame = waiting_for_first_frame_,
        &waiting_for_first_frame_condition = waiting_for_first_frame_condition_,
-       rasterizer = rasterizer_->GetWeakPtr(),
-       pipeline = std::move(pipeline)]() {
+       rasterizer = rasterizer_->GetWeakPtr(), pipeline = std::move(pipeline),
+       external_size_bytes = external_size_bytes]() {
         if (rasterizer) {
           rasterizer->Draw(pipeline);
 
@@ -987,6 +988,7 @@ void Shell::OnAnimatorDraw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline,
             waiting_for_first_frame_condition.notify_all();
           }
         }
+        FML_DLOG(ERROR) << "Scene Size: " << external_size_bytes;
       });
 }
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -490,7 +490,8 @@ class Shell final : public PlatformView::Delegate,
 
   // |Animator::Delegate|
   void OnAnimatorDraw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline,
-                      fml::TimePoint frame_target_time) override;
+                      fml::TimePoint frame_target_time,
+                      size_t external_size_bytes) override;
 
   // |Animator::Delegate|
   void OnAnimatorDrawLastLayerTree() override;

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -167,7 +167,7 @@ void ShellTest::PumpOneFrame(Shell* shell,
         if (builder) {
           builder(root_layer);
         }
-        runtime_delegate->Render(std::move(layer_tree));
+        runtime_delegate->Render(std::move(layer_tree), 0);
         latch.Signal();
       });
   latch.Wait();


### PR DESCRIPTION
This patch, in conjunction with some upstream change in Dart, could potentially be used to track when Flutter renders a scene that dramatically drops in size and thus would indicate that a GC might help free up significant memory.

The main test case for this is an application that renders a high resolution image when a user taps a button, and then drops the image when the user taps the button again, and then renders again when the user taps a button, etc. The goal is to find a good way to hint the GC that it should run a collection to reclaim freed up space - currently, it does not. In that application, numbers like the following are generated:

```
2020-06-08 14:51:41.269012-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 3192
2020-06-08 14:51:41.382722-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 1196
2020-06-08 14:51:41.714968-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 1196
2020-06-08 14:51:41.758725-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 1196
2020-06-08 14:51:44.692083-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 178961062
2020-06-08 14:52:12.319826-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 178962034
2020-06-08 14:52:12.368216-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4414
2020-06-08 14:52:12.380636-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.386194-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.402730-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.419597-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.436617-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.454227-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.471473-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.488152-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.504465-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.520033-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:12.537598-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4024
2020-06-08 14:52:16.116191-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4996
2020-06-08 14:52:16.144365-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 5540
2020-06-08 14:52:16.152809-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 5540
2020-06-08 14:52:16.168008-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 5540
2020-06-08 14:52:16.201666-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 5540
2020-06-08 14:52:16.205552-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4708
2020-06-08 14:52:16.504432-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4708
2020-06-08 14:52:16.518967-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 3192
2020-06-08 14:52:19.723345-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 178961062
2020-06-08 14:52:24.723954-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4414
2020-06-08 14:52:24.731342-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.743872-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.752420-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.769151-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.786141-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.802798-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.819453-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.836156-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.852813-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.869703-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.886291-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4686
2020-06-08 14:52:24.902197-0700 Runner[4111:1776253] [VERBOSE-2:shell.cc(991)] Scene Size: 4024
```

Unfortunately, it's a bit less clean on desktop, where the scene update might just be the mouse hovering over the FAB, and can look like the following, note the smaller numbers tucked in with the larger bursts - that's when I let the cursor go over the FAB, which triggered only a smaller scene update for just the hover effect on the FAB.

```
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 3192
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 1196
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
2020-06-08 14:35:44.649494-0700 imgmemory[85773:5035445] Metal API Validation Enabled
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 1196
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961724
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961724
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178961062
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178960862
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 1196
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178962060
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178963224
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178963224
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 178963224
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 6186
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 6186
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 6186
[ERROR:flutter/shell/common/shell.cc(991)] Scene Size: 5876
```

See also some discussion at https://dart-review.googlesource.com/c/sdk/+/149521, https://github.com/dart-lang/sdk/issues/42078

This would help to fix https://github.com/flutter/flutter/issues/56482 along with some way to tell the GC about this information.

@rmacnak-google @Hixie @goderbauer @liyuqian @chinmaygarde @jason-simmons 


