### PR TITLE
Allow access to raw zircon handle

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
@@ -20,17 +20,17 @@ class Handle extends NativeFieldWrapperClass2 {
   }
   static Handle _createInvalid() native 'Handle_CreateInvalid';
 
-  int get _handle native 'Handle_handle';
+  int get handle native 'Handle_handle';
 
   @override
-  String toString() => 'Handle($_handle)';
+  String toString() => 'Handle($handle)';
 
   @override
   bool operator ==(Object other) =>
-      (other is Handle) && (_handle == other._handle);
+      (other is Handle) && (handle == other.handle);
 
   @override
-  int get hashCode => _handle.hashCode;
+  int get hashCode => handle.hashCode;
 
   // Common handle operations.
   bool get isValid native 'Handle_is_valid';


### PR DESCRIPTION
## Description

As part of migrating Fuchsia from legacy SceneHost/ChildView based code
to Flutter Embedder based PlatformView, we need to expose the raw zircon
handle. Since we are converting a private getter to public getter, this
does not affect any existing code.


