### PR TITLE
using text capitalization value in web

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -411,6 +411,7 @@ FILE: ../../../flutter/lib/ui/window/viewport_metrics.cc
 FILE: ../../../flutter/lib/ui/window/viewport_metrics.h
 FILE: ../../../flutter/lib/ui/window/window.cc
 FILE: ../../../flutter/lib/ui/window/window.h
+FILE: ../../../flutter/lib/web_ui/lib/assets/Roboto-Regular.ttf
 FILE: ../../../flutter/lib/web_ui/lib/assets/houdini_painter.js
 FILE: ../../../flutter/lib/web_ui/lib/src/engine.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/alarm_clock.dart
@@ -521,6 +522,7 @@ FILE: ../../../flutter/lib/web_ui/lib/src/engine/text/word_break_properties.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text/word_breaker.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/autofill_hint.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/util.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/validators.dart

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -411,7 +411,6 @@ FILE: ../../../flutter/lib/ui/window/viewport_metrics.cc
 FILE: ../../../flutter/lib/ui/window/viewport_metrics.h
 FILE: ../../../flutter/lib/ui/window/window.cc
 FILE: ../../../flutter/lib/ui/window/window.h
-FILE: ../../../flutter/lib/web_ui/lib/assets/Roboto-Regular.ttf
 FILE: ../../../flutter/lib/web_ui/lib/assets/houdini_painter.js
 FILE: ../../../flutter/lib/web_ui/lib/src/engine.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/alarm_clock.dart

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -129,6 +129,7 @@ part 'engine/text/word_break_properties.dart';
 part 'engine/text/word_breaker.dart';
 part 'engine/text_editing/autofill_hint.dart';
 part 'engine/text_editing/input_type.dart';
+part 'engine/text_editing/text_capitalization.dart';
 part 'engine/text_editing/text_editing.dart';
 part 'engine/util.dart';
 part 'engine/validators.dart';

--- a/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
@@ -1,0 +1,92 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of engine;
+
+/// Controls the capitalization of the text.
+///
+/// This corresponds to Flutter's [TextCapitalization].
+///
+/// Uses `text-transform` css property.
+/// See: https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform
+enum TextCapitalization {
+  /// Uppercase for the first letter of each word.
+  words,
+
+  /// Currently not implemented on Flutter Web. Uppercase for the first letter
+  /// of each sentence.
+  sentences,
+
+  /// Uppercase for each letter.
+  characters,
+
+  /// Lowercase for each letter.
+  none,
+}
+
+/// Helper class for text capitalization.
+///
+/// Uses `text-transform` css property.
+/// See: https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform
+class TextCapitalizationConfig {
+  final TextCapitalization textCapitalization;
+
+  static final RegExp wordExp = new RegExp(r"(\w+)");
+  static final RegExp whiteSpaceExp = new RegExp(r"(\s+)");
+
+  const TextCapitalizationConfig.defaultCapitalization()
+      : textCapitalization = TextCapitalization.none;
+
+  // TODO: support sentence level text capitalization.
+  TextCapitalizationConfig.fromInputConfiguration(String inputConfiguration)
+      : this.textCapitalization =
+            inputConfiguration == 'TextCapitalization.words'
+                ? TextCapitalization.words
+                : (inputConfiguration == 'TextCapitalization.characters')
+                    ? TextCapitalization.characters
+                    : TextCapitalization.none;
+
+  /// Sets `autocapitalize` attribute on input elements.
+  ///
+  /// This attribute is only available for mobile browsers.
+  ///
+  /// Note that in mobile browsers the onscreen keyboards provide sentence
+  /// level capitalization as default as apposed to no capitalization on desktop
+  /// browser.
+  ///
+  /// See: https://developers.google.com/web/updates/2015/04/autocapitalize
+  /// https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize
+  void setAutocapitalizeAttribute(html.HtmlElement domElement) {
+    String autocapitalize = '';
+    switch (textCapitalization) {
+      case TextCapitalization.words:
+        // TODO: There is a bug for `words` level capitalization in IOS now.
+        // For now go back to default. Remove the check after bug is resolved.
+        // https://bugs.webkit.org/show_bug.cgi?id=148504
+        if(browserEngine == BrowserEngine.webkit) {
+           autocapitalize = 'sentences';
+        } else {
+          autocapitalize = 'words';
+        }
+        break;
+      case TextCapitalization.characters:
+        autocapitalize = 'characters';
+        break;
+      case TextCapitalization.sentences:
+        autocapitalize = 'sentences';
+        break;
+      case TextCapitalization.none:
+      default:
+        autocapitalize = 'off';
+        break;
+    }
+    if (domElement is html.InputElement) {
+      html.InputElement element = domElement;
+      element.setAttribute('autocapitalize', autocapitalize);
+    } else if (domElement is html.TextAreaElement) {
+      html.TextAreaElement element = domElement;
+      element.setAttribute('autocapitalize', autocapitalize);
+    }
+  }
+}

