### PR TITLE
Include the memory header as unique_ptr is used in ASCII Trie.

### DIFF
--- a/fml/ascii_trie.h
+++ b/fml/ascii_trie.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_FML_ASCIITRIE_H_
 #define FLUTTER_FML_ASCIITRIE_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This is the only remaining blocker to switching to MSVC 2019