### PR TITLE
Add @Keep annotation to FlutterMutatorsStack

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStack.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStack.java
@@ -8,6 +8,7 @@ import android.graphics.Matrix;
 import android.graphics.Path;
 import android.graphics.Rect;
 import android.graphics.RectF;
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ import java.util.List;
  * series mutations. See {@link io.flutter.embedding.engine.mutatorsstack.Mutator} for informations
  * on Mutators.
  */
+@Keep
 public class FlutterMutatorsStack {
   /**
    * The type of a Mutator See {@link io.flutter.embedding.engine.mutatorsstack.Mutator} for


### PR DESCRIPTION
## Description

This class is looked up by name in C++. Therefore, it needs the `@Keep` annotation.

## Related Issues

Crashes in https://github.com/flutter/flutter/pull/60937
