### PR TITLE
Fix NullPointerException in FlutterTextView

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -221,7 +221,9 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
     }
 
     flutterRenderer.stopRenderingToSurface();
-    renderSurface.release();
-    renderSurface = null;
+    if (renderSurface != null) {
+      renderSurface.release();
+      renderSurface = null;
+    }
   }
 }


### PR DESCRIPTION
## Description

`disconnectSurfaceFromRenderer()` is called from 2 places – `onSurfaceTextureDestroyed()` and `detachFromRenderer()`.
If `onSurfaceTextureDestroyed` is called first then subsequent call to `detachFromRenderer` will cause NPE on `renderSurface`

## Related Issues

https://github.com/flutter/flutter/issues/50950
https://github.com/flutter/flutter/issues/58767

## Tests

No test changes.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
