### PR TITLE
Added the ability to set properties in interface builder for FlutterViewController

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -79,6 +79,14 @@ FLUTTER_EXPORT
                          bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
 
 /**
+ * Initializer that is called from loading a FlutterViewController from a XIB.
+ *
+ * See also:
+ * https://developer.apple.com/documentation/foundation/nscoding/1416145-initwithcoder?language=objc
+ */
+- (instancetype)initWithCoder:(NSCoder*)aDecoder NS_DESIGNATED_INITIALIZER;
+
+/**
  * Registers a callback that will be invoked when the Flutter view has been rendered.
  * The callback will be fired only once.
  *
@@ -193,6 +201,17 @@ FLUTTER_EXPORT
  * This is just a convenient way to get the |FlutterEngine|'s binary messenger.
  */
 @property(nonatomic, readonly) NSObject<FlutterBinaryMessenger>* binaryMessenger;
+
+/**
+ * If the `FlutterViewController` creates a `FlutterEngine`, this property
+ * determines if that `FlutterEngine` has `allowHeadlessExecution` set.
+ *
+ * The intention is that this is used with the XIB.  Otherwise, a
+ * `FlutterEngine` can just be sent to the init methods.
+ *
+ * See also: `-[FlutterEngine initWithName:project:allowHeadlessExecution:]`
+ */
+@property(nonatomic, readonly) BOOL engineAllowHeadlessExecution;
 
 @end
 


### PR DESCRIPTION
## Description

Added the ability to set properties in interface builder for FlutterViewControllers and their subclasses.  I also added one property that controls if the created engine allows headless execution.

Since our templates use Storyboards we should probably support them better.

## Related Issues

[research into multiple flutters]

## Tests

Covered in other integration tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
