### PR TITLE
[web] don't run some tests on safari

### DIFF
--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
+@TestOn('chrome || firefox')
+
 import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js_util' as js_util;

--- a/lib/web_ui/test/text/measurement_test.dart
+++ b/lib/web_ui/test/text/measurement_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
+@TestOn('chrome || firefox')
+
 import 'package:ui/ui.dart' as ui;
 import 'package:ui/src/engine.dart';
 


### PR DESCRIPTION
I reenabled the Safari tests after changing the recipe and running many times (https://github.com/flutter/flutter/issues/58012) (https://flutter-review.googlesource.com/c/recipes/+/3500)

However, these tests are failing in prod bots:
- https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8877954507288737600/+/steps/felt_test_safari/0/stdout
- https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8877960478504328816/+/steps/felt_test_safari/0/stdout
- https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8877983757127818128/+/steps/felt_test_safari/0/stdout
- https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8878014776727176528/+/steps/felt_test_safari/0/stdout

Even though they were passing on the try bots: https://ci.chromium.org/p/flutter/builders/try/Mac%20Web%20Engine?limit=50 

This maybe due to https://github.com/flutter/flutter/issues/58045 Unless this issue is resolved I'm planning to skip the tests failing on bots so that at least we can keep a subset which passes in all Safari browsers.