--- a/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
@@ -27,25 +27,24 @@ enum TextCapitalization {
 
 /// Helper class for text capitalization.
 ///
-/// Uses `text-transform` css property.
-/// See: https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform
+/// Uses `autocapitalize` attribute on input element.
+/// See: https://developers.google.com/web/updates/2015/04/autocapitalize
+/// https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize
 class TextCapitalizationConfig {
   final TextCapitalization textCapitalization;
-
-  static final RegExp wordExp = new RegExp(r"(\w+)");
-  static final RegExp whiteSpaceExp = new RegExp(r"(\s+)");
 
   const TextCapitalizationConfig.defaultCapitalization()
       : textCapitalization = TextCapitalization.none;
 
-  // TODO: support sentence level text capitalization.
   TextCapitalizationConfig.fromInputConfiguration(String inputConfiguration)
       : this.textCapitalization =
             inputConfiguration == 'TextCapitalization.words'
                 ? TextCapitalization.words
-                : (inputConfiguration == 'TextCapitalization.characters')
+                : inputConfiguration == 'TextCapitalization.characters'
                     ? TextCapitalization.characters
-                    : TextCapitalization.none;
+                    : inputConfiguration == 'TextCapitalization.sentences'
+                        ? TextCapitalization.sentences
+                        : TextCapitalization.none;
 
   /// Sets `autocapitalize` attribute on input elements.
   ///
@@ -64,8 +63,8 @@ class TextCapitalizationConfig {
         // TODO: There is a bug for `words` level capitalization in IOS now.
         // For now go back to default. Remove the check after bug is resolved.
         // https://bugs.webkit.org/show_bug.cgi?id=148504
-        if(browserEngine == BrowserEngine.webkit) {
-           autocapitalize = 'sentences';
+        if (browserEngine == BrowserEngine.webkit) {
+          autocapitalize = 'sentences';
         } else {
           autocapitalize = 'words';
         }

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -859,6 +859,7 @@ class IOSTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
     } else {
       domRenderer.glassPaneElement!.append(domElement);
     }
+    inputConfig.textCapitalization.setAutocapitalizeAttribute(domElement);
   }
 
   @override
@@ -989,6 +990,7 @@ class AndroidTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
     } else {
       domRenderer.glassPaneElement!.append(domElement);
     }
+    inputConfig.textCapitalization.setAutocapitalizeAttribute(domElement);
   }
 
   @override
