### PR TITLE
Creates a new RenderMode for FlutterView

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -690,6 +690,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/Flutt
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterEngineProvider.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterSplashView.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -138,6 +138,7 @@ android_java_sources = [
   "io/flutter/embedding/android/FlutterEngineProvider.java",
   "io/flutter/embedding/android/FlutterFragment.java",
   "io/flutter/embedding/android/FlutterFragmentActivity.java",
+  "io/flutter/embedding/android/FlutterImageView.java",
   "io/flutter/embedding/android/FlutterSplashView.java",
   "io/flutter/embedding/android/FlutterSurfaceView.java",
   "io/flutter/embedding/android/FlutterTextureView.java",

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -5,6 +5,7 @@
 package io.flutter.embedding.android;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -13,11 +14,9 @@ import android.hardware.HardwareBuffer;
 import android.media.Image;
 import android.media.Image.Plane;
 import android.media.ImageReader;
-import android.os.Build;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import android.annotation.TargetApi;
 
 /**
  * Paints a Flutter UI provided by an {@link android.media.ImageReader} onto a {@link

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -32,7 +32,7 @@ import android.annotation.TargetApi;
  * onDraw}.
  */
 @SuppressLint("ViewConstructor")
-@TargetApi(Build.VERSION_CODES.KITKAT)
+@TargetApi(19)
 public class FlutterImageView extends View {
   private final ImageReader imageReader;
   @Nullable private Image nextImage;
@@ -48,7 +48,7 @@ public class FlutterImageView extends View {
   }
 
   /** Acquires the next image to be drawn to the {@link android.graphics.Canvas}. */
-  @TargetApi(Build.VERSION_CODES.KITKAT)
+  @TargetApi(19)
   public void acquireLatestImage() {
     nextImage = imageReader.acquireLatestImage();
     invalidate();
@@ -67,14 +67,14 @@ public class FlutterImageView extends View {
     currentImage = nextImage;
     nextImage = null;
 
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+    if (android.os.Build.VERSION.SDK_INT >= 29) {
       drawImageBuffer(canvas);
     }
 
     drawImagePlane(canvas);
   }
 
-  @TargetApi(Build.VERSION_CODES.Q)
+  @TargetApi(29)
   private void drawImageBuffer(@NonNull Canvas canvas) {
     final HardwareBuffer buffer = currentImage.getHardwareBuffer();
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -68,9 +68,9 @@ public class FlutterImageView extends View {
 
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
       drawImageBuffer(canvas);
-    } else if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-      drawImagePlane(canvas);
     }
+
+    drawImagePlane(canvas);
   }
 
   @RequiresApi(api = Build.VERSION_CODES.P)

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -14,17 +14,18 @@ import android.media.Image.Plane;
 import android.media.ImageReader;
 import android.os.Build;
 import android.view.View;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
 /**
  * Paints a Flutter UI provided by an {@link android.media.ImageReader} onto a {@link
  * android.graphics.Canvas}.
- * 
+ *
  * <p>A {@code FlutterImageView} is intended for situations where a developer needs to render a
  * Flutter UI, but also needs to render an interactive {@link
  * io.flutter.plugin.platform.PlatformView}.
- * 
+ *
  * <p>This {@code View} takes an {@link android.media.ImageReader} that provides the Flutter UI
  * in an {@link android.media.Image} and renders it to the {@link android.graphics.Canvas} in
  * {@code onDraw}.
@@ -39,7 +40,7 @@ public class FlutterImageView extends View {
    * Constructs a {@code FlutterImageView} with an {@link android.media.ImageReader} that provides
    * the Flutter UI.
    */
-  public FlutterImageView(@Nonnull Context context, @Nonnull ImageReader imageReader) {
+  public FlutterImageView(@NonNull Context context, @NonNull ImageReader imageReader) {
     super(context, null);
     this.imageReader = imageReader;
   }
@@ -73,7 +74,7 @@ public class FlutterImageView extends View {
   }
 
   @RequiresApi(api = Build.VERSION_CODES.P)
-  private void drawImageBuffer(@Nonnull Canvas canvas) {
+  private void drawImageBuffer(@NonNull Canvas canvas) {
     final HardwareBuffer buffer = currentImage.getHardwareBuffer();
 
     final Bitmap bitmap = Bitmap.wrapHardwareBuffer(
@@ -82,7 +83,7 @@ public class FlutterImageView extends View {
     canvas.drawBitmap(bitmap, 0, 0, null);
   }
 
-  private void drawImagePlane(@Nonnull Canvas canvas) {
+  private void drawImagePlane(@NonNull Canvas canvas) {
     if (currentImage == null) {
       return;
     }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -4,7 +4,18 @@
 
 package io.flutter.embedding.android;
 
-impo
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.ColorSpace;
+import android.hardware.HardwareBuffer;
+import android.media.Image;
+import android.media.Image.Plane;
+import android.media.ImageReader;
+import android.os.Build;
+import android.view.View;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 
 class FlutterImageView extends View implements RenderSurface {
   private final ImageReader imageReader;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -16,7 +16,7 @@ import android.os.Build;
 import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
+import android.annotation.TargetApi;
 
 /**
  * Paints a Flutter UI provided by an {@link android.media.ImageReader} onto a {@link
@@ -30,7 +30,7 @@ import androidx.annotation.RequiresApi;
  * an {@link android.media.Image} and renders it to the {@link android.graphics.Canvas} in {@code
  * onDraw}.
  */
-@RequiresApi(api = Build.VERSION_CODES.KITKAT)
+@TargetApi(api = Build.VERSION_CODES.K)
 public class FlutterImageView extends View {
   private final ImageReader imageReader;
   @Nullable private Image nextImage;
@@ -46,6 +46,7 @@ public class FlutterImageView extends View {
   }
 
   /** Acquires the next image to be drawn to the {@link android.graphics.Canvas}. */
+  @TargetApi(api = Build.VERSION_CODES.KITKAT)
   public void acquireLatestImage() {
     nextImage = imageReader.acquireLatestImage();
     invalidate();
@@ -71,7 +72,7 @@ public class FlutterImageView extends View {
     drawImagePlane(canvas);
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.P)
+  @TargetApi(api = Build.VERSION_CODES.P)
   private void drawImageBuffer(@NonNull Canvas canvas) {
     final HardwareBuffer buffer = currentImage.getHardwareBuffer();
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -67,14 +67,14 @@ public class FlutterImageView extends View {
     currentImage = nextImage;
     nextImage = null;
 
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+    if (29) {
       drawImageBuffer(canvas);
     }
 
     drawImagePlane(canvas);
   }
 
-  @TargetApi(Build.VERSION_CODES.Q)
+  @TargetApi(29)
   private void drawImageBuffer(@NonNull Canvas canvas) {
     final HardwareBuffer buffer = currentImage.getHardwareBuffer();
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -67,14 +67,14 @@ public class FlutterImageView extends View {
     currentImage = nextImage;
     nextImage = null;
 
-    if (29) {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
       drawImageBuffer(canvas);
     }
 
     drawImagePlane(canvas);
   }
 
-  @TargetApi(29)
+  @TargetApi(Build.VERSION_CODES.Q)
   private void drawImageBuffer(@NonNull Canvas canvas) {
     final HardwareBuffer buffer = currentImage.getHardwareBuffer();
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -26,9 +26,9 @@ import androidx.annotation.RequiresApi;
  * Flutter UI, but also needs to render an interactive {@link
  * io.flutter.plugin.platform.PlatformView}.
  *
- * <p>This {@code View} takes an {@link android.media.ImageReader} that provides the Flutter UI
- * in an {@link android.media.Image} and renders it to the {@link android.graphics.Canvas} in
- * {@code onDraw}.
+ * <p>This {@code View} takes an {@link android.media.ImageReader} that provides the Flutter UI in
+ * an {@link android.media.Image} and renders it to the {@link android.graphics.Canvas} in {@code
+ * onDraw}.
  */
 @RequiresApi(api = Build.VERSION_CODES.KITKAT)
 public class FlutterImageView extends View {
@@ -45,9 +45,7 @@ public class FlutterImageView extends View {
     this.imageReader = imageReader;
   }
 
-  /**
-   * Acquires the next image to be drawn to the {@link android.graphics.Canvas}.
-   */
+  /** Acquires the next image to be drawn to the {@link android.graphics.Canvas}. */
   public void acquireLatestImage() {
     nextImage = imageReader.acquireLatestImage();
     invalidate();
@@ -77,9 +75,7 @@ public class FlutterImageView extends View {
   private void drawImageBuffer(@NonNull Canvas canvas) {
     final HardwareBuffer buffer = currentImage.getHardwareBuffer();
 
-    final Bitmap bitmap = Bitmap.wrapHardwareBuffer(
-        buffer,
-        ColorSpace.get(ColorSpace.Named.SRGB));
+    final Bitmap bitmap = Bitmap.wrapHardwareBuffer(buffer, ColorSpace.get(ColorSpace.Named.SRGB));
     canvas.drawBitmap(bitmap, 0, 0, null);
   }
 
@@ -97,10 +93,9 @@ public class FlutterImageView extends View {
     final int desiredWidth = imagePlane.getRowStride() / imagePlane.getPixelStride();
     final int desiredHeight = currentImage.getHeight();
 
-    final Bitmap bitmap = android.graphics.Bitmap.createBitmap(
-      desiredWidth,
-      desiredHeight,
-      android.graphics.Bitmap.Config.ARGB_8888);
+    final Bitmap bitmap =
+        android.graphics.Bitmap.createBitmap(
+            desiredWidth, desiredHeight, android.graphics.Bitmap.Config.ARGB_8888);
 
     bitmap.copyPixelsFromBuffer(imagePlane.getBuffer());
     canvas.drawBitmap(bitmap, 0, 0, null);

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -17,23 +17,41 @@ import android.view.View;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
-class FlutterImageView extends View implements RenderSurface {
+/**
+ * Paints a Flutter UI provided by an {@link android.media.ImageReader} onto a {@link
+ * android.graphics.Canvas}.
+ * 
+ * <p>A {@code FlutterImageView} is intended for situations where a developer needs to render a
+ * Flutter UI, but also needs to render an interactive {@link
+ * io.flutter.plugin.platform.PlatformView}.
+ * 
+ * <p>This {@code View} takes an {@link android.media.ImageReader} that provides the Flutter UI
+ * in an {@link android.media.Image} and renders it to the {@link android.graphics.Canvas} in
+ * {@code onDraw}.
+ */
+@RequiresApi(api = Build.VERSION_CODES.KITKAT)
+public class FlutterImageView extends View {
   private final ImageReader imageReader;
   @Nullable private Image nextImage;
-  private Image currentImage;
+  @Nullable private Image currentImage;
 
-  public FlutterImageView(Context context, ImageReader imageReader) {
+  /**
+   * Constructs a {@code FlutterImageView} with an {@link android.media.ImageReader} that provides
+   * the Flutter UI.
+   */
+  public FlutterImageView(@Nonnull Context context, @Nonnull ImageReader imageReader) {
     super(context, null);
     this.imageReader = imageReader;
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+  /**
+   * Acquires the next image to be drawn to the {@link android.graphics.Canvas}.
+   */
   public void acquireLatestImage() {
     nextImage = imageReader.acquireLatestImage();
     invalidate();
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.P)
   @Override
   protected void onDraw(Canvas canvas) {
     super.onDraw(canvas);
@@ -41,7 +59,9 @@ class FlutterImageView extends View implements RenderSurface {
       return;
     }
 
-    currentImage.close();
+    if (currentImage != null) {
+      currentImage.close();
+    }
     currentImage = nextImage;
     nextImage = null;
 
@@ -53,7 +73,7 @@ class FlutterImageView extends View implements RenderSurface {
   }
 
   @RequiresApi(api = Build.VERSION_CODES.P)
-  private void drawImageBuffer(Canvas canvas) {
+  private void drawImageBuffer(@Nonnull Canvas canvas) {
     final HardwareBuffer buffer = currentImage.getHardwareBuffer();
 
     final Bitmap bitmap = Bitmap.wrapHardwareBuffer(
@@ -62,8 +82,7 @@ class FlutterImageView extends View implements RenderSurface {
     canvas.drawBitmap(bitmap, 0, 0, null);
   }
 
-  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
-  private void drawImagePlane(Canvas canvas) {
+  private void drawImagePlane(@Nonnull Canvas canvas) {
     if (currentImage == null) {
       return;
     }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -1,0 +1,77 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.embedding.android;
+
+impo
+
+class FlutterImageView extends View implements RenderSurface {
+  private final ImageReader imageReader;
+  @Nullable private Image nextImage;
+  private Image currentImage;
+
+  public FlutterImageView(Context context, ImageReader imageReader) {
+    super(context, null);
+    this.imageReader = imageReader;
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+  public void acquireLatestImage() {
+    nextImage = imageReader.acquireLatestImage();
+    invalidate();
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.P)
+  @Override
+  protected void onDraw(Canvas canvas) {
+    super.onDraw(canvas);
+    if (nextImage == null) {
+      return;
+    }
+
+    currentImage.close();
+    currentImage = nextImage;
+    nextImage = null;
+
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+      drawImageBuffer(canvas);
+    } else if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+      drawImagePlane(canvas);
+    }
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.P)
+  private void drawImageBuffer(Canvas canvas) {
+    final HardwareBuffer buffer = currentImage.getHardwareBuffer();
+
+    final Bitmap bitmap = Bitmap.wrapHardwareBuffer(
+        buffer,
+        ColorSpace.get(ColorSpace.Named.SRGB));
+    canvas.drawBitmap(bitmap, 0, 0, null);
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+  private void drawImagePlane(Canvas canvas) {
+    if (currentImage == null) {
+      return;
+    }
+
+    final Plane[] imagePlanes = currentImage.getPlanes();
+    if (imagePlanes.length != 1) {
+      return;
+    }
+
+    final Plane imagePlane = imagePlanes[0];
+    final int desiredWidth = imagePlane.getRowStride() / imagePlane.getPixelStride();
+    final int desiredHeight = currentImage.getHeight();
+
+    final Bitmap bitmap = android.graphics.Bitmap.createBitmap(
+      desiredWidth,
+      desiredHeight,
+      android.graphics.Bitmap.Config.ARGB_8888);
+
+    bitmap.copyPixelsFromBuffer(imagePlane.getBuffer());
+    canvas.drawBitmap(bitmap, 0, 0, null);
+  }
+}

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -4,6 +4,7 @@
 
 package io.flutter.embedding.android;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
@@ -30,6 +31,7 @@ import android.annotation.TargetApi;
  * an {@link android.media.Image} and renders it to the {@link android.graphics.Canvas} in {@code
  * onDraw}.
  */
+@SuppressLint("ViewConstructor")
 @TargetApi(Build.VERSION_CODES.KITKAT)
 public class FlutterImageView extends View {
   private final ImageReader imageReader;
@@ -65,7 +67,7 @@ public class FlutterImageView extends View {
     currentImage = nextImage;
     nextImage = null;
 
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
       drawImageBuffer(canvas);
     }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -68,6 +68,7 @@ public class FlutterImageView extends View {
 
     if (android.os.Build.VERSION.SDK_INT >= 29) {
       drawImageBuffer(canvas);
+      return;
     }
 
     drawImagePlane(canvas);

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -30,7 +30,7 @@ import android.annotation.TargetApi;
  * an {@link android.media.Image} and renders it to the {@link android.graphics.Canvas} in {@code
  * onDraw}.
  */
-@TargetApi(api = Build.VERSION_CODES.K)
+@TargetApi(Build.VERSION_CODES.KITKAT)
 public class FlutterImageView extends View {
   private final ImageReader imageReader;
   @Nullable private Image nextImage;
@@ -46,7 +46,7 @@ public class FlutterImageView extends View {
   }
 
   /** Acquires the next image to be drawn to the {@link android.graphics.Canvas}. */
-  @TargetApi(api = Build.VERSION_CODES.KITKAT)
+  @TargetApi(Build.VERSION_CODES.KITKAT)
   public void acquireLatestImage() {
     nextImage = imageReader.acquireLatestImage();
     invalidate();
@@ -72,7 +72,7 @@ public class FlutterImageView extends View {
     drawImagePlane(canvas);
   }
 
-  @TargetApi(api = Build.VERSION_CODES.P)
+  @TargetApi(Build.VERSION_CODES.Q)
   private void drawImageBuffer(@NonNull Canvas canvas) {
     final HardwareBuffer buffer = currentImage.getHardwareBuffer();
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -228,8 +228,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
    * <p>{@code FlutterView} requires an {@code Activity} instead of a generic {@code Context} to be
    * compatible with {@link PlatformViewsController}.
    */
-  public FlutterView(@NonNull Context context, @NonNull FlutterSurfaceView flutterSurfaceView) {
-    this(context, null, flutterSurfaceView);
+  public FlutterView(@NonNull Context context, @NonNull FlutterImageView flutterImageView) {
+    this(context, null, flutterImageView);
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -79,6 +79,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   // Internal view hierarchy references.
   @Nullable private FlutterSurfaceView flutterSurfaceView;
   @Nullable private FlutterTextureView flutterTextureView;
+  @Nullable private FlutterImageView flutterImageView;
   @Nullable private RenderSurface renderSurface;
   private final Set<FlutterUiDisplayListener> flutterUiDisplayListeners = new HashSet<>();
   private boolean isFlutterUiDisplayed;
@@ -155,7 +156,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
 
   /**
    * Deprecated - use {@link #FlutterView(Context, FlutterSurfaceView)} or {@link
-   * #FlutterView(Context, FlutterTextureView)} instead.
+   * #FlutterView(Context, FlutterTextureView)} or {@link
+   * #FlutterView(Context, FlutterImageView)} instead.
    */
   @Deprecated
   public FlutterView(@NonNull Context context, @NonNull RenderMode renderMode) {
@@ -164,9 +166,12 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     if (renderMode == RenderMode.surface) {
       flutterSurfaceView = new FlutterSurfaceView(context);
       renderSurface = flutterSurfaceView;
-    } else {
+    } else if (renderMode == RenderMode.texture) {
       flutterTextureView = new FlutterTextureView(context);
       renderSurface = flutterTextureView;
+    } else {
+      throw new IllegalArgumentException(String.format("RenderMode not supported with this constructor: ",
+       renderMode));
     }
 
     init();
@@ -217,6 +222,17 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
+   * Constructs a {@code FlutterView} programmatically, without any XML attributes, uses the given
+   * {@link FlutterImageView} to render the Flutter UI.
+   *
+   * <p>{@code FlutterView} requires an {@code Activity} instead of a generic {@code Context} to be
+   * compatible with {@link PlatformViewsController}.
+   */
+  public FlutterView(@NonNull Context context, @NonNull FlutterSurfaceView flutterSurfaceView) {
+    this(context, null, flutterSurfaceView);
+  }
+
+  /**
    * Constructs a {@code FlutterView} in an XML-inflation-compliant manner.
    *
    * <p>{@code FlutterView} requires an {@code Activity} instead of a generic {@code Context} to be
@@ -243,9 +259,12 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
       flutterSurfaceView =
           new FlutterSurfaceView(context, transparencyMode == TransparencyMode.transparent);
       renderSurface = flutterSurfaceView;
-    } else {
+    } else if (renderMode == RenderMode.texture){
       flutterTextureView = new FlutterTextureView(context);
       renderSurface = flutterTextureView;
+    } else {
+      throw new IllegalArgumentException(String.format("RenderMode not supported with this constructor: ",
+       renderMode));
     }
 
     init();
@@ -275,15 +294,29 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     init();
   }
 
+  private FlutterView(
+      @NonNull Context context,
+      @Nullable AttributeSet attrs,
+      @NonNull FlutterImageView flutterImageView) {
+    super(context, attrs);
+
+    this.flutterImageView = flutterImageView;
+
+    init();
+  }
+
   private void init() {
     Log.v(TAG, "Initializing FlutterView");
 
     if (flutterSurfaceView != null) {
       Log.v(TAG, "Internally using a FlutterSurfaceView.");
       addView(flutterSurfaceView);
-    } else {
+    } else if (flutterTextureView != null) {
       Log.v(TAG, "Internally using a FlutterTextureView.");
       addView(flutterTextureView);
+    } else {
+      Log.v(TAG, "Internally using a FlutterImageView.");
+      addView(flutterImageView);
     }
 
     // FlutterView needs to be focusable so that the InputMethodManager can interact with it.
@@ -1018,7 +1051,17 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
      * android.graphics.SurfaceTexture} are required, developers should strongly prefer the {@link
      * RenderMode#surface} render mode.
      */
-    texture
+    texture,
+    /**
+     * {@code RenderMode}, which paints Paints a Flutter UI provided by an {@link
+     * android.media.ImageReader} onto a {@link android.graphics.Canvas}.
+     * This mode is not as performant as {@link RenderMode#surface}, but a {@code FlutterView} in
+     * this mode can handle full interactivity with a {@link
+     * io.flutter.plugin.platform.PlatformView}. Unless {@link
+     * io.flutter.plugin.platform.PlatformView}s are required developers should strongly prefer
+     * the {@link RenderMode#surface} render mode.
+     */
+    image
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -156,8 +156,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
 
   /**
    * Deprecated - use {@link #FlutterView(Context, FlutterSurfaceView)} or {@link
-   * #FlutterView(Context, FlutterTextureView)} or {@link
-   * #FlutterView(Context, FlutterImageView)} instead.
+   * #FlutterView(Context, FlutterTextureView)} or {@link #FlutterView(Context, FlutterImageView)}
+   * instead.
    */
   @Deprecated
   public FlutterView(@NonNull Context context, @NonNull RenderMode renderMode) {
@@ -170,8 +170,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
       flutterTextureView = new FlutterTextureView(context);
       renderSurface = flutterTextureView;
     } else {
-      throw new IllegalArgumentException(String.format("RenderMode not supported with this constructor: ",
-       renderMode));
+      throw new IllegalArgumentException(
+          String.format("RenderMode not supported with this constructor: ", renderMode));
     }
 
     init();
@@ -259,12 +259,12 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
       flutterSurfaceView =
           new FlutterSurfaceView(context, transparencyMode == TransparencyMode.transparent);
       renderSurface = flutterSurfaceView;
-    } else if (renderMode == RenderMode.texture){
+    } else if (renderMode == RenderMode.texture) {
       flutterTextureView = new FlutterTextureView(context);
       renderSurface = flutterTextureView;
     } else {
-      throw new IllegalArgumentException(String.format("RenderMode not supported with this constructor: ",
-       renderMode));
+      throw new IllegalArgumentException(
+          String.format("RenderMode not supported with this constructor: ", renderMode));
     }
 
     init();
@@ -1054,12 +1054,11 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     texture,
     /**
      * {@code RenderMode}, which paints Paints a Flutter UI provided by an {@link
-     * android.media.ImageReader} onto a {@link android.graphics.Canvas}.
-     * This mode is not as performant as {@link RenderMode#surface}, but a {@code FlutterView} in
-     * this mode can handle full interactivity with a {@link
-     * io.flutter.plugin.platform.PlatformView}. Unless {@link
-     * io.flutter.plugin.platform.PlatformView}s are required developers should strongly prefer
-     * the {@link RenderMode#surface} render mode.
+     * android.media.ImageReader} onto a {@link android.graphics.Canvas}. This mode is not as
+     * performant as {@link RenderMode#surface}, but a {@code FlutterView} in this mode can handle
+     * full interactivity with a {@link io.flutter.plugin.platform.PlatformView}. Unless {@link
+     * io.flutter.plugin.platform.PlatformView}s are required developers should strongly prefer the
+     * {@link RenderMode#surface} render mode.
      */
     image
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -228,6 +228,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
    * <p>{@code FlutterView} requires an {@code Activity} instead of a generic {@code Context} to be
    * compatible with {@link PlatformViewsController}.
    */
+  @TargetApi(19)
   public FlutterView(@NonNull Context context, @NonNull FlutterImageView flutterImageView) {
     this(context, null, flutterImageView);
   }
@@ -294,6 +295,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     init();
   }
 
+  @TargetApi(19)
   private FlutterView(
       @NonNull Context context,
       @Nullable AttributeSet attrs,

--- a/shell/platform/android/io/flutter/embedding/android/RenderMode.java
+++ b/shell/platform/android/io/flutter/embedding/android/RenderMode.java
@@ -21,5 +21,15 @@ public enum RenderMode {
    * Views}. Unless the special capabilities of a {@link android.graphics.SurfaceTexture} are
    * required, developers should strongly prefer the {@link #surface} render mode.
    */
-  texture
+  texture,
+  /**
+   * {@code RenderMode}, which paints Paints a Flutter UI provided by an {@link
+   * android.media.ImageReader} onto a {@link android.graphics.Canvas}.
+   * This mode is not as performant as {@link RenderMode#surface}, but a {@code FlutterView} in
+   * this mode can handle full interactivity with a {@link
+   * io.flutter.plugin.platform.PlatformView}. Unless {@link
+   * io.flutter.plugin.platform.PlatformView}s are required developers should strongly prefer
+   * the {@link RenderMode#surface} render mode.
+   */
+  image
 }

--- a/shell/platform/android/io/flutter/embedding/android/RenderMode.java
+++ b/shell/platform/android/io/flutter/embedding/android/RenderMode.java
@@ -24,12 +24,11 @@ public enum RenderMode {
   texture,
   /**
    * {@code RenderMode}, which paints Paints a Flutter UI provided by an {@link
-   * android.media.ImageReader} onto a {@link android.graphics.Canvas}.
-   * This mode is not as performant as {@link RenderMode#surface}, but a {@code FlutterView} in
-   * this mode can handle full interactivity with a {@link
-   * io.flutter.plugin.platform.PlatformView}. Unless {@link
-   * io.flutter.plugin.platform.PlatformView}s are required developers should strongly prefer
-   * the {@link RenderMode#surface} render mode.
+   * android.media.ImageReader} onto a {@link android.graphics.Canvas}. This mode is not as
+   * performant as {@link RenderMode#surface}, but a {@code FlutterView} in this mode can handle
+   * full interactivity with a {@link io.flutter.plugin.platform.PlatformView}. Unless {@link
+   * io.flutter.plugin.platform.PlatformView}s are required developers should strongly prefer the
+   * {@link RenderMode#surface} render mode.
    */
   image
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -12,6 +12,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.media.ImageReader;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
@@ -34,7 +35,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import android.media.ImageReader;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
@@ -53,16 +53,6 @@ public class FlutterViewTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(mockFlutterJni.isAttached()).thenReturn(true);
-  }
-
-  @Test
-  public void imageView_test() {
-    final ImageReader mockReader = mock(ImageReader.class);
-    final FlutterImageView imageView = spy(new FlutterImageView(RuntimeEnvironment.application, mockReader));
-
-    imageView.acquireLatestImage();
-    verify(mockReader, times(1)).acquireLatestImage();
-    verify(imageView, times(1)).invalidate();
   }
 
   @Test
@@ -379,6 +369,17 @@ public class FlutterViewTest {
     // Left padding is zero because the rotation is 270deg
     assertEquals(0, viewportMetricsCaptor.getValue().paddingLeft);
     assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
+  }
+
+  @Test
+  public void flutterImageView_acquiresImageAndInvalidates() {
+    final ImageReader mockReader = mock(ImageReader.class);
+    final FlutterImageView imageView =
+        spy(new FlutterImageView(RuntimeEnvironment.application, mockReader));
+
+    imageView.acquireLatestImage();
+    verify(mockReader, times(1)).acquireLatestImage();
+    verify(imageView, times(1)).invalidate();
   }
 
   /*

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -55,6 +55,16 @@ public class FlutterViewTest {
   }
 
   @Test
+  public void imageView_test() {
+    final ImageReader mockReader = mock(ImageReader.class);
+    final FlutterImageView imageView = spy(new FlutterImageView(RuntimeEnvironment.application, mockReader));
+
+    imageView.acquireLatestImage();
+    verify(mockReader, times(1)).acquireLatestImage();
+    verify(imageView, times(1)).invalidate();
+  }
+
+  @Test
   public void attachToFlutterEngine_alertsPlatformViews() {
     FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
     FlutterEngine flutterEngine =

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -34,6 +34,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import android.media.ImageReader;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;


### PR DESCRIPTION
## Description

Creates an image `RenderMode` that paints a Flutter UI provided by an `ImageReader` onto a `Canvas`. This is needed for hybrid platform views on Android.

Since this adds a new `RenderMode`, this slightly changes the behavior in a deprecated constructor that defaulted to `RenderMode.texture` if `RenderMode.surface` was not selected.  

## Related Issues

https://github.com/flutter/flutter/issues/58289

## Tests

I added the following tests:

This PR only creates a new `RenderMode`, but doesn't actually set it up to be used. This is part of a larger project to support hybrid views: https://github.com/flutter/flutter/projects/138

I added a trivial test to verify that a call to `FlutterImageView.acquireLatestImage` calls `ImageReader.acquireLatestImage()` and `invalidate()`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
