### PR TITLE
Fix issue Flutter Web cubic bounds misaligning.

### DIFF
--- a/lib/web_ui/lib/src/engine/surface/path.dart
+++ b/lib/web_ui/lib/src/engine/surface/path.dart
@@ -1002,6 +1002,8 @@ class SurfacePath implements ui.Path {
                 }
               }
             }
+            curX = endX;
+            curY = endY;
             break;
           case PathCommandTypes.rect:
             final RectCommand cmd = op;


### PR DESCRIPTION
Paths with cubic commands will misalign as the next point isn't being propagated as the path commands are iterated while the bounds are computed. This is causing inaccurate bounds for shapes, as below:

![front_attachment](https://user-images.githubusercontent.com/454182/84723739-252f2780-af3b-11ea-99a7-9d4e6b9cb63b.png)

