### PR TITLE
[web] Fix fonts.clear exception in IE11

### DIFF
--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -98,7 +98,7 @@ class FontCollection {
   void clear() {
     _assetFontManager = null;
     _testFontManager = null;
-    if (supportsFontLoadingApi) {
+    if (supportsFontsClearApi) {
       html.document.fonts.clear();
     }
   }
@@ -313,4 +313,5 @@ class _PolyfillFontManager extends FontManager {
   }
 }
 
-final bool supportsFontLoadingApi = html.document.fonts != null;
+final bool supportsFontLoadingApi = js_util.hasProperty(html.window, 'FontFace');
+final bool supportsFontsClearApi = html.document.fonts != null && js_util.hasProperty(html.document.fonts, 'clear');


### PR DESCRIPTION
## Description

IE11 doesn't support document.fonts.clear api and causes crash for apps that contain font resources.

## Related Issues

https://github.com/flutter/flutter/issues/58991

## Tests

Gallery app is now starting up properly in IE11.
![Screen Shot 2020-06-19 at 10 17 06 PM](https://user-images.githubusercontent.com/5061034/85193188-2209a380-b27b-11ea-9c24-3e86252f829c.png)


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
