### PR TITLE
Move OnDisplayPlatformView JNI call

### DIFF
--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -91,16 +91,6 @@ bool AndroidExternalViewEmbedder::SubmitFrame(
 
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t view_id = composition_order_[i];
-    SkRect view_rect = GetViewRect(view_id);
-
-    // Display the platform view. If it's already displayed, then it's
-    // just positioned and sized.
-    jni_facade_->FlutterViewOnDisplayPlatformView(view_id,            //
-                                                  view_rect.x(),      //
-                                                  view_rect.y(),      //
-                                                  view_rect.width(),  //
-                                                  view_rect.height()  //
-    );
 
     sk_sp<SkPicture> picture =
         picture_recorders_.at(view_id)->finishRecordingAsPicture();
@@ -156,6 +146,15 @@ bool AndroidExternalViewEmbedder::SubmitFrame(
   frame->Submit();
 
   for (int64_t view_id : composition_order_) {
+    SkRect view_rect = GetViewRect(view_id);
+    // Display the platform view. If it's already displayed, then it's
+    // just positioned and sized.
+    jni_facade_->FlutterViewOnDisplayPlatformView(view_id,            //
+                                                  view_rect.x(),      //
+                                                  view_rect.y(),      //
+                                                  view_rect.width(),  //
+                                                  view_rect.height()  //
+    );
     for (const SkRect& overlay_rect : overlay_layers.at(view_id)) {
       CreateSurfaceIfNeeded(context,               //
                             view_id,               //


### PR DESCRIPTION
## Description

This will facilitate determining the z order of the platform views and the overlay surface views. 

## Related Issues

https://github.com/flutter/flutter/issues/60140
https://github.com/flutter/flutter/issues/60150

## Tests

I added the following tests: These cases are covered by the scenario app, but they don't run in presubmit because of https://github.com/flutter/flutter/issues/55326

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