@@ -1592,6 +1594,49 @@ class TextCapitalizationUtil {
       case TextCapitalization.none:
       default:
         return value;
+    }
+  }
+
+  /// Sets `autocapitalize` attribute on input elements.
+  ///
+  /// This attribute is only available for mobile browsers.
+  ///
+  /// Note that in mobile browsers the onscreen keyboards provide sentence
+  /// level capitalization as default as apposed to no capitalization on desktop
+  /// browser.
+  ///
+  /// See: https://developers.google.com/web/updates/2015/04/autocapitalize
+  /// https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize
+  void setAutocapitalizeAttribute(html.HtmlElement domElement) {
+    String autocapitalize = '';
+    switch (textCapitalization) {
+      case TextCapitalization.words:
+        // TODO: There is a bug for `words` level capitalization in IOS now.
+        // For now go back to default. Remove the check after bug is resolved.
+        // https://bugs.webkit.org/show_bug.cgi?id=148504
+        if(browserEngine == BrowserEngine.webkit) {
+           autocapitalize = 'sentences';
+        } else {
+          autocapitalize = 'words';
+        }
+        break;
+      case TextCapitalization.characters:
+        autocapitalize = 'characters';
+        break;
+      case TextCapitalization.sentences:
+        autocapitalize = 'sentences';
+        break;
+      case TextCapitalization.none:
+      default:
+        autocapitalize = 'off';
+        break;
+    }
+    if (domElement is html.InputElement) {
+      html.InputElement element = domElement;
+      element.setAttribute('autocapitalize', autocapitalize);
+    } else if (domElement is html.TextAreaElement) {
+      html.TextAreaElement element = domElement;
+      element.setAttribute('autocapitalize', autocapitalize);
     }
   }
 }

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -31,8 +31,8 @@ final InputConfiguration singlelineConfig = InputConfiguration(
   obscureText: false,
   inputAction: 'TextInputAction.done',
   autocorrect: true,
-  textCapitalization:
-      TextCapitalizationUtil.fromInputConfiguration('TextCapitalization.none'),
+  textCapitalization: TextCapitalizationConfig.fromInputConfiguration(
+      'TextCapitalization.none'),
 );
 final Map<String, dynamic> flutterSinglelineConfig =
     createFlutterConfig('text');
@@ -42,7 +42,7 @@ final InputConfiguration multilineConfig = InputConfiguration(
     obscureText: false,
     inputAction: 'TextInputAction.newline',
     autocorrect: true,
-    textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+    textCapitalization: TextCapitalizationConfig.fromInputConfiguration(
         'TextCapitalization.none'));
 final Map<String, dynamic> flutterMultilineConfig =
     createFlutterConfig('multiline');
