### PR TITLE
Clarify the relationship between PictureRecorder and Canvas

### DIFF
--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -79,7 +79,6 @@ fml::RefPtr<Canvas> Canvas::Create(PictureRecorder* recorder,
   if (!recorder)
     Dart_ThrowException(
         ToDart("Canvas constructor called with non-genuine PictureRecorder."));
-  FML_DCHECK(!recorder->isRecording());  // verified by Dart code
   fml::RefPtr<Canvas> canvas = fml::MakeRefCounted<Canvas>(
       recorder->BeginRecording(SkRect::MakeLTRB(left, top, right, bottom)));
   recorder->set_canvas(canvas);
@@ -432,12 +431,11 @@ void Canvas::drawShadow(const CanvasPath* path,
                                           elevation, transparentOccluder, dpr);
 }
 
-void Canvas::Clear() {
+void Canvas::Invalidate() {
+  if (dart_wrapper()) {
+    ClearDartWrapper();
+  }
   canvas_ = nullptr;
-}
-
-bool Canvas::IsRecording() const {
-  return !!canvas_;
 }
 
 }  // namespace flutter

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -165,8 +165,7 @@ class Canvas : public RefCountedDartWrappable<Canvas> {
                   bool transparentOccluder);
 
   SkCanvas* canvas() const { return canvas_; }
-  void Clear();
-  bool IsRecording() const;
+  void Invalidate();
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -20,9 +20,7 @@ static void PictureRecorder_constructor(Dart_NativeArguments args) {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, PictureRecorder);
 
-#define FOR_EACH_BINDING(V)       \
-  V(PictureRecorder, isRecording) \
-  V(PictureRecorder, endRecording)
+#define FOR_EACH_BINDING(V) V(PictureRecorder, endRecording)
 
 FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
 
@@ -40,16 +38,12 @@ PictureRecorder::PictureRecorder() {}
 
 PictureRecorder::~PictureRecorder() {}
 
-bool PictureRecorder::isRecording() {
-  return canvas_ && canvas_->IsRecording();
-}
-
 SkCanvas* PictureRecorder::BeginRecording(SkRect bounds) {
   return picture_recorder_.beginRecording(bounds, &rtree_factory_);
 }
 
 fml::RefPtr<Picture> PictureRecorder::endRecording(Dart_Handle dart_picture) {
-  if (!isRecording())
+  if (!canvas_)
     return nullptr;
 
   fml::RefPtr<Picture> picture =
@@ -58,8 +52,7 @@ fml::RefPtr<Picture> PictureRecorder::endRecording(Dart_Handle dart_picture) {
                           picture_recorder_.finishRecordingAsPicture()),
                       canvas_->external_allocation_size());
 
-  canvas_->Clear();
-  canvas_->ClearDartWrapper();
+  canvas_->Invalidate();
   canvas_ = nullptr;
   ClearDartWrapper();
   return picture;

--- a/lib/ui/painting/picture_recorder.h
+++ b/lib/ui/painting/picture_recorder.h
@@ -27,7 +27,6 @@ class PictureRecorder : public RefCountedDartWrappable<PictureRecorder> {
 
   SkCanvas* BeginRecording(SkRect bounds);
   fml::RefPtr<Picture> endRecording(Dart_Handle dart_picture);
-  bool isRecording();
 
   void set_canvas(fml::RefPtr<Canvas> canvas) { canvas_ = std::move(canvas); }
 


### PR DESCRIPTION
A Canvas is only valid as long as the PictureRecorder used to construct
the Canvas is alive.  Previously Dart was unaware of this relationship,
and it was possible for a PictureRecorder to be GCed before the Canvas.

* Canvas will hold a reference to its PictureRecorder in order to
  prevent the PictureRecorder from being GCed until endRecording
  is called or the Canvas itself is GCed.
* PictureRecorder.endRecording will disconnect the Canvas native object
  from its Dart peer.  Attempts to use the Canvas after endRecoding
  will result in an "Object has been disposed" exception thrown by
  Tonic.

See https://github.com/flutter/flutter/issues/60319
See https://github.com/flutter/flutter/issues/51066
