### PR TITLE
Enable firefox integration tests

### DIFF
--- a/lib/web_ui/dev/browser_lock.yaml
+++ b/lib/web_ui/dev/browser_lock.yaml
@@ -14,3 +14,7 @@ ios-safari:
   majorVersion: 13
   minorVersion: 5
   device: 'iPhone 11'
+## geckodriver is used for testing Firefox Browser. It works with multiple
+## Firefox Browser versions.
+## See: https://github.com/mozilla/geckodriver/releases
+geckodriver: 'v0.26.0'

--- a/lib/web_ui/dev/driver_manager.dart
+++ b/lib/web_ui/dev/driver_manager.dart
@@ -18,10 +18,11 @@ import 'utils.dart';
 
 /// [DriverManager] implementation for Chrome.
 ///
-/// This manager can be used for both MacOS and Linux.
+/// This manager can be used for both macOS and Linux.
 class ChromeDriverManager extends DriverManager {
   ChromeDriverManager(String browser) : super(browser);
 
+  @override
   Future<void> _installDriver() async {
     if (_browserDriverDir.existsSync()) {
       _browserDriverDir.deleteSync(recursive: true);
@@ -47,6 +48,7 @@ class ChromeDriverManager extends DriverManager {
   /// Throw an error if driver directory does not exists.
   ///
   /// Driver should already exist on LUCI as a CIPD package.
+  @override
   Future<void> _verifyDriverForLUCI() {
     if (!_browserDriverDir.existsSync()) {
       throw StateError('Failed to locate Chrome driver on LUCI on path:'
@@ -55,6 +57,7 @@ class ChromeDriverManager extends DriverManager {
     return Future<void>.value();
   }
 
+  @override
   Future<void> _startDriver(String driverPath) async {
     await startProcess('./chromedriver/chromedriver', ['--port=4444'],
         workingDirectory: driverPath);
@@ -64,13 +67,14 @@ class ChromeDriverManager extends DriverManager {
 
 /// [DriverManager] implementation for Firefox.
 ///
-/// This manager can be used for both MacOS and Linux.
+/// This manager can be used for both macOS and Linux.
 class FirefoxDriverManager extends DriverManager {
   FirefoxDriverManager(String browser) : super(browser);
 
   FirefoxDriverInstaller firefoxDriverInstaller =
-      FirefoxDriverInstaller(geckoDriverVersion: getLockedDeckoDriverVersion());
+      FirefoxDriverInstaller(geckoDriverVersion: getLockedGeckoDriverVersion());
 
+  @override
   Future<void> _installDriver() async {
     if (_browserDriverDir.existsSync()) {
       _browserDriverDir.deleteSync(recursive: true);
@@ -89,9 +93,10 @@ class FirefoxDriverManager extends DriverManager {
     }
   }
 
-  /// Throw an error if driver directory does not exists.
+  /// Throw an error if driver directory does not exist.
   ///
   /// Driver should already exist on LUCI as a CIPD package.
+  @override
   Future<void> _verifyDriverForLUCI() {
     if (!_browserDriverDir.existsSync()) {
       throw StateError('Failed to locate Firefox driver on LUCI on path:'
@@ -100,6 +105,7 @@ class FirefoxDriverManager extends DriverManager {
     return Future<void>.value();
   }
 
+  @override
   Future<void> _startDriver(String driverPath) async {
     await startProcess('./firefoxdriver/geckodriver', ['--port=4444'],
         workingDirectory: driverPath);
@@ -110,7 +116,7 @@ class FirefoxDriverManager extends DriverManager {
   ///
   /// For different versions of geckodriver. See:
   /// https://github.com/mozilla/geckodriver/releases
-  static String getLockedDeckoDriverVersion() {
+  static String getLockedGeckoDriverVersion() {
     final YamlMap browserLock = BrowserLock.instance.configuration;
     String geckoDriverReleaseVersion = browserLock['geckodriver'] as String;
     return geckoDriverReleaseVersion;
@@ -119,22 +125,25 @@ class FirefoxDriverManager extends DriverManager {
 
 /// [DriverManager] implementation for Safari.
 ///
-/// This manager is will only be created/used for MacOS.
+/// This manager is will only be created/used for macOS.
 class SafariDriverManager extends DriverManager {
   SafariDriverManager(String browser) : super(browser);
 
+  @override
   Future<void> _installDriver() {
     // No-op.
     // macOS comes with Safari Driver installed.
     return new Future<void>.value();
   }
 
+  @override
   Future<void> _verifyDriverForLUCI() {
     // No-op.
     // macOS comes with Safari Driver installed.
     return Future<void>.value();
   }
 
+  @override
   Future<void> _startDriver(String driverPath) async {
     final SafariDriverRunner safariDriverRunner = SafariDriverRunner();
 
@@ -200,7 +209,7 @@ abstract class DriverManager {
       return SafariDriverManager(browser);
     } else {
       throw StateError('Integration tests are only supported on Firefox, Chrome'
-          ' or on Safari (running on MacOS)');
+          ' and on Safari (running on macOS)');
     }
   }
 }

--- a/lib/web_ui/dev/driver_manager.dart
+++ b/lib/web_ui/dev/driver_manager.dart
@@ -7,7 +7,9 @@ import 'dart:io' as io;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as pathlib;
 import 'package:web_driver_installer/chrome_driver_installer.dart';
+import 'package:web_driver_installer/firefox_driver_installer.dart';
 import 'package:web_driver_installer/safari_driver_runner.dart';
+import 'package:yaml/yaml.dart';
 
 import 'chrome_installer.dart';
 import 'common.dart';
@@ -57,6 +59,61 @@ class ChromeDriverManager extends DriverManager {
     await startProcess('./chromedriver/chromedriver', ['--port=4444'],
         workingDirectory: driverPath);
     print('INFO: Driver started');
+  }
+}
+
+/// [DriverManager] implementation for Firefox.
+///
+/// This manager can be used for both MacOS and Linux.
+class FirefoxDriverManager extends DriverManager {
+  FirefoxDriverManager(String browser) : super(browser);
+
+  FirefoxDriverInstaller firefoxDriverInstaller =
+      FirefoxDriverInstaller(geckoDriverVersion: getLockedDeckoDriverVersion());
+
+  Future<void> _installDriver() async {
+    if (_browserDriverDir.existsSync()) {
+      _browserDriverDir.deleteSync(recursive: true);
+    }
+
+    _browserDriverDir.createSync(recursive: true);
+    temporaryDirectories.add(_drivers);
+
+    final io.Directory temp = io.Directory.current;
+    io.Directory.current = _browserDriverDir;
+
+    try {
+      await firefoxDriverInstaller.install(alwaysInstall: false);
+    } finally {
+      io.Directory.current = temp;
+    }
+  }
+
+  /// Throw an error if driver directory does not exists.
+  ///
+  /// Driver should already exist on LUCI as a CIPD package.
+  Future<void> _verifyDriverForLUCI() {
+    if (!_browserDriverDir.existsSync()) {
+      throw StateError('Failed to locate Firefox driver on LUCI on path:'
+          '${_browserDriverDir.path}');
+    }
+    return Future<void>.value();
+  }
+
+  Future<void> _startDriver(String driverPath) async {
+    await startProcess('./firefoxdriver/geckodriver', ['--port=4444'],
+        workingDirectory: driverPath);
+    print('INFO: Driver started');
+  }
+
+  /// Get the geckodriver version to be used with [FirefoxDriverInstaller].
+  ///
+  /// For different versions of geckodriver. See:
+  /// https://github.com/mozilla/geckodriver/releases
+  static String getLockedDeckoDriverVersion() {
+    final YamlMap browserLock = BrowserLock.instance.configuration;
+    String geckoDriverReleaseVersion = browserLock['geckodriver'] as String;
+    return geckoDriverReleaseVersion;
   }
 }
 
@@ -137,11 +194,13 @@ abstract class DriverManager {
   static DriverManager chooseDriver(String browser) {
     if (browser == 'chrome') {
       return ChromeDriverManager(browser);
+    } else if (browser == 'firefox') {
+      return FirefoxDriverManager(browser);
     } else if (browser == 'safari' && io.Platform.isMacOS) {
       return SafariDriverManager(browser);
     } else {
-      throw StateError('Integration tests are only supported on Chrome or '
-          'on Safari (running on MacOS)');
+      throw StateError('Integration tests are only supported on Firefox, Chrome'
+          ' or on Safari (running on MacOS)');
     }
   }
 }

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -15,7 +15,7 @@ import 'common.dart';
 import 'utils.dart';
 
 const String _unsupportedConfigurationWarning = 'WARNING: integration tests '
-    'are only supported on Chrome, Firefox or on Safari (running on MacOS)';
+    'are only supported on Chrome, Firefox and on Safari (running on macOS)';
 
 class IntegrationTestsManager {
   final String _browser;
@@ -285,7 +285,7 @@ class IntegrationTestsManager {
   /// Validate the given `browser`, `platform` combination is suitable for
   /// integration tests to run.
   bool validateIfTestsShouldRun() {
-    // Chrome tests should run at all Platforms (Linux, MacOS, Windows).
+    // Chrome tests should run at all Platforms (Linux, macOS, Windows).
     // They can also run successfully on CI and local.
     if (_browser == 'chrome') {
       return true;

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -14,8 +14,8 @@ import 'exceptions.dart';
 import 'common.dart';
 import 'utils.dart';
 
-const String _unsupportedConfigurationWarning = 'WARNING: integration '
-    'tests are only supported on Chrome or on Safari (running on MacOS)';
+const String _unsupportedConfigurationWarning = 'WARNING: integration tests '
+    'are only supported on Chrome, Firefox or on Safari (running on MacOS)';
 
 class IntegrationTestsManager {
   final String _browser;
@@ -289,6 +289,9 @@ class IntegrationTestsManager {
     // They can also run successfully on CI and local.
     if (_browser == 'chrome') {
       return true;
+    } else if (_browser == 'firefox' &&
+        (io.Platform.isLinux || io.Platform.isMacOS)) {
+      return true;
     } else if (_browser == 'safari' && io.Platform.isMacOS && !isLuci) {
       return true;
     } else {
@@ -306,6 +309,8 @@ abstract class IntegrationArguments {
   factory IntegrationArguments.fromBrowser(String browser) {
     if (browser == 'chrome') {
       return ChromeIntegrationArguments();
+    } else if (browser == 'firefox') {
+      return FirefoxIntegrationArguments();
     } else if (browser == 'safari' && io.Platform.isMacOS) {
       return SafariIntegrationArguments();
     } else {
@@ -344,6 +349,25 @@ class ChromeIntegrationArguments extends IntegrationArguments {
     }
     return statementToRun;
   }
+}
+
+/// Arguments to give `flutter drive` to run the integration tests on Firefox.
+class FirefoxIntegrationArguments extends IntegrationArguments {
+  List<String> getTestArguments(String testName, String mode) {
+    return <String>[
+      'drive',
+      '--target=test_driver/${testName}',
+      '-d',
+      'web-server',
+      '--$mode',
+      '--browser-name=firefox',
+      '--headless',
+      '--local-engine=host_debug_unopt',
+    ];
+  }
+
+  String getCommandToRun(String testName, String mode) =>
+      'flutter ${getTestArguments(testName, mode).join(' ')}';
 }
 
 /// Arguments to give `flutter drive` to run the integration tests on Safari.
@@ -396,5 +420,13 @@ const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
     'target_platform_ios_e2e.dart',
     'target_platform_android_e2e.dart',
     'image_loading_e2e.dart',
+  ],
+  'firefox-linux': [
+    'target_platform_ios_e2e.dart',
+    'target_platform_macos_e2e.dart',
+  ],
+  'firefox-macos': [
+    'target_platform_android_e2e.dart',
+    'target_platform_ios_e2e.dart',
   ],
 };

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -106,7 +106,7 @@ class TestCommand extends Command<bool> with ArgUtils {
       print('Running the unit tests only');
       return TestTypesRequested.unit;
     } else if (boolArg('integration-tests-only')) {
-      if (!isChrome && !isSafariOnMacOS) {
+      if (!isChrome && !isSafariOnMacOS && !isFirefox) {
         throw UnimplementedError(
             'Integration tests are only available on Chrome Desktop for now');
       }
@@ -132,7 +132,7 @@ class TestCommand extends Command<bool> with ArgUtils {
       case TestTypesRequested.all:
         // TODO(nurhan): https://github.com/flutter/flutter/issues/53322
         // TODO(nurhan): Expand browser matrix for felt integration tests.
-        if (runAllTests && (isChrome || isSafariOnMacOS)) {
+        if (runAllTests && (isChrome || isSafariOnMacOS || isFirefox)) {
           bool unitTestResult = await runUnitTests();
           bool integrationTestResult = await runIntegrationTests();
           if (integrationTestResult != unitTestResult) {
@@ -262,6 +262,9 @@ class TestCommand extends Command<bool> with ArgUtils {
 
   /// Whether [browser] is set to "chrome".
   bool get isChrome => browser == 'chrome';
+
+  /// Whether [browser] is set to "firefox".
+  bool get isFirefox => browser == 'firefox';
 
   /// Whether [browser] is set to "safari".
   bool get isSafariOnMacOS => browser == 'safari'

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -32,4 +32,4 @@ dev_dependencies:
     git:
       url: git://github.com/flutter/web_installers.git
       path: packages/web_drivers/
-      ref: 41f96bb55d2f064dac3c9fc727ebdf4b0cdf79c4
+      ref: 1cea0d79cad1ebc217c4bcbeba1be41470674a49


### PR DESCRIPTION
Enable firefox integration tests

LUCI run that shows the firefox integration tests are passing: https://chromium-swarm.appspot.com/task?id=4ce8d623bd36bb10

Note: I added the following cipd package flutter_internal/browser-drivers/firefoxdriver-linux in the recipe.

fixes: https://github.com/flutter/flutter/issues/59650