### PR TITLE
Make Shell::NotifyLowMemoryWarning trace

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -430,9 +430,10 @@ Shell::~Shell() {
   platform_latch.Wait();
 }
 
-void Shell::NotifyLowMemoryWarning() {
+void Shell::NotifyLowMemoryWarning() const {
+  auto trace_id = fml::tracing::TraceNonce();
   TRACE_EVENT_ASYNC_BEGIN0("flutter", "Shell::NotifyLowMemoryWarning",
-                           notify_low_memory_trace_id_);
+                           trace_id);
   // This does not require a current isolate but does require a running VM.
   // Since a valid shell will not be returned to the embedder without a valid
   // DartVMRef, we can be certain that this is a safe spot to assume a VM is
@@ -440,8 +441,7 @@ void Shell::NotifyLowMemoryWarning() {
   ::Dart_NotifyLowMemory();
 
   task_runners_.GetRasterTaskRunner()->PostTask(
-      [rasterizer = rasterizer_->GetWeakPtr(),
-       trace_id = notify_low_memory_trace_id_++]() {
+      [rasterizer = rasterizer_->GetWeakPtr(), trace_id = trace_id]() {
         if (rasterizer) {
           rasterizer->NotifyLowMemoryWarning();
         }

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -284,7 +284,7 @@ class Shell final : public PlatformView::Delegate,
   /// @brief      Used by embedders to notify that there is a low memory
   ///             warning. The shell will attempt to purge caches. Current, only
   ///             the rasterizer cache is purged.
-  void NotifyLowMemoryWarning();
+  void NotifyLowMemoryWarning() const;
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedders to check if all shell subcomponents are
@@ -397,7 +397,6 @@ class Shell final : public PlatformView::Delegate,
   std::atomic<bool> waiting_for_first_frame_ = true;
   std::mutex waiting_for_first_frame_mutex_;
   std::condition_variable waiting_for_first_frame_condition_;
-  size_t notify_low_memory_trace_id_ = 0;
 
   // Written in the UI thread and read from the raster thread. Hence make it
   // atomic.

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -284,7 +284,7 @@ class Shell final : public PlatformView::Delegate,
   /// @brief      Used by embedders to notify that there is a low memory
   ///             warning. The shell will attempt to purge caches. Current, only
   ///             the rasterizer cache is purged.
-  void NotifyLowMemoryWarning() const;
+  void NotifyLowMemoryWarning();
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedders to check if all shell subcomponents are
@@ -397,6 +397,7 @@ class Shell final : public PlatformView::Delegate,
   std::atomic<bool> waiting_for_first_frame_ = true;
   std::mutex waiting_for_first_frame_mutex_;
   std::condition_variable waiting_for_first_frame_condition_;
+  size_t notify_low_memory_trace_id_ = 0;
 
   // Written in the UI thread and read from the raster thread. Hence make it
   // atomic.


### PR DESCRIPTION
Add tracing to `Shell::NotifyLowMemoryWarning`, since it can be expensive and we want to know if/when it's getting called.

Not sure how to add a test for this - I don't think we typically test these.