### PR TITLE
Word substitutions

### DIFF
--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 2f4b26bff75b999feec0c8b74e7653cc
+Signature: d87fdd028d9cc76587c43c73be9d6541
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -245,7 +245,7 @@ TEST_F(ShellTest, LastEntrypoint) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
-TEST(ShellTestNoFixture, EnableMirrorsIsWhitelisted) {
+TEST(ShellTestNoFixture, EnableMirrorsIsAllowed) {
   if (DartVM::IsRunningPrecompiledCode()) {
     // This covers profile and release modes which use AOT (where this flag does
     // not make sense anyway).
@@ -264,7 +264,7 @@ TEST(ShellTestNoFixture, EnableMirrorsIsWhitelisted) {
   EXPECT_EQ(settings.dart_flags.size(), 1u);
 }
 
-TEST_F(ShellTest, BlacklistedDartVMFlag) {
+TEST_F(ShellTest, DisallowedDartVMFlag) {
   // Run this test in a thread-safe manner, otherwise gtest will complain.
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
@@ -272,13 +272,13 @@ TEST_F(ShellTest, BlacklistedDartVMFlag) {
       fml::CommandLine::Option("dart-flags", "--verify_after_gc")};
   fml::CommandLine command_line("", options, std::vector<std::string>());
 
-  // Upon encountering a non-whitelisted Dart flag the process terminates.
+  // Upon encountering a disallowed Dart flag the process terminates.
   const char* expected =
-      "Encountered blacklisted Dart VM flag: --verify_after_gc";
+      "Encountered disallowed Dart VM flag: --verify_after_gc";
   ASSERT_DEATH(flutter::SettingsFromCommandLine(command_line), expected);
 }
 
-TEST_F(ShellTest, WhitelistedDartVMFlag) {
+TEST_F(ShellTest, AllowedDartVMFlag) {
   const std::vector<fml::CommandLine::Option> options = {
 #if !FLUTTER_RELEASE
     fml::CommandLine::Option("dart-flags",

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -40,7 +40,7 @@ struct SwitchDesc {
 #if FLUTTER_RELEASE
 
 // clang-format off
-static const std::string gDartFlagsWhitelist[] = {
+static const std::string gAllowedDartFlags[] = {
     "--no-causal_async_stacks",
     "--lazy_async_stacks",
 };
@@ -49,7 +49,7 @@ static const std::string gDartFlagsWhitelist[] = {
 #else
 
 // clang-format off
-static const std::string gDartFlagsWhitelist[] = {
+static const std::string gAllowedDartFlags[] = {
     "--enable_mirrors",
     "--enable-service-port-fallback",
     "--lazy_async_stacks",
@@ -148,10 +148,10 @@ const std::string_view FlagForSwitch(Switch swtch) {
   return std::string_view();
 }
 
-static bool IsWhitelistedDartVMFlag(const std::string& flag) {
-  for (uint32_t i = 0; i < fml::size(gDartFlagsWhitelist); ++i) {
-    const std::string& allowed = gDartFlagsWhitelist[i];
-    // Check that the prefix of the flag matches one of the whitelisted flags.
+static bool IsAllowedDartVMFlag(const std::string& flag) {
+  for (uint32_t i = 0; i < fml::size(gAllowedDartFlags); ++i) {
+    const std::string& allowed = gAllowedDartFlags[i];
+    // Check that the prefix of the flag matches one of the allowed flags.
     // We don't need to worry about cases like "--safe --sneaky_dangerous" as
     // the VM will discard these as a single unrecognized flag.
     if (std::equal(allowed.begin(), allowed.end(), flag.begin())) {
@@ -372,8 +372,8 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
 
     // Assume that individual flags are comma separated.
     while (std::getline(stream, flag, ',')) {
-      if (!IsWhitelistedDartVMFlag(flag)) {
-        FML_LOG(FATAL) << "Encountered blacklisted Dart VM flag: " << flag;
+      if (!IsAllowedDartVMFlag(flag)) {
+        FML_LOG(FATAL) << "Encountered disallowed Dart VM flag: " << flag;
       }
       settings.dart_flags.push_back(flag);
     }

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -321,9 +321,8 @@ public final class FlutterActivityDelegate
       args.add("--endless-trace-buffer");
     }
     // NOTE: all flags provided with this argument are subject to filtering
-    // based on a whitelist in shell/common/switches.cc. If any flag provided
-    // is not present in the whitelist, the process will immediately
-    // terminate.
+    // based on a a list of allowed flags in shell/common/switches.cc. If any
+    // flag provided is not allowed, the process will immediately terminate.
     if (intent.hasExtra("dart-flags")) {
       args.add("--dart-flags=" + intent.getStringExtra("dart-flags"));
     }

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
@@ -107,9 +107,8 @@ public class FlutterShellArgs {
     }
 
     // NOTE: all flags provided with this argument are subject to filtering
-    // based on a whitelist in shell/common/switches.cc. If any flag provided
-    // is not present in the whitelist, the process will immediately
-    // terminate.
+    // based on a a list of allowed flags in shell/common/switches.cc. If any
+    // flag provided is not allowed, the process will immediately terminate.
     if (intent.hasExtra(ARG_KEY_DART_FLAGS)) {
       args.add(ARG_DART_FLAGS + "=" + intent.getStringExtra(ARG_KEY_DART_FLAGS));
     }

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -400,16 +400,16 @@ const uint32_t STAFF_OF_AESCULAPIUS = 0x2695;
 
 // Characters where we want to continue using existing font run instead of
 // recomputing the best match in the fallback list.
-static const uint32_t stickyWhitelist[] = {
+static const uint32_t stickyAllowlist[] = {
     '!',   ',',         '-',       '.',
     ':',   ';',         '?',       NBSP,
     ZWJ,   ZWNJ,        HYPHEN,    NB_HYPHEN,
     NNBSP, FEMALE_SIGN, MALE_SIGN, STAFF_OF_AESCULAPIUS};
 
-static bool isStickyWhitelisted(uint32_t c) {
-  for (size_t i = 0; i < sizeof(stickyWhitelist) / sizeof(stickyWhitelist[0]);
+static bool isStickyAllowed(uint32_t c) {
+  for (size_t i = 0; i < sizeof(stickyAllowlist) / sizeof(stickyAllowlist[0]);
        i++) {
-    if (stickyWhitelist[i] == c)
+    if (stickyAllowlist[i] == c)
       return true;
   }
   return false;
@@ -489,9 +489,9 @@ void FontCollection::itemize(const uint16_t* string,
 
     bool shouldContinueRun = false;
     if (lastFamily != nullptr) {
-      if (isStickyWhitelisted(ch)) {
+      if (isStickyAllowed(ch)) {
         // Continue using existing font as long as it has coverage and is
-        // whitelisted
+        // allowed.
         shouldContinueRun = lastFamily->getCoverage().get(ch);
       } else if (ch == SOFT_HYPHEN || isVariationSelector(ch)) {
         // Always continue if the character is the soft hyphen or a variation

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -2099,10 +2099,10 @@ class _RepositoryFlutterDirectory extends _RepositoryDirectory {
 /// A specialized crawler for "github.com/flutter/engine/lib" directory.
 ///
 /// It includes everything except build tools, test build artifacts, and test code.
-_RelativePathBlocklistRepositoryDirectory _createLibDirectoryRoot(fs.Directory entry, _RepositoryDirectory parent) {
-  return _RelativePathBlocklistRepositoryDirectory(
+_RelativePathDenylistRepositoryDirectory _createLibDirectoryRoot(fs.Directory entry, _RepositoryDirectory parent) {
+  return _RelativePathDenylistRepositoryDirectory(
     rootDir: entry,
-    blocklist: <Pattern>[
+    denylist: <Pattern>[
       'web_ui/lib/assets/ahem.ttf',  // this gitignored file exists only for testing purposes
       RegExp(r'web_ui/build/.*'),  // this is compiler-generated output
       RegExp(r'web_ui/dev/.*'),  // these are build tools; they do not end up in Engine artifacts
@@ -2117,10 +2117,10 @@ _RelativePathBlocklistRepositoryDirectory _createLibDirectoryRoot(fs.Directory e
 ///
 /// It includes everything except the "web_engine_tester" package, which is only
 /// used to test the engine itself and is not shipped as part of the Flutter SDK.
-_RelativePathBlocklistRepositoryDirectory _createWebSdkDirectoryRoot(fs.Directory entry, _RepositoryDirectory parent) {
-  return _RelativePathBlocklistRepositoryDirectory(
+_RelativePathDenylistRepositoryDirectory _createWebSdkDirectoryRoot(fs.Directory entry, _RepositoryDirectory parent) {
+  return _RelativePathDenylistRepositoryDirectory(
     rootDir: entry,
-    blocklist: <Pattern>[
+    denylist: <Pattern>[
       RegExp(r'web_engine_tester/.*'),  // contains test code for the engine itself
     ],
     parent: parent,
@@ -2128,32 +2128,32 @@ _RelativePathBlocklistRepositoryDirectory _createWebSdkDirectoryRoot(fs.Director
   );
 }
 
-/// Walks a [rootDir] recursively, omitting paths that match a [blocklist].
+/// Walks a [rootDir] recursively, omitting paths that match a [denylist].
 ///
-/// The path patterns in the [blocklist] are specified relative to the [rootDir].
-class _RelativePathBlocklistRepositoryDirectory extends _RepositoryDirectory {
-  _RelativePathBlocklistRepositoryDirectory({
+/// The path patterns in the [denylist] are specified relative to the [rootDir].
+class _RelativePathDenylistRepositoryDirectory extends _RepositoryDirectory {
+  _RelativePathDenylistRepositoryDirectory({
     @required this.rootDir,
-    @required this.blocklist,
+    @required this.denylist,
     @required _RepositoryDirectory parent,
     @required fs.Directory io,
   }) : super(parent, io);
 
-  /// The directory, relative to which the paths are [blocklist]ed.
+  /// The directory, relative to which the paths are [denylist]ed.
   final fs.Directory rootDir;
 
   /// Blocked path patterns.
   ///
   /// Paths are assumed relative to [rootDir].
-  final List<Pattern> blocklist;
+  final List<Pattern> denylist;
 
   @override
   bool shouldRecurse(fs.IoNode entry) {
     final String relativePath = path.relative(entry.fullName, from: rootDir.fullName);
-    final bool isBlocked = blocklist.any(
+    final bool denied = denylist.any(
       (Pattern pattern) => pattern.matchAsPrefix(relativePath) != null,
     );
-    if (isBlocked) {
+    if (denied) {
       return false;
     }
     return super.shouldRecurse(entry);
@@ -2161,9 +2161,9 @@ class _RelativePathBlocklistRepositoryDirectory extends _RepositoryDirectory {
 
   @override
   _RepositoryDirectory createSubdirectory(fs.Directory entry) {
-    return _RelativePathBlocklistRepositoryDirectory(
+    return _RelativePathDenylistRepositoryDirectory(
       rootDir: rootDir,
-      blocklist: blocklist,
+      denylist: denylist,
       parent: this,
       io: entry,
     );

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -2099,10 +2099,10 @@ class _RepositoryFlutterDirectory extends _RepositoryDirectory {
 /// A specialized crawler for "github.com/flutter/engine/lib" directory.
 ///
 /// It includes everything except build tools, test build artifacts, and test code.
-_RelativePathBlacklistRepositoryDirectory _createLibDirectoryRoot(fs.Directory entry, _RepositoryDirectory parent) {
-  return _RelativePathBlacklistRepositoryDirectory(
+_RelativePathBlocklistRepositoryDirectory _createLibDirectoryRoot(fs.Directory entry, _RepositoryDirectory parent) {
+  return _RelativePathBlocklistRepositoryDirectory(
     rootDir: entry,
-    blacklist: <Pattern>[
+    blocklist: <Pattern>[
       'web_ui/lib/assets/ahem.ttf',  // this gitignored file exists only for testing purposes
       RegExp(r'web_ui/build/.*'),  // this is compiler-generated output
       RegExp(r'web_ui/dev/.*'),  // these are build tools; they do not end up in Engine artifacts
@@ -2117,10 +2117,10 @@ _RelativePathBlacklistRepositoryDirectory _createLibDirectoryRoot(fs.Directory e
 ///
 /// It includes everything except the "web_engine_tester" package, which is only
 /// used to test the engine itself and is not shipped as part of the Flutter SDK.
-_RelativePathBlacklistRepositoryDirectory _createWebSdkDirectoryRoot(fs.Directory entry, _RepositoryDirectory parent) {
-  return _RelativePathBlacklistRepositoryDirectory(
+_RelativePathBlocklistRepositoryDirectory _createWebSdkDirectoryRoot(fs.Directory entry, _RepositoryDirectory parent) {
+  return _RelativePathBlocklistRepositoryDirectory(
     rootDir: entry,
-    blacklist: <Pattern>[
+    blocklist: <Pattern>[
       RegExp(r'web_engine_tester/.*'),  // contains test code for the engine itself
     ],
     parent: parent,
@@ -2128,32 +2128,32 @@ _RelativePathBlacklistRepositoryDirectory _createWebSdkDirectoryRoot(fs.Director
   );
 }
 
-/// Walks a [rootDir] recursively, omitting paths that match a [blacklist].
+/// Walks a [rootDir] recursively, omitting paths that match a [blocklist].
 ///
-/// The path patterns in the [blacklist] are specified relative to the [rootDir].
-class _RelativePathBlacklistRepositoryDirectory extends _RepositoryDirectory {
-  _RelativePathBlacklistRepositoryDirectory({
+/// The path patterns in the [blocklist] are specified relative to the [rootDir].
+class _RelativePathBlocklistRepositoryDirectory extends _RepositoryDirectory {
+  _RelativePathBlocklistRepositoryDirectory({
     @required this.rootDir,
-    @required this.blacklist,
+    @required this.blocklist,
     @required _RepositoryDirectory parent,
     @required fs.Directory io,
   }) : super(parent, io);
 
-  /// The directory, relative to which the paths are [blacklist]ed.
+  /// The directory, relative to which the paths are [blocklist]ed.
   final fs.Directory rootDir;
 
-  /// Blacklisted path patterns.
+  /// Blocked path patterns.
   ///
   /// Paths are assumed relative to [rootDir].
-  final List<Pattern> blacklist;
+  final List<Pattern> blocklist;
 
   @override
   bool shouldRecurse(fs.IoNode entry) {
     final String relativePath = path.relative(entry.fullName, from: rootDir.fullName);
-    final bool isBlacklisted = blacklist.any(
+    final bool isBlocked = blocklist.any(
       (Pattern pattern) => pattern.matchAsPrefix(relativePath) != null,
     );
-    if (isBlacklisted) {
+    if (isBlocked) {
       return false;
     }
     return super.shouldRecurse(entry);
@@ -2161,9 +2161,9 @@ class _RelativePathBlacklistRepositoryDirectory extends _RepositoryDirectory {
 
   @override
   _RepositoryDirectory createSubdirectory(fs.Directory entry) {
-    return _RelativePathBlacklistRepositoryDirectory(
+    return _RelativePathBlocklistRepositoryDirectory(
       rootDir: rootDir,
-      blacklist: blacklist,
+      blocklist: blocklist,
       parent: this,
       io: entry,
     );


### PR DESCRIPTION
## Tests

I added the following tests:

Adjusted to new names.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
