### PR TITLE
Move fuchsia/scenic integration behind #define

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -125,6 +125,20 @@ config("config") {
   }
 }
 
+# This "fuchsia_legacy" configuration includes old, non-embedder API sources and
+# defines the LEGACY_FUCHSIA_EMBEDDER symbol.  This config and its associated
+# template are both transitional and will be removed after the embedder API
+# transition is complete.
+#
+# See `source_set_maybe_fuchsia_legacy` in //flutter/common/config.gni
+#
+# TODO(fxb/54041): Remove when no longer neccesary.
+config("fuchsia_legacy") {
+  if (is_fuchsia) {
+    defines = [ "LEGACY_FUCHSIA_EMBEDDER" ]
+  }
+}
+
 config("export_dynamic_symbols") {
   if (is_linux || is_fuchsia) {
     inputs = [
@@ -151,9 +165,12 @@ if (is_fuchsia) {
 
     deps = [
       "//flutter/flow:flow_tests",
+      "//flutter/flow:flow_tests_next",
       "//flutter/fml:fml_tests",
       "//flutter/runtime:runtime_tests",
+      "//flutter/runtime:runtime_tests_next",
       "//flutter/shell/common:shell_tests",
+      "//flutter/shell/common:shell_tests_next",
       "//flutter/shell/platform/fuchsia/flutter:flutter_runner_scenic_tests",
       "//flutter/shell/platform/fuchsia/flutter:flutter_runner_tests",
     ]

--- a/common/config.gni
+++ b/common/config.gni
@@ -76,3 +76,119 @@ if (is_ios || is_mac) {
   ]
   flutter_cflags_objcc = flutter_cflags_objc
 }
+
+# This template creates a `source_set` in both standard and "fuchsia_legacy"
+# configurations.
+#
+# The "fuchsia_legacy" configuration includes old, non-embedder API sources and
+# defines the LEGACY_FUCHSIA_EMBEDDER symbol.  This template and the config
+# are both transitional and will be removed after the embedder API transition
+# is complete.
+# TODO(fxb/54041): Remove when no longer neccesary.
+#
+# `sources`, `defines`, `public_configs`, `configs`, `public_deps`, `deps` work
+# as they do in a normal `source_set`.
+#
+# `legacy_deps` is the list of dependencies which should be mutated by
+# appending '_fuchsia_legacy' when creating the 2 `source_set`'s.  The template adds
+# `legacy_deps` to `public_deps`, whether it mutates them or not.
+template("source_set_maybe_fuchsia_legacy") {
+  public_deps_non_legacy = []
+  deps_non_legacy = []
+  if (defined(invoker.public_deps)) {
+    public_deps_non_legacy += invoker.public_deps
+  }
+  if (defined(invoker.deps)) {
+    deps_non_legacy += invoker.deps
+  }
+  if (defined(invoker.public_deps_legacy_and_next)) {
+    foreach(legacy_dep, invoker.public_deps_legacy_and_next) {
+      public_deps_non_legacy += [ legacy_dep ]
+    }
+  }
+  if (defined(invoker.deps_legacy_and_next)) {
+    foreach(legacy_dep, invoker.deps_legacy_and_next) {
+      deps_non_legacy += [ legacy_dep ]
+    }
+  }
+
+  source_set(target_name) {
+    forward_variables_from(invoker,
+                           [
+                             "testonly",
+                             "sources",
+                             "defines",
+                             "public_configs",
+                             "configs",
+                           ])
+    public_deps = public_deps_non_legacy
+    deps = deps_non_legacy
+  }
+
+  if (is_fuchsia) {
+    legagcy_suffix = "_fuchsia_legacy"
+
+    sources_legacy = []
+    if (defined(invoker.sources_legacy)) {
+      sources_legacy += invoker.sources_legacy
+    }
+    if (defined(invoker.sources)) {
+      sources_legacy += invoker.sources
+    }
+
+    public_configs_legacy = [ "//flutter:fuchsia_legacy" ]
+    if (defined(invoker.public_configs)) {
+      public_configs_legacy += invoker.public_configs
+    }
+
+    public_deps_legacy = []
+    deps_legacy = []
+    if (defined(invoker.public_deps)) {
+      public_deps_legacy += invoker.public_deps
+    }
+    if (defined(invoker.deps)) {
+      deps_legacy += invoker.deps
+    }
+    if (defined(invoker.public_deps_legacy)) {
+      public_deps_legacy += invoker.public_deps_legacy
+    }
+    if (defined(invoker.deps_legacy)) {
+      deps_legacy += invoker.deps_legacy
+    }
+    if (defined(invoker.public_deps_legacy_and_next)) {
+      foreach(legacy_dep, invoker.public_deps_legacy_and_next) {
+        public_deps_legacy += [ legacy_dep + legagcy_suffix ]
+      }
+    }
+    if (defined(invoker.deps_legacy_and_next)) {
+      foreach(legacy_dep, invoker.deps_legacy_and_next) {
+        deps_legacy += [ legacy_dep + legagcy_suffix ]
+      }
+    }
+
+    source_set(target_name + legagcy_suffix) {
+      forward_variables_from(invoker,
+                             [
+                               "testonly",
+                               "defines",
+                               "configs",
+                             ])
+      sources = sources_legacy
+
+      public_configs = public_configs_legacy
+
+      public_deps = public_deps_legacy
+      deps = deps_legacy
+    }
+  } else {
+    if (defined(invoker.sources_legacy)) {
+      not_needed(invoker, [ "sources_legacy" ])
+    }
+    if (defined(invoker.public_deps_legacy)) {
+      not_needed(invoker, [ "public_deps_legacy" ])
+    }
+    if (defined(invoker.deps_legacy)) {
+      not_needed(invoker, [ "deps_legacy" ])
+    }
+  }
+}

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -2,13 +2,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
 if (is_fuchsia) {
   import("//build/fuchsia/sdk.gni")
   import("//flutter/tools/fuchsia/fuchsia_archive.gni")
 }
-import("//flutter/testing/testing.gni")
 
-source_set("flow") {
+source_set_maybe_fuchsia_legacy("flow") {
   sources = [
     "compositor_context.cc",
     "compositor_context.h",
@@ -74,37 +75,33 @@ source_set("flow") {
 
   public_configs = [ "//flutter:config" ]
 
-  public_deps = []
-
   deps = [
     "//flutter/common",
     "//flutter/fml",
     "//third_party/skia",
   ]
 
-  if (is_fuchsia) {
-    sources += [
-      "layers/child_scene_layer.cc",
-      "layers/child_scene_layer.h",
-      "scene_update_context.cc",
-      "scene_update_context.h",
-      "view_holder.cc",
-      "view_holder.h",
-    ]
+  sources_legacy = [
+    "layers/child_scene_layer.cc",
+    "layers/child_scene_layer.h",
+    "scene_update_context.cc",
+    "scene_update_context.h",
+    "view_holder.cc",
+    "view_holder.h",
+  ]
 
-    public_deps += [
-      "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
-      "$fuchsia_sdk_root/fidl:fuchsia.ui.gfx",
-      "$fuchsia_sdk_root/pkg:scenic_cpp",
-    ]
-  }
+  public_deps_legacy = [
+    "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
+    "$fuchsia_sdk_root/fidl:fuchsia.ui.gfx",
+    "$fuchsia_sdk_root/pkg:scenic_cpp",
+  ]
 }
 
 test_fixtures("flow_fixtures") {
   fixtures = []
 }
 
-source_set("flow_testing") {
+source_set_maybe_fuchsia_legacy("flow_testing") {
   testonly = true
 
   sources = [
@@ -113,6 +110,8 @@ source_set("flow_testing") {
     "testing/layer_test.h",
     "testing/mock_layer.cc",
     "testing/mock_layer.h",
+    "testing/mock_raster_cache.cc",
+    "testing/mock_raster_cache.h",
     "testing/mock_texture.cc",
     "testing/mock_texture.h",
     "testing/skia_gpu_object_layer_test.cc",
@@ -120,13 +119,14 @@ source_set("flow_testing") {
   ]
 
   public_deps = [
-    ":flow",
     "//flutter/testing:skia",
     "//third_party/googletest:gtest",
   ]
+
+  deps_legacy_and_next = [ ":flow" ]
 }
 
-executable("flow_unittests") {
+source_set_maybe_fuchsia_legacy("flow_unittests_common") {
   testonly = true
 
   sources = [
@@ -161,14 +161,8 @@ executable("flow_unittests") {
     "texture_unittests.cc",
   ]
 
-  if (is_fuchsia) {
-    sources += [ "layers/fuchsia_layer_unittests.cc" ]
-  }
-
   deps = [
-    ":flow",
     ":flow_fixtures",
-    ":flow_testing",
     "//flutter/fml",
     "//flutter/testing:skia",
     "//flutter/testing:testing_lib",
@@ -177,8 +171,38 @@ executable("flow_unittests") {
     "//third_party/skia",
   ]
 
-  if (is_fuchsia) {
-    deps += [ "//build/fuchsia/pkg:sys_cpp_testing" ]
+  sources_legacy = [ "layers/fuchsia_layer_unittests.cc" ]
+
+  deps_legacy = [ "//build/fuchsia/pkg:sys_cpp_testing" ]
+
+  deps_legacy_and_next = [
+    ":flow",
+    ":flow_testing",
+  ]
+}
+
+if (is_fuchsia) {
+  executable("flow_unittests") {
+    testonly = true
+
+    deps = [
+      ":flow_unittests_common_fuchsia_legacy",
+    ]
+  }
+  executable("flow_unittests_next") {
+    testonly = true
+
+    deps = [
+      ":flow_unittests_common",
+    ]
+  }
+} else {
+  executable("flow_unittests") {
+    testonly = true
+
+    deps = [
+      ":flow_unittests_common",
+    ]
   }
 }
 
@@ -191,6 +215,39 @@ if (is_fuchsia) {
     ]
 
     binary = "flow_unittests"
+
+    libraries = common_libs
+
+    meta_dir = "//flutter/testing/fuchsia/meta"
+    cmx_file = "$meta_dir/fuchsia_test.cmx"
+
+    resources = [
+      {
+        path = rebase_path(
+                "//flutter/testing/resources/performance_overlay_gold_60fps.png")
+        dest = "flutter/testing/resources/performance_overlay_gold_60fps.png"
+      },
+      {
+        path = rebase_path(
+                "//flutter/testing/resources/performance_overlay_gold_90fps.png")
+        dest = "flutter/testing/resources/performance_overlay_gold_90fps.png"
+      },
+      {
+        path = rebase_path(
+                "//flutter/testing/resources/performance_overlay_gold_120fps.png")
+        dest = "flutter/testing/resources/performance_overlay_gold_120fps.png"
+      },
+    ]
+  }
+
+  fuchsia_archive("flow_tests_next") {
+    testonly = true
+
+    deps = [
+      ":flow_unittests_next",
+    ]
+
+    binary = "flow_unittests_next"
 
     libraries = common_libs
 

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -15,7 +15,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/raster_thread_merger.h"
 #include "third_party/skia/include/core/SkCanvas.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
+#include "third_party/skia/include/gpu/GrContext.h"
 
 namespace flutter {
 

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -4,11 +4,11 @@
 
 #include "flutter/flow/layers/clip_path_layer.h"
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 
 #include "lib/ui/scenic/cpp/commands.h"
 
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 namespace flutter {
 
@@ -40,7 +40,7 @@ void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   context->cull_rect = previous_cull_rect;
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 
 void ClipPathLayer::UpdateScene(SceneUpdateContext& context) {
   TRACE_EVENT0("flutter", "ClipPathLayer::UpdateScene");
@@ -51,7 +51,7 @@ void ClipPathLayer::UpdateScene(SceneUpdateContext& context) {
   UpdateSceneChildren(context);
 }
 
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 void ClipPathLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ClipPathLayer::Paint");

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -21,9 +21,9 @@ class ClipPathLayer : public ContainerLayer {
     return clip_behavior_ == Clip::antiAliasWithSaveLayer;
   }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   void UpdateScene(SceneUpdateContext& context) override;
-#endif  // defined(OS_FUCHSIA)
+#endif
 
  private:
   SkPath clip_path_;

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -33,7 +33,7 @@ void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   context->cull_rect = previous_cull_rect;
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 
 void ClipRectLayer::UpdateScene(SceneUpdateContext& context) {
   TRACE_EVENT0("flutter", "ClipRectLayer::UpdateScene");
@@ -44,7 +44,7 @@ void ClipRectLayer::UpdateScene(SceneUpdateContext& context) {
   UpdateSceneChildren(context);
 }
 
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 void ClipRectLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ClipRectLayer::Paint");

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -20,9 +20,9 @@ class ClipRectLayer : public ContainerLayer {
     return clip_behavior_ == Clip::antiAliasWithSaveLayer;
   }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   void UpdateScene(SceneUpdateContext& context) override;
-#endif  // defined(OS_FUCHSIA)
+#endif
 
  private:
   SkRect clip_rect_;

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -34,7 +34,7 @@ void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   context->cull_rect = previous_cull_rect;
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 
 void ClipRRectLayer::UpdateScene(SceneUpdateContext& context) {
   TRACE_EVENT0("flutter", "ClipRRectLayer::UpdateScene");
@@ -45,7 +45,7 @@ void ClipRRectLayer::UpdateScene(SceneUpdateContext& context) {
   UpdateSceneChildren(context);
 }
 
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 void ClipRRectLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ClipRRectLayer::Paint");

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -21,9 +21,9 @@ class ClipRRectLayer : public ContainerLayer {
     return clip_behavior_ == Clip::antiAliasWithSaveLayer;
   }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   void UpdateScene(SceneUpdateContext& context) override;
-#endif  // defined(OS_FUCHSIA)
+#endif
 
  private:
   SkRRect clip_rrect_;

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -29,7 +29,7 @@ void ContainerLayer::Paint(PaintContext& context) const {
 void ContainerLayer::PrerollChildren(PrerollContext* context,
                                      const SkMatrix& child_matrix,
                                      SkRect* child_paint_bounds) {
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   child_layer_exists_below_ = context->child_scene_layer_exists_below;
   context->child_scene_layer_exists_below = false;
 #endif
@@ -57,7 +57,7 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
 
   context->has_platform_view = child_has_platform_view;
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   if (child_layer_exists_below_) {
     set_needs_system_composite(true);
   }
@@ -87,7 +87,7 @@ void ContainerLayer::TryToPrepareRasterCache(PrerollContext* context,
   }
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 
 void ContainerLayer::CheckForChildLayerBelow(PrerollContext* context) {
   // All ContainerLayers make the check in PrerollChildren.
@@ -158,7 +158,7 @@ void ContainerLayer::UpdateSceneChildren(SceneUpdateContext& context) {
   }
 }
 
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 MergedContainerLayer::MergedContainerLayer() {
   // Ensure the layer has only one direct child.

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -18,10 +18,10 @@ class ContainerLayer : public Layer {
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   void CheckForChildLayerBelow(PrerollContext* context) override;
   void UpdateScene(SceneUpdateContext& context) override;
-#endif  // defined(OS_FUCHSIA)
+#endif
 
   const std::vector<std::shared_ptr<Layer>>& layers() const { return layers_; }
 
@@ -31,9 +31,9 @@ class ContainerLayer : public Layer {
                        SkRect* child_paint_bounds);
   void PaintChildren(PaintContext& context) const;
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   void UpdateSceneChildren(SceneUpdateContext& context);
-#endif  // defined(OS_FUCHSIA)
+#endif
 
   // Try to prepare the raster cache for a given layer.
   //

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -55,7 +55,7 @@ Layer::AutoPrerollSaveLayerState::~AutoPrerollSaveLayerState() {
   }
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 
 void Layer::CheckForChildLayerBelow(PrerollContext* context) {
   child_layer_exists_below_ = context->child_scene_layer_exists_below;
@@ -103,7 +103,7 @@ void Layer::UpdateScene(SceneUpdateContext& context) {
   }
 }
 
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 Layer::AutoSaveLayer::AutoSaveLayer(const PaintContext& paint_context,
                                     const SkRect& bounds,

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -27,13 +27,13 @@
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/utils/SkNWayCanvas.h"
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 
 #include "flutter/flow/scene_update_context.h"  //nogncheck
 #include "lib/ui/scenic/cpp/resources.h"        //nogncheck
 #include "lib/ui/scenic/cpp/session.h"          //nogncheck
 
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 namespace flutter {
 
@@ -66,11 +66,11 @@ struct PrerollContext {
   float total_elevation = 0.0f;
   bool has_platform_view = false;
   bool is_opaque = true;
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   // True if, during the traversal so far, we have seen a child_scene_layer.
   // Informs whether a layer needs to be system composited.
   bool child_scene_layer_exists_below = false;
-#endif  // defined(OS_FUCHSIA)
+#endif
 };
 
 // Represents a single composited layer. Created on the UI thread but then
@@ -162,7 +162,7 @@ class Layer {
 
   virtual void Paint(PaintContext& context) const = 0;
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   // Updates the system composited scene.
   virtual void UpdateScene(SceneUpdateContext& context);
   virtual void CheckForChildLayerBelow(PrerollContext* context);
@@ -186,7 +186,7 @@ class Layer {
   uint64_t unique_id() const { return unique_id_; }
 
  protected:
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   bool child_layer_exists_below_ = false;
 #endif
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -61,7 +61,7 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
   return context.surface_needs_readback;
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 void LayerTree::UpdateScene(SceneUpdateContext& context,
                             scenic::ContainerNode& container) {
   TRACE_EVENT0("flutter", "LayerTree::UpdateScene");

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -34,7 +34,7 @@ class LayerTree {
   bool Preroll(CompositorContext::ScopedFrame& frame,
                bool ignore_raster_cache = false);
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   void UpdateScene(SceneUpdateContext& context,
                    scenic::ContainerNode& container);
 #endif

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -88,7 +88,7 @@ void OpacityLayer::Paint(PaintContext& context) const {
   PaintChildren(context);
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 
 void OpacityLayer::UpdateScene(SceneUpdateContext& context) {
   float saved_alpha = context.alphaf();
@@ -97,6 +97,6 @@ void OpacityLayer::UpdateScene(SceneUpdateContext& context) {
   context.set_alphaf(saved_alpha);
 }
 
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 }  // namespace flutter

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -31,9 +31,9 @@ class OpacityLayer : public MergedContainerLayer {
 
   void Paint(PaintContext& context) const override;
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   void UpdateScene(SceneUpdateContext& context) override;
-#endif  // defined(OS_FUCHSIA)
+#endif
 
  private:
   SkAlpha alpha_;

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -135,7 +135,7 @@ TEST_F(PhysicalShapeLayerTest, ElevationSimple) {
 
   // The Fuchsia system compositor handles all elevated PhysicalShapeLayers and
   // their shadows , so we do not use the direct |Paint()| path there.
-#if !defined(OS_FUCHSIA)
+#if !defined(LEGACY_FUCHSIA_EMBEDDER)
   SkPaint layer_paint;
   layer_paint.setColor(SK_ColorGREEN);
   layer_paint.setAntiAlias(true);
@@ -192,7 +192,7 @@ TEST_F(PhysicalShapeLayerTest, ElevationComplex) {
 
   // The Fuchsia system compositor handles all elevated PhysicalShapeLayers and
   // their shadows , so we do not use the direct |Paint()| path there.
-#if !defined(OS_FUCHSIA)
+#if !defined(LEGACY_FUCHSIA_EMBEDDER)
   SkPaint layer_paint;
   layer_paint.setColor(SK_ColorBLACK);
   layer_paint.setAntiAlias(true);

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -20,7 +20,7 @@ PictureLayer::PictureLayer(const SkPoint& offset,
 void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "PictureLayer::Preroll");
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   CheckForChildLayerBelow(context);
 #endif
 

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -13,7 +13,7 @@ PlatformViewLayer::PlatformViewLayer(const SkPoint& offset,
 
 void PlatformViewLayer::Preroll(PrerollContext* context,
                                 const SkMatrix& matrix) {
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   CheckForChildLayerBelow(context);
 #endif
 
@@ -31,25 +31,25 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
                                            context->mutators_stack);
   context->view_embedder->PrerollCompositeEmbeddedView(view_id_,
                                                        std::move(params));
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   // Set needs_system_composite flag so that rasterizer can call UpdateScene.
   set_needs_system_composite(true);
-#endif  // defined(OS_FUCHSIA)
+#endif
 }
 
 void PlatformViewLayer::Paint(PaintContext& context) const {
   if (context.view_embedder == nullptr) {
-#if !defined(OS_FUCHSIA)
+#if !defined(LEGACY_FUCHSIA_EMBEDDER)
     FML_LOG(ERROR) << "Trying to embed a platform view but the PaintContext "
                       "does not support embedding";
-#endif  // defined(OS_FUCHSIA)
+#endif
     return;
   }
   SkCanvas* canvas = context.view_embedder->CompositeEmbeddedView(view_id_);
   context.leaf_nodes_canvas = canvas;
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 void PlatformViewLayer::UpdateScene(SceneUpdateContext& context) {
   context.UpdateScene(view_id_, offset_, size_);
 }

--- a/flow/layers/platform_view_layer.h
+++ b/flow/layers/platform_view_layer.h
@@ -17,7 +17,7 @@ class PlatformViewLayer : public Layer {
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   // Updates the system composited scene.
   void UpdateScene(SceneUpdateContext& context) override;
 #endif

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -12,7 +12,7 @@ ShaderMaskLayer::ShaderMaskLayer(sk_sp<SkShader> shader,
     : shader_(shader), mask_rect_(mask_rect), blend_mode_(blend_mode) {}
 
 void ShaderMaskLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   CheckForChildLayerBelow(context);
 #endif
 

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -22,7 +22,7 @@ TextureLayer::TextureLayer(const SkPoint& offset,
 void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "TextureLayer::Preroll");
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   CheckForChildLayerBelow(context);
 #endif
 

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -50,7 +50,7 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   context->mutators_stack.Pop();
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 
 void TransformLayer::UpdateScene(SceneUpdateContext& context) {
   TRACE_EVENT0("flutter", "TransformLayer::UpdateScene");
@@ -64,7 +64,7 @@ void TransformLayer::UpdateScene(SceneUpdateContext& context) {
   }
 }
 
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 void TransformLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "TransformLayer::Paint");

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -19,9 +19,9 @@ class TransformLayer : public ContainerLayer {
 
   void Paint(PaintContext& context) const override;
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   void UpdateScene(SceneUpdateContext& context) override;
-#endif  // defined(OS_FUCHSIA)
+#endif
 
  private:
   SkMatrix transform_;

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include "flutter/flow/instrumentation.h"
 #include "flutter/flow/raster_cache_key.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -5,6 +5,8 @@
 #include "flutter/flow/raster_cache.h"
 
 #include "gtest/gtest.h"
+#include "third_party/skia/include/core/SkCanvas.h"
+#include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 

--- a/flow/surface.h
+++ b/flow/surface.h
@@ -7,8 +7,8 @@
 
 #include <memory>
 
-#include "flutter/flow/compositor_context.h"
 #include "flutter/flow/embedded_views.h"
+#include "flutter/flow/gl_context_switch.h"
 #include "flutter/flow/surface_frame.h"
 #include "flutter/fml/macros.h"
 

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -10,10 +10,10 @@
 #include <optional>
 #include <utility>
 
+#include "flutter/flow/testing/mock_raster_cache.h"
 #include "flutter/fml/macros.h"
 #include "flutter/testing/canvas_test.h"
 #include "flutter/testing/mock_canvas.h"
-#include "flutter/testing/mock_raster_cache.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
 #include "third_party/skia/include/utils/SkNWayCanvas.h"

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/testing/mock_raster_cache.h"
+#include "flutter/flow/testing/mock_raster_cache.h"
+
 #include "flutter/flow/layers/layer.h"
 
 namespace flutter {

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef TESTING_MOCK_RASTER_CACHE_H_
-#define TESTING_MOCK_RASTER_CACHE_H_
+#ifndef FLOW_TESTING_MOCK_RASTER_CACHE_H_
+#define FLOW_TESTING_MOCK_RASTER_CACHE_H_
 
 #include "flutter/flow/raster_cache.h"
 #include "third_party/skia/include/core/SkImage.h"
@@ -61,4 +61,4 @@ class MockRasterCache : public RasterCache {
 }  // namespace testing
 }  // namespace flutter
 
-#endif  // TESTING_MOCK_RASTER_CACHE_H_
+#endif  // FLOW_TESTING_MOCK_RASTER_CACHE_H_

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -6,7 +6,7 @@ import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
 
-source_set("ui") {
+source_set_maybe_fuchsia_legacy("ui") {
   sources = [
     "compositing/scene.cc",
     "compositing/scene.h",
@@ -109,10 +109,13 @@ source_set("ui") {
 
   public_configs = [ "//flutter:config" ]
 
+  public_deps = [
+    "//flutter/third_party/txt",
+  ]
+
   deps = [
     "//flutter/assets",
     "//flutter/common",
-    "//flutter/flow",
     "//flutter/fml",
     "//flutter/runtime:test_font",
     "//flutter/third_party/tonic",
@@ -121,26 +124,22 @@ source_set("ui") {
     "//third_party/skia",
   ]
 
-  public_deps = [
-    "//flutter/third_party/txt",
-  ]
-
   if (flutter_enable_skshaper) {
     defines = [ "FLUTTER_ENABLE_SKSHAPER" ]
   }
 
-  if (is_fuchsia) {
-    sources += [
-      "compositing/scene_host.cc",
-      "compositing/scene_host.h",
-    ]
+  sources_legacy = [
+    "compositing/scene_host.cc",
+    "compositing/scene_host.h",
+  ]
 
-    deps += [
-      "$fuchsia_sdk_root/pkg:async-cpp",
-      "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia",
-      "//flutter/shell/platform/fuchsia/dart-pkg/zircon",
-    ]
-  }
+  deps_legacy = [
+    "$fuchsia_sdk_root/pkg:async-cpp",
+    "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia",
+    "//flutter/shell/platform/fuchsia/dart-pkg/zircon",
+  ]
+
+  deps_legacy_and_next = [ "//flutter/flow:flow" ]
 }
 
 if (current_toolchain == host_toolchain) {

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -30,8 +30,8 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-#if defined(OS_FUCHSIA)
-#include "flutter/flow/layers/child_scene_layer.h"
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
+#include "flutter/flow/layers/child_scene_layer.h"  // nogncheck
 #endif
 
 namespace flutter {
@@ -67,7 +67,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, SceneBuilder);
   V(SceneBuilder, build)
 
 FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 DART_NATIVE_CALLBACK(SceneBuilder, addChildScene)
 #endif
 
@@ -75,7 +75,7 @@ void SceneBuilder::RegisterNatives(tonic::DartLibraryNatives* natives) {
   natives->Register({
     {"SceneBuilder_constructor", SceneBuilder_constructor, 1, true},
         FOR_EACH_BINDING(DART_REGISTER_NATIVE)
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
             DART_REGISTER_NATIVE(SceneBuilder, addChildScene)
 #endif
   });
@@ -247,7 +247,7 @@ void SceneBuilder::addPlatformView(double dx,
   AddLayer(std::move(layer));
 }
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
 void SceneBuilder::addChildScene(double dx,
                                  double dy,
                                  double width,
@@ -259,7 +259,7 @@ void SceneBuilder::addChildScene(double dx,
       hitTestable);
   AddLayer(std::move(layer));
 }
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 void SceneBuilder::addPerformanceOverlay(uint64_t enabledOptions,
                                          double left,

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -22,8 +22,8 @@
 #include "flutter/lib/ui/painting/shader.h"
 #include "third_party/tonic/typed_data/typed_list.h"
 
-#if defined(OS_FUCHSIA)
-#include "flutter/lib/ui/compositing/scene_host.h"
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
+#include "flutter/lib/ui/compositing/scene_host.h"  // nogncheck
 #endif
 
 namespace flutter {
@@ -101,7 +101,7 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
                        double height,
                        int64_t viewId);
 
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   void addChildScene(double dx,
                      double dy,
                      double width,

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -32,8 +32,8 @@
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/logging/dart_error.h"
 
-#if defined(OS_FUCHSIA)
-#include "flutter/lib/ui/compositing/scene_host.h"
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
+#include "flutter/lib/ui/compositing/scene_host.h"  // nogncheck
 #endif
 
 using tonic::ToDart;
@@ -82,7 +82,7 @@ void DartUI::InitForGlobal() {
     SemanticsUpdateBuilder::RegisterNatives(g_natives);
     Vertices::RegisterNatives(g_natives);
     Window::RegisterNatives(g_natives);
-#if defined(OS_FUCHSIA)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
     SceneHost::RegisterNatives(g_natives);
 #endif
   }

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -4,9 +4,7 @@
 
 import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
-
 if (is_fuchsia) {
-  import("//build/fuchsia/sdk.gni")
   import("//flutter/tools/fuchsia/fuchsia_archive.gni")
 }
 
@@ -42,7 +40,7 @@ group("libdart") {
   }
 }
 
-source_set("runtime") {
+source_set_maybe_fuchsia_legacy("runtime") {
   sources = [
     "dart_isolate.cc",
     "dart_isolate.h",
@@ -74,26 +72,24 @@ source_set("runtime") {
     "window_data.h",
   ]
 
+  public_deps = [
+    "//third_party/rapidjson",
+  ]
+
+  public_configs = [ "//flutter:config" ]
+
   deps = [
     ":test_font",
     "//flutter/assets",
     "//flutter/common",
-    "//flutter/flow",
     "//flutter/fml",
     "//flutter/lib/io",
-    "//flutter/lib/ui",
     "//flutter/third_party/tonic",
     "//flutter/third_party/txt",
     "//third_party/dart/runtime:dart_api",
     "//third_party/dart/runtime/bin:dart_io_api",
     "//third_party/skia",
   ]
-
-  public_deps = [
-    "//third_party/rapidjson",
-  ]
-
-  public_configs = [ "//flutter:config" ]
 
   if (flutter_runtime_mode != "release" && !is_fuchsia) {
     # Only link in Observatory in non-release modes on non-Fuchsia. Fuchsia
@@ -102,53 +98,77 @@ source_set("runtime") {
       "//third_party/dart/runtime/observatory:embedded_observatory_archive",
     ]
   }
+
+  deps_legacy_and_next = [
+    "//flutter/flow:flow",
+    "//flutter/lib/ui:ui",
+  ]
 }
 
 test_fixtures("runtime_fixtures") {
   dart_main = "fixtures/runtime_test.dart"
 }
 
-source_set("runtime_unittests_common") {
-  visibility = [ ":*" ]
-
+source_set_maybe_fuchsia_legacy("runtime_unittests_common") {
   testonly = true
-
-  sources = [
-    "runtime_test.cc",
-    "runtime_test.h",
-  ]
-
-  public_deps = [
-    ":libdart",
-    ":runtime",
-    ":runtime_fixtures",
-    "//flutter/common",
-    "//flutter/fml",
-    "//flutter/lib/snapshot",
-    "//flutter/shell/common",
-    "//flutter/testing",
-    "//flutter/testing:dart",
-    "//flutter/third_party/tonic",
-    "//third_party/dart/runtime/bin:elf_loader",
-    "//third_party/skia",
-  ]
-}
-
-executable("runtime_unittests") {
-  testonly = true
-
-  configs += [ "//flutter:export_dynamic_symbols" ]
 
   sources = [
     "dart_isolate_unittests.cc",
     "dart_lifecycle_unittests.cc",
     "dart_service_isolate_unittests.cc",
     "dart_vm_unittests.cc",
+    "runtime_test.cc",
+    "runtime_test.h",
   ]
 
-  deps = [
-    ":runtime_unittests_common",
+  public_deps = [
+    ":libdart",
+    ":runtime_fixtures",
+    "//flutter/common",
+    "//flutter/fml",
+    "//flutter/lib/snapshot",
+    "//flutter/testing",
+    "//flutter/third_party/tonic",
+    "//third_party/dart/runtime/bin:elf_loader",
+    "//third_party/skia",
   ]
+
+  deps_legacy_and_next = [
+    ":runtime",
+    "//flutter/testing:dart",
+  ]
+}
+
+if (is_fuchsia) {
+  executable("runtime_unittests") {
+    testonly = true
+
+    configs += [ "//flutter:export_dynamic_symbols" ]
+
+    deps = [
+      ":runtime_unittests_common_fuchsia_legacy",
+    ]
+  }
+
+  executable("runtime_unittests_next") {
+    testonly = true
+
+    configs += [ "//flutter:export_dynamic_symbols" ]
+
+    deps = [
+      ":runtime_unittests_common",
+    ]
+  }
+} else {
+  executable("runtime_unittests") {
+    testonly = true
+
+    configs += [ "//flutter:export_dynamic_symbols" ]
+
+    deps = [
+      ":runtime_unittests_common",
+    ]
+  }
 }
 
 if (is_fuchsia) {
@@ -159,6 +179,25 @@ if (is_fuchsia) {
     ]
 
     binary = "runtime_unittests"
+
+    # TODO(gw280): https://github.com/flutter/flutter/issues/50294
+    # Right now we need to manually specify all the fixtures that are
+    # declared in the test_fixtures() call above.
+    resources = [
+      {
+        path = "$target_gen_dir/assets/kernel_blob.bin"
+        dest = "assets/kernel_blob.bin"
+      },
+    ]
+  }
+
+  fuchsia_test_archive("runtime_tests_next") {
+    deps = [
+      ":runtime_fixtures",
+      ":runtime_unittests_next",
+    ]
+
+    binary = "runtime_unittests_next"
 
     # TODO(gw280): https://github.com/flutter/flutter/issues/50294
     # Right now we need to manually specify all the fixtures that are

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -77,7 +77,7 @@ template("dart_embedder_resources") {
   }
 }
 
-source_set("common") {
+source_set_maybe_fuchsia_legacy("common") {
   sources = [
     "animator.cc",
     "animator.h",
@@ -115,17 +115,7 @@ source_set("common") {
     "vsync_waiter_fallback.h",
   ]
 
-  deps = [
-    "//flutter/assets",
-    "//flutter/common",
-    "//flutter/flow",
-    "//flutter/fml",
-    "//flutter/lib/ui",
-    "//flutter/runtime",
-    "//flutter/shell/profiling",
-    "//third_party/dart/runtime:dart_api",
-    "//third_party/skia",
-  ]
+  public_configs = [ "//flutter:config" ]
 
   public_deps = [
     "//flutter/shell/version",
@@ -134,10 +124,30 @@ source_set("common") {
     "//third_party/rapidjson",
   ]
 
-  public_configs = [ "//flutter:config" ]
+  deps = [
+    "//flutter/assets",
+    "//flutter/common",
+    "//flutter/fml",
+    "//flutter/shell/profiling",
+    "//third_party/dart/runtime:dart_api",
+    "//third_party/skia",
+  ]
+
+  deps_legacy_and_next = [
+    "//flutter/flow:flow",
+    "//flutter/lib/ui:ui",
+    "//flutter/runtime:runtime",
+  ]
 }
 
 template("shell_host_executable") {
+  common_dep = ":common"
+  if (defined(invoker.fuchsia_legacy)) {
+    if (invoker.fuchsia_legacy) {
+      common_dep += "_fuchsia_legacy"
+    }
+  }
+
   executable(target_name) {
     testonly = true
 
@@ -148,17 +158,32 @@ template("shell_host_executable") {
     forward_variables_from(invoker, "*")
 
     deps += [
-      ":common",
-      "//flutter/fml",
       "//flutter/lib/snapshot",
-      "//flutter/runtime",
       "//flutter/runtime:libdart",
-      "//flutter/third_party/tonic",
-      "//third_party/skia",
+      common_dep,
     ]
 
     public_configs = [ "//flutter:export_dynamic_symbols" ]
   }
+}
+
+test_fixtures("shell_unittests_fixtures") {
+  dart_main = "fixtures/shell_test.dart"
+
+  fixtures = [ "fixtures/shelltest_screenshot.png" ]
+}
+
+shell_host_executable("shell_benchmarks") {
+  sources = [
+    "shell_benchmarks.cc",
+  ]
+
+  deps = [
+    ":shell_unittests_fixtures",
+    "//flutter/benchmarking",
+    "//flutter/testing:dart",
+    "//flutter/testing:testing_lib",
+  ]
 }
 
 if (enable_unittests) {
@@ -176,13 +201,7 @@ if (enable_unittests) {
     enable_metal = test_enable_metal
   }
 
-  test_fixtures("shell_unittests_fixtures") {
-    dart_main = "fixtures/shell_test.dart"
-
-    fixtures = [ "fixtures/shelltest_screenshot.png" ]
-  }
-
-  source_set("shell_test_fixture_sources") {
+  source_set_maybe_fuchsia_legacy("shell_test_fixture_sources") {
     testonly = true
 
     sources = [
@@ -197,15 +216,17 @@ if (enable_unittests) {
     ]
 
     public_deps = [
-      "//flutter/flow",
       "//flutter/fml/dart",
-      "//flutter/lib/ui",
-      "//flutter/runtime",
-      "//flutter/shell",
-      "//flutter/shell/common",
       "//flutter/testing",
-      "//flutter/testing:dart",
     ]
+
+    deps = [
+      "//flutter/assets",
+      "//flutter/common",
+      "//third_party/rapidjson",
+      "//third_party/skia",
+    ]
+
     defines = []
 
     # SwiftShader only supports x86/x64_64
@@ -216,10 +237,7 @@ if (enable_unittests) {
           "shell_test_platform_view_gl.h",
         ]
 
-        public_deps += [
-          "//flutter/shell/gpu:gpu_surface_gl",
-          "//flutter/testing:opengl",
-        ]
+        public_deps += [ "//flutter/testing:opengl" ]
 
         defines += [ "SHELL_ENABLE_GL" ]
       }
@@ -232,16 +250,29 @@ if (enable_unittests) {
       ]
 
       public_deps += [
-        "//flutter/shell/gpu:gpu_surface_vulkan",
         "//flutter/testing:vulkan",
         "//flutter/vulkan",
       ]
 
       defines += [ "SHELL_ENABLE_VULKAN" ]
     }
+
+    public_deps_legacy_and_next = [
+      "//flutter/shell/common:common",
+      "//flutter/flow:flow",
+      "//flutter/runtime:runtime",
+    ]
+
+    deps_legacy_and_next = [
+      ":shell_unittests_gpu_configuration",
+      "//flutter/lib/ui:ui",
+      "//flutter/testing:dart",
+    ]
   }
 
-  shell_host_executable("shell_unittests") {
+  source_set_maybe_fuchsia_legacy("shell_unittests_common") {
+    testonly = true
+
     sources = [
       "animator_unittests.cc",
       "canvas_spy_unittests.cc",
@@ -252,20 +283,35 @@ if (enable_unittests) {
     ]
 
     deps = [
-      ":shell_test_fixture_sources",
-      ":shell_unittests_fixtures",
-      ":shell_unittests_gpu_configuration",
       "//flutter/assets",
-      "//flutter/common",
-      "//flutter/shell",
+      "//flutter/shell/version",
     ]
 
-    if (!defined(defines)) {
-      defines = []
+    public_deps_legacy_and_next = [ ":shell_test_fixture_sources" ]
+  }
+
+  if (is_fuchsia) {
+    shell_host_executable("shell_unittests") {
+      deps = [
+        ":shell_unittests_common_fuchsia_legacy",
+        ":shell_unittests_fixtures",
+      ]
+
+      fuchsia_legacy = true
     }
 
-    if (test_enable_vulkan) {
-      defines += [ "SHELL_ENABLE_VULKAN" ]
+    shell_host_executable("shell_unittests_next") {
+      deps = [
+        ":shell_unittests_common",
+        ":shell_unittests_fixtures",
+      ]
+    }
+  } else {
+    shell_host_executable("shell_unittests") {
+      deps = [
+        ":shell_unittests_common",
+        ":shell_unittests_fixtures",
+      ]
     }
   }
 
@@ -297,18 +343,33 @@ if (enable_unittests) {
         resources += vulkan_icds
       }
     }
-  }
 
-  shell_host_executable("shell_benchmarks") {
-    sources = [
-      "shell_benchmarks.cc",
-    ]
+    fuchsia_test_archive("shell_tests_next") {
+      deps = [
+        ":shell_unittests_fixtures",
+        ":shell_unittests_next",
+      ]
 
-    deps = [
-      ":shell_unittests_fixtures",
-      "//flutter/benchmarking",
-      "//flutter/testing:dart",
-      "//flutter/testing:testing_lib",
-    ]
+      binary = "shell_unittests_next"
+
+      # TODO(gw280): https://github.com/flutter/flutter/issues/50294
+      # Right now we need to manually specify all the fixtures that are
+      # declared in the test_fixtures() call above.
+      resources = [
+        {
+          path = "$target_gen_dir/assets/kernel_blob.bin"
+          dest = "assets/kernel_blob.bin"
+        },
+        {
+          path = "$target_gen_dir/assets/shelltest_screenshot.png"
+          dest = "assets/shelltest_screenshot.png"
+        },
+      ]
+
+      if (test_enable_vulkan) {
+        libraries = vulkan_validation_libs
+        resources += vulkan_icds
+      }
+    }
   }
 }

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -86,7 +86,7 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
     raster_thread_merger_ =
         fml::MakeRefCounted<fml::RasterThreadMerger>(platform_id, gpu_id);
   }
-#endif  // defined(OS_FUCHSIA)
+#endif
 }
 
 void Rasterizer::Teardown() {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -32,6 +32,7 @@
 #include "flutter/shell/version/version.h"
 #include "flutter/testing/testing.h"
 #include "rapidjson/writer.h"
+#include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "third_party/tonic/converter/dart_converter.h"
 
 namespace flutter {
@@ -517,7 +518,7 @@ TEST_F(ShellTest,
 
   DestroyShell(std::move(shell));
 }
-#endif  // defined(OS_FUCHSIA)
+#endif
 
 TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
   // Ensure that all phases are in kPhases.

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -3,7 +3,8 @@
 # found in the LICENSE file.
 
 declare_args() {
-  shell_enable_vulkan = false
+  shell_enable_gl = !is_fuchsia
   shell_enable_metal = false
+  shell_enable_vulkan = false
   stripped_symbols = true
 }

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -2,19 +2,23 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/config.gni")
 import("//flutter/shell/config.gni")
 
 gpu_dir = "//flutter/shell/gpu"
 
 gpu_common_deps = [
   "//flutter/common",
-  "//flutter/flow",
   "//flutter/fml",
-  "//flutter/shell/common",
   "//third_party/skia",
 ]
 
-source_set("gpu_surface_software") {
+gpu_common_deps_legacy_and_next = [
+  "//flutter/flow:flow",
+  "//flutter/shell/common:common",
+]
+
+source_set_maybe_fuchsia_legacy("gpu_surface_software") {
   sources = [
     "$gpu_dir/gpu_surface_delegate.h",
     "$gpu_dir/gpu_surface_software.cc",
@@ -24,9 +28,11 @@ source_set("gpu_surface_software") {
   ]
 
   deps = gpu_common_deps
+
+  deps_legacy_and_next = gpu_common_deps_legacy_and_next
 }
 
-source_set("gpu_surface_gl") {
+source_set_maybe_fuchsia_legacy("gpu_surface_gl") {
   sources = [
     "$gpu_dir/gpu_surface_delegate.h",
     "$gpu_dir/gpu_surface_gl.cc",
@@ -35,10 +41,12 @@ source_set("gpu_surface_gl") {
     "$gpu_dir/gpu_surface_gl_delegate.h",
   ]
 
-  deps = gpu_common_deps + [ "//third_party/skia" ]
+  deps = gpu_common_deps
+
+  deps_legacy_and_next = gpu_common_deps_legacy_and_next
 }
 
-source_set("gpu_surface_vulkan") {
+source_set_maybe_fuchsia_legacy("gpu_surface_vulkan") {
   sources = [
     "$gpu_dir/gpu_surface_delegate.h",
     "$gpu_dir/gpu_surface_vulkan.cc",
@@ -47,18 +55,19 @@ source_set("gpu_surface_vulkan") {
     "$gpu_dir/gpu_surface_vulkan_delegate.h",
   ]
 
-  deps = gpu_common_deps + [
-           "//third_party/skia",
-           "//flutter/vulkan",
-         ]
+  deps = gpu_common_deps + [ "//flutter/vulkan" ]
+
+  deps_legacy_and_next = gpu_common_deps_legacy_and_next
 }
 
-source_set("gpu_surface_metal") {
+source_set_maybe_fuchsia_legacy("gpu_surface_metal") {
   sources = [
     "$gpu_dir/gpu_surface_delegate.h",
     "$gpu_dir/gpu_surface_metal.h",
     "$gpu_dir/gpu_surface_metal.mm",
   ]
 
-  deps = gpu_common_deps + [ "//third_party/skia" ]
+  deps = gpu_common_deps
+
+  deps_legacy_and_next = gpu_common_deps_legacy_and_next
 }

--- a/shell/gpu/gpu.gni
+++ b/shell/gpu/gpu.gni
@@ -33,4 +33,30 @@ template("shell_gpu_configuration") {
       public_deps += [ "//flutter/shell/gpu:gpu_surface_metal" ]
     }
   }
+
+  if (is_fuchsia) {
+    legagcy_suffix = "_fuchsia_legacy"
+    group(target_name + legagcy_suffix) {
+      public_deps = []
+
+      if (invoker.enable_software) {
+        public_deps +=
+            [ "//flutter/shell/gpu:gpu_surface_software" + legagcy_suffix ]
+      }
+
+      if (invoker.enable_gl) {
+        public_deps += [ "//flutter/shell/gpu:gpu_surface_gl" + legagcy_suffix ]
+      }
+
+      if (invoker.enable_vulkan) {
+        public_deps +=
+            [ "//flutter/shell/gpu:gpu_surface_vulkan" + legagcy_suffix ]
+      }
+
+      if (invoker.enable_metal) {
+        public_deps +=
+            [ "//flutter/shell/gpu:gpu_surface_metal" + legagcy_suffix ]
+      }
+    }
+  }
 }

--- a/shell/platform/android/external_view_embedder/BUILD.gn
+++ b/shell/platform/android/external_view_embedder/BUILD.gn
@@ -41,6 +41,7 @@ executable("android_external_view_embedder_unittests") {
   deps = [
     ":external_view_embedder",
     ":external_view_embedder_fixtures",
+    "//flutter/flow",
     "//flutter/shell/gpu:gpu_surface_gl",
     "//flutter/shell/platform/android/jni:jni_mock",
     "//flutter/shell/platform/android/surface:surface_mock",

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_VIEW_EMBEDDER_H_
 #define FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_VIEW_EMBEDDER_H_
 
+#include <unordered_map>
+
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/rtree.h"
 #include "flutter/shell/platform/android/context/android_context.h"

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -14,10 +14,11 @@ import("//flutter/tools/fuchsia/fuchsia_libs.gni")
 import("//flutter/vulkan/config.gni")
 import("engine_flutter_runner.gni")
 
-shell_gpu_configuration("fuchsia_gpu_configuration") {
+# Fuchsia uses its own custom Surface implementation.
+shell_gpu_configuration("fuchsia_legacy_gpu_configuration") {
   enable_software = false
   enable_gl = false
-  enable_vulkan = true
+  enable_vulkan = false
   enable_metal = false
 }
 
@@ -319,10 +320,10 @@ executable("flutter_runner_unittests") {
     "//build/fuchsia/pkg:scenic_cpp",
     "//build/fuchsia/pkg:sys_cpp_testing",
     "//flutter/common",
-    "//flutter/flow",
-    "//flutter/lib/ui",
-    "//flutter/runtime",
-    "//flutter/shell/common",
+    "//flutter/flow:flow_fuchsia_legacy",
+    "//flutter/lib/ui:ui_fuchsia_legacy",
+    "//flutter/runtime:runtime_fuchsia_legacy",
+    "//flutter/shell/common:common_fuchsia_legacy",
     "//flutter/shell/platform/fuchsia/runtime/dart/utils",
     "//flutter/testing",
     "//third_party/dart/runtime:libdart_jit",
@@ -352,9 +353,10 @@ executable("flutter_runner_tzdata_unittests") {
     "//build/fuchsia/pkg:async-loop-default",
     "//build/fuchsia/pkg:scenic_cpp",
     "//build/fuchsia/pkg:sys_cpp_testing",
-    "//flutter/lib/ui",
-    "//flutter/runtime",
-    "//flutter/shell/common",
+    "//flutter/flow:flow_fuchsia_legacy",
+    "//flutter/lib/ui:ui_fuchsia_legacy",
+    "//flutter/runtime:runtime_fuchsia_legacy",
+    "//flutter/shell/common:common_fuchsia_legacy",
     "//flutter/shell/platform/fuchsia/runtime/dart/utils",
     "//flutter/testing",
     "//third_party/dart/runtime:libdart_jit",
@@ -497,16 +499,16 @@ executable("flutter_runner_scenic_unittests") {
     "//build/fuchsia/pkg:async-loop-default",
     "//build/fuchsia/pkg:scenic_cpp",
     "//build/fuchsia/pkg:sys_cpp_testing",
-    "//flutter/common:common",
-    "//flutter/flow:flow",
-    "//flutter/lib/ui",
-    "//flutter/runtime",
-    "//flutter/shell/common",
-    "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia:sdk_ext",
-    "//flutter/shell/platform/fuchsia/dart-pkg/zircon:zircon",
+    "//flutter/common",
+    "//flutter/flow:flow_fuchsia_legacy",
+    "//flutter/lib/ui:ui_fuchsia_legacy",
+    "//flutter/runtime:runtime_fuchsia_legacy",
+    "//flutter/shell/common:common_fuchsia_legacy",
+    "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia",
+    "//flutter/shell/platform/fuchsia/dart-pkg/zircon",
     "//flutter/shell/platform/fuchsia/runtime/dart/utils",
     "//flutter/testing",
-    "//flutter/vulkan:vulkan",
+    "//flutter/vulkan",
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/dart/runtime/platform:libdart_platform_jit",
     "//third_party/icu",

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -9,6 +9,7 @@
 
 #include <sstream>
 
+#include "compositor_context.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/synchronization/waitable_event.h"

--- a/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
+++ b/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
@@ -90,16 +90,15 @@ template("flutter_runner") {
     # The use of these dependencies is temporary and will be moved behind the
     # embedder API.
     flutter_deps = [
-      "../flutter:fuchsia_gpu_configuration",
+      "../flutter:fuchsia_legacy_gpu_configuration",
       "//flutter/assets",
       "//flutter/common",
-      "//flutter/flow",
-      "//flutter/lib/ui",
-      "//flutter/runtime",
-      "//flutter/third_party/txt",
-      "//flutter/vulkan",
       "//flutter/fml",
-      "//flutter/shell/common",
+      "//flutter/flow:flow_fuchsia_legacy",
+      "//flutter/lib/ui:ui_fuchsia_legacy",
+      "//flutter/runtime:runtime_fuchsia_legacy",
+      "//flutter/shell/common:common_fuchsia_legacy",
+      "//flutter/vulkan",
     ]
 
     _fuchsia_platform = "//flutter/shell/platform/fuchsia"

--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -6,6 +6,7 @@
 
 #include <fcntl.h>
 #include <lib/fdio/watcher.h>
+#include <lib/zx/time.h>
 #include <unistd.h>
 
 #include "flutter/fml/unique_fd.h"
@@ -57,7 +58,8 @@ bool Surface::CanConnectToDisplay() {
   }
 
   zx_status_t status = fdio_watch_directory(
-      fd.get(), DriverWatcher, zx_deadline_after(ZX_SEC(5)), nullptr);
+      fd.get(), DriverWatcher,
+      zx::deadline_after(zx::duration(ZX_SEC(5))).get(), nullptr);
   return status == ZX_ERR_STOP;
 }
 

--- a/shell/platform/fuchsia/flutter/surface.h
+++ b/shell/platform/fuchsia/flutter/surface.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "compositor_context.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/config.gni")
 import("//flutter/shell/config.gni")
 import("testing.gni")
 
@@ -40,7 +41,7 @@ source_set("testing") {
   ]
 }
 
-source_set("dart") {
+source_set_maybe_fuchsia_legacy("dart") {
   testonly = true
 
   sources = [
@@ -55,12 +56,13 @@ source_set("dart") {
   public_deps = [
     ":testing_lib",
     "//flutter/common",
-    "//flutter/runtime",
     "//flutter/runtime:libdart",
     "//flutter/third_party/tonic",
     "//third_party/dart/runtime/bin:elf_loader",
     "//third_party/skia",
   ]
+
+  public_deps_legacy_and_next = [ "//flutter/runtime:runtime" ]
 }
 
 source_set("skia") {
@@ -72,13 +74,10 @@ source_set("skia") {
     "canvas_test.h",
     "mock_canvas.cc",
     "mock_canvas.h",
-    "mock_raster_cache.cc",
-    "mock_raster_cache.h",
   ]
 
   public_deps = [
     ":testing_lib",
-    "//flutter/flow",
     "//third_party/skia",
   ]
 }


### PR DESCRIPTION
Using the #define one can create a new flutter_runner_next executable
that does not contain any legacy integration code.

Test: Manually built all platforms, ran all unittests on Fuchsia / Linux
BUG:  53847