### PR TITLE
Changed iOS channels to start cleaning up the accessibility handler when the bridge is deleted

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -934,6 +934,9 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/connection_collection.cc
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/connection_collection.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/connection_collection_test.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/platform_message_router.h

--- a/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h
@@ -29,6 +29,8 @@ typedef void (^FlutterBinaryReply)(NSData* _Nullable reply);
  */
 typedef void (^FlutterBinaryMessageHandler)(NSData* _Nullable message, FlutterBinaryReply reply);
 
+typedef int64_t FlutterBinaryMessengerConnection;
+
 /**
  * A facility for communicating with the Flutter side using asynchronous message
  * passing with binary messages.
@@ -72,9 +74,20 @@ FLUTTER_EXPORT
  *
  * @param channel The channel name.
  * @param handler The message handler.
+ * @return An identifier that represents the connection that was just created to the channel.
  */
-- (void)setMessageHandlerOnChannel:(NSString*)channel
-              binaryMessageHandler:(FlutterBinaryMessageHandler _Nullable)handler;
+- (FlutterBinaryMessengerConnection)setMessageHandlerOnChannel:(NSString*)channel
+                                          binaryMessageHandler:
+                                              (FlutterBinaryMessageHandler _Nullable)handler;
+
+/**
+ * Clears out a channel's message handler if that handler is still the one that
+ * was created as a result of
+ * `setMessageHandlerOnChannel:binaryMessageHandler:`.
+ *
+ * @param connection The result from `setMessageHandlerOnChannel:binaryMessageHandler:`.
+ */
+- (void)cleanupConnection:(FlutterBinaryMessengerConnection)connection;
 @end
 NS_ASSUME_NONNULL_END
 #endif  // FLUTTER_FLUTTERBINARYMESSENGER_H_

--- a/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
@@ -20,6 +20,7 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
   NSObject<FlutterBinaryMessenger>* _messenger;
   NSString* _name;
   NSObject<FlutterMessageCodec>* _codec;
+  FlutterBinaryMessengerConnection _connection;
 }
 + (instancetype)messageChannelWithName:(NSString*)name
                        binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger {
@@ -68,7 +69,12 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
 
 - (void)setMessageHandler:(FlutterMessageHandler)handler {
   if (!handler) {
-    [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:nil];
+    if (_connection > 0) {
+      [_messenger cleanupConnection:_connection];
+      _connection = 0;
+    } else {
+      [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:nil];
+    }
     return;
   }
   // Grab reference to avoid retain on self.
@@ -78,7 +84,7 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
       callback([codec encode:reply]);
     });
   };
-  [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:messageHandler];
+  _connection = [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:messageHandler];
 }
 
 - (void)resizeChannelBuffer:(NSInteger)newSize {
@@ -168,6 +174,7 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
   NSObject<FlutterBinaryMessenger>* _messenger;
   NSString* _name;
   NSObject<FlutterMethodCodec>* _codec;
+  FlutterBinaryMessengerConnection _connection;
 }
 
 + (instancetype)methodChannelWithName:(NSString*)name
@@ -222,7 +229,12 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
 
 - (void)setMethodCallHandler:(FlutterMethodCallHandler)handler {
   if (!handler) {
-    [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:nil];
+    if (_connection > 0) {
+      [_messenger cleanupConnection:_connection];
+      _connection = 0;
+    } else {
+      [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:nil];
+    }
     return;
   }
   // Make sure the block captures the codec, not self.
@@ -238,7 +250,7 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
         callback([codec encodeSuccessEnvelope:result]);
     });
   };
