### PR TITLE
[buildroot] Roll to pick up fix for misleading .lib output for Windows

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -110,7 +110,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '2415cd5095c186fe5054552bbb26aaa2b8877ac8',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'a6103d43ed47c5cf91d47d614fe00a0665484fc5',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/59687.
