### PR TITLE
[CanvasKit] Dispose the overlay surface when a platform view is disposed

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/compositor/embedded_views.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 part of engine;
 
 /// This composites HTML views into the [ui.Scene].
@@ -255,7 +254,8 @@ class HtmlViewEmbedder {
             final CkPath path = CkPath();
             path.addRRect(mutator.rrect!);
             _ensureSvgPathDefs();
-            html.Element pathDefs = _svgPathDefs!.querySelector('#sk_path_defs')!;
+            html.Element pathDefs =
+                _svgPathDefs!.querySelector('#sk_path_defs')!;
             _clipPathCount += 1;
             html.Element newClipPath =
                 html.Element.html('<clipPath id="svgClip$_clipPathCount">'
@@ -266,7 +266,8 @@ class HtmlViewEmbedder {
           } else if (mutator.path != null) {
             final CkPath path = mutator.path as CkPath;
             _ensureSvgPathDefs();
-            html.Element pathDefs = _svgPathDefs!.querySelector('#sk_path_defs')!;
+            html.Element pathDefs =
+                _svgPathDefs!.querySelector('#sk_path_defs')!;
             _clipPathCount += 1;
             html.Element newClipPath =
                 html.Element.html('<clipPath id="svgClip$_clipPathCount">'
@@ -369,6 +370,8 @@ class HtmlViewEmbedder {
       if (_overlays[viewId] != null) {
         final Overlay overlay = _overlays[viewId]!;
         overlay.surface.htmlElement?.remove();
+        overlay.surface.htmlElement = null;
+        overlay.skSurface?.dispose();
       }
       _overlays.remove(viewId);
       _currentCompositionParams.remove(viewId);
@@ -402,10 +405,10 @@ class EmbeddedViewParams {
     if (identical(this, other)) {
       return true;
     }
-    return other is EmbeddedViewParams
-        && other.offset == offset
-        && other.size == size
-        && other.mutators == mutators;
+    return other is EmbeddedViewParams &&
+        other.offset == offset &&
+        other.size == size &&
+        other.mutators == mutators;
   }
 
   int get hashCode => ui.hashValues(offset, size, mutators);
@@ -524,8 +527,8 @@ class MutatorsStack extends Iterable<Mutator> {
     if (identical(other, this)) {
       return true;
     }
-    return other is MutatorsStack
-        && _listEquals<Mutator>(other._mutators, _mutators);
+    return other is MutatorsStack &&
+        _listEquals<Mutator>(other._mutators, _mutators);
   }
 
   int get hashCode => ui.hashList(_mutators);

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -134,7 +134,7 @@ class Surface {
   }
 
   bool _presentSurface() {
-    canvasKit.callMethod('setCurrentContext', <dynamic>[_surface!.context]);
+    canvasKit.callMethod('setCurrentContext', <int>[_surface!.context]);
     _surface!.getCanvas().flush();
     return true;
   }
@@ -159,8 +159,16 @@ class CkSurface {
   int height() => _surface.callMethod('height');
 
   void dispose() {
+    if (_isDisposed) {
+      return;
+    }
+    // Only resources from the current context can be disposed.
+    canvasKit.callMethod('setCurrentContext', <int>[_glContext]);
     _surface.callMethod('dispose');
     _grContext.callMethod('releaseResourcesAndAbandonContext');
     _grContext.callMethod('delete');
+    _isDisposed = true;
   }
+
+  bool _isDisposed = false;
 }


### PR DESCRIPTION
## Description

When we disposed of platform views previously, we weren't disposing of the associated SkSurface.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/50721

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
