### PR TITLE
Fixing memory leak with CanvasKit SkParagraphs never getting deleted.

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/canvas.dart
@@ -168,7 +168,7 @@ class SkCanvas {
   void drawParagraph(ui.Paragraph paragraph, ui.Offset offset) {
     final SkParagraph skParagraph = paragraph;
     skCanvas.callMethod('drawParagraph', <dynamic>[
-      skParagraph.skParagraph,
+      skParagraph.skiaObject,
       offset.dx,
       offset.dy,
     ]);


### PR DESCRIPTION
Hacky fix for: https://github.com/flutter/flutter/issues/56938

This is mostly meant to expose the investigative work @mjohnsullivan and I did to figure out what was leaking memory with the CanvasKit backend. We found that the Paragraphs created by the CanvasKit ParagraphBuilder were never deleted. We copied the SkiaObject pattern the CanvasKit backend is using elsewhere to resurrect and delete Paragraphs. Our example now runs without crashing.