-  [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:messageHandler];
+  _connection = [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:messageHandler];
 }
 
 - (void)resizeChannelBuffer:(NSInteger)newSize {

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -74,6 +74,8 @@ source_set("flutter_framework_source") {
     "framework/Source/accessibility_bridge.mm",
     "framework/Source/accessibility_text_entry.h",
     "framework/Source/accessibility_text_entry.mm",
+    "framework/Source/connection_collection.cc",
+    "framework/Source/connection_collection.h",
     "framework/Source/platform_message_response_darwin.h",
     "framework/Source/platform_message_response_darwin.mm",
     "framework/Source/platform_message_router.h",
@@ -208,6 +210,7 @@ shared_library("ios_test_flutter") {
     "framework/Source/FlutterTextInputPluginTest.m",
     "framework/Source/FlutterViewControllerTest.mm",
     "framework/Source/SemanticsObjectTest.mm",
+    "framework/Source/connection_collection_test.mm",
   ]
   deps = [
     ":flutter_framework_source",

--- a/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.mm
@@ -35,10 +35,20 @@
   }
 }
 
-- (void)setMessageHandlerOnChannel:(NSString*)channel
-              binaryMessageHandler:(FlutterBinaryMessageHandler)handler {
+- (FlutterBinaryMessengerConnection)setMessageHandlerOnChannel:(NSString*)channel
+                                          binaryMessageHandler:
+                                              (FlutterBinaryMessageHandler)handler {
   if (self.parent) {
-    [self.parent setMessageHandlerOnChannel:channel binaryMessageHandler:handler];
+    return [self.parent setMessageHandlerOnChannel:channel binaryMessageHandler:handler];
+  } else {
+    FML_LOG(WARNING) << "Communicating on a dead channel.";
+    return -1;
+  }
+}
+
+- (void)cleanupConnection:(FlutterBinaryMessengerConnection)connection {
+  if (self.parent) {
+    return [self.parent cleanupConnection:connection];
   } else {
     FML_LOG(WARNING) << "Communicating on a dead channel.";
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -23,6 +23,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/connection_collection.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/profiler_metrics_ios.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
@@ -78,6 +79,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
   BOOL _allowHeadlessExecution;
   FlutterBinaryMessengerRelay* _binaryMessenger;
+  std::unique_ptr<flutter::ConnectionCollection> _connections;
 }
 
 - (instancetype)initWithName:(NSString*)labelPrefix {
@@ -110,6 +112,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   _platformViewsController.reset(new flutter::FlutterPlatformViewsController());
 
   _binaryMessenger = [[FlutterBinaryMessengerRelay alloc] initWithParent:self];
+  _connections.reset(new flutter::ConnectionCollection());
 
   NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
   [center addObserver:self
@@ -693,14 +696,26 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   _shell->GetPlatformView()->DispatchPlatformMessage(platformMessage);
 }
 
-- (void)setMessageHandlerOnChannel:(NSString*)channel
-              binaryMessageHandler:(FlutterBinaryMessageHandler)handler {
+- (FlutterBinaryMessengerConnection)setMessageHandlerOnChannel:(NSString*)channel
+                                          binaryMessageHandler:
+                                              (FlutterBinaryMessageHandler)handler {
   NSParameterAssert(channel);
   if (_shell && _shell->IsSetup()) {
     self.iosPlatformView->GetPlatformMessageRouter().SetMessageHandler(channel.UTF8String, handler);
+    return _connections->AquireConnection(channel.UTF8String);
   } else {
     NSAssert(!handler, @"Setting a message handler before the FlutterEngine has been run.");
     // Setting a handler to nil for a not setup channel is a noop.
+    return -1;
+  }
+}
+
+- (void)cleanupConnection:(FlutterBinaryMessengerConnection)connection {
+  if (_shell && _shell->IsSetup()) {
+    std::string channel = _connections->CleanupConnection(connection);
+    if (!channel.empty()) {
+      self.iosPlatformView->GetPlatformMessageRouter().SetMessageHandler(channel.c_str(), nil);
+    }
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -706,7 +706,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   } else {
     NSAssert(!handler, @"Setting a message handler before the FlutterEngine has been run.");
     // Setting a handler to nil for a not setup channel is a noop.
-    return -1;
+    return flutter::ConnectionCollection::MakeErrorConnection(-1);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1204,10 +1204,16 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [_engine.get().binaryMessenger sendOnChannel:channel message:message binaryReply:callback];
 }
 
-- (void)setMessageHandlerOnChannel:(NSString*)channel
-              binaryMessageHandler:(FlutterBinaryMessageHandler)handler {
+- (FlutterBinaryMessengerConnection)setMessageHandlerOnChannel:(NSString*)channel
+                                          binaryMessageHandler:
+                                              (FlutterBinaryMessageHandler)handler {
   NSAssert(channel, @"The channel must not be null");
-  [_engine.get().binaryMessenger setMessageHandlerOnChannel:channel binaryMessageHandler:handler];
+  return [_engine.get().binaryMessenger setMessageHandlerOnChannel:channel
+                                              binaryMessageHandler:handler];
+}
+
+- (void)cleanupConnection:(FlutterBinaryMessengerConnection)connection {
+  [_engine.get().binaryMessenger cleanupConnection:connection];
 }
 
 #pragma mark - FlutterTextureRegistry

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -72,6 +72,7 @@ AccessibilityBridge::AccessibilityBridge(UIView* view,
 }
 
 AccessibilityBridge::~AccessibilityBridge() {
+  [accessibility_channel_.get() setMessageHandler:nil];
   clearState();
   view_.accessibilityElements = nil;
 }

--- a/shell/platform/darwin/ios/framework/Source/connection_collection.cc
+++ b/shell/platform/darwin/ios/framework/Source/connection_collection.cc
@@ -29,4 +29,18 @@ std::string ConnectionCollection::CleanupConnection(
   }
   return "";
 }
+
+bool ConnectionCollection::IsValidConnection(
+    ConnectionCollection::Connection connection) {
+  return connection > 0;
+}
+
+ConnectionCollection::Connection ConnectionCollection::MakeErrorConnection(
+    int errCode) {
+  if (errCode < 0) {
+    return -1 * errCode;
+  }
+  return errCode;
+}
+
 }  // namespace flutter

--- a/shell/platform/darwin/ios/framework/Source/connection_collection.cc
+++ b/shell/platform/darwin/ios/framework/Source/connection_collection.cc
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/darwin/ios/framework/Source/connection_collection.h"
+
+namespace flutter {
+ConnectionCollection::Connection ConnectionCollection::AquireConnection(
+    const std::string& name) {
+  Connection nextConnection = ++counter_;
+  connections_[name] = nextConnection;
+  return nextConnection;
+}
+
+std::string ConnectionCollection::CleanupConnection(
+    ConnectionCollection::Connection connection) {
+  if (connection > 0) {
+    std::string channel;
+    for (auto& keyValue : connections_) {
+      if (keyValue.second == connection) {
+        channel = keyValue.first;
+        break;
+      }
+    }
+    if (channel.length() > 0) {
+      connections_.erase(channel);
+      return channel;
+    }
+  }
+  return "";
+}
+}  // namespace flutter

--- a/shell/platform/darwin/ios/framework/Source/connection_collection.h
+++ b/shell/platform/darwin/ios/framework/Source/connection_collection.h
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_CONNECTION_COLLECTION_H_
+#define SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_CONNECTION_COLLECTION_H_
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+namespace flutter {
+
+/// Maintains a current integer assigned to a name (connections).
+class ConnectionCollection {
+ public:
+  typedef int64_t Connection;
+  Connection AquireConnection(const std::string& name);
+  ///\returns the name of the channel when cleanup is successful, otherwise
+  ///         the empty string.
+  std::string CleanupConnection(Connection connection);
+
+ private:
+  std::map<std::string, Connection> connections_;
+  Connection counter_ = 0;
+};
+
+}  // namespace flutter
+
+#endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_CONNECTION_COLLECTION_H_

--- a/shell/platform/darwin/ios/framework/Source/connection_collection.h
+++ b/shell/platform/darwin/ios/framework/Source/connection_collection.h
@@ -15,10 +15,16 @@ namespace flutter {
 class ConnectionCollection {
  public:
   typedef int64_t Connection;
+  static const Connection kInvalidConnection = 0;
+
   Connection AquireConnection(const std::string& name);
   ///\returns the name of the channel when cleanup is successful, otherwise
   ///         the empty string.
   std::string CleanupConnection(Connection connection);
+
+  static bool IsValidConnection(Connection connection);
+
+  static Connection MakeErrorConnection(int errCode);
 
  private:
   std::map<std::string, Connection> connections_;

--- a/shell/platform/darwin/ios/framework/Source/connection_collection_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/connection_collection_test.mm
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/connection_collection.h"
+
+@interface ConnectionCollectionTest : XCTestCase
+@end
+
+@implementation ConnectionCollectionTest
+
+- (void)testSimple {
+  auto connections = std::make_unique<flutter::ConnectionCollection>();
+  flutter::ConnectionCollection::Connection connection = connections->AquireConnection("foo");
+  XCTAssertTrue(connections->CleanupConnection(connection) == "foo");
+  XCTAssertTrue(connections->CleanupConnection(connection).empty());
+}
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -447,9 +447,15 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   }
 }
 
-- (void)setMessageHandlerOnChannel:(nonnull NSString*)channel
-              binaryMessageHandler:(nullable FlutterBinaryMessageHandler)handler {
+- (FlutterBinaryMessengerConnection)setMessageHandlerOnChannel:(nonnull NSString*)channel
+                                          binaryMessageHandler:
+                                              (nullable FlutterBinaryMessageHandler)handler {
   _messageHandlers[channel] = [handler copy];
+  return 0;
+}
+
+- (void)cleanupConnection:(FlutterBinaryMessengerConnection)connection {
+  // There hasn't been a need to implement this yet for macOS.
 }
 
 #pragma mark - FlutterPluginRegistry


### PR DESCRIPTION
## Description

I had to make nilling out a channel's handler safer.  That way when you do something like `_bridge.reset([AccessibilityBridge alloc] initWithMessenger:engine.messenger]);` the deallocator for the old bridge doesn't wipe out the handler of the new bridge on the messenger.

## Related Issues

b/159676567
https://github.com/flutter/flutter/issues/61027

## Tests

I added the following tests:

unit tests for flutter channels and for the accessibility bridge.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
