### PR TITLE
Roll buildroot to 2415cd5095c186fe5054552bbb26aaa2b8877ac8

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/dnfield/buildroot.git' + '@' + 'ad0d4e1c0d1d826097c8f2befee021e61a1d35f4',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '73cd40aa9d6b76aff637267e02fda6f6ce571c41',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/dnfield/buildroot.git' + '@' + '9c44bf4702ee29864a94a746cdeb3f54c4a7694d',
+  'src': 'https://github.com/dnfield/buildroot.git' + '@' + '36dd615da14134d101757581eb7ed9caffbb0c1f',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'edf6aa45cbd56aa0bdd9d9333f2ac8e2d29a8be8',
+  'src': 'https://github.com/dnfield/buildroot.git' + '@' + '5274e37e6cc6431b586e72200e6b55c6952eee8d',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '73cd40aa9d6b76aff637267e02fda6f6ce571c41',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '2415cd5095c186fe5054552bbb26aaa2b8877ac8',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/dnfield/buildroot.git' + '@' + '5274e37e6cc6431b586e72200e6b55c6952eee8d',
+  'src': 'https://github.com/dnfield/buildroot.git' + '@' + '0a6bed4dc933ae48bdf604f23e72d7ab9088c458',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/dnfield/buildroot.git' + '@' + '0a6bed4dc933ae48bdf604f23e72d7ab9088c458',
+  'src': 'https://github.com/dnfield/buildroot.git' + '@' + '9c44bf4702ee29864a94a746cdeb3f54c4a7694d',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/dnfield/buildroot.git' + '@' + '36dd615da14134d101757581eb7ed9caffbb0c1f',
+  'src': 'https://github.com/dnfield/buildroot.git' + '@' + 'ad0d4e1c0d1d826097c8f2befee021e61a1d35f4',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
See flutter/buildroot@73cd40aa9d6b76aff637267e02fda6f6ce571c41 and flutter/buildroot@2415cd5095c186fe5054552bbb26aaa2b8877ac8 - primarily deletes unused files and simplifies a couple rules.

Buildroot PR was flutter/buildroot#377 and flutter/buildroot#378