### PR TITLE
Adding ImageFilter support for CanvasKit

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/painting.dart
+++ b/lib/web_ui/lib/src/engine/compositor/painting.dart
@@ -190,12 +190,31 @@ class SkPaint extends SkiaObject implements ui.Paint {
 
   ui.MaskFilter _maskFilter;
 
-  // TODO(yjbanov): implement
   @override
   ui.FilterQuality get filterQuality => _filterQuality;
   @override
   set filterQuality(ui.FilterQuality value) {
     _filterQuality = value;
+    _syncFilterQuality(skiaObject);
+  }
+
+  void _syncFilterQuality(js.JsObject object) {
+    js.JsObject skFilterQuality;
+    switch (_filterQuality) {
+      case ui.FilterQuality.none:
+        skFilterQuality = canvasKit['FilterQuality']['None'];
+        break;
+      case ui.FilterQuality.low:
+        skFilterQuality = canvasKit['FilterQuality']['Low'];
+        break;
+      case ui.FilterQuality.medium:
+        skFilterQuality = canvasKit['FilterQuality']['Medium'];
+        break;
+      case ui.FilterQuality.high:
+        skFilterQuality = canvasKit['FilterQuality']['High'];
+        break;
+    }
+    object.callMethod('setFilterQuality', <js.JsObject>[skFilterQuality]);
   }
 
   ui.FilterQuality _filterQuality = ui.FilterQuality.none;
@@ -268,6 +287,7 @@ class SkPaint extends SkiaObject implements ui.Paint {
     _syncMaskFilter(obj);
     _syncColorFilter(obj);
     _syncImageFilter(obj);
+    _syncFilterQuality(obj);
     return obj;
   }
 }


### PR DESCRIPTION
Changing image filtering on a paint object was unsupported on the CanvasKit backend. This PR adds support for it following sync patterns used with other paint properties.