### PR TITLE
Add user agent for Chromium based Edge Browser to browser detection

### DIFF
--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -69,7 +69,7 @@ BrowserEngine _detectBrowserEngine() {
     return BrowserEngine.firefox;
   }
 
-  // Assume blink otherwise, but issue a warning.
+  // Assume unknown otherwise, but issue a warning.
   print('WARNING: failed to detect current browser engine.');
   return BrowserEngine.unknown;
 }

--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -57,6 +57,10 @@ BrowserEngine _detectBrowserEngine() {
     return BrowserEngine.webkit;
   } else if (agent.contains('edge/')) {
     return BrowserEngine.edge;
+  } else if (agent.contains('Edg/')) {
+    // Chromium based Microsoft Edge has `Edg` in the user-agent.
+    // https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string
+    return BrowserEngine.blink;
   } else if (agent.contains('trident/7.0')) {
     return BrowserEngine.ie11;
   } else if (vendor == '' && agent.contains('firefox')) {


### PR DESCRIPTION
Adding the user agent check for Chromium based Edge Browser. Based on: https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string

https://blogs.windows.com/msedgedev/2017/10/05/microsoft-edge-ios-android-developer/
The UA is different on IOS and Android however, since the vendor data is also checked, this already be works correctly for IOS and Android (I also manually tested them).
