### PR TITLE
Add PlatformView support for Fuchsia

### DIFF
--- a/flow/layers/platform_view_layer.h
+++ b/flow/layers/platform_view_layer.h
@@ -17,6 +17,10 @@ class PlatformViewLayer : public Layer {
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
+#if defined(OS_FUCHSIA)
+  // Updates the system composited scene.
+  void UpdateScene(SceneUpdateContext& context) override;
+#endif
 
  private:
   SkPoint offset_;

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "flutter/flow/compositor_context.h"
+#include "flutter/flow/embedded_views.h"
 #include "flutter/flow/raster_cache_key.h"
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/logging.h"
@@ -32,7 +33,7 @@ constexpr float kOneMinusEpsilon = 1 - FLT_EPSILON;
 // How much layers are separated in Scenic z elevation.
 constexpr float kScenicZElevationBetweenLayers = 10.f;
 
-class SceneUpdateContext {
+class SceneUpdateContext : public flutter::ExternalViewEmbedder {
  public:
   class SurfaceProducerSurface {
    public:
@@ -180,7 +181,7 @@ class SceneUpdateContext {
 
   // The transformation matrix of the current context. It's used to construct
   // the LayerRasterCacheKey for a given layer.
-  SkMatrix Matrix() const { return SkMatrix::Scale(ScaleX(), ScaleY()); }
+  SkMatrix Matrix() const { return SkMatrix::MakeScale(ScaleX(), ScaleY()); }
 
   bool HasRetainedNode(const LayerRasterCacheKey& key) const {
     return surface_producer_->HasRetainedNode(key);
@@ -203,6 +204,38 @@ class SceneUpdateContext {
     topmost_global_scenic_elevation_ += kScenicZElevationBetweenLayers;
     return elevation;
   }
+
+  // |ExternalViewEmbedder|
+  SkCanvas* GetRootCanvas() override { return nullptr; }
+
+  // |ExternalViewEmbedder|
+  void CancelFrame() override {}
+
+  // |ExternalViewEmbedder|
+  void BeginFrame(SkISize frame_size,
+                  GrContext* context,
+                  double device_pixel_ratio) override {}
+
+  // |ExternalViewEmbedder|
+  void PrerollCompositeEmbeddedView(
+      int view_id,
+      std::unique_ptr<EmbeddedViewParams> params) override {}
+
+  // |ExternalViewEmbedder|
+  std::vector<SkCanvas*> GetCurrentCanvases() override {
+    return std::vector<SkCanvas*>();
+  }
+
+  // |ExternalViewEmbedder|
+  virtual SkCanvas* CompositeEmbeddedView(int view_id) override {
+    return nullptr;
+  }
+
+  void CreateView(int64_t view_id, bool hit_testable, bool focusable);
+
+  void DestroyView(int64_t view_id);
+
+  void UpdateScene(int64_t view_id, const SkPoint& offset, const SkSize& size);
 
  private:
   struct PaintTask {

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -212,9 +212,11 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
   void CancelFrame() override {}
 
   // |ExternalViewEmbedder|
-  void BeginFrame(SkISize frame_size,
-                  GrContext* context,
-                  double device_pixel_ratio) override {}
+  void BeginFrame(
+      SkISize frame_size,
+      GrContext* context,
+      double device_pixel_ratio,
+      fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override {}
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(

--- a/flow/view_holder.h
+++ b/flow/view_holder.h
@@ -9,10 +9,10 @@
 #include <fuchsia/ui/views/cpp/fidl.h>
 #include <lib/ui/scenic/cpp/id.h>
 #include <lib/ui/scenic/cpp/resources.h>
+#include <third_party/skia/include/core/SkMatrix.h>
+#include <third_party/skia/include/core/SkPoint.h>
+#include <third_party/skia/include/core/SkSize.h>
 #include <zircon/types.h>
-#include "third_party/skia/include/core/SkMatrix.h"
-#include "third_party/skia/include/core/SkPoint.h"
-#include "third_party/skia/include/core/SkSize.h"
 
 #include <memory>
 
@@ -60,6 +60,12 @@ class ViewHolder {
                    SkAlpha opacity,
                    bool hit_testable);
 
+  bool hit_testable() { return hit_testable_; }
+  void set_hit_testable(bool value) { hit_testable_ = value; }
+
+  bool focusable() { return focusable_; }
+  void set_focusable(bool value) { focusable_ = value; }
+
  private:
   fml::RefPtr<fml::TaskRunner> ui_task_runner_;
 
@@ -69,6 +75,9 @@ class ViewHolder {
 
   fuchsia::ui::views::ViewHolderToken pending_view_holder_token_;
   BindCallback pending_bind_callback_;
+
+  bool hit_testable_ = true;
+  bool focusable_ = true;
 
   fuchsia::ui::gfx::ViewProperties pending_properties_;
   bool has_pending_properties_ = false;

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -4,12 +4,11 @@
 
 #include "flutter/shell/common/rasterizer.h"
 
-#include "flutter/shell/common/persistent_cache.h"
-
 #include <utility>
 
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"
+#include "flutter/shell/common/persistent_cache.h"
 #include "third_party/skia/include/core/SkEncodedImageFormat.h"
 #include "third_party/skia/include/core/SkImageEncoder.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
@@ -77,6 +76,9 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
                              user_override_resource_cache_bytes_);
   }
   compositor_context_->OnGrContextCreated();
+#if !defined(OS_FUCHSIA)
+  // TODO(sanjayc77): https://github.com/flutter/flutter/issues/53179. Add
+  // support for raster thread merger for Fuchsia.
   if (surface_->GetExternalViewEmbedder()) {
     const auto platform_id =
         task_runners_.GetPlatformTaskRunner()->GetTaskQueueId();
@@ -84,6 +86,7 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
     raster_thread_merger_ =
         fml::MakeRefCounted<fml::RasterThreadMerger>(platform_id, gpu_id);
   }
+#endif  // defined(OS_FUCHSIA)
 }
 
 void Rasterizer::Teardown() {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -469,6 +469,9 @@ TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
   DestroyShell(std::move(shell));
 }
 
+#if !defined(OS_FUCHSIA)
+// TODO(sanjayc77): https://github.com/flutter/flutter/issues/53179. Add
+// support for raster thread merger for Fuchsia.
 TEST_F(ShellTest,
        ExternalEmbedderEndFrameIsCalledWhenPostPrerollResultIsResubmit) {
   auto settings = CreateSettingsForFixture();
@@ -513,6 +516,7 @@ TEST_F(ShellTest,
 
   DestroyShell(std::move(shell));
 }
+#endif  // defined(OS_FUCHSIA)
 
 TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
   // Ensure that all phases are in kPhases.

--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -12,13 +12,14 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
  public:
   ScopedFrame(flutter::CompositorContext& context,
               const SkMatrix& root_surface_transformation,
+              flutter::ExternalViewEmbedder* view_embedder,
               bool instrumentation_enabled,
               SessionConnection& session_connection)
       : flutter::CompositorContext::ScopedFrame(
             context,
             session_connection.vulkan_surface_producer()->gr_context(),
             nullptr,
-            nullptr,
+            view_embedder,
             root_surface_transformation,
             instrumentation_enabled,
             true,
@@ -94,6 +95,17 @@ void CompositorContext::OnWireframeEnabled(bool enabled) {
   session_connection_.set_enable_wireframe(enabled);
 }
 
+void CompositorContext::OnCreateView(int64_t view_id,
+                                     bool hit_testable,
+                                     bool focusable) {
+  session_connection_.scene_update_context().CreateView(view_id, hit_testable,
+                                                        focusable);
+}
+
+void CompositorContext::OnDestroyView(int64_t view_id) {
+  session_connection_.scene_update_context().DestroyView(view_id);
+}
+
 CompositorContext::~CompositorContext() = default;
 
 std::unique_ptr<flutter::CompositorContext::ScopedFrame>
@@ -111,8 +123,9 @@ CompositorContext::AcquireFrame(
   return std::make_unique<flutter_runner::ScopedFrame>(
       *this,                        //
       root_surface_transformation,  //
-      instrumentation_enabled,      //
-      session_connection_           //
+      view_embedder,
+      instrumentation_enabled,  //
+      session_connection_       //
   );
 }
 

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -35,6 +35,13 @@ class CompositorContext final : public flutter::CompositorContext {
                                float height_change_factor);
 
   void OnWireframeEnabled(bool enabled);
+  void OnCreateView(int64_t view_id, bool hit_testable, bool focusable);
+  void OnDestroyView(int64_t view_id);
+
+  flutter::ExternalViewEmbedder* GetViewEmbedder() {
+    return reinterpret_cast<flutter::ExternalViewEmbedder*>(
+        &session_connection_.scene_update_context());
+  }
 
  private:
   const std::string debug_label_;

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -39,8 +39,7 @@ class CompositorContext final : public flutter::CompositorContext {
   void OnDestroyView(int64_t view_id);
 
   flutter::ExternalViewEmbedder* GetViewEmbedder() {
-    return reinterpret_cast<flutter::ExternalViewEmbedder*>(
-        &session_connection_.scene_update_context());
+    return &session_connection_.scene_update_context();
   }
 
  private:

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -6,6 +6,7 @@
 
 #include <lib/async/cpp/task.h>
 #include <zircon/status.h>
+
 #include <sstream>
 
 #include "flutter/common/task_runners.h"
@@ -102,6 +103,16 @@ Engine::Engine(Delegate& delegate,
   OnEnableWireframe on_enable_wireframe_callback = std::bind(
       &Engine::OnDebugWireframeSettingsChanged, this, std::placeholders::_1);
 
+  OnCreateView on_create_view_callback =
+      std::bind(&Engine::OnCreateViewMethodCall, this, std::placeholders::_1,
+                std::placeholders::_2, std::placeholders::_3);
+
+  OnDestroyView on_destroy_view_callback =
+      std::bind(&Engine::OnDestroyViewMethodCall, this, std::placeholders::_1);
+
+  OnGetViewEmbedder on_get_view_embedder_callback =
+      std::bind(&Engine::GetViewEmbedder, this);
+
   // SessionListener has a OnScenicError method; invoke this callback on the
   // platform thread when that happens. The Session itself should also be
   // disconnected when this happens, and it will also attempt to terminate.
@@ -135,6 +146,10 @@ Engine::Engine(Delegate& delegate,
                std::move(on_session_size_change_hint_callback),
            on_enable_wireframe_callback =
                std::move(on_enable_wireframe_callback),
+           on_create_view_callback = std::move(on_create_view_callback),
+           on_destroy_view_callback = std::move(on_destroy_view_callback),
+           on_get_view_embedder_callback =
+               std::move(on_get_view_embedder_callback),
            vsync_handle = vsync_event_.get(),
            product_config = product_config](flutter::Shell& shell) mutable {
             return std::make_unique<flutter_runner::PlatformView>(
@@ -149,6 +164,9 @@ Engine::Engine(Delegate& delegate,
                 std::move(on_session_metrics_change_callback),
                 std::move(on_session_size_change_hint_callback),
                 std::move(on_enable_wireframe_callback),
+                std::move(on_create_view_callback),
+                std::move(on_destroy_view_callback),
+                std::move(on_get_view_embedder_callback),
                 vsync_handle,  // vsync handle
                 product_config);
           });
@@ -499,6 +517,55 @@ void Engine::OnDebugWireframeSettingsChanged(bool enabled) {
           compositor_context->OnWireframeEnabled(enabled);
         }
       });
+}
+
+void Engine::OnCreateViewMethodCall(int64_t view_id,
+                                    bool hit_testable,
+                                    bool focusable) {
+  if (!shell_) {
+    return;
+  }
+
+  shell_->GetTaskRunners().GetRasterTaskRunner()->PostTask(
+      [rasterizer = shell_->GetRasterizer(), view_id, hit_testable,
+       focusable]() {
+        if (rasterizer) {
+          auto compositor_context =
+              reinterpret_cast<flutter_runner::CompositorContext*>(
+                  rasterizer->compositor_context());
+          compositor_context->OnCreateView(view_id, hit_testable, focusable);
+        }
+      });
+}
+
+void Engine::OnDestroyViewMethodCall(int64_t view_id) {
+  if (!shell_) {
+    return;
+  }
+
+  shell_->GetTaskRunners().GetRasterTaskRunner()->PostTask(
+      [rasterizer = shell_->GetRasterizer(), view_id]() {
+        if (rasterizer) {
+          auto compositor_context =
+              reinterpret_cast<flutter_runner::CompositorContext*>(
+                  rasterizer->compositor_context());
+          compositor_context->OnDestroyView(view_id);
+        }
+      });
+}
+
+flutter::ExternalViewEmbedder* Engine::GetViewEmbedder() {
+  // GetEmbedder should be called only after rasterizer is created.
+  FML_DCHECK(shell_);
+  FML_DCHECK(shell_->GetRasterizer());
+
+  auto rasterizer = shell_->GetRasterizer();
+  auto compositor_context =
+      reinterpret_cast<flutter_runner::CompositorContext*>(
+          rasterizer->compositor_context());
+  flutter::ExternalViewEmbedder* view_embedder =
+      compositor_context->GetViewEmbedder();
+  return view_embedder;
 }
 
 void Engine::OnSessionSizeChangeHint(float width_change_factor,

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -103,12 +103,12 @@ Engine::Engine(Delegate& delegate,
   OnEnableWireframe on_enable_wireframe_callback = std::bind(
       &Engine::OnDebugWireframeSettingsChanged, this, std::placeholders::_1);
 
-  OnCreateView on_create_view_callback =
-      std::bind(&Engine::OnCreateViewMethodCall, this, std::placeholders::_1,
+  flutter_runner::OnCreateView on_create_view_callback =
+      std::bind(&Engine::OnCreateView, this, std::placeholders::_1,
                 std::placeholders::_2, std::placeholders::_3);
 
-  OnDestroyView on_destroy_view_callback =
-      std::bind(&Engine::OnDestroyViewMethodCall, this, std::placeholders::_1);
+  flutter_runner::OnDestroyView on_destroy_view_callback =
+      std::bind(&Engine::OnDestroyView, this, std::placeholders::_1);
 
   OnGetViewEmbedder on_get_view_embedder_callback =
       std::bind(&Engine::GetViewEmbedder, this);
@@ -519,9 +519,7 @@ void Engine::OnDebugWireframeSettingsChanged(bool enabled) {
       });
 }
 
-void Engine::OnCreateViewMethodCall(int64_t view_id,
-                                    bool hit_testable,
-                                    bool focusable) {
+void Engine::OnCreateView(int64_t view_id, bool hit_testable, bool focusable) {
   if (!shell_) {
     return;
   }
@@ -538,7 +536,7 @@ void Engine::OnCreateViewMethodCall(int64_t view_id,
       });
 }
 
-void Engine::OnDestroyViewMethodCall(int64_t view_id) {
+void Engine::OnDestroyView(int64_t view_id) {
   if (!shell_) {
     return;
   }

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -14,6 +14,7 @@
 #include <lib/ui/scenic/cpp/view_ref_pair.h>
 #include <lib/zx/event.h>
 
+#include "flutter/flow/embedded_views.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/common/shell.h"
 #include "flutter_runner_product_configuration.h"
@@ -75,6 +76,14 @@ class Engine final {
                                float height_change_factor);
 
   void OnDebugWireframeSettingsChanged(bool enabled);
+
+  void OnCreateViewMethodCall(int64_t view_id,
+                              bool hit_testable,
+                              bool focusable);
+
+  void OnDestroyViewMethodCall(int64_t view_id);
+
+  flutter::ExternalViewEmbedder* GetViewEmbedder();
 
   FML_DISALLOW_COPY_AND_ASSIGN(Engine);
 };

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -77,11 +77,9 @@ class Engine final {
 
   void OnDebugWireframeSettingsChanged(bool enabled);
 
-  void OnCreateViewMethodCall(int64_t view_id,
-                              bool hit_testable,
-                              bool focusable);
+  void OnCreateView(int64_t view_id, bool hit_testable, bool focusable);
 
-  void OnDestroyViewMethodCall(int64_t view_id);
+  void OnDestroyView(int64_t view_id);
 
   flutter::ExternalViewEmbedder* GetViewEmbedder();
 

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -5,22 +5,21 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_PLATFORM_VIEW_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_PLATFORM_VIEW_H_
 
-#include <map>
-#include <set>
-
 #include <fuchsia/ui/gfx/cpp/fidl.h>
 #include <fuchsia/ui/input/cpp/fidl.h>
 #include <fuchsia/ui/scenic/cpp/fidl.h>
 #include <lib/fit/function.h>
 
+#include <map>
+#include <set>
+
 #include "flutter/fml/macros.h"
 #include "flutter/lib/ui/window/viewport_metrics.h"
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/platform/fuchsia/flutter/accessibility_bridge.h"
+#include "flutter_runner_product_configuration.h"
 #include "lib/fidl/cpp/binding.h"
 #include "lib/ui/scenic/cpp/id.h"
-
-#include "flutter_runner_product_configuration.h"
 #include "surface.h"
 
 namespace flutter_runner {
@@ -29,6 +28,9 @@ using OnMetricsUpdate = fit::function<void(const fuchsia::ui::gfx::Metrics&)>;
 using OnSizeChangeHint =
     fit::function<void(float width_change_factor, float height_change_factor)>;
 using OnEnableWireframe = fit::function<void(bool)>;
+using OnCreateView = fit::function<void(int64_t, bool, bool)>;
+using OnDestroyView = fit::function<void(int64_t)>;
+using OnGetViewEmbedder = fit::function<flutter::ExternalViewEmbedder*()>;
 
 // The per engine component residing on the platform thread is responsible for
 // all platform specific integrations.
@@ -54,6 +56,9 @@ class PlatformView final : public flutter::PlatformView,
                OnMetricsUpdate session_metrics_did_change_callback,
                OnSizeChangeHint session_size_change_hint_callback,
                OnEnableWireframe wireframe_enabled_callback,
+               OnCreateView on_create_view_callback,
+               OnDestroyView on_destroy_view_callback,
+               OnGetViewEmbedder on_get_view_embedder_callback,
                zx_handle_t vsync_event_handle,
                FlutterRunnerProductConfiguration product_config);
   PlatformView(flutter::PlatformView::Delegate& delegate,
@@ -90,6 +95,9 @@ class PlatformView final : public flutter::PlatformView,
   OnMetricsUpdate metrics_changed_callback_;
   OnSizeChangeHint size_change_hint_callback_;
   OnEnableWireframe wireframe_enabled_callback_;
+  OnCreateView on_create_view_callback_;
+  OnDestroyView on_destroy_view_callback_;
+  OnGetViewEmbedder on_get_view_embedder_callback_;
 
   int current_text_input_client_ = 0;
   fidl::Binding<fuchsia::ui::input::InputMethodEditorClient> ime_client_;
@@ -97,7 +105,6 @@ class PlatformView final : public flutter::PlatformView,
   fuchsia::ui::input::ImeServicePtr text_sync_service_;
 
   fuchsia::sys::ServiceProviderPtr parent_environment_service_provider_;
-  std::unique_ptr<Surface> surface_;
   flutter::LogicalMetrics metrics_;
   fuchsia::ui::gfx::Metrics scenic_metrics_;
   // last_text_state_ is the last state of the text input as reported by the IME

--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -12,8 +12,9 @@
 
 namespace flutter_runner {
 
-Surface::Surface(std::string debug_label)
-    : debug_label_(std::move(debug_label)) {}
+Surface::Surface(std::string debug_label,
+                 flutter::ExternalViewEmbedder* view_embedder)
+    : debug_label_(std::move(debug_label)), view_embedder_(view_embedder) {}
 
 Surface::~Surface() = default;
 
@@ -67,6 +68,11 @@ SkMatrix Surface::GetRootTransformation() const {
   SkMatrix matrix;
   matrix.reset();
   return matrix;
+}
+
+// |flutter::GetViewEmbedder|
+flutter::ExternalViewEmbedder* Surface::GetExternalViewEmbedder() {
+  return view_embedder_;
 }
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/surface.h
+++ b/shell/platform/fuchsia/flutter/surface.h
@@ -16,13 +16,15 @@ namespace flutter_runner {
 // raster thread.
 class Surface final : public flutter::Surface {
  public:
-  Surface(std::string debug_label);
+  Surface(std::string debug_label,
+          flutter::ExternalViewEmbedder* view_embedder);
 
   ~Surface() override;
 
  private:
   const bool valid_ = CanConnectToDisplay();
   const std::string debug_label_;
+  flutter::ExternalViewEmbedder* view_embedder_;
 
   // |flutter::Surface|
   bool IsValid() override;
@@ -36,6 +38,9 @@ class Surface final : public flutter::Surface {
 
   // |flutter::Surface|
   SkMatrix GetRootTransformation() const override;
+
+  // |flutter::Surface|
+  flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   static bool CanConnectToDisplay();
 


### PR DESCRIPTION
## Description

This change allows embedding views provided by fuchsia components into
a flutter app running on Fuchsia. This conforms to Flutters idiomatic
approach to composite PlatformView alongside other rendered layers.

This uses the `view embedder` infrastructure to allow
`PlatformViewLayer`
to hold fuchsia views. This is meant to eventually supplant the legacy
`SceneHost` and `ChildViewLayer` mechanism to embed fuchsia `ChildView`.

To see how this will get used check out:
https://fuchsia-review.googlesource.com/c/experiences/+/398536/6/examples/hello_experiences/lib/fuchsia_view.dart


Note: This change has no impact on the legacy code to embed fuchsia
views.

## Tests

Includes unittests for platform_view.cc.

