### PR TITLE
Replace GLFW key codes with native Flutter GTK support

### DIFF
--- a/shell/platform/linux/fl_key_event_plugin.cc
+++ b/shell/platform/linux/fl_key_event_plugin.cc
@@ -17,7 +17,7 @@ static constexpr char kModifiersKey[] = "modifiers";
 static constexpr char kToolkitKey[] = "toolkit";
 static constexpr char kUnicodeScalarValuesKey[] = "unicodeScalarValues";
 
-static constexpr char kGLFWToolkit[] = "glfw";
+static constexpr char kGtkToolkit[] = "gtk";
 static constexpr char kLinuxKeymap[] = "linux";
 
 struct _FlKeyEventPlugin {
@@ -27,197 +27,6 @@ struct _FlKeyEventPlugin {
 };
 
 G_DEFINE_TYPE(FlKeyEventPlugin, fl_key_event_plugin, G_TYPE_OBJECT)
-
-// Converts a Gdk key code to its GLFW equivalent.
-// TODO(robert-ancell) Create a "gtk" toolkit in Flutter so we don't have to
-// convert values. https://github.com/flutter/flutter/issues/57603
-static int gdk_keyval_to_glfw_key_code(guint keyval) {
-  switch (keyval) {
-    case GDK_KEY_space:
-      return 32;
-    case GDK_KEY_apostrophe:
-      return 39;
-    case GDK_KEY_comma:
-      return 44;
-    case GDK_KEY_minus:
-      return 45;
-    case GDK_KEY_period:
-      return 46;
-    case GDK_KEY_slash:
-      return 47;
-    case GDK_KEY_0:
-      return 48;
-    case GDK_KEY_1:
-      return 49;
-    case GDK_KEY_2:
-      return 50;
-    case GDK_KEY_3:
-      return 51;
-    case GDK_KEY_4:
-      return 52;
-    case GDK_KEY_5:
-      return 53;
-    case GDK_KEY_6:
-      return 54;
-    case GDK_KEY_7:
-      return 55;
-    case GDK_KEY_8:
-      return 56;
-    case GDK_KEY_9:
-      return 57;
-    case GDK_KEY_semicolon:
-      return 59;
-    case GDK_KEY_equal:
-      return 61;
-    case GDK_KEY_a:
-    case GDK_KEY_A:
-      return 65;
-    case GDK_KEY_b:
-    case GDK_KEY_B:
-      return 66;
-    case GDK_KEY_c:
-    case GDK_KEY_C:
-      return 67;
-    case GDK_KEY_d:
-    case GDK_KEY_D:
-      return 68;
-    case GDK_KEY_e:
-    case GDK_KEY_E:
-      return 69;
-    case GDK_KEY_f:
-    case GDK_KEY_F:
-      return 70;
-    case GDK_KEY_g:
-    case GDK_KEY_G:
-      return 71;
-    case GDK_KEY_h:
-    case GDK_KEY_H:
-      return 72;
-    case GDK_KEY_i:
-    case GDK_KEY_I:
-      return 73;
-    case GDK_KEY_j:
-    case GDK_KEY_J:
-      return 74;
-    case GDK_KEY_k:
-    case GDK_KEY_K:
-      return 75;
-    case GDK_KEY_l:
-    case GDK_KEY_L:
-      return 76;
-    case GDK_KEY_m:
-    case GDK_KEY_M:
-      return 77;
-    case GDK_KEY_n:
-    case GDK_KEY_N:
-      return 78;
-    case GDK_KEY_o:
-    case GDK_KEY_O:
-      return 79;
-    case GDK_KEY_p:
-    case GDK_KEY_P:
-      return 80;
-    case GDK_KEY_q:
-    case GDK_KEY_Q:
-      return 81;
-    case GDK_KEY_r:
-    case GDK_KEY_R:
-      return 82;
-    case GDK_KEY_s:
-    case GDK_KEY_S:
-      return 83;
-    case GDK_KEY_t:
-    case GDK_KEY_T:
-      return 84;
-    case GDK_KEY_u:
-    case GDK_KEY_U:
-      return 85;
-    case GDK_KEY_v:
-    case GDK_KEY_V:
-      return 86;
-    case GDK_KEY_w:
-    case GDK_KEY_W:
-      return 87;
-    case GDK_KEY_x:
-    case GDK_KEY_X:
-      return 88;
-    case GDK_KEY_y:
-    case GDK_KEY_Y:
-      return 89;
-    case GDK_KEY_z:
-    case GDK_KEY_Z:
-      return 90;
-    case GDK_KEY_bracketleft:
-      return 91;
-    case GDK_KEY_bracketright:
-      return 92;
-    case GDK_KEY_grave:
-      return 96;
-    case GDK_KEY_Escape:
-      return 256;
-    case GDK_KEY_Return:
-      return 257;
-    case GDK_KEY_Tab:
-    case GDK_KEY_ISO_Left_Tab:
-      return 258;
-    case GDK_KEY_BackSpace:
-      return 259;
-    case GDK_KEY_Insert:
-      return 260;
-    case GDK_KEY_Delete:
-      return 261;
-    case GDK_KEY_Right:
-      return 262;
-    case GDK_KEY_Left:
-      return 263;
-    case GDK_KEY_Down:
-      return 264;
-    case GDK_KEY_Up:
-      return 265;
-    case GDK_KEY_Page_Up:
-      return 266;
-    case GDK_KEY_Page_Down:
-      return 267;
-    case GDK_KEY_Home:
-      return 268;
-    case GDK_KEY_End:
-      return 269;
-    case GDK_KEY_Shift_L:
-      return 340;
-    case GDK_KEY_Control_L:
-      return 341;
-    case GDK_KEY_Alt_L:
-      return 342;
-    case GDK_KEY_Super_L:
-      return 343;
-    case GDK_KEY_Shift_R:
-      return 344;
-    case GDK_KEY_Control_R:
-      return 345;
-    case GDK_KEY_Alt_R:
-      return 346;
-    case GDK_KEY_Super_R:
-      return 347;
-    default:
-      return 0;
-  }
-}
-
-// Converts a Gdk key state to its GLFW equivalent.
-int64_t gdk_state_to_glfw_modifiers(guint8 state) {
-  int64_t modifiers = 0;
-
-  if ((state & GDK_SHIFT_MASK) != 0)
-    modifiers |= 0x0001;
-  if ((state & GDK_CONTROL_MASK) != 0)
-    modifiers |= 0x0002;
-  if ((state & GDK_MOD1_MASK) != 0)
-    modifiers |= 0x0004;
-  if ((state & GDK_SUPER_MASK) != 0)
-    modifiers |= 0x0008;
-
-  return modifiers;
-}
 
 static void fl_key_event_plugin_dispose(GObject* object) {
   FlKeyEventPlugin* self = FL_KEY_EVENT_PLUGIN(object);
@@ -260,8 +69,6 @@ void fl_key_event_plugin_send_key_event(FlKeyEventPlugin* self,
     return;
 
   int64_t scan_code = event->hardware_keycode;
-  int64_t key_code = gdk_keyval_to_glfw_key_code(event->keyval);
-  int64_t modifiers = gdk_state_to_glfw_modifiers(event->state);
   int64_t unicodeScalarValues = gdk_keyval_to_unicode(event->keyval);
 
   g_autoptr(FlValue) message = fl_value_new_map();
@@ -270,9 +77,9 @@ void fl_key_event_plugin_send_key_event(FlKeyEventPlugin* self,
                            fl_value_new_string(kLinuxKeymap));
   fl_value_set_string_take(message, kScanCodeKey, fl_value_new_int(scan_code));
   fl_value_set_string_take(message, kToolkitKey,
-                           fl_value_new_string(kGLFWToolkit));
-  fl_value_set_string_take(message, kKeyCodeKey, fl_value_new_int(key_code));
-  fl_value_set_string_take(message, kModifiersKey, fl_value_new_int(modifiers));
+                           fl_value_new_string(kGtkToolkit));
+  fl_value_set_string_take(message, kKeyCodeKey, fl_value_new_int(event->keyval));
+  fl_value_set_string_take(message, kModifiersKey, fl_value_new_int(event->state));
   if (unicodeScalarValues != 0) {
     fl_value_set_string_take(message, kUnicodeScalarValuesKey,
                              fl_value_new_int(unicodeScalarValues));

--- a/shell/platform/linux/fl_key_event_plugin.cc
+++ b/shell/platform/linux/fl_key_event_plugin.cc
@@ -78,8 +78,10 @@ void fl_key_event_plugin_send_key_event(FlKeyEventPlugin* self,
   fl_value_set_string_take(message, kScanCodeKey, fl_value_new_int(scan_code));
   fl_value_set_string_take(message, kToolkitKey,
                            fl_value_new_string(kGtkToolkit));
-  fl_value_set_string_take(message, kKeyCodeKey, fl_value_new_int(event->keyval));
-  fl_value_set_string_take(message, kModifiersKey, fl_value_new_int(event->state));
+  fl_value_set_string_take(message, kKeyCodeKey,
+                           fl_value_new_int(event->keyval));
+  fl_value_set_string_take(message, kModifiersKey,
+                           fl_value_new_int(event->state));
   if (unicodeScalarValues != 0) {
     fl_value_set_string_take(message, kUnicodeScalarValuesKey,
                              fl_value_new_int(unicodeScalarValues));


### PR DESCRIPTION
## Description

Replace the existing key events that are mapped to GLFW key codes with native GTK support in Flutter.

## Related Issues

This is the second part of https://github.com/flutter/flutter/issues/57603, once [Flutter supports GTK key codes](https://github.com/flutter/flutter/pull/59961).

## Tests

No test changes.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
