### PR TITLE
Autofill Menu appears on top left of the page

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1432,7 +1432,6 @@ class EditableTextGeometry {
   /// case this method should not be used.
   void applyToDomElement(html.HtmlElement domElement) {
     final String cssTransform = float64ListToCssTransform(globalTransform);
-    print('updated transform: $cssTransform');
     domElement.style
       ..width = '${width}px'
       ..height = '${height}px'

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -503,9 +503,9 @@ class GloballyPositionedTextEditingStrategy extends DefaultTextEditingStrategy {
   void placeElement() {
     super.placeElement();
     if (hasAutofillGroup) {
-       _geometry?.applyToDomElement(focusedFormElement());
+       _geometry?.applyToDomElement(focusedFormElement);
        placeForm();
-       focusedFormElement().focus();
+       focusedFormElement.focus();
     } else {
       _geometry?.applyToDomElement(domElement);
     }
@@ -584,7 +584,7 @@ abstract class DefaultTextEditingStrategy implements TextEditingStrategy {
 
     _setStaticStyleAttributes(domElement);
     _style?.applyToDomElement(domElement);
-    if (hasAutofillGroup) {
+    if (!hasAutofillGroup) {
       // If there is an Autofill Group the `FormElement`, it will be appended to the
       // DOM later, when the first location information arrived.
       // Otherwise, on Blink based Desktop browsers, the autofill menu appears

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -505,6 +505,15 @@ class GloballyPositionedTextEditingStrategy extends DefaultTextEditingStrategy {
     if (hasAutofillGroup) {
        _geometry?.applyToDomElement(focusedFormElement);
        placeForm();
+       // On Chrome, when a form is focused, it opens an autofill menu
+       // immeddiately.
+       // Flutter framework sends `setEditableSizeAndTransform` for informing
+       // the engine about the location of the text field. This call will
+       // arrive after `show` call.
+       // Therefore on Chrome we place the element when
+       //  `setEditableSizeAndTransform` method is called and focus on the form
+       // only after placing it to the correct position. Hence autofill menu
+       // does not appear on top-left of the page.
        focusedFormElement.focus();
     } else {
       _geometry?.applyToDomElement(domElement);

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -559,7 +559,7 @@ abstract class DefaultTextEditingStrategy implements TextEditingStrategy {
 
   bool get hasAutofillGroup => _inputConfiguration.autofillGroup != null;
 
-  html.FormElement focusedFormElement() =>
+  html.FormElement get focusedFormElement =>
       _inputConfiguration.autofillGroup.formElement;
 
   @override
@@ -585,7 +585,7 @@ abstract class DefaultTextEditingStrategy implements TextEditingStrategy {
     _setStaticStyleAttributes(domElement);
     _style?.applyToDomElement(domElement);
     if (hasAutofillGroup) {
-      // If there is an Autofill Group the `FormElemen` will be appended to the
+      // If there is an Autofill Group the `FormElement`, it will be appended to the
       // DOM later, when the first location information arrived.
       // Otherwise, on Blink based Desktop browsers, the autofill menu appears
       // on top left of the screen.


### PR DESCRIPTION
I realized on Desktop Chrome, initially, the Autofill menu appears where the form is located (top left of screen). Later when editing starts, it comes back to under focused input element.

This PR carries the form to the same place with the focused input element. Since changing form location in every call is not desired, I only made the change in the browser the problem observed.

fixes: https://github.com/flutter/flutter/issues/59377