### PR TITLE
Automatically register plugins for `FlutterFragmentActivity`

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -555,7 +555,7 @@ public class FlutterFragmentActivity extends FragmentActivity
     return null;
   }
 
-   /**
+  /**
    * Hook for subclasses to easily configure a {@code FlutterEngine}.
    *
    * <p>This method is called after {@link #provideFlutterEngine(Context)}.
@@ -704,7 +704,7 @@ public class FlutterFragmentActivity extends FragmentActivity
   private boolean isDebuggable() {
     return (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
   }
-  
+
   /**
    * Registers all plugins that an app lists in its pubspec.yaml.
    *


### PR DESCRIPTION
Follow up of flutter#15979

## Description

flutter#15979 only implemented automatic plugin registration for `FlutterActivity`. This PR implements the same for `FlutterFragmentActivity`.

## Related Issues

Fixes flutter/flutter#54386

## Checklist
- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

