### PR TITLE
[nnbd] build mobile/desktop platform dill in agnostic mode

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -250,7 +250,7 @@ compile_platform("strong_platform") {
   allow_causal_async_stacks = !is_runtime_mode_release
   args = [
     "--enable-experiment=non-nullable",
-    "--nnbd-weak",
+    "--nnbd-agnostic",
     "--target=flutter",
     "-Ddart.vm.product=$is_runtime_mode_release",
     "-Ddart.developer.causal_async_stacks=$allow_causal_async_stacks",


### PR DESCRIPTION
## Description

In agnostic mode, both sound and unsound modes are supported. Unfortunately, this only helps us for mobile/desktop and non web.

https://github.com/flutter/flutter/issues/59873