### PR TITLE
Expose options for developers to manage DartVM release time implicitly.

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -257,6 +257,9 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.disable_dart_asserts =
       command_line.HasOption(FlagForSwitch(Switch::DisableDartAsserts));
 
+  settings.leak_vm =
+      !command_line.HasOption(FlagForSwitch(Switch::DisableLeakVM));
+
   settings.start_paused =
       command_line.HasOption(FlagForSwitch(Switch::StartPaused));
 

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -198,6 +198,13 @@ DEF_SWITCH(UseEmbeddedView,
            "the platform thread."
            "This flag should be removed once the dynamic thread merging is "
            "enabled on android.")
+DEF_SWITCH(DisableLeakVM,
+           "disable-leak-vm",
+           "This flag defaults to false. Any shell launched with this flag "
+           "set to false will leak the VM in the process. There is no way to "
+           "shut down the VM once such a shell has been started. Make sure "
+           "this flag is set to true if you want the VM to shutdown and free "
+           "all associate resources.")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);


### PR DESCRIPTION
Expose the leak-vm flag so that developers can implicitly disable the default logic and release the dartvm and all related resources when needed.