### PR TITLE
Fix hybrid composition bugs

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -41,13 +41,33 @@ public class FlutterImageView extends View implements RenderSurface {
   @Nullable private Bitmap currentBitmap;
   @Nullable private FlutterRenderer flutterRenderer;
 
+  public enum SurfaceKind {
+    /** Displays the background canvas. */
+    background,
+
+    /** Displays the overlay surface canvas. */
+    overlay,
+  }
+
+  /** The kind of surface. */
+  private SurfaceKind kind;
+
+  /**
+   * The number of images acquired from the current {@link android.media.ImageReader} that are
+   * waiting to be painted. This counter is decreased after calling {@link
+   * android.media.Image#close()}.
+   */
+  private int pendingImages = 0;
+
   /**
    * Constructs a {@code FlutterImageView} with an {@link android.media.ImageReader} that provides
    * the Flutter UI.
    */
-  public FlutterImageView(@NonNull Context context, @NonNull ImageReader imageReader) {
+  public FlutterImageView(
+      @NonNull Context context, @NonNull ImageReader imageReader, SurfaceKind kind) {
     super(context, null);
     this.imageReader = imageReader;
+    this.kind = kind;
   }
 
   @Nullable
@@ -62,12 +82,16 @@ public class FlutterImageView extends View implements RenderSurface {
    */
   @Override
   public void attachToRenderer(@NonNull FlutterRenderer flutterRenderer) {
-    if (this.flutterRenderer != null) {
-      this.flutterRenderer.stopRenderingToSurface();
-    }
-
     this.flutterRenderer = flutterRenderer;
-    flutterRenderer.startRenderingToSurface(imageReader.getSurface());
+    switch (kind) {
+      case background:
+        flutterRenderer.swapSurface(imageReader.getSurface());
+        break;
+      case overlay:
+        // Don't do anything as this is done by the handler of
+        // `FlutterJNI#createOverlaySurface()` in the native side.
+        break;
+    }
   }
 
   /**
@@ -75,16 +99,37 @@ public class FlutterImageView extends View implements RenderSurface {
    * Flutter UI to this {@code FlutterImageView}.
    */
   public void detachFromRenderer() {
-    if (flutterRenderer != null) {
-      flutterRenderer.stopRenderingToSurface();
-      flutterRenderer = null;
+    switch (kind) {
+      case background:
+        // TODO: Swap the surface back to the original one.
+        break;
+      case overlay:
+        // TODO: Handle this in the native side.
+        break;
     }
+  }
+
+  public void pause() {
+    // Not supported.
   }
 
   /** Acquires the next image to be drawn to the {@link android.graphics.Canvas}. */
   @TargetApi(19)
   public void acquireLatestImage() {
-    nextImage = imageReader.acquireLatestImage();
+    // There's no guarantee that the image will be closed before the next call to
+    // `acquireLatestImage()`. For example, the device may not produce new frames if
+    // it's in sleep mode, so the calls to `invalidate()` will be queued up
+    // until the device produces a new frame.
+    //
+    // While the engine will also stop producing frames, there is a race condition.
+    //
+    // To avoid exceptions, check if a new image can be acquired.
+    if (pendingImages < imageReader.getMaxImages()) {
+      nextImage = imageReader.acquireLatestImage();
+      if (nextImage != null) {
+        pendingImages++;
+      }
+    }
     invalidate();
   }
 
@@ -94,6 +139,7 @@ public class FlutterImageView extends View implements RenderSurface {
     if (nextImage != null) {
       if (currentImage != null) {
         currentImage.close();
+        pendingImages--;
       }
       currentImage = nextImage;
       nextImage = null;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -102,9 +102,11 @@ public class FlutterImageView extends View implements RenderSurface {
     switch (kind) {
       case background:
         // TODO: Swap the surface back to the original one.
+        // https://github.com/flutter/flutter/issues/58291
         break;
       case overlay:
         // TODO: Handle this in the native side.
+        // https://github.com/flutter/flutter/issues/59904
         break;
     }
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
@@ -200,12 +200,27 @@ public class FlutterSurfaceView extends SurfaceView implements RenderSurface {
       // Make the SurfaceView invisible to avoid showing a black rectangle.
       setAlpha(0.0f);
 
-      this.flutterRenderer.removeIsDisplayingFlutterUiListener(flutterUiDisplayListener);
+      flutterRenderer.removeIsDisplayingFlutterUiListener(flutterUiDisplayListener);
 
       flutterRenderer = null;
       isAttachedToFlutterRenderer = false;
     } else {
       Log.w(TAG, "detachFromRenderer() invoked when no FlutterRenderer was attached.");
+    }
+  }
+
+  /**
+   * Invoked by the owner of this {@code FlutterSurfaceView} when it should pause rendering Flutter
+   * UI to this {@code FlutterSurfaceView}.
+   */
+  public void pause() {
+    if (flutterRenderer != null) {
+      // Don't remove the `flutterUiDisplayListener` as `nFlutterUiDisplayed` will make the
+      // `FlutterSurfaceView` visible.
+      flutterRenderer = null;
+      isAttachedToFlutterRenderer = false;
+    } else {
+      Log.w(TAG, "pause() invoked when no FlutterRenderer was attached.");
     }
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
@@ -215,8 +215,8 @@ public class FlutterSurfaceView extends SurfaceView implements RenderSurface {
    */
   public void pause() {
     if (flutterRenderer != null) {
-      // Don't remove the `flutterUiDisplayListener` as `nFlutterUiDisplayed` will make the
-      // `FlutterSurfaceView` visible.
+      // Don't remove the `flutterUiDisplayListener` as `onFlutterUiDisplayed()` will make
+      // the `FlutterSurfaceView` visible.
       flutterRenderer = null;
       isAttachedToFlutterRenderer = false;
     } else {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -173,6 +173,19 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
     }
   }
 
+  /**
+   * Invoked by the owner of this {@code FlutterTextureView} when it should pause rendering Flutter
+   * UI to this {@code FlutterTextureView}.
+   */
+  public void pause() {
+    if (flutterRenderer != null) {
+      flutterRenderer = null;
+      isAttachedToFlutterRenderer = false;
+    } else {
+      Log.w(TAG, "pause() invoked when no FlutterRenderer was attached.");
+    }
+  }
+
   // FlutterRenderer and getSurfaceTexture() must both be non-null.
   private void connectSurfaceToRenderer() {
     if (flutterRenderer == null || getSurfaceTexture() == null) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -943,16 +943,15 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   public void convertToImageView() {
-    renderSurface.detachFromRenderer();
+    renderSurface.pause();
 
     ImageReader imageReader = PlatformViewsController.createImageReader(getWidth(), getHeight());
-    flutterImageView = new FlutterImageView(getContext(), imageReader);
+    flutterImageView =
+        new FlutterImageView(getContext(), imageReader, FlutterImageView.SurfaceKind.background);
     renderSurface = flutterImageView;
     if (flutterEngine != null) {
       renderSurface.attachToRenderer(flutterEngine.getRenderer());
     }
-
-    removeAllViews();
     addView(flutterImageView);
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -314,6 +314,23 @@ public class FlutterJNI {
   private native void nativeSurfaceCreated(long nativePlatformViewId, @NonNull Surface surface);
 
   /**
+   * In hybrid composition, call this method when the {@link Surface} has changed.
+   *
+   * <p>In hybrid composition, the root surfaces changes from {@link
+   * android.view.SurfaceHolder#getSurface()} to {@link android.media.ImageReader#getSurface()} when
+   * a platform view is in the current frame.
+   */
+  @UiThread
+  public void onSurfaceWindowChanged(@NonNull Surface surface) {
+    ensureRunningOnMainThread();
+    ensureAttachedToNative();
+    nativeSurfaceWindowChanged(nativePlatformViewId, surface);
+  }
+
+  private native void nativeSurfaceWindowChanged(
+      long nativePlatformViewId, @NonNull Surface surface);
+
+  /**
    * Call this method when the {@link Surface} changes that was previously registered with {@link
    * #onSurfaceCreated(Surface)}.
    *

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -184,6 +184,18 @@ public class FlutterRenderer implements TextureRegistry {
   }
 
   /**
+   * Swaps the {@link Surface} used to render the current frame.
+   *
+   * <p>In hybrid composition, the root surfaces changes from {@link
+   * android.view.SurfaceHolder#getSurface()} to {@link android.media.ImageReader#getSurface()} when
+   * a platform view is in the current frame.
+   */
+  public void swapSurface(@NonNull Surface surface) {
+    this.surface = surface;
+    flutterJNI.onSurfaceWindowChanged(surface);
+  }
+
+  /**
    * Notifies Flutter that a {@code surface} previously registered with {@link
    * #startRenderingToSurface(Surface)} has changed size to the given {@code width} and {@code
    * height}.

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/RenderSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/RenderSurface.java
@@ -53,4 +53,11 @@ public interface RenderSurface {
    * connected {@code FlutterRenderer}.
    */
   void detachFromRenderer();
+
+  /**
+   * Instructs this {@code RenderSurface} to stop forwarding {@code Surface} notifications to the
+   * {@code FlutterRenderer} that was previously connected with {@link
+   * #attachToRenderer(FlutterRenderer)}.
+   */
+  void pause();
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -574,7 +574,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     initializeRootImageViewIfNeeded();
     FlutterImageView overlayView = overlayLayerViews.get(id);
     if (overlayView.getParent() == null) {
-      flutterView.addView(overlayView);
+      ((FlutterView) flutterView).addView(overlayView);
     }
 
     FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams((int) width, (int) height);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -54,7 +54,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   private Context context;
 
   // The View currently rendering the Flutter UI associated with these platform views.
-  private FlutterView flutterView;
+  // TODO(egarciad): Investigate if this can be downcasted to `FlutterView`.
+  private View flutterView;
 
   // The texture registry maintaining the textures into which the embedded views will be rendered.
   private TextureRegistry textureRegistry;
@@ -349,7 +350,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    * This {@code PlatformViewsController} and its {@code FlutterEngine} is now attached to an
    * Android {@code View} that renders a Flutter UI.
    */
-  public void attachToView(@NonNull FlutterView flutterView) {
+  public void attachToView(@NonNull View flutterView) {
     this.flutterView = flutterView;
 
     // Inform all existing platform views that they are now associated with
@@ -559,7 +560,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
 
   private void initializeRootImageViewIfNeeded() {
     if (!flutterViewConvertedToImageView) {
-      flutterView.convertToImageView();
+      ((FlutterView) flutterView).convertToImageView();
       flutterViewConvertedToImageView = true;
     }
   }
@@ -601,7 +602,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     }
 
     if (flutterViewConvertedToImageView) {
-      flutterView.acquireLatestImageViewFrame();
+      ((FlutterView) flutterView).acquireLatestImageViewFrame();
     }
   }
 

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -104,6 +104,22 @@ void PlatformViewAndroid::NotifyCreated(
   PlatformView::NotifyCreated();
 }
 
+void PlatformViewAndroid::NotifySurfaceWindowChanged(
+    fml::RefPtr<AndroidNativeWindow> native_window) {
+  if (android_surface_) {
+    fml::AutoResetWaitableEvent latch;
+    fml::TaskRunner::RunNowOrPostTask(
+        task_runners_.GetRasterTaskRunner(),
+        [&latch, surface = android_surface_.get(),
+         native_window = std::move(native_window)]() {
+          surface->TeardownOnScreenContext();
+          surface->SetNativeWindow(native_window);
+          latch.Signal();
+        });
+    latch.Wait();
+  }
+}
+
 void PlatformViewAndroid::NotifyDestroyed() {
   PlatformView::NotifyDestroyed();
 

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -41,6 +41,9 @@ class PlatformViewAndroid final : public PlatformView {
 
   void NotifyCreated(fml::RefPtr<AndroidNativeWindow> native_window);
 
+  void NotifySurfaceWindowChanged(
+      fml::RefPtr<AndroidNativeWindow> native_window);
+
   void NotifyChanged(const SkISize& size);
 
   // |PlatformView|

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -375,7 +375,11 @@ public class FlutterViewTest {
   public void flutterImageView_acquiresImageAndInvalidates() {
     final ImageReader mockReader = mock(ImageReader.class);
     final FlutterImageView imageView =
-        spy(new FlutterImageView(RuntimeEnvironment.application, mockReader));
+        spy(
+            new FlutterImageView(
+                RuntimeEnvironment.application,
+                mockReader,
+                FlutterImageView.SurfaceKind.background));
 
     imageView.acquireLatestImage();
     verify(mockReader, times(1)).acquireLatestImage();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -2,6 +2,7 @@ package io.flutter.embedding.android;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -12,6 +13,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.media.Image;
 import android.media.ImageReader;
 import android.view.View;
 import android.view.ViewGroup;
@@ -374,6 +376,8 @@ public class FlutterViewTest {
   @Test
   public void flutterImageView_acquiresImageAndInvalidates() {
     final ImageReader mockReader = mock(ImageReader.class);
+    when(mockReader.getMaxImages()).thenReturn(2);
+
     final FlutterImageView imageView =
         spy(
             new FlutterImageView(
@@ -384,6 +388,29 @@ public class FlutterViewTest {
     imageView.acquireLatestImage();
     verify(mockReader, times(1)).acquireLatestImage();
     verify(imageView, times(1)).invalidate();
+  }
+
+  @Test
+  public void flutterImageView_acquiresMaxImagesAtMost() {
+    final ImageReader mockReader = mock(ImageReader.class);
+    when(mockReader.getMaxImages()).thenReturn(2);
+
+    final Image mockImage = mock(Image.class);
+    when(mockReader.acquireLatestImage()).thenReturn(mockImage);
+
+    final FlutterImageView imageView =
+        spy(
+            new FlutterImageView(
+                RuntimeEnvironment.application,
+                mockReader,
+                FlutterImageView.SurfaceKind.background));
+
+    doNothing().when(imageView).invalidate();
+    imageView.acquireLatestImage();
+    imageView.acquireLatestImage();
+    imageView.acquireLatestImage();
+
+    verify(mockReader, times(2)).acquireLatestImage();
   }
 
   /*


### PR DESCRIPTION
## Description

Fixes bugs in the hybrid mode. For example:

1. Currently, we destroy the `SurfaceView`, which causes `PlatformView::NotifyDestroyed()` and therefore `Shell::OnPlatformViewDestroyed()`.

2. We remove the  `SurfaceView` from the view hierarchy _too_ early. Instead, we will keep in the background and rendered while we get the new one ready. This avoids an intermediary flash when switching the surface.

3. The Rtree and the picture recorders are never updated.

4. Dynamic surface switch should occur in `onDisplayPlatformView` as there could be platform views, but no overlay surfaces.

## Related Issues

https://github.com/flutter/flutter/issues/55270
https://github.com/flutter/flutter/issues/58291

## Tests

I added the following tests: These composite case are covered by the scenario app, but the presubmits aren't running.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
