### PR TITLE
Removes --causal-async-stacks from rule dart_snapshot_aot

### DIFF
--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -138,7 +138,6 @@ template("dart_snapshot_aot") {
     ]
 
     args = [
-      "--causal_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(elf_object),


### PR DESCRIPTION
## Description
The --causal-async-stacks flag is in the process of being phased out in favour of --lazy-async-stack which will become the new default.

## Related Issues
https://github.com/dart-lang/sdk/issues/39525

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.