### PR TITLE
Pin the version of meta used by web_ui

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
   sdk: ">=2.9.0-0 <3.0.0"
 
 dependencies:
-  meta: ^1.1.8
+  meta: 1.1.8
 
 dev_dependencies:
   analyzer: 0.39.10


### PR DESCRIPTION
The latest version of meta now exports "unawaited", which conflicts with the
version of test_api currently used by web_ui.
