### PR TITLE
Annotate valuePublishedByPlugin with nullable

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -415,7 +415,7 @@ typedef enum {
  *   nothing has been published. Will be `nil` if the plugin has not been
  *   registered.
  */
-- (NSObject*)valuePublishedByPlugin:(NSString*)pluginKey;
+- (nullable NSObject*)valuePublishedByPlugin:(NSString*)pluginKey;
 @end
 
 #pragma mark -


### PR DESCRIPTION
## Description

Adds the missing nullable flag to `[PluginRegistry valuePublishedByPlugin]`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
