### PR TITLE
[fuchsia] Adds --targets arg for build_fuchsia_artifacts.py

### DIFF
--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -215,14 +215,14 @@ def GetRunnerTarget(runner_type, product, aot):
   return base + target
 
 
-def GetTargetsToBuild(product=False):
+def GetTargetsToBuild(product=False, additional_targets=[]):
   targets_to_build = [
       'flutter/shell/platform/fuchsia:fuchsia',
-  ]
+  ] + additional_targets
   return targets_to_build
 
 
-def BuildTarget(runtime_mode, arch, product, enable_lto):
+def BuildTarget(runtime_mode, arch, product, enable_lto, additional_targets=[]):
   out_dir = 'fuchsia_%s_%s' % (runtime_mode, arch)
   flags = [
       '--fuchsia',
@@ -276,6 +276,12 @@ def main():
       default=False,
       help='If set, skips building and just creates packages.')
 
+  parser.add_argument(
+      '--targets',
+      default='',
+      help=('Comma-separated list; adds additional targets to build for '
+           'Fuchsia.'))
+
   args = parser.parse_args()
   RemoveDirectoryIfExists(_bucket_directory)
   build_mode = args.runtime_mode
@@ -292,7 +298,8 @@ def main():
       product = product_modes[i]
       if build_mode == 'all' or runtime_mode == build_mode:
         if not args.skip_build:
-          BuildTarget(runtime_mode, arch, product, enable_lto)
+          BuildTarget(runtime_mode, arch, product, enable_lto,
+                      args.targets.split(","))
         BuildBucket(runtime_mode, arch, product)
 
   if args.upload:


### PR DESCRIPTION
## Description

The Fuchsia artifact builder didn't allow the end user to add more
packages to build for Fuchsia.  The current default is building only
the platform-specific packages; but packages like
`flutter/shell/common:shell_tests` are also defined for Fuchsia but
not compiled by default.

This change makes it less of a hassle to compile such packages.

## Related Issues

* Closes https://github.com/flutter/flutter/issues/59794

## Tests

* I have been using this changed script for a while now myself.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
