### PR TITLE
Revert method channel platform resolved locale

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -90,22 +90,6 @@ void _updateLocales(List<String> locales) {
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _updatePlatformResolvedLocale(List<String> localeData) {
-  if (localeData.length != 4) {
-    return;
-  }
-  final String countryCode = localeData[1];
-  final String scriptCode = localeData[2];
-
-  window._platformResolvedLocale = Locale.fromSubtags(
-    languageCode: localeData[0],
-    countryCode: countryCode.isEmpty ? null : countryCode,
-    scriptCode: scriptCode.isEmpty ? null : scriptCode,
-  );
-}
-
-@pragma('vm:entry-point')
-// ignore: unused_element
 void _updateUserSettingsData(String jsonData) {
   final Map<String, dynamic> data = json.decode(jsonData) as Map<String, dynamic>;
   if (data.isEmpty) {

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -796,19 +796,6 @@ class Window {
   List<Locale>? get locales => _locales;
   List<Locale>? _locales;
 
-  /// The locale that the platform's native locale resolution system resolves to.
-  ///
-  /// This value may differ between platforms and is meant to allow Flutter's locale
-  /// resolution algorithms access to a locale that is consistent with other apps
-  /// on the device. Using this property is optional.
-  ///
-  /// This value may be used in a custom [localeListResolutionCallback] or used directly
-  /// in order to arrive at the most appropriate locale for the app.
-  ///
-  /// See [locales], which is the list of locales the user/device prefers.
-  Locale? get platformResolvedLocale => _platformResolvedLocale;
-  Locale? _platformResolvedLocale;
-
   /// Performs the platform-native locale resolution.
   ///
   /// Each platform may return different results.

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -224,19 +224,6 @@ void Window::UpdateLocales(const std::vector<std::string>& locales) {
       }));
 }
 
-void Window::UpdatePlatformResolvedLocale(
-    const std::vector<std::string>& locale) {
-  std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
-    return;
-  tonic::DartState::Scope scope(dart_state);
-  tonic::LogIfError(tonic::DartInvokeField(
-      library_.value(), "_updatePlatformResolvedLocale",
-      {
-          tonic::ToDart<std::vector<std::string>>(locale),
-      }));
-}
-
 void Window::UpdateUserSettingsData(const std::string& data) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
   if (!dart_state)

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -78,7 +78,6 @@ class Window final {
   void DidCreateIsolate();
   void UpdateWindowMetrics(const ViewportMetrics& metrics);
   void UpdateLocales(const std::vector<std::string>& locales);
-  void UpdatePlatformResolvedLocale(const std::vector<std::string>& locale);
   void UpdateUserSettingsData(const std::string& data);
   void UpdateLifecycleState(const std::string& data);
   void UpdateSemanticsEnabled(bool enabled);

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -303,10 +303,6 @@ class EngineWindow extends ui.Window {
     return locales;
   }
 
-  /// On the web "platform" is the browser, so it's the same as [locale].
-  @override
-  ui.Locale get platformResolvedLocale => locale;
-
   /// Engine code should use this method instead of the callback directly.
   /// Otherwise zones won't work properly.
   void invokeOnLocaleChanged() {

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -604,18 +604,6 @@ abstract class Window {
   ///    observe when this value changes.
   List<Locale>? get locales;
 
-  /// The locale that the platform's native locale resolution system resolves to.
-  ///
-  /// This value may differ between platforms and is meant to allow flutter locale
-  /// resolution algorithms to into resolving consistently with other apps on the
-  /// device.
-  ///
-  /// This value may be used in a custom [localeListResolutionCallback] or used directly
-  /// in order to arrive at the most appropriate locale for the app.
-  ///
-  /// See [locales], which is the list of locales the user/device prefers.
-  Locale? get platformResolvedLocale;
-
   /// Performs the platform-native locale resolution.
   ///
   /// Each platform may return different results.

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -131,8 +131,6 @@ std::unique_ptr<RuntimeController> RuntimeController::Clone() const {
 bool RuntimeController::FlushRuntimeStateToIsolate() {
   return SetViewportMetrics(window_data_.viewport_metrics) &&
          SetLocales(window_data_.locale_data) &&
-         SetPlatformResolvedLocale(
-             window_data_.platform_resolved_locale_data) &&
          SetSemanticsEnabled(window_data_.semantics_enabled) &&
          SetAccessibilityFeatures(window_data_.accessibility_feature_flags_) &&
          SetUserSettingsData(window_data_.user_settings_data) &&
@@ -155,18 +153,6 @@ bool RuntimeController::SetLocales(
 
   if (auto* window = GetWindowIfAvailable()) {
     window->UpdateLocales(locale_data);
-    return true;
-  }
-
-  return false;
-}
-
-bool RuntimeController::SetPlatformResolvedLocale(
-    const std::vector<std::string>& locale_data) {
-  window_data_.platform_resolved_locale_data = locale_data;
-
-  if (auto* window = GetWindowIfAvailable()) {
-    window->UpdatePlatformResolvedLocale(locale_data);
     return true;
   }
 

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -162,23 +162,6 @@ class RuntimeController final : public WindowClient {
   bool SetLocales(const std::vector<std::string>& locale_data);
 
   //----------------------------------------------------------------------------
-  /// @brief      Forward the specified locale data to the running isolate. If
-  ///             the isolate is not running, this data will be saved and
-  ///             flushed to the isolate when it starts running.
-  ///
-  ///
-  /// @deprecated The persistent isolate data must be used for this purpose
-  ///             instead.
-  ///
-  /// @param[in]  locale_data  The locale data. This should consist of a vector
-  ///             of 4 strings, representing languageCode, contryCode,
-  ///             scriptCode, and variant of the locale.
-  ///
-  /// @return     If the locale data was forwarded to the running isolate.
-  ///
-  bool SetPlatformResolvedLocale(const std::vector<std::string>& locale_data);
-
-  //----------------------------------------------------------------------------
   /// @brief      Forward the user settings data to the running isolate. If the
   ///             isolate is not running, this data will be saved and flushed to
   ///             the isolate when it starts running.

--- a/runtime/window_data.h
+++ b/runtime/window_data.h
@@ -36,7 +36,6 @@ struct WindowData {
   std::string script_code;
   std::string variant_code;
   std::vector<std::string> locale_data;
-  std::vector<std::string> platform_resolved_locale_data;
   std::string user_settings_data = "{}";
   std::string lifecycle_state;
   bool semantics_enabled = false;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -388,24 +388,6 @@ bool Engine::HandleLocalizationPlatformMessage(PlatformMessage* message) {
     }
 
     return runtime_controller_->SetLocales(locale_data);
-  } else if (method->value == "setPlatformResolvedLocale") {
-    // Decode and pass the single locale data onwards to dart.
-    auto args = root.FindMember("args");
-    if (args == root.MemberEnd() || !args->value.IsArray())
-      return false;
-
-    if (args->value.Size() != strings_per_locale)
-      return false;
-
-    std::vector<std::string> locale_data;
-    if (!args->value[0].IsString() || !args->value[1].IsString())
-      return false;
-    locale_data.push_back(args->value[0].GetString());
-    locale_data.push_back(args->value[1].GetString());
-    locale_data.push_back(args->value[2].GetString());
-    locale_data.push_back(args->value[3].GetString());
-
-    return runtime_controller_->SetPlatformResolvedLocale(locale_data);
   }
   return false;
 }

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
@@ -48,20 +48,4 @@ public class LocalizationChannel {
     }
     channel.invokeMethod("setLocale", data);
   }
-
-  /** Send the given {@code platformResolvedLocale} to Dart. */
-  public void sendPlatformResolvedLocales(Locale platformResolvedLocale) {
-    Log.v(TAG, "Sending Locales to Flutter.");
-    // Send platformResolvedLocale first as it may be used in the callback
-    // triggered by the user supported locales being updated/set.
-    if (platformResolvedLocale != null) {
-      List<String> platformResolvedLocaleData = new ArrayList<>();
-      platformResolvedLocaleData.add(platformResolvedLocale.getLanguage());
-      platformResolvedLocaleData.add(platformResolvedLocale.getCountry());
-      platformResolvedLocaleData.add(
-          Build.VERSION.SDK_INT >= 21 ? platformResolvedLocale.getScript() : "");
-      platformResolvedLocaleData.add(platformResolvedLocale.getVariant());
-      channel.invokeMethod("setPlatformResolvedLocale", platformResolvedLocaleData);
-    }
-  }
 }

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/LocalizationInitializationTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/LocalizationInitializationTest.m
@@ -33,10 +33,6 @@ FLUTTER_ASSERT_ARC
   XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:timeout]);
 
   [textInputSemanticsObject tap];
-
-  // [NSLocale currentLocale] always includes a country code.
-  textInputSemanticsObject = [self.application.textFields matchingIdentifier:@"en_US"].element;
-  XCTAssertTrue([textInputSemanticsObject waitForExistenceWithTimeout:timeout]);
 }
 
 @end

--- a/testing/scenario_app/lib/src/locale_initialization.dart
+++ b/testing/scenario_app/lib/src/locale_initialization.dart
@@ -78,7 +78,7 @@ class LocaleInitialization extends Scenario {
     String label;
     switch(_tapCount) {
       case 1: {
-        label = window.platformResolvedLocale.toString();
+        // Set label to string data we wish to pass on first frame.
         break;
       }
       // Expand for other test cases.


### PR DESCRIPTION
The method channel on-startup platform resolved locale introduced in https://github.com/flutter/engine/pull/17755 has been replaced by the direct JNI call added in https://github.com/flutter/engine/pull/18645. The old call can be removed.

This was never exposed/fully implemented and should be safe to remove.