### PR TITLE
[Example Docs] Added 'build' word, since run.sh also build project, not only run

### DIFF
--- a/examples/glfw/README.md
+++ b/examples/glfw/README.md
@@ -19,7 +19,7 @@ The example has the following dependencies:
  * [Flutter](https://flutter.dev/) - This can be installed from the [Flutter webpage](https://flutter.dev/docs/get-started/install)
  * [Flutter Engine](https://flutter.dev) - This can be built or downloaded, see [Custom Flutter Engine Embedders](https://github.com/flutter/flutter/wiki/Custom-Flutter-Engine-Embedders) for more information.
 
-In order to run the example you should be able to go into this directory and run
+In order to **build** and **run** the example you should be able to go into this directory and run
 `./run.sh`.
 
 ## Troubleshooting


### PR DESCRIPTION
## Description

Minor, but descriptive addition: added 'build' word, since `run.sh` also build project (called `cmake` internally), not only run it.

This may utilize cases, when user:
1. manually build project with `cmake`
2. call `run.sh`, which build project **again**.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.