### PR TITLE
Fix clipboard paste functionality not working

### DIFF
--- a/shell/platform/linux/fl_platform_plugin.cc
+++ b/shell/platform/linux/fl_platform_plugin.cc
@@ -12,7 +12,6 @@ static constexpr char kChannelName[] = "flutter/platform";
 static constexpr char kBadArgumentsError[] = "Bad Arguments";
 static constexpr char kUnknownClipboardFormatError[] =
     "Unknown Clipboard Format";
-static constexpr char kClipboardRequestError[] = "Clipboard Request Failed";
 static constexpr char kFailedError[] = "Failed";
 static constexpr char kGetClipboardDataMethod[] = "Clipboard.getData";
 static constexpr char kSetClipboardDataMethod[] = "Clipboard.setData";
@@ -43,17 +42,14 @@ static void clipboard_text_cb(GtkClipboard* clipboard,
                               gpointer user_data) {
   g_autoptr(FlMethodCall) method_call = FL_METHOD_CALL(user_data);
 
-  g_autoptr(FlMethodResponse) response = nullptr;
+  g_autoptr(FlValue) result = nullptr;
   if (text != nullptr) {
-    g_autoptr(FlValue) result = fl_value_new_map();
+    result = fl_value_new_map();
     fl_value_set_string_take(result, kTextKey, fl_value_new_string(text));
-    response = FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));
-  } else {
-    response = FL_METHOD_RESPONSE(fl_method_error_response_new(
-        kClipboardRequestError, "Failed to retrieve clipboard text from GTK",
-        nullptr));
   }
 
+  g_autoptr(FlMethodResponse) response =
+      FL_METHOD_RESPONSE(fl_method_success_response_new(result));
   send_response(method_call, response);
 }
 


### PR DESCRIPTION
## Description

Fix clipboard paste functionality not working - it wasn't sending a null success when no text was available, and wasn't actually sending the text when it was.

## Related Issues

https://github.com/flutter/flutter/issues/60729

## Tests

No test changes.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
