### PR TITLE
Fix CanvasKit text colors by not passing a Malloc'ed array.

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/text.dart
+++ b/lib/web_ui/lib/src/engine/compositor/text.dart
@@ -163,16 +163,14 @@ class SkTextStyle implements ui.TextStyle {
     List<ui.Shadow> shadows,
     List<ui.FontFeature> fontFeatures,
   }) {
-    final Map<String, dynamic> style = <String, dynamic>{};
+    final js.JsObject style = js.JsObject(js.context['Object']);
 
     if (background != null) {
-      setSharedSkColor2(background.color);
-      style['backgroundColor'] = sharedSkColor2;
+      style['backgroundColor'] = makeFreshSkColor(background.color);
     }
 
     if (color != null) {
-      setSharedSkColor1(color);
-      style['color'] = sharedSkColor1;
+      style['color'] = makeFreshSkColor(color);
     }
 
     if (decoration != null) {
@@ -211,15 +209,14 @@ class SkTextStyle implements ui.TextStyle {
       fontFamilies.addAll(fontFamilyFallback);
     }
 
-    style['fontFamilies'] = fontFamilies;
+    style['fontFamilies'] = js.JsArray.from(fontFamilies);
 
     if (fontWeight != null || fontStyle != null) {
       style['fontStyle'] = toSkFontStyle(fontWeight, fontStyle);
     }
 
     if (foreground != null) {
-      setSharedSkColor3(foreground.color);
-      style['foregroundColor'] = sharedSkColor3;
+      style['foregroundColor'] = makeFreshSkColor(foreground.color);
     }
 
     // TODO(hterkelsen): Add support for
@@ -232,8 +229,7 @@ class SkTextStyle implements ui.TextStyle {
     //   - locale
     //   - shadows
     //   - fontFeatures
-    skTextStyle = canvasKit
-        .callMethod('TextStyle', <js.JsObject>[js.JsObject.jsify(style)]);
+    skTextStyle = canvasKit.callMethod('TextStyle', <js.JsObject>[style]);
     assert(skTextStyle != null);
   }
 }


### PR DESCRIPTION
Also, don't use `jsify` since it will turn the `Float32Array` into
a JS Array, which CanvasKit doesn't recognize as an SkColor.

## Description

Also, don't use `jsify` since it will turn the `Float32Array` into
a JS Array, which CanvasKit doesn't recognize as an SkColor.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/59021

## Tests

Tested on example in issue above and gallery.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
