### PR TITLE
Fix wrong licensing in engine

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -29,6 +29,9 @@ FILE: ../../../flutter/flow/compositor_context.h
 FILE: ../../../flutter/flow/embedded_view_params_unittests.cc
 FILE: ../../../flutter/flow/embedded_views.cc
 FILE: ../../../flutter/flow/embedded_views.h
+FILE: ../../../flutter/flow/flow_run_all_unittests.cc
+FILE: ../../../flutter/flow/flow_test_utils.cc
+FILE: ../../../flutter/flow/flow_test_utils.h
 FILE: ../../../flutter/flow/gl_context_switch.cc
 FILE: ../../../flutter/flow/gl_context_switch.h
 FILE: ../../../flutter/flow/gl_context_switch_unittests.cc
@@ -1458,9 +1461,6 @@ LIBRARY: engine
 LIBRARY: txt
 ORIGIN: ../../../flutter/third_party/txt/LICENSE
 TYPE: LicenseType.apache
-FILE: ../../../flutter/flow/flow_run_all_unittests.cc
-FILE: ../../../flutter/flow/flow_test_utils.cc
-FILE: ../../../flutter/flow/flow_test_utils.h
 FILE: ../../../flutter/third_party/txt/benchmarks/paint_record_benchmarks.cc
 FILE: ../../../flutter/third_party/txt/benchmarks/paragraph_benchmarks.cc
 FILE: ../../../flutter/third_party/txt/benchmarks/paragraph_builder_benchmarks.cc

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1457,7 +1457,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
 
 ====================================================================================================
-LIBRARY: engine
 LIBRARY: txt
 ORIGIN: ../../../flutter/third_party/txt/LICENSE
 TYPE: LicenseType.apache

--- a/flow/flow_run_all_unittests.cc
+++ b/flow/flow_run_all_unittests.cc
@@ -1,19 +1,7 @@
-/*
- * Copyright 2017 Google, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"

--- a/flow/flow_test_utils.cc
+++ b/flow/flow_test_utils.cc
@@ -1,19 +1,7 @@
-/*
- * Copyright 2017 Google, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
 #include <string>
 
 namespace flutter {

--- a/flow/flow_test_utils.h
+++ b/flow/flow_test_utils.h
@@ -1,19 +1,7 @@
-/*
- * Copyright 2017 Google, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
 #include <string>
 
 namespace flutter {


### PR DESCRIPTION
This is the only Apache license other than third_party library. I assume it was a mistake. Please let me know if otherwise.