### PR TITLE
apply null safety syntax to mobile dart:ui

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,8 @@
 #    private fields, especially on the Window object):
 
 analyzer:
+  enable-experiment:
+    - non-nullable
   exclude: [
     # this test pretends to be part of dart:ui and results in lots of false
     # positives.

--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -7,6 +7,7 @@ dartanalyzer --version
 
 RESULTS=`dartanalyzer                                                          \
   --options flutter/analysis_options.yaml                                      \
+  --enable-experiment=non-nullable                                             \
   "$1out/host_debug_unopt/gen/sky/bindings/dart_ui/ui.dart"                    \
   2>&1                                                                         \
   | grep -Ev "No issues found!"                                                \

--- a/lib/ui/annotations.dart
+++ b/lib/ui/annotations.dart
@@ -4,7 +4,8 @@
 
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 // TODO(dnfield): Update this if/when we default this to on in the tool,
@@ -39,7 +40,7 @@ part of dart.ui;
 ///   }
 /// }
 /// ```
-const _KeepToString/*!*/ keepToString = _KeepToString();
+const _KeepToString keepToString = _KeepToString();
 
 class _KeepToString {
   const _KeepToString();

--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -157,7 +157,7 @@ class ChannelBuffers {
 
   bool _isEmpty(String channel) {
     final _RingBuffer<_StoredMessage>? queue = _messages[channel];
-    return (queue == null) ? true : queue.isEmpty;
+    return queue == null || queue.isEmpty;
   }
 
   /// Changes the capacity of the queue associated with the given channel.

--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 /// A saved platform message for a channel with its callback.
@@ -14,12 +15,12 @@ class _StoredMessage {
   _StoredMessage(this._data, this._callback);
 
   /// Representation of the message's payload.
-  final ByteData/*?*/ _data;
-  ByteData/*?*/ get data => _data;
+  final ByteData? _data;
+  ByteData? get data => _data;
 
   /// Callback to be called when the message is received.
-  final PlatformMessageResponseCallback/*!*/ _callback;
-  PlatformMessageResponseCallback/*!*/ get callback => _callback;
+  final PlatformMessageResponseCallback _callback;
+  PlatformMessageResponseCallback get callback => _callback;
 }
 
 /// A fixed-size circular queue.
@@ -43,7 +44,7 @@ class _RingBuffer<T> {
 
   /// A callback that get's called when items are ejected from the [_RingBuffer]
   /// by way of an overflow or a resizing.
-  Function(T) _dropItemCallback;
+  Function(T)? _dropItemCallback;
   set dropItemCallback(Function(T) callback) {
     _dropItemCallback = callback;
   }
@@ -60,7 +61,7 @@ class _RingBuffer<T> {
   }
 
   /// Returns null when empty.
-  T pop() {
+  T? pop() {
     return _queue.isEmpty ? null : _queue.removeFirst();
   }
 
@@ -71,7 +72,7 @@ class _RingBuffer<T> {
     while (_queue.length > lengthLimit) {
       final T item = _queue.removeFirst();
       if (_dropItemCallback != null) {
-        _dropItemCallback(item);
+        _dropItemCallback!(item);
       }
       result += 1;
     }
@@ -86,7 +87,7 @@ class _RingBuffer<T> {
 }
 
 /// Signature for [ChannelBuffers.drain].
-typedef DrainChannelCallback = Future<void>/*!*/ Function(ByteData/*?*/, PlatformMessageResponseCallback/*!*/);
+typedef DrainChannelCallback = Future<void> Function(ByteData?, PlatformMessageResponseCallback);
 
 /// Storage of channel messages until the channels are completely routed,
 /// i.e. when a message handler is attached to the channel on the framework side.
@@ -116,8 +117,8 @@ class ChannelBuffers {
   static const String kControlChannelName = 'dev.flutter/channel-buffers';
 
   /// A mapping between a channel name and its associated [_RingBuffer].
-  final Map<String, _RingBuffer<_StoredMessage>> _messages =
-    <String, _RingBuffer<_StoredMessage>>{};
+  final Map<String, _RingBuffer<_StoredMessage>?> _messages =
+    <String, _RingBuffer<_StoredMessage>?>{};
 
   _RingBuffer<_StoredMessage> _makeRingBuffer(int size) {
     final _RingBuffer<_StoredMessage> result = _RingBuffer<_StoredMessage>(size);
@@ -130,8 +131,8 @@ class ChannelBuffers {
   }
 
   /// Returns true on overflow.
-  bool/*!*/ push(String/*!*/ channel, ByteData/*?*/ data, PlatformMessageResponseCallback/*!*/ callback) {
-    _RingBuffer<_StoredMessage> queue = _messages[channel];
+  bool push(String channel, ByteData? data, PlatformMessageResponseCallback callback) {
+    _RingBuffer<_StoredMessage>? queue = _messages[channel];
     if (queue == null) {
       queue = _makeRingBuffer(kDefaultBufferSize);
       _messages[channel] = queue;
@@ -150,14 +151,14 @@ class ChannelBuffers {
   }
 
   /// Returns null on underflow.
-  _StoredMessage _pop(String channel) {
-    final _RingBuffer<_StoredMessage> queue = _messages[channel];
-    final _StoredMessage result = queue?.pop();
+  _StoredMessage? _pop(String channel) {
+    final _RingBuffer<_StoredMessage>? queue = _messages[channel];
+    final _StoredMessage? result = queue?.pop();
     return result;
   }
 
   bool _isEmpty(String channel) {
-    final _RingBuffer<_StoredMessage> queue = _messages[channel];
+    final _RingBuffer<_StoredMessage>? queue = _messages[channel];
     return (queue == null) ? true : queue.isEmpty;
   }
 
@@ -166,7 +167,7 @@ class ChannelBuffers {
   /// This could result in the dropping of messages if newSize is less
   /// than the current length of the queue.
   void _resize(String channel, int newSize) {
-    _RingBuffer<_StoredMessage> queue = _messages[channel];
+    _RingBuffer<_StoredMessage>? queue = _messages[channel];
     if (queue == null) {
       queue = _makeRingBuffer(newSize);
       _messages[channel] = queue;
@@ -182,9 +183,9 @@ class ChannelBuffers {
   ///
   /// This should be called once a channel is prepared to handle messages
   /// (i.e. when a message handler is setup in the framework).
-  Future<void>/*!*/ drain(String/*!*/ channel, DrainChannelCallback/*!*/ callback) async {
+  Future<void> drain(String channel, DrainChannelCallback callback) async {
     while (!_isEmpty(channel)) {
-      final _StoredMessage message = _pop(channel);
+      final _StoredMessage message = _pop(channel)!;
       await callback(message.data, message.callback);
     }
   }
@@ -204,7 +205,7 @@ class ChannelBuffers {
   ///   Arity: 2
   ///   Format: `resize\r<channel name>\r<new size>`
   ///   Description: Allows you to set the size of a channel's buffer.
-  void handleMessage(ByteData/*!*/ data) {
+  void handleMessage(ByteData data) {
     final List<String> command = _getString(data).split('\r');
     if (command.length == /*arity=*/2 + 1 && command[0] == 'resize') {
       _resize(command[1], int.parse(command[2]));
@@ -220,4 +221,4 @@ class ChannelBuffers {
 ///
 /// See also:
 /// * [BinaryMessenger] - The place where ChannelBuffers are typically read.
-final ChannelBuffers/*!*/ channelBuffers = ChannelBuffers();
+final ChannelBuffers channelBuffers = ChannelBuffers();

--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -71,9 +71,7 @@ class _RingBuffer<T> {
     int result = 0;
     while (_queue.length > lengthLimit) {
       final T item = _queue.removeFirst();
-      if (_dropItemCallback != null) {
-        _dropItemCallback!(item);
-      }
+      _dropItemCallback?.call(item);
       result += 1;
     }
     return result;

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 /// An opaque object representing a composited scene.
@@ -22,7 +23,7 @@ class Scene extends NativeFieldWrapperClass2 {
 
   /// Creates a raster image representation of the current state of the scene.
   /// This is a slow operation that is performed on a background thread.
-  Future<Image/*!*/>/*!*/ toImage(int/*!*/ width, int/*!*/ height) {
+  Future<Image> toImage(int width, int height) {
     if (width <= 0 || height <= 0) {
       throw Exception('Invalid image dimensions.');
     }
@@ -53,7 +54,7 @@ abstract class _EngineLayerWrapper implements EngineLayer {
   //
   // Null if this layer has no children. This field is populated only in debug
   // mode.
-  List<_EngineLayerWrapper> _debugChildren;
+  List<_EngineLayerWrapper>? _debugChildren;
 
   // Whether this layer was used as `oldLayer` in a past frame.
   //
@@ -200,10 +201,6 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   // In debug mode checks that the `layer` is only used once in a given scene.
   bool _debugCheckUsedOnce(EngineLayer layer, String usage) {
     assert(() {
-      if (layer == null) {
-        return true;
-      }
-
       assert(
           !_usedLayers.containsKey(layer),
           'Layer ${layer.runtimeType} already used.\n'
@@ -217,7 +214,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     return true;
   }
 
-  bool _debugCheckCanBeUsedAsOldLayer(_EngineLayerWrapper layer, String methodName) {
+  bool _debugCheckCanBeUsedAsOldLayer(_EngineLayerWrapper? layer, String methodName) {
     assert(() {
       if (layer == null) {
         return true;
@@ -239,7 +236,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
       if (_layerStack.isNotEmpty) {
         final _EngineLayerWrapper currentLayer = _layerStack.last;
         currentLayer._debugChildren ??= <_EngineLayerWrapper>[];
-        currentLayer._debugChildren.add(newLayer);
+        currentLayer._debugChildren!.add(newLayer);
       }
       _layerStack.add(newLayer);
       return true;
@@ -275,9 +272,9 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@endtemplate}
   ///
   /// See [pop] for details about the operation stack.
-  TransformEngineLayer/*?*/ pushTransform(
-    Float64List/*!*/ matrix4, {
-    TransformEngineLayer/*?*/ oldLayer,
+  TransformEngineLayer? pushTransform(
+    Float64List matrix4, {
+    TransformEngineLayer? oldLayer,
   }) {
     assert(_matrix4IsValid(matrix4));
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushTransform'));
@@ -299,10 +296,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  OffsetEngineLayer/*?*/ pushOffset(
-    double/*!*/ dx,
-    double/*!*/ dy, {
-    OffsetEngineLayer/*?*/ oldLayer,
+  OffsetEngineLayer? pushOffset(
+    double dx,
+    double dy, {
+    OffsetEngineLayer? oldLayer,
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushOffset'));
     final EngineLayer engineLayer = EngineLayer._();
@@ -324,12 +321,12 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
-  ClipRectEngineLayer/*?*/ pushClipRect(
-    Rect/*!*/ rect, {
-    Clip/*!*/ clipBehavior = Clip.antiAlias,
-    ClipRectEngineLayer/*?*/ oldLayer,
+  ClipRectEngineLayer? pushClipRect(
+    Rect rect, {
+    Clip clipBehavior = Clip.antiAlias,
+    ClipRectEngineLayer? oldLayer,
   }) {
-    assert(clipBehavior != null);
+    assert(clipBehavior != null); // ignore: unnecessary_null_comparison
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipRect'));
     final EngineLayer engineLayer = EngineLayer._();
@@ -352,12 +349,12 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
-  ClipRRectEngineLayer/*?*/ pushClipRRect(
-    RRect/*!*/ rrect, {
-    Clip/*!*/ clipBehavior = Clip.antiAlias,
-    ClipRRectEngineLayer/*?*/ oldLayer,
+  ClipRRectEngineLayer? pushClipRRect(
+    RRect rrect, {
+    Clip clipBehavior = Clip.antiAlias,
+    ClipRRectEngineLayer? oldLayer,
   }) {
-    assert(clipBehavior != null);
+    assert(clipBehavior != null); // ignore: unnecessary_null_comparison
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipRRect'));
     final EngineLayer engineLayer = EngineLayer._();
@@ -380,12 +377,12 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack. See [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
-  ClipPathEngineLayer/*?*/ pushClipPath(
-    Path/*!*/ path, {
-    Clip/*!*/ clipBehavior = Clip.antiAlias,
-    ClipPathEngineLayer/*?*/ oldLayer,
+  ClipPathEngineLayer? pushClipPath(
+    Path path, {
+    Clip clipBehavior = Clip.antiAlias,
+    ClipPathEngineLayer? oldLayer,
   }) {
-    assert(clipBehavior != null);
+    assert(clipBehavior != null); // ignore: unnecessary_null_comparison
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipPath'));
     final EngineLayer engineLayer = EngineLayer._();
@@ -409,14 +406,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  OpacityEngineLayer/*?*/ pushOpacity(
-    int/*!*/ alpha, {
-    Offset/*?*/ offset = Offset.zero,
-    OpacityEngineLayer/*?*/ oldLayer,
+  OpacityEngineLayer? pushOpacity(
+    int alpha, {
+    Offset? offset = Offset.zero,
+    OpacityEngineLayer? oldLayer,
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushOpacity'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushOpacity(engineLayer, alpha, offset.dx, offset.dy);
+    _pushOpacity(engineLayer, alpha, offset!.dx, offset.dy);
     final OpacityEngineLayer layer = OpacityEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
@@ -434,14 +431,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  ColorFilterEngineLayer/*?*/ pushColorFilter(
-    ColorFilter/*!*/ filter, {
-    ColorFilterEngineLayer/*?*/ oldLayer,
+  ColorFilterEngineLayer? pushColorFilter(
+    ColorFilter filter, {
+    ColorFilterEngineLayer? oldLayer,
   }) {
-    assert(filter != null);
+    assert(filter != null); // ignore: unnecessary_null_comparison
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushColorFilter'));
-    final _ColorFilter nativeFilter = filter._toNativeColorFilter();
-    assert(nativeFilter != null);
+    final _ColorFilter nativeFilter = filter._toNativeColorFilter()!;
+    assert(nativeFilter != null); // ignore: unnecessary_null_comparison
     final EngineLayer engineLayer = EngineLayer._();
     _pushColorFilter(engineLayer, nativeFilter);
     final ColorFilterEngineLayer layer = ColorFilterEngineLayer._(engineLayer);
@@ -461,14 +458,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  ImageFilterEngineLayer/*?*/ pushImageFilter(
-    ImageFilter/*!*/ filter, {
-    ImageFilterEngineLayer/*?*/ oldLayer,
+  ImageFilterEngineLayer? pushImageFilter(
+    ImageFilter filter, {
+    ImageFilterEngineLayer? oldLayer,
   }) {
-    assert(filter != null);
+    assert(filter != null); // ignore: unnecessary_null_comparison
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushImageFilter'));
     final _ImageFilter nativeFilter = filter._toNativeImageFilter();
-    assert(nativeFilter != null);
+    assert(nativeFilter != null); // ignore: unnecessary_null_comparison
     final EngineLayer engineLayer = EngineLayer._();
     _pushImageFilter(engineLayer, nativeFilter);
     final ImageFilterEngineLayer layer = ImageFilterEngineLayer._(engineLayer);
@@ -488,9 +485,9 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  BackdropFilterEngineLayer/*?*/ pushBackdropFilter(
-    ImageFilter/*!*/ filter, {
-    BackdropFilterEngineLayer/*?*/ oldLayer,
+  BackdropFilterEngineLayer? pushBackdropFilter(
+    ImageFilter filter, {
+    BackdropFilterEngineLayer? oldLayer,
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushBackdropFilter'));
     final EngineLayer engineLayer = EngineLayer._();
@@ -512,11 +509,11 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  ShaderMaskEngineLayer/*?*/ pushShaderMask(
-    Shader/*!*/ shader,
-    Rect/*!*/ maskRect,
-    BlendMode/*!*/ blendMode, {
-    ShaderMaskEngineLayer/*?*/ oldLayer,
+  ShaderMaskEngineLayer? pushShaderMask(
+    Shader shader,
+    Rect maskRect,
+    BlendMode blendMode, {
+    ShaderMaskEngineLayer? oldLayer,
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushShaderMask'));
     final EngineLayer engineLayer = EngineLayer._();
@@ -560,13 +557,13 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   // ignore: deprecated_member_use
-  PhysicalShapeEngineLayer/*?*/ pushPhysicalShape({
-    Path/*!*/ path,
-    double/*!*/ elevation,
-    Color/*!*/ color,
-    Color/*?*/ shadowColor,
-    Clip/*!*/ clipBehavior = Clip.none,
-    PhysicalShapeEngineLayer/*?*/ oldLayer,
+  PhysicalShapeEngineLayer? pushPhysicalShape({
+    required Path path,
+    required double elevation,
+    required Color color,
+    Color? shadowColor,
+    Clip clipBehavior = Clip.none,
+    PhysicalShapeEngineLayer? oldLayer,
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushPhysicalShape'));
     final EngineLayer engineLayer = EngineLayer._();
@@ -611,7 +608,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// no need to call [addToScene] for its children layers.
   ///
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
-  void addRetained(EngineLayer/*!*/ retainedLayer) {
+  void addRetained(EngineLayer retainedLayer) {
     assert(retainedLayer is _EngineLayerWrapper);
     assert(() {
       final _EngineLayerWrapper layer = retainedLayer as _EngineLayerWrapper;
@@ -620,11 +617,11 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
         _debugCheckUsedOnce(parentLayer, 'retained layer');
         parentLayer._debugCheckNotUsedAsOldLayer();
 
-        if (parentLayer._debugChildren == null || parentLayer._debugChildren.isEmpty) {
+        final List<_EngineLayerWrapper>? children = parentLayer._debugChildren;
+        if (children == null || children.isEmpty) {
           return;
         }
-
-        parentLayer._debugChildren.forEach(recursivelyCheckChildrenUsedOnce);
+        children.forEach(recursivelyCheckChildrenUsedOnce);
       }
 
       recursivelyCheckChildrenUsedOnce(layer);
@@ -662,7 +659,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// See also the [PerformanceOverlayOption] enum in the rendering library.
   /// for more details.
   // Values above must match constants in //engine/src/sky/compositor/performance_overlay_layer.h
-  void addPerformanceOverlay(int/*!*/ enabledOptions, Rect/*!*/ bounds) {
+  void addPerformanceOverlay(int enabledOptions, Rect bounds) {
     _addPerformanceOverlay(enabledOptions, bounds.left, bounds.right, bounds.top, bounds.bottom);
   }
 
@@ -678,10 +675,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// The picture is rasterized at the given offset.
   void addPicture(
-    Offset/*!*/ offset,
-    Picture/*!*/ picture, {
-    bool/*!*/ isComplexHint = false,
-    bool/*!*/ willChangeHint = false,
+    Offset offset,
+    Picture picture, {
+    bool isComplexHint = false,
+    bool willChangeHint = false,
   }) {
     final int hints = (isComplexHint ? 1 : 0) | (willChangeHint ? 2 : 0);
     _addPicture(offset.dx, offset.dy, picture, hints);
@@ -702,13 +699,13 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// texture just before resizing the Android view and un-freezes it when it is
   /// certain that a frame with the new size is ready.
   void addTexture(
-    int/*!*/ textureId, {
-    Offset/*!*/ offset = Offset.zero,
-    double/*!*/ width = 0.0,
-    double/*!*/ height = 0.0,
-    bool/*!*/ freeze = false,
+    int textureId, {
+    Offset offset = Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    bool freeze = false,
   }) {
-    assert(offset != null, 'Offset argument was null');
+    assert(offset != null, 'Offset argument was null'); // ignore: unnecessary_null_comparison
     _addTexture(offset.dx, offset.dy, width, height, textureId, freeze);
   }
 
@@ -732,12 +729,12 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// embedded UIView. In addition to that, on iOS versions greater than 9, the Flutter frames are
   /// synchronized with the UIView frames adding additional performance overhead.
   void addPlatformView(
-    int/*!*/ viewId, {
-    Offset/*!*/ offset = Offset.zero,
-    double/*!*/ width = 0.0,
-    double/*!*/ height = 0.0,
+    int viewId, {
+    Offset offset = Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
   }) {
-    assert(offset != null, 'Offset argument was null');
+    assert(offset != null, 'Offset argument was null'); // ignore: unnecessary_null_comparison
     _addPlatformView(offset.dx, offset.dy, width, height, viewId);
   }
 
@@ -747,11 +744,11 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// (Fuchsia-only) Adds a scene rendered by another application to the scene
   /// for this application.
   void addChildScene({
-    Offset/*!*/ offset = Offset.zero,
-    double/*!*/ width = 0.0,
-    double/*!*/ height = 0.0,
-    SceneHost/*!*/ sceneHost,
-    bool/*!*/ hitTestable = true,
+    Offset offset = Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    required SceneHost sceneHost,
+    bool hitTestable = true,
   }) {
     _addChildScene(offset.dx, offset.dy, width, height, sceneHost, hitTestable);
   }
@@ -765,7 +762,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// interested in using this feature, please contact [flutter-dev](https://groups.google.com/forum/#!forum/flutter-dev).
   /// We'll hopefully be able to figure out how to make this feature more useful
   /// to you.
-  void setRasterizerTracingThreshold(int/*!*/ frameInterval)
+  void setRasterizerTracingThreshold(int frameInterval)
       native 'SceneBuilder_setRasterizerTracingThreshold';
 
   /// Sets whether the raster cache should checkerboard cached entries. This is
@@ -783,14 +780,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// Currently this interface is difficult to use by end-developers. If you're
   /// interested in using this feature, please contact [flutter-dev](https://groups.google.com/forum/#!forum/flutter-dev).
-  void setCheckerboardRasterCacheImages(bool/*!*/ checkerboard)
+  void setCheckerboardRasterCacheImages(bool checkerboard)
       native 'SceneBuilder_setCheckerboardRasterCacheImages';
 
   /// Sets whether the compositor should checkerboard layers that are rendered
   /// to offscreen bitmaps.
   ///
   /// This is only useful for debugging purposes.
-  void setCheckerboardOffscreenLayers(bool/*!*/ checkerboard)
+  void setCheckerboardOffscreenLayers(bool checkerboard)
       native 'SceneBuilder_setCheckerboardOffscreenLayers';
 
   /// Finishes building the scene.
@@ -801,7 +798,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// After calling this function, the scene builder object is invalid and
   /// cannot be used further.
-  Scene/*!*/ build() {
+  Scene build() {
     final Scene scene = Scene._();
     _build(scene);
     return scene;
@@ -825,9 +822,9 @@ class SceneHost extends NativeFieldWrapperClass2 {
   /// The SceneHost takes ownership of the provided ViewHolder token.
   SceneHost(
     dynamic viewHolderToken,
-    void Function()/*?*/ viewConnectedCallback,
-    void Function()/*?*/ viewDisconnectedCallback,
-    void Function(bool/*!*/)/*?*/ viewStateChangedCallback,
+    void Function()? viewConnectedCallback,
+    void Function()? viewDisconnectedCallback,
+    void Function(bool)? viewStateChangedCallback,
   ) {
     _constructor(
         viewHolderToken, viewConnectedCallback, viewDisconnectedCallback, viewStateChangedCallback);
@@ -835,9 +832,9 @@ class SceneHost extends NativeFieldWrapperClass2 {
 
   void _constructor(
     dynamic viewHolderToken,
-    void Function() viewConnectedCallback,
-    void Function() viewDisconnectedCallback,
-    void Function(bool) viewStateChangedCallbac,
+    void Function()? viewConnectedCallback,
+    void Function()? viewDisconnectedCallback,
+    void Function(bool)? viewStateChangedCallbac,
   ) native 'SceneHost_constructor';
 
   /// Releases the resources associated with the SceneHost.
@@ -848,12 +845,12 @@ class SceneHost extends NativeFieldWrapperClass2 {
   /// Set properties on the linked scene.  These properties include its bounds,
   /// as well as whether it can be the target of focus events or not.
   void setProperties(
-    double/*!*/ width,
-    double/*!*/ height,
-    double/*!*/ insetTop,
-    double/*!*/ insetRight,
-    double/*!*/ insetBottom,
-    double/*!*/ insetLeft,
-    bool/*!*/ focusable,
+    double width,
+    double height,
+    double insetTop,
+    double insetRight,
+    double insetBottom,
+    double insetLeft,
+    bool focusable,
   ) native 'SceneHost_setProperties';
 }

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 /// Base class for [Size] and [Offset], which are both ways to describe
@@ -14,11 +15,11 @@ abstract class OffsetBase {
   /// The first argument sets the horizontal component, and the second the
   /// vertical component.
   const OffsetBase(this._dx, this._dy)
-      : assert(_dx != null),
-        assert(_dy != null);
+      : assert(_dx != null), // ignore: unnecessary_null_comparison
+        assert(_dy != null); // ignore: unnecessary_null_comparison
 
-  final double/*!*/ _dx;
-  final double/*!*/ _dy;
+  final double _dx;
+  final double _dy;
 
   /// Returns true if either component is [double.infinity], and false if both
   /// are finite (or negative infinity, or NaN).
@@ -29,7 +30,7 @@ abstract class OffsetBase {
   /// See also:
   ///
   ///  * [isFinite], which is true if both components are finite (and not NaN).
-  bool/*!*/ get isInfinite => _dx >= double.infinity || _dy >= double.infinity;
+  bool get isInfinite => _dx >= double.infinity || _dy >= double.infinity;
 
   /// Whether both components are finite (neither infinite nor NaN).
   ///
@@ -37,7 +38,7 @@ abstract class OffsetBase {
   ///
   ///  * [isInfinite], which returns true if either component is equal to
   ///    positive infinity.
-  bool/*!*/ get isFinite => _dx.isFinite && _dy.isFinite;
+  bool get isFinite => _dx.isFinite && _dy.isFinite;
 
   /// Less-than operator. Compares an [Offset] or [Size] to another [Offset] or
   /// [Size], and returns true if both the horizontal and vertical values of the
@@ -46,7 +47,7 @@ abstract class OffsetBase {
   ///
   /// This is a partial ordering. It is possible for two values to be neither
   /// less, nor greater than, nor equal to, another.
-  bool/*!*/ operator <(OffsetBase/*!*/ other) => _dx < other._dx && _dy < other._dy;
+  bool operator <(OffsetBase other) => _dx < other._dx && _dy < other._dy;
 
   /// Less-than-or-equal-to operator. Compares an [Offset] or [Size] to another
   /// [Offset] or [Size], and returns true if both the horizontal and vertical
@@ -56,7 +57,7 @@ abstract class OffsetBase {
   ///
   /// This is a partial ordering. It is possible for two values to be neither
   /// less, nor greater than, nor equal to, another.
-  bool/*!*/ operator <=(OffsetBase/*!*/ other) => _dx <= other._dx && _dy <= other._dy;
+  bool operator <=(OffsetBase other) => _dx <= other._dx && _dy <= other._dy;
 
   /// Greater-than operator. Compares an [Offset] or [Size] to another [Offset]
   /// or [Size], and returns true if both the horizontal and vertical values of
@@ -66,7 +67,7 @@ abstract class OffsetBase {
   ///
   /// This is a partial ordering. It is possible for two values to be neither
   /// less, nor greater than, nor equal to, another.
-  bool/*!*/ operator >(OffsetBase/*!*/ other) => _dx > other._dx && _dy > other._dy;
+  bool operator >(OffsetBase other) => _dx > other._dx && _dy > other._dy;
 
   /// Greater-than-or-equal-to operator. Compares an [Offset] or [Size] to
   /// another [Offset] or [Size], and returns true if both the horizontal and
@@ -76,24 +77,24 @@ abstract class OffsetBase {
   ///
   /// This is a partial ordering. It is possible for two values to be neither
   /// less, nor greater than, nor equal to, another.
-  bool/*!*/ operator >=(OffsetBase/*!*/ other) => _dx >= other._dx && _dy >= other._dy;
+  bool operator >=(OffsetBase other) => _dx >= other._dx && _dy >= other._dy;
 
   /// Equality operator. Compares an [Offset] or [Size] to another [Offset] or
   /// [Size], and returns true if the horizontal and vertical values of the
   /// left-hand-side operand are equal to the horizontal and vertical values of
   /// the right-hand-side operand respectively. Returns false otherwise.
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     return other is OffsetBase
         && other._dx == _dx
         && other._dy == _dy;
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(_dx, _dy);
+  int get hashCode => hashValues(_dx, _dy);
 
   @override
-  String/*!*/ toString() => 'OffsetBase(${_dx.toStringAsFixed(1)}, ${_dy.toStringAsFixed(1)})';
+  String toString() => 'OffsetBase(${_dx.toStringAsFixed(1)}, ${_dy.toStringAsFixed(1)})';
 }
 
 /// An immutable 2D floating-point offset.
@@ -120,37 +121,37 @@ abstract class OffsetBase {
 class Offset extends OffsetBase {
   /// Creates an offset. The first argument sets [dx], the horizontal component,
   /// and the second sets [dy], the vertical component.
-  const Offset(double/*!*/ dx, double/*!*/ dy) : super(dx, dy);
+  const Offset(double dx, double dy) : super(dx, dy);
 
   /// Creates an offset from its [direction] and [distance].
   ///
   /// The direction is in radians clockwise from the positive x-axis.
   ///
   /// The distance can be omitted, to create a unit vector (distance = 1.0).
-  factory Offset.fromDirection(double/*!*/ direction, [ double/*!*/ distance = 1.0 ]) {
+  factory Offset.fromDirection(double direction, [ double distance = 1.0 ]) {
     return Offset(distance * math.cos(direction), distance * math.sin(direction));
   }
 
   /// The x component of the offset.
   ///
   /// The y component is given by [dy].
-  double/*!*/ get dx => _dx;
+  double get dx => _dx;
 
   /// The y component of the offset.
   ///
   /// The x component is given by [dx].
-  double/*!*/ get dy => _dy;
+  double get dy => _dy;
 
   /// The magnitude of the offset.
   ///
   /// If you need this value to compare it to another [Offset]'s distance,
   /// consider using [distanceSquared] instead, since it is cheaper to compute.
-  double/*!*/ get distance => math.sqrt(dx * dx + dy * dy);
+  double get distance => math.sqrt(dx * dx + dy * dy);
 
   /// The square of the magnitude of the offset.
   ///
   /// This is cheaper than computing the [distance] itself.
-  double/*!*/ get distanceSquared => dx * dx + dy * dy;
+  double get distanceSquared => dx * dx + dy * dy;
 
   /// The angle of this offset as radians clockwise from the positive x-axis, in
   /// the range -[pi] to [pi], assuming positive values of the x-axis go to the
@@ -179,7 +180,7 @@ class Offset extends OffsetBase {
   ///
   ///  * [distance], to compute the magnitude of the vector.
   ///  * [Canvas.rotate], which uses the same convention for its angle.
-  double/*!*/ get direction => math.atan2(dy, dx);
+  double get direction => math.atan2(dy, dx);
 
   /// An offset with zero magnitude.
   ///
@@ -213,7 +214,7 @@ class Offset extends OffsetBase {
   /// Offset a = const Offset(10.0, 10.0);
   /// Offset b = -a; // same as: a.scale(-1.0, -1.0)
   /// ```
-  Offset/*!*/ scale(double/*!*/ scaleX, double/*!*/ scaleY) => Offset(dx * scaleX, dy * scaleY);
+  Offset scale(double scaleX, double scaleY) => Offset(dx * scaleX, dy * scaleY);
 
   /// Returns a new offset with translateX added to the x component and
   /// translateY added to the y component.
@@ -227,7 +228,7 @@ class Offset extends OffsetBase {
   /// Offset c = a + b; // same as: a.translate(b.dx, b.dy)
   /// Offset d = a - b; // same as: a.translate(-b.dx, -b.dy)
   /// ```
-  Offset/*!*/ translate(double/*!*/ translateX, double/*!*/ translateY) => Offset(dx + translateX, dy + translateY);
+  Offset translate(double translateX, double translateY) => Offset(dx + translateX, dy + translateY);
 
   /// Unary negation operator.
   ///
@@ -235,7 +236,7 @@ class Offset extends OffsetBase {
   ///
   /// If the [Offset] represents an arrow on a plane, this operator returns the
   /// same arrow but pointing in the reverse direction.
-  Offset/*!*/ operator -() => Offset(-dx, -dy);
+  Offset operator -() => Offset(-dx, -dy);
 
   /// Binary subtraction operator.
   ///
@@ -244,7 +245,7 @@ class Offset extends OffsetBase {
   /// left-hand-side operand's [dy] minus the right-hand-side operand's [dy].
   ///
   /// See also [translate].
-  Offset/*!*/ operator -(Offset/*!*/ other) => Offset(dx - other.dx, dy - other.dy);
+  Offset operator -(Offset other) => Offset(dx - other.dx, dy - other.dy);
 
   /// Binary addition operator.
   ///
@@ -253,7 +254,7 @@ class Offset extends OffsetBase {
   /// two operands.
   ///
   /// See also [translate].
-  Offset/*!*/ operator +(Offset/*!*/ other) => Offset(dx + other.dx, dy + other.dy);
+  Offset operator +(Offset other) => Offset(dx + other.dx, dy + other.dy);
 
   /// Multiplication operator.
   ///
@@ -262,7 +263,7 @@ class Offset extends OffsetBase {
   /// right-hand-side operand (a double).
   ///
   /// See also [scale].
-  Offset/*!*/ operator *(double/*!*/ operand) => Offset(dx * operand, dy * operand);
+  Offset operator *(double operand) => Offset(dx * operand, dy * operand);
 
   /// Division operator.
   ///
@@ -271,21 +272,21 @@ class Offset extends OffsetBase {
   /// operand (a double).
   ///
   /// See also [scale].
-  Offset/*!*/ operator /(double/*!*/ operand) => Offset(dx / operand, dy / operand);
+  Offset operator /(double operand) => Offset(dx / operand, dy / operand);
 
   /// Integer (truncating) division operator.
   ///
   /// Returns an offset whose coordinates are the coordinates of the
   /// left-hand-side operand (an Offset) divided by the scalar right-hand-side
   /// operand (a double), rounded towards zero.
-  Offset/*!*/ operator ~/(double/*!*/ operand) => Offset((dx ~/ operand).toDouble(), (dy ~/ operand).toDouble());
+  Offset operator ~/(double operand) => Offset((dx ~/ operand).toDouble(), (dy ~/ operand).toDouble());
 
   /// Modulo (remainder) operator.
   ///
   /// Returns an offset whose coordinates are the remainder of dividing the
   /// coordinates of the left-hand-side operand (an Offset) by the scalar
   /// right-hand-side operand (a double).
-  Offset/*!*/ operator %(double/*!*/ operand) => Offset(dx % operand, dy % operand);
+  Offset operator %(double operand) => Offset(dx % operand, dy % operand);
 
   /// Rectangle constructor operator.
   ///
@@ -297,7 +298,7 @@ class Offset extends OffsetBase {
   /// Rect myRect = Offset.zero & const Size(100.0, 100.0);
   /// // same as: Rect.fromLTWH(0.0, 0.0, 100.0, 100.0)
   /// ```
-  Rect/*!*/ operator &(Size/*!*/ other) => Rect.fromLTWH(dx, dy, other.width, other.height);
+  Rect operator &(Size other) => Rect.fromLTWH(dx, dy, other.width, other.height);
 
   /// Linearly interpolate between two offsets.
   ///
@@ -314,8 +315,8 @@ class Offset extends OffsetBase {
   ///
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
-  static Offset/*?*/ lerp(Offset/*?*/ a, Offset/*?*/ b, double/*!*/ t) {
-    assert(t != null);
+  static Offset? lerp(Offset? a, Offset? b, double t) {
+    assert(t != null); // ignore: unnecessary_null_comparison
     if (b == null) {
       if (a == null) {
         return null;
@@ -333,17 +334,17 @@ class Offset extends OffsetBase {
 
   /// Compares two Offsets for equality.
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     return other is Offset
         && other.dx == dx
         && other.dy == dy;
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(dx, dy);
+  int get hashCode => hashValues(dx, dy);
 
   @override
-  String/*!*/ toString() => 'Offset(${dx.toStringAsFixed(1)}, ${dy.toStringAsFixed(1)})';
+  String toString() => 'Offset(${dx.toStringAsFixed(1)}, ${dy.toStringAsFixed(1)})';
 }
 
 /// Holds a 2D floating-point size.
@@ -351,11 +352,11 @@ class Offset extends OffsetBase {
 /// You can think of this as an [Offset] from the origin.
 class Size extends OffsetBase {
   /// Creates a [Size] with the given [width] and [height].
-  const Size(double/*!*/ width, double/*!*/ height) : super(width, height);
+  const Size(double width, double height) : super(width, height);
 
   /// Creates an instance of [Size] that has the same values as another.
   // Used by the rendering library's _DebugSize hack.
-  Size.copy(Size/*!*/ source) : super(source.width, source.height);
+  Size.copy(Size source) : super(source.width, source.height);
 
   /// Creates a square [Size] whose [width] and [height] are the given dimension.
   ///
@@ -363,13 +364,13 @@ class Size extends OffsetBase {
   ///
   ///  * [Size.fromRadius], which is more convenient when the available size
   ///    is the radius of a circle.
-  const Size.square(double/*!*/ dimension) : super(dimension, dimension);
+  const Size.square(double dimension) : super(dimension, dimension);
 
   /// Creates a [Size] with the given [width] and an infinite [height].
-  const Size.fromWidth(double/*!*/ width) : super(width, double.infinity);
+  const Size.fromWidth(double width) : super(width, double.infinity);
 
   /// Creates a [Size] with the given [height] and an infinite [width].
-  const Size.fromHeight(double/*!*/ height) : super(double.infinity, height);
+  const Size.fromHeight(double height) : super(double.infinity, height);
 
   /// Creates a square [Size] whose [width] and [height] are twice the given
   /// dimension.
@@ -379,13 +380,13 @@ class Size extends OffsetBase {
   /// See also:
   ///
   ///  * [Size.square], which creates a square with the given dimension.
-  const Size.fromRadius(double/*!*/ radius) : super(radius * 2.0, radius * 2.0);
+  const Size.fromRadius(double radius) : super(radius * 2.0, radius * 2.0);
 
   /// The horizontal extent of this size.
-  double/*!*/ get width => _dx;
+  double get width => _dx;
 
   /// The vertical extent of this size.
-  double/*!*/ get height => _dy;
+  double get height => _dy;
 
   /// The aspect ratio of this size.
   ///
@@ -401,7 +402,7 @@ class Size extends OffsetBase {
   ///    ratio.
   ///  * [FittedBox], a widget that (in most modes) attempts to maintain a
   ///    child widget's aspect ratio while changing its size.
-  double/*!*/ get aspectRatio {
+  double get aspectRatio {
     if (height != 0.0)
       return width / height;
     if (width > 0.0)
@@ -425,7 +426,7 @@ class Size extends OffsetBase {
   /// Whether this size encloses a non-zero area.
   ///
   /// Negative areas are considered empty.
-  bool/*!*/ get isEmpty => width <= 0.0 || height <= 0.0;
+  bool get isEmpty => width <= 0.0 || height <= 0.0;
 
   /// Binary subtraction operator for [Size].
   ///
@@ -443,7 +444,7 @@ class Size extends OffsetBase {
   /// right-hand-side operand, and a [height] consisting of the [height] of the
   /// left-hand-side operand minus the [Offset.dy] dimension of the
   /// right-hand-side operand.
-  OffsetBase/*!*/ operator -(OffsetBase/*!*/ other) {
+  OffsetBase operator -(OffsetBase other) {
     if (other is Size)
       return Offset(width - other.width, height - other.height);
     if (other is Offset)
@@ -458,41 +459,41 @@ class Size extends OffsetBase {
   /// right-hand-side operand, an [Offset], and whose [height] is the sum of the
   /// [height] of the left-hand-side operand and the [Offset.dy] dimension of
   /// the right-hand-side operand.
-  Size/*!*/ operator +(Offset/*!*/ other) => Size(width + other.dx, height + other.dy);
+  Size operator +(Offset other) => Size(width + other.dx, height + other.dy);
 
   /// Multiplication operator.
   ///
   /// Returns a [Size] whose dimensions are the dimensions of the left-hand-side
   /// operand (a [Size]) multiplied by the scalar right-hand-side operand (a
   /// [double]).
-  Size/*!*/ operator *(double/*!*/ operand) => Size(width * operand, height * operand);
+  Size operator *(double operand) => Size(width * operand, height * operand);
 
   /// Division operator.
   ///
   /// Returns a [Size] whose dimensions are the dimensions of the left-hand-side
   /// operand (a [Size]) divided by the scalar right-hand-side operand (a
   /// [double]).
-  Size/*!*/ operator /(double/*!*/ operand) => Size(width / operand, height / operand);
+  Size operator /(double operand) => Size(width / operand, height / operand);
 
   /// Integer (truncating) division operator.
   ///
   /// Returns a [Size] whose dimensions are the dimensions of the left-hand-side
   /// operand (a [Size]) divided by the scalar right-hand-side operand (a
   /// [double]), rounded towards zero.
-  Size/*!*/ operator ~/(double/*!*/ operand) => Size((width ~/ operand).toDouble(), (height ~/ operand).toDouble());
+  Size operator ~/(double operand) => Size((width ~/ operand).toDouble(), (height ~/ operand).toDouble());
 
   /// Modulo (remainder) operator.
   ///
   /// Returns a [Size] whose dimensions are the remainder of dividing the
   /// left-hand-side operand (a [Size]) by the scalar right-hand-side operand (a
   /// [double]).
-  Size/*!*/ operator %(double/*!*/ operand) => Size(width % operand, height % operand);
+  Size operator %(double operand) => Size(width % operand, height % operand);
 
   /// The lesser of the magnitudes of the [width] and the [height].
-  double/*!*/ get shortestSide => math.min(width.abs(), height.abs());
+  double get shortestSide => math.min(width.abs(), height.abs());
 
   /// The greater of the magnitudes of the [width] and the [height].
-  double/*!*/ get longestSide => math.max(width.abs(), height.abs());
+  double get longestSide => math.max(width.abs(), height.abs());
 
   // Convenience methods that do the equivalent of calling the similarly named
   // methods on a Rect constructed from the given origin and this size.
@@ -502,60 +503,60 @@ class Size extends OffsetBase {
   /// and this [Size].
   ///
   /// See also [Rect.topLeft].
-  Offset/*!*/ topLeft(Offset/*!*/ origin) => origin;
+  Offset topLeft(Offset origin) => origin;
 
   /// The offset to the center of the top edge of the rectangle described by the
   /// given offset (which is interpreted as the top-left corner) and this size.
   ///
   /// See also [Rect.topCenter].
-  Offset/*!*/ topCenter(Offset origin) => Offset(origin.dx + width / 2.0, origin.dy);
+  Offset topCenter(Offset origin) => Offset(origin.dx + width / 2.0, origin.dy);
 
   /// The offset to the intersection of the top and right edges of the rectangle
   /// described by the given offset (which is interpreted as the top-left corner)
   /// and this size.
   ///
   /// See also [Rect.topRight].
-  Offset/*!*/ topRight(Offset/*!*/ origin) => Offset(origin.dx + width, origin.dy);
+  Offset topRight(Offset origin) => Offset(origin.dx + width, origin.dy);
 
   /// The offset to the center of the left edge of the rectangle described by the
   /// given offset (which is interpreted as the top-left corner) and this size.
   ///
   /// See also [Rect.centerLeft].
-  Offset/*!*/ centerLeft(Offset/*!*/ origin) => Offset(origin.dx, origin.dy + height / 2.0);
+  Offset centerLeft(Offset origin) => Offset(origin.dx, origin.dy + height / 2.0);
 
   /// The offset to the point halfway between the left and right and the top and
   /// bottom edges of the rectangle described by the given offset (which is
   /// interpreted as the top-left corner) and this size.
   ///
   /// See also [Rect.center].
-  Offset/*!*/ center(Offset/*!*/ origin) => Offset(origin.dx + width / 2.0, origin.dy + height / 2.0);
+  Offset center(Offset origin) => Offset(origin.dx + width / 2.0, origin.dy + height / 2.0);
 
   /// The offset to the center of the right edge of the rectangle described by the
   /// given offset (which is interpreted as the top-left corner) and this size.
   ///
   /// See also [Rect.centerLeft].
-  Offset/*!*/ centerRight(Offset/*!*/ origin) => Offset(origin.dx + width, origin.dy + height / 2.0);
+  Offset centerRight(Offset origin) => Offset(origin.dx + width, origin.dy + height / 2.0);
 
   /// The offset to the intersection of the bottom and left edges of the
   /// rectangle described by the given offset (which is interpreted as the
   /// top-left corner) and this size.
   ///
   /// See also [Rect.bottomLeft].
-  Offset/*!*/ bottomLeft(Offset/*!*/ origin) => Offset(origin.dx, origin.dy + height);
+  Offset bottomLeft(Offset origin) => Offset(origin.dx, origin.dy + height);
 
   /// The offset to the center of the bottom edge of the rectangle described by
   /// the given offset (which is interpreted as the top-left corner) and this
   /// size.
   ///
   /// See also [Rect.bottomLeft].
-  Offset/*!*/ bottomCenter(Offset/*!*/ origin) => Offset(origin.dx + width / 2.0, origin.dy + height);
+  Offset bottomCenter(Offset origin) => Offset(origin.dx + width / 2.0, origin.dy + height);
 
   /// The offset to the intersection of the bottom and right edges of the
   /// rectangle described by the given offset (which is interpreted as the
   /// top-left corner) and this size.
   ///
   /// See also [Rect.bottomRight].
-  Offset/*!*/ bottomRight(Offset/*!*/ origin) => Offset(origin.dx + width, origin.dy + height);
+  Offset bottomRight(Offset origin) => Offset(origin.dx + width, origin.dy + height);
 
   /// Whether the point specified by the given offset (which is assumed to be
   /// relative to the top left of the size) lies between the left and right and
@@ -563,12 +564,12 @@ class Size extends OffsetBase {
   ///
   /// Rectangles include their top and left edges but exclude their bottom and
   /// right edges.
-  bool/*!*/ contains(Offset/*!*/ offset) {
+  bool contains(Offset offset) {
     return offset.dx >= 0.0 && offset.dx < width && offset.dy >= 0.0 && offset.dy < height;
   }
 
   /// A [Size] with the [width] and [height] swapped.
-  Size/*!*/ get flipped => Size(height, width);
+  Size get flipped => Size(height, width);
 
   /// Linearly interpolate between two sizes
   ///
@@ -585,8 +586,8 @@ class Size extends OffsetBase {
   ///
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
-  static Size/*?*/ lerp(Size/*?*/ a, Size/*?*/ b, double/*!*/ t) {
-    assert(t != null);
+  static Size? lerp(Size? a, Size? b, double t) {
+    assert(t != null); // ignore: unnecessary_null_comparison
     if (b == null) {
       if (a == null) {
         return null;
@@ -605,17 +606,17 @@ class Size extends OffsetBase {
   /// Compares two Sizes for equality.
   // We don't compare the runtimeType because of _DebugSize in the framework.
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     return other is Size
         && other._dx == _dx
         && other._dy == _dy;
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(_dx, _dy);
+  int get hashCode => hashValues(_dx, _dy);
 
   @override
-  String/*!*/ toString() => 'Size(${width.toStringAsFixed(1)}, ${height.toStringAsFixed(1)})';
+  String toString() => 'Size(${width.toStringAsFixed(1)}, ${height.toStringAsFixed(1)})';
 }
 
 /// An immutable, 2D, axis-aligned, floating-point rectangle whose coordinates
@@ -631,22 +632,22 @@ class Rect {
   /// Construct a rectangle from its left, top, right, and bottom edges.
   @pragma('vm:entry-point')
   const Rect.fromLTRB(this.left, this.top, this.right, this.bottom)
-      : assert(left != null),
-        assert(top != null),
-        assert(right != null),
-        assert(bottom != null);
+      : assert(left != null), // ignore: unnecessary_null_comparison
+        assert(top != null), // ignore: unnecessary_null_comparison
+        assert(right != null), // ignore: unnecessary_null_comparison
+        assert(bottom != null); // ignore: unnecessary_null_comparison
 
   /// Construct a rectangle from its left and top edges, its width, and its
   /// height.
   ///
   /// To construct a [Rect] from an [Offset] and a [Size], you can use the
   /// rectangle constructor operator `&`. See [Offset.&].
-  const Rect.fromLTWH(double/*!*/ left, double/*!*/ top, double/*!*/ width, double/*!*/ height) : this.fromLTRB(left, top, left + width, top + height);
+  const Rect.fromLTWH(double left, double top, double width, double height) : this.fromLTRB(left, top, left + width, top + height);
 
   /// Construct a rectangle that bounds the given circle.
   ///
   /// The `center` argument is assumed to be an offset from the origin.
-  Rect.fromCircle({ Offset/*!*/ center, double/*!*/ radius }) : this.fromCenter(
+  Rect.fromCircle({ required Offset center, required double radius }) : this.fromCenter(
     center: center,
     width: radius * 2,
     height: radius * 2,
@@ -655,7 +656,7 @@ class Rect {
   /// Constructs a rectangle from its center point, width, and height.
   ///
   /// The `center` argument is assumed to be an offset from the origin.
-  Rect.fromCenter({ Offset center/*!*/, double/*!*/ width, double/*!*/ height }) : this.fromLTRB(
+  Rect.fromCenter({ required Offset center/*!*/, required double width, required double height }) : this.fromLTRB(
     center.dx - width / 2,
     center.dy - height / 2,
     center.dx + width / 2,
@@ -664,39 +665,39 @@ class Rect {
 
   /// Construct the smallest rectangle that encloses the given offsets, treating
   /// them as vectors from the origin.
-  Rect.fromPoints(Offset/*!*/ a, Offset/*!*/ b) : this.fromLTRB(
+  Rect.fromPoints(Offset a, Offset b) : this.fromLTRB(
     math.min(a.dx, b.dx),
     math.min(a.dy, b.dy),
     math.max(a.dx, b.dx),
     math.max(a.dy, b.dy),
   );
 
-  Float32List/*!*/ get _value32 => Float32List.fromList(<double>[left, top, right, bottom]);
+  Float32List get _value32 => Float32List.fromList(<double>[left, top, right, bottom]);
 
   /// The offset of the left edge of this rectangle from the x axis.
-  final double/*!*/ left;
+  final double left;
 
   /// The offset of the top edge of this rectangle from the y axis.
-  final double/*!*/ top;
+  final double top;
 
   /// The offset of the right edge of this rectangle from the x axis.
-  final double/*!*/ right;
+  final double right;
 
   /// The offset of the bottom edge of this rectangle from the y axis.
-  final double/*!*/ bottom;
+  final double bottom;
 
   /// The distance between the left and right edges of this rectangle.
-  double/*!*/ get width => right - left;
+  double get width => right - left;
 
   /// The distance between the top and bottom edges of this rectangle.
-  double/*!*/ get height => bottom - top;
+  double get height => bottom - top;
 
   /// The distance between the upper-left corner and the lower-right corner of
   /// this rectangle.
-  Size/*!*/ get size => Size(width, height);
+  Size get size => Size(width, height);
 
   /// Whether any of the dimensions are `NaN`.
-  bool/*!*/ get hasNaN => left.isNaN || top.isNaN || right.isNaN || bottom.isNaN;
+  bool get hasNaN => left.isNaN || top.isNaN || right.isNaN || bottom.isNaN;
 
   /// A rectangle with left, top, right, and bottom edges all at zero.
   static const Rect zero = Rect.fromLTRB(0.0, 0.0, 0.0, 0.0);
@@ -711,7 +712,7 @@ class Rect {
 
   /// Whether any of the coordinates of this rectangle are equal to positive infinity.
   // included for consistency with Offset and Size
-  bool/*!*/ get isInfinite {
+  bool get isInfinite {
     return left >= double.infinity
         || top >= double.infinity
         || right >= double.infinity
@@ -719,17 +720,17 @@ class Rect {
   }
 
   /// Whether all coordinates of this rectangle are finite.
-  bool/*!*/ get isFinite => left.isFinite && top.isFinite && right.isFinite && bottom.isFinite;
+  bool get isFinite => left.isFinite && top.isFinite && right.isFinite && bottom.isFinite;
 
   /// Whether this rectangle encloses a non-zero area. Negative areas are
   /// considered empty.
-  bool/*!*/ get isEmpty => left >= right || top >= bottom;
+  bool get isEmpty => left >= right || top >= bottom;
 
   /// Returns a new rectangle translated by the given offset.
   ///
   /// To translate a rectangle by separate x and y components rather than by an
   /// [Offset], consider [translate].
-  Rect/*!*/ shift(Offset/*!*/ offset) {
+  Rect shift(Offset offset) {
     return Rect.fromLTRB(left + offset.dx, top + offset.dy, right + offset.dx, bottom + offset.dy);
   }
 
@@ -738,23 +739,23 @@ class Rect {
   ///
   /// To translate a rectangle by an [Offset] rather than by separate x and y
   /// components, consider [shift].
-  Rect/*!*/ translate(double/*!*/ translateX, double/*!*/ translateY) {
+  Rect translate(double translateX, double translateY) {
     return Rect.fromLTRB(left + translateX, top + translateY, right + translateX, bottom + translateY);
   }
 
   /// Returns a new rectangle with edges moved outwards by the given delta.
-  Rect/*!*/ inflate(double/*!*/ delta) {
+  Rect inflate(double delta) {
     return Rect.fromLTRB(left - delta, top - delta, right + delta, bottom + delta);
   }
 
   /// Returns a new rectangle with edges moved inwards by the given delta.
-  Rect/*!*/ deflate(double/*!*/ delta) => inflate(-delta);
+  Rect deflate(double delta) => inflate(-delta);
 
   /// Returns a new rectangle that is the intersection of the given
   /// rectangle and this rectangle. The two rectangles must overlap
   /// for this to be meaningful. If the two rectangles do not overlap,
   /// then the resulting Rect will have a negative width or height.
-  Rect/*!*/ intersect(Rect/*!*/ other) {
+  Rect intersect(Rect other) {
     return Rect.fromLTRB(
       math.max(left, other.left),
       math.max(top, other.top),
@@ -765,7 +766,7 @@ class Rect {
 
   /// Returns a new rectangle which is the bounding box containing this
   /// rectangle and the given rectangle.
-  Rect/*!*/ expandToInclude(Rect/*!*/ other) {
+  Rect expandToInclude(Rect other) {
     return Rect.fromLTRB(
         math.min(left, other.left),
         math.min(top, other.top),
@@ -775,7 +776,7 @@ class Rect {
   }
 
   /// Whether `other` has a nonzero area of overlap with this rectangle.
-  bool/*!*/ overlaps(Rect/*!*/ other) {
+  bool overlaps(Rect other) {
     if (right <= other.left || other.right <= left)
       return false;
     if (bottom <= other.top || other.bottom <= top)
@@ -785,57 +786,57 @@ class Rect {
 
   /// The lesser of the magnitudes of the [width] and the [height] of this
   /// rectangle.
-  double/*!*/ get shortestSide => math.min(width.abs(), height.abs());
+  double get shortestSide => math.min(width.abs(), height.abs());
 
   /// The greater of the magnitudes of the [width] and the [height] of this
   /// rectangle.
-  double/*!*/ get longestSide => math.max(width.abs(), height.abs());
+  double get longestSide => math.max(width.abs(), height.abs());
 
   /// The offset to the intersection of the top and left edges of this rectangle.
   ///
   /// See also [Size.topLeft].
-  Offset/*!*/ get topLeft => Offset(left, top);
+  Offset get topLeft => Offset(left, top);
 
   /// The offset to the center of the top edge of this rectangle.
   ///
   /// See also [Size.topCenter].
-  Offset/*!*/ get topCenter => Offset(left + width / 2.0, top);
+  Offset get topCenter => Offset(left + width / 2.0, top);
 
   /// The offset to the intersection of the top and right edges of this rectangle.
   ///
   /// See also [Size.topRight].
-  Offset/*!*/ get topRight => Offset(right, top);
+  Offset get topRight => Offset(right, top);
 
   /// The offset to the center of the left edge of this rectangle.
   ///
   /// See also [Size.centerLeft].
-  Offset/*!*/ get centerLeft => Offset(left, top + height / 2.0);
+  Offset get centerLeft => Offset(left, top + height / 2.0);
 
   /// The offset to the point halfway between the left and right and the top and
   /// bottom edges of this rectangle.
   ///
   /// See also [Size.center].
-  Offset/*!*/ get center => Offset(left + width / 2.0, top + height / 2.0);
+  Offset get center => Offset(left + width / 2.0, top + height / 2.0);
 
   /// The offset to the center of the right edge of this rectangle.
   ///
   /// See also [Size.centerLeft].
-  Offset/*!*/ get centerRight => Offset(right, top + height / 2.0);
+  Offset get centerRight => Offset(right, top + height / 2.0);
 
   /// The offset to the intersection of the bottom and left edges of this rectangle.
   ///
   /// See also [Size.bottomLeft].
-  Offset/*!*/ get bottomLeft => Offset(left, bottom);
+  Offset get bottomLeft => Offset(left, bottom);
 
   /// The offset to the center of the bottom edge of this rectangle.
   ///
   /// See also [Size.bottomLeft].
-  Offset/*!*/ get bottomCenter => Offset(left + width / 2.0, bottom);
+  Offset get bottomCenter => Offset(left + width / 2.0, bottom);
 
   /// The offset to the intersection of the bottom and right edges of this rectangle.
   ///
   /// See also [Size.bottomRight].
-  Offset/*!*/ get bottomRight => Offset(right, bottom);
+  Offset get bottomRight => Offset(right, bottom);
 
   /// Whether the point specified by the given offset (which is assumed to be
   /// relative to the origin) lies between the left and right and the top and
@@ -843,7 +844,7 @@ class Rect {
   ///
   /// Rectangles include their top and left edges but exclude their bottom and
   /// right edges.
-  bool/*!*/ contains(Offset/*!*/ offset) {
+  bool contains(Offset offset) {
     return offset.dx >= left && offset.dx < right && offset.dy >= top && offset.dy < bottom;
   }
 
@@ -862,8 +863,8 @@ class Rect {
   ///
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
-  static Rect/*?*/ lerp(Rect/*?*/ a, Rect/*?*/ b, double/*!*/ t) {
-    assert(t != null);
+  static Rect? lerp(Rect? a, Rect? b, double t) {
+    assert(t != null); // ignore: unnecessary_null_comparison
     if (b == null) {
       if (a == null) {
         return null;
@@ -886,7 +887,7 @@ class Rect {
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     if (runtimeType != other.runtimeType)
@@ -899,25 +900,25 @@ class Rect {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(left, top, right, bottom);
+  int get hashCode => hashValues(left, top, right, bottom);
 
   @override
-  String/*!*/ toString() => 'Rect.fromLTRB(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)})';
+  String toString() => 'Rect.fromLTRB(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)})';
 }
 
 /// A radius for either circular or elliptical shapes.
 class Radius {
   /// Constructs a circular radius. [x] and [y] will have the same radius value.
-  const Radius.circular(double/*!*/ radius) : this.elliptical(radius, radius);
+  const Radius.circular(double radius) : this.elliptical(radius, radius);
 
   /// Constructs an elliptical radius with the given radii.
   const Radius.elliptical(this.x, this.y);
 
   /// The radius value on the horizontal axis.
-  final double/*!*/ x;
+  final double x;
 
   /// The radius value on the vertical axis.
-  final double/*!*/ y;
+  final double y;
 
   /// A radius with [x] and [y] values set to zero.
   ///
@@ -932,49 +933,49 @@ class Radius {
   /// occur as part of expressions. For example, negating a radius of one pixel
   /// and then adding the result to another radius is equivalent to subtracting
   /// a radius of one pixel from the other.
-  Radius/*!*/ operator -() => Radius.elliptical(-x, -y);
+  Radius operator -() => Radius.elliptical(-x, -y);
 
   /// Binary subtraction operator.
   ///
   /// Returns a radius whose [x] value is the left-hand-side operand's [x]
   /// minus the right-hand-side operand's [x] and whose [y] value is the
   /// left-hand-side operand's [y] minus the right-hand-side operand's [y].
-  Radius/*!*/ operator -(Radius/*!*/ other) => Radius.elliptical(x - other.x, y - other.y);
+  Radius operator -(Radius other) => Radius.elliptical(x - other.x, y - other.y);
 
   /// Binary addition operator.
   ///
   /// Returns a radius whose [x] value is the sum of the [x] values of the
   /// two operands, and whose [y] value is the sum of the [y] values of the
   /// two operands.
-  Radius/*!*/ operator +(Radius/*!*/ other) => Radius.elliptical(x + other.x, y + other.y);
+  Radius operator +(Radius other) => Radius.elliptical(x + other.x, y + other.y);
 
   /// Multiplication operator.
   ///
   /// Returns a radius whose coordinates are the coordinates of the
   /// left-hand-side operand (a radius) multiplied by the scalar
   /// right-hand-side operand (a double).
-  Radius/*!*/ operator *(double/*!*/ operand) => Radius.elliptical(x * operand, y * operand);
+  Radius operator *(double operand) => Radius.elliptical(x * operand, y * operand);
 
   /// Division operator.
   ///
   /// Returns a radius whose coordinates are the coordinates of the
   /// left-hand-side operand (a radius) divided by the scalar right-hand-side
   /// operand (a double).
-  Radius/*!*/ operator /(double/*!*/ operand) => Radius.elliptical(x / operand, y / operand);
+  Radius operator /(double operand) => Radius.elliptical(x / operand, y / operand);
 
   /// Integer (truncating) division operator.
   ///
   /// Returns a radius whose coordinates are the coordinates of the
   /// left-hand-side operand (a radius) divided by the scalar right-hand-side
   /// operand (a double), rounded towards zero.
-  Radius/*!*/ operator ~/(double/*!*/ operand) => Radius.elliptical((x ~/ operand).toDouble(), (y ~/ operand).toDouble());
+  Radius operator ~/(double operand) => Radius.elliptical((x ~/ operand).toDouble(), (y ~/ operand).toDouble());
 
   /// Modulo (remainder) operator.
   ///
   /// Returns a radius whose coordinates are the remainder of dividing the
   /// coordinates of the left-hand-side operand (a radius) by the scalar
   /// right-hand-side operand (a double).
-  Radius/*!*/ operator %(double/*!*/ operand) => Radius.elliptical(x % operand, y % operand);
+  Radius operator %(double operand) => Radius.elliptical(x % operand, y % operand);
 
   /// Linearly interpolate between two radii.
   ///
@@ -991,8 +992,8 @@ class Radius {
   ///
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
-  static Radius/*?*/ lerp(Radius/*?*/ a, Radius/*?*/ b, double/*!*/ t) {
-    assert(t != null);
+  static Radius? lerp(Radius? a, Radius? b, double t) {
+    assert(t != null); // ignore: unnecessary_null_comparison
     if (b == null) {
       if (a == null) {
         return null;
@@ -1013,7 +1014,7 @@ class Radius {
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     if (runtimeType != other.runtimeType)
@@ -1025,10 +1026,10 @@ class Radius {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(x, y);
+  int get hashCode => hashValues(x, y);
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     return x == y ? 'Radius.circular(${x.toStringAsFixed(1)})' :
                     'Radius.elliptical(${x.toStringAsFixed(1)}, '
                     '${y.toStringAsFixed(1)})';
@@ -1039,8 +1040,8 @@ class Radius {
 class RRect {
   /// Construct a rounded rectangle from its left, top, right, and bottom edges,
   /// and the same radii along its horizontal axis and its vertical axis.
-  const RRect.fromLTRBXY(double/*!*/ left, double/*!*/ top, double/*!*/ right, double/*!*/ bottom,
-                   double/*!*/ radiusX, double/*!*/ radiusY) : this._raw(
+  const RRect.fromLTRBXY(double left, double top, double right, double bottom,
+                   double radiusX, double radiusY) : this._raw(
     top: top,
     left: left,
     right: right,
@@ -1057,8 +1058,8 @@ class RRect {
 
   /// Construct a rounded rectangle from its left, top, right, and bottom edges,
   /// and the same radius in each corner.
-  RRect.fromLTRBR(double/*!*/ left, double/*!*/ top, double/*!*/ right, double/*!*/ bottom,
-                  Radius/*!*/ radius)
+  RRect.fromLTRBR(double left, double top, double right, double bottom,
+                  Radius radius)
     : this._raw(
         top: top,
         left: left,
@@ -1076,7 +1077,7 @@ class RRect {
 
   /// Construct a rounded rectangle from its bounding box and the same radii
   /// along its horizontal axis and its vertical axis.
-  RRect.fromRectXY(Rect/*!*/ rect, double/*!*/ radiusX, double/*!*/ radiusY)
+  RRect.fromRectXY(Rect rect, double radiusX, double radiusY)
     : this._raw(
         top: rect.top,
         left: rect.left,
@@ -1094,7 +1095,7 @@ class RRect {
 
   /// Construct a rounded rectangle from its bounding box and a radius that is
   /// the same in each corner.
-  RRect.fromRectAndRadius(Rect/*!*/ rect, Radius/*!*/ radius)
+  RRect.fromRectAndRadius(Rect rect, Radius radius)
     : this._raw(
         top: rect.top,
         left: rect.left,
@@ -1115,14 +1116,14 @@ class RRect {
   ///
   /// The corner radii default to [Radius.zero], i.e. right-angled corners.
   RRect.fromLTRBAndCorners(
-    double/*!*/ left,
-    double/*!*/ top,
-    double/*!*/ right,
-    double/*!*/ bottom, {
-    Radius/*!*/ topLeft = Radius.zero,
-    Radius/*!*/ topRight = Radius.zero,
-    Radius/*!*/ bottomRight = Radius.zero,
-    Radius/*!*/ bottomLeft = Radius.zero,
+    double left,
+    double top,
+    double right,
+    double bottom, {
+    Radius topLeft = Radius.zero,
+    Radius topRight = Radius.zero,
+    Radius bottomRight = Radius.zero,
+    Radius bottomLeft = Radius.zero,
   }) : this._raw(
          top: top,
          left: left,
@@ -1143,12 +1144,12 @@ class RRect {
   ///
   /// The corner radii default to [Radius.zero], i.e. right-angled corners
   RRect.fromRectAndCorners(
-    Rect/*!*/ rect,
+    Rect rect,
     {
-      Radius/*!*/ topLeft = Radius.zero,
-      Radius/*!*/ topRight = Radius.zero,
-      Radius/*!*/ bottomRight = Radius.zero,
-      Radius/*!*/ bottomLeft = Radius.zero
+      Radius topLeft = Radius.zero,
+      Radius topRight = Radius.zero,
+      Radius bottomRight = Radius.zero,
+      Radius bottomLeft = Radius.zero
     }
   ) : this._raw(
         top: rect.top,
@@ -1178,18 +1179,18 @@ class RRect {
     this.brRadiusY = 0.0,
     this.blRadiusX = 0.0,
     this.blRadiusY = 0.0,
-  }) : assert(left != null),
-       assert(top != null),
-       assert(right != null),
-       assert(bottom != null),
-       assert(tlRadiusX != null),
-       assert(tlRadiusY != null),
-       assert(trRadiusX != null),
-       assert(trRadiusY != null),
-       assert(brRadiusX != null),
-       assert(brRadiusY != null),
-       assert(blRadiusX != null),
-       assert(blRadiusY != null);
+  }) : assert(left != null), // ignore: unnecessary_null_comparison
+       assert(top != null), // ignore: unnecessary_null_comparison
+       assert(right != null), // ignore: unnecessary_null_comparison
+       assert(bottom != null), // ignore: unnecessary_null_comparison
+       assert(tlRadiusX != null), // ignore: unnecessary_null_comparison
+       assert(tlRadiusY != null), // ignore: unnecessary_null_comparison
+       assert(trRadiusX != null), // ignore: unnecessary_null_comparison
+       assert(trRadiusY != null), // ignore: unnecessary_null_comparison
+       assert(brRadiusX != null), // ignore: unnecessary_null_comparison
+       assert(brRadiusY != null), // ignore: unnecessary_null_comparison
+       assert(blRadiusX != null), // ignore: unnecessary_null_comparison
+       assert(blRadiusY != null); // ignore: unnecessary_null_comparison
 
   Float32List get _value32 => Float32List.fromList(<double>[
     left,
@@ -1207,58 +1208,58 @@ class RRect {
   ]);
 
   /// The offset of the left edge of this rectangle from the x axis.
-  final double/*!*/ left;
+  final double left;
 
   /// The offset of the top edge of this rectangle from the y axis.
-  final double/*!*/ top;
+  final double top;
 
   /// The offset of the right edge of this rectangle from the x axis.
-  final double/*!*/ right;
+  final double right;
 
   /// The offset of the bottom edge of this rectangle from the y axis.
-  final double/*!*/ bottom;
+  final double bottom;
 
   /// The top-left horizontal radius.
-  final double/*!*/ tlRadiusX;
+  final double tlRadiusX;
 
   /// The top-left vertical radius.
-  final double/*!*/ tlRadiusY;
+  final double tlRadiusY;
 
   /// The top-left [Radius].
-  Radius/*!*/ get tlRadius => Radius.elliptical(tlRadiusX, tlRadiusY);
+  Radius get tlRadius => Radius.elliptical(tlRadiusX, tlRadiusY);
 
   /// The top-right horizontal radius.
-  final double/*!*/ trRadiusX;
+  final double trRadiusX;
 
   /// The top-right vertical radius.
-  final double/*!*/ trRadiusY;
+  final double trRadiusY;
 
   /// The top-right [Radius].
-  Radius/*!*/ get trRadius => Radius.elliptical(trRadiusX, trRadiusY);
+  Radius get trRadius => Radius.elliptical(trRadiusX, trRadiusY);
 
   /// The bottom-right horizontal radius.
-  final double/*!*/ brRadiusX;
+  final double brRadiusX;
 
   /// The bottom-right vertical radius.
-  final double/*!*/ brRadiusY;
+  final double brRadiusY;
 
   /// The bottom-right [Radius].
-  Radius/*!*/ get brRadius => Radius.elliptical(brRadiusX, brRadiusY);
+  Radius get brRadius => Radius.elliptical(brRadiusX, brRadiusY);
 
   /// The bottom-left horizontal radius.
-  final double/*!*/ blRadiusX;
+  final double blRadiusX;
 
   /// The bottom-left vertical radius.
-  final double/*!*/ blRadiusY;
+  final double blRadiusY;
 
   /// The bottom-left [Radius].
-  Radius/*!*/ get blRadius => Radius.elliptical(blRadiusX, blRadiusY);
+  Radius get blRadius => Radius.elliptical(blRadiusX, blRadiusY);
 
   /// A rounded rectangle with all the values set to zero.
   static const RRect zero = RRect._raw();
 
   /// Returns a new [RRect] translated by the given offset.
-  RRect/*!*/ shift(Offset/*!*/ offset) {
+  RRect shift(Offset offset) {
     return RRect._raw(
       left: left + offset.dx,
       top: top + offset.dy,
@@ -1277,7 +1278,7 @@ class RRect {
 
   /// Returns a new [RRect] with edges and radii moved outwards by the given
   /// delta.
-  RRect/*!*/ inflate(double/*!*/ delta) {
+  RRect inflate(double delta) {
     return RRect._raw(
       left: left - delta,
       top: top - delta,
@@ -1295,22 +1296,22 @@ class RRect {
   }
 
   /// Returns a new [RRect] with edges and radii moved inwards by the given delta.
-  RRect/*!*/ deflate(double/*!*/ delta) => inflate(-delta);
+  RRect deflate(double delta) => inflate(-delta);
 
   /// The distance between the left and right edges of this rectangle.
-  double/*!*/ get width => right - left;
+  double get width => right - left;
 
   /// The distance between the top and bottom edges of this rectangle.
-  double/*!*/ get height => bottom - top;
+  double get height => bottom - top;
 
   /// The bounding box of this rounded rectangle (the rectangle with no rounded corners).
-  Rect/*!*/ get outerRect => Rect.fromLTRB(left, top, right, bottom);
+  Rect get outerRect => Rect.fromLTRB(left, top, right, bottom);
 
   /// The non-rounded rectangle that is constrained by the smaller of the two
   /// diagonals, with each diagonal traveling through the middle of the curve
   /// corners. The middle of a corner is the intersection of the curve with its
   /// respective quadrant bisector.
-  Rect/*!*/ get safeInnerRect {
+  Rect get safeInnerRect {
     const double kInsetFactor = 0.29289321881; // 1-cos(pi/4)
 
     final double leftRadius = math.max(blRadiusX, tlRadiusX);
@@ -1332,7 +1333,7 @@ class RRect {
   /// intersection of the [wideMiddleRect] and the [tallMiddleRect]. If any of
   /// the intersections are void, the resulting [Rect] will have negative width
   /// or height.
-  Rect/*!*/ get middleRect {
+  Rect get middleRect {
     final double leftRadius = math.max(blRadiusX, tlRadiusX);
     final double topRadius = math.max(tlRadiusY, trRadiusY);
     final double rightRadius = math.max(trRadiusX, brRadiusX);
@@ -1349,7 +1350,7 @@ class RRect {
   /// has the full width of the rounded rectangle. If the rounded rectangle does
   /// not have an axis-aligned intersection of its left and right side, the
   /// resulting [Rect] will have negative width or height.
-  Rect/*!*/ get wideMiddleRect {
+  Rect get wideMiddleRect {
     final double topRadius = math.max(tlRadiusY, trRadiusY);
     final double bottomRadius = math.max(brRadiusY, blRadiusY);
     return Rect.fromLTRB(
@@ -1364,7 +1365,7 @@ class RRect {
   /// has the full height of the rounded rectangle. If the rounded rectangle
   /// does not have an axis-aligned intersection of its top and bottom side, the
   /// resulting [Rect] will have negative width or height.
-  Rect/*!*/ get tallMiddleRect {
+  Rect get tallMiddleRect {
     final double leftRadius = math.max(blRadiusX, tlRadiusX);
     final double rightRadius = math.max(trRadiusX, brRadiusX);
     return Rect.fromLTRB(
@@ -1377,14 +1378,14 @@ class RRect {
 
   /// Whether this rounded rectangle encloses a non-zero area.
   /// Negative areas are considered empty.
-  bool/*!*/ get isEmpty => left >= right || top >= bottom;
+  bool get isEmpty => left >= right || top >= bottom;
 
   /// Whether all coordinates of this rounded rectangle are finite.
-  bool/*!*/ get isFinite => left.isFinite && top.isFinite && right.isFinite && bottom.isFinite;
+  bool get isFinite => left.isFinite && top.isFinite && right.isFinite && bottom.isFinite;
 
   /// Whether this rounded rectangle is a simple rectangle with zero
   /// corner radii.
-  bool/*!*/ get isRect {
+  bool get isRect {
     return (tlRadiusX == 0.0 || tlRadiusY == 0.0) &&
            (trRadiusX == 0.0 || trRadiusY == 0.0) &&
            (blRadiusX == 0.0 || blRadiusY == 0.0) &&
@@ -1392,7 +1393,7 @@ class RRect {
   }
 
   /// Whether this rounded rectangle has a side with no straight section.
-  bool/*!*/ get isStadium {
+  bool get isStadium {
     return tlRadius == trRadius
         && trRadius == brRadius
         && brRadius == blRadius
@@ -1400,7 +1401,7 @@ class RRect {
   }
 
   /// Whether this rounded rectangle has no side with a straight section.
-  bool/*!*/ get isEllipse {
+  bool get isEllipse {
     return tlRadius == trRadius
         && trRadius == brRadius
         && brRadius == blRadius
@@ -1409,24 +1410,24 @@ class RRect {
   }
 
   /// Whether this rounded rectangle would draw as a circle.
-  bool/*!*/ get isCircle => width == height && isEllipse;
+  bool get isCircle => width == height && isEllipse;
 
   /// The lesser of the magnitudes of the [width] and the [height] of this
   /// rounded rectangle.
-  double/*!*/ get shortestSide => math.min(width.abs(), height.abs());
+  double get shortestSide => math.min(width.abs(), height.abs());
 
   /// The greater of the magnitudes of the [width] and the [height] of this
   /// rounded rectangle.
-  double/*!*/ get longestSide => math.max(width.abs(), height.abs());
+  double get longestSide => math.max(width.abs(), height.abs());
 
   /// Whether any of the dimensions are `NaN`.
-  bool/*!*/ get hasNaN => left.isNaN || top.isNaN || right.isNaN || bottom.isNaN ||
+  bool get hasNaN => left.isNaN || top.isNaN || right.isNaN || bottom.isNaN ||
                      trRadiusX.isNaN || trRadiusY.isNaN || tlRadiusX.isNaN || tlRadiusY.isNaN ||
                      brRadiusX.isNaN || brRadiusY.isNaN || blRadiusX.isNaN || blRadiusY.isNaN;
 
   /// The offset to the point halfway between the left and right and the top and
   /// bottom edges of this rectangle.
-  Offset/*!*/ get center => Offset(left + width / 2.0, top + height / 2.0);
+  Offset get center => Offset(left + width / 2.0, top + height / 2.0);
 
   // Returns the minimum between min and scale to which radius1 and radius2
   // should be scaled with in order not to exceed the limit.
@@ -1446,7 +1447,7 @@ class RRect {
   ///
   /// See the [Skia scaling implementation](https://github.com/google/skia/blob/master/src/core/SkRRect.cpp)
   /// for more details.
-  RRect/*!*/ scaleRadii() {
+  RRect scaleRadii() {
     double scale = 1.0;
     scale = _getMin(scale, blRadiusY, tlRadiusY, height);
     scale = _getMin(scale, tlRadiusX, trRadiusX, width);
@@ -1493,7 +1494,7 @@ class RRect {
   /// radii the first time it is called on a particular [RRect] instance. When
   /// using this method, prefer to reuse existing [RRect]s rather than
   /// recreating the object each time.
-  bool/*!*/ contains(Offset/*!*/ point) {
+  bool contains(Offset point) {
     if (point.dx < left || point.dx >= right || point.dy < top || point.dy >= bottom)
       return false; // outside bounding box
 
@@ -1556,8 +1557,8 @@ class RRect {
   ///
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
-  static RRect/*?*/ lerp(RRect/*?*/ a, RRect/*?*/ b, double/*!*/ t) {
-    assert(t != null);
+  static RRect? lerp(RRect? a, RRect? b, double t) {
+    assert(t != null); // ignore: unnecessary_null_comparison
     if (b == null) {
       if (a == null) {
         return null;
@@ -1614,7 +1615,7 @@ class RRect {
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     if (runtimeType != other.runtimeType)
@@ -1635,12 +1636,12 @@ class RRect {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(left, top, right, bottom,
+  int get hashCode => hashValues(left, top, right, bottom,
     tlRadiusX, tlRadiusY, trRadiusX, trRadiusY,
     blRadiusX, blRadiusY, brRadiusX, brRadiusY);
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     final String rect = '${left.toStringAsFixed(1)}, '
                         '${top.toStringAsFixed(1)}, '
                         '${right.toStringAsFixed(1)}, '
@@ -1692,7 +1693,7 @@ class RSTransform {
   /// computations of the sine and cosine of the rotation so that they can be
   /// reused over multiple calls to this constructor, it may be more efficient
   /// to directly use this constructor instead.
-  RSTransform(double/*!*/ scos, double/*!*/ ssin, double/*!*/ tx, double/*!*/ ty) {
+  RSTransform(double scos, double ssin, double tx, double ty) {
     _value
       ..[0] = scos
       ..[1] = ssin
@@ -1720,12 +1721,12 @@ class RSTransform {
   /// over multiple [RSTransform] objects, it may be more efficient to directly
   /// use the more direct [new RSTransform] constructor instead.
   factory RSTransform.fromComponents({
-    double/*!*/ rotation,
-    double/*!*/ scale,
-    double/*!*/ anchorX,
-    double/*!*/ anchorY,
-    double/*!*/ translateX,
-    double/*!*/ translateY
+    required double rotation,
+    required double scale,
+    required double anchorX,
+    required double anchorY,
+    required double translateX,
+    required double translateY
   }) {
     final double scos = math.cos(rotation) * scale;
     final double ssin = math.sin(rotation) * scale;
@@ -1737,18 +1738,18 @@ class RSTransform {
   final Float32List _value = Float32List(4);
 
   /// The cosine of the rotation multiplied by the scale factor.
-  double/*!*/ get scos => _value[0];
+  double get scos => _value[0];
 
   /// The sine of the rotation multiplied by that same scale factor.
-  double/*!*/ get ssin => _value[1];
+  double get ssin => _value[1];
 
   /// The x coordinate of the translation, minus [scos] multiplied by the
   /// x-coordinate of the rotation point, plus [ssin] multiplied by the
   /// y-coordinate of the rotation point.
-  double/*!*/ get tx => _value[2];
+  double get tx => _value[2];
 
   /// The y coordinate of the translation, minus [ssin] multiplied by the
   /// x-coordinate of the rotation point, minus [scos] multiplied by the
   /// y-coordinate of the rotation point.
-  double/*!*/ get ty => _value[3];
+  double get ty => _value[3];
 }

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -15,7 +15,7 @@ const _HashEnd _hashEnd = _HashEnd();
 class _Jenkins {
   static int combine(int hash, Object? o) {
     assert(o is! Iterable);
-    hash = 0x1fffffff & (hash + o!.hashCode);
+    hash = 0x1fffffff & (hash + o.hashCode);
     hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
     return hash ^ (hash >> 6);
   }

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 class _HashEnd { const _HashEnd(); }
@@ -12,9 +13,9 @@ const _HashEnd _hashEnd = _HashEnd();
 //
 // Borrowed from the dart sdk: sdk/lib/math/jenkins_smi_hash.dart.
 class _Jenkins {
-  static int combine(int hash, Object o) {
+  static int combine(int hash, Object? o) {
     assert(o is! Iterable);
-    hash = 0x1fffffff & (hash + o.hashCode);
+    hash = 0x1fffffff & (hash + o!.hashCode);
     hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
     return hash ^ (hash >> 6);
   }
@@ -40,14 +41,14 @@ class _Jenkins {
 /// ```dart
 /// int hashCode => hashValues(foo, bar, hashList(quux), baz);
 /// ```
-int/*!*/ hashValues(
-  Object/*?*/ arg01,            Object/*?*/ arg02,          [ Object/*?*/ arg03 = _hashEnd,
-  Object/*?*/ arg04 = _hashEnd, Object/*?*/ arg05 = _hashEnd, Object/*?*/ arg06 = _hashEnd,
-  Object/*?*/ arg07 = _hashEnd, Object/*?*/ arg08 = _hashEnd, Object/*?*/ arg09 = _hashEnd,
-  Object/*?*/ arg10 = _hashEnd, Object/*?*/ arg11 = _hashEnd, Object/*?*/ arg12 = _hashEnd,
-  Object/*?*/ arg13 = _hashEnd, Object/*?*/ arg14 = _hashEnd, Object/*?*/ arg15 = _hashEnd,
-  Object/*?*/ arg16 = _hashEnd, Object/*?*/ arg17 = _hashEnd, Object/*?*/ arg18 = _hashEnd,
-  Object/*?*/ arg19 = _hashEnd, Object/*?*/ arg20 = _hashEnd ]) {
+int hashValues(
+  Object? arg01,            Object? arg02,          [ Object? arg03 = _hashEnd,
+  Object? arg04 = _hashEnd, Object? arg05 = _hashEnd, Object? arg06 = _hashEnd,
+  Object? arg07 = _hashEnd, Object? arg08 = _hashEnd, Object? arg09 = _hashEnd,
+  Object? arg10 = _hashEnd, Object? arg11 = _hashEnd, Object? arg12 = _hashEnd,
+  Object? arg13 = _hashEnd, Object? arg14 = _hashEnd, Object? arg15 = _hashEnd,
+  Object? arg16 = _hashEnd, Object? arg17 = _hashEnd, Object? arg18 = _hashEnd,
+  Object? arg19 = _hashEnd, Object? arg20 = _hashEnd ]) {
   int result = 0;
   result = _Jenkins.combine(result, arg01);
   result = _Jenkins.combine(result, arg02);
@@ -112,10 +113,10 @@ int/*!*/ hashValues(
 /// Combine the [Object.hashCode] values of an arbitrary number of objects from
 /// an [Iterable] into one value. This function will return the same value if
 /// given null as if given an empty list.
-int/*!*/ hashList(Iterable<Object/*?*/>/*?*/ arguments) {
+int hashList(Iterable<Object?>? arguments) {
   int result = 0;
   if (arguments != null) {
-    for (Object argument in arguments)
+    for (Object? argument in arguments)
       result = _Jenkins.combine(result, argument);
   }
   return _Jenkins.finish(result);

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -111,7 +111,7 @@ void _updateUserSettingsData(String jsonData) {
   if (data.isEmpty) {
     return;
   }
-  _updateTextScaleFactor((data['textScaleFactor'] as num?)!.toDouble());
+  _updateTextScaleFactor((data['textScaleFactor'] as num).toDouble());
   _updateAlwaysUse24HourFormat(data['alwaysUse24HourFormat'] as bool);
   _updatePlatformBrightness(data['platformBrightness'] as String);
 }

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -61,7 +61,7 @@ String? _localeClosure() {
   if (window.locale == null) {
     return null;
   }
-  return window.locale!.toString();
+  return window.locale.toString();
 }
 
 @pragma('vm:entry-point')

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -4,28 +4,29 @@
 
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 @pragma('vm:entry-point')
 // ignore: unused_element
 void _updateWindowMetrics(
-  double/*!*/ devicePixelRatio,
-  double/*!*/ width,
-  double/*!*/ height,
-  double/*!*/ depth,
-  double/*!*/ viewPaddingTop,
-  double/*!*/ viewPaddingRight,
-  double/*!*/ viewPaddingBottom,
-  double/*!*/ viewPaddingLeft,
-  double/*!*/ viewInsetTop,
-  double/*!*/ viewInsetRight,
-  double/*!*/ viewInsetBottom,
-  double/*!*/ viewInsetLeft,
-  double/*!*/ systemGestureInsetTop,
-  double/*!*/ systemGestureInsetRight,
-  double/*!*/ systemGestureInsetBottom,
-  double/*!*/ systemGestureInsetLeft,
+  double devicePixelRatio,
+  double width,
+  double height,
+  double depth,
+  double viewPaddingTop,
+  double viewPaddingRight,
+  double viewPaddingBottom,
+  double viewPaddingLeft,
+  double viewInsetTop,
+  double viewInsetRight,
+  double viewInsetBottom,
+  double viewInsetLeft,
+  double systemGestureInsetTop,
+  double systemGestureInsetRight,
+  double systemGestureInsetBottom,
+  double systemGestureInsetLeft,
 ) {
   window
     .._devicePixelRatio = devicePixelRatio
@@ -54,41 +55,42 @@ void _updateWindowMetrics(
   _invoke(window.onMetricsChanged, window._onMetricsChangedZone);
 }
 
-typedef _LocaleClosure = String/*?*/ Function();
+typedef _LocaleClosure = String? Function();
 
-String/*?*/ _localeClosure() {
+String? _localeClosure() {
   if (window.locale == null) {
     return null;
   }
-  return window.locale.toString();
+  return window.locale!.toString();
 }
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-_LocaleClosure/*?*/ _getLocaleClosure() => _localeClosure;
+_LocaleClosure? _getLocaleClosure() => _localeClosure;
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _updateLocales(List<String/*!*/>/*!*/ locales) {
+void _updateLocales(List<String> locales) {
   const int stringsPerLocale = 4;
   final int numLocales = locales.length ~/ stringsPerLocale;
-  window._locales = List<Locale>(numLocales);
+  final List<Locale> newLocales = <Locale>[];
   for (int localeIndex = 0; localeIndex < numLocales; localeIndex++) {
     final String countryCode = locales[localeIndex * stringsPerLocale + 1];
     final String scriptCode = locales[localeIndex * stringsPerLocale + 2];
 
-    window._locales[localeIndex] = Locale.fromSubtags(
+    newLocales.add(Locale.fromSubtags(
       languageCode: locales[localeIndex * stringsPerLocale],
       countryCode: countryCode.isEmpty ? null : countryCode,
       scriptCode: scriptCode.isEmpty ? null : scriptCode,
-    );
+    ));
   }
+  window._locales = newLocales;
   _invoke(window.onLocaleChanged, window._onLocaleChangedZone);
 }
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _updatePlatformResolvedLocale(List<String/*!*/>/*!*/ localeData) {
+void _updatePlatformResolvedLocale(List<String> localeData) {
   if (localeData.length != 4) {
     return;
   }
@@ -104,19 +106,19 @@ void _updatePlatformResolvedLocale(List<String/*!*/>/*!*/ localeData) {
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _updateUserSettingsData(String/*!*/ jsonData) {
+void _updateUserSettingsData(String jsonData) {
   final Map<String, dynamic> data = json.decode(jsonData) as Map<String, dynamic>;
   if (data.isEmpty) {
     return;
   }
-  _updateTextScaleFactor((data['textScaleFactor'] as num).toDouble());
+  _updateTextScaleFactor((data['textScaleFactor'] as num?)!.toDouble());
   _updateAlwaysUse24HourFormat(data['alwaysUse24HourFormat'] as bool);
   _updatePlatformBrightness(data['platformBrightness'] as String);
 }
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _updateLifecycleState(String/*!*/ state) {
+void _updateLifecycleState(String state) {
   // We do not update the state if the state has already been used to initialize
   // the lifecycleState.
   if (!window._initialLifecycleStateAccessed)
@@ -124,30 +126,30 @@ void _updateLifecycleState(String/*!*/ state) {
 }
 
 
-void _updateTextScaleFactor(double/*!*/ textScaleFactor) {
+void _updateTextScaleFactor(double textScaleFactor) {
   window._textScaleFactor = textScaleFactor;
   _invoke(window.onTextScaleFactorChanged, window._onTextScaleFactorChangedZone);
 }
 
-void _updateAlwaysUse24HourFormat(bool/*!*/ alwaysUse24HourFormat) {
+void _updateAlwaysUse24HourFormat(bool alwaysUse24HourFormat) {
   window._alwaysUse24HourFormat = alwaysUse24HourFormat;
 }
 
-void _updatePlatformBrightness(String/*!*/ brightnessName) {
+void _updatePlatformBrightness(String brightnessName) {
   window._platformBrightness = brightnessName == 'dark' ? Brightness.dark : Brightness.light;
   _invoke(window.onPlatformBrightnessChanged, window._onPlatformBrightnessChangedZone);
 }
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _updateSemanticsEnabled(bool/*!*/ enabled) {
+void _updateSemanticsEnabled(bool enabled) {
   window._semanticsEnabled = enabled;
   _invoke(window.onSemanticsEnabledChanged, window._onSemanticsEnabledChangedZone);
 }
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _updateAccessibilityFeatures(int/*!*/ values) {
+void _updateAccessibilityFeatures(int values) {
   final AccessibilityFeatures newFeatures = AccessibilityFeatures._(values);
   if (newFeatures == window._accessibilityFeatures)
     return;
@@ -157,27 +159,27 @@ void _updateAccessibilityFeatures(int/*!*/ values) {
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _dispatchPlatformMessage(String/*!*/ name, ByteData/*?*/ data, int/*!*/ responseId) {
+void _dispatchPlatformMessage(String name, ByteData? data, int responseId) {
   if (name == ChannelBuffers.kControlChannelName) {
     try {
-      channelBuffers.handleMessage(data);
+      channelBuffers.handleMessage(data!);
     } catch (ex) {
       _printDebug('Message to "$name" caused exception $ex');
     } finally {
       window._respondToPlatformMessage(responseId, null);
     }
   } else if (window.onPlatformMessage != null) {
-    _invoke3<String, ByteData, PlatformMessageResponseCallback>(
+    _invoke3<String, ByteData?, PlatformMessageResponseCallback>(
       window.onPlatformMessage,
       window._onPlatformMessageZone,
       name,
       data,
-      (ByteData responseData) {
+      (ByteData? responseData) {
         window._respondToPlatformMessage(responseId, responseData);
       },
     );
   } else {
-    channelBuffers.push(name, data, (ByteData responseData) {
+    channelBuffers.push(name, data, (ByteData? responseData) {
       window._respondToPlatformMessage(responseId, responseData);
     });
   }
@@ -185,32 +187,32 @@ void _dispatchPlatformMessage(String/*!*/ name, ByteData/*?*/ data, int/*!*/ res
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _dispatchPointerDataPacket(ByteData/*!*/ packet) {
+void _dispatchPointerDataPacket(ByteData packet) {
   if (window.onPointerDataPacket != null)
     _invoke1<PointerDataPacket>(window.onPointerDataPacket, window._onPointerDataPacketZone, _unpackPointerDataPacket(packet));
 }
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _dispatchSemanticsAction(int/*!*/ id, int/*!*/ action, ByteData/*?*/ args) {
-  _invoke3<int, SemanticsAction, ByteData>(
+void _dispatchSemanticsAction(int id, int action, ByteData? args) {
+  _invoke3<int, SemanticsAction, ByteData?>(
     window.onSemanticsAction,
     window._onSemanticsActionZone,
     id,
-    SemanticsAction.values[action],
+    SemanticsAction.values[action]!,
     args,
   );
 }
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _beginFrame(int/*!*/ microseconds) {
+void _beginFrame(int microseconds) {
   _invoke1<Duration>(window.onBeginFrame, window._onBeginFrameZone, Duration(microseconds: microseconds));
 }
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _reportTimings(List<int/*!*/>/*!*/ timings) {
+void _reportTimings(List<int> timings) {
   assert(timings.length % FramePhase.values.length == 0);
   final List<FrameTiming> frameTimings = <FrameTiming>[];
   for (int i = 0; i < timings.length; i += FramePhase.values.length) {
@@ -226,15 +228,15 @@ void _drawFrame() {
 }
 
 // ignore: always_declare_return_types, prefer_generic_function_type_aliases
-typedef _UnaryFunction(Null/*!*/ args);
+typedef _UnaryFunction(Null args);
 // ignore: always_declare_return_types, prefer_generic_function_type_aliases
-typedef _BinaryFunction(Null/*!*/ args, Null/*!*/ message);
+typedef _BinaryFunction(Null args, Null message);
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _runMainZoned(Function/*!*/ startMainIsolateFunction,
-                   Function/*!*/ userMainFunction,
-                   List<String/*!*/>/*!*/ args) {
+void _runMainZoned(Function startMainIsolateFunction,
+                   Function userMainFunction,
+                   List<String> args) {
   startMainIsolateFunction((){
     runZonedGuarded<void>(() {
       if (userMainFunction is _BinaryFunction) {
@@ -252,14 +254,14 @@ void _runMainZoned(Function/*!*/ startMainIsolateFunction,
   }, null);
 }
 
-void _reportUnhandledException(String/*!*/ error, String/*!*/ stackTrace) native 'Window_reportUnhandledException';
+void _reportUnhandledException(String error, String stackTrace) native 'Window_reportUnhandledException';
 
 /// Invokes [callback] inside the given [zone].
-void _invoke(void callback()/*?*/, Zone/*!*/ zone) {
+void _invoke(void callback()?, Zone zone) {
   if (callback == null)
     return;
 
-  assert(zone != null);
+  assert(zone != null); // ignore: unnecessary_null_comparison
 
   if (identical(zone, Zone.current)) {
     callback();
@@ -269,11 +271,11 @@ void _invoke(void callback()/*?*/, Zone/*!*/ zone) {
 }
 
 /// Invokes [callback] inside the given [zone] passing it [arg].
-void _invoke1<A>(void callback(A a)/*?*/, Zone/*!*/ zone, A arg) {
+void _invoke1<A>(void callback(A a)?, Zone zone, A arg) {
   if (callback == null)
     return;
 
-  assert(zone != null);
+  assert(zone != null); // ignore: unnecessary_null_comparison
 
   if (identical(zone, Zone.current)) {
     callback(arg);
@@ -283,11 +285,11 @@ void _invoke1<A>(void callback(A a)/*?*/, Zone/*!*/ zone, A arg) {
 }
 
 /// Invokes [callback] inside the given [zone] passing it [arg1], [arg2], and [arg3].
-void _invoke3<A1, A2, A3>(void callback(A1 a1, A2 a2, A3 a3)/*?*/, Zone/*!*/ zone, A1 arg1, A2 arg2, A3 arg3) {
+void _invoke3<A1, A2, A3>(void callback(A1 a1, A2 a2, A3 a3)?, Zone zone, A1 arg1, A2 arg2, A3 arg3) {
   if (callback == null)
     return;
 
-  assert(zone != null);
+  assert(zone != null); // ignore: unnecessary_null_comparison
 
   if (identical(zone, Zone.current)) {
     callback(arg1, arg2, arg3);
@@ -305,15 +307,15 @@ void _invoke3<A1, A2, A3>(void callback(A1 a1, A2 a2, A3 a3)/*?*/, Zone/*!*/ zon
 //  * AndroidTouchProcessor.java
 const int _kPointerDataFieldCount = 28;
 
-PointerDataPacket/*!*/ _unpackPointerDataPacket(ByteData/*!*/ packet) {
+PointerDataPacket _unpackPointerDataPacket(ByteData packet) {
   const int kStride = Int64List.bytesPerElement;
   const int kBytesPerPointerData = _kPointerDataFieldCount * kStride;
   final int length = packet.lengthInBytes ~/ kBytesPerPointerData;
   assert(length * kBytesPerPointerData == packet.lengthInBytes);
-  final List<PointerData> data = List<PointerData>(length);
+  final List<PointerData> data = <PointerData>[];
   for (int i = 0; i < length; ++i) {
     int offset = i * _kPointerDataFieldCount;
-    data[i] = PointerData(
+    data.add(PointerData(
       timeStamp: Duration(microseconds: packet.getInt64(kStride * offset++, _kFakeHostEndian)),
       change: PointerChange.values[packet.getInt64(kStride * offset++, _kFakeHostEndian)],
       kind: PointerDeviceKind.values[packet.getInt64(kStride * offset++, _kFakeHostEndian)],
@@ -342,7 +344,7 @@ PointerDataPacket/*!*/ _unpackPointerDataPacket(ByteData/*!*/ packet) {
       platformData: packet.getInt64(kStride * offset++, _kFakeHostEndian),
       scrollDeltaX: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
       scrollDeltaY: packet.getFloat64(kStride * offset++, _kFakeHostEndian)
-    );
+    ));
     assert(offset == (i + 1) * _kPointerDataFieldCount);
   }
   return PointerDataPacket(data: data);

--- a/lib/ui/isolate_name_server.dart
+++ b/lib/ui/isolate_name_server.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 /// Static methods to allow for simple sharing of [SendPort]s across [Isolate]s.
@@ -31,8 +32,8 @@ class IsolateNameServer {
   /// place, consider [registerPortWithName].
   ///
   /// The `name` argument must not be null.
-  static SendPort/*?*/ lookupPortByName(String/*!*/ name) {
-    assert(name != null, "'name' cannot be null.");
+  static SendPort? lookupPortByName(String name) {
+    assert(name != null, "'name' cannot be null."); // ignore: unnecessary_null_comparison
     return _lookupPortByName(name);
   }
 
@@ -49,9 +50,9 @@ class IsolateNameServer {
   /// name, as there is an inherent race condition in doing so.
   ///
   /// The `port` and `name` arguments must not be null.
-  static bool/*!*/ registerPortWithName(SendPort port, String name) {
-    assert(port != null, "'port' cannot be null.");
-    assert(name != null, "'name' cannot be null.");
+  static bool registerPortWithName(SendPort port, String name) {
+    assert(port != null, "'port' cannot be null."); // ignore: unnecessary_null_comparison
+    assert(name != null, "'name' cannot be null."); // ignore: unnecessary_null_comparison
     return _registerPortWithName(port, name);
   }
 
@@ -66,15 +67,15 @@ class IsolateNameServer {
   /// after it has been removed).
   ///
   /// The `name` argument must not be null.
-  static bool/*!*/ removePortNameMapping(String name) {
-    assert(name != null, "'name' cannot be null.");
+  static bool removePortNameMapping(String name) {
+    assert(name != null, "'name' cannot be null."); // ignore: unnecessary_null_comparison
     return _removePortNameMapping(name);
   }
 
-  static SendPort/*?*/ _lookupPortByName(String name)
+  static SendPort? _lookupPortByName(String name)
       native 'IsolateNameServerNatives_LookupPortByName';
-  static bool/*!*/ _registerPortWithName(SendPort port, String name)
+  static bool _registerPortWithName(SendPort port, String name)
       native 'IsolateNameServerNatives_RegisterPortWithName';
-  static bool/*!*/ _removePortNameMapping(String name)
+  static bool _removePortNameMapping(String name)
       native 'IsolateNameServerNatives_RemovePortNameMapping';
 }

--- a/lib/ui/lerp.dart
+++ b/lib/ui/lerp.dart
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 /// Linearly interpolate between two numbers.
-double/*!*/ lerpDouble(num/*?*/ a, num/*?*/ b, double/*!*/ t) {
+double? lerpDouble(num? a, num? b, double t) {
   if (a == null && b == null)
     return null;
   a ??= 0.0;
@@ -17,19 +18,19 @@ double/*!*/ lerpDouble(num/*?*/ a, num/*?*/ b, double/*!*/ t) {
 /// Linearly interpolate between two doubles.
 ///
 /// Same as [lerpDouble] but specialized for non-null `double` type.
-double/*!*/ _lerpDouble(double/*!*/ a, double/*!*/ b, double/*!*/ t) {
+double _lerpDouble(double a, double b, double t) {
   return a + (b - a) * t;
 }
 
 /// Linearly interpolate between two integers.
 ///
 /// Same as [lerpDouble] but specialized for non-null `int` type.
-double/*!*/ _lerpInt(int/*!*/ a, int/*!*/ b, double/*!*/ t) {
+double _lerpInt(int a, int b, double t) {
   return a + (b - a) * t;
 }
 
 /// Same as [num.clamp] but specialized for non-null [int].
-int/*!*/ _clampInt(int/*!*/ value, int/*!*/ min, int/*!*/ max) {
+int _clampInt(int value, int min, int max) {
   assert(min <= max);
   if (value < min) {
     return min;

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -4,7 +4,8 @@
 
 // TODO(dnfield): remove unused_element ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 // Corelib 'print' implementation.
@@ -17,8 +18,8 @@ void _printDebug(dynamic arg) {
 }
 
 class _Logger {
-  static void _printString(String/*?*/ s) native 'Logger_PrintString';
-  static void _printDebugString(String/*?*/ s) native 'Logger_PrintDebugString';
+  static void _printString(String? s) native 'Logger_PrintString';
+  static void _printDebugString(String? s) native 'Logger_PrintDebugString';
 }
 
 // If we actually run on big endian machines, we'll need to do something smarter
@@ -68,7 +69,7 @@ void _setupHooks() {  // ignore: unused_element
 /// ```
 ///
 /// This function is only effective in debug and dynamic modes, and will throw in AOT mode.
-List<int/*!*/>/*!*/ saveCompilationTrace() {
+List<int> saveCompilationTrace() {
   final dynamic result = _saveCompilationTrace();
   if (result is Error)
     throw result;
@@ -79,11 +80,11 @@ dynamic _saveCompilationTrace() native 'SaveCompilationTrace';
 
 void _scheduleMicrotask(void callback()) native 'ScheduleMicrotask';
 
-int/*?*/ _getCallbackHandle(Function closure) native 'GetCallbackHandle';
-Function/*?*/ _getCallbackFromHandle(int handle) native 'GetCallbackFromHandle';
+int? _getCallbackHandle(Function closure) native 'GetCallbackHandle';
+Function? _getCallbackFromHandle(int handle) native 'GetCallbackFromHandle';
 
 // Required for gen_snapshot to work correctly.
-int/*?*/ _isolateId; // ignore: unused_element
+int? _isolateId; // ignore: unused_element
 
 @pragma('vm:entry-point')
 Function _getPrintClosure() => _print;  // ignore: unused_element

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1349,10 +1349,7 @@ class Paint {
   ///  * [colorFilter], which overrides [shader].
   ///  * [color], which is used if [shader] and [colorFilter] are null.
   Shader? get shader {
-    final List<dynamic>? objects = _objects;
-    if (objects == null)
-      return null;
-    return objects[_kShaderIndex] as Shader?;
+    return _objects?[_kShaderIndex] as Shader?;
   }
   set shader(Shader? value) {
     _ensureObjectsInitialized()[_kShaderIndex] = value;
@@ -1365,11 +1362,7 @@ class Paint {
   ///
   /// When a shape is being drawn, [colorFilter] overrides [color] and [shader].
   ColorFilter? get colorFilter {
-    final List<dynamic>? objects = _objects;
-    if (objects == null || objects[_kColorFilterIndex] == null) {
-      return null;
-    }
-    return objects[_kColorFilterIndex].creator as ColorFilter?;
+    return _objects?[_kColorFilterIndex]?.creator as ColorFilter?;
   }
 
   set colorFilter(ColorFilter? value) {
@@ -1406,10 +1399,7 @@ class Paint {
   ///
   ///  * [MaskFilter], which is used for drawing geometry.
   ImageFilter? get imageFilter {
-    final List<dynamic>? objects = _objects;
-    if (objects == null || objects[_kImageFilterIndex] == null)
-      return null;
-    return objects[_kImageFilterIndex].creator as ImageFilter?;
+    return _objects?[_kImageFilterIndex]?.creator as ImageFilter?;
   }
 
   set imageFilter(ImageFilter? value) {
@@ -2809,7 +2799,9 @@ class _ColorFilter extends NativeFieldWrapperClass2 {
 class ImageFilter {
   /// Creates an image filter that applies a Gaussian blur.
   ImageFilter.blur({ double sigmaX = 0.0, double sigmaY = 0.0 })
-      : _data = _makeList(sigmaX, sigmaY),
+      : assert(sigmaX != null), // ignore: unnecessary_null_comparison
+        assert(sigmaY != null), // ignore: unnecessary_null_comparison
+        _data = _makeList(sigmaX, sigmaY),
         _filterQuality = null,
         _type = _kTypeBlur;
 
@@ -2819,7 +2811,8 @@ class ImageFilter {
   /// when used with [BackdropFilter] would magnify the background image.
   ImageFilter.matrix(Float64List matrix4,
                      { FilterQuality filterQuality = FilterQuality.low })
-      : _data = Float64List.fromList(matrix4),
+      : assert(matrix4 != null), // ignore: unnecessary_null_comparison
+        _data = Float64List.fromList(matrix4),
         _filterQuality = filterQuality,
         _type = _kTypeMatrix {
     if (matrix4.length != 16)

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2354,7 +2354,11 @@ class PathMetricIterator implements Iterator<PathMetric> {
   PathMetric get current {
     final PathMetric? currentMetric = _pathMetric;
     if (currentMetric == null) {
-      throw RangeError('No more path metrics.');
+      throw RangeError(
+        'PathMetricIterator is not pointing to a PathMetric. This can happen in two situations:\n'
+        '- The iteration has not started yet. If so, call "moveNext" to start iteration.'
+        '- The iterator ran out of elements. If so, check that "moveNext" returns true prior to calling "current".'
+      );
     }
     return currentMetric;
   }

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 // Some methods in this file assert that their arguments are not null. These
@@ -23,32 +24,32 @@ part of dart.ui;
 /// {@endtemplate}
 
 bool _rectIsValid(Rect rect) {
-  assert(rect != null, 'Rect argument was null.');
+  assert(rect != null, 'Rect argument was null.'); // ignore: unnecessary_null_comparison
   assert(!rect.hasNaN, 'Rect argument contained a NaN value.');
   return true;
 }
 
 bool _rrectIsValid(RRect rrect) {
-  assert(rrect != null, 'RRect argument was null.');
+  assert(rrect != null, 'RRect argument was null.'); // ignore: unnecessary_null_comparison
   assert(!rrect.hasNaN, 'RRect argument contained a NaN value.');
   return true;
 }
 
 bool _offsetIsValid(Offset offset) {
-  assert(offset != null, 'Offset argument was null.');
+  assert(offset != null, 'Offset argument was null.'); // ignore: unnecessary_null_comparison
   assert(!offset.dx.isNaN && !offset.dy.isNaN, 'Offset argument contained a NaN value.');
   return true;
 }
 
 bool _matrix4IsValid(Float64List matrix4) {
-  assert(matrix4 != null, 'Matrix4 argument was null.');
+  assert(matrix4 != null, 'Matrix4 argument was null.'); // ignore: unnecessary_null_comparison
   assert(matrix4.length == 16, 'Matrix4 must have 16 entries.');
   assert(matrix4.every((double value) => value.isFinite), 'Matrix4 entries must be finite.');
   return true;
 }
 
 bool _radiusIsValid(Radius radius) {
-  assert(radius != null, 'Radius argument was null.');
+  assert(radius != null, 'Radius argument was null.'); // ignore: unnecessary_null_comparison
   assert(!radius.x.isNaN && !radius.y.isNaN, 'Radius argument contained a NaN value.');
   return true;
 }
@@ -105,7 +106,7 @@ class Color {
   /// Color(0xFFFF9000)` (`FF` for the alpha, `FF` for the red, `90` for the
   /// green, and `00` for the blue).
   @pragma('vm:entry-point')
-  const Color(int/*!*/ value) : value = value & 0xFFFFFFFF;
+  const Color(int value) : value = value & 0xFFFFFFFF;
 
   /// Construct a color from the lower 8 bits of four integers.
   ///
@@ -119,7 +120,7 @@ class Color {
   ///
   /// See also [fromRGBO], which takes the alpha value as a floating point
   /// value.
-  const Color.fromARGB(int/*!*/ a, int/*!*/ r, int/*!*/ g, int/*!*/ b) :
+  const Color.fromARGB(int a, int r, int g, int b) :
     value = (((a & 0xff) << 24) |
              ((r & 0xff) << 16) |
              ((g & 0xff) << 8)  |
@@ -136,7 +137,7 @@ class Color {
   /// Out of range values are brought into range using modulo 255.
   ///
   /// See also [fromARGB], which takes the opacity as an integer value.
-  const Color.fromRGBO(int/*!*/ r, int/*!*/ g, int/*!*/ b, double/*!*/ opacity) :
+  const Color.fromRGBO(int r, int g, int b, double opacity) :
     value = ((((opacity * 0xff ~/ 1) & 0xff) << 24) |
               ((r                    & 0xff) << 16) |
               ((g                    & 0xff) << 8)  |
@@ -150,34 +151,34 @@ class Color {
   /// * Bits 16-23 are the red value.
   /// * Bits 8-15 are the green value.
   /// * Bits 0-7 are the blue value.
-  final int/*!*/ value;
+  final int value;
 
   /// The alpha channel of this color in an 8 bit value.
   ///
   /// A value of 0 means this color is fully transparent. A value of 255 means
   /// this color is fully opaque.
-  int/*!*/ get alpha => (0xff000000 & value) >> 24;
+  int get alpha => (0xff000000 & value) >> 24;
 
   /// The alpha channel of this color as a double.
   ///
   /// A value of 0.0 means this color is fully transparent. A value of 1.0 means
   /// this color is fully opaque.
-  double/*!*/ get opacity => alpha / 0xFF;
+  double get opacity => alpha / 0xFF;
 
   /// The red channel of this color in an 8 bit value.
-  int/*!*/ get red => (0x00ff0000 & value) >> 16;
+  int get red => (0x00ff0000 & value) >> 16;
 
   /// The green channel of this color in an 8 bit value.
-  int/*!*/ get green => (0x0000ff00 & value) >> 8;
+  int get green => (0x0000ff00 & value) >> 8;
 
   /// The blue channel of this color in an 8 bit value.
-  int/*!*/ get blue => (0x000000ff & value) >> 0;
+  int get blue => (0x000000ff & value) >> 0;
 
   /// Returns a new color that matches this color with the alpha channel
   /// replaced with `a` (which ranges from 0 to 255).
   ///
   /// Out of range values will have unexpected effects.
-  Color/*!*/ withAlpha(int/*!*/ a) {
+  Color withAlpha(int a) {
     return Color.fromARGB(a, red, green, blue);
   }
 
@@ -185,7 +186,7 @@ class Color {
   /// replaced with the given `opacity` (which ranges from 0.0 to 1.0).
   ///
   /// Out of range values will have unexpected effects.
-  Color/*!*/ withOpacity(double/*!*/ opacity) {
+  Color withOpacity(double opacity) {
     assert(opacity >= 0.0 && opacity <= 1.0);
     return withAlpha((255.0 * opacity).round());
   }
@@ -194,7 +195,7 @@ class Color {
   /// with `r` (which ranges from 0 to 255).
   ///
   /// Out of range values will have unexpected effects.
-  Color/*!*/ withRed(int/*!*/ r) {
+  Color withRed(int r) {
     return Color.fromARGB(alpha, r, green, blue);
   }
 
@@ -202,7 +203,7 @@ class Color {
   /// replaced with `g` (which ranges from 0 to 255).
   ///
   /// Out of range values will have unexpected effects.
-  Color/*!*/ withGreen(int/*!*/ g) {
+  Color withGreen(int g) {
     return Color.fromARGB(alpha, red, g, blue);
   }
 
@@ -210,7 +211,7 @@ class Color {
   /// with `b` (which ranges from 0 to 255).
   ///
   /// Out of range values will have unexpected effects.
-  Color/*!*/ withBlue(int/*!*/ b) {
+  Color withBlue(int b) {
     return Color.fromARGB(alpha, red, green, b);
   }
 
@@ -227,7 +228,7 @@ class Color {
   /// expensive to calculate.
   ///
   /// See <https://en.wikipedia.org/wiki/Relative_luminance>.
-  double/*!*/ computeLuminance() {
+  double computeLuminance() {
     // See <https://www.w3.org/TR/WCAG20/#relativeluminancedef>
     final double R = _linearizeColorComponent(red / 0xFF);
     final double G = _linearizeColorComponent(green / 0xFF);
@@ -257,8 +258,8 @@ class Color {
   ///
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
-  static Color/*?*/ lerp(Color/*?*/ a, Color/*?*/ b, double/*!*/ t) {
-    assert(t != null);
+  static Color? lerp(Color? a, Color? b, double t) {
+    assert(t != null); // ignore: unnecessary_null_comparison
     if (b == null) {
       if (a == null) {
         return null;
@@ -287,7 +288,7 @@ class Color {
   /// enhancement when trying to avoid needless alpha blending compositing
   /// operations for two things that are solid colors with the same shape, but
   /// overlay each other: instead, just paint one with the combined color.
-  static Color/*!*/ alphaBlend(Color/*!*/ foreground, Color/*!*/ background) {
+  static Color alphaBlend(Color foreground, Color background) {
     final int alpha = foreground.alpha;
     if (alpha == 0x00) { // Foreground completely transparent.
       return background;
@@ -317,13 +318,13 @@ class Color {
   /// Returns an alpha value representative of the provided [opacity] value.
   ///
   /// The [opacity] value may not be null.
-  static int/*!*/ getAlphaFromOpacity(double/*!*/ opacity) {
-    assert(opacity != null);
+  static int getAlphaFromOpacity(double opacity) {
+    assert(opacity != null); // ignore: unnecessary_null_comparison
     return (opacity.clamp(0.0, 1.0) * 255).round();
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     if (other.runtimeType != runtimeType)
@@ -333,10 +334,10 @@ class Color {
   }
 
   @override
-  int/*!*/ get hashCode => value.hashCode;
+  int get hashCode => value.hashCode;
 
   @override
-  String/*!*/ toString() => 'Color(0x${value.toRadixString(16).padLeft(8, '0')})';
+  String toString() => 'Color(0x${value.toRadixString(16).padLeft(8, '0')})';
 }
 
 /// Algorithms to use when painting on the canvas.
@@ -1093,7 +1094,12 @@ class Paint {
   static const int _kDataByteCount = 56;
 
   // Binary format must match the deserialization code in paint.cc.
-  List<dynamic>/*?*/ _objects;
+  List<dynamic>? _objects;
+
+  List<dynamic> _ensureObjectsInitialized() {
+    return _objects ??= List<dynamic>.filled(_kObjectCount, null, growable: false);
+  }
+
   static const int _kShaderIndex = 0;
   static const int _kColorFilterIndex = 1;
   static const int _kImageFilterIndex = 2;
@@ -1111,10 +1117,10 @@ class Paint {
   /// canvas.
   ///
   /// Defaults to true.
-  bool/*!*/ get isAntiAlias {
+  bool get isAntiAlias {
     return _data.getInt32(_kIsAntiAliasOffset, _kFakeHostEndian) == 0;
   }
-  set isAntiAlias(bool/*!*/ value) {
+  set isAntiAlias(bool value) {
     // We encode true as zero and false as one because the default value, which
     // we always encode as zero, is true.
     final int encoded = value ? 0 : 1;
@@ -1136,12 +1142,12 @@ class Paint {
   ///
   /// This color is not used when compositing. To colorize a layer, use
   /// [colorFilter].
-  Color/*!*/ get color {
+  Color get color {
     final int encoded = _data.getInt32(_kColorOffset, _kFakeHostEndian);
     return Color(encoded ^ _kColorDefault);
   }
-  set color(Color/*!*/ value) {
-    assert(value != null);
+  set color(Color value) {
+    assert(value != null); // ignore: unnecessary_null_comparison
     final int encoded = value.value ^ _kColorDefault;
     _data.setInt32(_kColorOffset, encoded, _kFakeHostEndian);
   }
@@ -1166,12 +1172,12 @@ class Paint {
   ///  * [Canvas.saveLayer], which uses its [Paint]'s [blendMode] to composite
   ///    the layer when [restore] is called.
   ///  * [BlendMode], which discusses the user of [saveLayer] with [blendMode].
-  BlendMode/*!*/ get blendMode {
+  BlendMode get blendMode {
     final int encoded = _data.getInt32(_kBlendModeOffset, _kFakeHostEndian);
     return BlendMode.values[encoded ^ _kBlendModeDefault];
   }
-  set blendMode(BlendMode/*!*/ value) {
-    assert(value != null);
+  set blendMode(BlendMode value) {
+    assert(value != null); // ignore: unnecessary_null_comparison
     final int encoded = value.index ^ _kBlendModeDefault;
     _data.setInt32(_kBlendModeOffset, encoded, _kFakeHostEndian);
   }
@@ -1179,11 +1185,11 @@ class Paint {
   /// Whether to paint inside shapes, the edges of shapes, or both.
   ///
   /// Defaults to [PaintingStyle.fill].
-  PaintingStyle/*!*/ get style {
+  PaintingStyle get style {
     return PaintingStyle.values[_data.getInt32(_kStyleOffset, _kFakeHostEndian)];
   }
-  set style(PaintingStyle/*!*/ value) {
-    assert(value != null);
+  set style(PaintingStyle value) {
+    assert(value != null); // ignore: unnecessary_null_comparison
     final int encoded = value.index;
     _data.setInt32(_kStyleOffset, encoded, _kFakeHostEndian);
   }
@@ -1193,11 +1199,11 @@ class Paint {
   /// the direction orthogonal to the direction of the path.
   ///
   /// Defaults to 0.0, which correspond to a hairline width.
-  double/*!*/ get strokeWidth {
+  double get strokeWidth {
     return _data.getFloat32(_kStrokeWidthOffset, _kFakeHostEndian);
   }
-  set strokeWidth(double/*!*/ value) {
-    assert(value != null);
+  set strokeWidth(double value) {
+    assert(value != null); // ignore: unnecessary_null_comparison
     final double encoded = value;
     _data.setFloat32(_kStrokeWidthOffset, encoded, _kFakeHostEndian);
   }
@@ -1206,11 +1212,11 @@ class Paint {
   /// [style] is set to [PaintingStyle.stroke].
   ///
   /// Defaults to [StrokeCap.butt], i.e. no caps.
-  StrokeCap/*!*/ get strokeCap {
+  StrokeCap get strokeCap {
     return StrokeCap.values[_data.getInt32(_kStrokeCapOffset, _kFakeHostEndian)];
   }
-  set strokeCap(StrokeCap/*!*/ value) {
-    assert(value != null);
+  set strokeCap(StrokeCap value) {
+    assert(value != null); // ignore: unnecessary_null_comparison
     final int encoded = value.index;
     _data.setInt32(_kStrokeCapOffset, encoded, _kFakeHostEndian);
   }
@@ -1240,11 +1246,11 @@ class Paint {
   ///    this is set to [StrokeJoin.miter].
   ///  * [strokeCap] to control what is drawn at the ends of the stroke.
   ///  * [StrokeJoin] for the definitive list of stroke joins.
-  StrokeJoin/*!*/ get strokeJoin {
+  StrokeJoin get strokeJoin {
     return StrokeJoin.values[_data.getInt32(_kStrokeJoinOffset, _kFakeHostEndian)];
   }
-  set strokeJoin(StrokeJoin/*!*/ value) {
-    assert(value != null);
+  set strokeJoin(StrokeJoin value) {
+    assert(value != null); // ignore: unnecessary_null_comparison
     final int encoded = value.index;
     _data.setInt32(_kStrokeJoinOffset, encoded, _kFakeHostEndian);
   }
@@ -1278,11 +1284,11 @@ class Paint {
   ///  * [strokeJoin] to control the kind of finish to place on the joins
   ///    between segments.
   ///  * [strokeCap] to control what is drawn at the ends of the stroke.
-  double/*!*/ get strokeMiterLimit {
+  double get strokeMiterLimit {
     return _data.getFloat32(_kStrokeMiterLimitOffset, _kFakeHostEndian);
   }
-  set strokeMiterLimit(double/*!*/ value) {
-    assert(value != null);
+  set strokeMiterLimit(double value) {
+    assert(value != null); // ignore: unnecessary_null_comparison
     final double encoded = value - _kStrokeMiterLimitDefault;
     _data.setFloat32(_kStrokeMiterLimitOffset, encoded, _kFakeHostEndian);
   }
@@ -1291,7 +1297,7 @@ class Paint {
   /// drawn but before it has been composited into the image.
   ///
   /// See [MaskFilter] for details.
-  MaskFilter/*?*/ get maskFilter {
+  MaskFilter? get maskFilter {
     switch (_data.getInt32(_kMaskFilterOffset, _kFakeHostEndian)) {
       case MaskFilter._TypeNone:
         return null;
@@ -1303,7 +1309,7 @@ class Paint {
     }
     return null;
   }
-  set maskFilter(MaskFilter/*?*/ value) {
+  set maskFilter(MaskFilter? value) {
     if (value == null) {
       _data.setInt32(_kMaskFilterOffset, MaskFilter._TypeNone, _kFakeHostEndian);
       _data.setInt32(_kMaskFilterBlurStyleOffset, 0, _kFakeHostEndian);
@@ -1323,11 +1329,11 @@ class Paint {
   ///
   /// Defaults to [FilterQuality.none].
   // TODO(ianh): verify that the image drawing methods actually respect this
-  FilterQuality/*!*/ get filterQuality {
+  FilterQuality get filterQuality {
     return FilterQuality.values[_data.getInt32(_kFilterQualityOffset, _kFakeHostEndian)];
   }
-  set filterQuality(FilterQuality/*!*/ value) {
-    assert(value != null);
+  set filterQuality(FilterQuality value) {
+    assert(value != null); // ignore: unnecessary_null_comparison
     final int encoded = value.index;
     _data.setInt32(_kFilterQualityOffset, encoded, _kFakeHostEndian);
   }
@@ -1342,14 +1348,14 @@ class Paint {
   ///  * [ImageShader], a shader that tiles an [Image].
   ///  * [colorFilter], which overrides [shader].
   ///  * [color], which is used if [shader] and [colorFilter] are null.
-  Shader/*?*/ get shader {
-    if (_objects == null)
+  Shader? get shader {
+    final List<dynamic>? objects = _objects;
+    if (objects == null)
       return null;
-    return _objects[_kShaderIndex] as Shader;
+    return objects[_kShaderIndex] as Shader?;
   }
-  set shader(Shader/*?*/ value) {
-    _objects ??= List<dynamic>(_kObjectCount);
-    _objects[_kShaderIndex] = value;
+  set shader(Shader? value) {
+    _ensureObjectsInitialized()[_kShaderIndex] = value;
   }
 
   /// A color filter to apply when a shape is drawn or when a layer is
@@ -1358,26 +1364,22 @@ class Paint {
   /// See [ColorFilter] for details.
   ///
   /// When a shape is being drawn, [colorFilter] overrides [color] and [shader].
-  ColorFilter/*?*/ get colorFilter {
-    if (_objects == null || _objects[_kColorFilterIndex] == null) {
+  ColorFilter? get colorFilter {
+    final List<dynamic>? objects = _objects;
+    if (objects == null || objects[_kColorFilterIndex] == null) {
       return null;
     }
-    return _objects[_kColorFilterIndex].creator as ColorFilter;
+    return objects[_kColorFilterIndex].creator as ColorFilter?;
   }
 
-  set colorFilter(ColorFilter/*?*/ value) {
-    final _ColorFilter nativeFilter = value?._toNativeColorFilter();
+  set colorFilter(ColorFilter? value) {
+    final _ColorFilter? nativeFilter = value?._toNativeColorFilter();
     if (nativeFilter == null) {
       if (_objects != null) {
-        _objects[_kColorFilterIndex] = null;
+        _objects![_kColorFilterIndex] = null;
       }
     } else {
-      if (_objects == null) {
-        _objects = List<dynamic>(_kObjectCount);
-        _objects[_kColorFilterIndex] = nativeFilter;
-      } else if (_objects[_kColorFilterIndex]?.creator != value) {
-        _objects[_kColorFilterIndex] = nativeFilter;
-      }
+      _ensureObjectsInitialized()[_kColorFilterIndex] = nativeFilter;
     }
   }
 
@@ -1403,21 +1405,22 @@ class Paint {
   /// See also:
   ///
   ///  * [MaskFilter], which is used for drawing geometry.
-  ImageFilter/*?*/ get imageFilter {
-    if (_objects == null || _objects[_kImageFilterIndex] == null)
+  ImageFilter? get imageFilter {
+    final List<dynamic>? objects = _objects;
+    if (objects == null || objects[_kImageFilterIndex] == null)
       return null;
-    return _objects[_kImageFilterIndex].creator as ImageFilter;
+    return objects[_kImageFilterIndex].creator as ImageFilter?;
   }
 
-  set imageFilter(ImageFilter/*?*/ value) {
+  set imageFilter(ImageFilter? value) {
     if (value == null) {
       if (_objects != null) {
-        _objects[_kImageFilterIndex] = null;
+        _objects![_kImageFilterIndex] = null;
       }
     } else {
-      _objects ??= List<dynamic>(_kObjectCount);
-      if (_objects[_kImageFilterIndex]?.creator != value) {
-        _objects[_kImageFilterIndex] = value._toNativeImageFilter();
+      final List<dynamic> objects = _ensureObjectsInitialized();
+      if (objects[_kImageFilterIndex]?.creator != value) {
+        objects[_kImageFilterIndex] = value._toNativeImageFilter();
       }
     }
   }
@@ -1427,17 +1430,17 @@ class Paint {
   /// Inverting the colors of an image applies a new color filter that will
   /// be composed with any user provided color filters. This is primarily
   /// used for implementing smart invert on iOS.
-  bool/*!*/ get invertColors {
+  bool get invertColors {
     return _data.getInt32(_kInvertColorOffset, _kFakeHostEndian) == 1;
   }
-  set invertColors(bool/*!*/ value) {
+  set invertColors(bool value) {
     _data.setInt32(_kInvertColorOffset, value ? 1 : 0, _kFakeHostEndian);
   }
 
-  bool/*!*/ get _dither {
+  bool get _dither {
     return _data.getInt32(_kDitherOffset, _kFakeHostEndian) == 1;
   }
-  set _dither(bool/*!*/ value) {
+  set _dither(bool value) {
     _data.setInt32(_kDitherOffset, value ? 1 : 0, _kFakeHostEndian);
   }
 
@@ -1456,10 +1459,10 @@ class Paint {
   ///
   /// To ensure that dithering is consistently enabled for your entire
   /// application, set this to true before invoking any drawing related code.
-  static bool/*!*/ enableDithering = false;
+  static bool enableDithering = false;
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     if (const bool.fromEnvironment('dart.vm.product', defaultValue: false)) {
       return super.toString();
     }
@@ -1487,10 +1490,7 @@ class Paint {
       semicolon = '; ';
     }
     if (color != const Color(_kColorDefault)) {
-      if (color != null)
-        result.write('$semicolon$color');
-      else
-        result.write('${semicolon}no color');
+      result.write('$semicolon$color');
       semicolon = '; ';
     }
     if (blendMode.index != _kBlendModeDefault) {
@@ -1572,16 +1572,16 @@ enum PixelFormat {
 }
 
 class _ImageInfo {
-  _ImageInfo(this.width, this.height, this.format, int/*?*/ rowBytes) : rowBytes = rowBytes ?? width * 4;
+  _ImageInfo(this.width, this.height, this.format, int? rowBytes) : rowBytes = rowBytes ?? width * 4;
 
   @pragma('vm:entry-point', 'get')
-  int/*!*/ width;
+  int width;
   @pragma('vm:entry-point', 'get')
-  int/*!*/ height;
+  int height;
   @pragma('vm:entry-point', 'get')
-  int/*!*/ format;
+  int format;
   @pragma('vm:entry-point', 'get')
-  int/*!*/ rowBytes;
+  int rowBytes;
 }
 
 /// Opaque handle to raw decoded image data (pixels).
@@ -1605,10 +1605,10 @@ class Image extends NativeFieldWrapperClass2 {
   Image._();
 
   /// The number of image pixels along the image's horizontal axis.
-  int/*!*/ get width native 'Image_width';
+  int get width native 'Image_width';
 
   /// The number of image pixels along the image's vertical axis.
-  int/*!*/ get height native 'Image_height';
+  int get height native 'Image_height';
 
   /// Converts the [Image] object into a byte array.
   ///
@@ -1617,23 +1617,23 @@ class Image extends NativeFieldWrapperClass2 {
   ///
   /// Returns a future that completes with the binary image data or an error
   /// if encoding fails.
-  Future<ByteData/*?*/>/*!*/ toByteData({ImageByteFormat/*!*/ format = ImageByteFormat.rawRgba}) {
+  Future<ByteData?> toByteData({ImageByteFormat format = ImageByteFormat.rawRgba}) {
     return _futurize((_Callback<ByteData> callback) {
-      return _toByteData(format.index, (Uint8List/*?*/ encoded) {
-        callback(encoded.buffer.asByteData());
+      return _toByteData(format.index, (Uint8List? encoded) {
+        callback(encoded!.buffer.asByteData());
       });
     });
   }
 
   /// Returns an error message on failure, null on success.
-  String/*?*/ _toByteData(int format, _Callback<Uint8List/*?*/> callback) native 'Image_toByteData';
+  String? _toByteData(int format, _Callback<Uint8List?> callback) native 'Image_toByteData';
 
   /// Release the resources used by this object. The object is no longer usable
   /// after this method is called.
   void dispose() native 'Image_dispose';
 
   @override
-  String/*!*/ toString() => '[$width\u00D7$height]';
+  String toString() => '[$width\u00D7$height]';
 }
 
 /// Callback signature for [decodeImageFromList].
@@ -1654,11 +1654,11 @@ class FrameInfo extends NativeFieldWrapperClass2 {
   FrameInfo._();
 
   /// The duration this frame should be shown.
-  Duration/*!*/ get duration => Duration(milliseconds: _durationMillis);
-  int/*!*/ get _durationMillis native 'FrameInfo_durationMillis';
+  Duration get duration => Duration(milliseconds: _durationMillis);
+  int get _durationMillis native 'FrameInfo_durationMillis';
 
   /// The [Image] object for this frame.
-  Image/*!*/ get image native 'FrameInfo_image';
+  Image get image native 'FrameInfo_image';
 }
 
 /// A handle to an image codec.
@@ -1680,20 +1680,20 @@ class Codec extends NativeFieldWrapperClass2 {
   Codec._();
 
   /// Number of frames in this image.
-  int/*!*/ get frameCount native 'Codec_frameCount';
+  int get frameCount native 'Codec_frameCount';
 
   /// Number of times to repeat the animation.
   ///
   /// * 0 when the animation should be played once.
   /// * -1 for infinity repetitions.
-  int/*!*/ get repetitionCount native 'Codec_repetitionCount';
+  int get repetitionCount native 'Codec_repetitionCount';
 
   /// Fetches the next animation frame.
   ///
   /// Wraps back to the first frame after returning the last frame.
   ///
   /// The returned future can complete with an error if the decoding has failed.
-  Future<FrameInfo/*!*/>/*!*/ getNextFrame() {
+  Future<FrameInfo> getNextFrame() {
     return _futurize(_getNextFrame);
   }
 
@@ -1719,9 +1719,9 @@ class Codec extends NativeFieldWrapperClass2 {
 ///
 /// The returned future can complete with an error if the image decoding has
 /// failed.
-Future<Codec/*!*/>/*!*/ instantiateImageCodec(Uint8List/*!*/ list, {
-  int/*?*/ targetWidth,
-  int/*?*/ targetHeight,
+Future<Codec> instantiateImageCodec(Uint8List list, {
+  int? targetWidth,
+  int? targetHeight,
 }) {
   return _futurize(
     (_Callback<Codec> callback) => _instantiateImageCodec(list, callback, null, targetWidth ?? _kDoNotResizeDimension, targetHeight ?? _kDoNotResizeDimension)
@@ -1739,7 +1739,7 @@ Future<Codec/*!*/>/*!*/ instantiateImageCodec(Uint8List/*!*/ list, {
 /// If both are equal to [_kDoNotResizeDimension], then the image maintains its real size.
 ///
 /// Returns an error message if the instantiation has failed, null otherwise.
-String/*?*/ _instantiateImageCodec(Uint8List list, _Callback<Codec/*!*/> callback, _ImageInfo imageInfo, int targetWidth, int targetHeight)
+String? _instantiateImageCodec(Uint8List list, _Callback<Codec> callback, _ImageInfo? imageInfo, int targetWidth, int targetHeight)
   native 'instantiateImageCodec';
 
 /// Loads a single image frame from a byte array into an [Image] object.
@@ -1747,12 +1747,12 @@ String/*?*/ _instantiateImageCodec(Uint8List list, _Callback<Codec/*!*/> callbac
 /// This is a convenience wrapper around [instantiateImageCodec]. Prefer using
 /// [instantiateImageCodec] which also supports multi frame images and offers
 /// better error handling. This function swallows asynchronous errors.
-void decodeImageFromList(Uint8List/*!*/ list, ImageDecoderCallback/*!*/ callback) {
+void decodeImageFromList(Uint8List list, ImageDecoderCallback callback) {
   _decodeImageFromListAsync(list, callback);
 }
 
-Future<void> _decodeImageFromListAsync(Uint8List/*!*/ list,
-                                       ImageDecoderCallback/*!*/ callback) async {
+Future<void> _decodeImageFromListAsync(Uint8List list,
+                                       ImageDecoderCallback callback) async {
   final Codec codec = await instantiateImageCodec(list);
   final FrameInfo frameInfo = await codec.getNextFrame();
   callback(frameInfo.image);
@@ -1773,12 +1773,12 @@ Future<void> _decodeImageFromListAsync(Uint8List/*!*/ list,
 /// while forcing the image to match the other given dimension. If neither is
 /// specified, then the image maintains its real size.
 void decodeImageFromPixels(
-  Uint8List/*!*/ pixels,
-  int/*!*/ width,
-  int/*!*/ height,
-  PixelFormat/*!*/ format,
-  ImageDecoderCallback/*!*/ callback,
-  {int/*?*/ rowBytes, int/*?*/ targetWidth, int/*?*/ targetHeight}
+  Uint8List pixels,
+  int width,
+  int height,
+  PixelFormat format,
+  ImageDecoderCallback callback,
+  {int? rowBytes, int? targetWidth, int? targetHeight}
 ) {
   final _ImageInfo imageInfo = _ImageInfo(width, height, format.index, rowBytes);
   final Future<Codec> codecFuture = _futurize(
@@ -1909,7 +1909,7 @@ class Path extends NativeFieldWrapperClass2 {
   ///
   /// This copy is fast and does not require additional memory unless either
   /// the `source` path or the path returned by this constructor are modified.
-  factory Path.from(Path/*!*/ source) {
+  factory Path.from(Path source) {
     final Path clonedPath = Path._();
     source._clone(clonedPath);
     return clonedPath;
@@ -1919,54 +1919,54 @@ class Path extends NativeFieldWrapperClass2 {
   /// Determines how the interior of this path is calculated.
   ///
   /// Defaults to the non-zero winding rule, [PathFillType.nonZero].
-  PathFillType/*!*/ get fillType => PathFillType.values[_getFillType()];
-  set fillType(PathFillType/*!*/ value) => _setFillType(value.index);
+  PathFillType get fillType => PathFillType.values[_getFillType()];
+  set fillType(PathFillType value) => _setFillType(value.index);
 
   int _getFillType() native 'Path_getFillType';
-  void _setFillType(int/*!*/ fillType) native 'Path_setFillType';
+  void _setFillType(int fillType) native 'Path_setFillType';
 
   /// Starts a new sub-path at the given coordinate.
-  void moveTo(double/*!*/ x, double/*!*/ y) native 'Path_moveTo';
+  void moveTo(double x, double y) native 'Path_moveTo';
 
   /// Starts a new sub-path at the given offset from the current point.
-  void relativeMoveTo(double/*!*/ dx, double/*!*/ dy) native 'Path_relativeMoveTo';
+  void relativeMoveTo(double dx, double dy) native 'Path_relativeMoveTo';
 
   /// Adds a straight line segment from the current point to the given
   /// point.
-  void lineTo(double/*!*/ x, double/*!*/ y) native 'Path_lineTo';
+  void lineTo(double x, double y) native 'Path_lineTo';
 
   /// Adds a straight line segment from the current point to the point
   /// at the given offset from the current point.
-  void relativeLineTo(double/*!*/ dx, double/*!*/ dy) native 'Path_relativeLineTo';
+  void relativeLineTo(double dx, double dy) native 'Path_relativeLineTo';
 
   /// Adds a quadratic bezier segment that curves from the current
   /// point to the given point (x2,y2), using the control point
   /// (x1,y1).
-  void quadraticBezierTo(double/*!*/ x1, double/*!*/ y1, double/*!*/ x2, double/*!*/ y2) native 'Path_quadraticBezierTo';
+  void quadraticBezierTo(double x1, double y1, double x2, double y2) native 'Path_quadraticBezierTo';
 
   /// Adds a quadratic bezier segment that curves from the current
   /// point to the point at the offset (x2,y2) from the current point,
   /// using the control point at the offset (x1,y1) from the current
   /// point.
-  void relativeQuadraticBezierTo(double/*!*/ x1, double/*!*/ y1, double/*!*/ x2, double/*!*/ y2) native 'Path_relativeQuadraticBezierTo';
+  void relativeQuadraticBezierTo(double x1, double y1, double x2, double y2) native 'Path_relativeQuadraticBezierTo';
 
   /// Adds a cubic bezier segment that curves from the current point
   /// to the given point (x3,y3), using the control points (x1,y1) and
   /// (x2,y2).
-  void cubicTo(double/*!*/ x1, double/*!*/ y1, double/*!*/ x2, double/*!*/ y2, double/*!*/ x3, double/*!*/ y3) native 'Path_cubicTo';
+  void cubicTo(double x1, double y1, double x2, double y2, double x3, double y3) native 'Path_cubicTo';
 
   /// Adds a cubic bezier segment that curves from the current point
   /// to the point at the offset (x3,y3) from the current point, using
   /// the control points at the offsets (x1,y1) and (x2,y2) from the
   /// current point.
-  void relativeCubicTo(double/*!*/ x1, double/*!*/ y1, double/*!*/ x2, double/*!*/ y2, double/*!*/ x3, double/*!*/ y3) native 'Path_relativeCubicTo';
+  void relativeCubicTo(double x1, double y1, double x2, double y2, double x3, double y3) native 'Path_relativeCubicTo';
 
   /// Adds a bezier segment that curves from the current point to the
   /// given point (x2,y2), using the control points (x1,y1) and the
   /// weight w. If the weight is greater than 1, then the curve is a
   /// hyperbola; if the weight equals 1, it's a parabola; and if it is
   /// less than 1, it is an ellipse.
-  void conicTo(double/*!*/ x1, double/*!*/ y1, double/*!*/ x2, double/*!*/ y2, double/*!*/ w) native 'Path_conicTo';
+  void conicTo(double x1, double y1, double x2, double y2, double w) native 'Path_conicTo';
 
   /// Adds a bezier segment that curves from the current point to the
   /// point at the offset (x2,y2) from the current point, using the
@@ -1974,7 +1974,7 @@ class Path extends NativeFieldWrapperClass2 {
   /// the weight w. If the weight is greater than 1, then the curve is
   /// a hyperbola; if the weight equals 1, it's a parabola; and if it
   /// is less than 1, it is an ellipse.
-  void relativeConicTo(double/*!*/ x1, double/*!*/ y1, double/*!*/ x2, double/*!*/ y2, double/*!*/ w) native 'Path_relativeConicTo';
+  void relativeConicTo(double x1, double y1, double x2, double y2, double w) native 'Path_relativeConicTo';
 
   /// If the `forceMoveTo` argument is false, adds a straight line
   /// segment and an arc segment.
@@ -1992,12 +1992,12 @@ class Path extends NativeFieldWrapperClass2 {
   ///
   /// The line segment added if `forceMoveTo` is false starts at the
   /// current point and ends at the start of the arc.
-  void arcTo(Rect/*!*/ rect, double/*!*/ startAngle, double/*!*/ sweepAngle, bool/*!*/ forceMoveTo) {
+  void arcTo(Rect rect, double startAngle, double sweepAngle, bool forceMoveTo) {
     assert(_rectIsValid(rect));
     _arcTo(rect.left, rect.top, rect.right, rect.bottom, startAngle, sweepAngle, forceMoveTo);
   }
-  void _arcTo(double/*!*/ left, double/*!*/ top, double/*!*/ right, double/*!*/ bottom,
-              double/*!*/ startAngle, double/*!*/ sweepAngle, bool/*!*/ forceMoveTo) native 'Path_arcTo';
+  void _arcTo(double left, double top, double right, double bottom,
+              double startAngle, double sweepAngle, bool forceMoveTo) native 'Path_arcTo';
 
   /// Appends up to four conic curves weighted to describe an oval of `radius`
   /// and rotated by `rotation`.
@@ -2011,20 +2011,20 @@ class Path extends NativeFieldWrapperClass2 {
   /// point in the path is `arcEnd`. The radii are scaled to fit the last path
   /// point if both are greater than zero but too small to describe an arc.
   ///
-  void arcToPoint(Offset/*!*/ arcEnd, {
-    Radius/*!*/ radius = Radius.zero,
-    double/*!*/ rotation = 0.0,
-    bool/*!*/ largeArc = false,
-    bool/*!*/ clockwise = true,
+  void arcToPoint(Offset arcEnd, {
+    Radius radius = Radius.zero,
+    double rotation = 0.0,
+    bool largeArc = false,
+    bool clockwise = true,
   }) {
     assert(_offsetIsValid(arcEnd));
     assert(_radiusIsValid(radius));
     _arcToPoint(arcEnd.dx, arcEnd.dy, radius.x, radius.y, rotation,
                 largeArc, clockwise);
   }
-  void _arcToPoint(double/*!*/ arcEndX, double/*!*/ arcEndY, double/*!*/ radiusX,
-                   double/*!*/ radiusY, double/*!*/ rotation, bool/*!*/ largeArc,
-                   bool/*!*/ clockwise) native 'Path_arcToPoint';
+  void _arcToPoint(double arcEndX, double arcEndY, double radiusX,
+                   double radiusY, double rotation, bool largeArc,
+                   bool clockwise) native 'Path_arcToPoint';
 
 
   /// Appends up to four conic curves weighted to describe an oval of `radius`
@@ -2041,11 +2041,11 @@ class Path extends NativeFieldWrapperClass2 {
   /// `arcEndDelta.dx` and `arcEndDelta.dy` are zero. The radii are scaled to
   /// fit the last path point if both are greater than zero but too small to
   /// describe an arc.
-  void relativeArcToPoint(Offset/*!*/ arcEndDelta, {
-    Radius/*!*/ radius = Radius.zero,
-    double/*!*/ rotation = 0.0,
-    bool/*!*/ largeArc = false,
-    bool/*!*/ clockwise = true,
+  void relativeArcToPoint(Offset arcEndDelta, {
+    Radius radius = Radius.zero,
+    double rotation = 0.0,
+    bool largeArc = false,
+    bool clockwise = true,
   }) {
     assert(_offsetIsValid(arcEndDelta));
     assert(_radiusIsValid(radius));
@@ -2059,7 +2059,7 @@ class Path extends NativeFieldWrapperClass2 {
 
   /// Adds a new sub-path that consists of four lines that outline the
   /// given rectangle.
-  void addRect(Rect/*!*/ rect) {
+  void addRect(Rect rect) {
     assert(_rectIsValid(rect));
     _addRect(rect.left, rect.top, rect.right, rect.bottom);
   }
@@ -2070,7 +2070,7 @@ class Path extends NativeFieldWrapperClass2 {
   ///
   /// To add a circle, pass an appropriate rectangle as `oval`. [Rect.fromCircle]
   /// can be used to easily describe the circle's center [Offset] and radius.
-  void addOval(Rect/*!*/ oval) {
+  void addOval(Rect oval) {
     assert(_rectIsValid(oval));
     _addOval(oval.left, oval.top, oval.right, oval.bottom);
   }
@@ -2084,7 +2084,7 @@ class Path extends NativeFieldWrapperClass2 {
   /// crosses the horizontal line that intersects the center of the
   /// rectangle and with positive angles going clockwise around the
   /// oval.
-  void addArc(Rect/*!*/ oval, double/*!*/ startAngle, double/*!*/ sweepAngle) {
+  void addArc(Rect oval, double startAngle, double sweepAngle) {
     assert(_rectIsValid(oval));
     _addArc(oval.left, oval.top, oval.right, oval.bottom, startAngle, sweepAngle);
   }
@@ -2098,8 +2098,8 @@ class Path extends NativeFieldWrapperClass2 {
   /// last point to the first point.
   ///
   /// The `points` argument is interpreted as offsets from the origin.
-  void addPolygon(List<Offset/*!*/>/*!*/ points, bool/*!*/ close) {
-    assert(points != null);
+  void addPolygon(List<Offset> points, bool close) {
+    assert(points != null); // ignore: unnecessary_null_comparison
     _addPolygon(_encodePointList(points), close);
   }
   void _addPolygon(Float32List points, bool close) native 'Path_addPolygon';
@@ -2107,7 +2107,7 @@ class Path extends NativeFieldWrapperClass2 {
   /// Adds a new sub-path that consists of the straight lines and
   /// curves needed to form the rounded rectangle described by the
   /// argument.
-  void addRRect(RRect/*!*/ rrect) {
+  void addRRect(RRect rrect) {
     assert(_rrectIsValid(rrect));
     _addRRect(rrect._value32);
   }
@@ -2119,7 +2119,8 @@ class Path extends NativeFieldWrapperClass2 {
   /// If `matrix4` is specified, the path will be transformed by this matrix
   /// after the matrix is translated by the given offset. The matrix is a 4x4
   /// matrix stored in column major order.
-  void addPath(Path/*!*/ path, Offset/*!*/ offset, {Float64List/*?*/ matrix4}) {
+  void addPath(Path path, Offset offset, {Float64List? matrix4}) {
+    // ignore: unnecessary_null_comparison
     assert(path != null); // path is checked on the engine side
     assert(_offsetIsValid(offset));
     if (matrix4 != null) {
@@ -2138,7 +2139,8 @@ class Path extends NativeFieldWrapperClass2 {
   /// If `matrix4` is specified, the path will be transformed by this matrix
   /// after the matrix is translated by the given `offset`.  The matrix is a 4x4
   /// matrix stored in column major order.
-  void extendWithPath(Path/*!*/ path, Offset/*!*/ offset, {Float64List/*?*/ matrix4}) {
+  void extendWithPath(Path path, Offset offset, {Float64List? matrix4}) {
+    // ignore: unnecessary_null_comparison
     assert(path != null); // path is checked on the engine side
     assert(_offsetIsValid(offset));
     if (matrix4 != null) {
@@ -2167,7 +2169,7 @@ class Path extends NativeFieldWrapperClass2 {
   /// The `point` argument is interpreted as an offset from the origin.
   ///
   /// Returns true if the point is in the path, and false otherwise.
-  bool/*!*/ contains(Offset/*!*/ point) {
+  bool contains(Offset point) {
     assert(_offsetIsValid(point));
     return _contains(point.dx, point.dy);
   }
@@ -2175,7 +2177,7 @@ class Path extends NativeFieldWrapperClass2 {
 
   /// Returns a copy of the path with all the segments of every
   /// sub-path translated by the given offset.
-  Path/*!*/ shift(Offset/*!*/ offset) {
+  Path shift(Offset offset) {
     assert(_offsetIsValid(offset));
     final Path path = Path._();
     _shift(path, offset.dx, offset.dy);
@@ -2185,7 +2187,7 @@ class Path extends NativeFieldWrapperClass2 {
 
   /// Returns a copy of the path with all the segments of every
   /// sub-path transformed by the given matrix.
-  Path/*!*/ transform(Float64List/*!*/ matrix4) {
+  Path transform(Float64List matrix4) {
     assert(_matrix4IsValid(matrix4));
     final Path path = Path._();
     _transform(path, matrix4);
@@ -2208,7 +2210,7 @@ class Path extends NativeFieldWrapperClass2 {
   /// therefore ends up grossly overestimating the actual area covered by the
   /// circle.
   // see https://skia.org/user/api/SkPath_Reference#SkPath_getBounds
-  Rect/*!*/ getBounds() {
+  Rect getBounds() {
     final Float32List rect = _getBounds();
     return Rect.fromLTRB(rect[0], rect[1], rect[2], rect[3]);
   }
@@ -2220,16 +2222,16 @@ class Path extends NativeFieldWrapperClass2 {
   /// The resulting path will be constructed from non-overlapping contours. The
   /// curve order is reduced where possible so that cubics may be turned into
   /// quadratics, and quadratics maybe turned into lines.
-  static Path/*!*/ combine(PathOperation/*!*/ operation, Path/*!*/ path1, Path/*!*/ path2) {
-    assert(path1 != null);
-    assert(path2 != null);
+  static Path combine(PathOperation operation, Path path1, Path path2) {
+    assert(path1 != null); // ignore: unnecessary_null_comparison
+    assert(path2 != null); // ignore: unnecessary_null_comparison
     final Path path = Path();
     if (path._op(path1, path2, operation.index)) {
       return path;
     }
     throw StateError('Path.combine() failed.  This may be due an invalid path; in particular, check for NaN values.');
   }
-  bool/*!*/ _op(Path/*!*/ path1, Path/*!*/ path2, int/*!*/ operation) native 'Path_op';
+  bool _op(Path path1, Path path2, int operation) native 'Path_op';
 
   /// Creates a [PathMetrics] object for this path, which can describe various
   /// properties about the contours of the path.
@@ -2262,7 +2264,7 @@ class Path extends NativeFieldWrapperClass2 {
   ///
   /// If `forceClosed` is set to true, the contours of the path will be measured
   /// as if they had been closed, even if they were not explicitly closed.
-  PathMetrics/*!*/ computeMetrics({bool/*!*/ forceClosed = false}) {
+  PathMetrics computeMetrics({bool forceClosed = false}) {
     return PathMetrics._(this, forceClosed);
   }
 }
@@ -2276,14 +2278,14 @@ class Tangent {
   ///
   /// The arguments must not be null.
   const Tangent(this.position, this.vector)
-    : assert(position != null),
-      assert(vector != null);
+    : assert(position != null), // ignore: unnecessary_null_comparison
+      assert(vector != null); // ignore: unnecessary_null_comparison
 
   /// Creates a [Tangent] based on the angle rather than the vector.
   ///
   /// The [vector] is computed to be the unit vector at the given angle, interpreted
   /// as clockwise radians from the x axis.
-  factory Tangent.fromAngle(Offset/*!*/ position, double/*!*/ angle) {
+  factory Tangent.fromAngle(Offset position, double angle) {
     return Tangent(position, Offset(math.cos(angle), math.sin(angle)));
   }
 
@@ -2291,14 +2293,14 @@ class Tangent {
   ///
   /// When used with [PathMetric.getTangentForOffset], this represents the precise
   /// position that the given offset along the path corresponds to.
-  final Offset/*!*/ position;
+  final Offset position;
 
   /// The vector of the curve at [position].
   ///
   /// When used with [PathMetric.getTangentForOffset], this is the vector of the
   /// curve that is at the given offset along the path (i.e. the direction of the
   /// curve at [position]).
-  final Offset/*!*/ vector;
+  final Offset vector;
 
   /// The direction of the curve at [position].
   ///
@@ -2312,7 +2314,7 @@ class Tangent {
   /// pointing upward toward the positive y-axis, i.e. in a counter-clockwise
   /// direction.
   // flip the sign to be consistent with [Path.arcTo]'s `sweepAngle`
-  double/*!*/ get angle => -math.atan2(vector.dy, vector.dx);
+  double get angle => -math.atan2(vector.dy, vector.dx);
 }
 
 /// An iterable collection of [PathMetric] objects describing a [Path].
@@ -2330,29 +2332,35 @@ class Tangent {
 /// This iterable does not memoize. Callers who need to traverse the list
 /// multiple times, or who need to randomly access elements of the list, should
 /// use [toList] on this object.
-class PathMetrics extends collection.IterableBase<PathMetric/*!*/> {
+class PathMetrics extends collection.IterableBase<PathMetric> {
   PathMetrics._(Path path, bool forceClosed) :
     _iterator = PathMetricIterator._(_PathMeasure(path, forceClosed));
 
-  final Iterator<PathMetric/*!*/>/*!*/ _iterator;
+  final Iterator<PathMetric> _iterator;
 
   @override
-  Iterator<PathMetric/*!*/>/*!*/ get iterator => _iterator;
+  Iterator<PathMetric> get iterator => _iterator;
 }
 
 /// Used by [PathMetrics] to track iteration from one segment of a path to the
 /// next for measurement.
 class PathMetricIterator implements Iterator<PathMetric> {
-  PathMetricIterator._(this._pathMeasure) : assert(_pathMeasure != null);
+  PathMetricIterator._(this._pathMeasure) : assert(_pathMeasure != null); // ignore: unnecessary_null_comparison
 
-  PathMetric/*?*/ _pathMetric;
-  _PathMeasure/*!*/ _pathMeasure;
-
-  @override
-  PathMetric/*?*/ get current => _pathMetric;
+  PathMetric? _pathMetric;
+  _PathMeasure _pathMeasure;
 
   @override
-  bool/*!*/ moveNext() {
+  PathMetric get current {
+    final PathMetric? currentMetric = _pathMetric;
+    if (currentMetric == null) {
+      throw RangeError('No more path metrics.');
+    }
+    return currentMetric;
+  }
+
+  @override
+  bool moveNext() {
     if (_pathMeasure._nextContour()) {
       _pathMetric = PathMetric._(_pathMeasure);
       return true;
@@ -2377,13 +2385,13 @@ class PathMetricIterator implements Iterator<PathMetric> {
 /// the path.
 class PathMetric {
   PathMetric._(this._measure)
-    : assert(_measure != null),
+    : assert(_measure != null), // ignore: unnecessary_null_comparison
       length = _measure.length(_measure.currentContourIndex),
       isClosed = _measure.isClosed(_measure.currentContourIndex),
       contourIndex = _measure.currentContourIndex;
 
   /// Return the total length of the current contour.
-  final double/*!*/ length;
+  final double length;
 
   /// Whether the contour is closed.
   ///
@@ -2391,7 +2399,7 @@ class PathMetric {
   /// have been implied when using methods like [Path.addRect]) or if
   /// `forceClosed` was specified as true in the call to [Path.computeMetrics].
   /// Returns false otherwise.
-  final bool/*!*/ isClosed;
+  final bool isClosed;
 
   /// The zero-based index of the contour.
   ///
@@ -2405,9 +2413,9 @@ class PathMetric {
   /// the contours of the path at the time the path's metrics were computed. If
   /// additional contours were added or existing contours updated, this metric
   /// will be invalid for the current state of the path.
-  final int/*!*/ contourIndex;
+  final int contourIndex;
 
-  final _PathMeasure/*!*/ _measure;
+  final _PathMeasure _measure;
 
 
   /// Computes the position of the current contour at the given offset, and the
@@ -2420,7 +2428,7 @@ class PathMetric {
   /// Returns null if the contour has zero [length].
   ///
   /// The distance is clamped to the [length] of the current contour.
-  Tangent/*?*/ getTangentForOffset(double/*!*/ distance) {
+  Tangent? getTangentForOffset(double distance) {
     return _measure.getTangentForOffset(contourIndex, distance);
   }
 
@@ -2429,17 +2437,16 @@ class PathMetric {
   /// `start` and `end` are clamped to legal values (0..[length])
   /// Returns null if the segment is 0 length or `start` > `stop`.
   /// Begin the segment with a moveTo if `startWithMoveTo` is true.
-  Path/*?*/ extractPath(double/*!*/ start, double/*!*/ end, {bool/*!*/ startWithMoveTo = true}) {
+  Path? extractPath(double start, double end, {bool startWithMoveTo = true}) {
     return _measure.extractPath(contourIndex, start, end, startWithMoveTo: startWithMoveTo);
   }
 
   @override
-  String/*!*/ toString() => '$runtimeType{length: $length, isClosed: $isClosed, contourIndex:$contourIndex}';
+  String toString() => '$runtimeType{length: $length, isClosed: $isClosed, contourIndex:$contourIndex}';
 }
 
 class _PathMeasure extends NativeFieldWrapperClass2 {
   _PathMeasure(Path path, bool forceClosed) {
-    currentContourIndex = -1; // nextContour will increment this to the zero based index.
     _constructor(path, forceClosed);
   }
   void _constructor(Path path, bool forceClosed) native 'PathMeasure_constructor';
@@ -2450,7 +2457,7 @@ class _PathMeasure extends NativeFieldWrapperClass2 {
   }
   double _length(int contourIndex) native 'PathMeasure_getLength';
 
-  Tangent/*?*/ getTangentForOffset(int contourIndex, double distance) {
+  Tangent? getTangentForOffset(int contourIndex, double distance) {
     assert(contourIndex <= currentContourIndex, 'Iterator must be advanced before index $contourIndex can be used.');
     final Float32List posTan = _getPosTan(contourIndex, distance);
     // first entry == 0 indicates that Skia returned false
@@ -2492,7 +2499,10 @@ class _PathMeasure extends NativeFieldWrapperClass2 {
   }
   bool _nativeNextContour() native 'PathMeasure_nextContour';
 
-  int currentContourIndex;
+  /// The index of the current contour in the list of contours in the path.
+  ///
+  /// [nextContour] will increment this to the zero based index.
+  int currentContourIndex = -1;
 }
 
 /// Styles to use for blurs in [MaskFilter] objects.
@@ -2546,11 +2556,11 @@ class MaskFilter {
   const MaskFilter.blur(
     this._style,
     this._sigma,
-  ) : assert(_style != null),
-      assert(_sigma != null);
+  ) : assert(_style != null), // ignore: unnecessary_null_comparison
+      assert(_sigma != null); // ignore: unnecessary_null_comparison
 
-  final BlurStyle/*!*/ _style;
-  final double/*!*/ _sigma;
+  final BlurStyle _style;
+  final double _sigma;
 
   // The type of MaskFilter class to create for Skia.
   // These constants must be kept in sync with MaskFilterType in paint.cc.
@@ -2558,17 +2568,17 @@ class MaskFilter {
   static const int _TypeBlur = 1; // SkBlurMaskFilter
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     return other is MaskFilter
         && other._style == _style
         && other._sigma == _sigma;
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(_style, _sigma);
+  int get hashCode => hashValues(_style, _sigma);
 
   @override
-  String/*!*/ toString() => 'MaskFilter.blur($_style, ${_sigma.toStringAsFixed(1)})';
+  String toString() => 'MaskFilter.blur($_style, ${_sigma.toStringAsFixed(1)})';
 }
 
 /// A description of a color filter to apply when drawing a shape or compositing
@@ -2587,7 +2597,7 @@ class ColorFilter {
   /// The output of this filter is then composited into the background according
   /// to the [Paint.blendMode], using the output of this filter as the source
   /// and the background as the destination.
-  const ColorFilter.mode(Color/*!*/ color, BlendMode/*!*/ blendMode)
+  const ColorFilter.mode(Color color, BlendMode blendMode)
       : _color = color,
         _blendMode = blendMode,
         _matrix = null,
@@ -2653,7 +2663,7 @@ class ColorFilter {
   ///   0,      0,      0,      1, 0,
   /// ]);
   /// ```
-  const ColorFilter.matrix(List<double/*!*/>/*!*/ matrix)
+  const ColorFilter.matrix(List<double> matrix)
       : _color = null,
         _blendMode = null,
         _matrix = matrix,
@@ -2675,9 +2685,9 @@ class ColorFilter {
         _matrix = null,
         _type = _TypeSrgbToLinearGamma;
 
-  final Color _color;
-  final BlendMode _blendMode;
-  final List<double> _matrix;
+  final Color? _color;
+  final BlendMode? _blendMode;
+  final List<double>? _matrix;
   final int _type;
 
   // The type of SkColorFilter class to create for Skia.
@@ -2687,7 +2697,7 @@ class ColorFilter {
   static const int _TypeSrgbToLinearGamma = 4; // MakeSRGBToLinearGamma
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     return other is ColorFilter
         && other._type == _type
         && _listEquals<double>(other._matrix, _matrix)
@@ -2695,7 +2705,7 @@ class ColorFilter {
         && other._blendMode == _blendMode;
   }
 
-  _ColorFilter/*?*/ _toNativeColorFilter() {
+  _ColorFilter? _toNativeColorFilter() {
     switch (_type) {
       case _TypeMode:
         if (_color == null || _blendMode == null) {
@@ -2706,7 +2716,7 @@ class ColorFilter {
         if (_matrix == null) {
           return null;
         }
-        assert(_matrix.length == 20, 'Color Matrix must have 20 entries.');
+        assert(_matrix!.length == 20, 'Color Matrix must have 20 entries.');
         return _ColorFilter.matrix(this);
       case _TypeLinearToSrgbGamma:
         return _ColorFilter.linearToSrgbGamma(this);
@@ -2718,10 +2728,10 @@ class ColorFilter {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(_color, _blendMode, hashList(_matrix), _type);
+  int get hashCode => hashValues(_color, _blendMode, hashList(_matrix), _type);
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     switch (_type) {
       case _TypeMode:
         return 'ColorFilter.mode($_color, $_blendMode)';
@@ -2745,27 +2755,27 @@ class ColorFilter {
 /// avoid repainting.
 class _ColorFilter extends NativeFieldWrapperClass2 {
   _ColorFilter.mode(this.creator)
-    : assert(creator != null),
+    : assert(creator != null), // ignore: unnecessary_null_comparison
       assert(creator._type == ColorFilter._TypeMode) {
     _constructor();
-    _initMode(creator._color.value, creator._blendMode.index);
+    _initMode(creator._color!.value, creator._blendMode!.index);
   }
 
   _ColorFilter.matrix(this.creator)
-    : assert(creator != null),
+    : assert(creator != null), // ignore: unnecessary_null_comparison
       assert(creator._type == ColorFilter._TypeMatrix) {
     _constructor();
-    _initMatrix(Float32List.fromList(creator._matrix));
+    _initMatrix(Float32List.fromList(creator._matrix!));
   }
   _ColorFilter.linearToSrgbGamma(this.creator)
-    : assert(creator != null),
+    : assert(creator != null), // ignore: unnecessary_null_comparison
       assert(creator._type == ColorFilter._TypeLinearToSrgbGamma) {
     _constructor();
     _initLinearToSrgbGamma();
   }
 
   _ColorFilter.srgbToLinearGamma(this.creator)
-    : assert(creator != null),
+    : assert(creator != null), // ignore: unnecessary_null_comparison
       assert(creator._type == ColorFilter._TypeSrgbToLinearGamma) {
     _constructor();
     _initSrgbToLinearGamma();
@@ -2794,7 +2804,7 @@ class _ColorFilter extends NativeFieldWrapperClass2 {
 ///    this class as a child layer filter.
 class ImageFilter {
   /// Creates an image filter that applies a Gaussian blur.
-  ImageFilter.blur({ double/*!*/ sigmaX = 0.0, double/*!*/ sigmaY = 0.0 })
+  ImageFilter.blur({ double sigmaX = 0.0, double sigmaY = 0.0 })
       : _data = _makeList(sigmaX, sigmaY),
         _filterQuality = null,
         _type = _kTypeBlur;
@@ -2803,8 +2813,8 @@ class ImageFilter {
   ///
   /// For example, applying a positive scale matrix (see [Matrix4.diagonal3])
   /// when used with [BackdropFilter] would magnify the background image.
-  ImageFilter.matrix(Float64List/*!*/ matrix4,
-                     { FilterQuality/*!*/ filterQuality = FilterQuality.low })
+  ImageFilter.matrix(Float64List matrix4,
+                     { FilterQuality filterQuality = FilterQuality.low })
       : _data = Float64List.fromList(matrix4),
         _filterQuality = filterQuality,
         _type = _kTypeMatrix {
@@ -2814,17 +2824,15 @@ class ImageFilter {
 
   static Float64List _makeList(double a, double b) {
     final Float64List list = Float64List(2);
-    if (a != null)
-      list[0] = a;
-    if (b != null)
-      list[1] = b;
+    list[0] = a;
+    list[1] = b;
     return list;
   }
 
-  final Float64List/*!*/ _data;
-  final FilterQuality/*?*/ _filterQuality;
-  final int/*!*/ _type;
-  _ImageFilter/*?*/ _nativeFilter;
+  final Float64List _data;
+  final FilterQuality? _filterQuality;
+  final int _type;
+  _ImageFilter? _nativeFilter;
 
   // The type of SkImageFilter class to create for Skia.
   static const int _kTypeBlur = 0;   // MakeBlurFilter
@@ -2841,9 +2849,6 @@ class ImageFilter {
   _ImageFilter _toNativeImageFilter() => _nativeFilter ??= _makeNativeImageFilter();
 
   _ImageFilter _makeNativeImageFilter() {
-    if (_data == null) {
-      return null;
-    }
     switch (_type) {
       case _kTypeBlur:
         return _ImageFilter.blur(this);
@@ -2855,10 +2860,10 @@ class ImageFilter {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(_filterQuality, hashList(_data), _type);
+  int get hashCode => hashValues(_filterQuality, hashList(_data), _type);
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     switch (_type) {
       case _kTypeBlur:
         return 'ImageFilter.blur(${_data[0]}, ${_data[1]})';
@@ -2880,7 +2885,7 @@ class _ImageFilter extends NativeFieldWrapperClass2 {
 
   /// Creates an image filter that applies a Gaussian blur.
   _ImageFilter.blur(this.creator)
-    : assert(creator != null),
+    : assert(creator != null), // ignore: unnecessary_null_comparison
       assert(creator._type == ImageFilter._kTypeBlur) {
     _constructor();
     _initBlur(creator._data[0], creator._data[1]);
@@ -2892,18 +2897,18 @@ class _ImageFilter extends NativeFieldWrapperClass2 {
   /// For example, applying a positive scale matrix (see [Matrix4.diagonal3])
   /// when used with [BackdropFilter] would magnify the background image.
   _ImageFilter.matrix(this.creator)
-    : assert(creator != null),
+    : assert(creator != null), // ignore: unnecessary_null_comparison
       assert(creator._type == ImageFilter._kTypeMatrix) {
     if (creator._data.length != 16)
       throw ArgumentError('"matrix4" must have 16 entries.');
     _constructor();
-    _initMatrix(creator._data, creator._filterQuality.index);
+    _initMatrix(creator._data, creator._filterQuality!.index);
   }
   void _initMatrix(Float64List matrix4, int filterQuality) native 'ImageFilter_initMatrix';
 
   /// The original Dart object that created the native wrapper, which retains
   /// the values used for the filter.
-  final ImageFilter/*!*/ creator;
+  final ImageFilter creator;
 }
 
 /// Base class for objects such as [Gradient] and [ImageShader] which
@@ -2966,7 +2971,7 @@ enum TileMode {
   mirror,
 }
 
-Int32List/*!*/ _encodeColorList(List<Color/*!*/>/*!*/ colors) {
+Int32List _encodeColorList(List<Color> colors) {
   final int colorCount = colors.length;
   final Int32List result = Int32List(colorCount);
   for (int i = 0; i < colorCount; ++i)
@@ -2974,8 +2979,8 @@ Int32List/*!*/ _encodeColorList(List<Color/*!*/>/*!*/ colors) {
   return result;
 }
 
-Float32List/*!*/ _encodePointList(List<Offset/*!*/>/*!*/ points) {
-  assert(points != null);
+Float32List _encodePointList(List<Offset> points) {
+  assert(points != null); // ignore: unnecessary_null_comparison
   final int pointCount = points.length;
   final Float32List result = Float32List(pointCount * 2);
   for (int i = 0; i < pointCount; ++i) {
@@ -2989,7 +2994,7 @@ Float32List/*!*/ _encodePointList(List<Offset/*!*/>/*!*/ points) {
   return result;
 }
 
-Float32List/*!*/ _encodeTwoPoints(Offset/*!*/ pointA, Offset/*!*/ pointB) {
+Float32List _encodeTwoPoints(Offset pointA, Offset pointB) {
   assert(_offsetIsValid(pointA));
   assert(_offsetIsValid(pointB));
   final Float32List result = Float32List(4);
@@ -3035,26 +3040,26 @@ class Gradient extends Shader {
   /// specified 4x4 matrix relative to the local coordinate system. `matrix4` must
   /// be a column-major matrix packed into a list of 16 values.
   Gradient.linear(
-    Offset/*!*/ from,
-    Offset/*!*/ to,
-    List<Color/*!*/>/*!*/ colors, [
-    List<double/*!*/>/*?*/ colorStops,
-    TileMode/*!*/ tileMode = TileMode.clamp,
-    Float64List/*?*/ matrix4,
+    Offset from,
+    Offset to,
+    List<Color> colors, [
+    List<double>? colorStops,
+    TileMode tileMode = TileMode.clamp,
+    Float64List? matrix4,
   ]) : assert(_offsetIsValid(from)),
        assert(_offsetIsValid(to)),
-       assert(colors != null),
-       assert(tileMode != null),
-       assert(matrix4 == null || _matrix4IsValid(matrix4)),
+       assert(colors != null), // ignore: unnecessary_null_comparison
+       assert(tileMode != null), // ignore: unnecessary_null_comparison
+       assert(matrix4 == null || _matrix4IsValid(matrix4)), // ignore: unnecessary_null_comparison
        super._() {
     _validateColorStops(colors, colorStops);
     final Float32List endPointsBuffer = _encodeTwoPoints(from, to);
     final Int32List colorsBuffer = _encodeColorList(colors);
-    final Float32List colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
+    final Float32List? colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
     _constructor();
     _initLinear(endPointsBuffer, colorsBuffer, colorStopsBuffer, tileMode.index, matrix4);
   }
-  void _initLinear(Float32List endPoints, Int32List colors, Float32List colorStops, int tileMode, Float64List matrix4) native 'Gradient_initLinear';
+  void _initLinear(Float32List endPoints, Int32List colors, Float32List? colorStops, int tileMode, Float64List? matrix4) native 'Gradient_initLinear';
 
   /// Creates a radial gradient centered at `center` that ends at `radius`
   /// distance from the center.
@@ -3086,23 +3091,23 @@ class Gradient extends Shader {
   /// provided and not equal to `center`, at least one of the two offsets must
   /// not be equal to [Offset.zero].
   Gradient.radial(
-    Offset/*!*/ center,
-    double/*!*/ radius,
-    List<Color/*!*/>/*!*/ colors, [
-    List<double/*!*/>/*?*/ colorStops,
-    TileMode/*!*/ tileMode = TileMode.clamp,
-    Float64List/*?*/ matrix4,
-    Offset/*?*/ focal,
-    double/*!*/ focalRadius = 0.0
+    Offset center,
+    double radius,
+    List<Color> colors, [
+    List<double>? colorStops,
+    TileMode tileMode = TileMode.clamp,
+    Float64List? matrix4,
+    Offset? focal,
+    double focalRadius = 0.0
   ]) : assert(_offsetIsValid(center)),
-       assert(colors != null),
-       assert(tileMode != null),
+       assert(colors != null), // ignore: unnecessary_null_comparison
+       assert(tileMode != null), // ignore: unnecessary_null_comparison
        assert(matrix4 == null || _matrix4IsValid(matrix4)),
        super._() {
-    focalRadius ??= 0.0;
+    focalRadius ??= 0.0; // ignore: dead_null_aware_expression
     _validateColorStops(colors, colorStops);
     final Int32List colorsBuffer = _encodeColorList(colors);
-    final Float32List colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
+    final Float32List? colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
 
     // If focal is null or focal radius is null, this should be treated as a regular radial gradient
     // If focal == center and the focal radius is 0.0, it's still a regular radial gradient
@@ -3115,8 +3120,8 @@ class Gradient extends Shader {
       _initConical(focal.dx, focal.dy, focalRadius, center.dx, center.dy, radius, colorsBuffer, colorStopsBuffer, tileMode.index, matrix4);
     }
   }
-  void _initRadial(double centerX, double centerY, double radius, Int32List colors, Float32List colorStops, int tileMode, Float64List matrix4) native 'Gradient_initRadial';
-  void _initConical(double startX, double startY, double startRadius, double endX, double endY, double endRadius, Int32List colors, Float32List colorStops, int tileMode, Float64List matrix4) native 'Gradient_initTwoPointConical';
+  void _initRadial(double centerX, double centerY, double radius, Int32List colors, Float32List? colorStops, int tileMode, Float64List? matrix4) native 'Gradient_initRadial';
+  void _initConical(double startX, double startY, double startRadius, double endX, double endY, double endRadius, Int32List colors, Float32List? colorStops, int tileMode, Float64List? matrix4) native 'Gradient_initTwoPointConical';
 
   /// Creates a sweep gradient centered at `center` that starts at `startAngle`
   /// and ends at `endAngle`.
@@ -3145,30 +3150,30 @@ class Gradient extends Shader {
   /// specified 4x4 matrix relative to the local coordinate system. `matrix4` must
   /// be a column-major matrix packed into a list of 16 values.
   Gradient.sweep(
-    Offset/*!*/ center,
-    List<Color/*!*/>/*!*/ colors, [
-    List<double/*!*/>/*?*/ colorStops,
+    Offset center,
+    List<Color> colors, [
+    List<double>? colorStops,
     TileMode tileMode = TileMode.clamp,
     double startAngle/*?*/ = 0.0,
     double endAngle/*!*/ = math.pi * 2,
-    Float64List/*?*/ matrix4,
+    Float64List? matrix4,
   ]) : assert(_offsetIsValid(center)),
-       assert(colors != null),
-       assert(tileMode != null),
-       assert(startAngle != null),
-       assert(endAngle != null),
+       assert(colors != null), // ignore: unnecessary_null_comparison
+       assert(tileMode != null), // ignore: unnecessary_null_comparison
+       assert(startAngle != null), // ignore: unnecessary_null_comparison
+       assert(endAngle != null), // ignore: unnecessary_null_comparison
        assert(startAngle < endAngle),
        assert(matrix4 == null || _matrix4IsValid(matrix4)),
        super._() {
     _validateColorStops(colors, colorStops);
     final Int32List colorsBuffer = _encodeColorList(colors);
-    final Float32List colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
+    final Float32List? colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);
     _constructor();
     _initSweep(center.dx, center.dy, colorsBuffer, colorStopsBuffer, tileMode.index, startAngle, endAngle, matrix4);
   }
-  void _initSweep(double centerX, double centerY, Int32List colors, Float32List colorStops, int tileMode, double startAngle, double endAngle, Float64List matrix) native 'Gradient_initSweep';
+  void _initSweep(double centerX, double centerY, Int32List colors, Float32List? colorStops, int tileMode, double startAngle, double endAngle, Float64List? matrix) native 'Gradient_initSweep';
 
-  static void _validateColorStops(List<Color> colors, List<double> colorStops) {
+  static void _validateColorStops(List<Color> colors, List<double>? colorStops) {
     if (colorStops == null) {
       if (colors.length != 2)
         throw ArgumentError('"colors" must have length 2 if "colorStops" is omitted.');
@@ -3187,11 +3192,12 @@ class ImageShader extends Shader {
   /// matrix to apply to the effect. All the arguments are required and must not
   /// be null.
   @pragma('vm:entry-point')
-  ImageShader(Image/*!*/ image, TileMode/*!*/ tmx, TileMode/*!*/ tmy, Float64List/*!*/ matrix4) :
+  ImageShader(Image image, TileMode tmx, TileMode tmy, Float64List matrix4) :
+    // ignore: unnecessary_null_comparison
     assert(image != null), // image is checked on the engine side
-    assert(tmx != null),
-    assert(tmy != null),
-    assert(matrix4 != null),
+    assert(tmx != null), // ignore: unnecessary_null_comparison
+    assert(tmy != null), // ignore: unnecessary_null_comparison
+    assert(matrix4 != null), // ignore: unnecessary_null_comparison
     super._() {
     if (matrix4.length != 16)
       throw ArgumentError('"matrix4" must have 16 entries.');
@@ -3229,13 +3235,13 @@ class Vertices extends NativeFieldWrapperClass2 {
   /// If the [indices] parameter is provided, all values in the list must be
   /// valid index values for [positions].
   Vertices(
-    VertexMode/*!*/ mode,
-    List<Offset/*!*/>/*!*/ positions, {
-    List<Offset/*!*/>/*?*/ textureCoordinates,
-    List<Color/*!*/>/*?*/ colors,
-    List<int/*!*/>/*?*/ indices,
-  }) : assert(mode != null),
-       assert(positions != null) {
+    VertexMode mode,
+    List<Offset> positions, {
+    List<Offset>? textureCoordinates,
+    List<Color>? colors,
+    List<int>? indices,
+  }) : assert(mode != null), // ignore: unnecessary_null_comparison
+       assert(positions != null) { // ignore: unnecessary_null_comparison
     if (textureCoordinates != null && textureCoordinates.length != positions.length)
       throw ArgumentError('"positions" and "textureCoordinates" lengths must match.');
     if (colors != null && colors.length != positions.length)
@@ -3244,13 +3250,13 @@ class Vertices extends NativeFieldWrapperClass2 {
       throw ArgumentError('"indices" values must be valid indices in the positions list.');
 
     final Float32List encodedPositions = _encodePointList(positions);
-    final Float32List encodedTextureCoordinates = (textureCoordinates != null)
+    final Float32List? encodedTextureCoordinates = (textureCoordinates != null)
       ? _encodePointList(textureCoordinates)
       : null;
-    final Int32List encodedColors = colors != null
+    final Int32List? encodedColors = colors != null
       ? _encodeColorList(colors)
       : null;
-    final Uint16List encodedIndices = indices != null
+    final Uint16List? encodedIndices = indices != null
       ? Uint16List.fromList(indices)
       : null;
 
@@ -3277,13 +3283,13 @@ class Vertices extends NativeFieldWrapperClass2 {
   /// If the [indices] list is provided, all values in the list must be
   /// valid index values for [positions].
   Vertices.raw(
-    VertexMode/*!*/ mode,
-    Float32List/*!*/ positions, {
-    Float32List/*?*/ textureCoordinates,
-    Int32List/*?*/ colors,
-    Uint16List/*?*/ indices,
-  }) : assert(mode != null),
-       assert(positions != null) {
+    VertexMode mode,
+    Float32List positions, {
+    Float32List? textureCoordinates,
+    Int32List? colors,
+    Uint16List? indices,
+  }) : assert(mode != null), // ignore: unnecessary_null_comparison
+       assert(positions != null) { // ignore: unnecessary_null_comparison
     if (textureCoordinates != null && textureCoordinates.length != positions.length)
       throw ArgumentError('"positions" and "textureCoordinates" lengths must match.');
     if (colors != null && colors.length * 2 != positions.length)
@@ -3298,9 +3304,9 @@ class Vertices extends NativeFieldWrapperClass2 {
   bool _init(Vertices outVertices,
              int mode,
              Float32List positions,
-             Float32List textureCoordinates,
-             Int32List colors,
-             Uint16List indices) native 'Vertices_init';
+             Float32List? textureCoordinates,
+             Int32List? colors,
+             Uint16List? indices) native 'Vertices_init';
 }
 
 /// Defines how a list of points is interpreted when drawing a set of points.
@@ -3378,7 +3384,7 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// To end the recording, call [PictureRecorder.endRecording] on the
   /// given recorder.
   @pragma('vm:entry-point')
-  Canvas(PictureRecorder/*!*/ recorder, [ Rect/*?*/ cullRect ]) : assert(recorder != null) {
+  Canvas(PictureRecorder recorder, [ Rect? cullRect ]) : assert(recorder != null) { // ignore: unnecessary_null_comparison
     if (recorder.isRecording)
       throw ArgumentError('"recorder" must not already be associated with another Canvas.');
     cullRect ??= Rect.largest;
@@ -3509,8 +3515,8 @@ class Canvas extends NativeFieldWrapperClass2 {
   ///    for subsequent commands.
   ///  * [BlendMode], which discusses the use of [Paint.blendMode] with
   ///    [saveLayer].
-  void saveLayer(Rect/*?*/ bounds, Paint/*!*/ paint) {
-    assert(paint != null);
+  void saveLayer(Rect? bounds, Paint paint) {
+    assert(paint != null); // ignore: unnecessary_null_comparison
     if (bounds == null) {
       _saveLayerWithoutBounds(paint._objects, paint._data);
     } else {
@@ -3519,13 +3525,13 @@ class Canvas extends NativeFieldWrapperClass2 {
                  paint._objects, paint._data);
     }
   }
-  void _saveLayerWithoutBounds(List<dynamic> paintObjects, ByteData paintData)
+  void _saveLayerWithoutBounds(List<dynamic>? paintObjects, ByteData paintData)
       native 'Canvas_saveLayerWithoutBounds';
   void _saveLayer(double left,
                   double top,
                   double right,
                   double bottom,
-                  List<dynamic> paintObjects,
+                  List<dynamic>? paintObjects,
                   ByteData paintData) native 'Canvas_saveLayer';
 
   /// Pops the current save stack, if there is anything to pop.
@@ -3543,11 +3549,11 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// each matching call to [restore] decrements it.
   ///
   /// This number cannot go below 1.
-  int/*!*/ getSaveCount() native 'Canvas_getSaveCount';
+  int getSaveCount() native 'Canvas_getSaveCount';
 
   /// Add a translation to the current transform, shifting the coordinate space
   /// horizontally by the first argument and vertically by the second argument.
-  void translate(double/*!*/ dx, double/*!*/ dy) native 'Canvas_translate';
+  void translate(double dx, double dy) native 'Canvas_translate';
 
   /// Add an axis-aligned scale to the current transform, scaling by the first
   /// argument in the horizontal direction and the second in the vertical
@@ -3555,23 +3561,23 @@ class Canvas extends NativeFieldWrapperClass2 {
   ///
   /// If [sy] is unspecified, [sx] will be used for the scale in both
   /// directions.
-  void scale(double/*!*/ sx, [double/*?*/ sy]) => _scale(sx, sy ?? sx);
+  void scale(double sx, [double? sy]) => _scale(sx, sy ?? sx);
 
   void _scale(double sx, double sy) native 'Canvas_scale';
 
   /// Add a rotation to the current transform. The argument is in radians clockwise.
-  void rotate(double/*!*/ radians) native 'Canvas_rotate';
+  void rotate(double radians) native 'Canvas_rotate';
 
   /// Add an axis-aligned skew to the current transform, with the first argument
   /// being the horizontal skew in rise over run units clockwise around the
   /// origin, and the second argument being the vertical skew in rise over run
   /// units clockwise around the origin.
-  void skew(double/*!*/ sx, double/*!*/ sy) native 'Canvas_skew';
+  void skew(double sx, double sy) native 'Canvas_skew';
 
   /// Multiply the current transform by the specified 4⨉4 transformation matrix
   /// specified as a list of values in column-major order.
-  void transform(Float64List/*!*/ matrix4) {
-    assert(matrix4 != null);
+  void transform(Float64List matrix4) {
+    assert(matrix4 != null); // ignore: unnecessary_null_comparison
     if (matrix4.length != 16)
       throw ArgumentError('"matrix4" must have 16 entries.');
     _transform(matrix4);
@@ -3589,10 +3595,10 @@ class Canvas extends NativeFieldWrapperClass2 {
   ///
   /// Use [ClipOp.difference] to subtract the provided rectangle from the
   /// current clip.
-  void clipRect(Rect/*!*/ rect, { ClipOp/*!*/ clipOp = ClipOp.intersect, bool/*!*/ doAntiAlias = true }) {
+  void clipRect(Rect rect, { ClipOp clipOp = ClipOp.intersect, bool doAntiAlias = true }) {
     assert(_rectIsValid(rect));
-    assert(clipOp != null);
-    assert(doAntiAlias != null);
+    assert(clipOp != null); // ignore: unnecessary_null_comparison
+    assert(doAntiAlias != null); // ignore: unnecessary_null_comparison
     _clipRect(rect.left, rect.top, rect.right, rect.bottom, clipOp.index, doAntiAlias);
   }
   void _clipRect(double left,
@@ -3610,9 +3616,9 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// If multiple draw commands intersect with the clip boundary, this can result
   /// in incorrect blending at the clip boundary. See [saveLayer] for a
   /// discussion of how to address that and some examples of using [clipRRect].
-  void clipRRect(RRect/*!*/ rrect, {bool/*!*/ doAntiAlias = true}) {
+  void clipRRect(RRect rrect, {bool doAntiAlias = true}) {
     assert(_rrectIsValid(rrect));
-    assert(doAntiAlias != null);
+    assert(doAntiAlias != null); // ignore: unnecessary_null_comparison
     _clipRRect(rrect._value32, doAntiAlias);
   }
   void _clipRRect(Float32List rrect, bool doAntiAlias) native 'Canvas_clipRRect';
@@ -3626,9 +3632,10 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// multiple draw commands intersect with the clip boundary, this can result
   /// in incorrect blending at the clip boundary. See [saveLayer] for a
   /// discussion of how to address that.
-  void clipPath(Path/*!*/ path, {bool/*!*/ doAntiAlias = true}) {
+  void clipPath(Path path, {bool doAntiAlias = true}) {
+    // ignore: unnecessary_null_comparison
     assert(path != null); // path is checked on the engine side
-    assert(doAntiAlias != null);
+    assert(doAntiAlias != null); // ignore: unnecessary_null_comparison
     _clipPath(path, doAntiAlias);
   }
   void _clipPath(Path path, bool doAntiAlias) native 'Canvas_clipPath';
@@ -3636,9 +3643,9 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// Paints the given [Color] onto the canvas, applying the given
   /// [BlendMode], with the given color being the source and the background
   /// being the destination.
-  void drawColor(Color/*!*/ color, BlendMode/*!*/ blendMode) {
-    assert(color != null);
-    assert(blendMode != null);
+  void drawColor(Color color, BlendMode blendMode) {
+    assert(color != null); // ignore: unnecessary_null_comparison
+    assert(blendMode != null); // ignore: unnecessary_null_comparison
     _drawColor(color.value, blendMode.index);
   }
   void _drawColor(int color, int blendMode) native 'Canvas_drawColor';
@@ -3647,34 +3654,34 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// stroked, the value of the [Paint.style] is ignored for this call.
   ///
   /// The `p1` and `p2` arguments are interpreted as offsets from the origin.
-  void drawLine(Offset/*!*/ p1, Offset/*!*/ p2, Paint/*!*/ paint) {
+  void drawLine(Offset p1, Offset p2, Paint paint) {
     assert(_offsetIsValid(p1));
     assert(_offsetIsValid(p2));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawLine(p1.dx, p1.dy, p2.dx, p2.dy, paint._objects, paint._data);
   }
   void _drawLine(double x1,
                  double y1,
                  double x2,
                  double y2,
-                 List<dynamic> paintObjects,
+                 List<dynamic>? paintObjects,
                  ByteData paintData) native 'Canvas_drawLine';
 
   /// Fills the canvas with the given [Paint].
   ///
   /// To fill the canvas with a solid color and blend mode, consider
   /// [drawColor] instead.
-  void drawPaint(Paint/*!*/ paint) {
-    assert(paint != null);
+  void drawPaint(Paint paint) {
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawPaint(paint._objects, paint._data);
   }
-  void _drawPaint(List<dynamic> paintObjects, ByteData paintData) native 'Canvas_drawPaint';
+  void _drawPaint(List<dynamic>? paintObjects, ByteData paintData) native 'Canvas_drawPaint';
 
   /// Draws a rectangle with the given [Paint]. Whether the rectangle is filled
   /// or stroked (or both) is controlled by [Paint.style].
-  void drawRect(Rect/*!*/ rect, Paint/*!*/ paint) {
+  void drawRect(Rect rect, Paint paint) {
     assert(_rectIsValid(rect));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawRect(rect.left, rect.top, rect.right, rect.bottom,
               paint._objects, paint._data);
   }
@@ -3682,18 +3689,18 @@ class Canvas extends NativeFieldWrapperClass2 {
                  double top,
                  double right,
                  double bottom,
-                 List<dynamic> paintObjects,
+                 List<dynamic>? paintObjects,
                  ByteData paintData) native 'Canvas_drawRect';
 
   /// Draws a rounded rectangle with the given [Paint]. Whether the rectangle is
   /// filled or stroked (or both) is controlled by [Paint.style].
-  void drawRRect(RRect/*!*/ rrect, Paint/*!*/ paint) {
+  void drawRRect(RRect rrect, Paint paint) {
     assert(_rrectIsValid(rrect));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawRRect(rrect._value32, paint._objects, paint._data);
   }
   void _drawRRect(Float32List rrect,
-                  List<dynamic> paintObjects,
+                  List<dynamic>? paintObjects,
                   ByteData paintData) native 'Canvas_drawRRect';
 
   /// Draws a shape consisting of the difference between two rounded rectangles
@@ -3701,23 +3708,23 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// is controlled by [Paint.style].
   ///
   /// This shape is almost but not quite entirely unlike an annulus.
-  void drawDRRect(RRect/*!*/ outer, RRect/*!*/ inner, Paint/*!*/ paint) {
+  void drawDRRect(RRect outer, RRect inner, Paint paint) {
     assert(_rrectIsValid(outer));
     assert(_rrectIsValid(inner));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawDRRect(outer._value32, inner._value32, paint._objects, paint._data);
   }
   void _drawDRRect(Float32List outer,
                    Float32List inner,
-                   List<dynamic> paintObjects,
+                   List<dynamic>? paintObjects,
                    ByteData paintData) native 'Canvas_drawDRRect';
 
   /// Draws an axis-aligned oval that fills the given axis-aligned rectangle
   /// with the given [Paint]. Whether the oval is filled or stroked (or both) is
   /// controlled by [Paint.style].
-  void drawOval(Rect/*!*/ rect, Paint/*!*/ paint) {
+  void drawOval(Rect rect, Paint paint) {
     assert(_rectIsValid(rect));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawOval(rect.left, rect.top, rect.right, rect.bottom,
               paint._objects, paint._data);
   }
@@ -3725,22 +3732,22 @@ class Canvas extends NativeFieldWrapperClass2 {
                  double top,
                  double right,
                  double bottom,
-                 List<dynamic> paintObjects,
+                 List<dynamic>? paintObjects,
                  ByteData paintData) native 'Canvas_drawOval';
 
   /// Draws a circle centered at the point given by the first argument and
   /// that has the radius given by the second argument, with the [Paint] given in
   /// the third argument. Whether the circle is filled or stroked (or both) is
   /// controlled by [Paint.style].
-  void drawCircle(Offset/*!*/ c, double/*!*/ radius, Paint/*!*/ paint) {
+  void drawCircle(Offset c, double radius, Paint paint) {
     assert(_offsetIsValid(c));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawCircle(c.dx, c.dy, radius, paint._objects, paint._data);
   }
   void _drawCircle(double x,
                    double y,
                    double radius,
-                   List<dynamic> paintObjects,
+                   List<dynamic>? paintObjects,
                    ByteData paintData) native 'Canvas_drawCircle';
 
   /// Draw an arc scaled to fit inside the given rectangle.
@@ -3754,9 +3761,9 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// not closed, forming a circle segment.
   ///
   /// This method is optimized for drawing arcs and should be faster than [Path.arcTo].
-  void drawArc(Rect/*!*/ rect, double/*!*/ startAngle, double/*!*/ sweepAngle, bool/*!*/ useCenter, Paint/*!*/ paint) {
+  void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter, Paint paint) {
     assert(_rectIsValid(rect));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawArc(rect.left, rect.top, rect.right, rect.bottom, startAngle,
              sweepAngle, useCenter, paint._objects, paint._data);
   }
@@ -3767,7 +3774,7 @@ class Canvas extends NativeFieldWrapperClass2 {
                 double startAngle,
                 double sweepAngle,
                 bool useCenter,
-                List<dynamic> paintObjects,
+                List<dynamic>? paintObjects,
                 ByteData paintData) native 'Canvas_drawArc';
 
   /// Draws the given [Path] with the given [Paint].
@@ -3775,27 +3782,29 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// Whether this shape is filled or stroked (or both) is controlled by
   /// [Paint.style]. If the path is filled, then sub-paths within it are
   /// implicitly closed (see [Path.close]).
-  void drawPath(Path/*!*/ path, Paint/*!*/ paint) {
+  void drawPath(Path path, Paint paint) {
+    // ignore: unnecessary_null_comparison
     assert(path != null); // path is checked on the engine side
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawPath(path, paint._objects, paint._data);
   }
   void _drawPath(Path path,
-                 List<dynamic> paintObjects,
+                 List<dynamic>? paintObjects,
                  ByteData paintData) native 'Canvas_drawPath';
 
   /// Draws the given [Image] into the canvas with its top-left corner at the
   /// given [Offset]. The image is composited into the canvas using the given [Paint].
-  void drawImage(Image/*!*/ image, Offset/*!*/ offset, Paint/*!*/ paint) {
+  void drawImage(Image image, Offset offset, Paint paint) {
+    // ignore: unnecessary_null_comparison
     assert(image != null); // image is checked on the engine side
     assert(_offsetIsValid(offset));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawImage(image, offset.dx, offset.dy, paint._objects, paint._data);
   }
   void _drawImage(Image image,
                   double x,
                   double y,
-                  List<dynamic> paintObjects,
+                  List<dynamic>? paintObjects,
                   ByteData paintData) native 'Canvas_drawImage';
 
   /// Draws the subset of the given image described by the `src` argument into
@@ -3807,11 +3816,12 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// Multiple calls to this method with different arguments (from the same
   /// image) can be batched into a single call to [drawAtlas] to improve
   /// performance.
-  void drawImageRect(Image/*!*/ image, Rect/*!*/ src, Rect/*!*/ dst, Paint/*!*/ paint) {
+  void drawImageRect(Image image, Rect src, Rect dst, Paint paint) {
+    // ignore: unnecessary_null_comparison
     assert(image != null); // image is checked on the engine side
     assert(_rectIsValid(src));
     assert(_rectIsValid(dst));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawImageRect(image,
                    src.left,
                    src.top,
@@ -3833,7 +3843,7 @@ class Canvas extends NativeFieldWrapperClass2 {
                       double dstTop,
                       double dstRight,
                       double dstBottom,
-                      List<dynamic> paintObjects,
+                      List<dynamic>? paintObjects,
                       ByteData paintData) native 'Canvas_drawImageRect';
 
   /// Draws the given [Image] into the canvas using the given [Paint].
@@ -3849,11 +3859,12 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// five regions are drawn by stretching them to fit such that they exactly
   /// cover the destination rectangle while maintaining their relative
   /// positions.
-  void drawImageNine(Image/*!*/ image, Rect/*!*/ center, Rect/*!*/ dst, Paint/*!*/ paint) {
+  void drawImageNine(Image image, Rect center, Rect dst, Paint paint) {
+    // ignore: unnecessary_null_comparison
     assert(image != null); // image is checked on the engine side
     assert(_rectIsValid(center));
     assert(_rectIsValid(dst));
-    assert(paint != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawImageNine(image,
                    center.left,
                    center.top,
@@ -3875,12 +3886,13 @@ class Canvas extends NativeFieldWrapperClass2 {
                       double dstTop,
                       double dstRight,
                       double dstBottom,
-                      List<dynamic> paintObjects,
+                      List<dynamic>? paintObjects,
                       ByteData paintData) native 'Canvas_drawImageNine';
 
   /// Draw the given picture onto the canvas. To create a picture, see
   /// [PictureRecorder].
-  void drawPicture(Picture/*!*/ picture) {
+  void drawPicture(Picture picture) {
+    // ignore: unnecessary_null_comparison
     assert(picture != null); // picture is checked on the engine side
     _drawPicture(picture);
   }
@@ -3906,8 +3918,8 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// If the text is centered, the centering axis will be at the position
   /// described by adding half of the [ParagraphConstraints.width] given to
   /// [Paragraph.layout], to the `offset` argument's [Offset.dx] coordinate.
-  void drawParagraph(Paragraph/*!*/ paragraph, Offset/*!*/ offset) {
-    assert(paragraph != null);
+  void drawParagraph(Paragraph paragraph, Offset offset) {
+    assert(paragraph != null); // ignore: unnecessary_null_comparison
     assert(_offsetIsValid(offset));
     paragraph._paint(this, offset.dx, offset.dy);
   }
@@ -3920,10 +3932,10 @@ class Canvas extends NativeFieldWrapperClass2 {
   ///
   ///  * [drawRawPoints], which takes `points` as a [Float32List] rather than a
   ///    [List<Offset>].
-  void drawPoints(PointMode/*!*/ pointMode, List<Offset/*!*/>/*!*/ points, Paint/*!*/ paint) {
-    assert(pointMode != null);
-    assert(points != null);
-    assert(paint != null);
+  void drawPoints(PointMode pointMode, List<Offset> points, Paint paint) {
+    assert(pointMode != null); // ignore: unnecessary_null_comparison
+    assert(points != null); // ignore: unnecessary_null_comparison
+    assert(paint != null); // ignore: unnecessary_null_comparison
     _drawPoints(paint._objects, paint._data, pointMode.index, _encodePointList(points));
   }
 
@@ -3936,16 +3948,16 @@ class Canvas extends NativeFieldWrapperClass2 {
   ///
   ///  * [drawPoints], which takes `points` as a [List<Offset>] rather than a
   ///    [List<Float32List>].
-  void drawRawPoints(PointMode/*!*/ pointMode, Float32List/*!*/ points, Paint/*!*/ paint) {
-    assert(pointMode != null);
-    assert(points != null);
-    assert(paint != null);
+  void drawRawPoints(PointMode pointMode, Float32List points, Paint paint) {
+    assert(pointMode != null); // ignore: unnecessary_null_comparison
+    assert(points != null); // ignore: unnecessary_null_comparison
+    assert(paint != null); // ignore: unnecessary_null_comparison
     if (points.length % 2 != 0)
       throw ArgumentError('"points" must have an even number of values.');
     _drawPoints(paint._objects, paint._data, pointMode.index, points);
   }
 
-  void _drawPoints(List<dynamic> paintObjects,
+  void _drawPoints(List<dynamic>? paintObjects,
                    ByteData paintData,
                    int pointMode,
                    Float32List points) native 'Canvas_drawPoints';
@@ -3958,15 +3970,16 @@ class Canvas extends NativeFieldWrapperClass2 {
   ///   * [new Vertices], which creates a set of vertices to draw on the canvas.
   ///   * [Vertices.raw], which creates the vertices using typed data lists
   ///     rather than unencoded lists.
-  void drawVertices(Vertices/*!*/ vertices, BlendMode/*!*/ blendMode, Paint/*!*/ paint) {
+  void drawVertices(Vertices vertices, BlendMode blendMode, Paint paint) {
+    // ignore: unnecessary_null_comparison
     assert(vertices != null); // vertices is checked on the engine side
-    assert(paint != null);
-    assert(blendMode != null);
+    assert(paint != null); // ignore: unnecessary_null_comparison
+    assert(blendMode != null); // ignore: unnecessary_null_comparison
     _drawVertices(vertices, blendMode.index, paint._objects, paint._data);
   }
   void _drawVertices(Vertices vertices,
                      int blendMode,
-                     List<dynamic> paintObjects,
+                     List<dynamic>? paintObjects,
                      ByteData paintData) native 'Canvas_drawVertices';
 
   /// Draws part of an image - the [atlas] - onto the canvas.
@@ -3981,19 +3994,20 @@ class Canvas extends NativeFieldWrapperClass2 {
   ///
   ///  * [drawRawAtlas], which takes its arguments as typed data lists rather
   ///    than objects.
-  void drawAtlas(Image/*!*/ atlas,
-                 List<RSTransform/*!*/>/*!*/ transforms,
-                 List<Rect/*!*/>/*!*/ rects,
-                 List<Color/*!*/>/*!*/ colors,
-                 BlendMode/*!*/ blendMode,
-                 Rect/*?*/ cullRect,
-                 Paint/*!*/ paint) {
+  void drawAtlas(Image atlas,
+                 List<RSTransform> transforms,
+                 List<Rect> rects,
+                 List<Color> colors,
+                 BlendMode blendMode,
+                 Rect? cullRect,
+                 Paint paint) {
+    // ignore: unnecessary_null_comparison
     assert(atlas != null); // atlas is checked on the engine side
-    assert(transforms != null);
-    assert(rects != null);
-    assert(colors != null);
-    assert(blendMode != null);
-    assert(paint != null);
+    assert(transforms != null); // ignore: unnecessary_null_comparison
+    assert(rects != null); // ignore: unnecessary_null_comparison
+    assert(colors != null); // ignore: unnecessary_null_comparison
+    assert(blendMode != null); // ignore: unnecessary_null_comparison
+    assert(paint != null); // ignore: unnecessary_null_comparison
 
     final int rectCount = rects.length;
     if (transforms.length != rectCount)
@@ -4022,8 +4036,8 @@ class Canvas extends NativeFieldWrapperClass2 {
       rectBuffer[index3] = rect.bottom;
     }
 
-    final Int32List colorBuffer = colors.isEmpty ? null : _encodeColorList(colors);
-    final Float32List cullRectBuffer = cullRect?._value32;
+    final Int32List? colorBuffer = colors.isEmpty ? null : _encodeColorList(colors);
+    final Float32List? cullRectBuffer = cullRect?._value32;
 
     _drawAtlas(
       paint._objects, paint._data, atlas, rstTransformBuffer, rectBuffer,
@@ -4051,26 +4065,27 @@ class Canvas extends NativeFieldWrapperClass2 {
   ///
   ///  * [drawAtlas], which takes its arguments as objects rather than typed
   ///    data lists.
-  void drawRawAtlas(Image/*!*/ atlas,
-                    Float32List/*!*/ rstTransforms,
-                    Float32List/*!*/ rects,
-                    Int32List/*!*/ colors,
-                    BlendMode/*!*/ blendMode,
-                    Rect/*?*/ cullRect,
-                    Paint/*!*/ paint) {
+  void drawRawAtlas(Image atlas,
+                    Float32List rstTransforms,
+                    Float32List rects,
+                    Int32List colors,
+                    BlendMode blendMode,
+                    Rect? cullRect,
+                    Paint paint) {
+    // ignore: unnecessary_null_comparison
     assert(atlas != null); // atlas is checked on the engine side
-    assert(rstTransforms != null);
-    assert(rects != null);
-    assert(colors != null);
-    assert(blendMode != null);
-    assert(paint != null);
+    assert(rstTransforms != null); // ignore: unnecessary_null_comparison
+    assert(rects != null); // ignore: unnecessary_null_comparison
+    assert(colors != null); // ignore: unnecessary_null_comparison
+    assert(blendMode != null); // ignore: unnecessary_null_comparison
+    assert(paint != null); // ignore: unnecessary_null_comparison
 
     final int rectCount = rects.length;
     if (rstTransforms.length != rectCount)
       throw ArgumentError('"rstTransforms" and "rects" lengths must match.');
     if (rectCount % 4 != 0)
       throw ArgumentError('"rstTransforms" and "rects" lengths must be a multiple of four.');
-    if (colors != null && colors.length * 4 != rectCount)
+    if (colors.length * 4 != rectCount)
       throw ArgumentError('If non-null, "colors" length must be one fourth the length of "rstTransforms" and "rects".');
 
     _drawAtlas(
@@ -4079,14 +4094,14 @@ class Canvas extends NativeFieldWrapperClass2 {
     );
   }
 
-  void _drawAtlas(List<dynamic> paintObjects,
+  void _drawAtlas(List<dynamic>? paintObjects,
                   ByteData paintData,
                   Image atlas,
                   Float32List rstTransforms,
                   Float32List rects,
-                  Int32List colors,
+                  Int32List? colors,
                   int blendMode,
-                  Float32List cullRect) native 'Canvas_drawAtlas';
+                  Float32List? cullRect) native 'Canvas_drawAtlas';
 
   /// Draws a shadow for a [Path] representing the given material elevation.
   ///
@@ -4094,10 +4109,11 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// is not opaque.
   ///
   /// The arguments must not be null.
-  void drawShadow(Path/*!*/ path, Color/*!*/ color, double/*!*/ elevation, bool/*!*/ transparentOccluder) {
+  void drawShadow(Path path, Color color, double elevation, bool transparentOccluder) {
+    // ignore: unnecessary_null_comparison
     assert(path != null); // path is checked on the engine side
-    assert(color != null);
-    assert(transparentOccluder != null);
+    assert(color != null); // ignore: unnecessary_null_comparison
+    assert(transparentOccluder != null); // ignore: unnecessary_null_comparison
     _drawShadow(path, color.value, elevation, transparentOccluder);
   }
   void _drawShadow(Path path,
@@ -4130,7 +4146,7 @@ class Picture extends NativeFieldWrapperClass2 {
   ///
   /// Although the image is returned synchronously, the picture is actually
   /// rasterized the first time the image is drawn and then cached.
-  Future<Image/*!*/>/*!*/ toImage(int/*!*/ width, int/*!*/ height) {
+  Future<Image> toImage(int width, int height) {
     if (width <= 0 || height <= 0)
       throw Exception('Invalid image dimensions.');
     return _futurize(
@@ -4148,7 +4164,7 @@ class Picture extends NativeFieldWrapperClass2 {
   ///
   /// The actual size of this picture may be larger, particularly if it contains
   /// references to image or other large objects.
-  int/*!*/ get approximateBytesUsed native 'Picture_GetAllocationSize';
+  int get approximateBytesUsed native 'Picture_GetAllocationSize';
 }
 
 /// Records a [Picture] containing a sequence of graphical operations.
@@ -4170,14 +4186,14 @@ class PictureRecorder extends NativeFieldWrapperClass2 {
   /// call to [endRecording], and false if either this
   /// [PictureRecorder] has not yet been associated with a [Canvas],
   /// or the [endRecording] method has already been called.
-  bool/*!*/ get isRecording native 'PictureRecorder_isRecording';
+  bool get isRecording native 'PictureRecorder_isRecording';
 
   /// Finishes recording graphical operations.
   ///
   /// Returns a picture containing the graphical operations that have been
   /// recorded thus far. After calling this function, both the picture recorder
   /// and the canvas objects are invalid and cannot be used further.
-  Picture/*!*/ endRecording() {
+  Picture endRecording() {
     final Picture picture = Picture._();
     _endRecording(picture);
     return picture;
@@ -4204,8 +4220,8 @@ class Shadow {
     this.color = const Color(_kColorDefault),
     this.offset = Offset.zero,
     this.blurRadius = 0.0,
-  }) : assert(color != null, 'Text shadow color was null.'),
-       assert(offset != null, 'Text shadow offset was null.'),
+  }) : assert(color != null, 'Text shadow color was null.'), // ignore: unnecessary_null_comparison
+       assert(offset != null, 'Text shadow offset was null.'), // ignore: unnecessary_null_comparison
        assert(blurRadius >= 0.0, 'Text shadow blur radius should be non-negative.');
 
   static const int _kColorDefault = 0xFF000000;
@@ -4220,17 +4236,17 @@ class Shadow {
   ///
   /// The shadows are shapes composited directly over the base canvas, and do not
   /// represent optical occlusion.
-  final Color/*!*/ color;
+  final Color color;
 
   /// The displacement of the shadow from the casting element.
   ///
   /// Positive x/y offsets will shift the shadow to the right and down, while
   /// negative offsets shift the shadow to the left and up. The offsets are
   /// relative to the position of the element that is casting it.
-  final Offset/*!*/ offset;
+  final Offset offset;
 
   /// The standard deviation of the Gaussian to convolve with the shadow's shape.
-  final double/*!*/ blurRadius;
+  final double blurRadius;
 
   /// Converts a blur radius in pixels to sigmas.
   ///
@@ -4238,14 +4254,14 @@ class Shadow {
   ///
   // See SkBlurMask::ConvertRadiusToSigma().
   // <https://github.com/google/skia/blob/bb5b77db51d2e149ee66db284903572a5aac09be/src/effects/SkBlurMask.cpp#L23>
-  static double/*!*/ convertRadiusToSigma(double/*!*/ radius) {
+  static double convertRadiusToSigma(double radius) {
     return radius * 0.57735 + 0.5;
   }
 
   /// The [blurRadius] in sigmas instead of logical pixels.
   ///
   /// See the sigma argument to [MaskFilter.blur].
-  double/*!*/ get blurSigma => convertRadiusToSigma(blurRadius);
+  double get blurSigma => convertRadiusToSigma(blurRadius);
 
   /// Create the [Paint] object that corresponds to this shadow description.
   ///
@@ -4257,7 +4273,7 @@ class Shadow {
   /// inconsistencies in shadow blur rendering, primarily as a method of
   /// reducing test flakiness. [toPaint] should be overridden in subclasses to
   /// provide this functionality.
-  Paint/*!*/ toPaint() {
+  Paint toPaint() {
     return Paint()
       ..color = color
       ..maskFilter = MaskFilter.blur(BlurStyle.normal, blurSigma);
@@ -4265,7 +4281,7 @@ class Shadow {
 
   /// Returns a new shadow with its [offset] and [blurRadius] scaled by the given
   /// factor.
-  Shadow/*!*/ scale(double/*!*/ factor) {
+  Shadow scale(double factor) {
     return Shadow(
       color: color,
       offset: offset * factor,
@@ -4292,8 +4308,8 @@ class Shadow {
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
   /// {@endtemplate}
-  static Shadow/*?*/ lerp(Shadow/*?*/ a, Shadow/*?*/ b, double/*!*/ t) {
-    assert(t != null);
+  static Shadow? lerp(Shadow? a, Shadow? b, double t) {
+    assert(t != null); // ignore: unnecessary_null_comparison
     if (b == null) {
       if (a == null) {
         return null;
@@ -4305,9 +4321,9 @@ class Shadow {
         return b.scale(t);
       } else {
         return Shadow(
-          color: Color.lerp(a.color, b.color, t),
-          offset: Offset.lerp(a.offset, b.offset, t),
-          blurRadius: lerpDouble(a.blurRadius, b.blurRadius, t),
+          color: Color.lerp(a.color, b.color, t)!,
+          offset: Offset.lerp(a.offset, b.offset, t)!,
+          blurRadius: _lerpDouble(a.blurRadius, b.blurRadius, t),
         );
       }
     }
@@ -4318,16 +4334,16 @@ class Shadow {
   /// If the lists differ in length, excess items are lerped with null.
   ///
   /// {@macro dart.ui.shadow.lerp}
-  static List<Shadow/*!*/>/*?*/ lerpList(List<Shadow/*!*/>/*?*/ a, List<Shadow/*!*/>/*?*/ b, double/*!*/ t) {
-    assert(t != null);
+  static List<Shadow>? lerpList(List<Shadow>? a, List<Shadow>? b, double t) {
+    assert(t != null); // ignore: unnecessary_null_comparison
     if (a == null && b == null)
       return null;
-    a ??= <Shadow/*!*/>[];
-    b ??= <Shadow/*!*/>[];
-    final List<Shadow/*!*/> result = <Shadow/*!*/>[];
+    a ??= <Shadow>[];
+    b ??= <Shadow>[];
+    final List<Shadow> result = <Shadow>[];
     final int commonLength = math.min(a.length, b.length);
     for (int i = 0; i < commonLength; i += 1)
-      result.add(Shadow.lerp(a[i], b[i], t));
+      result.add(Shadow.lerp(a[i], b[i], t)!);
     for (int i = commonLength; i < a.length; i += 1)
       result.add(a[i].scale(1.0 - t));
     for (int i = commonLength; i < b.length; i += 1)
@@ -4336,7 +4352,7 @@ class Shadow {
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     return other is Shadow
@@ -4346,12 +4362,12 @@ class Shadow {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(color, offset, blurRadius);
+  int get hashCode => hashValues(color, offset, blurRadius);
 
   // Serialize [shadows] into ByteData. The format is a single uint_32_t at
   // the beginning indicating the number of shadows, followed by _kBytesPerShadow
   // bytes for each shadow.
-  static ByteData _encodeShadows(List<Shadow> shadows) {
+  static ByteData _encodeShadows(List<Shadow>? shadows) {
     if (shadows == null)
       return ByteData(0);
 
@@ -4361,6 +4377,10 @@ class Shadow {
     int shadowOffset = 0;
     for (int shadowIndex = 0; shadowIndex < shadows.length; ++shadowIndex) {
       final Shadow shadow = shadows[shadowIndex];
+      // TODO(yjbanov): remove the null check when the framework is migrated. While the list
+      //                of shadows contains non-nullable elements, unmigrated code can still
+      //                pass nulls.
+      // ignore: unnecessary_null_comparison
       if (shadow == null)
         continue;
       shadowOffset = shadowIndex * _kBytesPerShadow;
@@ -4382,7 +4402,7 @@ class Shadow {
   }
 
   @override
-  String/*!*/ toString() => 'TextShadow($color, $offset, $blurRadius)';
+  String toString() => 'TextShadow($color, $offset, $blurRadius)';
 }
 
 /// Generic callback signature, used by [_futurize].
@@ -4392,7 +4412,7 @@ typedef _Callback<T> = void Function(T result);
 ///
 /// Return value should be null on success, and a string error message on
 /// failure.
-typedef _Callbacker<T> = String/*?*/ Function(_Callback<T>/*!*/ callback);
+typedef _Callbacker<T> = String? Function(_Callback<T> callback);
 
 /// Converts a method that receives a value-returning callback to a method that
 /// returns a Future.
@@ -4415,9 +4435,9 @@ typedef _Callbacker<T> = String/*?*/ Function(_Callback<T>/*!*/ callback);
 ///   return _futurize(_doSomethingAndCallback);
 /// }
 /// ```
-Future<T>/*!*/ _futurize<T>(_Callbacker<T>/*!*/ callbacker) {
+Future<T> _futurize<T>(_Callbacker<T> callbacker) {
   final Completer<T> completer = Completer<T>.sync();
-  final String error = callbacker((T t) {
+  final String? error = callbacker((T t) {
     if (t == null) {
       completer.completeError(Exception('operation failed'));
     } else {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3104,7 +3104,6 @@ class Gradient extends Shader {
        assert(tileMode != null), // ignore: unnecessary_null_comparison
        assert(matrix4 == null || _matrix4IsValid(matrix4)),
        super._() {
-    focalRadius ??= 0.0; // ignore: dead_null_aware_expression
     _validateColorStops(colors, colorStops);
     final Int32List colorsBuffer = _encodeColorList(colors);
     final Float32List? colorStopsBuffer = colorStops == null ? null : Float32List.fromList(colorStops);

--- a/lib/ui/plugins.dart
+++ b/lib/ui/plugins.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 /// A wrapper for a raw callback handle.
@@ -14,13 +15,13 @@ class CallbackHandle {
   /// Only values produced by a call to [CallbackHandle.toRawHandle] should be
   /// used, otherwise this object will be an invalid handle.
   CallbackHandle.fromRawHandle(this._handle)
-      : assert(_handle != null, "'_handle' must not be null.");
+      : assert(_handle != null, "'_handle' must not be null."); // ignore: unnecessary_null_comparison
 
-  final int/*!*/ _handle;
+  final int _handle;
 
   /// Get the raw callback handle to pass over a [MethodChannel] or [SendPort]
   /// (to pass to another [Isolate]).
-  int/*!*/ toRawHandle() => _handle;
+  int toRawHandle() => _handle;
 
   @override
   bool operator ==(dynamic other) {
@@ -45,10 +46,10 @@ class PluginUtilities {
   // extended directly.
   factory PluginUtilities._() => throw UnsupportedError('Namespace');
 
-  static Map<Function/*!*/, CallbackHandle/*?*/>/*!*/ _forwardCache =
-      <Function/*!*/, CallbackHandle/*?*/>{};
-  static Map<CallbackHandle/*!*/, Function/*?*/>/*!*/ _backwardCache =
-      <CallbackHandle/*!*/, Function/*?*/>{};
+  static Map<Function, CallbackHandle?> _forwardCache =
+      <Function, CallbackHandle?>{};
+  static Map<CallbackHandle, Function?> _backwardCache =
+      <CallbackHandle, Function?>{};
 
   /// Get a handle to a named top-level or static callback function which can
   /// be easily passed between isolates.
@@ -59,10 +60,10 @@ class PluginUtilities {
   /// [PluginUtilities.getCallbackFromHandle] to retrieve a tear-off of the
   /// original callback. If `callback` is not a top-level or static function,
   /// null is returned.
-  static CallbackHandle/*?*/ getCallbackHandle(Function/*!*/ callback) {
-    assert(callback != null, "'callback' must not be null.");
+  static CallbackHandle? getCallbackHandle(Function callback) {
+    assert(callback != null, "'callback' must not be null."); // ignore: unnecessary_null_comparison
     return _forwardCache.putIfAbsent(callback, () {
-      final int/*?*/ handle = _getCallbackHandle(callback);
+      final int? handle = _getCallbackHandle(callback);
       return handle != null ? CallbackHandle.fromRawHandle(handle) : null;
     });
   }
@@ -75,8 +76,8 @@ class PluginUtilities {
   /// If `handle` is not a valid handle returned by
   /// [PluginUtilities.getCallbackHandle], null is returned. Otherwise, a
   /// tear-off of the callback associated with `handle` is returned.
-  static Function/*?*/ getCallbackFromHandle(CallbackHandle/*!*/ handle) {
-    assert(handle != null, "'handle' must not be null.");
+  static Function? getCallbackFromHandle(CallbackHandle handle) {
+    assert(handle != null, "'handle' must not be null."); // ignore: unnecessary_null_comparison
     return _backwardCache.putIfAbsent(
         handle, () => _getCallbackFromHandle(handle.toRawHandle()));
   }

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 /// How the pointer has changed since the last report.
@@ -102,50 +103,50 @@ class PointerData {
   });
 
   /// Time of event dispatch, relative to an arbitrary timeline.
-  final Duration/*!*/ timeStamp;
+  final Duration timeStamp;
 
   /// How the pointer has changed since the last report.
-  final PointerChange/*!*/ change;
+  final PointerChange change;
 
   /// The kind of input device for which the event was generated.
-  final PointerDeviceKind/*!*/ kind;
+  final PointerDeviceKind kind;
 
   /// The kind of signal for a pointer signal event.
-  final PointerSignalKind/*?*/ signalKind;
+  final PointerSignalKind? signalKind;
 
   /// Unique identifier for the pointing device, reused across interactions.
-  final int/*!*/ device;
+  final int device;
 
   /// Unique identifier for the pointer.
   ///
   /// This field changes for each new pointer down event. Framework uses this
   /// identifier to determine hit test result.
-  final int/*!*/ pointerIdentifier;
+  final int pointerIdentifier;
 
   /// X coordinate of the position of the pointer, in physical pixels in the
   /// global coordinate space.
-  final double/*!*/ physicalX;
+  final double physicalX;
 
   /// Y coordinate of the position of the pointer, in physical pixels in the
   /// global coordinate space.
-  final double/*!*/ physicalY;
+  final double physicalY;
 
   /// The distance of pointer movement on X coordinate in physical pixels.
-  final double/*!*/ physicalDeltaX;
+  final double physicalDeltaX;
 
   /// The distance of pointer movement on Y coordinate in physical pixels.
-  final double/*!*/ physicalDeltaY;
+  final double physicalDeltaY;
 
   /// Bit field using the *Button constants (primaryMouseButton,
   /// secondaryStylusButton, etc). For example, if this has the value 6 and the
   /// [kind] is [PointerDeviceKind.invertedStylus], then this indicates an
   /// upside-down stylus with both its primary and secondary buttons pressed.
-  final int/*!*/ buttons;
+  final int buttons;
 
   /// Set if an application from a different security domain is in any way
   /// obscuring this application's window. (Aspirational; not currently
   /// implemented.)
-  final bool/*!*/ obscured;
+  final bool obscured;
 
   /// Set if this pointer data was synthesized by pointer data packet converter.
   /// pointer data packet converter will synthesize additional pointer datas if
@@ -153,34 +154,34 @@ class PointerData {
   ///
   /// For example, a down pointer data will be synthesized if the converter receives
   /// a move pointer data while the pointer is not previously down.
-  final bool/*!*/ synthesized;
+  final bool synthesized;
 
   /// The pressure of the touch as a number ranging from 0.0, indicating a touch
   /// with no discernible pressure, to 1.0, indicating a touch with "normal"
   /// pressure, and possibly beyond, indicating a stronger touch. For devices
   /// that do not detect pressure (e.g. mice), returns 1.0.
-  final double/*!*/ pressure;
+  final double pressure;
 
   /// The minimum value that [pressure] can return for this pointer. For devices
   /// that do not detect pressure (e.g. mice), returns 1.0. This will always be
   /// a number less than or equal to 1.0.
-  final double/*!*/ pressureMin;
+  final double pressureMin;
 
   /// The maximum value that [pressure] can return for this pointer. For devices
   /// that do not detect pressure (e.g. mice), returns 1.0. This will always be
   /// a greater than or equal to 1.0.
-  final double/*!*/ pressureMax;
+  final double pressureMax;
 
   /// The distance of the detected object from the input surface (e.g. the
   /// distance of a stylus or finger from a touch screen), in arbitrary units on
   /// an arbitrary (not necessarily linear) scale. If the pointer is down, this
   /// is 0.0 by definition.
-  final double/*!*/ distance;
+  final double distance;
 
   /// The maximum value that a distance can return for this pointer. If this
   /// input device cannot detect "hover touch" input events, then this will be
   /// 0.0.
-  final double/*!*/ distanceMax;
+  final double distanceMax;
 
   /// The area of the screen being pressed, scaled to a value between 0 and 1.
   /// The value of size can be used to determine fat touch events. This value
@@ -188,21 +189,21 @@ class PointerData {
   /// the range of detectable values. So, for example, the value of 0.1 could
   /// mean a touch with the tip of the finger, 0.2 a touch with full finger,
   /// and 0.3 the full palm.
-  final double/*!*/ size;
+  final double size;
 
   /// The radius of the contact ellipse along the major axis, in logical pixels.
-  final double/*!*/ radiusMajor;
+  final double radiusMajor;
 
   /// The radius of the contact ellipse along the minor axis, in logical pixels.
-  final double/*!*/ radiusMinor;
+  final double radiusMinor;
 
   /// The minimum value that could be reported for radiusMajor and radiusMinor
   /// for this pointer, in logical pixels.
-  final double/*!*/ radiusMin;
+  final double radiusMin;
 
   /// The minimum value that could be reported for radiusMajor and radiusMinor
   /// for this pointer, in logical pixels.
-  final double/*!*/ radiusMax;
+  final double radiusMax;
 
   /// For PointerDeviceKind.touch events:
   ///
@@ -229,7 +230,7 @@ class PointerData {
   /// indicate that the stylus would go down in the negative y-axis direction;
   /// pi/4 would indicate that the stylus goes up and to the right, -pi/2 would
   /// indicate that the stylus goes to the left, etc).
-  final double/*!*/ orientation;
+  final double orientation;
 
   /// For PointerDeviceKind.stylus and PointerDeviceKind.invertedStylus events:
   ///
@@ -241,20 +242,20 @@ class PointerData {
   /// perpendicular to the input surface (thus 0.0 indicates the stylus is
   /// orthogonal to the plane of the input surface, while pi/2 indicates that
   /// the stylus is flat on that surface).
-  final double/*!*/ tilt;
+  final double tilt;
 
   /// Opaque platform-specific data associated with the event.
-  final int/*!*/ platformData;
+  final int platformData;
 
   /// For events with signalKind of PointerSignalKind.scroll:
   ///
   /// The amount to scroll in the x direction, in physical pixels.
-  final double/*!*/ scrollDeltaX;
+  final double scrollDeltaX;
 
   /// For events with signalKind of PointerSignalKind.scroll:
   ///
   /// The amount to scroll in the y direction, in physical pixels.
-  final double/*!*/ scrollDeltaY;
+  final double scrollDeltaY;
 
   @override
   String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
@@ -296,10 +297,10 @@ class PointerData {
 /// A sequence of reports about the state of pointers.
 class PointerDataPacket {
   /// Creates a packet of pointer data reports.
-  const PointerDataPacket({ this.data = const <PointerData>[] }) : assert(data != null);
+  const PointerDataPacket({ this.data = const <PointerData>[] }) : assert(data != null); // ignore: unnecessary_null_comparison
 
   /// Data about the individual pointers in this packet.
   ///
   /// This list might contain multiple pieces of data about the same pointer.
-  final List<PointerData/*!*/>/*!*/ data;
+  final List<PointerData> data;
 }

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -690,32 +690,32 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
   /// node starts at `elevation` above the parent and ends at `elevation` +
   /// `thickness` above the parent.
   void updateNode({
-    /*required*/ required int id,
-    /*required*/ required int flags,
-    /*required*/ required int actions,
-    /*required*/ required int maxValueLength,
-    /*required*/ required int currentValueLength,
-    /*required*/ required int textSelectionBase,
-    /*required*/ required int textSelectionExtent,
-    /*required*/ required int platformViewId,
-    /*required*/ required int scrollChildren,
-    /*required*/ required int scrollIndex,
-    /*required*/ required double scrollPosition,
-    /*required*/ required double scrollExtentMax,
-    /*required*/ required double scrollExtentMin,
-    /*required*/ required double elevation,
-    /*required*/ required double thickness,
-    /*required*/ required Rect rect,
-    /*required*/ required String label,
-    /*required*/ required String hint,
-    /*required*/ required String value,
-    /*required*/ required String increasedValue,
-    /*required*/ required String decreasedValue,
+    required int id,
+    required int flags,
+    required int actions,
+    required int maxValueLength,
+    required int currentValueLength,
+    required int textSelectionBase,
+    required int textSelectionExtent,
+    required int platformViewId,
+    required int scrollChildren,
+    required int scrollIndex,
+    required double scrollPosition,
+    required double scrollExtentMax,
+    required double scrollExtentMin,
+    required double elevation,
+    required double thickness,
+    required Rect rect,
+    required String label,
+    required String hint,
+    required String value,
+    required String increasedValue,
+    required String decreasedValue,
     TextDirection? textDirection,
-    /*required*/ required Float64List transform,
-    /*required*/ required Int32List childrenInTraversalOrder,
-    /*required*/ required Int32List childrenInHitTestOrder,
-    /*required*/ required Int32List additionalActions,
+    required Float64List transform,
+    required Int32List childrenInTraversalOrder,
+    required Int32List childrenInHitTestOrder,
+    required Int32List additionalActions,
   }) {
     assert(_matrix4IsValid(transform));
     assert(
@@ -802,7 +802,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
   /// For overridden standard actions, `overrideId` corresponds with a
   /// [SemanticsAction.index] value. For custom actions this argument should not be
   /// provided.
-  void updateCustomAction({/*required*/ required int id, String? label, String? hint, int overrideId = -1}) {
+  void updateCustomAction({required int id, String? label, String? hint, int overrideId = -1}) {
     assert(id != null); // ignore: unnecessary_null_comparison
     assert(overrideId != null); // ignore: unnecessary_null_comparison
     _updateCustomAction(id, label, hint, overrideId);

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 /// The possible actions that can be conveyed from the operating system
@@ -12,7 +13,7 @@ part of dart.ui;
 // `lib/ui/semantics/semantics_node.h` and in each of the embedders *must* be
 // updated.
 class SemanticsAction {
-  const SemanticsAction._(this.index) : assert(index != null);
+  const SemanticsAction._(this.index) : assert(index != null); // ignore: unnecessary_null_comparison
 
   static const int _kTapIndex = 1 << 0;
   static const int _kLongPressIndex = 1 << 1;
@@ -42,7 +43,7 @@ class SemanticsAction {
   /// The numerical value for this action.
   ///
   /// Each action has one bit set in this bit field.
-  final int/*!*/ index;
+  final int index;
 
   /// The equivalent of a user briefly tapping the screen with the finger
   /// without moving it.
@@ -300,12 +301,12 @@ class SemanticsFlag {
   // READ THIS: if you add a flag here, you MUST update the numSemanticsFlags
   // value in testing/dart/semantics_test.dart, or tests will fail.
 
-  const SemanticsFlag._(this.index) : assert(index != null);
+  const SemanticsFlag._(this.index) : assert(index != null); // ignore: unnecessary_null_comparison
 
   /// The numerical value for this flag.
   ///
   /// Each flag has one bit set in this bit field.
-  final int/*!*/ index;
+  final int index;
 
   /// The semantics node has the quality of either being "checked" or "unchecked".
   ///
@@ -689,35 +690,36 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
   /// node starts at `elevation` above the parent and ends at `elevation` +
   /// `thickness` above the parent.
   void updateNode({
-    /*required*/ int/*!*/ id,
-    /*required*/ int/*!*/ flags,
-    /*required*/ int/*!*/ actions,
-    /*required*/ int/*!*/ maxValueLength,
-    /*required*/ int/*!*/ currentValueLength,
-    /*required*/ int/*!*/ textSelectionBase,
-    /*required*/ int/*!*/ textSelectionExtent,
-    /*required*/ int/*!*/ platformViewId,
-    /*required*/ int/*!*/ scrollChildren,
-    /*required*/ int/*!*/ scrollIndex,
-    /*required*/ double/*!*/ scrollPosition,
-    /*required*/ double/*!*/ scrollExtentMax,
-    /*required*/ double/*!*/ scrollExtentMin,
-    /*required*/ double/*!*/ elevation,
-    /*required*/ double/*!*/ thickness,
-    /*required*/ Rect/*!*/ rect,
-    /*required*/ String/*!*/ label,
-    /*required*/ String/*!*/ hint,
-    /*required*/ String/*!*/ value,
-    /*required*/ String/*!*/ increasedValue,
-    /*required*/ String/*!*/ decreasedValue,
-    TextDirection/*?*/ textDirection,
-    /*required*/ Float64List/*!*/ transform,
-    /*required*/ Int32List/*!*/ childrenInTraversalOrder,
-    /*required*/ Int32List/*!*/ childrenInHitTestOrder,
-    /*required*/ Int32List/*!*/ additionalActions,
+    /*required*/ required int id,
+    /*required*/ required int flags,
+    /*required*/ required int actions,
+    /*required*/ required int maxValueLength,
+    /*required*/ required int currentValueLength,
+    /*required*/ required int textSelectionBase,
+    /*required*/ required int textSelectionExtent,
+    /*required*/ required int platformViewId,
+    /*required*/ required int scrollChildren,
+    /*required*/ required int scrollIndex,
+    /*required*/ required double scrollPosition,
+    /*required*/ required double scrollExtentMax,
+    /*required*/ required double scrollExtentMin,
+    /*required*/ required double elevation,
+    /*required*/ required double thickness,
+    /*required*/ required Rect rect,
+    /*required*/ required String label,
+    /*required*/ required String hint,
+    /*required*/ required String value,
+    /*required*/ required String increasedValue,
+    /*required*/ required String decreasedValue,
+    TextDirection? textDirection,
+    /*required*/ required Float64List transform,
+    /*required*/ required Int32List childrenInTraversalOrder,
+    /*required*/ required Int32List childrenInHitTestOrder,
+    /*required*/ required Int32List additionalActions,
   }) {
     assert(_matrix4IsValid(transform));
     assert(
+      // ignore: unnecessary_null_comparison
       scrollChildren == 0 || scrollChildren == null || (scrollChildren > 0 && childrenInHitTestOrder != null),
       'If a node has scrollChildren, it must have childrenInHitTestOrder',
     );
@@ -754,35 +756,35 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
     );
   }
   void _updateNode(
-    int/*!*/ id,
-    int/*!*/ flags,
-    int/*!*/ actions,
-    int/*!*/ maxValueLength,
-    int/*!*/ currentValueLength,
-    int/*!*/ textSelectionBase,
-    int/*!*/ textSelectionExtent,
-    int/*!*/ platformViewId,
-    int/*!*/ scrollChildren,
-    int/*!*/ scrollIndex,
-    double/*!*/ scrollPosition,
-    double/*!*/ scrollExtentMax,
-    double/*!*/ scrollExtentMin,
-    double/*!*/ left,
-    double/*!*/ top,
-    double/*!*/ right,
-    double/*!*/ bottom,
-    double/*!*/ elevation,
-    double/*!*/ thickness,
-    String/*!*/ label,
-    String/*!*/ hint,
-    String/*!*/ value,
-    String/*!*/ increasedValue,
-    String/*!*/ decreasedValue,
-    int/*!*/ textDirection,
-    Float64List/*!*/ transform,
-    Int32List/*!*/ childrenInTraversalOrder,
-    Int32List/*!*/ childrenInHitTestOrder,
-    Int32List/*!*/ additionalActions,
+    int id,
+    int flags,
+    int actions,
+    int maxValueLength,
+    int currentValueLength,
+    int textSelectionBase,
+    int textSelectionExtent,
+    int platformViewId,
+    int scrollChildren,
+    int scrollIndex,
+    double scrollPosition,
+    double scrollExtentMax,
+    double scrollExtentMin,
+    double left,
+    double top,
+    double right,
+    double bottom,
+    double elevation,
+    double thickness,
+    String label,
+    String hint,
+    String value,
+    String increasedValue,
+    String decreasedValue,
+    int textDirection,
+    Float64List transform,
+    Int32List childrenInTraversalOrder,
+    Int32List childrenInHitTestOrder,
+    Int32List additionalActions,
   ) native 'SemanticsUpdateBuilder_updateNode';
 
   /// Update the custom semantics action associated with the given `id`.
@@ -800,28 +802,28 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
   /// For overridden standard actions, `overrideId` corresponds with a
   /// [SemanticsAction.index] value. For custom actions this argument should not be
   /// provided.
-  void updateCustomAction({/*required*/ int/*!*/ id, String/*?*/ label, String/*?*/ hint, int/*!*/ overrideId = -1}) {
-    assert(id != null);
-    assert(overrideId != null);
+  void updateCustomAction({/*required*/ required int id, String? label, String? hint, int overrideId = -1}) {
+    assert(id != null); // ignore: unnecessary_null_comparison
+    assert(overrideId != null); // ignore: unnecessary_null_comparison
     _updateCustomAction(id, label, hint, overrideId);
   }
   void _updateCustomAction(
-      int/*!*/ id,
-      String/*?*/ label,
-      String/*?*/ hint,
-      int/*!*/ overrideId) native 'SemanticsUpdateBuilder_updateCustomAction';
+      int id,
+      String? label,
+      String? hint,
+      int overrideId) native 'SemanticsUpdateBuilder_updateCustomAction';
 
   /// Creates a [SemanticsUpdate] object that encapsulates the updates recorded
   /// by this object.
   ///
   /// The returned object can be passed to [Window.updateSemantics] to actually
   /// update the semantics retained by the system.
-  SemanticsUpdate/*!*/ build() {
+  SemanticsUpdate build() {
     final SemanticsUpdate semanticsUpdate = SemanticsUpdate._();
     _build(semanticsUpdate);
     return semanticsUpdate;
   }
-  void _build(SemanticsUpdate/*!*/ outSemanticsUpdate) native 'SemanticsUpdateBuilder_build';
+  void _build(SemanticsUpdate outSemanticsUpdate) native 'SemanticsUpdateBuilder_build';
 }
 
 /// An opaque object representing a batch of semantics updates.

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
+
 part of dart.ui;
 
 /// Whether to slant the glyphs in the font
@@ -19,7 +20,7 @@ class FontWeight {
   const FontWeight._(this.index);
 
   /// The encoded integer value of this font weight.
-  final int/*!*/ index;
+  final int index;
 
   /// Thin, the least thick
   static const FontWeight w100 = FontWeight._(0);
@@ -55,7 +56,7 @@ class FontWeight {
   static const FontWeight bold = w700;
 
   /// A list of all the font weights.
-  static const List<FontWeight/*!*/> values = <FontWeight/*!*/>[
+  static const List<FontWeight> values = <FontWeight>[
     w100, w200, w300, w400, w500, w600, w700, w800, w900
   ];
 
@@ -80,15 +81,15 @@ class FontWeight {
   ///
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
-  static FontWeight/*?*/ lerp(FontWeight/*?*/ a, FontWeight/*?*/ b, double/*!*/ t) {
-    assert(t != null);
+  static FontWeight? lerp(FontWeight? a, FontWeight? b, double t) {
+    assert(t != null); // ignore: unnecessary_null_comparison
     if (a == null && b == null)
       return null;
-    return values[lerpDouble(a?.index ?? normal.index, b?.index ?? normal.index, t).round().clamp(0, 8) as int];
+    return values[_lerpInt(a?.index ?? normal.index, b?.index ?? normal.index, t).round().clamp(0, 8) as int];
   }
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     return const <int, String>{
       0: 'FontWeight.w100',
       1: 'FontWeight.w200',
@@ -99,7 +100,7 @@ class FontWeight {
       6: 'FontWeight.w700',
       7: 'FontWeight.w800',
       8: 'FontWeight.w900',
-    }[index];
+    }[index]!;
   }
 }
 
@@ -187,6 +188,7 @@ class FontFeature {
   /// flags whose value can be 1 (when enabled) or 0 (when disabled).
   ///
   /// See <https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags>
+  // ignore: unnecessary_null_comparison
   const FontFeature(this.feature, [ this.value = 1 ]) : assert(feature != null), assert(feature.length == 4), assert(value != null), assert(value >= 0);
 
   /// Create a [FontFeature] object that enables the feature with the given tag.
@@ -214,7 +216,7 @@ class FontFeature {
   /// See also:
   ///
   ///  * <https://docs.microsoft.com/en-us/typography/opentype/spec/features_pt#ssxx>
-  factory FontFeature.stylisticSet(int/*!*/ value) {
+  factory FontFeature.stylisticSet(int value) {
     assert(value >= 1);
     assert(value <= 20);
     return FontFeature('ss${value.toString().padLeft(2, "0")}');
@@ -277,13 +279,13 @@ class FontFeature {
   /// ASCII characters (typically lowercase letters).
   ///
   /// See <https://docs.microsoft.com/en-us/typography/opentype/spec/featuretags>
-  final String/*!*/ feature;
+  final String feature;
 
   /// The value assigned to this feature.
   ///
   /// Must be a positive integer.  Many features are Boolean values that accept
   /// values of either 0 (feature is disabled) or 1 (feature is enabled).
-  final int/*!*/ value;
+  final int value;
 
   static const int _kEncodedSize = 8;
 
@@ -296,7 +298,7 @@ class FontFeature {
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     if (other.runtimeType != runtimeType)
@@ -307,10 +309,10 @@ class FontFeature {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(feature, value);
+  int get hashCode => hashValues(feature, value);
 
   @override
-  String/*!*/ toString() => 'FontFeature($feature, $value)';
+  String toString() => 'FontFeature($feature, $value)';
 }
 
 /// Whether and how to align text horizontally.
@@ -360,17 +362,17 @@ class TextDecoration {
   const TextDecoration._(this._mask);
 
   /// Creates a decoration that paints the union of all the given decorations.
-  factory TextDecoration.combine(List<TextDecoration/*!*/>/*!*/ decorations) {
+  factory TextDecoration.combine(List<TextDecoration> decorations) {
     int mask = 0;
     for (TextDecoration decoration in decorations)
       mask |= decoration._mask;
     return TextDecoration._(mask);
   }
 
-  final int/*!*/ _mask;
+  final int _mask;
 
   /// Whether this decoration will paint at least as much decoration as the given decoration.
-  bool/*!*/ contains(TextDecoration/*!*/ other) {
+  bool contains(TextDecoration other) {
     return (_mask | other._mask) == _mask;
   }
 
@@ -387,16 +389,16 @@ class TextDecoration {
   static const TextDecoration lineThrough = TextDecoration._(0x4);
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     return other is TextDecoration
         && other._mask == _mask;
   }
 
   @override
-  int/*!*/ get hashCode => _mask.hashCode;
+  int get hashCode => _mask.hashCode;
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     if (_mask == 0)
       return 'TextDecoration.none';
     final List<String> values = <String>[];
@@ -459,7 +461,7 @@ class TextHeightBehavior {
   /// Creates a new TextHeightBehavior object from an encoded form.
   ///
   /// See [encode] for the creation of the encoded form.
-  const TextHeightBehavior.fromEncoded(int/*!*/ encoded)
+  const TextHeightBehavior.fromEncoded(int encoded)
     : applyHeightToFirstAscent = (encoded & 0x1) == 0,
       applyHeightToLastDescent = (encoded & 0x2) == 0;
 
@@ -474,7 +476,7 @@ class TextHeightBehavior {
   /// This property only has effect if a non-null [TextStyle.height] is specified.
   ///
   /// Defaults to true (height modifications applied as normal).
-  final bool/*!*/ applyHeightToFirstAscent;
+  final bool applyHeightToFirstAscent;
 
   /// Whether to apply the [TextStyle.height] modifier to the descent of the last
   /// line in the paragraph.
@@ -486,15 +488,15 @@ class TextHeightBehavior {
   /// This property only has effect if a non-null [TextStyle.height] is specified.
   ///
   /// Defaults to true (height modifications applied as normal).
-  final bool/*!*/ applyHeightToLastDescent;
+  final bool applyHeightToLastDescent;
 
   /// Returns an encoded int representation of this object.
-  int/*!*/ encode() {
+  int encode() {
     return (applyHeightToFirstAscent ? 0 : 1 << 0) | (applyHeightToLastDescent ? 0 : 1 << 1);
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (other.runtimeType != runtimeType)
       return false;
     return other is TextHeightBehavior
@@ -503,7 +505,7 @@ class TextHeightBehavior {
   }
 
   @override
-  int/*!*/ get hashCode {
+  int get hashCode {
     return hashValues(
       applyHeightToFirstAscent,
       applyHeightToLastDescent,
@@ -511,7 +513,7 @@ class TextHeightBehavior {
   }
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     return 'TextHeightBehavior('
              'applyHeightToFirstAscent: $applyHeightToFirstAscent, '
              'applyHeightToLastDescent: $applyHeightToLastDescent'
@@ -524,7 +526,7 @@ class TextHeightBehavior {
 /// Returns true if the lists are both null, or if they are both non-null, have
 /// the same length, and contain the same elements in the same order. Returns
 /// false otherwise.
-bool/*!*/ _listEquals<T>(List<T>/*?*/ a, List<T>/*?*/ b) {
+bool _listEquals<T>(List<T>? a, List<T>? b) {
   if (a == null)
     return b == null;
   if (b == null || a.length != b.length)
@@ -562,25 +564,25 @@ bool/*!*/ _listEquals<T>(List<T>/*?*/ a, List<T>/*?*/ b) {
 //  - Element 7: The enum index of the |textBaseline|.
 //
 Int32List _encodeTextStyle(
-  Color color,
-  TextDecoration decoration,
-  Color decorationColor,
-  TextDecorationStyle decorationStyle,
-  double decorationThickness,
-  FontWeight fontWeight,
-  FontStyle fontStyle,
-  TextBaseline textBaseline,
-  String fontFamily,
-  List<String/*!*/> fontFamilyFallback,
-  double fontSize,
-  double letterSpacing,
-  double wordSpacing,
-  double height,
-  Locale locale,
-  Paint background,
-  Paint foreground,
-  List<Shadow/*!*/> shadows,
-  List<FontFeature/*!*/> fontFeatures,
+  Color? color,
+  TextDecoration? decoration,
+  Color? decorationColor,
+  TextDecorationStyle? decorationStyle,
+  double? decorationThickness,
+  FontWeight? fontWeight,
+  FontStyle? fontStyle,
+  TextBaseline? textBaseline,
+  String? fontFamily,
+  List<String>? fontFamilyFallback,
+  double? fontSize,
+  double? letterSpacing,
+  double? wordSpacing,
+  double? height,
+  Locale? locale,
+  Paint? background,
+  Paint? foreground,
+  List<Shadow>? shadows,
+  List<FontFeature>? fontFeatures,
 ) {
   final Int32List result = Int32List(8);
   if (color != null) {
@@ -693,25 +695,25 @@ class TextStyle {
   /// * `foreground`: The paint used to draw the text. If this is specified, `color` must be null.
   /// * `fontFeatures`: The font features that should be applied to the text.
   TextStyle({
-    Color/*?*/ color,
-    TextDecoration/*?*/ decoration,
-    Color/*?*/ decorationColor,
-    TextDecorationStyle/*?*/ decorationStyle,
-    double/*?*/ decorationThickness,
-    FontWeight/*?*/ fontWeight,
-    FontStyle/*?*/ fontStyle,
-    TextBaseline/*?*/ textBaseline,
-    String/*?*/ fontFamily,
-    List<String/*!*/>/*?*/ fontFamilyFallback,
-    double/*?*/ fontSize,
-    double/*?*/ letterSpacing,
-    double/*?*/ wordSpacing,
-    double/*?*/ height,
-    Locale/*?*/ locale,
-    Paint/*?*/ background,
-    Paint/*?*/ foreground,
-    List<Shadow/*!*/>/*?*/ shadows,
-    List<FontFeature/*!*/>/*?*/ fontFeatures,
+    Color? color,
+    TextDecoration? decoration,
+    Color? decorationColor,
+    TextDecorationStyle? decorationStyle,
+    double? decorationThickness,
+    FontWeight? fontWeight,
+    FontStyle? fontStyle,
+    TextBaseline? textBaseline,
+    String? fontFamily,
+    List<String>? fontFamilyFallback,
+    double? fontSize,
+    double? letterSpacing,
+    double? wordSpacing,
+    double? height,
+    Locale? locale,
+    Paint? background,
+    Paint? foreground,
+    List<Shadow>? shadows,
+    List<FontFeature>? fontFeatures,
   }) : assert(color == null || foreground == null,
          'Cannot provide both a color and a foreground\n'
          'The color argument is just a shorthand for "foreground: Paint()..color = color".'
@@ -752,20 +754,20 @@ class TextStyle {
 
   final Int32List _encoded;
   final String _fontFamily;
-  final List<String> _fontFamilyFallback;
-  final double _fontSize;
-  final double _letterSpacing;
-  final double _wordSpacing;
-  final double _height;
-  final double _decorationThickness;
-  final Locale _locale;
-  final Paint _background;
-  final Paint _foreground;
-  final List<Shadow> _shadows;
-  final List<FontFeature> _fontFeatures;
+  final List<String>? _fontFamilyFallback;
+  final double? _fontSize;
+  final double? _letterSpacing;
+  final double? _wordSpacing;
+  final double? _height;
+  final double? _decorationThickness;
+  final Locale? _locale;
+  final Paint? _background;
+  final Paint? _foreground;
+  final List<Shadow>? _shadows;
+  final List<FontFeature>? _fontFeatures;
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     return other is TextStyle
@@ -785,10 +787,10 @@ class TextStyle {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(hashList(_encoded), _fontFamily, _fontFamilyFallback, _fontSize, _letterSpacing, _wordSpacing, _height, _locale, _background, _foreground, hashList(_shadows), _decorationThickness, hashList(_fontFeatures));
+  int get hashCode => hashValues(hashList(_encoded), _fontFamily, _fontFamilyFallback, _fontSize, _letterSpacing, _wordSpacing, _height, _locale, _background, _foreground, hashList(_shadows), _decorationThickness, hashList(_fontFeatures));
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     return 'TextStyle('
              'color: ${              _encoded[0] & 0x00002 == 0x00002  ? Color(_encoded[1])                  : "unspecified"}, '
              'decoration: ${         _encoded[0] & 0x00004 == 0x00004  ? TextDecoration._(_encoded[2])       : "unspecified"}, '
@@ -800,10 +802,10 @@ class TextStyle {
              'fontStyle: ${          _encoded[0] & 0x00040 == 0x00040  ? FontStyle.values[_encoded[6]]           : "unspecified"}, '
              'textBaseline: ${       _encoded[0] & 0x00080 == 0x00080  ? TextBaseline.values[_encoded[7]]        : "unspecified"}, '
              'fontFamily: ${         _encoded[0] & 0x00200 == 0x00200
-                                     && _fontFamily != null            ? _fontFamily                             : "unspecified"}, '
+                                     && _fontFamily != ''              ? _fontFamily                             : "unspecified"}, '
              'fontFamilyFallback: ${ _encoded[0] & 0x00200 == 0x00200
                                      && _fontFamilyFallback != null
-                                     && _fontFamilyFallback.isNotEmpty ? _fontFamilyFallback                     : "unspecified"}, '
+                                     && _fontFamilyFallback!.isNotEmpty ? _fontFamilyFallback                     : "unspecified"}, '
              'fontSize: ${           _encoded[0] & 0x00400 == 0x00400  ? _fontSize                               : "unspecified"}, '
              'letterSpacing: ${      _encoded[0] & 0x00800 == 0x00800  ? "${_letterSpacing}x"                    : "unspecified"}, '
              'wordSpacing: ${        _encoded[0] & 0x01000 == 0x01000  ? "${_wordSpacing}x"                      : "unspecified"}, '
@@ -839,18 +841,18 @@ class TextStyle {
 //  - Element 6: The encoded value of |textHeightBehavior|.
 //
 Int32List _encodeParagraphStyle(
-  TextAlign textAlign,
-  TextDirection textDirection,
-  int maxLines,
-  String fontFamily,
-  double fontSize,
-  double height,
-  TextHeightBehavior textHeightBehavior,
-  FontWeight fontWeight,
-  FontStyle fontStyle,
-  StrutStyle strutStyle,
-  String ellipsis,
-  Locale locale,
+  TextAlign? textAlign,
+  TextDirection? textDirection,
+  int? maxLines,
+  String? fontFamily,
+  double? fontSize,
+  double? height,
+  TextHeightBehavior? textHeightBehavior,
+  FontWeight? fontWeight,
+  FontStyle? fontStyle,
+  StrutStyle? strutStyle,
+  String? ellipsis,
+  Locale? locale,
 ) {
   final Int32List result = Int32List(7); // also update paragraph_builder.cc
   if (textAlign != null) {
@@ -963,18 +965,18 @@ class ParagraphStyle {
   ///
   /// * `locale`: The locale used to select region-specific glyphs.
   ParagraphStyle({
-    TextAlign/*?*/ textAlign,
-    TextDirection/*?*/ textDirection,
-    int/*?*/ maxLines,
-    String/*?*/ fontFamily,
-    double/*?*/ fontSize,
-    double/*?*/ height,
-    TextHeightBehavior/*?*/ textHeightBehavior,
-    FontWeight/*?*/ fontWeight,
-    FontStyle/*?*/ fontStyle,
-    StrutStyle/*?*/ strutStyle,
-    String/*?*/ ellipsis,
-    Locale/*?*/ locale,
+    TextAlign? textAlign,
+    TextDirection? textDirection,
+    int? maxLines,
+    String? fontFamily,
+    double? fontSize,
+    double? height,
+    TextHeightBehavior? textHeightBehavior,
+    FontWeight? fontWeight,
+    FontStyle? fontStyle,
+    StrutStyle? strutStyle,
+    String? ellipsis,
+    Locale? locale,
   }) : _encoded = _encodeParagraphStyle(
          textAlign,
          textDirection,
@@ -997,15 +999,15 @@ class ParagraphStyle {
        _locale = locale;
 
   final Int32List _encoded;
-  final String _fontFamily;
-  final double _fontSize;
-  final double _height;
-  final StrutStyle _strutStyle;
-  final String _ellipsis;
-  final Locale _locale;
+  final String? _fontFamily;
+  final double? _fontSize;
+  final double? _height;
+  final StrutStyle? _strutStyle;
+  final String? _ellipsis;
+  final Locale? _locale;
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     if (other.runtimeType != runtimeType)
@@ -1021,10 +1023,10 @@ class ParagraphStyle {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(hashList(_encoded), _fontFamily, _fontSize, _height, _ellipsis, _locale);
+  int get hashCode => hashValues(hashList(_encoded), _fontFamily, _fontSize, _height, _ellipsis, _locale);
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     return 'ParagraphStyle('
              'textAlign: ${     _encoded[0] & 0x002 == 0x002 ? TextAlign.values[_encoded[1]]     : "unspecified"}, '
              'textDirection: ${ _encoded[0] & 0x004 == 0x004 ? TextDirection.values[_encoded[2]] : "unspecified"}, '
@@ -1053,14 +1055,14 @@ class ParagraphStyle {
 // much more likely that the strut is empty/null and we wish to add
 // minimal overhead for non-strut cases.
 ByteData _encodeStrut(
-  String fontFamily,
-  List<String> fontFamilyFallback,
-  double fontSize,
-  double height,
-  double leading,
-  FontWeight fontWeight,
-  FontStyle fontStyle,
-  bool forceStrutHeight) {
+  String? fontFamily,
+  List<String>? fontFamilyFallback,
+  double? fontSize,
+  double? height,
+  double? leading,
+  FontWeight? fontWeight,
+  FontStyle? fontStyle,
+  bool? forceStrutHeight) {
   if (fontFamily == null &&
     fontSize == null &&
     height == null &&
@@ -1157,14 +1159,14 @@ class StrutStyle {
   ///   of the `fontFamily` and `(height + leading) * fontSize`. Otherwise, it
   ///   will be determined by the Ascent + half-leading of the first text.
   StrutStyle({
-    String/*?*/ fontFamily,
-    List<String/*!*/>/*?*/ fontFamilyFallback,
-    double/*?*/ fontSize,
-    double/*?*/ height,
-    double/*?*/ leading,
-    FontWeight/*?*/ fontWeight,
-    FontStyle/*?*/ fontStyle,
-    bool/*?*/ forceStrutHeight,
+    String? fontFamily,
+    List<String>? fontFamilyFallback,
+    double? fontSize,
+    double? height,
+    double? leading,
+    FontWeight? fontWeight,
+    FontStyle? fontStyle,
+    bool? forceStrutHeight,
   }) : _encoded = _encodeStrut(
          fontFamily,
          fontFamilyFallback,
@@ -1179,12 +1181,12 @@ class StrutStyle {
        _fontFamilyFallback = fontFamilyFallback;
 
   final ByteData _encoded; // Most of the data for strut is encoded.
-  final String _fontFamily;
-  final List<String> _fontFamilyFallback;
+  final String? _fontFamily;
+  final List<String>? _fontFamilyFallback;
 
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     if (other.runtimeType != runtimeType)
@@ -1196,7 +1198,7 @@ class StrutStyle {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(hashList(_encoded.buffer.asInt8List()), _fontFamily);
+  int get hashCode => hashValues(hashList(_encoded.buffer.asInt8List()), _fontFamily);
 
 }
 
@@ -1310,31 +1312,31 @@ class TextBox {
   /// The left edge of the text box, irrespective of direction.
   ///
   /// To get the leading edge (which may depend on the [direction]), consider [start].
-  final double/*!*/ left;
+  final double left;
 
   /// The top edge of the text box.
-  final double/*!*/ top;
+  final double top;
 
   /// The right edge of the text box, irrespective of direction.
   ///
   /// To get the trailing edge (which may depend on the [direction]), consider [end].
-  final double/*!*/ right;
+  final double right;
 
   /// The bottom edge of the text box.
-  final double/*!*/ bottom;
+  final double bottom;
 
   /// The direction in which text inside this box flows.
-  final TextDirection/*!*/ direction;
+  final TextDirection direction;
 
   /// Returns a rect of the same size as this box.
-  Rect/*!*/ toRect() => Rect.fromLTRB(left, top, right, bottom);
+  Rect toRect() => Rect.fromLTRB(left, top, right, bottom);
 
   /// The [left] edge of the box for left-to-right text; the [right] edge of the box for right-to-left text.
   ///
   /// See also:
   ///
   ///  * [direction], which specifies the text direction.
-  double/*!*/ get start {
+  double get start {
     return (direction == TextDirection.ltr) ? left : right;
   }
 
@@ -1343,12 +1345,12 @@ class TextBox {
   /// See also:
   ///
   ///  * [direction], which specifies the text direction.
-  double/*!*/ get end {
+  double get end {
     return (direction == TextDirection.ltr) ? right : left;
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     if (other.runtimeType != runtimeType)
@@ -1362,10 +1364,10 @@ class TextBox {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(left, top, right, bottom, direction);
+  int get hashCode => hashValues(left, top, right, bottom, direction);
 
   @override
-  String/*!*/ toString() => 'TextBox.fromLTRBD(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)}, $direction)';
+  String toString() => 'TextBox.fromLTRBD(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)}, $direction)';
 }
 
 /// A way to disambiguate a [TextPosition] when its offset could match two
@@ -1437,10 +1439,10 @@ class TextPosition {
   ///
   /// The arguments must not be null (so the [offset] argument is required).
   const TextPosition({
-    this.offset,
+    required this.offset,
     this.affinity = TextAffinity.downstream,
-  }) : assert(offset != null),
-       assert(affinity != null);
+  }) : assert(offset != null), // ignore: unnecessary_null_comparison
+       assert(affinity != null); // ignore: unnecessary_null_comparison
 
   /// The index of the character that immediately follows the position in the
   /// string representation of the text.
@@ -1448,7 +1450,7 @@ class TextPosition {
   /// For example, given the string `'Hello'`, offset 0 represents the cursor
   /// being before the `H`, while offset 5 represents the cursor being just
   /// after the `o`.
-  final int/*!*/ offset;
+  final int offset;
 
   /// Disambiguates cases where the position in the string given by [offset]
   /// could represent two different visual positions in the rendered text. For
@@ -1457,10 +1459,10 @@ class TextPosition {
   ///
   /// See the documentation for [TextAffinity] for more information on how
   /// TextAffinity disambiguates situations like these.
-  final TextAffinity/*!*/ affinity;
+  final TextAffinity affinity;
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (other.runtimeType != runtimeType)
       return false;
     return other is TextPosition
@@ -1469,10 +1471,10 @@ class TextPosition {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(offset, affinity);
+  int get hashCode => hashValues(offset, affinity);
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     return 'TextPosition(offset: $offset, affinity: $affinity)';
   }
 }
@@ -1490,16 +1492,16 @@ class TextRange {
   /// Instead of creating an empty text range, consider using the [empty]
   /// constant.
   const TextRange({
-    this.start,
-    this.end,
-  }) : assert(start != null && start >= -1),
-        assert(end != null && end >= -1);
+    required this.start,
+    required this.end,
+  }) : assert(start != null && start >= -1), // ignore: unnecessary_null_comparison
+        assert(end != null && end >= -1); // ignore: unnecessary_null_comparison
 
   /// A text range that starts and ends at offset.
   ///
   /// The [offset] argument must be non-null and greater than or equal to -1.
   const TextRange.collapsed(int offset)
-      : assert(offset != null && offset >= -1),
+      : assert(offset != null && offset >= -1), // ignore: unnecessary_null_comparison
         start = offset,
         end = offset;
 
@@ -1509,42 +1511,42 @@ class TextRange {
   /// The index of the first character in the range.
   ///
   /// If [start] and [end] are both -1, the text range is empty.
-  final int/*!*/ start;
+  final int start;
 
   /// The next index after the characters in this range.
   ///
   /// If [start] and [end] are both -1, the text range is empty.
-  final int/*!*/ end;
+  final int end;
 
   /// Whether this range represents a valid position in the text.
-  bool/*!*/ get isValid => start >= 0 && end >= 0;
+  bool get isValid => start >= 0 && end >= 0;
 
   /// Whether this range is empty (but still potentially placed inside the text).
-  bool/*!*/ get isCollapsed => start == end;
+  bool get isCollapsed => start == end;
 
   /// Whether the start of this range precedes the end.
-  bool/*!*/ get isNormalized => end >= start;
+  bool get isNormalized => end >= start;
 
   /// The text before this range.
-  String/*!*/ textBefore(String/*!*/ text) {
+  String textBefore(String text) {
     assert(isNormalized);
     return text.substring(0, start);
   }
 
   /// The text after this range.
-  String/*!*/ textAfter(String/*!*/ text) {
+  String textAfter(String text) {
     assert(isNormalized);
     return text.substring(end);
   }
 
   /// The text inside this range.
-  String/*!*/ textInside(String/*!*/ text) {
+  String textInside(String text) {
     assert(isNormalized);
     return text.substring(start, end);
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     return other is TextRange
@@ -1553,13 +1555,13 @@ class TextRange {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(
+  int get hashCode => hashValues(
     start.hashCode,
     end.hashCode,
   );
 
   @override
-  String/*!*/ toString() => 'TextRange(start: $start, end: $end)';
+  String toString() => 'TextRange(start: $start, end: $end)';
 }
 
 /// Layout constraints for [Paragraph] objects.
@@ -1573,8 +1575,8 @@ class ParagraphConstraints {
   ///
   /// The [width] argument must not be null.
   const ParagraphConstraints({
-    this.width,
-  }) : assert(width != null);
+    required this.width,
+  }) : assert(width != null); // ignore: unnecessary_null_comparison
 
   /// The width the paragraph should use whey computing the positions of glyphs.
   ///
@@ -1593,10 +1595,10 @@ class ParagraphConstraints {
   /// This width is also used to position glyphs according to the [TextAlign]
   /// alignment described in the [ParagraphStyle] used when building the
   /// [Paragraph] with a [ParagraphBuilder].
-  final double/*!*/ width;
+  final double width;
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (other.runtimeType != runtimeType)
       return false;
     return other is ParagraphConstraints
@@ -1604,10 +1606,10 @@ class ParagraphConstraints {
   }
 
   @override
-  int/*!*/ get hashCode => width.hashCode;
+  int get hashCode => width.hashCode;
 
   @override
-  String/*!*/ toString() => 'ParagraphConstraints(width: $width)';
+  String toString() => 'ParagraphConstraints(width: $width)';
 }
 
 /// Defines various ways to vertically bound the boxes returned by
@@ -1744,20 +1746,20 @@ class LineMetrics {
   /// Omitted values will remain null. [Paragraph.computeLineMetrics] produces
   /// fully defined [LineMetrics] with no null values.
   LineMetrics({
-    this.hardBreak,
-    this.ascent,
-    this.descent,
-    this.unscaledAscent,
-    this.height,
-    this.width,
-    this.left,
-    this.baseline,
-    this.lineNumber,
+    required this.hardBreak,
+    required this.ascent,
+    required this.descent,
+    required this.unscaledAscent,
+    required this.height,
+    required this.width,
+    required this.left,
+    required this.baseline,
+    required this.lineNumber,
   });
 
   /// True if this line ends with an explicit line break (e.g. '\n') or is the end
   /// of the paragraph. False otherwise.
-  final bool/*!*/ hardBreak;
+  final bool hardBreak;
 
   /// The rise from the [baseline] as calculated from the font and style for this line.
   ///
@@ -1768,7 +1770,7 @@ class LineMetrics {
   /// in fonts as negative. This is to ensure the signage of operations with these
   /// metrics directly reflects the intended signage of the value. For example,
   /// the y coordinate of the top edge of the line is `baseline - ascent`.
-  final double/*!*/ ascent;
+  final double ascent;
 
   /// The drop from the [baseline] as calculated from the font and style for this line.
   ///
@@ -1776,7 +1778,7 @@ class LineMetrics {
   /// as well as outlying runs that are very tall.
   ///
   /// The y coordinate of the bottom edge of the line is `baseline + descent`.
-  final double/*!*/ descent;
+  final double descent;
 
   /// The rise from the [baseline] as calculated from the font and style for this line
   /// ignoring the [TextStyle.height].
@@ -1784,14 +1786,14 @@ class LineMetrics {
   /// The [unscaledAscent] is provided as a positive value, even though it is typically
   /// defined in fonts as negative. This is to ensure the signage of operations with
   /// these metrics directly reflects the intended signage of the value.
-  final double/*!*/ unscaledAscent;
+  final double unscaledAscent;
 
   /// Total height of the line from the top edge to the bottom edge.
   ///
   /// This is equivalent to `round(ascent + descent)`. This value is provided
   /// separately due to rounding causing sub-pixel differences from the unrounded
   /// values.
-  final double/*!*/ height;
+  final double height;
 
   /// Width of the line from the left edge of the leftmost glyph to the right
   /// edge of the rightmost glyph.
@@ -1802,27 +1804,27 @@ class LineMetrics {
   ///
   ///  * [Paragraph.width], the max width passed in during layout.
   ///  * [Paragraph.longestLine], the width of the longest line in the paragraph.
-  final double/*!*/ width;
+  final double width;
 
   /// The x coordinate of left edge of the line.
   ///
   /// The right edge can be obtained with `left + width`.
-  final double/*!*/ left;
+  final double left;
 
   /// The y coordinate of the baseline for this line from the top of the paragraph.
   ///
   /// The bottom edge of the paragraph up to and including this line may be obtained
   /// through `baseline + descent`.
-  final double/*!*/ baseline;
+  final double baseline;
 
   /// The number of this line in the overall paragraph, with the first line being
   /// index zero.
   ///
   /// For example, the first line is line 0, second line is line 1.
-  final int/*!*/ lineNumber;
+  final int lineNumber;
 
   @override
-  bool/*!*/ operator ==(Object other) {
+  bool operator ==(Object other) {
     if (other.runtimeType != runtimeType) {
       return false;
     }
@@ -1839,10 +1841,10 @@ class LineMetrics {
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(hardBreak, ascent, descent, unscaledAscent, height, width, left, baseline, lineNumber);
+  int get hashCode => hashValues(hardBreak, ascent, descent, unscaledAscent, height, width, left, baseline, lineNumber);
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     return 'LineMetrics(hardBreak: $hardBreak, '
                        'ascent: $ascent, '
                        'descent: $descent, '
@@ -1876,38 +1878,38 @@ class Paragraph extends NativeFieldWrapperClass2 {
   /// The amount of horizontal space this paragraph occupies.
   ///
   /// Valid only after [layout] has been called.
-  double/*!*/ get width native 'Paragraph_width';
+  double get width native 'Paragraph_width';
 
   /// The amount of vertical space this paragraph occupies.
   ///
   /// Valid only after [layout] has been called.
-  double/*!*/ get height native 'Paragraph_height';
+  double get height native 'Paragraph_height';
 
   /// The distance from the left edge of the leftmost glyph to the right edge of
   /// the rightmost glyph in the paragraph.
   ///
   /// Valid only after [layout] has been called.
-  double/*!*/ get longestLine native 'Paragraph_longestLine';
+  double get longestLine native 'Paragraph_longestLine';
 
   /// The minimum width that this paragraph could be without failing to paint
   /// its contents within itself.
   ///
   /// Valid only after [layout] has been called.
-  double/*!*/ get minIntrinsicWidth native 'Paragraph_minIntrinsicWidth';
+  double get minIntrinsicWidth native 'Paragraph_minIntrinsicWidth';
 
   /// Returns the smallest width beyond which increasing the width never
   /// decreases the height.
   ///
   /// Valid only after [layout] has been called.
-  double/*!*/ get maxIntrinsicWidth native 'Paragraph_maxIntrinsicWidth';
+  double get maxIntrinsicWidth native 'Paragraph_maxIntrinsicWidth';
 
   /// The distance from the top of the paragraph to the alphabetic
   /// baseline of the first line, in logical pixels.
-  double/*!*/ get alphabeticBaseline native 'Paragraph_alphabeticBaseline';
+  double get alphabeticBaseline native 'Paragraph_alphabeticBaseline';
 
   /// The distance from the top of the paragraph to the ideographic
   /// baseline of the first line, in logical pixels.
-  double/*!*/ get ideographicBaseline native 'Paragraph_ideographicBaseline';
+  double get ideographicBaseline native 'Paragraph_ideographicBaseline';
 
   /// True if there is more vertical content, but the text was truncated, either
   /// because we reached `maxLines` lines of text or because the `maxLines` was
@@ -1916,29 +1918,30 @@ class Paragraph extends NativeFieldWrapperClass2 {
   ///
   /// See the discussion of the `maxLines` and `ellipsis` arguments at
   /// [new ParagraphStyle].
-  bool/*!*/ get didExceedMaxLines native 'Paragraph_didExceedMaxLines';
+  bool get didExceedMaxLines native 'Paragraph_didExceedMaxLines';
 
   /// Computes the size and position of each glyph in the paragraph.
   ///
   /// The [ParagraphConstraints] control how wide the text is allowed to be.
-  void layout(ParagraphConstraints/*!*/ constraints) => _layout(constraints.width);
+  void layout(ParagraphConstraints constraints) => _layout(constraints.width);
   void _layout(double width) native 'Paragraph_layout';
 
   List<TextBox> _decodeTextBoxes(Float32List encoded) {
     final int count = encoded.length ~/ 5;
-    final List<TextBox> boxes = List<TextBox>(count);
+    final List<TextBox> boxes = <TextBox>[];
     int position = 0;
     for (int index = 0; index < count; index += 1) {
-      boxes[index] = TextBox.fromLTRBD(
+      boxes.add(TextBox.fromLTRBD(
         encoded[position++],
         encoded[position++],
         encoded[position++],
         encoded[position++],
         TextDirection.values[encoded[position++].toInt()],
-      );
+      ));
     }
     return boxes;
   }
+
   /// Returns a list of text boxes that enclose the given text range.
   ///
   /// The [boxHeightStyle] and [boxWidthStyle] parameters allow customization
@@ -1952,9 +1955,9 @@ class Paragraph extends NativeFieldWrapperClass2 {
   /// The [boxHeightStyle] and [boxWidthStyle] parameters must not be null.
   ///
   /// See [BoxHeightStyle] and [BoxWidthStyle] for full descriptions of each option.
-  List<TextBox/*!*/>/*!*/ getBoxesForRange(int/*!*/ start, int/*!*/ end, {BoxHeightStyle/*!*/ boxHeightStyle = BoxHeightStyle.tight, BoxWidthStyle/*!*/ boxWidthStyle = BoxWidthStyle.tight}) {
-    assert(boxHeightStyle != null);
-    assert(boxWidthStyle != null);
+  List<TextBox> getBoxesForRange(int start, int end, {BoxHeightStyle boxHeightStyle = BoxHeightStyle.tight, BoxWidthStyle boxWidthStyle = BoxWidthStyle.tight}) {
+    assert(boxHeightStyle != null); // ignore: unnecessary_null_comparison
+    assert(boxWidthStyle != null); // ignore: unnecessary_null_comparison
     return _decodeTextBoxes(_getBoxesForRange(start, end, boxHeightStyle.index, boxWidthStyle.index));
   }
   // See paragraph.cc for the layout of this return value.
@@ -1966,13 +1969,13 @@ class Paragraph extends NativeFieldWrapperClass2 {
   ///
   /// Coordinates of the [TextBox] are relative to the upper-left corner of the paragraph,
   /// where positive y values indicate down.
-  List<TextBox/*!*/>/*!*/ getBoxesForPlaceholders() {
+  List<TextBox> getBoxesForPlaceholders() {
     return _decodeTextBoxes(_getBoxesForPlaceholders());
   }
   Float32List _getBoxesForPlaceholders() native 'Paragraph_getRectsForPlaceholders';
 
   /// Returns the text position closest to the given offset.
-  TextPosition/*!*/ getPositionForOffset(Offset/*!*/ offset) {
+  TextPosition getPositionForOffset(Offset offset) {
     final List<int> encoded = _getPositionForOffset(offset.dx, offset.dy);
     return TextPosition(offset: encoded[0], affinity: TextAffinity.values[encoded[1]]);
   }
@@ -1984,7 +1987,7 @@ class Paragraph extends NativeFieldWrapperClass2 {
   /// have word breaks on both sides. In such cases, this method will return
   /// [offset, offset+1]. Word boundaries are defined more precisely in Unicode
   /// Standard Annex #29 http://www.unicode.org/reports/tr29/#Word_Boundaries
-  TextRange/*!*/ getWordBoundary(TextPosition/*!*/ position) {
+  TextRange getWordBoundary(TextPosition position) {
     final List<int> boundary = _getWordBoundary(position.offset);
     return TextRange(start: boundary[0], end: boundary[1]);
   }
@@ -1998,11 +2001,11 @@ class Paragraph extends NativeFieldWrapperClass2 {
   ///
   /// This can potentially be expensive, since it needs to compute the line
   /// metrics, so use it sparingly.
-  TextRange/*!*/ getLineBoundary(TextPosition/*!*/ position) {
+  TextRange getLineBoundary(TextPosition position) {
     final List<int> boundary = _getLineBoundary(position.offset);
     return TextRange(start: boundary[0], end: boundary[1]);
   }
-  List<int/*!*/>/*!*/ _getLineBoundary(int/*!*/ offset) native 'Paragraph_getLineBoundary';
+  List<int> _getLineBoundary(int offset) native 'Paragraph_getLineBoundary';
 
   // Redirecting the paint function in this way solves some dependency problems
   // in the C++ code. If we straighten out the C++ dependencies, we can remove
@@ -2016,13 +2019,12 @@ class Paragraph extends NativeFieldWrapperClass2 {
   ///
   /// This can potentially return a large amount of data, so it is not recommended
   /// to repeatedly call this. Instead, cache the results.
-  List<LineMetrics/*!*/>/*!*/ computeLineMetrics() {
+  List<LineMetrics> computeLineMetrics() {
     final Float64List encoded = _computeLineMetrics();
-    final int count = encoded.length ~/ 9;
     int position = 0;
-    final List<LineMetrics> metrics = List<LineMetrics>(count);
+    final List<LineMetrics> metrics = <LineMetrics>[];
     for (int index = 0; index < metrics.length; index += 1) {
-      metrics[index] = LineMetrics(
+      metrics.add(LineMetrics(
         hardBreak:      encoded[position++] != 0,
         ascent:         encoded[position++],
         descent:        encoded[position++],
@@ -2032,7 +2034,7 @@ class Paragraph extends NativeFieldWrapperClass2 {
         left:           encoded[position++],
         baseline:       encoded[position++],
         lineNumber:     encoded[position++].toInt(),
-      );
+      ));
     }
     return metrics;
   }
@@ -2058,14 +2060,14 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
   /// Creates a new [ParagraphBuilder] object, which is used to create a
   /// [Paragraph].
   @pragma('vm:entry-point')
-  ParagraphBuilder(ParagraphStyle/*!*/ style) {
-    List<String> strutFontFamilies;
+  ParagraphBuilder(ParagraphStyle style) {
+    List<String?>? strutFontFamilies;
     if (style._strutStyle != null) {
-      strutFontFamilies = <String>[];
-      if (style._strutStyle._fontFamily != null)
-        strutFontFamilies.add(style._strutStyle._fontFamily);
-      if (style._strutStyle._fontFamilyFallback != null)
-        strutFontFamilies.addAll(style._strutStyle._fontFamilyFallback);
+      strutFontFamilies = <String?>[];
+      if (style._strutStyle!._fontFamily != null)
+        strutFontFamilies.add(style._strutStyle!._fontFamily);
+      if (style._strutStyle!._fontFamilyFallback != null)
+        strutFontFamilies.addAll(style._strutStyle!._fontFamilyFallback!);
     }
     _constructor(
       style._encoded,
@@ -2081,38 +2083,37 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
 
   void _constructor(
     Int32List encoded,
-    ByteData strutData,
-    String fontFamily,
-    List<dynamic> strutFontFamily,
-    double fontSize,
-    double height,
-    String ellipsis,
+    ByteData? strutData,
+    String? fontFamily,
+    List<dynamic>? strutFontFamily,
+    double? fontSize,
+    double? height,
+    String? ellipsis,
     String locale
   ) native 'ParagraphBuilder_constructor';
 
   /// The number of placeholders currently in the paragraph.
-  int/*!*/ get placeholderCount => _placeholderCount;
-  int/*!*/ _placeholderCount = 0;
+  int get placeholderCount => _placeholderCount;
+  int _placeholderCount = 0;
 
   /// The scales of the placeholders in the paragraph.
-  List<double/*!*/>/*!*/ get placeholderScales => _placeholderScales;
-  List<double/*!*/>/*!*/ _placeholderScales = <double>[];
+  List<double> get placeholderScales => _placeholderScales;
+  List<double> _placeholderScales = <double>[];
 
   /// Applies the given style to the added text until [pop] is called.
   ///
   /// See [pop] for details.
-  void pushStyle(TextStyle/*!*/ style) {
+  void pushStyle(TextStyle style) {
     final List<String> fullFontFamilies = <String>[];
-    if (style._fontFamily != null)
-      fullFontFamilies.add(style._fontFamily);
+    fullFontFamilies.add(style._fontFamily);
     if (style._fontFamilyFallback != null)
-    fullFontFamilies.addAll(style._fontFamilyFallback);
+    fullFontFamilies.addAll(style._fontFamilyFallback!);
 
-    ByteData encodedFontFeatures;
+    ByteData? encodedFontFeatures;
     if (style._fontFeatures != null) {
-      encodedFontFeatures = ByteData(style._fontFeatures.length * FontFeature._kEncodedSize);
+      encodedFontFeatures = ByteData(style._fontFeatures!.length * FontFeature._kEncodedSize);
       int byteOffset = 0;
-      for (FontFeature feature in style._fontFeatures) {
+      for (FontFeature feature in style._fontFeatures!) {
         feature._encode(ByteData.view(encodedFontFeatures.buffer, byteOffset, FontFeature._kEncodedSize));
         byteOffset += FontFeature._kEncodedSize;
       }
@@ -2139,21 +2140,21 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
   void _pushStyle(
     Int32List encoded,
     List<dynamic> fontFamilies,
-    double fontSize,
-    double letterSpacing,
-    double wordSpacing,
-    double height,
-    double decorationThickness,
+    double? fontSize,
+    double? letterSpacing,
+    double? wordSpacing,
+    double? height,
+    double? decorationThickness,
     String locale,
-    List<dynamic> backgroundObjects,
-    ByteData backgroundData,
-    List<dynamic> foregroundObjects,
-    ByteData foregroundData,
+    List<dynamic>? backgroundObjects,
+    ByteData? backgroundData,
+    List<dynamic>? foregroundObjects,
+    ByteData? foregroundData,
     ByteData shadowsData,
-    ByteData fontFeaturesData,
+    ByteData? fontFeaturesData,
   ) native 'ParagraphBuilder_pushStyle';
 
-  static String _encodeLocale(Locale locale) => locale?.toString() ?? '';
+  static String _encodeLocale(Locale? locale) => locale?.toString() ?? '';
 
   /// Ends the effect of the most recent call to [pushStyle].
   ///
@@ -2166,12 +2167,12 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
   /// Adds the given text to the paragraph.
   ///
   /// The text will be styled according to the current stack of text styles.
-  void addText(String/*!*/ text) {
-    final String error = _addText(text);
+  void addText(String text) {
+    final String? error = _addText(text);
     if (error != null)
       throw ArgumentError(error);
   }
-  String/*?*/ _addText(String text) native 'ParagraphBuilder_addText';
+  String? _addText(String text) native 'ParagraphBuilder_addText';
 
   /// Adds an inline placeholder space to the paragraph.
   ///
@@ -2220,10 +2221,10 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
   /// The `scale` parameter will scale the `width` and `height` by the specified amount,
   /// and keep track of the scale. The scales of placeholders added can be accessed
   /// through [placeholderScales]. This is primarily used for acessibility scaling.
-  void addPlaceholder(double/*!*/ width, double/*!*/ height, PlaceholderAlignment/*!*/ alignment, {
-    double/*!*/ scale = 1.0,
-    double/*?*/ baselineOffset,
-    TextBaseline/*?*/ baseline,
+  void addPlaceholder(double width, double height, PlaceholderAlignment alignment, {
+    double scale = 1.0,
+    double? baselineOffset,
+    TextBaseline? baseline,
   }) {
     // Require a baseline to be specified if using a baseline-based alignment.
     assert((alignment == PlaceholderAlignment.aboveBaseline ||
@@ -2232,18 +2233,18 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
     // Default the baselineOffset to height if null. This will place the placeholder
     // fully above the baseline, similar to [PlaceholderAlignment.aboveBaseline].
     baselineOffset = baselineOffset ?? height;
-    _addPlaceholder(width * scale, height * scale, alignment.index, (baselineOffset == null ? height : baselineOffset) * scale, baseline == null ? null : baseline.index);
+    _addPlaceholder(width * scale, height * scale, alignment.index, baselineOffset * scale, baseline == null ? null : baseline.index);
     _placeholderCount++;
     _placeholderScales.add(scale);
   }
-  String _addPlaceholder(double width, double height, int alignment, double baselineOffset, int baseline) native 'ParagraphBuilder_addPlaceholder';
+  String _addPlaceholder(double width, double height, int alignment, double baselineOffset, int? baseline) native 'ParagraphBuilder_addPlaceholder';
 
   /// Applies the given paragraph style and returns a [Paragraph] containing the
   /// added text and associated styling.
   ///
   /// After calling this function, the paragraph builder object is invalid and
   /// cannot be used further.
-  Paragraph/*!*/ build() {
+  Paragraph build() {
     final Paragraph paragraph = Paragraph._();
     _build(paragraph);
     return paragraph;
@@ -2256,7 +2257,7 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
 /// * `list`: A list of bytes containing the font file.
 /// * `fontFamily`: The family name used to identify the font in text styles.
 ///  If this is not provided, then the family name will be extracted from the font file.
-Future<void>/*!*/ loadFontFromList(Uint8List/*!*/ list, {String/*?*/ fontFamily}) {
+Future<void> loadFontFromList(Uint8List list, {String? fontFamily}) {
   return _futurize(
     (_Callback<void> callback) => _loadFontFromList(list, callback, fontFamily)
   ).then((_) => _sendFontChangeMessage());
@@ -2268,11 +2269,11 @@ final ByteData _fontChangeMessage = utf8.encoder.convert(
 
 FutureOr<void> _sendFontChangeMessage() async {
   if (window.onPlatformMessage != null)
-    window.onPlatformMessage(
+    window.onPlatformMessage!(
       'flutter/system',
       _fontChangeMessage,
       (_) {},
     );
 }
 
-String _loadFontFromList(Uint8List list, _Callback<void> callback, String fontFamily) native 'loadFontFromList';
+String _loadFontFromList(Uint8List list, _Callback<void> callback, String? fontFamily) native 'loadFontFromList';

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -85,7 +85,7 @@ class FontWeight {
     assert(t != null); // ignore: unnecessary_null_comparison
     if (a == null && b == null)
       return null;
-    return values[_lerpInt(a?.index ?? normal.index, b?.index ?? normal.index, t).round().clamp(0, 8) as int];
+    return values[_lerpInt((a ?? normal).index, (b ?? normal).index, t).round().clamp(0, 8) as int];
   }
 
   @override
@@ -2023,20 +2023,20 @@ class Paragraph extends NativeFieldWrapperClass2 {
     final Float64List encoded = _computeLineMetrics();
     final int count = encoded.length ~/ 9;
     int position = 0;
-    final List<LineMetrics> metrics = <LineMetrics>[];
-    for (int index = 0; index < count; index += 1) {
-      metrics.add(LineMetrics(
-        hardBreak:      encoded[position++] != 0,
-        ascent:         encoded[position++],
-        descent:        encoded[position++],
-        unscaledAscent: encoded[position++],
-        height:         encoded[position++],
-        width:          encoded[position++],
-        left:           encoded[position++],
-        baseline:       encoded[position++],
-        lineNumber:     encoded[position++].toInt(),
-      ));
-    }
+    final List<LineMetrics> metrics = <LineMetrics>[
+      for (int index = 0; index < count; index += 1)
+        LineMetrics(
+          hardBreak:      encoded[position++] != 0,
+          ascent:         encoded[position++],
+          descent:        encoded[position++],
+          unscaledAscent: encoded[position++],
+          height:         encoded[position++],
+          width:          encoded[position++],
+          left:           encoded[position++],
+          baseline:       encoded[position++],
+          lineNumber:     encoded[position++].toInt(),
+        )
+    ];
     return metrics;
   }
   Float64List _computeLineMetrics() native 'Paragraph_computeLineMetrics';
@@ -2272,12 +2272,11 @@ final ByteData _fontChangeMessage = utf8.encoder.convert(
 ).buffer.asByteData();
 
 FutureOr<void> _sendFontChangeMessage() async {
-  if (window.onPlatformMessage != null)
-    window.onPlatformMessage!(
-      'flutter/system',
-      _fontChangeMessage,
-      (_) {},
-    );
+  window.onPlatformMessage?.call(
+    'flutter/system',
+    _fontChangeMessage,
+    (_) {},
+  );
 }
 
 String _loadFontFromList(Uint8List list, _Callback<void> callback, String? fontFamily) native 'loadFontFromList';

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2021,9 +2021,10 @@ class Paragraph extends NativeFieldWrapperClass2 {
   /// to repeatedly call this. Instead, cache the results.
   List<LineMetrics> computeLineMetrics() {
     final Float64List encoded = _computeLineMetrics();
+    final int count = encoded.length ~/ 9;
     int position = 0;
     final List<LineMetrics> metrics = <LineMetrics>[];
-    for (int index = 0; index < metrics.length; index += 1) {
+    for (int index = 0; index < count; index += 1) {
       metrics.add(LineMetrics(
         hardBreak:      encoded[position++] != 0,
         ascent:         encoded[position++],

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2062,17 +2062,19 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
   /// [Paragraph].
   @pragma('vm:entry-point')
   ParagraphBuilder(ParagraphStyle style) {
-    List<String?>? strutFontFamilies;
-    if (style._strutStyle != null) {
-      strutFontFamilies = <String?>[];
-      if (style._strutStyle!._fontFamily != null)
-        strutFontFamilies.add(style._strutStyle!._fontFamily);
-      if (style._strutStyle!._fontFamilyFallback != null)
-        strutFontFamilies.addAll(style._strutStyle!._fontFamilyFallback!);
+    List<String>? strutFontFamilies;
+    final StrutStyle? strutStyle = style._strutStyle;
+    if (strutStyle != null) {
+      strutFontFamilies = <String>[];
+      final String? fontFamily = strutStyle._fontFamily;
+      if (fontFamily != null)
+        strutFontFamilies.add(fontFamily);
+      if (strutStyle._fontFamilyFallback != null)
+        strutFontFamilies.addAll(strutStyle._fontFamilyFallback!);
     }
     _constructor(
       style._encoded,
-      style._strutStyle?._encoded,
+      strutStyle?._encoded,
       style._fontFamily,
       strutFontFamilies,
       style._fontSize,
@@ -2111,10 +2113,11 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
     fullFontFamilies.addAll(style._fontFamilyFallback!);
 
     ByteData? encodedFontFeatures;
-    if (style._fontFeatures != null) {
-      encodedFontFeatures = ByteData(style._fontFeatures!.length * FontFeature._kEncodedSize);
+    final List<FontFeature>? fontFeatures = style._fontFeatures;
+    if (fontFeatures != null) {
+      encodedFontFeatures = ByteData(fontFeatures.length * FontFeature._kEncodedSize);
       int byteOffset = 0;
-      for (FontFeature feature in style._fontFeatures!) {
+      for (FontFeature feature in fontFeatures) {
         feature._encode(ByteData.view(encodedFontFeatures.buffer, byteOffset, FontFeature._kEncodedSize));
         byteOffset += FontFeature._kEncodedSize;
       }

--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -9,7 +9,7 @@
 /// This library exposes the lowest-level services that Flutter frameworks use
 /// to bootstrap applications, such as classes for driving the input, graphics
 /// text, layout, and rendering subsystems.
-// @dart = 2.6
+// @dart = 2.9
 library dart.ui;
 
 import 'dart:_internal' hide Symbol; // ignore: unused_import

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -473,12 +473,16 @@ class Locale {
   bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
-    return other is Locale
-        && other.languageCode == languageCode
+    if (other is! Locale) {
+      return false;
+    }
+    final String? countryCode = _countryCode;
+    final String? otherCountryCode = other.countryCode;
+    return other.languageCode == languageCode
         && other.scriptCode == scriptCode // scriptCode cannot be ''
         && (other.countryCode == countryCode // Treat '' as equal to null.
-            || other.countryCode != null && other.countryCode!.isEmpty && countryCode == null
-            || countryCode != null && countryCode!.isEmpty && other.countryCode == null);
+            || otherCountryCode != null && otherCountryCode.isEmpty && countryCode == null
+            || countryCode != null && countryCode.isEmpty && other.countryCode == null);
   }
 
   @override

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -2,14 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
 part of dart.ui;
 
 /// Signature of callbacks that have no arguments and return no data.
 typedef VoidCallback = void Function();
 
 /// Signature for [Window.onBeginFrame].
-typedef FrameCallback = void Function(Duration/*!*/ duration);
+typedef FrameCallback = void Function(Duration duration);
 
 /// Signature for [Window.onReportTimings].
 ///
@@ -23,25 +23,25 @@ typedef FrameCallback = void Function(Duration/*!*/ duration);
 /// even if there are no later frames to batch. The timing of the first frame
 /// will be sent immediately without batching.
 /// {@endtemplate}
-typedef TimingsCallback = void Function(List<FrameTiming/*!*/>/*!*/ timings);
+typedef TimingsCallback = void Function(List<FrameTiming> timings);
 
 /// Signature for [Window.onPointerDataPacket].
-typedef PointerDataPacketCallback = void Function(PointerDataPacket/*!*/ packet);
+typedef PointerDataPacketCallback = void Function(PointerDataPacket packet);
 
 /// Signature for [Window.onSemanticsAction].
-typedef SemanticsActionCallback = void Function(int/*!*/ id, SemanticsAction/*!*/ action, ByteData/*?*/ args);
+typedef SemanticsActionCallback = void Function(int id, SemanticsAction action, ByteData? args);
 
 /// Signature for responses to platform messages.
 ///
 /// Used as a parameter to [Window.sendPlatformMessage] and
 /// [Window.onPlatformMessage].
-typedef PlatformMessageResponseCallback = void Function(ByteData/*?*/ data);
+typedef PlatformMessageResponseCallback = void Function(ByteData? data);
 
 /// Signature for [Window.onPlatformMessage].
-typedef PlatformMessageCallback = void Function(String/*!*/ name, ByteData/*?*/ data, PlatformMessageResponseCallback/*?*/ callback);
+typedef PlatformMessageCallback = void Function(String name, ByteData? data, PlatformMessageResponseCallback? callback);
 
 // Signature for _setNeedsReportTimings.
-typedef _SetNeedsReportTimingsFunc = void Function(bool/*!*/ value);
+typedef _SetNeedsReportTimingsFunc = void Function(bool value);
 
 /// Various important time points in the lifetime of a frame.
 ///
@@ -89,14 +89,14 @@ class FrameTiming {
   ///
   /// This constructor is usually only called by the Flutter engine, or a test.
   /// To get the [FrameTiming] of your app, see [Window.onReportTimings].
-  FrameTiming(List<int/*!*/>/*!*/ timestamps)
+  FrameTiming(List<int> timestamps)
       : assert(timestamps.length == FramePhase.values.length), _timestamps = timestamps;
 
   /// This is a raw timestamp in microseconds from some epoch. The epoch in all
   /// [FrameTiming] is the same, but it may not match [DateTime]'s epoch.
-  int/*!*/ timestampInMicroseconds(FramePhase/*!*/ phase) => _timestamps[phase.index];
+  int timestampInMicroseconds(FramePhase phase) => _timestamps[phase.index];
 
-  Duration/*!*/ _rawDuration(FramePhase/*!*/ phase) => Duration(microseconds: _timestamps[phase.index]);
+  Duration _rawDuration(FramePhase phase) => Duration(microseconds: _timestamps[phase.index]);
 
   /// The duration to build the frame on the UI thread.
   ///
@@ -113,13 +113,13 @@ class FrameTiming {
   /// {@template dart.ui.FrameTiming.fps_milliseconds}
   /// That's about 16ms for 60fps, and 8ms for 120fps.
   /// {@endtemplate}
-  Duration/*!*/ get buildDuration => _rawDuration(FramePhase.buildFinish) - _rawDuration(FramePhase.buildStart);
+  Duration get buildDuration => _rawDuration(FramePhase.buildFinish) - _rawDuration(FramePhase.buildStart);
 
   /// The duration to rasterize the frame on the raster thread.
   ///
   /// {@macro dart.ui.FrameTiming.fps_smoothness_milliseconds}
   /// {@macro dart.ui.FrameTiming.fps_milliseconds}
-  Duration/*!*/ get rasterDuration => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.rasterStart);
+  Duration get rasterDuration => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.rasterStart);
 
   /// The timespan between build start and raster finish.
   ///
@@ -128,9 +128,9 @@ class FrameTiming {
   /// {@macro dart.ui.FrameTiming.fps_milliseconds}
   ///
   /// See also [buildDuration] and [rasterDuration].
-  Duration/*!*/ get totalSpan => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.buildStart);
+  Duration get totalSpan => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.buildStart);
 
-  final List<int/*!*/>/*!*/ _timestamps;  // in microseconds
+  final List<int> _timestamps;  // in microseconds
 
   String _formatMS(Duration duration) => '${duration.inMicroseconds * 0.001}ms';
 
@@ -206,19 +206,19 @@ enum AppLifecycleState {
 ///  * [Scaffold], which automatically applies the padding in material design
 ///    applications.
 class WindowPadding {
-  const WindowPadding._({ this.left, this.top, this.right, this.bottom });
+  const WindowPadding._({ required this.left, required this.top, required this.right, required this.bottom });
 
   /// The distance from the left edge to the first unpadded pixel, in physical pixels.
-  final double/*!*/ left;
+  final double left;
 
   /// The distance from the top edge to the first unpadded pixel, in physical pixels.
-  final double/*!*/ top;
+  final double top;
 
   /// The distance from the right edge to the first unpadded pixel, in physical pixels.
-  final double/*!*/ right;
+  final double right;
 
   /// The distance from the bottom edge to the first unpadded pixel, in physical pixels.
-  final double/*!*/ bottom;
+  final double bottom;
 
   /// A window padding that has zeros for each edge.
   static const WindowPadding zero = WindowPadding._(left: 0.0, top: 0.0, right: 0.0, bottom: 0.0);
@@ -282,7 +282,7 @@ class Locale {
   const Locale(
     this._languageCode, [
     this._countryCode,
-  ]) : assert(_languageCode != null),
+  ]) : assert(_languageCode != null), // ignore: unnecessary_null_comparison
        assert(_languageCode != ''),
        scriptCode = null;
 
@@ -303,10 +303,10 @@ class Locale {
   /// Validity is not checked by default, but some methods may throw away
   /// invalid data.
   const Locale.fromSubtags({
-    String/*!*/ languageCode = 'und',
+    String languageCode = 'und',
     this.scriptCode,
-    String/*?*/ countryCode,
-  }) : assert(languageCode != null),
+    String? countryCode,
+  }) : assert(languageCode != null), // ignore: unnecessary_null_comparison
        assert(languageCode != ''),
        _languageCode = languageCode,
        assert(scriptCode != ''),
@@ -336,8 +336,8 @@ class Locale {
   ///
   ///  * [Locale.fromSubtags], which describes the conventions for creating
   ///    [Locale] objects.
-  String/*!*/ get languageCode => _deprecatedLanguageSubtagMap[_languageCode] ?? _languageCode;
-  final String/*!*/ _languageCode;
+  String get languageCode => _deprecatedLanguageSubtagMap[_languageCode] ?? _languageCode;
+  final String _languageCode;
 
   // This map is generated by //flutter/tools/gen_locale.dart
   // Mappings generated for language subtag registry as of 2019-02-27.
@@ -434,7 +434,7 @@ class Locale {
   ///
   ///  * [Locale.fromSubtags], which describes the conventions for creating
   ///    [Locale] objects.
-  final String/*?*/ scriptCode;
+  final String? scriptCode;
 
   /// The region subtag for the locale.
   ///
@@ -455,8 +455,8 @@ class Locale {
   ///
   ///  * [Locale.fromSubtags], which describes the conventions for creating
   ///    [Locale] objects.
-  String/*?*/ get countryCode => _deprecatedRegionSubtagMap[_countryCode] ?? _countryCode;
-  final String/*?*/ _countryCode;
+  String? get countryCode => _deprecatedRegionSubtagMap[_countryCode] ?? _countryCode;
+  final String? _countryCode;
 
   // This map is generated by //flutter/tools/gen_locale.dart
   // Mappings generated for language subtag registry as of 2019-02-27.
@@ -470,22 +470,22 @@ class Locale {
   };
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
     return other is Locale
         && other.languageCode == languageCode
         && other.scriptCode == scriptCode // scriptCode cannot be ''
         && (other.countryCode == countryCode // Treat '' as equal to null.
-            || other.countryCode != null && other.countryCode.isEmpty && countryCode == null
-            || countryCode != null && countryCode.isEmpty && other.countryCode == null);
+            || other.countryCode != null && other.countryCode!.isEmpty && countryCode == null
+            || countryCode != null && countryCode!.isEmpty && other.countryCode == null);
   }
 
   @override
-  int/*!*/ get hashCode => hashValues(languageCode, scriptCode, countryCode == '' ? null : countryCode);
+  int get hashCode => hashValues(languageCode, scriptCode, countryCode == '' ? null : countryCode);
 
-  static Locale/*?*/ _cachedLocale;
-  static String/*?*/ _cachedLocaleString;
+  static Locale? _cachedLocale;
+  static String? _cachedLocaleString;
 
   /// Returns a string representing the locale.
   ///
@@ -499,7 +499,7 @@ class Locale {
       _cachedLocale = this;
       _cachedLocaleString = _rawToString('_');
     }
-    return _cachedLocaleString;
+    return _cachedLocaleString!;
   }
 
   /// Returns a syntactically valid Unicode BCP47 Locale Identifier.
@@ -507,13 +507,13 @@ class Locale {
   /// Some examples of such identifiers: "en", "es-419", "hi-Deva-IN" and
   /// "zh-Hans-CN". See http://www.unicode.org/reports/tr35/ for technical
   /// details.
-  String/*!*/ toLanguageTag() => _rawToString('-');
+  String toLanguageTag() => _rawToString('-');
 
-  String/*!*/ _rawToString(String separator) {
+  String _rawToString(String separator) {
     final StringBuffer out = StringBuffer(languageCode);
-    if (scriptCode != null && scriptCode.isNotEmpty)
+    if (scriptCode != null && scriptCode!.isNotEmpty)
       out.write('$separator$scriptCode');
-    if (_countryCode != null && _countryCode.isNotEmpty)
+    if (_countryCode != null && _countryCode!.isNotEmpty)
       out.write('$separator$countryCode');
     return out.toString();
   }
@@ -600,8 +600,8 @@ class Window {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
-  double/*!*/ get devicePixelRatio => _devicePixelRatio;
-  double/*!*/ _devicePixelRatio = 1.0;
+  double get devicePixelRatio => _devicePixelRatio;
+  double _devicePixelRatio = 1.0;
 
   /// The dimensions of the rectangle into which the application will be drawn,
   /// in physical pixels.
@@ -620,8 +620,8 @@ class Window {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
-  Size/*!*/ get physicalSize => _physicalSize;
-  Size/*!*/ _physicalSize = Size.zero;
+  Size get physicalSize => _physicalSize;
+  Size _physicalSize = Size.zero;
 
   /// The physical depth is the maximum elevation that the Window allows.
   ///
@@ -634,8 +634,8 @@ class Window {
   /// The default value is [double.maxFinite], which is used for platforms that
   /// do not specify a maximum elevation. This property is currently on expected
   /// to be set to a non-default value on Fuchsia.
-  double/*!*/ get physicalDepth => _physicalDepth;
-  double/*!*/ _physicalDepth = double.maxFinite;
+  double get physicalDepth => _physicalDepth;
+  double _physicalDepth = double.maxFinite;
 
   /// The number of physical pixels on each side of the display rectangle into
   /// which the application can render, but over which the operating system
@@ -655,8 +655,8 @@ class Window {
   ///  * [MediaQuery.of], a simpler mechanism for the same.
   ///  * [Scaffold], which automatically applies the view insets in material
   ///    design applications.
-  WindowPadding/*!*/ get viewInsets => _viewInsets;
-  WindowPadding/*!*/ _viewInsets = WindowPadding.zero;
+  WindowPadding get viewInsets => _viewInsets;
+  WindowPadding _viewInsets = WindowPadding.zero;
 
   /// The number of physical pixels on each side of the display rectangle into
   /// which the application can render, but which may be partially obscured by
@@ -682,8 +682,8 @@ class Window {
   ///  * [MediaQuery.of], a simpler mechanism for the same.
   ///  * [Scaffold], which automatically applies the padding in material design
   ///    applications.
-  WindowPadding/*!*/ get viewPadding => _viewPadding;
-  WindowPadding/*!*/ _viewPadding = WindowPadding.zero;
+  WindowPadding get viewPadding => _viewPadding;
+  WindowPadding _viewPadding = WindowPadding.zero;
 
   /// The number of physical pixels on each side of the display rectangle into
   /// which the application can render, but where the operating system will
@@ -700,8 +700,8 @@ class Window {
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
   ///  * [MediaQuery.of], a simpler mechanism for the same.
-  WindowPadding/*!*/ get systemGestureInsets => _systemGestureInsets;
-  WindowPadding/*!*/ _systemGestureInsets = WindowPadding.zero;
+  WindowPadding get systemGestureInsets => _systemGestureInsets;
+  WindowPadding _systemGestureInsets = WindowPadding.zero;
 
   /// The number of physical pixels on each side of the display rectangle into
   /// which the application can render, but which may be partially obscured by
@@ -730,8 +730,8 @@ class Window {
   ///  * [MediaQuery.of], a simpler mechanism for the same.
   ///  * [Scaffold], which automatically applies the padding in material design
   ///    applications.
-  WindowPadding/*!*/ get padding => _padding;
-  WindowPadding/*!*/ _padding = WindowPadding.zero;
+  WindowPadding get padding => _padding;
+  WindowPadding _padding = WindowPadding.zero;
 
   /// A callback that is invoked whenever the [devicePixelRatio],
   /// [physicalSize], [padding], [viewInsets], or [systemGestureInsets]
@@ -750,10 +750,10 @@ class Window {
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    register for notifications when this is called.
   ///  * [MediaQuery.of], a simpler mechanism for the same.
-  VoidCallback/*?*/ get onMetricsChanged => _onMetricsChanged;
-  VoidCallback/*?*/ _onMetricsChanged;
-  Zone/*!*/ _onMetricsChangedZone = Zone.root;
-  set onMetricsChanged(VoidCallback/*?*/ callback) {
+  VoidCallback? get onMetricsChanged => _onMetricsChanged;
+  VoidCallback? _onMetricsChanged;
+  Zone _onMetricsChangedZone = Zone.root;
+  set onMetricsChanged(VoidCallback? callback) {
     _onMetricsChanged = callback;
     _onMetricsChangedZone = Zone.current;
   }
@@ -768,9 +768,9 @@ class Window {
   ///
   /// This is equivalent to `locales.first` and will provide an empty non-null locale
   /// if the [locales] list has not been set or is empty.
-  Locale/*?*/ get locale {
-    if (_locales != null && _locales.isNotEmpty) {
-      return _locales.first;
+  Locale? get locale {
+    if (_locales != null && _locales!.isNotEmpty) {
+      return _locales!.first;
     }
     return null;
   }
@@ -789,8 +789,8 @@ class Window {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
-  List<Locale/*!*/>/*?*/ get locales => _locales;
-  List<Locale/*!*/>/*?*/ _locales;
+  List<Locale>? get locales => _locales;
+  List<Locale>? _locales;
 
   /// The locale that the platform's native locale resolution system resolves to.
   ///
@@ -802,8 +802,8 @@ class Window {
   /// in order to arrive at the most appropriate locale for the app.
   ///
   /// See [locales], which is the list of locales the user/device prefers.
-  Locale/*?*/ get platformResolvedLocale => _platformResolvedLocale;
-  Locale/*?*/ _platformResolvedLocale;
+  Locale? get platformResolvedLocale => _platformResolvedLocale;
+  Locale? _platformResolvedLocale;
 
   /// A callback that is invoked whenever [locale] changes value.
   ///
@@ -814,10 +814,10 @@ class Window {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this callback is invoked.
-  VoidCallback/*?*/ get onLocaleChanged => _onLocaleChanged;
-  VoidCallback/*?*/ _onLocaleChanged;
-  Zone/*!*/ _onLocaleChangedZone = Zone.root;
-  set onLocaleChanged(VoidCallback callback) {
+  VoidCallback? get onLocaleChanged => _onLocaleChanged;
+  VoidCallback? _onLocaleChanged;
+  Zone _onLocaleChangedZone = Zone.root;
+  set onLocaleChanged(VoidCallback? callback) {
     _onLocaleChanged = callback;
     _onLocaleChangedZone = Zone.current;
   }
@@ -828,15 +828,15 @@ class Window {
   ///
   /// It is used to initialize [SchedulerBinding.lifecycleState] at startup
   /// with any buffered lifecycle state events.
-  String/*!*/ get initialLifecycleState {
+  String get initialLifecycleState {
     _initialLifecycleStateAccessed = true;
     return _initialLifecycleState;
   }
-  /*late*/ String/*!*/ _initialLifecycleState;
+  late String _initialLifecycleState;
   /// Tracks if the initial state has been accessed. Once accessed, we
   /// will stop updating the [initialLifecycleState], as it is not the
   /// preferred way to access the state.
-  bool/*!*/ _initialLifecycleStateAccessed = false;
+  bool _initialLifecycleStateAccessed = false;
 
   /// The system-reported text scale.
   ///
@@ -850,15 +850,15 @@ class Window {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
-  double/*!*/ get textScaleFactor => _textScaleFactor;
-  double/*!*/ _textScaleFactor = 1.0;
+  double get textScaleFactor => _textScaleFactor;
+  double _textScaleFactor = 1.0;
 
   /// The setting indicating whether time should always be shown in the 24-hour
   /// format.
   ///
   /// This option is used by [showTimePicker].
-  bool/*!*/ get alwaysUse24HourFormat => _alwaysUse24HourFormat;
-  bool/*!*/ _alwaysUse24HourFormat = false;
+  bool get alwaysUse24HourFormat => _alwaysUse24HourFormat;
+  bool _alwaysUse24HourFormat = false;
 
   /// A callback that is invoked whenever [textScaleFactor] changes value.
   ///
@@ -869,18 +869,18 @@ class Window {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this callback is invoked.
-  VoidCallback/*?*/ get onTextScaleFactorChanged => _onTextScaleFactorChanged;
-  VoidCallback/*?*/ _onTextScaleFactorChanged;
-  Zone/*!*/ _onTextScaleFactorChangedZone = Zone.root;
-  set onTextScaleFactorChanged(VoidCallback/*?*/ callback) {
+  VoidCallback? get onTextScaleFactorChanged => _onTextScaleFactorChanged;
+  VoidCallback? _onTextScaleFactorChanged;
+  Zone _onTextScaleFactorChangedZone = Zone.root;
+  set onTextScaleFactorChanged(VoidCallback? callback) {
     _onTextScaleFactorChanged = callback;
     _onTextScaleFactorChangedZone = Zone.current;
   }
 
   /// The setting indicating the current brightness mode of the host platform.
   /// If the platform has no preference, [platformBrightness] defaults to [Brightness.light].
-  Brightness/*!*/ get platformBrightness => _platformBrightness;
-  Brightness/*!*/ _platformBrightness = Brightness.light;
+  Brightness get platformBrightness => _platformBrightness;
+  Brightness _platformBrightness = Brightness.light;
 
   /// A callback that is invoked whenever [platformBrightness] changes value.
   ///
@@ -891,10 +891,10 @@ class Window {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this callback is invoked.
-  VoidCallback/*?*/ get onPlatformBrightnessChanged => _onPlatformBrightnessChanged;
-  VoidCallback/*?*/ _onPlatformBrightnessChanged;
-  Zone/*!*/ _onPlatformBrightnessChangedZone = Zone.root;
-  set onPlatformBrightnessChanged(VoidCallback/*?*/ callback) {
+  VoidCallback? get onPlatformBrightnessChanged => _onPlatformBrightnessChanged;
+  VoidCallback? _onPlatformBrightnessChanged;
+  Zone _onPlatformBrightnessChangedZone = Zone.root;
+  set onPlatformBrightnessChanged(VoidCallback? callback) {
     _onPlatformBrightnessChanged = callback;
     _onPlatformBrightnessChangedZone = Zone.current;
   }
@@ -918,10 +918,10 @@ class Window {
   ///    scheduling of frames.
   ///  * [RendererBinding], the Flutter framework class which manages layout and
   ///    painting.
-  FrameCallback/*?*/ get onBeginFrame => _onBeginFrame;
-  FrameCallback/*?*/ _onBeginFrame;
-  Zone/*!*/ _onBeginFrameZone = Zone.root;
-  set onBeginFrame(FrameCallback/*?*/ callback) {
+  FrameCallback? get onBeginFrame => _onBeginFrame;
+  FrameCallback? _onBeginFrame;
+  Zone _onBeginFrameZone = Zone.root;
+  set onBeginFrame(FrameCallback? callback) {
     _onBeginFrame = callback;
     _onBeginFrameZone = Zone.current;
   }
@@ -940,10 +940,10 @@ class Window {
   ///    scheduling of frames.
   ///  * [RendererBinding], the Flutter framework class which manages layout and
   ///    painting.
-  VoidCallback/*?*/ get onDrawFrame => _onDrawFrame;
-  VoidCallback/*?*/ _onDrawFrame;
-  Zone/*!*/ _onDrawFrameZone = Zone.root;
-  set onDrawFrame(VoidCallback/*?*/ callback) {
+  VoidCallback? get onDrawFrame => _onDrawFrame;
+  VoidCallback? _onDrawFrame;
+  Zone _onDrawFrameZone = Zone.root;
+  set onDrawFrame(VoidCallback? callback) {
     _onDrawFrame = callback;
     _onDrawFrameZone = Zone.current;
   }
@@ -969,10 +969,10 @@ class Window {
   /// Flutter spends less than 0.1ms every 1 second to report the timings
   /// (measured on iPhone6S). The 0.1ms is about 0.6% of 16ms (frame budget for
   /// 60fps), or 0.01% CPU usage per second.
-  TimingsCallback/*?*/ get onReportTimings => _onReportTimings;
-  TimingsCallback/*?*/ _onReportTimings;
-  Zone/*!*/ _onReportTimingsZone = Zone.root;
-  set onReportTimings(TimingsCallback/*?*/ callback) {
+  TimingsCallback? get onReportTimings => _onReportTimings;
+  TimingsCallback? _onReportTimings;
+  Zone _onReportTimingsZone = Zone.root;
+  set onReportTimings(TimingsCallback? callback) {
     if ((callback == null) != (_onReportTimings == null)) {
       _setNeedsReportTimings(callback != null);
     }
@@ -980,8 +980,8 @@ class Window {
     _onReportTimingsZone = Zone.current;
   }
 
-  /*late*/ _SetNeedsReportTimingsFunc/*!*/ _setNeedsReportTimings;
-  void _nativeSetNeedsReportTimings(bool/*!*/ value) native 'Window_setNeedsReportTimings';
+  late _SetNeedsReportTimingsFunc _setNeedsReportTimings;
+  void _nativeSetNeedsReportTimings(bool value) native 'Window_setNeedsReportTimings';
 
   /// A callback that is invoked when pointer data is available.
   ///
@@ -992,10 +992,10 @@ class Window {
   ///
   ///  * [GestureBinding], the Flutter framework class which manages pointer
   ///    events.
-  PointerDataPacketCallback/*?*/ get onPointerDataPacket => _onPointerDataPacket;
-  PointerDataPacketCallback/*?*/ _onPointerDataPacket;
-  Zone/*!*/ _onPointerDataPacketZone = Zone.root;
-  set onPointerDataPacket(PointerDataPacketCallback/*?*/ callback) {
+  PointerDataPacketCallback? get onPointerDataPacket => _onPointerDataPacket;
+  PointerDataPacketCallback? _onPointerDataPacket;
+  Zone _onPointerDataPacketZone = Zone.root;
+  set onPointerDataPacket(PointerDataPacketCallback? callback) {
     _onPointerDataPacket = callback;
     _onPointerDataPacketZone = Zone.current;
   }
@@ -1030,8 +1030,8 @@ class Window {
   ///  * [Navigator], a widget that handles routing.
   ///  * [SystemChannels.navigation], which handles subsequent navigation
   ///    requests from the embedder.
-  String/*!*/ get defaultRouteName => _defaultRouteName();
-  String/*!*/ _defaultRouteName() native 'Window_defaultRouteName';
+  String get defaultRouteName => _defaultRouteName();
+  String _defaultRouteName() native 'Window_defaultRouteName';
 
   /// Requests that, at the next appropriate opportunity, the [onBeginFrame]
   /// and [onDrawFrame] callbacks be invoked.
@@ -1066,24 +1066,24 @@ class Window {
   ///    scheduling of frames.
   ///  * [RendererBinding], the Flutter framework class which manages layout and
   ///    painting.
-  void render(Scene/*!*/ scene) native 'Window_render';
+  void render(Scene scene) native 'Window_render';
 
   /// Whether the user has requested that [updateSemantics] be called when
   /// the semantic contents of window changes.
   ///
   /// The [onSemanticsEnabledChanged] callback is called whenever this value
   /// changes.
-  bool/*!*/ get semanticsEnabled => _semanticsEnabled;
-  bool/*!*/ _semanticsEnabled = false;
+  bool get semanticsEnabled => _semanticsEnabled;
+  bool _semanticsEnabled = false;
 
   /// A callback that is invoked when the value of [semanticsEnabled] changes.
   ///
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.
-  VoidCallback/*?*/ get onSemanticsEnabledChanged => _onSemanticsEnabledChanged;
-  VoidCallback/*?*/ _onSemanticsEnabledChanged;
-  Zone/*!*/ _onSemanticsEnabledChangedZone = Zone.root;
-  set onSemanticsEnabledChanged(VoidCallback/*?*/ callback) {
+  VoidCallback? get onSemanticsEnabledChanged => _onSemanticsEnabledChanged;
+  VoidCallback? _onSemanticsEnabledChanged;
+  Zone _onSemanticsEnabledChangedZone = Zone.root;
+  set onSemanticsEnabledChanged(VoidCallback? callback) {
     _onSemanticsEnabledChanged = callback;
     _onSemanticsEnabledChangedZone = Zone.current;
   }
@@ -1096,27 +1096,27 @@ class Window {
   ///
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.
-  SemanticsActionCallback/*?*/ get onSemanticsAction => _onSemanticsAction;
-  SemanticsActionCallback/*?*/ _onSemanticsAction;
-  Zone/*!*/ _onSemanticsActionZone = Zone.root;
-  set onSemanticsAction(SemanticsActionCallback/*?*/ callback) {
+  SemanticsActionCallback? get onSemanticsAction => _onSemanticsAction;
+  SemanticsActionCallback? _onSemanticsAction;
+  Zone _onSemanticsActionZone = Zone.root;
+  set onSemanticsAction(SemanticsActionCallback? callback) {
     _onSemanticsAction = callback;
     _onSemanticsActionZone = Zone.current;
   }
 
   /// Additional accessibility features that may be enabled by the platform.
-  AccessibilityFeatures/*!*/ get accessibilityFeatures => _accessibilityFeatures;
+  AccessibilityFeatures get accessibilityFeatures => _accessibilityFeatures;
   // The zero value matches the default value in `window_data.h`.
-  AccessibilityFeatures/*!*/ _accessibilityFeatures = const AccessibilityFeatures._(0);
+  AccessibilityFeatures _accessibilityFeatures = const AccessibilityFeatures._(0);
 
   /// A callback that is invoked when the value of [accessibilityFeatures] changes.
   ///
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.
-  VoidCallback/*?*/ get onAccessibilityFeaturesChanged => _onAccessibilityFeaturesChanged;
-  VoidCallback/*?*/ _onAccessibilityFeaturesChanged;
-  Zone/*!*/ _onAccessibilityFeaturesChangedZone = Zone.root;
-  set onAccessibilityFeaturesChanged(VoidCallback/*?*/ callback) {
+  VoidCallback? get onAccessibilityFeaturesChanged => _onAccessibilityFeaturesChanged;
+  VoidCallback? _onAccessibilityFeaturesChanged;
+  Zone _onAccessibilityFeaturesChangedZone = Zone.root;
+  set onAccessibilityFeaturesChanged(VoidCallback? callback) {
     _onAccessibilityFeaturesChanged = callback;
     _onAccessibilityFeaturesChangedZone = Zone.current;
   }
@@ -1128,7 +1128,7 @@ class Window {
   ///
   /// In either case, this function disposes the given update, which means the
   /// semantics update cannot be used further.
-  void updateSemantics(SemanticsUpdate/*!*/ update) native 'Window_updateSemantics';
+  void updateSemantics(SemanticsUpdate update) native 'Window_updateSemantics';
 
   /// Set the debug name associated with this window's root isolate.
   ///
@@ -1138,7 +1138,7 @@ class Window {
   /// This can be combined with flutter tools `--isolate-filter` flag to debug
   /// specific root isolates. For example: `flutter attach --isolate-filter=[name]`.
   /// Note that this does not rename any child isolates of the root.
-  void setIsolateDebugName(String/*!*/ name) native 'Window_setIsolateDebugName';
+  void setIsolateDebugName(String name) native 'Window_setIsolateDebugName';
 
   /// Sends a message to a platform-specific plugin.
   ///
@@ -1149,17 +1149,17 @@ class Window {
   ///
   /// The framework invokes [callback] in the same zone in which this method
   /// was called.
-  void sendPlatformMessage(String/*!*/ name,
-                           ByteData/*?*/ data,
-                           PlatformMessageResponseCallback/*?*/ callback) {
-    final String error =
+  void sendPlatformMessage(String name,
+                           ByteData? data,
+                           PlatformMessageResponseCallback? callback) {
+    final String? error =
         _sendPlatformMessage(name, _zonedPlatformMessageResponseCallback(callback), data);
     if (error != null)
       throw Exception(error);
   }
-  String _sendPlatformMessage(String/*!*/ name,
-                              PlatformMessageResponseCallback/*?*/ callback,
-                              ByteData/*?*/ data) native 'Window_sendPlatformMessage';
+  String? _sendPlatformMessage(String name,
+                              PlatformMessageResponseCallback? callback,
+                              ByteData? data) native 'Window_sendPlatformMessage';
 
   /// Called whenever this window receives a message from a platform-specific
   /// plugin.
@@ -1174,28 +1174,28 @@ class Window {
   ///
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.
-  PlatformMessageCallback/*?*/ get onPlatformMessage => _onPlatformMessage;
-  PlatformMessageCallback/*?*/ _onPlatformMessage;
-  Zone/*!*/ _onPlatformMessageZone = Zone.root;
-  set onPlatformMessage(PlatformMessageCallback/*?*/ callback) {
+  PlatformMessageCallback? get onPlatformMessage => _onPlatformMessage;
+  PlatformMessageCallback? _onPlatformMessage;
+  Zone _onPlatformMessageZone = Zone.root;
+  set onPlatformMessage(PlatformMessageCallback? callback) {
     _onPlatformMessage = callback;
     _onPlatformMessageZone = Zone.current;
   }
 
   /// Called by [_dispatchPlatformMessage].
-  void _respondToPlatformMessage(int/*!*/ responseId, ByteData/*?*/ data)
+  void _respondToPlatformMessage(int responseId, ByteData? data)
       native 'Window_respondToPlatformMessage';
 
   /// Wraps the given [callback] in another callback that ensures that the
   /// original callback is called in the zone it was registered in.
-  static PlatformMessageResponseCallback/*?*/ _zonedPlatformMessageResponseCallback(PlatformMessageResponseCallback/*?*/ callback) {
+  static PlatformMessageResponseCallback? _zonedPlatformMessageResponseCallback(PlatformMessageResponseCallback? callback) {
     if (callback == null)
       return null;
 
     // Store the zone in which the callback is being registered.
     final Zone registrationZone = Zone.current;
 
-    return (ByteData data) {
+    return (ByteData? data) {
       registrationZone.runUnaryGuarded(callback, data);
     };
   }
@@ -1210,7 +1210,7 @@ class Window {
   ///
   /// For asynchronous communication between the embedder and isolate, a
   /// platform channel may be used.
-  ByteData/*?*/ getPersistentIsolateData() native 'Window_getPersistentIsolateData';
+  ByteData? getPersistentIsolateData() native 'Window_getPersistentIsolateData';
 }
 
 /// Additional accessibility features that may be enabled by the platform.
@@ -1232,38 +1232,38 @@ class AccessibilityFeatures {
   static const int _kHighContrastIndex = 1 << 5;
 
   // A bitfield which represents each enabled feature.
-  final int/*!*/ _index;
+  final int _index;
 
   /// Whether there is a running accessibility service which is changing the
   /// interaction model of the device.
   ///
   /// For example, TalkBack on Android and VoiceOver on iOS enable this flag.
-  bool/*!*/ get accessibleNavigation => _kAccessibleNavigation & _index != 0;
+  bool get accessibleNavigation => _kAccessibleNavigation & _index != 0;
 
   /// The platform is inverting the colors of the application.
-  bool/*!*/ get invertColors => _kInvertColorsIndex & _index != 0;
+  bool get invertColors => _kInvertColorsIndex & _index != 0;
 
   /// The platform is requesting that animations be disabled or simplified.
-  bool/*!*/ get disableAnimations => _kDisableAnimationsIndex & _index != 0;
+  bool get disableAnimations => _kDisableAnimationsIndex & _index != 0;
 
   /// The platform is requesting that text be rendered at a bold font weight.
   ///
   /// Only supported on iOS.
-  bool/*!*/ get boldText => _kBoldTextIndex & _index != 0;
+  bool get boldText => _kBoldTextIndex & _index != 0;
 
   /// The platform is requesting that certain animations be simplified and
   /// parallax effects removed.
   ///
   /// Only supported on iOS.
-  bool/*!*/ get reduceMotion => _kReduceMotionIndex & _index != 0;
+  bool get reduceMotion => _kReduceMotionIndex & _index != 0;
 
   /// The platform is requesting that UI be rendered with darker colors.
   ///
   /// Only supported on iOS.
-  bool/*!*/ get highContrast => _kHighContrastIndex & _index != 0;
+  bool get highContrast => _kHighContrastIndex & _index != 0;
 
   @override
-  String/*!*/ toString() {
+  String toString() {
     final List<String> features = <String>[];
     if (accessibleNavigation)
       features.add('accessibleNavigation');
@@ -1281,7 +1281,7 @@ class AccessibilityFeatures {
   }
 
   @override
-  bool/*!*/ operator ==(dynamic other) {
+  bool operator ==(dynamic other) {
     if (other.runtimeType != runtimeType)
       return false;
     return other is AccessibilityFeatures
@@ -1289,7 +1289,7 @@ class AccessibilityFeatures {
   }
 
   @override
-  int/*!*/ get hashCode => _index.hashCode;
+  int get hashCode => _index.hashCode;
 }
 
 /// Describes the contrast of a theme or color palette.
@@ -1322,4 +1322,4 @@ enum Brightness {
 /// The only place that `WidgetsBinding.instance.window` is inappropriate is if
 /// a `Window` is required before invoking `runApp()`. In that case, it is
 /// acceptable (though unfortunate) to use this object statically.
-final Window/*!*/ window = Window._();
+final Window window = Window._();

--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -667,32 +667,32 @@ class SemanticsUpdateBuilder {
   /// The `transform` is a matrix that maps this node's coordinate system into
   /// its parent's coordinate system.
   void updateNode({
-    /*required*/ int/*!*/ id,
-    /*required*/ int/*!*/ flags,
-    /*required*/ int/*!*/ actions,
-    /*required*/ int/*!*/ maxValueLength,
-    /*required*/ int/*!*/ currentValueLength,
-    /*required*/ int/*!*/ textSelectionBase,
-    /*required*/ int/*!*/ textSelectionExtent,
-    /*required*/ int/*!*/ platformViewId,
-    /*required*/ int/*!*/ scrollChildren,
-    /*required*/ int/*!*/ scrollIndex,
-    /*required*/ double/*!*/ scrollPosition,
-    /*required*/ double/*!*/ scrollExtentMax,
-    /*required*/ double/*!*/ scrollExtentMin,
-    /*required*/ double/*!*/ elevation,
-    /*required*/ double/*!*/ thickness,
-    /*required*/ Rect/*!*/ rect,
-    /*required*/ String/*!*/ label,
-    /*required*/ String/*!*/ hint,
-    /*required*/ String/*!*/ value,
-    /*required*/ String/*!*/ increasedValue,
-    /*required*/ String/*!*/ decreasedValue,
+    int/*!*/ id,
+    int/*!*/ flags,
+    int/*!*/ actions,
+    int/*!*/ maxValueLength,
+    int/*!*/ currentValueLength,
+    int/*!*/ textSelectionBase,
+    int/*!*/ textSelectionExtent,
+    int/*!*/ platformViewId,
+    int/*!*/ scrollChildren,
+    int/*!*/ scrollIndex,
+    double/*!*/ scrollPosition,
+    double/*!*/ scrollExtentMax,
+    double/*!*/ scrollExtentMin,
+    double/*!*/ elevation,
+    double/*!*/ thickness,
+    Rect/*!*/ rect,
+    String/*!*/ label,
+    String/*!*/ hint,
+    String/*!*/ value,
+    String/*!*/ increasedValue,
+    String/*!*/ decreasedValue,
     TextDirection/*?*/ textDirection,
-    /*required*/ Float64List/*!*/ transform,
-    /*required*/ Int32List/*!*/ childrenInTraversalOrder,
-    /*required*/ Int32List/*!*/ childrenInHitTestOrder,
-    /*required*/ Int32List/*!*/ additionalActions,
+    Float64List/*!*/ transform,
+    Int32List/*!*/ childrenInTraversalOrder,
+    Int32List/*!*/ childrenInHitTestOrder,
+    Int32List/*!*/ additionalActions,
   }) {
     if (transform.length != 16)
       throw ArgumentError('transform argument must have 16 entries.');
@@ -727,7 +727,7 @@ class SemanticsUpdateBuilder {
   }
 
   void updateCustomAction(
-      {/*required*/ int/*!*/ id, String/*?*/ label, String/*?*/ hint, int/*!*/ overrideId = -1}) {
+      {int/*!*/ id, String/*?*/ label, String/*?*/ hint, int/*!*/ overrideId = -1}) {
     // TODO(yjbanov): implement.
   }
 

--- a/testing/dart/image_filter_test.dart
+++ b/testing/dart/image_filter_test.dart
@@ -86,13 +86,6 @@ void main() {
     checkEquality(B, B);
   });
 
-  test('ImageFilter - nulls', () async {
-    final Paint paint = Paint()..imageFilter = ImageFilter.blur(sigmaX: null, sigmaY: null);
-    expect(paint.imageFilter, equals(ImageFilter.blur()));
-
-    expect(() => ImageFilter.matrix(null), throwsNoSuchMethodError);
-  });
-
   void checkBytes(Uint32List bytes, int center, int side, int corner) {
     expect(bytes[0], equals(corner));
     expect(bytes[1], equals(side));

--- a/testing/dart/path_test.dart
+++ b/testing/dart/path_test.dart
@@ -115,7 +115,7 @@ void main() {
 
     // basic tests on horizontal line
     final PathMetrics simpleHorizontalMetrics = simpleHorizontalLine.computeMetrics();
-    expect(simpleHorizontalMetrics.iterator.current, isNull);
+    expect(() => simpleHorizontalMetrics.iterator.current, throwsRangeError);
     expect(simpleHorizontalMetrics.iterator.moveNext(), isTrue);
     expect(simpleHorizontalMetrics.iterator.current, isNotNull);
     expect(simpleHorizontalMetrics.iterator.current.length, equals(10.0));
@@ -128,11 +128,11 @@ void main() {
     expect(posTan.angle, equals(0.0));
 
     expect(simpleHorizontalMetrics.iterator.moveNext(), isFalse);
-    expect(simpleHorizontalMetrics.iterator.current, isNull);
+    expect(() => simpleHorizontalMetrics.iterator.current, throwsRangeError);
 
     // test with forceClosed
     final PathMetrics simpleMetricsClosed = simpleHorizontalLine.computeMetrics(forceClosed: true);
-    expect(simpleMetricsClosed.iterator.current, isNull);
+    expect(() => simpleHorizontalMetrics.iterator.current, throwsRangeError);
     expect(simpleMetricsClosed.iterator.moveNext(), isTrue);
     expect(simpleMetricsClosed.iterator.current, isNotNull);
     expect(simpleMetricsClosed.iterator.current.length, equals(20.0)); // because we forced close
@@ -163,7 +163,7 @@ void main() {
       ..lineTo(10.0, 15.0);
 
     final PathMetrics multiContourMetric = multiContour.computeMetrics();
-    expect(multiContourMetric.iterator.current, isNull);
+    expect(() => multiContourMetric.iterator.current, throwsRangeError);
     expect(multiContourMetric.iterator.moveNext(), isTrue);
     expect(multiContourMetric.iterator.current, isNotNull);
     expect(multiContourMetric.iterator.current.length, equals(10.0));
@@ -171,7 +171,7 @@ void main() {
     expect(multiContourMetric.iterator.current, isNotNull);
     expect(multiContourMetric.iterator.current.length, equals(5.0));
     expect(multiContourMetric.iterator.moveNext(), isFalse);
-    expect(multiContourMetric.iterator.current, isNull);
+    expect(() => multiContourMetric.iterator.current, throwsRangeError);
   });
 
   test('PathMetrics can remember lengths and isClosed', () {

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 // HACK: pretend to be dart.ui in order to access its internals
-// @dart = 2.6
 library dart.ui;
 
 import 'dart:async';
@@ -15,8 +16,6 @@ import 'dart:math' as math;
 import 'dart:nativewrappers'; // ignore: unused_import
 import 'dart:typed_data';
 
-
-import 'package:test/test.dart';
 
 // HACK: these parts are to get access to private functions tested here.
 part '../../lib/ui/annotations.dart';
@@ -34,362 +33,395 @@ part '../../lib/ui/text.dart';
 part '../../lib/ui/window.dart';
 
 void main() {
-  group('window callback zones', () {
-    VoidCallback originalOnMetricsChanged;
-    VoidCallback originalOnLocaleChanged;
-    FrameCallback originalOnBeginFrame;
-    VoidCallback originalOnDrawFrame;
-    TimingsCallback originalOnReportTimings;
-    PointerDataPacketCallback originalOnPointerDataPacket;
-    VoidCallback originalOnSemanticsEnabledChanged;
-    SemanticsActionCallback originalOnSemanticsAction;
-    PlatformMessageCallback originalOnPlatformMessage;
-    VoidCallback originalOnTextScaleFactorChanged;
+  VoidCallback? originalOnMetricsChanged;
+  VoidCallback? originalOnLocaleChanged;
+  FrameCallback? originalOnBeginFrame;
+  VoidCallback? originalOnDrawFrame;
+  TimingsCallback? originalOnReportTimings;
+  PointerDataPacketCallback? originalOnPointerDataPacket;
+  VoidCallback? originalOnSemanticsEnabledChanged;
+  SemanticsActionCallback? originalOnSemanticsAction;
+  PlatformMessageCallback? originalOnPlatformMessage;
+  VoidCallback? originalOnTextScaleFactorChanged;
 
-    double oldDPR;
-    Size oldSize;
-    double oldDepth;
-    WindowPadding oldPadding;
-    WindowPadding oldInsets;
-    WindowPadding oldSystemGestureInsets;
+  double? oldDPR;
+  Size? oldSize;
+  double? oldDepth;
+  WindowPadding? oldPadding;
+  WindowPadding? oldInsets;
+  WindowPadding? oldSystemGestureInsets;
 
-    setUp(() {
-      oldDPR = window.devicePixelRatio;
-      oldSize = window.physicalSize;
-      oldDepth = window.physicalDepth;
-      oldPadding = window.viewPadding;
-      oldInsets = window.viewInsets;
-      oldSystemGestureInsets = window.systemGestureInsets;
+  void setUp() {
+    oldDPR = window.devicePixelRatio;
+    oldSize = window.physicalSize;
+    oldDepth = window.physicalDepth;
+    oldPadding = window.viewPadding;
+    oldInsets = window.viewInsets;
+    oldSystemGestureInsets = window.systemGestureInsets;
 
-      originalOnMetricsChanged = window.onMetricsChanged;
-      originalOnLocaleChanged = window.onLocaleChanged;
-      originalOnBeginFrame = window.onBeginFrame;
-      originalOnDrawFrame = window.onDrawFrame;
-      originalOnReportTimings = window.onReportTimings;
-      originalOnPointerDataPacket = window.onPointerDataPacket;
-      originalOnSemanticsEnabledChanged = window.onSemanticsEnabledChanged;
-      originalOnSemanticsAction = window.onSemanticsAction;
-      originalOnPlatformMessage = window.onPlatformMessage;
-      originalOnTextScaleFactorChanged = window.onTextScaleFactorChanged;
+    originalOnMetricsChanged = window.onMetricsChanged;
+    originalOnLocaleChanged = window.onLocaleChanged;
+    originalOnBeginFrame = window.onBeginFrame;
+    originalOnDrawFrame = window.onDrawFrame;
+    originalOnReportTimings = window.onReportTimings;
+    originalOnPointerDataPacket = window.onPointerDataPacket;
+    originalOnSemanticsEnabledChanged = window.onSemanticsEnabledChanged;
+    originalOnSemanticsAction = window.onSemanticsAction;
+    originalOnPlatformMessage = window.onPlatformMessage;
+    originalOnTextScaleFactorChanged = window.onTextScaleFactorChanged;
+  }
+
+  void tearDown() {
+    _updateWindowMetrics(
+      oldDPR!,                         // DPR
+      oldSize!.width,                  // width
+      oldSize!.height,                 // height
+      oldDepth!,                       // depth
+      oldPadding!.top,                 // padding top
+      oldPadding!.right,               // padding right
+      oldPadding!.bottom,              // padding bottom
+      oldPadding!.left,                // padding left
+      oldInsets!.top,                  // inset top
+      oldInsets!.right,                // inset right
+      oldInsets!.bottom,               // inset bottom
+      oldInsets!.left,                 // inset left
+      oldSystemGestureInsets!.top,     // system gesture inset top
+      oldSystemGestureInsets!.right,   // system gesture inset right
+      oldSystemGestureInsets!.bottom,  // system gesture inset bottom
+      oldSystemGestureInsets!.left,    // system gesture inset left
+    );
+    window.onMetricsChanged = originalOnMetricsChanged;
+    window.onLocaleChanged = originalOnLocaleChanged;
+    window.onBeginFrame = originalOnBeginFrame;
+    window.onDrawFrame = originalOnDrawFrame;
+    window.onReportTimings = originalOnReportTimings;
+    window.onPointerDataPacket = originalOnPointerDataPacket;
+    window.onSemanticsEnabledChanged = originalOnSemanticsEnabledChanged;
+    window.onSemanticsAction = originalOnSemanticsAction;
+    window.onPlatformMessage = originalOnPlatformMessage;
+    window.onTextScaleFactorChanged = originalOnTextScaleFactorChanged;
+  }
+
+  void test(String description, void Function() testFunction) {
+    print(description);
+    setUp();
+    testFunction();
+    tearDown();
+  }
+
+  void expectEquals(dynamic actual, dynamic expected) {
+    if (actual != expected) {
+      throw Exception('Equality check failed:\n  Expected: $expected\n  Actual: $actual');
+    }
+  }
+
+  void expectIterablesEqual(Iterable<dynamic> actual, Iterable<dynamic> expected) {
+    expectEquals(actual.length, expected.length);
+    final Iterator<dynamic> actualIter = actual.iterator;
+    final Iterator<dynamic> expectedIter = expected.iterator;
+    while (expectedIter.moveNext()) {
+      expectEquals(actualIter.moveNext(), true);
+      expectEquals(actualIter.current, expectedIter.current);
+    }
+    expectEquals(actualIter.moveNext(), false);
+  }
+
+  void expectNotEquals(dynamic actual, dynamic expected) {
+    if (actual == expected) {
+      throw Exception('Inequality check failed:\n  Expected: $expected\n  Actual: $actual');
+    }
+  }
+
+  void expectIdentical(dynamic actual, dynamic expected) {
+    if (!identical(actual, expected)) {
+      throw Exception('Identity check failed:\n  Expected: $expected\n  Actual: $actual');
+    }
+  }
+
+  test('updateUserSettings can handle an empty object', () {
+    // this should not throw.
+    _updateUserSettingsData('{}');
+  });
+
+  test('onMetricsChanged preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
+    late double devicePixelRatio;
+
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onMetricsChanged = () {
+        runZone = Zone.current;
+        devicePixelRatio = window.devicePixelRatio;
+      };
     });
 
-    tearDown(() {
-      _updateWindowMetrics(
-        oldDPR,                         // DPR
-        oldSize.width,                  // width
-        oldSize.height,                 // height
-        oldDepth,                       // depth
-        oldPadding.top,                 // padding top
-        oldPadding.right,               // padding right
-        oldPadding.bottom,              // padding bottom
-        oldPadding.left,                // padding left
-        oldInsets.top,                  // inset top
-        oldInsets.right,                // inset right
-        oldInsets.bottom,               // inset bottom
-        oldInsets.left,                 // inset left
-        oldSystemGestureInsets.top,     // system gesture inset top
-        oldSystemGestureInsets.right,   // system gesture inset right
-        oldSystemGestureInsets.bottom,  // system gesture inset bottom
-        oldSystemGestureInsets.left,    // system gesture inset left
-      );
-      window.onMetricsChanged = originalOnMetricsChanged;
-      window.onLocaleChanged = originalOnLocaleChanged;
-      window.onBeginFrame = originalOnBeginFrame;
-      window.onDrawFrame = originalOnDrawFrame;
-      window.onReportTimings = originalOnReportTimings;
-      window.onPointerDataPacket = originalOnPointerDataPacket;
-      window.onSemanticsEnabledChanged = originalOnSemanticsEnabledChanged;
-      window.onSemanticsAction = originalOnSemanticsAction;
-      window.onPlatformMessage = originalOnPlatformMessage;
-      window.onTextScaleFactorChanged = originalOnTextScaleFactorChanged;
+    window.onMetricsChanged!();
+    _updateWindowMetrics(
+      0.1234, // DPR
+      0.0,    // width
+      0.0,    // height
+      0.0,    // depth
+      0.0,    // padding top
+      0.0,    // padding right
+      0.0,    // padding bottom
+      0.0,    // padding left
+      0.0,    // inset top
+      0.0,    // inset right
+      0.0,    // inset bottom
+      0.0,    // inset left
+      0.0,    // system gesture inset top
+      0.0,    // system gesture inset right
+      0.0,    // system gesture inset bottom
+      0.0,    // system gesture inset left
+    );
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+    expectEquals(devicePixelRatio, 0.1234);
+  });
+
+  test('onLocaleChanged preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
+    Locale? locale;
+
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onLocaleChanged = () {
+        runZone = Zone.current;
+        locale = window.locale;
+      };
     });
 
-    test('updateUserSettings can handle an empty object', () {
-      // this should now throw.
-      _updateUserSettingsData('{}');
-      expect(true, equals(true));
+    _updateLocales(<String>['en', 'US', '', '']);
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+    expectEquals(locale, const Locale('en', 'US'));
+  });
+
+  test('onBeginFrame preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
+    late Duration start;
+
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onBeginFrame = (Duration value) {
+        runZone = Zone.current;
+        start = value;
+      };
     });
 
-    test('onMetricsChanged preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
-      double devicePixelRatio;
+    _beginFrame(1234);
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+    expectEquals(start, const Duration(microseconds: 1234));
+  });
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onMetricsChanged = () {
-          runZone = Zone.current;
-          devicePixelRatio = window.devicePixelRatio;
-        };
-      });
+  test('onDrawFrame preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
 
-      window.onMetricsChanged();
-      _updateWindowMetrics(
-        0.1234, // DPR
-        0.0,    // width
-        0.0,    // height
-        0.0,    // depth
-        0.0,    // padding top
-        0.0,    // padding right
-        0.0,    // padding bottom
-        0.0,    // padding left
-        0.0,    // inset top
-        0.0,    // inset right
-        0.0,    // inset bottom
-        0.0,    // inset left
-        0.0,    // system gesture inset top
-        0.0,    // system gesture inset right
-        0.0,    // system gesture inset bottom
-        0.0,    // system gesture inset left
-      );
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
-      expect(devicePixelRatio, equals(0.1234));
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onDrawFrame = () {
+        runZone = Zone.current;
+      };
     });
 
-    test('onLocaleChanged preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
-      Locale locale;
+    _drawFrame();
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+  });
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onLocaleChanged = () {
-          runZone = Zone.current;
-          locale = window.locale;
-        };
-      });
+  test('onReportTimings preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
 
-      _updateLocales(<String>['en', 'US', '', '']);
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
-      expect(locale, equals(const Locale('en', 'US')));
+    window._setNeedsReportTimings = (bool _) {};
+
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onReportTimings = (List<FrameTiming> timings) {
+        runZone = Zone.current;
+      };
     });
 
-    test('onBeginFrame preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
-      Duration start;
+    _reportTimings(<int>[]);
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+  });
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onBeginFrame = (Duration value) {
-          runZone = Zone.current;
-          start = value;
-        };
-      });
+  test('onPointerDataPacket preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
+    late PointerDataPacket data;
 
-      _beginFrame(1234);
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
-      expect(start, equals(const Duration(microseconds: 1234)));
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onPointerDataPacket = (PointerDataPacket value) {
+        runZone = Zone.current;
+        data = value;
+      };
     });
 
-    test('onDrawFrame preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
+    final ByteData testData = ByteData.view(Uint8List(0).buffer);
+    _dispatchPointerDataPacket(testData);
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+    expectIterablesEqual(data.data, _unpackPointerDataPacket(testData).data);
+  });
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onDrawFrame = () {
-          runZone = Zone.current;
-        };
-      });
+  test('onSemanticsEnabledChanged preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
+    late bool enabled;
 
-      _drawFrame();
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onSemanticsEnabledChanged = () {
+        runZone = Zone.current;
+        enabled = window.semanticsEnabled;
+      };
     });
 
-    test('onReportTimings preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
+    _updateSemanticsEnabled(window._semanticsEnabled);
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+    expectNotEquals(enabled, null);
+    expectEquals(enabled, window._semanticsEnabled);
+  });
 
-      window._setNeedsReportTimings = (bool _) {};
+  test('onSemanticsAction preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
+    late int id;
+    late int action;
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onReportTimings = (List<FrameTiming> timings) {
-          runZone = Zone.current;
-        };
-      });
-
-      _reportTimings(<int>[]);
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onSemanticsAction = (int i, SemanticsAction a, ByteData? _) {
+        runZone = Zone.current;
+        action = a.index;
+        id = i;
+      };
     });
 
-    test('onPointerDataPacket preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
-      PointerDataPacket data;
+    _dispatchSemanticsAction(1234, 4, null);
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+    expectEquals(id, 1234);
+    expectEquals(action, 4);
+  });
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onPointerDataPacket = (PointerDataPacket value) {
-          runZone = Zone.current;
-          data = value;
-        };
-      });
+  test('onPlatformMessage preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
+    late String name;
 
-      final ByteData testData = ByteData.view(Uint8List(0).buffer);
-      _dispatchPointerDataPacket(testData);
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
-      expect(data.data, equals(_unpackPointerDataPacket(testData).data));
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onPlatformMessage = (String value, _, __) {
+        runZone = Zone.current;
+        name = value;
+      };
     });
 
-    test('onSemanticsEnabledChanged preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
-      bool enabled;
+    _dispatchPlatformMessage('testName', null, 123456789);
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+    expectEquals(name, 'testName');
+  });
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onSemanticsEnabledChanged = () {
-          runZone = Zone.current;
-          enabled = window.semanticsEnabled;
-        };
-      });
+  test('onTextScaleFactorChanged preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
+    late double textScaleFactor;
 
-      _updateSemanticsEnabled(window._semanticsEnabled);
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
-      expect(enabled, isNotNull);
-      expect(enabled, equals(window._semanticsEnabled));
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onTextScaleFactorChanged = () {
+        runZone = Zone.current;
+        textScaleFactor = window.textScaleFactor;
+      };
     });
 
-    test('onSemanticsAction preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
-      int id;
-      int action;
+    window.onTextScaleFactorChanged!();
+    _updateTextScaleFactor(0.5);
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+    expectEquals(textScaleFactor, 0.5);
+  });
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onSemanticsAction = (int i, SemanticsAction a, ByteData _) {
-          runZone = Zone.current;
-          action = a.index;
-          id = i;
-        };
-      });
+  test('onThemeBrightnessMode preserves callback zone', () {
+    late Zone innerZone;
+    late Zone runZone;
+    late Brightness platformBrightness;
 
-      _dispatchSemanticsAction(1234, 4, null);
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
-      expect(id, equals(1234));
-      expect(action, equals(4));
+    runZoned(() {
+      innerZone = Zone.current;
+      window.onPlatformBrightnessChanged = () {
+        runZone = Zone.current;
+        platformBrightness = window.platformBrightness;
+      };
     });
 
-    test('onPlatformMessage preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
-      String name;
+    window.onPlatformBrightnessChanged!();
+    _updatePlatformBrightness('dark');
+    expectNotEquals(runZone, null);
+    expectIdentical(runZone, innerZone);
+    expectEquals(platformBrightness, Brightness.dark);
+  });
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onPlatformMessage = (String value, _, __) {
-          runZone = Zone.current;
-          name = value;
-        };
-      });
+  test('Window padding/insets/viewPadding/systemGestureInsets', () {
+    _updateWindowMetrics(
+      1.0,   // DPR
+      800.0, // width
+      600.0, // height
+      100.0, // depth
+      50.0,  // padding top
+      0.0,   // padding right
+      40.0,  // padding bottom
+      0.0,   // padding left
+      0.0,   // inset top
+      0.0,   // inset right
+      0.0,   // inset bottom
+      0.0,   // inset left
+      0.0,   // system gesture inset top
+      0.0,   // system gesture inset right
+      0.0,   // system gesture inset bottom
+      0.0,   // system gesture inset left
+    );
 
-      _dispatchPlatformMessage('testName', null, null);
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
-      expect(name, equals('testName'));
-    });
+    expectEquals(window.viewInsets.bottom, 0.0);
+    expectEquals(window.viewPadding.bottom, 40.0);
+    expectEquals(window.padding.bottom, 40.0);
+    expectEquals(window.physicalDepth, 100.0);
+    expectEquals(window.systemGestureInsets.bottom, 0.0);
 
-    test('onTextScaleFactorChanged preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
-      double textScaleFactor;
+    _updateWindowMetrics(
+      1.0,   // DPR
+      800.0, // width
+      600.0, // height
+      100.0, // depth
+      50.0,  // padding top
+      0.0,   // padding right
+      40.0,  // padding bottom
+      0.0,   // padding left
+      0.0,   // inset top
+      0.0,   // inset right
+      400.0, // inset bottom
+      0.0,   // inset left
+      0.0,   // system gesture insets top
+      0.0,   // system gesture insets right
+      44.0,  // system gesture insets bottom
+      0.0,   // system gesture insets left
+    );
 
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onTextScaleFactorChanged = () {
-          runZone = Zone.current;
-          textScaleFactor = window.textScaleFactor;
-        };
-      });
-
-      window.onTextScaleFactorChanged();
-      _updateTextScaleFactor(0.5);
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
-      expect(textScaleFactor, equals(0.5));
-    });
-
-    test('onThemeBrightnessMode preserves callback zone', () {
-      Zone innerZone;
-      Zone runZone;
-      Brightness platformBrightness;
-
-      runZoned(() {
-        innerZone = Zone.current;
-        window.onPlatformBrightnessChanged = () {
-          runZone = Zone.current;
-          platformBrightness = window.platformBrightness;
-        };
-      });
-
-      window.onPlatformBrightnessChanged();
-      _updatePlatformBrightness('dark');
-      expect(runZone, isNotNull);
-      expect(runZone, same(innerZone));
-      expect(platformBrightness, equals(Brightness.dark));
-    });
-
-    test('Window padding/insets/viewPadding/systemGestureInsets', () {
-      _updateWindowMetrics(
-        1.0,   // DPR
-        800.0, // width
-        600.0, // height
-        100.0, // depth
-        50.0,  // padding top
-        0.0,   // padding right
-        40.0,  // padding bottom
-        0.0,   // padding left
-        0.0,   // inset top
-        0.0,   // inset right
-        0.0,   // inset bottom
-        0.0,   // inset left
-        0.0,   // system gesture inset top
-        0.0,   // system gesture inset right
-        0.0,   // system gesture inset bottom
-        0.0,   // system gesture inset left
-      );
-
-      expect(window.viewInsets.bottom, 0.0);
-      expect(window.viewPadding.bottom, 40.0);
-      expect(window.padding.bottom, 40.0);
-      expect(window.physicalDepth, 100.0);
-      expect(window.systemGestureInsets.bottom, 0.0);
-
-      _updateWindowMetrics(
-        1.0,   // DPR
-        800.0, // width
-        600.0, // height
-        100.0, // depth
-        50.0,  // padding top
-        0.0,   // padding right
-        40.0,  // padding bottom
-        0.0,   // padding left
-        0.0,   // inset top
-        0.0,   // inset right
-        400.0, // inset bottom
-        0.0,   // inset left
-        0.0,   // system gesture insets top
-        0.0,   // system gesture insets right
-        44.0,  // system gesture insets bottom
-        0.0,   // system gesture insets left
-      );
-
-      expect(window.viewInsets.bottom, 400.0);
-      expect(window.viewPadding.bottom, 40.0);
-      expect(window.padding.bottom, 0.0);
-      expect(window.physicalDepth, 100.0);
-      expect(window.systemGestureInsets.bottom, 44.0);
-    });
+    expectEquals(window.viewInsets.bottom, 400.0);
+    expectEquals(window.viewPadding.bottom, 40.0);
+    expectEquals(window.padding.bottom, 0.0);
+    expectEquals(window.physicalDepth, 100.0);
+    expectEquals(window.systemGestureInsets.bottom, 44.0);
   });
 }

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -181,6 +181,8 @@ def SnapshotTest(build_dir, dart_file, kernel_file_output, verbose_dart_snapshot
   snapshot_command = [
     dart,
     frontend_server,
+    '--enable-experiment=non-nullable',
+    '--no-null-safety',
     '--sdk-root',
     flutter_patched_sdk,
     '--incremental',

--- a/web_sdk/test/api_conform_test.dart
+++ b/web_sdk/test/api_conform_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:analyzer/analyzer.dart';
+import 'package:analyzer/dart/analysis/features.dart';
 
 // Ignore members defined on Object.
 const Set<String> _kObjectMembers = <String>{
@@ -15,8 +16,9 @@ const Set<String> _kObjectMembers = <String>{
 
 void main() {
   // These files just contain imports to the part files;
+  final FeatureSet analyzerFeatures = FeatureSet.fromEnableFlags(<String>['non-nullable']);
   final CompilationUnit uiUnit = parseDartFile('lib/ui/ui.dart',
-      parseFunctionBodies: false, suppressErrors: false);
+      parseFunctionBodies: false, suppressErrors: false, featureSet: analyzerFeatures);
   final CompilationUnit webUnit = parseDartFile('lib/web_ui/lib/ui.dart',
       parseFunctionBodies: false, suppressErrors: false);
   final Map<String, ClassDeclaration> uiClasses = <String, ClassDeclaration>{};
@@ -24,7 +26,7 @@ void main() {
 
   // Gather all public classes from each library. For now we are skiping
   // other top level members.
-  _collectPublicClasses(uiUnit, uiClasses, 'lib/ui/');
+  _collectPublicClasses(uiUnit, uiClasses, 'lib/ui/', analyzerFeatures: analyzerFeatures);
   _collectPublicClasses(webUnit, webClasses, 'lib/web_ui/lib/');
 
   if (uiClasses.isEmpty || webClasses.isEmpty) {
@@ -179,7 +181,7 @@ void main() {
 
 // Collects all public classes defined by the part files of [unit].
 void _collectPublicClasses(CompilationUnit unit,
-    Map<String, ClassDeclaration> destination, String root) {
+    Map<String, ClassDeclaration> destination, String root, {FeatureSet analyzerFeatures}) {
   for (Directive directive in unit.directives) {
     if (directive is! PartDirective) {
       continue;
@@ -190,6 +192,7 @@ void _collectPublicClasses(CompilationUnit unit,
       '$root${literalUri.substring(1, literalUri.length - 1)}',
       parseFunctionBodies: false,
       suppressErrors: false,
+      featureSet: analyzerFeatures,
     );
     for (CompilationUnitMember member in subUnit.declarations) {
       if (member is! ClassDeclaration) {

--- a/web_sdk/test/api_conform_test.dart
+++ b/web_sdk/test/api_conform_test.dart
@@ -15,6 +15,10 @@ const Set<String> _kObjectMembers = <String>{
 };
 
 void main() {
+  // TODO(yjbanov): fix and re-enable API conform test.
+  if (!Platform.environment.containsKey('REALLY_DO_RUN_API_CONFORM_TEST')) {
+    return;
+  }
   // These files just contain imports to the part files;
   final FeatureSet analyzerFeatures = FeatureSet.fromEnableFlags(<String>['non-nullable']);
   final CompilationUnit uiUnit = parseDartFile('lib/ui/ui.dart',


### PR DESCRIPTION
## Description

Applies the null safety syntax to the mobile implementation of `dart:ui`.

Notable changes:

* Use the migration tool to convert temporary annotations to new NNBD syntax, with some manual assistance.
* Temporarily disable `api_conform_test.dart`. The parser crashes on NNBD code. We are using deprecate analyzer API, so we'll need to migrate to something supported.
* Enable non-nullable analysis option in `analysis_options.yaml` and `analyze.sh`.
* Add `// ignore: unnecessary_null_comparison` where we null-check arguments, because until everyone opts-in the type annotations themselves won't have an effect in opted out code.
* Remove usages of `List` constructor in favor of `List.filled` for nullables, and plain `[]` for non-nullables.
* `TextStyle._fontFamily` seems to have never been null, so I removed the null checking code paths.
* `PathMetricIterator` now throws `RangeError` instead of returning `null` if `current` is accessed before iteration starts, or when the iterator runs out of elements. This is so we can make `PathMetric` non-nullable.
* Changed `window_hooks_integration_test.dart` to not depend on `package:test`. This test is special in the it makes `dart:ui` files `part of` itself. It's weird to have fully migrated `dart:ui` to depend on non-migrated code.

## Related Issues

https://github.com/flutter/flutter/issues/53661