### PR TITLE
Firefox gives an error if the directory is not empty

### DIFF
--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -59,7 +59,7 @@ user_pref("dom.max_script_run_time", 0);
       // https://developer.mozilla.org/en-US/docs/Mozilla/Command_Line_Options#Browser
       //
       if (temporaryProfileDirectory.existsSync()) {
-        temporaryProfileDirectory.deleteSync();
+        temporaryProfileDirectory.deleteSync(recursive: true);
       }
       temporaryProfileDirectory.createSync(recursive: true);
 


### PR DESCRIPTION
Encountered error: `Failed to run Firefox: Deletion failed, path = '/Users/nurhan/development/engine/src/flutter/lib/web_ui/.dart_tool/firefox_profile'`

Change: Delete the directory even if it is not empty.
