### PR TITLE
Rename Sk* classes to Ck* in preparation for @JS migration

### DIFF
--- a/lib/web_ui/lib/src/engine/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/color_filter.dart
@@ -114,7 +114,7 @@ class EngineColorFilter implements ui.ColorFilter {
   final List<double>? _matrix;
   final int _type;
 
-  // The type of SkColorFilter class to create for Skia.
+  // The type of CkColorFilter class to create for Skia.
   static const int _TypeMode = 1; // MakeModeFilter
   static const int _TypeMatrix = 2; // MakeMatrixFilterRowMajor255
   static const int _TypeLinearToSrgbGamma = 3; // MakeLinearToSRGBGamma
@@ -129,23 +129,23 @@ class EngineColorFilter implements ui.ColorFilter {
         && other._blendMode == _blendMode;
   }
 
-  SkColorFilter? _toSkColorFilter() {
+  CkColorFilter? _toCkColorFilter() {
     switch (_type) {
       case _TypeMode:
         if (_color == null || _blendMode == null) {
           return null;
         }
-        return SkColorFilter.mode(this);
+        return CkColorFilter.mode(this);
       case _TypeMatrix:
         if (_matrix == null) {
           return null;
         }
         assert(_matrix!.length == 20, 'Color Matrix must have 20 entries.');
-        return SkColorFilter.matrix(this);
+        return CkColorFilter.matrix(this);
       case _TypeLinearToSrgbGamma:
-        return SkColorFilter.linearToSrgbGamma(this);
+        return CkColorFilter.linearToSrgbGamma(this);
       case _TypeSrgbToLinearGamma:
-        return SkColorFilter.srgbToLinearGamma(this);
+        return CkColorFilter.srgbToLinearGamma(this);
       default:
         throw StateError('Unknown mode $_type for ColorFilter.');
     }

--- a/lib/web_ui/lib/src/engine/compositor/canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/canvas.dart
@@ -5,10 +5,10 @@
 part of engine;
 
 /// A Dart wrapper around Skia's SKCanvas.
-class SkCanvas {
+class CkCanvas {
   final js.JsObject skCanvas;
 
-  SkCanvas(this.skCanvas);
+  CkCanvas(this.skCanvas);
 
   int? get saveCount => skCanvas.callMethod('getSaveCount');
 
@@ -18,7 +18,7 @@ class SkCanvas {
   }
 
   void clipPath(ui.Path path, bool doAntiAlias) {
-    final SkPath skPath = path as SkPath;
+    final CkPath skPath = path as CkPath;
     final js.JsObject? intersectClipOp = canvasKit['ClipOp']['Intersect'];
     skCanvas.callMethod('clipPath', <dynamic>[
       skPath._skPath,
@@ -56,7 +56,7 @@ class SkCanvas {
     double startAngle,
     double sweepAngle,
     bool useCenter,
-    SkPaint paint,
+    CkPaint paint,
   ) {
     const double toDegrees = 180 / math.pi;
     skCanvas.callMethod('drawArc', <dynamic>[
@@ -69,14 +69,14 @@ class SkCanvas {
   }
 
   void drawAtlasRaw(
-    SkPaint paint,
+    CkPaint paint,
     ui.Image atlas,
     Float32List rstTransforms,
     Float32List rects,
     js.JsArray<Float32List>? colors,
     ui.BlendMode blendMode,
   ) {
-    final SkImage skAtlas = atlas as SkImage;
+    final CkImage skAtlas = atlas as CkImage;
     skCanvas.callMethod('drawAtlas', <dynamic>[
       skAtlas.skImage,
       rects,
@@ -87,7 +87,7 @@ class SkCanvas {
     ]);
   }
 
-  void drawCircle(ui.Offset c, double radius, SkPaint paint) {
+  void drawCircle(ui.Offset c, double radius, CkPaint paint) {
     skCanvas.callMethod('drawCircle', <dynamic>[
       c.dx,
       c.dy,
@@ -103,7 +103,7 @@ class SkCanvas {
     ]);
   }
 
-  void drawDRRect(ui.RRect outer, ui.RRect inner, SkPaint paint) {
+  void drawDRRect(ui.RRect outer, ui.RRect inner, CkPaint paint) {
     skCanvas.callMethod('drawDRRect', <js.JsObject?>[
       makeSkRRect(outer),
       makeSkRRect(inner),
@@ -111,8 +111,8 @@ class SkCanvas {
     ]);
   }
 
-  void drawImage(ui.Image image, ui.Offset offset, SkPaint paint) {
-    final SkImage skImage = image as SkImage;
+  void drawImage(ui.Image image, ui.Offset offset, CkPaint paint) {
+    final CkImage skImage = image as CkImage;
     skCanvas.callMethod('drawImage', <dynamic>[
       skImage.skImage,
       offset.dx,
@@ -121,8 +121,8 @@ class SkCanvas {
     ]);
   }
 
-  void drawImageRect(ui.Image image, ui.Rect src, ui.Rect dst, SkPaint paint) {
-    final SkImage skImage = image as SkImage;
+  void drawImageRect(ui.Image image, ui.Rect src, ui.Rect dst, CkPaint paint) {
+    final CkImage skImage = image as CkImage;
     skCanvas.callMethod('drawImageRect', <dynamic>[
       skImage.skImage,
       makeSkRect(src),
@@ -133,8 +133,8 @@ class SkCanvas {
   }
 
   void drawImageNine(
-      ui.Image image, ui.Rect center, ui.Rect dst, SkPaint paint) {
-    final SkImage skImage = image as SkImage;
+      ui.Image image, ui.Rect center, ui.Rect dst, CkPaint paint) {
+    final CkImage skImage = image as CkImage;
     skCanvas.callMethod('drawImageNine', <dynamic>[
       skImage.skImage,
       makeSkRect(center),
@@ -143,7 +143,7 @@ class SkCanvas {
     ]);
   }
 
-  void drawLine(ui.Offset p1, ui.Offset p2, SkPaint paint) {
+  void drawLine(ui.Offset p1, ui.Offset p2, CkPaint paint) {
     skCanvas.callMethod('drawLine', <dynamic>[
       p1.dx,
       p1.dy,
@@ -153,19 +153,19 @@ class SkCanvas {
     ]);
   }
 
-  void drawOval(ui.Rect rect, SkPaint paint) {
+  void drawOval(ui.Rect rect, CkPaint paint) {
     skCanvas.callMethod('drawOval', <js.JsObject?>[
       makeSkRect(rect),
       paint.skiaObject,
     ]);
   }
 
-  void drawPaint(SkPaint paint) {
+  void drawPaint(CkPaint paint) {
     skCanvas.callMethod('drawPaint', <js.JsObject?>[paint.skiaObject]);
   }
 
   void drawParagraph(ui.Paragraph paragraph, ui.Offset offset) {
-    final SkParagraph skParagraph = paragraph as SkParagraph;
+    final CkParagraph skParagraph = paragraph as CkParagraph;
     skCanvas.callMethod('drawParagraph', <dynamic>[
       skParagraph.skiaObject,
       offset.dx,
@@ -173,21 +173,21 @@ class SkCanvas {
     ]);
   }
 
-  void drawPath(ui.Path path, SkPaint paint) {
+  void drawPath(ui.Path path, CkPaint paint) {
     final js.JsObject? skPaint = paint.skiaObject;
-    final SkPath enginePath = path as SkPath;
+    final CkPath enginePath = path as CkPath;
     final js.JsObject? skPath = enginePath._skPath;
     skCanvas.callMethod('drawPath', <js.JsObject?>[skPath, skPaint]);
   }
 
   void drawPicture(ui.Picture picture) {
-    final SkPicture skPicture = picture as SkPicture;
+    final CkPicture skPicture = picture as CkPicture;
     skCanvas.callMethod(
         'drawPicture', <js.JsObject?>[skPicture.skPicture.skiaObject]);
   }
 
   // TODO(hterkelsen): https://github.com/flutter/flutter/issues/58824
-  void drawPoints(SkPaint paint, ui.PointMode pointMode,
+  void drawPoints(CkPaint paint, ui.PointMode pointMode,
       js.JsArray<js.JsArray<double>>? points) {
     skCanvas.callMethod('drawPoints', <dynamic>[
       makeSkPointMode(pointMode),
@@ -196,14 +196,14 @@ class SkCanvas {
     ]);
   }
 
-  void drawRRect(ui.RRect rrect, SkPaint paint) {
+  void drawRRect(ui.RRect rrect, CkPaint paint) {
     skCanvas.callMethod('drawRRect', <js.JsObject?>[
       makeSkRRect(rrect),
       paint.skiaObject,
     ]);
   }
 
-  void drawRect(ui.Rect rect, SkPaint paint) {
+  void drawRect(ui.Rect rect, CkPaint paint) {
     final js.JsObject skRect = makeSkRect(rect);
     final js.JsObject? skPaint = paint.skiaObject;
     skCanvas.callMethod('drawRect', <js.JsObject?>[skRect, skPaint]);
@@ -211,13 +211,13 @@ class SkCanvas {
 
   void drawShadow(ui.Path path, ui.Color color, double elevation,
       bool transparentOccluder) {
-    drawSkShadow(skCanvas, path as SkPath, color, elevation,
+    drawSkShadow(skCanvas, path as CkPath, color, elevation,
         transparentOccluder, ui.window.devicePixelRatio);
   }
 
   void drawVertices(
-      ui.Vertices vertices, ui.BlendMode blendMode, SkPaint paint) {
-    SkVertices skVertices = vertices as SkVertices;
+      ui.Vertices vertices, ui.BlendMode blendMode, CkPaint paint) {
+    CkVertices skVertices = vertices as CkVertices;
     skCanvas.callMethod('drawVertices', <js.JsObject?>[
       skVertices.skVertices,
       makeSkBlendMode(blendMode),
@@ -242,19 +242,19 @@ class SkCanvas {
     return skCanvas.callMethod('save');
   }
 
-  void saveLayer(ui.Rect bounds, SkPaint paint) {
+  void saveLayer(ui.Rect bounds, CkPaint paint) {
     skCanvas.callMethod('saveLayer', <js.JsObject?>[
       makeSkRect(bounds),
       paint.skiaObject,
     ]);
   }
 
-  void saveLayerWithoutBounds(SkPaint paint) {
+  void saveLayerWithoutBounds(CkPaint paint) {
     skCanvas.callMethod('saveLayer', <js.JsObject?>[paint.skiaObject]);
   }
 
   void saveLayerWithFilter(ui.Rect bounds, ui.ImageFilter filter) {
-    final SkImageFilter skImageFilter = filter as SkImageFilter;
+    final CkImageFilter skImageFilter = filter as CkImageFilter;
     return skCanvas.callMethod(
       'saveLayer',
       <dynamic>[

--- a/lib/web_ui/lib/src/engine/compositor/canvas_kit_canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/canvas_kit_canvas.dart
@@ -7,7 +7,7 @@ part of engine;
 
 /// An implementation of [ui.Canvas] that is backed by a CanvasKit canvas.
 class CanvasKitCanvas implements ui.Canvas {
-  final SkCanvas? _canvas;
+  final CkCanvas? _canvas;
 
   factory CanvasKitCanvas(ui.PictureRecorder recorder, [ui.Rect? cullRect]) {
     assert(recorder != null); // ignore: unnecessary_null_comparison
@@ -16,7 +16,7 @@ class CanvasKitCanvas implements ui.Canvas {
           '"recorder" must not already be associated with another Canvas.');
     }
     cullRect ??= ui.Rect.largest;
-    final SkPictureRecorder skRecorder = recorder as SkPictureRecorder;
+    final CkPictureRecorder skRecorder = recorder as CkPictureRecorder;
     return CanvasKitCanvas._(skRecorder.beginRecording(cullRect));
   }
 
@@ -39,11 +39,11 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _saveLayerWithoutBounds(ui.Paint paint) {
-    _canvas!.saveLayerWithoutBounds(paint as SkPaint);
+    _canvas!.saveLayerWithoutBounds(paint as CkPaint);
   }
 
   void _saveLayer(ui.Rect bounds, ui.Paint paint) {
-    _canvas!.saveLayer(bounds, paint as SkPaint);
+    _canvas!.saveLayer(bounds, paint as CkPaint);
   }
 
   @override
@@ -147,7 +147,7 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _drawLine(ui.Offset p1, ui.Offset p2, ui.Paint paint) {
-    _canvas!.drawLine(p1, p2, paint as SkPaint);
+    _canvas!.drawLine(p1, p2, paint as CkPaint);
   }
 
   @override
@@ -157,7 +157,7 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _drawPaint(ui.Paint paint) {
-    _canvas!.drawPaint(paint as SkPaint);
+    _canvas!.drawPaint(paint as CkPaint);
   }
 
   @override
@@ -168,7 +168,7 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _drawRect(ui.Rect rect, ui.Paint paint) {
-    _canvas!.drawRect(rect, paint as SkPaint);
+    _canvas!.drawRect(rect, paint as CkPaint);
   }
 
   @override
@@ -179,7 +179,7 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _drawRRect(ui.RRect rrect, ui.Paint paint) {
-    _canvas!.drawRRect(rrect, paint as SkPaint);
+    _canvas!.drawRRect(rrect, paint as CkPaint);
   }
 
   @override
@@ -191,7 +191,7 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _drawDRRect(ui.RRect outer, ui.RRect inner, ui.Paint paint) {
-    _canvas!.drawDRRect(outer, inner, paint as SkPaint);
+    _canvas!.drawDRRect(outer, inner, paint as CkPaint);
   }
 
   @override
@@ -202,7 +202,7 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _drawOval(ui.Rect rect, ui.Paint paint) {
-    _canvas!.drawOval(rect, paint as SkPaint);
+    _canvas!.drawOval(rect, paint as CkPaint);
   }
 
   @override
@@ -213,7 +213,7 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _drawCircle(ui.Offset c, double radius, ui.Paint paint) {
-    _canvas!.drawCircle(c, radius, paint as SkPaint);
+    _canvas!.drawCircle(c, radius, paint as CkPaint);
   }
 
   @override
@@ -226,7 +226,7 @@ class CanvasKitCanvas implements ui.Canvas {
 
   void _drawArc(ui.Rect rect, double startAngle, double sweepAngle,
       bool useCenter, ui.Paint paint) {
-    _canvas!.drawArc(rect, startAngle, sweepAngle, useCenter, paint as SkPaint);
+    _canvas!.drawArc(rect, startAngle, sweepAngle, useCenter, paint as CkPaint);
   }
 
   @override
@@ -238,7 +238,7 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _drawPath(ui.Path path, ui.Paint paint) {
-    _canvas!.drawPath(path, paint as SkPaint);
+    _canvas!.drawPath(path, paint as CkPaint);
   }
 
   @override
@@ -251,7 +251,7 @@ class CanvasKitCanvas implements ui.Canvas {
   }
 
   void _drawImage(ui.Image image, ui.Offset p, ui.Paint paint) {
-    _canvas!.drawImage(image, p, paint as SkPaint);
+    _canvas!.drawImage(image, p, paint as CkPaint);
   }
 
   @override
@@ -266,7 +266,7 @@ class CanvasKitCanvas implements ui.Canvas {
 
   void _drawImageRect(
       ui.Image image, ui.Rect src, ui.Rect dst, ui.Paint paint) {
-    _canvas!.drawImageRect(image, src, dst, paint as SkPaint);
+    _canvas!.drawImageRect(image, src, dst, paint as CkPaint);
   }
 
   @override
@@ -282,7 +282,7 @@ class CanvasKitCanvas implements ui.Canvas {
 
   void _drawImageNine(
       ui.Image image, ui.Rect center, ui.Rect dst, ui.Paint paint) {
-    _canvas!.drawImageNine(image, center, dst, paint as SkPaint);
+    _canvas!.drawImageNine(image, center, dst, paint as CkPaint);
   }
 
   @override
@@ -330,7 +330,7 @@ class CanvasKitCanvas implements ui.Canvas {
 
   void _drawPoints(
       ui.Paint paint, ui.PointMode pointMode, List<List<double>>? points) {
-    _canvas!.drawPoints(paint as SkPaint, pointMode, points as js.JsArray<js.JsArray<double>>?);
+    _canvas!.drawPoints(paint as CkPaint, pointMode, points as js.JsArray<js.JsArray<double>>?);
   }
 
   @override
@@ -345,7 +345,7 @@ class CanvasKitCanvas implements ui.Canvas {
 
   void _drawVertices(
       ui.Vertices vertices, ui.BlendMode blendMode, ui.Paint paint) {
-    _canvas!.drawVertices(vertices, blendMode, paint as SkPaint);
+    _canvas!.drawVertices(vertices, blendMode, paint as CkPaint);
   }
 
   @override
@@ -442,7 +442,7 @@ class CanvasKitCanvas implements ui.Canvas {
     js.JsArray<Float32List>? colors,
     ui.BlendMode blendMode,
   ) {
-    _canvas!.drawAtlasRaw(paint as SkPaint, atlas, rstTransforms, rects, colors, blendMode);
+    _canvas!.drawAtlasRaw(paint as CkPaint, atlas, rstTransforms, rects, colors, blendMode);
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/compositor/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/compositor/color_filter.dart
@@ -5,18 +5,18 @@
 
 part of engine;
 
-/// A [ui.ColorFilter] backed by Skia's [SkColorFilter].
-class SkColorFilter extends ResurrectableSkiaObject {
+/// A [ui.ColorFilter] backed by Skia's [CkColorFilter].
+class CkColorFilter extends ResurrectableSkiaObject {
   final EngineColorFilter _engineFilter;
 
-  SkColorFilter.mode(EngineColorFilter filter) : _engineFilter = filter;
+  CkColorFilter.mode(EngineColorFilter filter) : _engineFilter = filter;
 
-  SkColorFilter.matrix(EngineColorFilter filter) : _engineFilter = filter;
+  CkColorFilter.matrix(EngineColorFilter filter) : _engineFilter = filter;
 
-  SkColorFilter.linearToSrgbGamma(EngineColorFilter filter)
+  CkColorFilter.linearToSrgbGamma(EngineColorFilter filter)
       : _engineFilter = filter;
 
-  SkColorFilter.srgbToLinearGamma(EngineColorFilter filter)
+  CkColorFilter.srgbToLinearGamma(EngineColorFilter filter)
       : _engineFilter = filter;
 
   js.JsObject _createSkiaObjectFromFilter() {

--- a/lib/web_ui/lib/src/engine/compositor/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/compositor/embedded_views.dart
@@ -13,8 +13,8 @@ class HtmlViewEmbedder {
   /// for further paint commands to paint to, since the composited view will
   /// be on top of the current canvas, and we want further paint commands to
   /// be on top of the platform view.
-  final Map<int, SkPictureRecorder> _pictureRecorders =
-      <int, SkPictureRecorder>{};
+  final Map<int, CkPictureRecorder> _pictureRecorders =
+      <int, CkPictureRecorder>{};
 
   /// The most recent composition parameters for a given view id.
   ///
@@ -128,8 +128,8 @@ class HtmlViewEmbedder {
     callback(codec.encodeSuccessEnvelope(null));
   }
 
-  List<SkCanvas?> getCurrentCanvases() {
-    final List<SkCanvas?> canvases = <SkCanvas?>[];
+  List<CkCanvas?> getCurrentCanvases() {
+    final List<CkCanvas?> canvases = <CkCanvas?>[];
     for (int i = 0; i < _compositionOrder.length; i++) {
       final int viewId = _compositionOrder[i];
       canvases.add(_pictureRecorders[viewId]!.recordingCanvas);
@@ -138,7 +138,7 @@ class HtmlViewEmbedder {
   }
 
   void prerollCompositeEmbeddedView(int viewId, EmbeddedViewParams params) {
-    final pictureRecorder = SkPictureRecorder();
+    final pictureRecorder = CkPictureRecorder();
     pictureRecorder.beginRecording(ui.Offset.zero & _frameSize);
     pictureRecorder.recordingCanvas!.clear(ui.Color(0x00000000));
     _pictureRecorders[viewId] = pictureRecorder;
@@ -152,7 +152,7 @@ class HtmlViewEmbedder {
     _viewsToRecomposite.add(viewId);
   }
 
-  SkCanvas? compositeEmbeddedView(int viewId) {
+  CkCanvas? compositeEmbeddedView(int viewId) {
     // Do nothing if this view doesn't need to be composited.
     if (!_viewsToRecomposite.contains(viewId)) {
       return _pictureRecorders[viewId]!.recordingCanvas;
@@ -252,7 +252,7 @@ class HtmlViewEmbedder {
             clipView.style.clip = 'rect(${rect.top}px, ${rect.right}px, '
                 '${rect.bottom}px, ${rect.left}px)';
           } else if (mutator.rrect != null) {
-            final SkPath path = SkPath();
+            final CkPath path = CkPath();
             path.addRRect(mutator.rrect!);
             _ensureSvgPathDefs();
             html.Element pathDefs = _svgPathDefs!.querySelector('#sk_path_defs')!;
@@ -264,7 +264,7 @@ class HtmlViewEmbedder {
             pathDefs.append(newClipPath);
             clipView.style.clipPath = 'url(#svgClip$_clipPathCount)';
           } else if (mutator.path != null) {
-            final SkPath path = mutator.path as SkPath;
+            final CkPath path = mutator.path as CkPath;
             _ensureSvgPathDefs();
             html.Element pathDefs = _svgPathDefs!.querySelector('#sk_path_defs')!;
             _clipPathCount += 1;
@@ -332,7 +332,7 @@ class HtmlViewEmbedder {
       ensureOverlayInitialized(viewId);
       final SurfaceFrame frame =
           _overlays[viewId]!.surface.acquireFrame(_frameSize);
-      final SkCanvas canvas = frame.skiaCanvas;
+      final CkCanvas canvas = frame.skiaCanvas;
       canvas.drawPicture(_pictureRecorders[viewId]!.endRecording());
       frame.submit();
     }
@@ -384,7 +384,7 @@ class HtmlViewEmbedder {
       return;
     }
     Surface surface = Surface(this);
-    SkSurface? skSurface = surface.acquireRenderSurface(_frameSize);
+    CkSurface? skSurface = surface.acquireRenderSurface(_frameSize);
     _overlays[viewId] = Overlay(surface, skSurface);
   }
 }
@@ -537,7 +537,7 @@ class MutatorsStack extends Iterable<Mutator> {
 /// Represents a surface overlaying a platform view.
 class Overlay {
   final Surface surface;
-  final SkSurface? skSurface;
+  final CkSurface? skSurface;
 
   Overlay(this.surface, this.skSurface);
 }

--- a/lib/web_ui/lib/src/engine/compositor/image.dart
+++ b/lib/web_ui/lib/src/engine/compositor/image.dart
@@ -10,16 +10,16 @@ void skiaInstantiateImageCodec(Uint8List list, Callback<ui.Codec> callback,
     [int? width, int? height, int? format, int? rowBytes]) {
   final js.JsObject? skAnimatedImage =
       canvasKit.callMethod('MakeAnimatedImageFromEncoded', <Uint8List>[list]);
-  final SkAnimatedImage animatedImage = SkAnimatedImage(skAnimatedImage);
-  final SkAnimatedImageCodec codec = SkAnimatedImageCodec(animatedImage);
+  final CkAnimatedImage animatedImage = CkAnimatedImage(skAnimatedImage);
+  final CkAnimatedImageCodec codec = CkAnimatedImageCodec(animatedImage);
   callback(codec);
 }
 
 /// A wrapper for `SkAnimatedImage`.
-class SkAnimatedImage implements ui.Image {
+class CkAnimatedImage implements ui.Image {
   final js.JsObject? _skAnimatedImage;
 
-  SkAnimatedImage(this._skAnimatedImage);
+  CkAnimatedImage(this._skAnimatedImage);
 
   @override
   void dispose() {
@@ -36,10 +36,10 @@ class SkAnimatedImage implements ui.Image {
 
   int? get repetitionCount => _skAnimatedImage!.callMethod('getRepetitionCount');
 
-  SkImage get currentFrameAsImage {
+  CkImage get currentFrameAsImage {
     final js.JsObject? _currentFrame =
         _skAnimatedImage!.callMethod('getCurrentFrame');
-    return SkImage(_currentFrame);
+    return CkImage(_currentFrame);
   }
 
   @override
@@ -56,10 +56,10 @@ class SkAnimatedImage implements ui.Image {
 }
 
 /// A [ui.Image] backed by an `SkImage` from Skia.
-class SkImage implements ui.Image {
+class CkImage implements ui.Image {
   js.JsObject? skImage;
 
-  SkImage(this.skImage);
+  CkImage(this.skImage);
 
   @override
   void dispose() {
@@ -81,10 +81,10 @@ class SkImage implements ui.Image {
 }
 
 /// A [Codec] that wraps an `SkAnimatedImage`.
-class SkAnimatedImageCodec implements ui.Codec {
-  SkAnimatedImage? animatedImage;
+class CkAnimatedImageCodec implements ui.Codec {
+  CkAnimatedImage? animatedImage;
 
-  SkAnimatedImageCodec(this.animatedImage);
+  CkAnimatedImageCodec(this.animatedImage);
 
   @override
   void dispose() {
@@ -101,7 +101,7 @@ class SkAnimatedImageCodec implements ui.Codec {
   @override
   Future<ui.FrameInfo> getNextFrame() {
     final Duration duration = animatedImage!.decodeNextFrame();
-    final SkImage image = animatedImage!.currentFrameAsImage;
+    final CkImage image = animatedImage!.currentFrameAsImage;
     return Future<ui.FrameInfo>.value(AnimatedImageFrameInfo(duration, image));
   }
 }
@@ -109,7 +109,7 @@ class SkAnimatedImageCodec implements ui.Codec {
 /// Data for a single frame of an animated image.
 class AnimatedImageFrameInfo implements ui.FrameInfo {
   final Duration _duration;
-  final SkImage _image;
+  final CkImage _image;
 
   AnimatedImageFrameInfo(this._duration, this._image);
 

--- a/lib/web_ui/lib/src/engine/compositor/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/compositor/image_filter.dart
@@ -7,8 +7,8 @@ part of engine;
 /// The CanvasKit implementation of [ui.ImageFilter].
 ///
 /// Currently only supports `blur`.
-class SkImageFilter extends ResurrectableSkiaObject implements ui.ImageFilter {
-  SkImageFilter.blur({double sigmaX = 0.0, double sigmaY = 0.0})
+class CkImageFilter extends ResurrectableSkiaObject implements ui.ImageFilter {
+  CkImageFilter.blur({double sigmaX = 0.0, double sigmaY = 0.0})
       : _sigmaX = sigmaX,
         _sigmaY = sigmaY;
 
@@ -33,7 +33,7 @@ class SkImageFilter extends ResurrectableSkiaObject implements ui.ImageFilter {
 
   @override
   bool operator ==(Object other) {
-    return other is SkImageFilter
+    return other is CkImageFilter
         && other._sigmaX == _sigmaX
         && other._sigmaY == _sigmaY;
   }

--- a/lib/web_ui/lib/src/engine/compositor/layer.dart
+++ b/lib/web_ui/lib/src/engine/compositor/layer.dart
@@ -48,10 +48,10 @@ class PaintContext {
   /// A multi-canvas that applies clips, transforms, and opacity
   /// operations to all canvases (root canvas and overlay canvases for the
   /// platform views).
-  SkNWayCanvas internalNodesCanvas;
+  CkNWayCanvas internalNodesCanvas;
 
   /// The canvas for leaf nodes to paint to.
-  SkCanvas? leafNodesCanvas;
+  CkCanvas? leafNodesCanvas;
 
   /// A raster cache potentially containing pre-rendered pictures.
   final RasterCache? rasterCache;
@@ -365,7 +365,7 @@ class ImageFilterLayer extends ContainerLayer implements ui.OpacityEngineLayer {
 /// A layer containing a [Picture].
 class PictureLayer extends Layer {
   /// The picture to paint into the canvas.
-  final SkPicture picture;
+  final CkPicture picture;
 
   /// The offset at which to paint the picture.
   final ui.Offset offset;
@@ -486,7 +486,7 @@ class PhysicalShapeLayer extends ContainerLayer
 
     final ui.Paint paint = ui.Paint()..color = _color!;
     if (_clipBehavior != ui.Clip.antiAliasWithSaveLayer) {
-      paintContext.leafNodesCanvas!.drawPath(_path!, paint as SkPaint);
+      paintContext.leafNodesCanvas!.drawPath(_path!, paint as CkPaint);
     }
 
     final int? saveCount = paintContext.internalNodesCanvas.save();
@@ -510,7 +510,7 @@ class PhysicalShapeLayer extends ContainerLayer
       // (https://github.com/flutter/flutter/issues/18057#issue-328003931)
       // using saveLayer, we have to call drawPaint instead of drawPath as
       // anti-aliased drawPath will always have such artifacts.
-      paintContext.leafNodesCanvas!.drawPaint(paint as SkPaint);
+      paintContext.leafNodesCanvas!.drawPaint(paint as CkPaint);
     }
 
     paintChildren(paintContext);
@@ -522,7 +522,7 @@ class PhysicalShapeLayer extends ContainerLayer
   ///
   /// The blur of the shadow is decided by the [elevation], and the
   /// shadow is painted with the given [color].
-  static void drawShadow(SkCanvas canvas, ui.Path path, ui.Color color,
+  static void drawShadow(CkCanvas canvas, ui.Path path, ui.Color color,
       double elevation, bool transparentOccluder) {
     canvas.drawShadow(path, color, elevation, transparentOccluder);
   }
@@ -552,7 +552,7 @@ class PlatformViewLayer extends Layer {
 
   @override
   void paint(PaintContext context) {
-    SkCanvas? canvas = context.viewEmbedder!.compositeEmbeddedView(viewId);
+    CkCanvas? canvas = context.viewEmbedder!.compositeEmbeddedView(viewId);
     context.leafNodesCanvas = canvas;
   }
 }

--- a/lib/web_ui/lib/src/engine/compositor/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/compositor/layer_scene_builder.dart
@@ -49,7 +49,7 @@ class LayerSceneBuilder implements ui.SceneBuilder {
     bool willChangeHint = false,
   }) {
     currentLayer!.add(PictureLayer(
-        picture as SkPicture, offset, isComplexHint, willChangeHint));
+        picture as CkPicture, offset, isComplexHint, willChangeHint));
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/compositor/layer_tree.dart
+++ b/lib/web_ui/lib/src/engine/compositor/layer_tree.dart
@@ -35,9 +35,9 @@ class LayerTree {
   /// If [ignoreRasterCache] is `true`, then the raster cache will
   /// not be used.
   void paint(Frame frame, {bool ignoreRasterCache = false}) {
-    final SkNWayCanvas internalNodesCanvas = SkNWayCanvas();
+    final CkNWayCanvas internalNodesCanvas = CkNWayCanvas();
     internalNodesCanvas.addCanvas(frame.canvas);
-    final List<SkCanvas?> overlayCanvases =
+    final List<CkCanvas?> overlayCanvases =
         frame.viewEmbedder!.getCurrentCanvases();
     for (int i = 0; i < overlayCanvases.length; i++) {
       internalNodesCanvas.addCanvas(overlayCanvases[i]);
@@ -65,7 +65,7 @@ ui.Size _computeFrameSize() {
 /// A single frame to be rendered.
 class Frame {
   /// The canvas to render this frame to.
-  final SkCanvas canvas;
+  final CkCanvas canvas;
 
   /// A cache of pre-rastered pictures.
   final RasterCache? rasterCache;
@@ -93,7 +93,7 @@ class CompositorContext {
   RasterCache? rasterCache;
 
   /// Acquire a frame using this compositor's settings.
-  Frame acquireFrame(SkCanvas canvas, HtmlViewEmbedder? viewEmbedder) {
+  Frame acquireFrame(CkCanvas canvas, HtmlViewEmbedder? viewEmbedder) {
     return Frame(canvas, rasterCache, viewEmbedder);
   }
 }

--- a/lib/web_ui/lib/src/engine/compositor/mask_filter.dart
+++ b/lib/web_ui/lib/src/engine/compositor/mask_filter.dart
@@ -5,8 +5,8 @@
 part of engine;
 
 /// The CanvasKit implementation of [ui.MaskFilter].
-class SkMaskFilter extends ResurrectableSkiaObject {
-  SkMaskFilter.blur(ui.BlurStyle blurStyle, double sigma)
+class CkMaskFilter extends ResurrectableSkiaObject {
+  CkMaskFilter.blur(ui.BlurStyle blurStyle, double sigma)
       : _blurStyle = blurStyle,
         _sigma = sigma;
 

--- a/lib/web_ui/lib/src/engine/compositor/n_way_canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/n_way_canvas.dart
@@ -6,10 +6,10 @@
 part of engine;
 
 /// A virtual canvas that applies operations to multiple canvases at once.
-class SkNWayCanvas {
-  final List<SkCanvas?> _canvases = <SkCanvas?>[];
+class CkNWayCanvas {
+  final List<CkCanvas?> _canvases = <CkCanvas?>[];
 
-  void addCanvas(SkCanvas? canvas) {
+  void addCanvas(CkCanvas? canvas) {
     _canvases.add(canvas);
   }
 
@@ -25,7 +25,7 @@ class SkNWayCanvas {
   /// Calls [saveLayer] on all canvases.
   void saveLayer(ui.Rect bounds, ui.Paint? paint) {
     for (int i = 0; i < _canvases.length; i++) {
-      _canvases[i]!.saveLayer(bounds, paint as SkPaint);
+      _canvases[i]!.saveLayer(bounds, paint as CkPaint);
     }
   }
 

--- a/lib/web_ui/lib/src/engine/compositor/painting.dart
+++ b/lib/web_ui/lib/src/engine/compositor/painting.dart
@@ -9,8 +9,8 @@ part of engine;
 ///
 /// This class is backed by a Skia object that must be explicitly
 /// deleted to avoid a memory leak. This is done by extending [SkiaObject].
-class SkPaint extends ResurrectableSkiaObject implements ui.Paint {
-  SkPaint();
+class CkPaint extends ResurrectableSkiaObject implements ui.Paint {
+  CkPaint();
 
   static const ui.Color _defaultPaintColor = ui.Color(0xFF000000);
   static final js.JsObject? _skPaintStyleStroke =
@@ -157,12 +157,12 @@ class SkPaint extends ResurrectableSkiaObject implements ui.Paint {
   }
 
   void _syncMaskFilter(js.JsObject object) {
-    SkMaskFilter? skMaskFilter;
+    CkMaskFilter? skMaskFilter;
     if (_maskFilter != null) {
       final ui.BlurStyle blurStyle = _maskFilter!.webOnlyBlurStyle;
       final double sigma = _maskFilter!.webOnlySigma;
 
-      skMaskFilter = SkMaskFilter.blur(blurStyle, sigma);
+      skMaskFilter = CkMaskFilter.blur(blurStyle, sigma);
     }
     object.callMethod('setMaskFilter', <js.JsObject?>[skMaskFilter?.skiaObject]);
   }
@@ -209,7 +209,7 @@ class SkPaint extends ResurrectableSkiaObject implements ui.Paint {
   void _syncColorFilter(js.JsObject object) {
     js.JsObject? skColorFilterJs;
     if (_colorFilter != null) {
-      SkColorFilter? skFilter = _colorFilter!._toSkColorFilter();
+      CkColorFilter? skFilter = _colorFilter!._toCkColorFilter();
       skColorFilterJs = skFilter!.skiaObject;
     }
     object.callMethod('setColorFilter', <js.JsObject?>[skColorFilterJs]);
@@ -231,7 +231,7 @@ class SkPaint extends ResurrectableSkiaObject implements ui.Paint {
   ui.ImageFilter? get imageFilter => _imageFilter;
   @override
   set imageFilter(ui.ImageFilter? value) {
-    _imageFilter = value as SkImageFilter?;
+    _imageFilter = value as CkImageFilter?;
     _syncImageFilter(skiaObject);
   }
 
@@ -243,7 +243,7 @@ class SkPaint extends ResurrectableSkiaObject implements ui.Paint {
     object.callMethod('setImageFilter', <js.JsObject?>[imageFilterJs]);
   }
 
-  SkImageFilter? _imageFilter;
+  CkImageFilter? _imageFilter;
 
   @override
   js.JsObject createDefault() {

--- a/lib/web_ui/lib/src/engine/compositor/path.dart
+++ b/lib/web_ui/lib/src/engine/compositor/path.dart
@@ -7,25 +7,25 @@ part of engine;
 
 /// An implementation of [ui.Path] which is backed by an `SkPath`.
 ///
-/// The `SkPath` is required for `SkCanvas` methods which take a path.
-class SkPath implements ui.Path {
+/// The `SkPath` is required for `CkCanvas` methods which take a path.
+class CkPath implements ui.Path {
   js.JsObject? _skPath;
 
   /// Cached constructor function for `SkPath`, so we don't have to look it up
   /// every time we construct a new path.
   static final js.JsFunction? _skPathConstructor = canvasKit['SkPath'];
 
-  SkPath() {
+  CkPath() {
     _skPath = js.JsObject(_skPathConstructor!);
     fillType = ui.PathFillType.nonZero;
   }
 
-  SkPath.from(SkPath other) {
+  CkPath.from(CkPath other) {
     _skPath = js.JsObject(_skPathConstructor!, <js.JsObject?>[other._skPath]);
     fillType = other.fillType;
   }
 
-  SkPath._fromSkPath(js.JsObject? skPath) : _skPath = skPath;
+  CkPath._fromSkPath(js.JsObject? skPath) : _skPath = skPath;
 
   late ui.PathFillType _fillType;
 
@@ -75,7 +75,7 @@ class SkPath implements ui.Path {
       skMatrix[2] += offset.dx;
       skMatrix[5] += offset.dy;
     }
-    final SkPath otherPath = path as SkPath;
+    final CkPath otherPath = path as CkPath;
     _skPath!.callMethod('addPath', <dynamic>[
       otherPath._skPath,
       skMatrix[0],
@@ -157,7 +157,7 @@ class SkPath implements ui.Path {
 
   @override
   ui.PathMetrics computeMetrics({bool forceClosed = false}) {
-    return SkPathMetrics(this, forceClosed);
+    return CkPathMetrics(this, forceClosed);
   }
 
   @override
@@ -187,7 +187,7 @@ class SkPath implements ui.Path {
       skMatrix[2] += offset.dx;
       skMatrix[5] += offset.dy;
     }
-    final SkPath otherPath = path as SkPath;
+    final CkPath otherPath = path as CkPath;
     _skPath!.callMethod('addPath', <dynamic>[
       otherPath._skPath,
       skMatrix[0],
@@ -279,16 +279,16 @@ class SkPath implements ui.Path {
     final js.JsObject newPath = _skPath!.callMethod('copy');
     newPath.callMethod('transform',
         <double>[1.0, 0.0, offset.dx, 0.0, 1.0, offset.dy, 0.0, 0.0, 0.0]);
-    return SkPath._fromSkPath(newPath);
+    return CkPath._fromSkPath(newPath);
   }
 
-  static SkPath combine(
+  static CkPath combine(
     ui.PathOperation operation,
     ui.Path uiPath1,
     ui.Path uiPath2,
   ) {
-    final SkPath path1 = uiPath1 as SkPath;
-    final SkPath path2 = uiPath2 as SkPath;
+    final CkPath path1 = uiPath1 as CkPath;
+    final CkPath path2 = uiPath2 as CkPath;
     js.JsObject? pathOp;
     switch (operation) {
       case ui.PathOperation.difference:
@@ -315,14 +315,14 @@ class SkPath implements ui.Path {
         pathOp,
       ],
     );
-    return SkPath._fromSkPath(newPath);
+    return CkPath._fromSkPath(newPath);
   }
 
   @override
   ui.Path transform(Float64List matrix4) {
     final js.JsObject newPath = _skPath!.callMethod('copy');
     newPath.callMethod('transform', <js.JsArray>[makeSkMatrixFromFloat64(matrix4)]);
-    return SkPath._fromSkPath(newPath);
+    return CkPath._fromSkPath(newPath);
   }
 
   String? toSvgString() {

--- a/lib/web_ui/lib/src/engine/compositor/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/compositor/path_metrics.dart
@@ -4,24 +4,24 @@
 
 part of engine;
 
-class SkPathMetrics extends IterableBase<ui.PathMetric>
+class CkPathMetrics extends IterableBase<ui.PathMetric>
     implements ui.PathMetrics {
-  SkPathMetrics(this._path, this._forceClosed);
+  CkPathMetrics(this._path, this._forceClosed);
 
-  final SkPath _path;
+  final CkPath _path;
   final bool _forceClosed;
 
-  /// The [SkPath.isEmpty] case is special-cased to avoid booting the WASM machinery just to find out there are no contours.
+  /// The [CkPath.isEmpty] case is special-cased to avoid booting the WASM machinery just to find out there are no contours.
   @override
-  Iterator<ui.PathMetric> get iterator => _path.isEmpty! ? const SkPathMetricIteratorEmpty._() : SkContourMeasureIter(_path, _forceClosed);
+  Iterator<ui.PathMetric> get iterator => _path.isEmpty! ? const CkPathMetricIteratorEmpty._() : CkContourMeasureIter(_path, _forceClosed);
 }
 
-class SkContourMeasureIter implements Iterator<ui.PathMetric> {
+class CkContourMeasureIter implements Iterator<ui.PathMetric> {
   /// Cached constructor function for `SkContourMeasureIter`, so we don't have to look it
   /// up every time we're constructing a new instance.
   static final js.JsFunction? _skContourMeasureIterConstructor = canvasKit['SkContourMeasureIter'];
 
-  SkContourMeasureIter(SkPath path, bool forceClosed)
+  CkContourMeasureIter(CkPath path, bool forceClosed)
     : _skObject = js.JsObject(_skContourMeasureIterConstructor!, <dynamic>[
         path._skPath,
         forceClosed,
@@ -48,7 +48,7 @@ class SkContourMeasureIter implements Iterator<ui.PathMetric> {
     }
     return currentMetric;
   }
-  SkContourMeasure? _current;
+  CkContourMeasure? _current;
 
   @override
   bool moveNext() {
@@ -58,14 +58,14 @@ class SkContourMeasureIter implements Iterator<ui.PathMetric> {
       return false;
     }
 
-    _current = SkContourMeasure(_contourIndexCounter, skContourMeasure);
+    _current = CkContourMeasure(_contourIndexCounter, skContourMeasure);
     _contourIndexCounter += 1;
     return true;
   }
 }
 
-class SkContourMeasure implements ui.PathMetric {
-  SkContourMeasure(this.contourIndex, this._skObject);
+class CkContourMeasure implements ui.PathMetric {
+  CkContourMeasure(this.contourIndex, this._skObject);
 
   final js.JsObject _skObject;
 
@@ -76,7 +76,7 @@ class SkContourMeasure implements ui.PathMetric {
   ui.Path extractPath(double start, double end, {bool startWithMoveTo = true}) {
     final js.JsObject? skPath = _skObject
         .callMethod('getSegment', <dynamic>[start, end, startWithMoveTo]);
-    return SkPath._fromSkPath(skPath);
+    return CkPath._fromSkPath(skPath);
   }
 
   @override
@@ -99,8 +99,8 @@ class SkContourMeasure implements ui.PathMetric {
   }
 }
 
-class SkPathMetricIteratorEmpty implements Iterator<ui.PathMetric> {
-  const SkPathMetricIteratorEmpty._();
+class CkPathMetricIteratorEmpty implements Iterator<ui.PathMetric> {
+  const CkPathMetricIteratorEmpty._();
 
   @override
   ui.PathMetric get current {

--- a/lib/web_ui/lib/src/engine/compositor/picture.dart
+++ b/lib/web_ui/lib/src/engine/compositor/picture.dart
@@ -4,11 +4,11 @@
 
 part of engine;
 
-class SkPicture implements ui.Picture {
+class CkPicture implements ui.Picture {
   final SkiaObject skPicture;
   final ui.Rect? cullRect;
 
-  SkPicture(this.skPicture, this.cullRect);
+  CkPicture(this.skPicture, this.cullRect);
 
   @override
   int get approximateBytesUsed => 0;

--- a/lib/web_ui/lib/src/engine/compositor/picture_recorder.dart
+++ b/lib/web_ui/lib/src/engine/compositor/picture_recorder.dart
@@ -4,23 +4,23 @@
 
 part of engine;
 
-class SkPictureRecorder implements ui.PictureRecorder {
+class CkPictureRecorder implements ui.PictureRecorder {
   ui.Rect? _cullRect;
   js.JsObject? _recorder;
-  SkCanvas? _recordingCanvas;
+  CkCanvas? _recordingCanvas;
 
-  SkCanvas? beginRecording(ui.Rect bounds) {
+  CkCanvas? beginRecording(ui.Rect bounds) {
     _cullRect = bounds;
     _recorder = js.JsObject(canvasKit['SkPictureRecorder']);
     final js.JsObject skRect = js.JsObject(canvasKit['LTRBRect'],
         <double>[bounds.left, bounds.top, bounds.right, bounds.bottom]);
     final js.JsObject skCanvas =
         _recorder!.callMethod('beginRecording', <js.JsObject>[skRect]);
-    _recordingCanvas = SkCanvas(skCanvas);
+    _recordingCanvas = CkCanvas(skCanvas);
     return _recordingCanvas;
   }
 
-  SkCanvas? get recordingCanvas => _recordingCanvas;
+  CkCanvas? get recordingCanvas => _recordingCanvas;
 
   @override
   ui.Picture endRecording() {
@@ -29,7 +29,7 @@ class SkPictureRecorder implements ui.PictureRecorder {
     _recorder!.callMethod('delete');
     _recorder = null;
 
-    return SkPicture(OneShotSkiaObject(skPicture), _cullRect);
+    return CkPicture(OneShotSkiaObject(skPicture), _cullRect);
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/compositor/raster_cache.dart
+++ b/lib/web_ui/lib/src/engine/compositor/raster_cache.dart
@@ -48,5 +48,5 @@ class RasterCacheResult {
   bool get isValid => false;
 
   /// Draws the rasterized picture into the [canvas].
-  void draw(SkCanvas canvas) {}
+  void draw(CkCanvas canvas) {}
 }

--- a/lib/web_ui/lib/src/engine/compositor/rasterizer.dart
+++ b/lib/web_ui/lib/src/engine/compositor/rasterizer.dart
@@ -24,7 +24,7 @@ class Rasterizer {
 
       final SurfaceFrame frame = surface.acquireFrame(layerTree.frameSize);
       surface.viewEmbedder.frameSize = layerTree.frameSize;
-      final SkCanvas canvas = frame.skiaCanvas;
+      final CkCanvas canvas = frame.skiaCanvas;
       final Frame compositorFrame =
           context.acquireFrame(canvas, surface.viewEmbedder);
 

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -4,11 +4,11 @@
 
 part of engine;
 
-typedef SubmitCallback = bool Function(SurfaceFrame, SkCanvas);
+typedef SubmitCallback = bool Function(SurfaceFrame, CkCanvas);
 
 /// A frame which contains a canvas to be drawn into.
 class SurfaceFrame {
-  final SkSurface skiaSurface;
+  final CkSurface skiaSurface;
   final SubmitCallback submitCallback;
   bool _submitted;
 
@@ -25,18 +25,18 @@ class SurfaceFrame {
     return submitCallback(this, skiaCanvas);
   }
 
-  SkCanvas get skiaCanvas => skiaSurface.getCanvas();
+  CkCanvas get skiaCanvas => skiaSurface.getCanvas();
 }
 
 /// A surface which can be drawn into by the compositor.
 ///
-/// The underlying representation is a [SkSurface], which can be reused by
-/// successive frames if they are the same size. Otherwise, a new [SkSurface] is
+/// The underlying representation is a [CkSurface], which can be reused by
+/// successive frames if they are the same size. Otherwise, a new [CkSurface] is
 /// created.
 class Surface {
   Surface(this.viewEmbedder);
 
-  SkSurface? _surface;
+  CkSurface? _surface;
   html.Element? htmlElement;
 
   bool _addedToScene = false;
@@ -49,18 +49,18 @@ class Surface {
   ///
   /// The given [size] is in physical pixels.
   SurfaceFrame acquireFrame(ui.Size size) {
-    final SkSurface surface = acquireRenderSurface(size);
+    final CkSurface surface = acquireRenderSurface(size);
 
     canvasKit.callMethod('setCurrentContext', <int?>[surface.context]);
     SubmitCallback submitCallback =
-        (SurfaceFrame surfaceFrame, SkCanvas canvas) {
+        (SurfaceFrame surfaceFrame, CkCanvas canvas) {
       return _presentSurface();
     };
 
     return SurfaceFrame(surface, submitCallback);
   }
 
-  SkSurface acquireRenderSurface(ui.Size size) {
+  CkSurface acquireRenderSurface(ui.Size size) {
     _createOrUpdateSurfaces(size);
     return _surface!;
   }
@@ -77,7 +77,7 @@ class Surface {
       throw CanvasKitError('Cannot create surfaces of empty size.');
     }
 
-    final SkSurface? currentSurface = _surface;
+    final CkSurface? currentSurface = _surface;
     if (currentSurface != null) {
       final bool isSameSize = size.width == currentSurface.width() &&
           size.height == currentSurface.height();
@@ -96,7 +96,7 @@ class Surface {
     _surface = _wrapHtmlCanvas(size);
   }
 
-  SkSurface _wrapHtmlCanvas(ui.Size size) {
+  CkSurface _wrapHtmlCanvas(ui.Size size) {
     final ui.Size logicalSize = size / ui.window.devicePixelRatio;
     final html.CanvasElement htmlCanvas = html.CanvasElement(
         width: size.width.ceil(), height: size.height.ceil());
@@ -130,7 +130,7 @@ class Surface {
     }
 
     htmlElement = htmlCanvas;
-    return SkSurface(skSurface, grContext, glContext);
+    return CkSurface(skSurface, grContext, glContext);
   }
 
   bool _presentSurface() {
@@ -140,17 +140,17 @@ class Surface {
   }
 }
 
-/// A Dart wrapper around Skia's SkSurface.
-class SkSurface {
+/// A Dart wrapper around Skia's CkSurface.
+class CkSurface {
   final js.JsObject _surface;
   final js.JsObject _grContext;
   final int _glContext;
 
-  SkSurface(this._surface, this._grContext, this._glContext);
+  CkSurface(this._surface, this._grContext, this._glContext);
 
-  SkCanvas getCanvas() {
+  CkCanvas getCanvas() {
     final js.JsObject skCanvas = _surface.callMethod('getCanvas');
-    return SkCanvas(skCanvas);
+    return CkCanvas(skCanvas);
   }
 
   int get context => _glContext;

--- a/lib/web_ui/lib/src/engine/compositor/text.dart
+++ b/lib/web_ui/lib/src/engine/compositor/text.dart
@@ -4,8 +4,8 @@
 
 part of engine;
 
-class SkParagraphStyle implements ui.ParagraphStyle {
-  SkParagraphStyle({
+class CkParagraphStyle implements ui.ParagraphStyle {
+  CkParagraphStyle({
     ui.TextAlign? textAlign,
     ui.TextDirection? textDirection,
     int? maxLines,
@@ -19,7 +19,7 @@ class SkParagraphStyle implements ui.ParagraphStyle {
     String? ellipsis,
     ui.Locale? locale,
   }) {
-    skParagraphStyle = toSkParagraphStyle(
+    skParagraphStyle = toCkParagraphStyle(
       textAlign,
       textDirection,
       maxLines,
@@ -40,7 +40,7 @@ class SkParagraphStyle implements ui.ParagraphStyle {
   ui.TextDirection? _textDirection;
   String? _fontFamily;
 
-  static Map<String, dynamic> toSkTextStyle(
+  static Map<String, dynamic> toCkTextStyle(
     String? fontFamily,
     double? fontSize,
     ui.FontWeight? fontWeight,
@@ -67,7 +67,7 @@ class SkParagraphStyle implements ui.ParagraphStyle {
     return skTextStyle;
   }
 
-  static js.JsObject? toSkParagraphStyle(
+  static js.JsObject? toCkParagraphStyle(
     ui.TextAlign? textAlign,
     ui.TextDirection? textDirection,
     int? maxLines,
@@ -132,17 +132,17 @@ class SkParagraphStyle implements ui.ParagraphStyle {
     }
 
     skParagraphStyle['textStyle'] =
-        toSkTextStyle(fontFamily, fontSize, fontWeight, fontStyle);
+        toCkTextStyle(fontFamily, fontSize, fontWeight, fontStyle);
 
     return canvasKit.callMethod(
         'ParagraphStyle', <js.JsObject>[js.JsObject.jsify(skParagraphStyle)]);
   }
 }
 
-class SkTextStyle implements ui.TextStyle {
+class CkTextStyle implements ui.TextStyle {
   js.JsObject? skTextStyle;
 
-  SkTextStyle({
+  CkTextStyle({
     ui.Color? color,
     ui.TextDecoration? decoration,
     ui.Color? decorationColor,
@@ -158,8 +158,8 @@ class SkTextStyle implements ui.TextStyle {
     double? wordSpacing,
     double? height,
     ui.Locale? locale,
-    SkPaint? background,
-    SkPaint? foreground,
+    CkPaint? background,
+    CkPaint? foreground,
     List<ui.Shadow>? shadows,
     List<ui.FontFeature>? fontFeatures,
   }) {
@@ -282,11 +282,11 @@ Map<String, js.JsObject?> toSkFontStyle(
   return style;
 }
 
-class SkParagraph extends ResurrectableSkiaObject implements ui.Paragraph {
-  SkParagraph(
+class CkParagraph extends ResurrectableSkiaObject implements ui.Paragraph {
+  CkParagraph(
       this._initialParagraph, this._paragraphStyle, this._paragraphCommands);
 
-  /// The result of calling `build()` on the JS SkParagraphBuilder.
+  /// The result of calling `build()` on the JS CkParagraphBuilder.
   ///
   /// This may be invalidated later.
   final js.JsObject _initialParagraph;
@@ -295,7 +295,7 @@ class SkParagraph extends ResurrectableSkiaObject implements ui.Paragraph {
   ///
   /// This is used to resurrect the paragraph if the initial paragraph
   /// is deleted.
-  final SkParagraphStyle _paragraphStyle;
+  final CkParagraphStyle _paragraphStyle;
 
   /// The paragraph builder commands used to build this paragraph.
   ///
@@ -314,7 +314,7 @@ class SkParagraph extends ResurrectableSkiaObject implements ui.Paragraph {
 
   @override
   js.JsObject resurrect() {
-    final builder = SkParagraphBuilder(_paragraphStyle);
+    final builder = CkParagraphBuilder(_paragraphStyle);
     for (_ParagraphCommand command in _paragraphCommands) {
       switch (command.type) {
         case _ParagraphCommandType.addText:
@@ -329,7 +329,7 @@ class SkParagraph extends ResurrectableSkiaObject implements ui.Paragraph {
       }
     }
 
-    final js.JsObject result = builder._buildSkParagraph();
+    final js.JsObject result = builder._buildCkParagraph();
     if (_lastLayoutConstraints != null) {
       // We need to set the Skia object early so layout works.
       _skiaObject = result;
@@ -491,14 +491,14 @@ class SkParagraph extends ResurrectableSkiaObject implements ui.Paragraph {
   }
 }
 
-class SkParagraphBuilder implements ui.ParagraphBuilder {
+class CkParagraphBuilder implements ui.ParagraphBuilder {
   js.JsObject? _paragraphBuilder;
-  final SkParagraphStyle _style;
+  final CkParagraphStyle _style;
   final List<_ParagraphCommand> _commands;
 
-  SkParagraphBuilder(ui.ParagraphStyle style)
+  CkParagraphBuilder(ui.ParagraphStyle style)
       : _commands = <_ParagraphCommand>[],
-        _style = style as SkParagraphStyle {
+        _style = style as CkParagraphStyle {
     _paragraphBuilder = canvasKit['ParagraphBuilder'].callMethod(
       'Make',
       <js.JsObject?>[
@@ -529,12 +529,12 @@ class SkParagraphBuilder implements ui.ParagraphBuilder {
 
   @override
   ui.Paragraph build() {
-    final builtParagraph = _buildSkParagraph();
-    return SkParagraph(builtParagraph, _style, _commands);
+    final builtParagraph = _buildCkParagraph();
+    return CkParagraph(builtParagraph, _style, _commands);
   }
 
-  /// Builds the SkParagraph with the builder and deletes the builder.
-  js.JsObject _buildSkParagraph() {
+  /// Builds the CkParagraph with the builder and deletes the builder.
+  js.JsObject _buildCkParagraph() {
     final js.JsObject result = _paragraphBuilder!.callMethod('build');
     _paragraphBuilder!.callMethod('delete');
     _paragraphBuilder = null;
@@ -556,7 +556,7 @@ class SkParagraphBuilder implements ui.ParagraphBuilder {
 
   @override
   void pushStyle(ui.TextStyle style) {
-    final SkTextStyle skStyle = style as SkTextStyle;
+    final CkTextStyle skStyle = style as CkTextStyle;
     _commands.add(_ParagraphCommand.pushStyle(skStyle));
     _paragraphBuilder!
         .callMethod('pushStyle', <js.JsObject?>[skStyle.skTextStyle]);
@@ -566,7 +566,7 @@ class SkParagraphBuilder implements ui.ParagraphBuilder {
 class _ParagraphCommand {
   final _ParagraphCommandType type;
   final String? text;
-  final SkTextStyle? style;
+  final CkTextStyle? style;
 
   const _ParagraphCommand._(this.type, this.text, this.style);
 
@@ -575,7 +575,7 @@ class _ParagraphCommand {
 
   const _ParagraphCommand.pop() : this._(_ParagraphCommandType.pop, null, null);
 
-  const _ParagraphCommand.pushStyle(SkTextStyle style)
+  const _ParagraphCommand.pushStyle(CkTextStyle style)
       : this._(_ParagraphCommandType.pushStyle, null, style);
 }
 

--- a/lib/web_ui/lib/src/engine/compositor/util.dart
+++ b/lib/web_ui/lib/src/engine/compositor/util.dart
@@ -313,7 +313,7 @@ js.JsArray<double> makeSkiaColorStops(List<double>? colorStops) {
 
 void drawSkShadow(
   js.JsObject skCanvas,
-  SkPath path,
+  CkPath path,
   ui.Color color,
   double elevation,
   bool transparentOccluder,

--- a/lib/web_ui/lib/src/engine/compositor/vertices.dart
+++ b/lib/web_ui/lib/src/engine/compositor/vertices.dart
@@ -14,10 +14,10 @@ js.JsArray<Float32List> _encodeRawColorList(Int32List rawColors) {
   return makeColorList(colors);
 }
 
-class SkVertices implements ui.Vertices {
+class CkVertices implements ui.Vertices {
   js.JsObject? skVertices;
 
-  SkVertices(
+  CkVertices(
     ui.VertexMode mode,
     List<ui.Offset> positions, {
     List<ui.Offset>? textureCoordinates,
@@ -45,7 +45,7 @@ class SkVertices implements ui.Vertices {
       throw ArgumentError('Invalid configuration for vertices.');
   }
 
-  SkVertices.raw(
+  CkVertices.raw(
     ui.VertexMode mode,
     Float32List positions, {
     Float32List? textureCoordinates,

--- a/lib/web_ui/lib/src/engine/shader.dart
+++ b/lib/web_ui/lib/src/engine/shader.dart
@@ -309,12 +309,12 @@ js.JsObject? _skTileMode(ui.TileMode tileMode) {
 class EngineImageShader implements ui.ImageShader, EngineShader {
   EngineImageShader(
       ui.Image image, this.tileModeX, this.tileModeY, this.matrix4)
-      : _skImage = image as SkImage;
+      : _skImage = image as CkImage;
 
   final ui.TileMode tileModeX;
   final ui.TileMode tileModeY;
   final Float64List matrix4;
-  final SkImage _skImage;
+  final CkImage _skImage;
 
   js.JsObject? createSkiaShader() => _skImage.skImage!.callMethod(
       'makeShader', <dynamic>[_skTileMode(tileModeX), _skTileMode(tileModeY)]);

--- a/lib/web_ui/lib/src/ui/canvas.dart
+++ b/lib/web_ui/lib/src/ui/canvas.dart
@@ -77,7 +77,7 @@ class Vertices {
     List<int>? indices,
   }) {
     if (engine.experimentalUseSkia) {
-      return engine.SkVertices(mode, positions,
+      return engine.CkVertices(mode, positions,
           textureCoordinates: textureCoordinates,
           colors: colors,
           indices: indices);
@@ -113,7 +113,7 @@ class Vertices {
     Uint16List? indices,
   }) {
     if (engine.experimentalUseSkia) {
-      return engine.SkVertices.raw(mode, positions,
+      return engine.CkVertices.raw(mode, positions,
           textureCoordinates: textureCoordinates,
           colors: colors,
           indices: indices);
@@ -134,7 +134,7 @@ abstract class PictureRecorder {
   /// [Canvas] constructor.
   factory PictureRecorder() {
     if (engine.experimentalUseSkia) {
-      return engine.SkPictureRecorder();
+      return engine.CkPictureRecorder();
     } else {
       return engine.EnginePictureRecorder();
     }

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -903,7 +903,7 @@ abstract class Paint {
   /// Constructs an empty [Paint] object with all fields initialized to
   /// their defaults.
   factory Paint() =>
-      engine.experimentalUseSkia ? engine.SkPaint() : engine.SurfacePaint();
+      engine.experimentalUseSkia ? engine.CkPaint() : engine.SurfacePaint();
 
   /// Whether to dither the output when drawing images.
   ///
@@ -1439,7 +1439,7 @@ class ImageFilter {
   /// Creates an image filter that applies a Gaussian blur.
   factory ImageFilter.blur({double sigmaX = 0.0, double sigmaY = 0.0}) {
     if (engine.experimentalUseSkia) {
-      return engine.SkImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY);
+      return engine.CkImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY);
     }
     return engine.EngineImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY);
   }

--- a/lib/web_ui/lib/src/ui/path.dart
+++ b/lib/web_ui/lib/src/ui/path.dart
@@ -26,7 +26,7 @@ abstract class Path {
   /// Create a new empty [Path] object.
   factory Path() {
     if (engine.experimentalUseSkia) {
-      return engine.SkPath();
+      return engine.CkPath();
     } else {
       return engine.SurfacePath();
     }
@@ -38,7 +38,7 @@ abstract class Path {
   /// the `source` path or the path returned by this constructor are modified.
   factory Path.from(Path source) {
     if (engine.experimentalUseSkia) {
-      return engine.SkPath.from(source as engine.SkPath);
+      return engine.CkPath.from(source as engine.CkPath);
     } else {
       return engine.SurfacePath.from(source as engine.SurfacePath);
     }
@@ -272,7 +272,7 @@ abstract class Path {
     assert(path1 != null); // ignore: unnecessary_null_comparison
     assert(path2 != null); // ignore: unnecessary_null_comparison
     if (engine.experimentalUseSkia) {
-      return engine.SkPath.combine(operation, path1, path2);
+      return engine.CkPath.combine(operation, path1, path2);
     }
     throw UnimplementedError();
   }

--- a/lib/web_ui/lib/src/ui/text.dart
+++ b/lib/web_ui/lib/src/ui/text.dart
@@ -558,7 +558,7 @@ abstract class TextStyle {
     List<FontFeature>? fontFeatures,
   }) {
     if (engine.experimentalUseSkia) {
-      return engine.SkTextStyle(
+      return engine.CkTextStyle(
           color: color,
           decoration: decoration,
           decorationColor: decorationColor,
@@ -574,8 +574,8 @@ abstract class TextStyle {
           wordSpacing: wordSpacing,
           height: height,
           locale: locale,
-          background: background as engine.SkPaint?,
-          foreground: foreground as engine.SkPaint?,
+          background: background as engine.CkPaint?,
+          foreground: foreground as engine.CkPaint?,
           shadows: shadows,
           fontFeatures: fontFeatures,
       );
@@ -677,7 +677,7 @@ abstract class ParagraphStyle {
     Locale? locale,
   }) {
     if (engine.experimentalUseSkia) {
-      return engine.SkParagraphStyle(
+      return engine.CkParagraphStyle(
         textAlign: textAlign,
         textDirection: textDirection,
         maxLines: maxLines,
@@ -1485,7 +1485,7 @@ abstract class ParagraphBuilder {
   /// [Paragraph].
   factory ParagraphBuilder(ParagraphStyle style) {
     if (engine.experimentalUseSkia) {
-      return engine.SkParagraphBuilder(style);
+      return engine.CkParagraphBuilder(style);
     } else {
       return engine.EngineParagraphBuilder(style as engine.EngineParagraphStyle);
     }

--- a/lib/web_ui/test/canvaskit/path_metrics_test.dart
+++ b/lib/web_ui/test/canvaskit/path_metrics_test.dart
@@ -18,9 +18,9 @@ void main() {
       expect(experimentalUseSkia, true);
     });
 
-    test(SkPathMetrics, () {
+    test(CkPathMetrics, () {
       final ui.Path path = ui.Path();
-      expect(path, isA<SkPath>());
+      expect(path, isA<CkPath>());
       expect(path.computeMetrics().length, 0);
 
       path.addRect(ui.Rect.fromLTRB(0, 0, 10, 10));


### PR DESCRIPTION
## Description

Rename Sk* classes to Ck* classes. This is so we can reserve the "Sk" prefix for the actual CanvasKit objects. "Ck" can be used for wrappers.
