### PR TITLE
Fix ImageReader "unable to acquire a buffer item" warnings in FlutterImageView

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -611,10 +611,10 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           width,
           height,
           PixelFormat.RGBA_8888,
-          2,
+          3,
           HardwareBuffer.USAGE_GPU_SAMPLED_IMAGE | HardwareBuffer.USAGE_GPU_COLOR_OUTPUT);
     } else {
-      return ImageReader.newInstance(width, height, PixelFormat.RGBA_8888, 2);
+      return ImageReader.newInstance(width, height, PixelFormat.RGBA_8888, 3);
     }
   }
 


### PR DESCRIPTION
According the the ImageReader documentation, maxImages - currentAcquiredImages
should be at least 2.  Setting maxImages to 3 because FlutterImageView
holds one reference to an acquired image.
