### PR TITLE
Add support for resizeLeftRight and resizeUpDown cursors

### DIFF
--- a/lib/web_ui/lib/src/engine/mouse_cursor.dart
+++ b/lib/web_ui/lib/src/engine/mouse_cursor.dart
@@ -30,6 +30,8 @@ class MouseCursor {
     'forbidden': 'not-allowed',
     'grab': 'grab',
     'grabbing': 'grabbing',
+    'resizeLeftRight': 'ew-resize',
+    'resizeUpDown': 'ns-resize',
   };
   static String _mapKindToCssValue(String kind) {
     return _kindToCssValueMap[kind] ?? 'default';

--- a/shell/platform/android/io/flutter/plugin/mouse/MouseCursorPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/mouse/MouseCursorPlugin.java
@@ -54,6 +54,8 @@ public class MouseCursorPlugin {
               //  "forbidden": default
               put("grab", Integer.valueOf(PointerIcon.TYPE_GRAB));
               put("grabbing", Integer.valueOf(PointerIcon.TYPE_GRABBING));
+              put("resizeLeftRight", Integer.valueOf(PointerIcon.TYPE_HORIZONTAL_DOUBLE_ARROW));
+              put("resizeUpDown", Integer.valueOf(PointerIcon.TYPE_VERTICAL_DOUBLE_ARROW));
             }
           };
     }

--- a/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
@@ -34,6 +34,10 @@ static NSCursor* GetCursorForKind(NSString* kind) {
     return [NSCursor openHandCursor];
   else if ([kind isEqualToString:@"grabbing"])
     return [NSCursor closedHandCursor];
+  else if ([kind isEqualToString:@"resizeLeftRight"])
+    return [NSCursor resizeLeftRightCursor];
+  else if ([kind isEqualToString:@"resizeUpDown"])
+    return [NSCursor resizeUpDownCursor];
   else
     return [NSCursor arrowCursor];
 }


### PR DESCRIPTION
## Description

This adds engine support for the resize up-down and resize left-right cursors, which enable
callers to build a splitter widget.

## Checklist

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
