### PR TITLE
Fix hit testing logic in fuchsia a11y

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -384,11 +384,13 @@ std::optional<int32_t> AccessibilityBridge::GetHitNode(int32_t node_id,
       !node.screen_rect.contains(x, y)) {
     return {};
   }
-  auto hit = node_id;
   for (int32_t child_id : node.children_in_hit_test_order) {
-    hit = GetHitNode(child_id, x, y).value_or(hit);
+    auto candidate = GetHitNode(child_id, x, y);
+    if (candidate) {
+      return candidate;
+    }
   }
-  return hit;
+  return node_id;
 }
 
 // |fuchsia::accessibility::semantics::SemanticListener|


### PR DESCRIPTION
Hit testing has a bug where instead of returning the _first_ hit node it finds, it returns the _last_. This means that it is returning nodes that may be "under" other nodes, instead of the top most one that can receive the hit.

~~I'm unable to test this locally, so I'm pushing what I believe is the failing test first, then I will push up the fix once CI fails.~~

https://chromium-swarm.appspot.com/task?id=4cc3da1494b50c10 has the expected failure.

Fixes https://github.com/flutter/flutter/issues/59269

/cc @ankitdave06 @neelsa @apwilson 