### PR TITLE
Fix TextEditingController.clear() not working on Linux shell

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Dwayne Slater <ds84182@gmail.com>
 Tetsuhiro Ueda <najeira@gmail.com>
 shoryukenn <naifu.guan@gmail.com>
 SOTEC GmbH & Co. KG <sotec-contributors@sotec.eu>
+Nobuhiro Tabuki <japanese.around30@gmail.com>

--- a/shell/platform/common/cpp/text_input_model.cc
+++ b/shell/platform/common/cpp/text_input_model.cc
@@ -34,17 +34,27 @@ TextInputModel::TextInputModel()
 
 TextInputModel::~TextInputModel() = default;
 
-bool TextInputModel::SetEditingState(size_t selection_base,
-                                     size_t selection_extent,
+bool TextInputModel::SetEditingState(int64_t selection_base,
+                                     int64_t selection_extent,
                                      const std::string& text) {
-  if (selection_base > text.size() || selection_extent > text.size()) {
+  if ((selection_base >= 0 &&
+       static_cast<size_t>(selection_base) > text.size()) ||
+      (selection_extent >= 0 &&
+       static_cast<size_t>(selection_extent) > text.size())) {
     return false;
   }
-  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>
-      utf16_converter;
-  text_ = utf16_converter.from_bytes(text);
-  selection_base_ = text_.begin() + selection_base;
-  selection_extent_ = text_.begin() + selection_extent;
+  if (selection_base == -1 && selection_extent == -1 && text.empty()) {
+    // Action on TextEditingValue.empty
+    text_.clear();
+    selection_base_ = text_.begin();
+    selection_extent_ = text_.begin();
+  } else {
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t>
+        utf16_converter;
+    text_ = utf16_converter.from_bytes(text);
+    selection_base_ = text_.begin() + selection_base;
+    selection_extent_ = text_.begin() + selection_extent;
+  }
   return true;
 }
 
@@ -151,8 +161,9 @@ bool TextInputModel::DeleteSurrounding(int offset_from_cursor, int count) {
 }
 
 bool TextInputModel::MoveCursorToBeginning() {
-  if (selection_base_ == text_.begin() && selection_extent_ == text_.begin())
+  if (selection_base_ == text_.begin() && selection_extent_ == text_.begin()) {
     return false;
+  }
 
   selection_base_ = text_.begin();
   selection_extent_ = text_.begin();
@@ -161,8 +172,9 @@ bool TextInputModel::MoveCursorToBeginning() {
 }
 
 bool TextInputModel::MoveCursorToEnd() {
-  if (selection_base_ == text_.end() && selection_extent_ == text_.end())
+  if (selection_base_ == text_.end() && selection_extent_ == text_.end()) {
     return false;
+  }
 
   selection_base_ = text_.end();
   selection_extent_ = text_.end();

--- a/shell/platform/common/cpp/text_input_model.h
+++ b/shell/platform/common/cpp/text_input_model.h
@@ -19,10 +19,10 @@ class TextInputModel {
 
   // Attempts to set the text state.
   //
-  // Returns false if the state is not valid (base or extent are out of
-  // bounds, or base is less than extent).
-  bool SetEditingState(size_t selection_base,
-                       size_t selection_extent,
+  // Returns false if the state is not valid (base or extent are larger than
+  // current text length).
+  bool SetEditingState(int64_t selection_base,
+                       int64_t selection_extent,
                        const std::string& text);
 
   // Adds a Unicode code point.

--- a/shell/platform/common/cpp/text_input_model_unittests.cc
+++ b/shell/platform/common/cpp/text_input_model_unittests.cc
@@ -593,4 +593,13 @@ TEST(TextInputModel, GetCursorOffsetReverseSelection) {
   EXPECT_EQ(model->GetCursorOffset(), 1);
 }
 
+TEST(TextInputModel, Clear) {
+  auto model = std::make_unique<TextInputModel>();
+  model->AddText("abc");
+
+  EXPECT_TRUE(model->SetEditingState(-1, -1, ""));
+  EXPECT_EQ(model->selection_base(), 0);
+  EXPECT_EQ(model->selection_extent(), 0);
+  EXPECT_STREQ(model->GetText().c_str(), "");
+}
 }  // namespace flutter


### PR DESCRIPTION
## Description

Fix flutter/flutter#59140

TextEditingController.clear() send message corresponding to `TextEditingValue.empty`.
TextEditingValue.empty has empty text and selection_base/extent=-1.
However TextInputModel::SetEditingState can not handle this.

## Related Issues

flutter/flutter#59140

## Tests

I added the following tests:

shell/platform/common/cpp/text_input_model_unittests.cc
  TEST(TextInputModel, Clear)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
