### PR TITLE
Enable lazy-async-stacks by-default in all modes (2)

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -59,7 +59,8 @@ static const char* kDartLanguageArgs[] = {
     // clang-format off
     "--enable_mirrors=false",
     "--background_compilation",
-    "--causal_async_stacks",
+    "--no-causal_async_stacks",
+    "--lazy_async_stacks",
     // clang-format on
 };
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -284,6 +284,7 @@ TEST_F(ShellTest, AllowedDartVMFlag) {
   const std::vector<fml::CommandLine::Option> options = {
 #if !FLUTTER_RELEASE
     fml::CommandLine::Option("dart-flags",
+                             "--lazy_async_stacks,--no-causal_async_stacks,"
                              "--max_profile_depth 1,--random_seed 42")
 #endif
   };
@@ -291,9 +292,11 @@ TEST_F(ShellTest, AllowedDartVMFlag) {
   flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
 
 #if !FLUTTER_RELEASE
-  EXPECT_EQ(settings.dart_flags.size(), 2u);
-  EXPECT_EQ(settings.dart_flags[0], "--max_profile_depth 1");
-  EXPECT_EQ(settings.dart_flags[1], "--random_seed 42");
+  EXPECT_EQ(settings.dart_flags.size(), 4u);
+  EXPECT_EQ(settings.dart_flags[0], "--lazy_async_stacks");
+  EXPECT_EQ(settings.dart_flags[1], "--no-causal_async_stacks");
+  EXPECT_EQ(settings.dart_flags[2], "--max_profile_depth 1");
+  EXPECT_EQ(settings.dart_flags[3], "--random_seed 42");
 #else
   EXPECT_EQ(settings.dart_flags.size(), 0u);
 #endif

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -35,9 +35,8 @@ namespace {
 
 const char* kDartVMArgs[] = {
     // clang-format off
-    // TODO(FL-117): Re-enable causal async stack traces when this issue is
-    // addressed.
     "--no_causal_async_stacks",
+    "--lazy_async_stacks",
 
 #if !defined(FLUTTER_PROFILE)
     "--systrace_timeline",

--- a/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
@@ -53,6 +53,7 @@ template("create_aot_snapshot") {
 
     args = [
       "--no_causal_async_stacks",
+      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=vm-aot-assembly",
       "--assembly=" + rebase_path(snapshot_assembly),

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -74,9 +74,8 @@ template("create_kernel_core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
-      # TODO(FL-117): Re-enable causal async stack traces when this issue is
-      # addressed.
       "--no_causal_async_stacks",
+      "--lazy_async_stacks",
       "--use_bytecode_compiler",
       "--enable_mirrors=false",
       "--deterministic",

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -64,6 +64,7 @@ template("aot_snapshot") {
 
     args = [
       "--no_causal_async_stacks",
+      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(snapshot_path),

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -392,10 +392,6 @@ Application::Application(
   settings_.task_observer_remove = std::bind(
       &CurrentMessageLoopRemoveAfterTaskObserver, std::placeholders::_1);
 
-  // TODO(FL-117): Re-enable causal async stack traces when this issue is
-  // addressed.
-  settings_.dart_flags = {"--no_causal_async_stacks"};
-
   // Disable code collection as it interferes with JIT code warmup
   // by decreasing usage counters and flushing code which is still useful.
   settings_.dart_flags.push_back("--no-collect_code");

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -78,9 +78,8 @@ template("core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
-      # TODO(FL-117): Re-enable causal async stack traces when this issue is
-      # addressed.
       "--no_causal_async_stacks",
+      "--lazy_async_stacks",
       "--use_bytecode_compiler",
       "--enable_mirrors=false",
       "--deterministic",

--- a/testing/scenario_app/compile_ios_jit.sh
+++ b/testing/scenario_app/compile_ios_jit.sh
@@ -48,7 +48,8 @@ echo "Compiling JIT Snapshot..."
 
 "$DEVICE_TOOLS/gen_snapshot" --deterministic \
   --enable-asserts \
-  --causal_async_stacks \
+  --no-causal_async_stacks \
+  --lazy_async_stacks \
   --isolate_snapshot_instructions="$OUTDIR/isolate_snapshot_instr" \
   --snapshot_kind=app-jit \
   --load_vm_snapshot_data="$DEVICE_TOOLS/../gen/flutter/lib/snapshot/vm_isolate_snapshot.bin" \

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -138,7 +138,8 @@ template("dart_snapshot_aot") {
     ]
 
     args = [
-      "--causal_async_stacks",
+      "--no-causal_async_stacks",
+      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(elf_object),


### PR DESCRIPTION
This is a second attempt at https://github.com/flutter/engine/pull/16556 which was reverted in https://github.com/flutter/engine/pull/16781.

I have manually run the offending test locally and found no issues:
```bash
$ cd ~/src/flutter/flutter/ 
$ SHARD=tool_tests SUBSHARD=integration ./bin/cache/dart-sdk/bin/dart ./dev/bots/test.dart --local-engine host_debug
```

Original CL description:
```
This was already enabled by-default in AOT mode in [0] - which made the
gen_snapshot invocations use "--lazy-async-stacks --no-causal-async-stacks".

This change does the same with the engine defaults, which makes this be enabled
by-default in JIT mode as well.

See go/dart-10x-faster-async for more information.

[0] flutter/flutter@3478232
```