@@ -115,7 +115,7 @@ void main() {
           inputAction: 'TextInputAction.done',
           obscureText: true,
           autocorrect: true,
-          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+          textCapitalization: TextCapitalizationConfig.fromInputConfiguration(
               'TextCapitalization.none'));
       editingElement.enable(
         config,
@@ -136,7 +136,7 @@ void main() {
           inputAction: 'TextInputAction.done',
           obscureText: false,
           autocorrect: false,
-          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+          textCapitalization: TextCapitalizationConfig.fromInputConfiguration(
               'TextCapitalization.none'));
       editingElement.enable(
         config,
@@ -157,7 +157,7 @@ void main() {
           inputAction: 'TextInputAction.done',
           obscureText: false,
           autocorrect: true,
-          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+          textCapitalization: TextCapitalizationConfig.fromInputConfiguration(
               'TextCapitalization.none'));
       editingElement.enable(
         config,
@@ -297,7 +297,7 @@ void main() {
           obscureText: false,
           inputAction: 'TextInputAction.done',
           autocorrect: true,
-          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+          textCapitalization: TextCapitalizationConfig.fromInputConfiguration(
               'TextCapitalization.none'));
       editingElement.enable(
         config,
@@ -324,7 +324,7 @@ void main() {
           obscureText: false,
           inputAction: 'TextInputAction.done',
           autocorrect: true,
-          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+          textCapitalization: TextCapitalizationConfig.fromInputConfiguration(
               'TextCapitalization.none'));
       editingElement.enable(
         config,
@@ -868,12 +868,11 @@ void main() {
     });
 
     test(
-        'Word capitilization: setClient, setEditingState, show, '
-        'updateEditingState', () {
+        'No capitilization: setClient, setEditingState, show', () {
       // Create a configuration with an AutofillGroup of four text fields.
       final Map<String, dynamic> capitilizeWordsConfig = createFlutterConfig(
           'text',
-          textCapitalization: 'TextCapitalization.words');
+          textCapitalization: 'TextCapitalization.none');
       final MethodCall setClient = MethodCall(
           'TextInput.setClient', <dynamic>[123, capitilizeWordsConfig]);
       sendFrameworkMessage(codec.encodeMethodCall(setClient));
@@ -890,44 +889,27 @@ void main() {
       sendFrameworkMessage(codec.encodeMethodCall(show));
       spy.messages.clear();
 
-      expect(textEditing.editingElement.domElement.style.textTransform,
-          'capitalize');
-
-      // Test for mobile Safari.
+      // Test for mobile Safari. `sentences` is the default attribute for
+      // mobile browsers. Check if `off` is added to the input element.
       if (browserEngine == BrowserEngine.webkit &&
           operatingSystem == OperatingSystem.iOs) {
         expect(
             textEditing.editingElement.domElement
                 .getAttribute('autocapitalize'),
-            'sentences');
+            'off');
+      } else {
+        expect(
+            textEditing.editingElement.domElement
+                .getAttribute('autocapitalize'),
+            isNull);
       }
-
-      final InputElement element = textEditing.editingElement.domElement;
-      element.value = 'something some test';
-      element.dispatchEvent(Event.eventType('Event', 'input'));
-
-      expect(spy.messages, hasLength(1));
-      expect(spy.messages[0].channel, 'flutter/textinput');
-      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingState');
-      expect(
-        spy.messages[0].methodArguments,
-        <dynamic>[
-          123, // Client ID
-          <String, dynamic>{
-            'text': 'Something Some Test',
-            'selectionBase': 19,
-            'selectionExtent': 19,
-          },
-        ],
-      );
 
       spy.messages.clear();
       hideKeyboard();
     });
 
     test(
-        'All characters capitilization: setClient, setEditingState, show, '
-        'updateEditingState', () {
+        'All characters capitilization: setClient, setEditingState, show', () {
       // Create a configuration with an AutofillGroup of four text fields.
       final Map<String, dynamic> capitilizeWordsConfig = createFlutterConfig(
           'text',
@@ -948,9 +930,6 @@ void main() {
       sendFrameworkMessage(codec.encodeMethodCall(show));
       spy.messages.clear();
 
-      expect(textEditing.editingElement.domElement.style.textTransform,
-          'uppercase');
-
       // Test for mobile Safari.
       if (browserEngine == BrowserEngine.webkit &&
           operatingSystem == OperatingSystem.iOs) {
@@ -959,25 +938,6 @@ void main() {
                 .getAttribute('autocapitalize'),
             'characters');
       }
-
-      final InputElement element = textEditing.editingElement.domElement;
-      element.value = 'something some test';
-      element.dispatchEvent(Event.eventType('Event', 'input'));
-
-      expect(spy.messages, hasLength(1));
-      expect(spy.messages[0].channel, 'flutter/textinput');
-      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingState');
-      expect(
-        spy.messages[0].methodArguments,
-        <dynamic>[
-          123, // Client ID
-          <String, dynamic>{
-            'text': 'SOMETHING SOME TEST',
-            'selectionBase': 19,
-            'selectionExtent': 19,
-          },
-        ],
-      );
 
       spy.messages.clear();
       hideKeyboard();

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -875,7 +875,7 @@ void main() {
 
     test(
         'Word capitilization: setClient, setEditingState, show, '
-        'setEditingState, clearClient', () {
+        'updateEditingState', () {
       // Create a configuration with an AutofillGroup of four text fields.
       final Map<String, dynamic> capitilizeWordsConfig =
           createFlutterConfig('text',
@@ -895,12 +895,32 @@ void main() {
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
+      spy.messages.clear();
 
       expect(textEditing.editingElement.domElement.style.textTransform,
           'capitalize');
 
-      const MethodCall clearClient = MethodCall('TextInput.clearClient');
-      sendFrameworkMessage(codec.encodeMethodCall(clearClient));
+      final InputElement element = textEditing.editingElement.domElement;
+      element.value = 'something some test';
+      element.dispatchEvent(Event.eventType('Event', 'input'));
+
+      expect(spy.messages, hasLength(1));
+      expect(spy.messages[0].channel, 'flutter/textinput');
+      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingState');
+      expect(
+        spy.messages[0].methodArguments,
+        <dynamic>[
+          123, // Client ID
+          <String, dynamic>{
+            'text': 'Something Some Test',
+            'selectionBase': 19,
+            'selectionExtent': 19,
+          },
+        ],
+      );
+
+      spy.messages.clear();
+      hideKeyboard();
     });
 
     test(

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -31,20 +31,19 @@ final InputConfiguration singlelineConfig = InputConfiguration(
   obscureText: false,
   inputAction: 'TextInputAction.done',
   autocorrect: true,
-  textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
-      'TextCapitalization.none'),
+  textCapitalization:
+      TextCapitalizationUtil.fromInputConfiguration('TextCapitalization.none'),
 );
 final Map<String, dynamic> flutterSinglelineConfig =
     createFlutterConfig('text');
 
 final InputConfiguration multilineConfig = InputConfiguration(
-  inputType: EngineInputType.multiline,
-  obscureText: false,
-  inputAction: 'TextInputAction.newline',
-  autocorrect: true,
-  textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
-      'TextCapitalization.none')
-);
+    inputType: EngineInputType.multiline,
+    obscureText: false,
+    inputAction: 'TextInputAction.newline',
+    autocorrect: true,
+    textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+        'TextCapitalization.none'));
 final Map<String, dynamic> flutterMultilineConfig =
     createFlutterConfig('multiline');
 
@@ -112,13 +111,12 @@ void main() {
 
     test('Knows how to create password fields', () {
       final InputConfiguration config = InputConfiguration(
-        inputType: EngineInputType.text,
-        inputAction: 'TextInputAction.done',
-        obscureText: true,
-        autocorrect: true,
-        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
-            'TextCapitalization.none')
-      );
+          inputType: EngineInputType.text,
+          inputAction: 'TextInputAction.done',
+          obscureText: true,
+          autocorrect: true,
+          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+              'TextCapitalization.none'));
       editingElement.enable(
         config,
         onChange: trackEditingState,
@@ -134,13 +132,12 @@ void main() {
 
     test('Knows to turn autocorrect off', () {
       final InputConfiguration config = InputConfiguration(
-        inputType: EngineInputType.text,
-        inputAction: 'TextInputAction.done',
-        obscureText: false,
-        autocorrect: false,
-        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
-            'TextCapitalization.none')
-      );
+          inputType: EngineInputType.text,
+          inputAction: 'TextInputAction.done',
+          obscureText: false,
+          autocorrect: false,
+          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+              'TextCapitalization.none'));
       editingElement.enable(
         config,
         onChange: trackEditingState,
@@ -156,13 +153,12 @@ void main() {
 
     test('Knows to turn autocorrect on', () {
       final InputConfiguration config = InputConfiguration(
-        inputType: EngineInputType.text,
-        inputAction: 'TextInputAction.done',
-        obscureText: false,
-        autocorrect: true,
-        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
-            'TextCapitalization.none')
-      );
+          inputType: EngineInputType.text,
+          inputAction: 'TextInputAction.done',
+          obscureText: false,
+          autocorrect: true,
+          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+              'TextCapitalization.none'));
       editingElement.enable(
         config,
         onChange: trackEditingState,
@@ -297,13 +293,12 @@ void main() {
 
     test('Triggers input action', () {
       final InputConfiguration config = InputConfiguration(
-        inputType: EngineInputType.text,
-        obscureText: false,
-        inputAction: 'TextInputAction.done',
-        autocorrect: true,
-        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
-            'TextCapitalization.none')
-      );
+          inputType: EngineInputType.text,
+          obscureText: false,
+          inputAction: 'TextInputAction.done',
+          autocorrect: true,
+          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+              'TextCapitalization.none'));
       editingElement.enable(
         config,
         onChange: trackEditingState,
@@ -325,13 +320,12 @@ void main() {
 
     test('Does not trigger input action in multi-line mode', () {
       final InputConfiguration config = InputConfiguration(
-        inputType: EngineInputType.multiline,
-        obscureText: false,
-        inputAction: 'TextInputAction.done',
-        autocorrect: true,
-        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
-            'TextCapitalization.none')
-      );
+          inputType: EngineInputType.multiline,
+          obscureText: false,
+          inputAction: 'TextInputAction.done',
+          autocorrect: true,
+          textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+              'TextCapitalization.none'));
       editingElement.enable(
         config,
         onChange: trackEditingState,
@@ -877,12 +871,11 @@ void main() {
         'Word capitilization: setClient, setEditingState, show, '
         'updateEditingState', () {
       // Create a configuration with an AutofillGroup of four text fields.
-      final Map<String, dynamic> capitilizeWordsConfig =
-          createFlutterConfig('text',
-           textCapitalization: 'TextCapitalization.words'
-          );
-      final MethodCall setClient = MethodCall('TextInput.setClient',
-          <dynamic>[123, capitilizeWordsConfig]);
+      final Map<String, dynamic> capitilizeWordsConfig = createFlutterConfig(
+          'text',
+          textCapitalization: 'TextCapitalization.words');
+      final MethodCall setClient = MethodCall(
+          'TextInput.setClient', <dynamic>[123, capitilizeWordsConfig]);
       sendFrameworkMessage(codec.encodeMethodCall(setClient));
 
       const MethodCall setEditingState1 =
@@ -900,6 +893,15 @@ void main() {
       expect(textEditing.editingElement.domElement.style.textTransform,
           'capitalize');
 
+      // Test for mobile Safari.
+      if (browserEngine == BrowserEngine.webkit &&
+          operatingSystem == OperatingSystem.iOs) {
+        expect(
+            textEditing.editingElement.domElement
+                .getAttribute('autocapitalize'),
+            'sentences');
+      }
+
       final InputElement element = textEditing.editingElement.domElement;
       element.value = 'something some test';
       element.dispatchEvent(Event.eventType('Event', 'input'));
@@ -913,6 +915,64 @@ void main() {
           123, // Client ID
           <String, dynamic>{
             'text': 'Something Some Test',
+            'selectionBase': 19,
+            'selectionExtent': 19,
+          },
+        ],
+      );
+
+      spy.messages.clear();
+      hideKeyboard();
+    });
+
+    test(
+        'All characters capitilization: setClient, setEditingState, show, '
+        'updateEditingState', () {
+      // Create a configuration with an AutofillGroup of four text fields.
+      final Map<String, dynamic> capitilizeWordsConfig = createFlutterConfig(
+          'text',
+          textCapitalization: 'TextCapitalization.characters');
+      final MethodCall setClient = MethodCall(
+          'TextInput.setClient', <dynamic>[123, capitilizeWordsConfig]);
+      sendFrameworkMessage(codec.encodeMethodCall(setClient));
+
+      const MethodCall setEditingState1 =
+          MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': '',
+        'selectionBase': 0,
+        'selectionExtent': 0,
+      });
+      sendFrameworkMessage(codec.encodeMethodCall(setEditingState1));
+
+      const MethodCall show = MethodCall('TextInput.show');
+      sendFrameworkMessage(codec.encodeMethodCall(show));
+      spy.messages.clear();
+
+      expect(textEditing.editingElement.domElement.style.textTransform,
+          'uppercase');
+
+      // Test for mobile Safari.
+      if (browserEngine == BrowserEngine.webkit &&
+          operatingSystem == OperatingSystem.iOs) {
+        expect(
+            textEditing.editingElement.domElement
+                .getAttribute('autocapitalize'),
+            'characters');
+      }
+
+      final InputElement element = textEditing.editingElement.domElement;
+      element.value = 'something some test';
+      element.dispatchEvent(Event.eventType('Event', 'input'));
+
+      expect(spy.messages, hasLength(1));
+      expect(spy.messages[0].channel, 'flutter/textinput');
+      expect(spy.messages[0].methodName, 'TextInputClient.updateEditingState');
+      expect(
+        spy.messages[0].methodArguments,
+        <dynamic>[
+          123, // Client ID
+          <String, dynamic>{
+            'text': 'SOMETHING SOME TEST',
             'selectionBase': 19,
             'selectionExtent': 19,
           },

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -31,6 +31,8 @@ final InputConfiguration singlelineConfig = InputConfiguration(
   obscureText: false,
   inputAction: 'TextInputAction.done',
   autocorrect: true,
+  textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+      'TextCapitalization.none'),
 );
 final Map<String, dynamic> flutterSinglelineConfig =
     createFlutterConfig('text');
@@ -40,6 +42,8 @@ final InputConfiguration multilineConfig = InputConfiguration(
   obscureText: false,
   inputAction: 'TextInputAction.newline',
   autocorrect: true,
+  textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+      'TextCapitalization.none')
 );
 final Map<String, dynamic> flutterMultilineConfig =
     createFlutterConfig('multiline');
@@ -112,6 +116,8 @@ void main() {
         inputAction: 'TextInputAction.done',
         obscureText: true,
         autocorrect: true,
+        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+            'TextCapitalization.none')
       );
       editingElement.enable(
         config,
@@ -132,6 +138,8 @@ void main() {
         inputAction: 'TextInputAction.done',
         obscureText: false,
         autocorrect: false,
+        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+            'TextCapitalization.none')
       );
       editingElement.enable(
         config,
@@ -152,6 +160,8 @@ void main() {
         inputAction: 'TextInputAction.done',
         obscureText: false,
         autocorrect: true,
+        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+            'TextCapitalization.none')
       );
       editingElement.enable(
         config,
@@ -291,6 +301,8 @@ void main() {
         obscureText: false,
         inputAction: 'TextInputAction.done',
         autocorrect: true,
+        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+            'TextCapitalization.none')
       );
       editingElement.enable(
         config,
@@ -317,6 +329,8 @@ void main() {
         obscureText: false,
         inputAction: 'TextInputAction.done',
         autocorrect: true,
+        textCapitalization: TextCapitalizationUtil.fromInputConfiguration(
+            'TextCapitalization.none')
       );
       editingElement.enable(
         config,
@@ -857,6 +871,36 @@ void main() {
       // Confirm that [HybridTextEditing] didn't send any messages.
       expect(spy.messages, isEmpty);
       expect(document.getElementsByTagName('form'), isEmpty);
+    });
+
+    test(
+        'Word capitilization: setClient, setEditingState, show, '
+        'setEditingState, clearClient', () {
+      // Create a configuration with an AutofillGroup of four text fields.
+      final Map<String, dynamic> capitilizeWordsConfig =
+          createFlutterConfig('text',
+           textCapitalization: 'TextCapitalization.words'
+          );
+      final MethodCall setClient = MethodCall('TextInput.setClient',
+          <dynamic>[123, capitilizeWordsConfig]);
+      sendFrameworkMessage(codec.encodeMethodCall(setClient));
+
+      const MethodCall setEditingState1 =
+          MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': '',
+        'selectionBase': 0,
+        'selectionExtent': 0,
+      });
+      sendFrameworkMessage(codec.encodeMethodCall(setEditingState1));
+
+      const MethodCall show = MethodCall('TextInput.show');
+      sendFrameworkMessage(codec.encodeMethodCall(show));
+
+      expect(textEditing.editingElement.domElement.style.textTransform,
+          'capitalize');
+
+      const MethodCall clearClient = MethodCall('TextInput.clearClient');
+      sendFrameworkMessage(codec.encodeMethodCall(clearClient));
     });
 
     test(
@@ -1710,6 +1754,7 @@ Map<String, dynamic> createFlutterConfig(
   String inputType, {
   bool obscureText = false,
   bool autocorrect = true,
+  String textCapitalization = 'TextCapitalization.none',
   String inputAction,
   String autofillHint,
   List<String> autofillHintsForFields,
@@ -1721,6 +1766,7 @@ Map<String, dynamic> createFlutterConfig(
     'obscureText': obscureText,
     'autocorrect': autocorrect,
     'inputAction': inputAction ?? 'TextInputAction.done',
+    'textCapitalization': textCapitalization,
     if (autofillHint != null)
       'autofill': createAutofillInfo(autofillHint, autofillHint),
     if (autofillHintsForFields != null)
@@ -1763,5 +1809,6 @@ Map<String, dynamic> createOneFieldValue(String hint, String uniqueId) =>
         'signed': null,
         'decimal': null
       },
+      'textCapitalization': 'TextCapitalization.none',
       'autofill': createAutofillInfo(hint, uniqueId)
     };


### PR DESCRIPTION
Flutter for Web text fields were not utilizing the  text capitalization information received from the framework side. This PR adds it to the InputConfiguration and uses css text-transform property to implement the functionality.

Fixes: https://github.com/flutter/flutter/issues/43929 