### PR TITLE
Fixes crash when multiple Flutter VC shared one engine

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -610,9 +610,11 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 
 - (void)applicationBecameActive:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationBecameActive");
-  if (_viewportMetrics.physical_width)
-    [self surfaceUpdated:YES];
-  [self goToApplicationLifecycle:@"AppLifecycleState.resumed"];
+  if ([_engine.get() viewController] == self) {
+    if (_viewportMetrics.physical_width)
+      [self surfaceUpdated:YES];
+    [self goToApplicationLifecycle:@"AppLifecycleState.resumed"];
+  }
 }
 
 - (void)applicationWillResignActive:(NSNotification*)notification {
@@ -892,6 +894,9 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 #pragma mark - Keyboard events
 
 - (void)keyboardWillChangeFrame:(NSNotification*)notification {
+  if ([_engine.get() viewController] != self) {
+    return;
+  }
   NSDictionary* info = [notification userInfo];
 
   if (@available(iOS 9, *)) {
@@ -923,6 +928,9 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)keyboardWillBeHidden:(NSNotification*)notification {
+  if ([_engine.get() viewController] != self) {
+    return;
+  }
   _viewportMetrics.physical_view_inset_bottom = 0;
   [self updateViewportMetrics];
 }


### PR DESCRIPTION
## Description

1、Fix crash when app become active from background
Crash can be reproduce this demo  https://github.com/jaysephjw/tab_switch_example
a、run the demo
b、turn app to background
c、turn app to foreground

Why:
If engine.viewController == nil  then app become active from background all FlutterViewController instance receive UIApplicationDidBecomeActiveNotification notification,
at this time FlutterViewController call [surfaceUpdate:YES] ,  rasterizer call SetUp but  the surface is nullptr  cause crash.

2、Two or more FlutterViewController instance shared one Engine;  keyboard appear.  All instance receive  UIKeyboardWillChangeFrameNotification notification, and then updateViewportMetrics

if FlutterViewController instance's viewport is no the same, something bad happen.



## Related Issues

[#52455](https://github.com/flutter/flutter/issues/52455)  the same  crash
[#39036](https://github.com/flutter/flutter/issues/39036) Demo come from the issue

## Tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
