### PR TITLE
Both ui.image and ui.picture should have a GetAllocationSize interface

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1600,6 +1600,8 @@ class Image extends NativeFieldWrapperClass2 {
   /// The number of image pixels along the image's vertical axis.
   int get height native 'Image_height';
 
+  int get approximateBytesUsed native 'Image_GetAllocationSize';
+
   /// Converts the [Image] object into a byte array.
   ///
   /// The [format] argument specifies the format in which the bytes will be

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -16,10 +16,11 @@ typedef CanvasImage Image;
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, Image);
 
-#define FOR_EACH_BINDING(V) \
-  V(Image, width)           \
-  V(Image, height)          \
-  V(Image, toByteData)      \
+#define FOR_EACH_BINDING(V)   \
+  V(Image, width)             \
+  V(Image, height)            \
+  V(Image, GetAllocationSize) \
+  V(Image, toByteData)        \
   V(Image, dispose)
 
 FOR_EACH_BINDING(DART_NATIVE_CALLBACK)

--- a/lib/web_ui/lib/src/engine/compositor/image.dart
+++ b/lib/web_ui/lib/src/engine/compositor/image.dart
@@ -49,6 +49,9 @@ class SkAnimatedImage implements ui.Image {
   int get height => _skAnimatedImage.callMethod('height');
 
   @override
+  int get approximateBytesUsed => 0;
+
+  @override
   Future<ByteData> toByteData(
       {ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) {
     throw 'unimplemented';
@@ -72,6 +75,9 @@ class SkImage implements ui.Image {
 
   @override
   int get height => skImage.callMethod('height');
+
+  @override
+  int get approximateBytesUsed => 0;
 
   @override
   Future<ByteData> toByteData(

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -133,6 +133,9 @@ class HtmlImage implements ui.Image {
   final int height;
 
   @override
+  int get approximateBytesUsed => 0;
+
+  @override
   Future<ByteData> toByteData(
       {ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) {
     return futurize((Callback<ByteData> callback) {

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -1205,6 +1205,9 @@ abstract class Image {
   /// The number of image pixels along the image's vertical axis.
   int get height;
 
+  /// Returns the approximate number of bytes allocated for this object.
+  int get approximateBytesUsed;
+
   /// Converts the [Image] object into a byte array.
   ///
   /// The [format] argument specifies the format in which the bytes will be

--- a/lib/web_ui/test/golden_tests/engine/recording_canvas_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/recording_canvas_golden_test.dart
@@ -674,6 +674,9 @@ class TestImage implements Image {
   int get height => 10;
 
   @override
+  int get approximateBytesUsed => 0;
+
+  @override
   Future<ByteData> toByteData(
       {ImageByteFormat format = ImageByteFormat.rawRgba}) async {
     throw UnsupportedError('Cannot encode test image');


### PR DESCRIPTION
## Description

ui.image doesn't have GetAllocationSize query interface this patch add one, GetAllocationSize method is helpful for devtools.

## Related Issues

this patch will make the flutter frameworks compile fails, all ui.Image derived classes in flutter sdk tests need a patch:
>  @override
 > int get approximateBytesUsed => 0;


## Tests



## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

The following patch should be apply to flutter sdk.

_____start of patch_____
diff --git a/packages/flutter/test/painting/binding_test.dart b/packages/flutter/test/painting/binding_test.dart
index bf9da5b897..7ec26c5fb3 100644
--- a/packages/flutter/test/painting/binding_test.dart
+++ b/packages/flutter/test/painting/binding_test.dart
@@ -130,4 +130,7 @@ class FakeImage implements ui.Image {
 
   @override
   int get width => 10;
+
+  @override
+  int get approximateBytesUsed => 0;
 }
diff --git a/packages/flutter/test/painting/decoration_test.dart b/packages/flutter/test/painting/decoration_test.dart
index 6eded7067e..9592735b9d 100644
--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -100,6 +100,9 @@ class TestImage implements ui.Image {
   @override
   int get height => 100;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   void dispose() { }
 
diff --git a/packages/flutter/test/painting/image_stream_test.dart b/packages/flutter/test/painting/image_stream_test.dart
index a013b8d00b..b5c99edf61 100644
--- a/packages/flutter/test/painting/image_stream_test.dart
+++ b/packages/flutter/test/painting/image_stream_test.dart
@@ -39,6 +39,9 @@ class FakeImage implements Image {
   @override
   int get height => _height;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   void dispose() { }
 
diff --git a/packages/flutter/test/painting/mocks_for_image_cache.dart b/packages/flutter/test/painting/mocks_for_image_cache.dart
index 8e588f7bde..d0cdee4342 100644
--- a/packages/flutter/test/painting/mocks_for_image_cache.dart
+++ b/packages/flutter/test/painting/mocks_for_image_cache.dart
@@ -76,6 +76,9 @@ class TestImage implements ui.Image {
   @override
   final int width;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   void dispose() { }
 
diff --git a/packages/flutter/test/painting/paint_image_test.dart b/packages/flutter/test/painting/paint_image_test.dart
index e0e84463bd..6ab7d103fb 100644
--- a/packages/flutter/test/painting/paint_image_test.dart
+++ b/packages/flutter/test/painting/paint_image_test.dart
@@ -21,6 +21,9 @@ class TestImage implements ui.Image {
   @override
   final int height;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   void dispose() { }
 
diff --git a/packages/flutter/test/painting/shape_decoration_test.dart b/packages/flutter/test/painting/shape_decoration_test.dart
index 30085f151e..45c8cda72c 100644
--- a/packages/flutter/test/painting/shape_decoration_test.dart
+++ b/packages/flutter/test/painting/shape_decoration_test.dart
@@ -134,6 +134,9 @@ class TestImage implements ui.Image {
   @override
   int get height => 200;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   void dispose() { }
 
diff --git a/packages/flutter/test/rendering/image_test.dart b/packages/flutter/test/rendering/image_test.dart
index 0e082f159b..c4becd553d 100644
--- a/packages/flutter/test/rendering/image_test.dart
+++ b/packages/flutter/test/rendering/image_test.dart
@@ -20,6 +20,9 @@ class SquareImage implements ui.Image {
   @override
   int get height => 10;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   Future<ByteData> toByteData({ ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba }) async {
     throw UnsupportedError('Cannot encode test image');
@@ -39,6 +42,9 @@ class WideImage implements ui.Image {
   @override
   int get height => 10;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   Future<ByteData> toByteData({ ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba }) async {
     throw UnsupportedError('Cannot encode test image');
@@ -58,6 +64,9 @@ class TallImage implements ui.Image {
   @override
   int get height => 20;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   Future<ByteData> toByteData({ ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba }) async {
     throw UnsupportedError('Cannot encode test image');
diff --git a/packages/flutter/test/widgets/image_resolution_test.dart b/packages/flutter/test/widgets/image_resolution_test.dart
index 63df873201..ade5671d9b 100644
--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -27,6 +27,9 @@ class TestImage implements ui.Image {
   @override
   int get height => (48*scale).floor();
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   void dispose() { }
 
diff --git a/packages/flutter/test/widgets/image_rtl_test.dart b/packages/flutter/test/widgets/image_rtl_test.dart
index e284c9c96b..dad61b1e58 100644
--- a/packages/flutter/test/widgets/image_rtl_test.dart
+++ b/packages/flutter/test/widgets/image_rtl_test.dart
@@ -35,6 +35,9 @@ class TestImage implements ui.Image {
   @override
   int get height => 9;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   void dispose() { }
 
diff --git a/packages/flutter/test/widgets/image_test.dart b/packages/flutter/test/widgets/image_test.dart
index 472181cd67..cb74198a2e 100644
--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -1868,6 +1868,9 @@ class TestImage implements ui.Image {
   @override
   int get height => 100;
 
+  @override
+  int get approximateBytesUsed => 0;
+
   @override
   void dispose() { }
 
_____end of patch_____

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [x] I wrote a flutter SDK patch above

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
