### PR TITLE
Run ios-safari tests on try bots

### DIFF
--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -16,7 +16,6 @@ import 'package:test_core/src/executable.dart'
     as test; // ignore: implementation_imports
 import 'package:simulators/simulator_manager.dart';
 
-import 'common.dart';
 import 'environment.dart';
 import 'exceptions.dart';
 import 'integration_tests_manager.dart';
@@ -121,12 +120,6 @@ class TestCommand extends Command<bool> with ArgUtils {
   Future<bool> run() async {
     SupportedBrowsers.instance
       ..argParsers.forEach((t) => t.parseOptions(argResults));
-
-    // Mac Web Engine Try bots are failing. Investigate further.
-    // TODO: https://github.com/flutter/flutter/issues/60251
-    if(isSafariOnMacOS && isLuci) {
-      return true;
-    }
 
     // Check the flags to see what type of integration tests are requested.
     testTypesRequested = findTestType();

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
     git:
       url: git://github.com/flutter/web_installers.git
       path: packages/simulators/
-      ref: 9ede7e3c069180b28322bb3f0d0307c824071fb5
+      ref: 1da6bb8df222f0d124e737e8abc20d68ddb7ea43
   web_driver_installer:
     git:
       url: git://github.com/flutter/web_installers.git


### PR DESCRIPTION
Run ios-safari tests on try bots with the web_installers change.

I run it many times on the bots. It failed once. Info: https://github.com/flutter/flutter/issues/60251

If we don't want to enable them (due to possible flakes, please have look at PR: https://github.com/flutter/engine/pull/19302)