### PR TITLE
Remove cbracken from reviewer auto-assign

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -17,7 +17,6 @@ reviewers:
   - GaryQian
   - jason-simmons
   - iskakaushik
-  - cbracken
   - flar
 
 # A number of reviewers added to the pull request


### PR DESCRIPTION
Prefer to get my random Flutter PRs through skimming the incoming PRs list
rather than randomly.