### PR TITLE
[shell] Adds a shell test for timezone fetches

### DIFF
--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -138,3 +138,15 @@ void canDecompressImageFromAsset() {
 }
 
 List<int> getFixtureImage() native 'GetFixtureImage';
+
+void notifyLocalTime(String string) native 'NotifyLocalTime';
+
+@pragma('vm:entry-point')
+void localtimesMatch() {
+  final now = DateTime.now().toLocal();
+  // This is: "$y-$m-$d $h:$min:$sec.$ms$us";
+  final timeStr = now.toString();
+  // Forward only "$y-$m-$d $h" for timestamp comparison.  Not using DateTime
+  // formatting since package:intl is not available.
+  notifyLocalTime(timeStr.split(":")[0]);
+}

--- a/testing/fuchsia/meta/fuchsia_test.cmx
+++ b/testing/fuchsia/meta/fuchsia_test.cmx
@@ -17,7 +17,8 @@
       "fuchsia.sysmem.Allocator",
       "fuchsia.vulkan.loader.Loader",
       "fuchsia.logger.LogSink",
-      "fuchsia.tracing.provider.Registry"
+      "fuchsia.tracing.provider.Registry",
+      "fuchsia.intl.PropertyProvider"
     ]
   }
 }


### PR DESCRIPTION
## Description

Adds a test that verifies that the view of the local time is the same in
the Dart isolate and the process that is running the test.

Specifically, this test is useful to verify that the code paths for
timezone retrieval do not break while the underlying FIDL protocols are
being refactored.

However, since the check is generally useful, the test is written as a
general flutter test.

Running this on Fuchsia required adding `fuchsia.intl.ProfileProvider`
to the CMX file that is used for all build Fuchsia packages.

Testing is a bit involved on Fuchsia.  You must build the Fuchsia
package `fluter/shell/common:shell_tests` and publish it to the dev
repository for your Fuchsia device.  It seems that a way to do so is to
modify the script `flutter/tools/fuchsia/build_fuchsia_artifacts.py` and
modify its function `GetTargetsToBuild` like so:

```
def GetTargetsToBuild(product=False):
  targets_to_build = [
    'flutter/shell/platform/fuchsia:fuchsia',
    'flutter/shell/common:shell_tests',
  ]
  return targets_to_build
```

Next, the Fuchsia packages need to be compiled and published.

Once done, the following `fx` invocation will run the test, assuming
that you have your Fuchsia setup:

```
fx shell run \
    fuchsia-pkg://fuchsia.com/shell_tests#meta/shell_tests.cmx \
    -- --gtest_filter=ShellTest.LocaltimesMatch
```

## Related Issues

* Closes https://github.com/flutter/flutter/issues/59723

## Tests

I added the following tests:

* `ShellTest.LocaltimesMatch`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
  - To the extent that I added a new test without changing any behaviors and that running that tests passes.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
