### PR TITLE
Set child_layer_exists_below flag for Fuchsia PlatformViewLayer

### DIFF
--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -14,6 +14,7 @@ PlatformViewLayer::PlatformViewLayer(const SkPoint& offset,
 void PlatformViewLayer::Preroll(PrerollContext* context,
                                 const SkMatrix& matrix) {
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
+  context->child_scene_layer_exists_below = true;
   CheckForChildLayerBelow(context);
 #endif
 
@@ -31,10 +32,6 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
                                            context->mutators_stack);
   context->view_embedder->PrerollCompositeEmbeddedView(view_id_,
                                                        std::move(params));
-#if defined(LEGACY_FUCHSIA_EMBEDDER)
-  // Set needs_system_composite flag so that rasterizer can call UpdateScene.
-  set_needs_system_composite(true);
-#endif
 }
 
 void PlatformViewLayer::Paint(PaintContext& context) const {

--- a/flow/layers/platform_view_layer_unittests.cc
+++ b/flow/layers/platform_view_layer_unittests.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/platform_view_layer.h"
-
 #include "flutter/flow/testing/layer_test.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/fml/macros.h"
@@ -27,7 +26,11 @@ TEST_F(PlatformViewLayerTest, NullViewEmbedderDoesntPrerollCompositeOrPaint) {
             SkRect::MakeSize(layer_size)
                 .makeOffset(layer_offset.fX, layer_offset.fY));
   EXPECT_TRUE(layer->needs_painting());
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
+  EXPECT_TRUE(layer->needs_system_composite());
+#else
   EXPECT_FALSE(layer->needs_system_composite());
+#endif  // LEGACY_FUCHSIA_EMBEDDER
 
   layer->Paint(paint_context());
   EXPECT_EQ(paint_context().leaf_nodes_canvas, &mock_canvas());


### PR DESCRIPTION
This enables proper compositing of surfaces with elevation over
a PlatformViewLayer.