### PR TITLE
EndFrame should be always called by rasterizer

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -287,16 +287,15 @@ class ExternalViewEmbedder {
   virtual bool SubmitFrame(GrContext* context,
                            std::unique_ptr<SurfaceFrame> frame);
 
-  // This should only be called after |SubmitFrame|.
   // This method provides the embedder a way to do additional tasks after
-  // |SubmitFrame|. After invoking this method, the current task on the
-  // TaskRunner should end immediately.
+  // |SubmitFrame|. For example, merge tasks if `should_resubmit_frame` is true.
   //
   // For example on the iOS embedder, threads are merged in this call.
   // A new frame on the platform thread starts immediately. If the GPU thread
   // still has some task running, there could be two frames being rendered
   // concurrently, which causes undefined behaviors.
   virtual void EndFrame(
+      bool should_resubmit_frame,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {}
 
   FML_DISALLOW_COPY_AND_ASSIGN(ExternalViewEmbedder);

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -288,7 +288,8 @@ class ExternalViewEmbedder {
                            std::unique_ptr<SurfaceFrame> frame);
 
   // This method provides the embedder a way to do additional tasks after
-  // |SubmitFrame|. For example, merge tasks if `should_resubmit_frame` is true.
+  // |SubmitFrame|. For example, merge task runners if `should_resubmit_frame`
+  // is true.
   //
   // For example on the iOS embedder, threads are merged in this call.
   // A new frame on the platform thread starts immediately. If the GPU thread

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -151,11 +151,10 @@ void Rasterizer::Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline) {
 
   // Merging the thread as we know the next `Draw` should be run on the platform
   // thread.
-  auto* external_view_embedder = surface_->GetExternalViewEmbedder();
-  if (external_view_embedder != nullptr) {
+  if (surface_ != nullptr && surface_->GetExternalViewEmbedder() != nullptr) {
     auto should_resubmit_frame = raster_status == RasterStatus::kResubmit;
-    external_view_embedder->EndFrame(should_resubmit_frame,
-                                     raster_thread_merger_);
+    surface_->GetExternalViewEmbedder()->EndFrame(should_resubmit_frame,
+                                                  raster_thread_merger_);
   }
 
   // Consume as many pipeline items as possible. But yield the event loop

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -151,12 +151,11 @@ void Rasterizer::Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline) {
 
   // Merging the thread as we know the next `Draw` should be run on the platform
   // thread.
-  if (raster_status == RasterStatus::kResubmit) {
-    auto* external_view_embedder = surface_->GetExternalViewEmbedder();
-    // We know only the `external_view_embedder` can
-    // causes|RasterStatus::kResubmit|. Check to make sure.
-    FML_DCHECK(external_view_embedder != nullptr);
-    external_view_embedder->EndFrame(raster_thread_merger_);
+  auto* external_view_embedder = surface_->GetExternalViewEmbedder();
+  if (external_view_embedder != nullptr) {
+    auto should_resubmit_frame = raster_status == RasterStatus::kResubmit;
+    external_view_embedder->EndFrame(should_resubmit_frame,
+                                     raster_thread_merger_);
   }
 
   // Consume as many pipeline items as possible. But yield the event loop

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -45,7 +45,7 @@ bool ShellTestExternalViewEmbedder::SubmitFrame(
 void ShellTestExternalViewEmbedder::EndFrame(
     bool should_resubmit_frame,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
-  end_frame_call_back_();
+  end_frame_call_back_(should_resubmit_frame);
 }
 
 // |ExternalViewEmbedder|

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -43,6 +43,7 @@ bool ShellTestExternalViewEmbedder::SubmitFrame(
 
 // |ExternalViewEmbedder|
 void ShellTestExternalViewEmbedder::EndFrame(
+    bool should_resubmit_frame,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
   end_frame_call_back_();
 }

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -15,7 +15,7 @@ namespace flutter {
 ///
 class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
  public:
-  using EndFrameCallBack = std::function<void(void)>;
+  using EndFrameCallBack = std::function<void(bool)>;
 
   ShellTestExternalViewEmbedder(const EndFrameCallBack& end_frame_call_back,
                                 PostPrerollResult post_preroll_result)

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -56,6 +56,7 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void EndFrame(
+      bool should_resubmit_frame,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
   // |ExternalViewEmbedder|

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -474,7 +474,8 @@ TEST_F(ShellTest,
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent endFrameLatch;
   bool end_frame_called = false;
-  auto end_frame_callback = [&] {
+  auto end_frame_callback = [&](bool should_resubmit_frame) {
+    ASSERT_TRUE(should_resubmit_frame);
     end_frame_called = true;
     endFrameLatch.Signal();
   };

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -255,8 +255,9 @@ void AndroidExternalViewEmbedder::CancelFrame() {
 
 // |ExternalViewEmbedder|
 void AndroidExternalViewEmbedder::EndFrame(
+    bool should_resubmit_frame,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
-  if (should_run_rasterizer_on_platform_thread_) {
+  if (should_resubmit_frame && should_run_rasterizer_on_platform_thread_) {
     raster_thread_merger->MergeWithLease(kDefaultMergedLeaseDuration);
     should_run_rasterizer_on_platform_thread_ = false;
   }

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -65,6 +65,7 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void EndFrame(
+      bool should_resubmit_frame,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
   // Gets the rect based on the device pixel ratio of a platform view displayed

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -158,7 +158,7 @@ TEST(AndroidExternalViewEmbedder, RasterizerRunsOnPlatformThread) {
   ASSERT_TRUE(embedder->SubmitFrame(nullptr, nullptr));
 
   EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
-  embedder->EndFrame(raster_thread_merger);
+  embedder->EndFrame(/*should_resubmit_frame=*/true, raster_thread_merger);
 
   ASSERT_TRUE(raster_thread_merger->IsMerged());
 
@@ -182,7 +182,7 @@ TEST(AndroidExternalViewEmbedder, RasterizerRunsOnRasterizerThread) {
   ASSERT_EQ(PostPrerollResult::kSuccess, result);
 
   EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
-  embedder->EndFrame(raster_thread_merger);
+  embedder->EndFrame(/*should_resubmit_frame=*/true, raster_thread_merger);
 
   ASSERT_FALSE(raster_thread_merger->IsMerged());
 }
@@ -332,7 +332,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame__RecycleSurfaces) {
     embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
     EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
-    embedder->EndFrame(raster_thread_merger);
+    embedder->EndFrame(/*should_resubmit_frame=*/false, raster_thread_merger);
   }
 
   // ------------------ Second frame ------------------ //
@@ -380,7 +380,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame__RecycleSurfaces) {
     embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
     EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
-    embedder->EndFrame(raster_thread_merger);
+    embedder->EndFrame(/*should_resubmit_frame=*/false, raster_thread_merger);
   }
 }
 
@@ -399,7 +399,7 @@ TEST(AndroidExternalViewEmbedder, DoesNotCallJNIPlatformThreadOnlyMethods) {
                        raster_thread_merger);
 
   EXPECT_CALL(*jni_mock, FlutterViewEndFrame()).Times(0);
-  embedder->EndFrame(raster_thread_merger);
+  embedder->EndFrame(/*should_resubmit_frame=*/false, raster_thread_merger);
 }
 
 }  // namespace testing

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -604,8 +604,9 @@ void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
 }
 
 void FlutterPlatformViewsController::EndFrame(
+    bool should_resubmit_frame,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
-  if (merge_threads_) {
+  if (should_resubmit_frame && merge_threads_) {
     raster_thread_merger->MergeWithLease(kDefaultMergedLeaseDuration);
     merge_threads_ = false;
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -168,7 +168,8 @@ class FlutterPlatformViewsController {
   // Invoked at the very end of a frame.
   // After invoking this method, nothing should happen on the current TaskRunner during the same
   // frame.
-  void EndFrame(fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger);
+  void EndFrame(bool should_resubmit_frame,
+                fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger);
 
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -85,7 +85,8 @@ class IOSSurface : public ExternalViewEmbedder {
   bool SubmitFrame(GrContext* context, std::unique_ptr<SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|
-  void EndFrame(fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
+  void EndFrame(bool should_resubmit_frame,
+                fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
  public:
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurface);

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -149,10 +149,11 @@ bool IOSSurface::SubmitFrame(GrContext* context, std::unique_ptr<SurfaceFrame> f
 }
 
 // |ExternalViewEmbedder|
-void IOSSurface::EndFrame(fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
+void IOSSurface::EndFrame(bool should_resubmit_frame,
+                          fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
   TRACE_EVENT0("flutter", "IOSSurface::EndFrame");
   FML_CHECK(platform_views_controller_ != nullptr);
-  return platform_views_controller_->EndFrame(raster_thread_merger);
+  return platform_views_controller_->EndFrame(raster_status, raster_thread_merger);
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -153,7 +153,7 @@ void IOSSurface::EndFrame(bool should_resubmit_frame,
                           fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
   TRACE_EVENT0("flutter", "IOSSurface::EndFrame");
   FML_CHECK(platform_views_controller_ != nullptr);
-  return platform_views_controller_->EndFrame(raster_status, raster_thread_merger);
+  return platform_views_controller_->EndFrame(should_resubmit_frame, raster_thread_merger);
 }
 
 }  // namespace flutter


### PR DESCRIPTION
## Description

`EndFrame` should be called by the rasterizer as it is used to restore up state or recycle the overlay surfaces.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/60124

## Tests

I added the following tests: updated unit tests


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
