### PR TITLE
Add CanvasKit platform support for Skia.setResourceCacheMaxBytes.

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/rasterizer.dart
+++ b/lib/web_ui/lib/src/engine/compositor/rasterizer.dart
@@ -13,7 +13,7 @@ class Rasterizer {
 
   Rasterizer(this.surface);
 
-  void setSkiaResourceCacheMaxBytes(int bytes) => 
+  void setSkiaResourceCacheMaxBytes(int bytes) =>
     surface.setSkiaResourceCacheMaxBytes(bytes);
 
   /// Creates a new frame from this rasterizer's surface, draws the given

--- a/lib/web_ui/lib/src/engine/compositor/rasterizer.dart
+++ b/lib/web_ui/lib/src/engine/compositor/rasterizer.dart
@@ -13,6 +13,9 @@ class Rasterizer {
 
   Rasterizer(this.surface);
 
+  void setSkiaResourceCacheMaxBytes(int bytes) => 
+    surface.setSkiaResourceCacheMaxBytes(bytes);
+
   /// Creates a new frame from this rasterizer's surface, draws the given
   /// [LayerTree] into it, and then submits the frame.
   void draw(LayerTree layerTree) {

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -131,7 +131,7 @@ class Surface {
     if (_grContext == null) {
       throw CanvasKitError('Could not create a graphics context.');
     }
-    
+
     // Set the cache byte limit for this grContext, if not specified it will use
     // CanvasKit's default.
     _syncCacheBytes();

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -38,6 +38,21 @@ class Surface {
 
   CkSurface? _surface;
   html.Element? htmlElement;
+  js.JsObject? _grContext;
+  int? _skiaCacheBytes;
+
+  /// Specify the GPU resource cache limits.
+  void setSkiaResourceCacheMaxBytes(int bytes) {
+    _skiaCacheBytes = bytes;
+    _syncCacheBytes();
+  }
+
+  void _syncCacheBytes() {
+    if(_skiaCacheBytes != null) {
+      _grContext?.callMethod('setResourceCacheLimitBytes', <dynamic>[
+        _skiaCacheBytes]);
+    }
+  }
 
   bool _addedToScene = false;
 
@@ -110,16 +125,20 @@ class Surface {
       // anti-aliased by setting their `Paint` object's `antialias` property.
       js.JsObject.jsify({'antialias': 0}),
     ]);
-    final js.JsObject? grContext =
+    _grContext =
         canvasKit.callMethod('MakeGrContext', <dynamic>[glContext]);
 
-    if (grContext == null) {
+    if (_grContext == null) {
       throw CanvasKitError('Could not create a graphics context.');
     }
+    
+    // Set the cache byte limit for this grContext, if not specified it will use
+    // CanvasKit's default.
+    _syncCacheBytes();
 
     final js.JsObject? skSurface =
         canvasKit.callMethod('MakeOnScreenGLSurface', <dynamic>[
-      grContext,
+      _grContext,
       size.width,
       size.height,
       canvasKit['SkColorSpace']['SRGB'],
@@ -130,7 +149,7 @@ class Surface {
     }
 
     htmlElement = htmlCanvas;
-    return CkSurface(skSurface, grContext, glContext);
+    return CkSurface(skSurface, _grContext, glContext);
   }
 
   bool _presentSurface() {

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -149,7 +149,7 @@ class Surface {
     }
 
     htmlElement = htmlCanvas;
-    return CkSurface(skSurface, _grContext, glContext);
+    return CkSurface(skSurface, _grContext!, glContext);
   }
 
   bool _presentSurface() {

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -494,12 +494,13 @@ class EngineWindow extends ui.Window {
     }
 
     switch (name) {
+      /// This should be in sync with shell/common/shell.cc
       case 'flutter/skia':
-      const MethodCodec codec = JSONMethodCodec();
+        const MethodCodec codec = JSONMethodCodec();
         final MethodCall decoded = codec.decodeMethodCall(data);
         switch (decoded.method) {
           case 'Skia.setResourceCacheMaxBytes':
-            if(decoded.arguments is int) {
+            if (decoded.arguments is int) {
               rasterizer?.setSkiaResourceCacheMaxBytes(decoded.arguments);
             }
             break;

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -494,6 +494,18 @@ class EngineWindow extends ui.Window {
     }
 
     switch (name) {
+      case 'flutter/skia':
+      const MethodCodec codec = JSONMethodCodec();
+        final MethodCall decoded = codec.decodeMethodCall(data);
+        switch (decoded.method) {
+          case 'Skia.setResourceCacheMaxBytes':
+            if(decoded.arguments is int) {
+              rasterizer?.setSkiaResourceCacheMaxBytes(decoded.arguments);
+            }
+            break;
+        }
+
+        return;
       case 'flutter/assets':
         assert(ui.webOnlyAssetManager != null); // ignore: unnecessary_null_comparison
         final String url = utf8.decode(data!.buffer.asUint8List());


### PR DESCRIPTION
Handles calls to the 'flutter/skia' method channel in Flutter Web piping the cache value to CanvasKit when FlutterWeb runs with the CanvasKit backend.

Fixes: https://github.com/flutter/flutter/issues/60153