### PR TITLE
[Android] Prevent listener from calling JNI after detach

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -131,11 +131,11 @@ public class FlutterRenderer implements TextureRegistry {
         new SurfaceTexture.OnFrameAvailableListener() {
           @Override
           public void onFrameAvailable(@NonNull SurfaceTexture texture) {
-            if (released) {
-              // Even though we make sure to unregister the callback before releasing, as of Android
-              // O
-              // SurfaceTexture has a data race when accessing the callback, so the callback may
-              // still be called by a stale reference after released==true and mNativeView==null.
+            if (released || !flutterJNI.isAttached()) {
+              // Even though we make sure to unregister the callback before releasing, as of
+              // Android O, SurfaceTexture has a data race when accessing the callback, so the
+              // callback may still be called by a stale reference after released==true and
+              // mNativeView==null.
               return;
             }
             markTextureFrameAvailable(id);

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -103,16 +103,17 @@ public class FlutterRendererTest {
     // Setup the test.
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
 
-    flutterRenderer.startRenderingToSurface(fakeSurface);
-    flutterRenderer.stopRenderingToSurface();
+    fakeFlutterJNI.detachFromNativeAndReleaseResources();
 
-    fakeFlutterJNI.detachFromNativeAndReleaseResources()
+    FlutterRenderer.SurfaceTextureRegistryEntry entry =
+        (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
 
     flutterRenderer.startRenderingToSurface(fakeSurface);
+
     // Execute the behavior under test.
     flutterRenderer.stopRenderingToSurface();
 
     // Verify behavior under test.
-    verify(fakeFlutterJNI, times(1)).markTextureFrameAvailable();
+    verify(fakeFlutterJNI, times(0)).markTextureFrameAvailable(eq(entry.id()));
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -104,11 +104,15 @@ public class FlutterRendererTest {
     FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
 
     flutterRenderer.startRenderingToSurface(fakeSurface);
+    flutterRenderer.stopRenderingToSurface();
 
+    fakeFlutterJNI.detachFromNativeAndReleaseResources()
+
+    flutterRenderer.startRenderingToSurface(fakeSurface);
     // Execute the behavior under test.
     flutterRenderer.stopRenderingToSurface();
 
     // Verify behavior under test.
-    verify(fakeFlutterJNI, times(1)).onSurfaceDestroyed();
+    verify(fakeFlutterJNI, times(1)).markTextureFrameAvailable();
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -97,4 +97,18 @@ public class FlutterRendererTest {
     // Verify behavior under test.
     verify(fakeFlutterJNI, times(1)).onSurfaceDestroyed();
   }
+
+  @Test
+  public void itStopsSurfaceTextureCallbackWhenDetached() {
+    // Setup the test.
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+
+    flutterRenderer.startRenderingToSurface(fakeSurface);
+
+    // Execute the behavior under test.
+    flutterRenderer.stopRenderingToSurface();
+
+    // Verify behavior under test.
+    verify(fakeFlutterJNI, times(1)).onSurfaceDestroyed();
+  }
 }


### PR DESCRIPTION
One of the patches for the various cleanup needed for https://github.com/flutter/flutter/issues/28651