### PR TITLE
Fixes UI update problem when multiple Flutter VC shared one engine

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -527,7 +527,7 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
   if ([_engine.get() viewController] != self) {
     [_engine.get() setViewController:self];
   }
-  
+
   // Send platform settings to Flutter, e.g., platform brightness.
   [self onUserSettingsChanged:nil];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -522,6 +522,12 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 - (void)viewWillAppear:(BOOL)animated {
   TRACE_EVENT0("flutter", "viewWillAppear");
 
+  // When multiple viewControllers share one engine
+  // Maybe engine's current viewController is not self
+  if ([_engine.get() viewController] != self) {
+    [_engine.get() setViewController:self];
+  }
+  
   // Send platform settings to Flutter, e.g., platform brightness.
   [self onUserSettingsChanged:nil];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -60,6 +60,32 @@ typedef enum UIAccessibilityContrast : NSInteger {
 
 @implementation FlutterViewControllerTest
 
+- (void)testViewWillAppearResetEngineViewController {
+  id engine = OCMClassMock([FlutterEngine class]);
+  
+  // 1. create view controller A
+  FlutterViewController* viewControllerA = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                 nibName:nil
+                                                                                  bundle:nil];
+  // now engine's view controller is A
+  OCMStub([engine viewController]).andReturn(viewControllerA);
+
+  // 2. create view controller B
+  FlutterViewController* viewControllerB = [[FlutterViewController alloc] initWithEngine:engine
+                                                                                 nibName:nil
+                                                                                  bundle:nil];
+  // now engine's view controller is B
+  OCMStub([engine viewController]).andReturn(viewControllerB);
+  
+  // 3. mock B disappear and release, now engine's view controller should be nil
+  [viewControllerB viewDidDisappear:NO];
+  viewControllerB = nil;
+  
+  // 4. mock A appear again, now engine's view controller should be A
+  [viewControllerA viewWillAppear:NO];
+  OCMStub([engine viewController]).andReturn(viewControllerA);
+}
+
 - (void)testViewDidDisappearDoesntPauseEngineWhenNotTheViewController {
   id engine = OCMClassMock([FlutterEngine class]);
   id lifecycleChannel = OCMClassMock([FlutterBasicMessageChannel class]);

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -62,7 +62,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
 
 - (void)testViewWillAppearResetEngineViewController {
   id engine = OCMClassMock([FlutterEngine class]);
-  
+
   // 1. create view controller A
   FlutterViewController* viewControllerA = [[FlutterViewController alloc] initWithEngine:engine
                                                                                  nibName:nil
@@ -76,11 +76,11 @@ typedef enum UIAccessibilityContrast : NSInteger {
                                                                                   bundle:nil];
   // now engine's view controller is B
   OCMStub([engine viewController]).andReturn(viewControllerB);
-  
+
   // 3. mock B disappear and release, now engine's view controller should be nil
   [viewControllerB viewDidDisappear:NO];
   viewControllerB = nil;
-  
+
   // 4. mock A appear again, now engine's view controller should be A
   [viewControllerA viewWillAppear:NO];
   OCMStub([engine viewController]).andReturn(viewControllerA);


### PR DESCRIPTION
## Description

Assume we have two view controllers A、B, both share the same engine. when we push B from A then back to A, A will not update UI, because engine's current view controller change to B but not reset to A again, so it break the surface creation.

## Related Issues

Here is the issue's gif, when  A -> B -> A, click "+" button always update UI in B.

[issue gif](https://github.com/cxjwin/HelloFlutter/blob/master/flutter_bug_001.gif)

There are also some sample code in my repository.
[sample code](https://github.com/cxjwin/HelloFlutter)

## Tests

Not yet.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
