### PR TITLE
fix FlutterViewUpdateCustomAccessibilityActions uses correct string list

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -116,6 +116,7 @@ group("flutter") {
       public_deps += [
         "//flutter/shell/platform/android/external_view_embedder:android_external_view_embedder_unittests",
         "//flutter/shell/platform/android/jni:jni_unittests",
+        "//flutter/shell/platform/android/platform_view_android_delegate:platform_view_android_delegate_unittests",
       ]
     }
 

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -815,6 +815,9 @@ FILE: ../../../flutter/shell/platform/android/platform_message_response_android.
 FILE: ../../../flutter/shell/platform/android/platform_message_response_android.h
 FILE: ../../../flutter/shell/platform/android/platform_view_android.cc
 FILE: ../../../flutter/shell/platform/android/platform_view_android.h
+FILE: ../../../flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+FILE: ../../../flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
+FILE: ../../../flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
 FILE: ../../../flutter/shell/platform/android/platform_view_android_jni_impl.cc
 FILE: ../../../flutter/shell/platform/android/platform_view_android_jni_impl.h
 FILE: ../../../flutter/shell/platform/android/robolectric.properties

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -64,6 +64,7 @@ shared_library("flutter_shell_native") {
     "//flutter/shell/platform/android/context",
     "//flutter/shell/platform/android/external_view_embedder",
     "//flutter/shell/platform/android/jni",
+    "//flutter/shell/platform/android/platform_view_android_delegate",
     "//flutter/shell/platform/android/surface",
     "//flutter/shell/platform/android/surface:native_window",
     "//third_party/skia",

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -52,7 +52,9 @@ PlatformViewAndroid::PlatformViewAndroid(
     flutter::TaskRunners task_runners,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
     bool use_software_rendering)
-    : PlatformView(delegate, std::move(task_runners)), jni_facade_(jni_facade) {
+    : PlatformView(delegate, std::move(task_runners)),
+      jni_facade_(jni_facade),
+      platform_view_android_delegate_(jni_facade) {
   std::shared_ptr<AndroidContext> android_context;
   if (use_software_rendering) {
     android_context =
@@ -81,7 +83,8 @@ PlatformViewAndroid::PlatformViewAndroid(
     flutter::TaskRunners task_runners,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
     : PlatformView(delegate, std::move(task_runners)),
-      jni_facade_(jni_facade) {}
+      jni_facade_(jni_facade),
+      platform_view_android_delegate_(jni_facade) {}
 
 PlatformViewAndroid::~PlatformViewAndroid() = default;
 
@@ -260,143 +263,7 @@ void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,
 void PlatformViewAndroid::UpdateSemantics(
     flutter::SemanticsNodeUpdates update,
     flutter::CustomAccessibilityActionUpdates actions) {
-  constexpr size_t kBytesPerNode = 41 * sizeof(int32_t);
-  constexpr size_t kBytesPerChild = sizeof(int32_t);
-  constexpr size_t kBytesPerAction = 4 * sizeof(int32_t);
-
-  {
-    size_t num_bytes = 0;
-    for (const auto& value : update) {
-      num_bytes += kBytesPerNode;
-      num_bytes +=
-          value.second.childrenInTraversalOrder.size() * kBytesPerChild;
-      num_bytes += value.second.childrenInHitTestOrder.size() * kBytesPerChild;
-      num_bytes +=
-          value.second.customAccessibilityActions.size() * kBytesPerChild;
-    }
-
-    // The encoding defined here is used in:
-    //
-    //  * AccessibilityBridge.java
-    //  * AccessibilityBridgeTest.java
-    //  * accessibility_bridge.mm
-    //
-    // If any of the encoding structure or length is changed, those locations
-    // must be updated (at a minimum).
-    std::vector<uint8_t> buffer(num_bytes);
-    int32_t* buffer_int32 = reinterpret_cast<int32_t*>(&buffer[0]);
-    float* buffer_float32 = reinterpret_cast<float*>(&buffer[0]);
-
-    std::vector<std::string> strings;
-    size_t position = 0;
-    for (const auto& value : update) {
-      // If you edit this code, make sure you update kBytesPerNode
-      // and/or kBytesPerChild above to match the number of values you are
-      // sending.
-      const flutter::SemanticsNode& node = value.second;
-      buffer_int32[position++] = node.id;
-      buffer_int32[position++] = node.flags;
-      buffer_int32[position++] = node.actions;
-      buffer_int32[position++] = node.maxValueLength;
-      buffer_int32[position++] = node.currentValueLength;
-      buffer_int32[position++] = node.textSelectionBase;
-      buffer_int32[position++] = node.textSelectionExtent;
-      buffer_int32[position++] = node.platformViewId;
-      buffer_int32[position++] = node.scrollChildren;
-      buffer_int32[position++] = node.scrollIndex;
-      buffer_float32[position++] = (float)node.scrollPosition;
-      buffer_float32[position++] = (float)node.scrollExtentMax;
-      buffer_float32[position++] = (float)node.scrollExtentMin;
-      if (node.label.empty()) {
-        buffer_int32[position++] = -1;
-      } else {
-        buffer_int32[position++] = strings.size();
-        strings.push_back(node.label);
-      }
-      if (node.value.empty()) {
-        buffer_int32[position++] = -1;
-      } else {
-        buffer_int32[position++] = strings.size();
-        strings.push_back(node.value);
-      }
-      if (node.increasedValue.empty()) {
-        buffer_int32[position++] = -1;
-      } else {
-        buffer_int32[position++] = strings.size();
-        strings.push_back(node.increasedValue);
-      }
-      if (node.decreasedValue.empty()) {
-        buffer_int32[position++] = -1;
-      } else {
-        buffer_int32[position++] = strings.size();
-        strings.push_back(node.decreasedValue);
-      }
-      if (node.hint.empty()) {
-        buffer_int32[position++] = -1;
-      } else {
-        buffer_int32[position++] = strings.size();
-        strings.push_back(node.hint);
-      }
-      buffer_int32[position++] = node.textDirection;
-      buffer_float32[position++] = node.rect.left();
-      buffer_float32[position++] = node.rect.top();
-      buffer_float32[position++] = node.rect.right();
-      buffer_float32[position++] = node.rect.bottom();
-      node.transform.getColMajor(&buffer_float32[position]);
-      position += 16;
-
-      buffer_int32[position++] = node.childrenInTraversalOrder.size();
-      for (int32_t child : node.childrenInTraversalOrder)
-        buffer_int32[position++] = child;
-
-      for (int32_t child : node.childrenInHitTestOrder)
-        buffer_int32[position++] = child;
-
-      buffer_int32[position++] = node.customAccessibilityActions.size();
-      for (int32_t child : node.customAccessibilityActions)
-        buffer_int32[position++] = child;
-    }
-
-    // custom accessibility actions.
-    size_t num_action_bytes = actions.size() * kBytesPerAction;
-    std::vector<uint8_t> actions_buffer(num_action_bytes);
-    int32_t* actions_buffer_int32 =
-        reinterpret_cast<int32_t*>(&actions_buffer[0]);
-
-    std::vector<std::string> action_strings;
-    size_t actions_position = 0;
-    for (const auto& value : actions) {
-      // If you edit this code, make sure you update kBytesPerAction
-      // to match the number of values you are
-      // sending.
-      const flutter::CustomAccessibilityAction& action = value.second;
-      actions_buffer_int32[actions_position++] = action.id;
-      actions_buffer_int32[actions_position++] = action.overrideId;
-      if (action.label.empty()) {
-        actions_buffer_int32[actions_position++] = -1;
-      } else {
-        actions_buffer_int32[actions_position++] = action_strings.size();
-        action_strings.push_back(action.label);
-      }
-      if (action.hint.empty()) {
-        actions_buffer_int32[actions_position++] = -1;
-      } else {
-        actions_buffer_int32[actions_position++] = action_strings.size();
-        action_strings.push_back(action.hint);
-      }
-    }
-
-    // Calling NewDirectByteBuffer in API level 22 and below with a size of zero
-    // will cause a JNI crash.
-    if (actions_buffer.size() > 0) {
-      jni_facade_->FlutterViewUpdateCustomAccessibilityActions(actions_buffer,
-                                                               strings);
-    }
-
-    if (buffer.size() > 0) {
-      jni_facade_->FlutterViewUpdateSemantics(buffer, strings);
-    }
-  }
+  platform_view_android_delegate_.UpdateSemantics(update, actions);
 }
 
 void PlatformViewAndroid::RegisterExternalTexture(

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -16,6 +16,7 @@
 #include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
+#include "flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h"
 #include "flutter/shell/platform/android/surface/android_native_window.h"
 #include "flutter/shell/platform/android/surface/android_surface.h"
 
@@ -79,6 +80,8 @@ class PlatformViewAndroid final : public PlatformView {
 
  private:
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
+
+  PlatformViewAndroidDelegate platform_view_android_delegate_;
 
   std::unique_ptr<AndroidSurface> android_surface_;
   // We use id 0 to mean that no response is expected.

--- a/shell/platform/android/platform_view_android_delegate/BUILD.gn
+++ b/shell/platform/android/platform_view_android_delegate/BUILD.gn
@@ -1,0 +1,47 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
+import("//flutter/shell/gpu/gpu.gni")
+
+
+source_set("platform_view_android_delegate") {
+  sources = [
+    "platform_view_android_delegate.cc",
+    "platform_view_android_delegate.h",
+  ]
+
+  public_configs = [ "//flutter:config" ]
+
+  deps = [
+    "//flutter/common",
+    "//flutter/fml",
+    "//flutter/lib/ui",
+    "//flutter/shell/common",
+    "//flutter/shell/platform/android/jni",
+    "//third_party/skia",
+  ]
+}
+
+test_fixtures("platform_view_android_delegate_fixtures") {
+  fixtures = []
+}
+
+executable("platform_view_android_delegate_unittests") {
+  testonly = true
+
+  sources = [
+    "platform_view_android_delegate_unittests.cc",
+  ]
+
+  deps = [
+    ":platform_view_android_delegate",
+    ":platform_view_android_delegate_fixtures",
+    "//flutter/shell/platform/android/jni:jni_mock",
+    "//flutter/testing",
+    "//flutter/testing:dart",
+    "//flutter/third_party/txt",
+  ]
+}

--- a/shell/platform/android/platform_view_android_delegate/BUILD.gn
+++ b/shell/platform/android/platform_view_android_delegate/BUILD.gn
@@ -4,8 +4,6 @@
 
 import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
-import("//flutter/shell/gpu/gpu.gni")
-
 
 source_set("platform_view_android_delegate") {
   sources = [

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -1,0 +1,154 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h"
+
+namespace flutter {
+
+PlatformViewAndroidDelegate::PlatformViewAndroidDelegate(
+  std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
+  : jni_facade_(jni_facade) {};
+
+void PlatformViewAndroidDelegate::UpdateSemantics(
+    flutter::SemanticsNodeUpdates update,
+    flutter::CustomAccessibilityActionUpdates actions) {
+  constexpr size_t kBytesPerNode = 41 * sizeof(int32_t);
+  constexpr size_t kBytesPerChild = sizeof(int32_t);
+  constexpr size_t kBytesPerAction = 4 * sizeof(int32_t);
+
+  {
+    size_t num_bytes = 0;
+    for (const auto& value : update) {
+      num_bytes += kBytesPerNode;
+      num_bytes +=
+          value.second.childrenInTraversalOrder.size() * kBytesPerChild;
+      num_bytes += value.second.childrenInHitTestOrder.size() * kBytesPerChild;
+      num_bytes +=
+          value.second.customAccessibilityActions.size() * kBytesPerChild;
+    }
+    // The encoding defined here is used in:
+    //
+    //  * AccessibilityBridge.java
+    //  * AccessibilityBridgeTest.java
+    //  * accessibility_bridge.mm
+    //
+    // If any of the encoding structure or length is changed, those locations
+    // must be updated (at a minimum).
+    std::vector<uint8_t> buffer(num_bytes);
+    int32_t* buffer_int32 = reinterpret_cast<int32_t*>(&buffer[0]);
+    float* buffer_float32 = reinterpret_cast<float*>(&buffer[0]);
+
+    std::vector<std::string> strings;
+    size_t position = 0;
+    for (const auto& value : update) {
+      // If you edit this code, make sure you update kBytesPerNode
+      // and/or kBytesPerChild above to match the number of values you are
+      // sending.
+      const flutter::SemanticsNode& node = value.second;
+      buffer_int32[position++] = node.id;
+      buffer_int32[position++] = node.flags;
+      buffer_int32[position++] = node.actions;
+      buffer_int32[position++] = node.maxValueLength;
+      buffer_int32[position++] = node.currentValueLength;
+      buffer_int32[position++] = node.textSelectionBase;
+      buffer_int32[position++] = node.textSelectionExtent;
+      buffer_int32[position++] = node.platformViewId;
+      buffer_int32[position++] = node.scrollChildren;
+      buffer_int32[position++] = node.scrollIndex;
+      buffer_float32[position++] = (float)node.scrollPosition;
+      buffer_float32[position++] = (float)node.scrollExtentMax;
+      buffer_float32[position++] = (float)node.scrollExtentMin;
+      if (node.label.empty()) {
+        buffer_int32[position++] = -1;
+      } else {
+        buffer_int32[position++] = strings.size();
+        strings.push_back(node.label);
+      }
+      if (node.value.empty()) {
+        buffer_int32[position++] = -1;
+      } else {
+        buffer_int32[position++] = strings.size();
+        strings.push_back(node.value);
+      }
+      if (node.increasedValue.empty()) {
+        buffer_int32[position++] = -1;
+      } else {
+        buffer_int32[position++] = strings.size();
+        strings.push_back(node.increasedValue);
+      }
+      if (node.decreasedValue.empty()) {
+        buffer_int32[position++] = -1;
+      } else {
+        buffer_int32[position++] = strings.size();
+        strings.push_back(node.decreasedValue);
+      }
+      if (node.hint.empty()) {
+        buffer_int32[position++] = -1;
+      } else {
+        buffer_int32[position++] = strings.size();
+        strings.push_back(node.hint);
+      }
+      buffer_int32[position++] = node.textDirection;
+      buffer_float32[position++] = node.rect.left();
+      buffer_float32[position++] = node.rect.top();
+      buffer_float32[position++] = node.rect.right();
+      buffer_float32[position++] = node.rect.bottom();
+      node.transform.getColMajor(&buffer_float32[position]);
+      position += 16;
+
+      buffer_int32[position++] = node.childrenInTraversalOrder.size();
+      for (int32_t child : node.childrenInTraversalOrder)
+        buffer_int32[position++] = child;
+
+      for (int32_t child : node.childrenInHitTestOrder)
+        buffer_int32[position++] = child;
+
+      buffer_int32[position++] = node.customAccessibilityActions.size();
+      for (int32_t child : node.customAccessibilityActions)
+        buffer_int32[position++] = child;
+    }
+
+    // custom accessibility actions.
+    size_t num_action_bytes = actions.size() * kBytesPerAction;
+    std::vector<uint8_t> actions_buffer(num_action_bytes);
+    int32_t* actions_buffer_int32 =
+        reinterpret_cast<int32_t*>(&actions_buffer[0]);
+
+    std::vector<std::string> action_strings;
+    size_t actions_position = 0;
+    for (const auto& value : actions) {
+      // If you edit this code, make sure you update kBytesPerAction
+      // to match the number of values you are
+      // sending.
+      const flutter::CustomAccessibilityAction& action = value.second;
+      actions_buffer_int32[actions_position++] = action.id;
+      actions_buffer_int32[actions_position++] = action.overrideId;
+      if (action.label.empty()) {
+        actions_buffer_int32[actions_position++] = -1;
+      } else {
+        actions_buffer_int32[actions_position++] = action_strings.size();
+        action_strings.push_back(action.label);
+      }
+      if (action.hint.empty()) {
+        actions_buffer_int32[actions_position++] = -1;
+      } else {
+        actions_buffer_int32[actions_position++] = action_strings.size();
+        action_strings.push_back(action.hint);
+      }
+    }
+
+    // Calling NewDirectByteBuffer in API level 22 and below with a size of zero
+    // will cause a JNI crash.
+    if (actions_buffer.size() > 0) {
+      jni_facade_->FlutterViewUpdateCustomAccessibilityActions(actions_buffer,
+                                                               action_strings);
+    }
+
+    if (buffer.size() > 0) {
+      jni_facade_->FlutterViewUpdateSemantics(buffer, strings);
+    }
+  }
+}
+
+}  // namespace flutter

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -7,8 +7,8 @@
 namespace flutter {
 
 PlatformViewAndroidDelegate::PlatformViewAndroidDelegate(
-  std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
-  : jni_facade_(jni_facade) {};
+    std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
+    : jni_facade_(jni_facade){};
 
 void PlatformViewAndroidDelegate::UpdateSemantics(
     flutter::SemanticsNodeUpdates update,

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.cc
@@ -56,9 +56,9 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
       buffer_int32[position++] = node.platformViewId;
       buffer_int32[position++] = node.scrollChildren;
       buffer_int32[position++] = node.scrollIndex;
-      buffer_float32[position++] = (float)node.scrollPosition;
-      buffer_float32[position++] = (float)node.scrollExtentMax;
-      buffer_float32[position++] = (float)node.scrollExtentMin;
+      buffer_float32[position++] = static_cast<float>(node.scrollPosition);
+      buffer_float32[position++] = static_cast<float>(node.scrollExtentMax);
+      buffer_float32[position++] = static_cast<float>(node.scrollExtentMin);
       if (node.label.empty()) {
         buffer_int32[position++] = -1;
       } else {
@@ -98,15 +98,18 @@ void PlatformViewAndroidDelegate::UpdateSemantics(
       position += 16;
 
       buffer_int32[position++] = node.childrenInTraversalOrder.size();
-      for (int32_t child : node.childrenInTraversalOrder)
+      for (int32_t child : node.childrenInTraversalOrder) {
         buffer_int32[position++] = child;
+      }
 
-      for (int32_t child : node.childrenInHitTestOrder)
+      for (int32_t child : node.childrenInHitTestOrder) {
         buffer_int32[position++] = child;
+      }
 
       buffer_int32[position++] = node.customAccessibilityActions.size();
-      for (int32_t child : node.customAccessibilityActions)
+      for (int32_t child : node.customAccessibilityActions) {
         buffer_int32[position++] = child;
+      }
     }
 
     // custom accessibility actions.

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_PLATFORM_ANDROID_PLATFORM_VIEW_ANDROID_DELEGATE_H_
+#define SHELL_PLATFORM_ANDROID_PLATFORM_VIEW_ANDROID_DELEGATE_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "flutter/shell/common/platform_view.h"
+#include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
+
+namespace flutter {
+
+class PlatformViewAndroidDelegate {
+ public:
+  PlatformViewAndroidDelegate(std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
+  void UpdateSemantics(
+    flutter::SemanticsNodeUpdates update,
+    flutter::CustomAccessibilityActionUpdates actions);
+ private:
+  const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
+};
+}  // namespace flutter
+
+#endif  // SHELL_PLATFORM_ANDROID_PLATFORM_VIEW_ANDROID_H_

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
@@ -16,10 +16,11 @@ namespace flutter {
 
 class PlatformViewAndroidDelegate {
  public:
-  PlatformViewAndroidDelegate(std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
-  void UpdateSemantics(
-    flutter::SemanticsNodeUpdates update,
-    flutter::CustomAccessibilityActionUpdates actions);
+  PlatformViewAndroidDelegate(
+      std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
+  void UpdateSemantics(flutter::SemanticsNodeUpdates update,
+                       flutter::CustomAccessibilityActionUpdates actions);
+
  private:
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
 };

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
@@ -1,0 +1,96 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h"
+#include "flutter/shell/platform/android/jni/jni_mock.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
+  auto jni_mock = std::make_shared<JNIMock>();
+
+  PlatformViewAndroidDelegate* platformViewAndroidDelegate = new PlatformViewAndroidDelegate(jni_mock);
+
+  flutter::SemanticsNodeUpdates update;
+  flutter::SemanticsNode node0;
+  node0.id = 0;
+  node0.label = "label";
+  update.insert(std::make_pair(0, std::move(node0)));
+
+  std::vector<uint8_t> expected_buffer(164);
+  size_t position = 0;
+  int32_t* buffer_int32 = reinterpret_cast<int32_t*>(&expected_buffer[0]);
+  float* buffer_float32 = reinterpret_cast<float*>(&expected_buffer[0]);
+  std::vector<std::string> expected_strings;
+  buffer_int32[position++] = node0.id;
+  buffer_int32[position++] = node0.flags;
+  buffer_int32[position++] = node0.actions;
+  buffer_int32[position++] = node0.maxValueLength;
+  buffer_int32[position++] = node0.currentValueLength;
+  buffer_int32[position++] = node0.textSelectionBase;
+  buffer_int32[position++] = node0.textSelectionExtent;
+  buffer_int32[position++] = node0.platformViewId;
+  buffer_int32[position++] = node0.scrollChildren;
+  buffer_int32[position++] = node0.scrollIndex;
+  buffer_float32[position++] = (float)node0.scrollPosition;
+  buffer_float32[position++] = (float)node0.scrollExtentMax;
+  buffer_float32[position++] = (float)node0.scrollExtentMin;
+  buffer_int32[position++] = expected_strings.size(); // node0.label
+  expected_strings.push_back(node0.label);
+  buffer_int32[position++] = -1; // node0.value
+  buffer_int32[position++] = -1; // node0.increasedValue
+  buffer_int32[position++] = -1; // node0.decreasedValue
+  buffer_int32[position++] = -1; // node0.hint
+  buffer_int32[position++] = node0.textDirection;
+  buffer_float32[position++] = node0.rect.left();
+  buffer_float32[position++] = node0.rect.top();
+  buffer_float32[position++] = node0.rect.right();
+  buffer_float32[position++] = node0.rect.bottom();
+  node0.transform.getColMajor(&buffer_float32[position]);
+  position += 16;
+  buffer_int32[position++] = 0; // node0.childrenInTraversalOrder.size();
+  buffer_int32[position++] = 0; // node0.customAccessibilityActions.size();
+  EXPECT_CALL(*jni_mock, FlutterViewUpdateSemantics(expected_buffer, expected_strings));
+
+  // Creates empty custom actions.
+  flutter::CustomAccessibilityActionUpdates actions;
+  EXPECT_CALL(*jni_mock, FlutterViewUpdateSemantics(expected_buffer, expected_strings));
+  platformViewAndroidDelegate->UpdateSemantics(update, actions);
+}
+
+TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateCustomAccessibilityActions) {
+  auto jni_mock = std::make_shared<JNIMock>();
+
+  PlatformViewAndroidDelegate* platformViewAndroidDelegate = new PlatformViewAndroidDelegate(jni_mock);
+
+  flutter::CustomAccessibilityActionUpdates actions;
+  flutter::CustomAccessibilityAction action0;
+  action0.id = 0;
+  action0.overrideId = 1;
+  action0.label = "label";
+  action0.hint = "hint";
+  actions.insert(std::make_pair(0, std::move(action0)));
+
+  std::vector<uint8_t> expected_actions_buffer(16);
+  int32_t* actions_buffer_int32 =
+    reinterpret_cast<int32_t*>(&expected_actions_buffer[0]);
+  std::vector<std::string> expected_action_strings;
+  actions_buffer_int32[0] = action0.id;
+  actions_buffer_int32[1] = action0.overrideId;
+  actions_buffer_int32[2] = expected_action_strings.size();
+  expected_action_strings.push_back(action0.label);
+  actions_buffer_int32[3] = expected_action_strings.size();
+  expected_action_strings.push_back(action0.hint);
+
+  // Creates empty update.
+  flutter::SemanticsNodeUpdates update;
+  EXPECT_CALL(*jni_mock, FlutterViewUpdateCustomAccessibilityActions(expected_actions_buffer, expected_action_strings));
+  platformViewAndroidDelegate->UpdateSemantics(update, actions);
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
@@ -35,9 +35,9 @@ TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
   buffer_int32[position++] = node0.platformViewId;
   buffer_int32[position++] = node0.scrollChildren;
   buffer_int32[position++] = node0.scrollIndex;
-  buffer_float32[position++] = (float)node0.scrollPosition;
-  buffer_float32[position++] = (float)node0.scrollExtentMax;
-  buffer_float32[position++] = (float)node0.scrollExtentMin;
+  buffer_float32[position++] = static_cast<float>(node0.scrollPosition);
+  buffer_float32[position++] = static_cast<float>(node0.scrollExtentMax);
+  buffer_float32[position++] = static_cast<float>(node0.scrollExtentMin);
   buffer_int32[position++] = expected_strings.size();  // node0.label
   expected_strings.push_back(node0.label);
   buffer_int32[position++] = -1;  // node0.value

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
@@ -12,9 +12,7 @@ namespace testing {
 
 TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
   auto jni_mock = std::make_shared<JNIMock>();
-
-  PlatformViewAndroidDelegate* platformViewAndroidDelegate =
-      new PlatformViewAndroidDelegate(jni_mock);
+  auto delegate = std::make_unique<PlatformViewAndroidDelegate>(jni_mock);
 
   flutter::SemanticsNodeUpdates update;
   flutter::SemanticsNode node0;
@@ -55,22 +53,18 @@ TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
   position += 16;
   buffer_int32[position++] = 0;  // node0.childrenInTraversalOrder.size();
   buffer_int32[position++] = 0;  // node0.customAccessibilityActions.size();
+
   EXPECT_CALL(*jni_mock,
               FlutterViewUpdateSemantics(expected_buffer, expected_strings));
-
   // Creates empty custom actions.
   flutter::CustomAccessibilityActionUpdates actions;
-  EXPECT_CALL(*jni_mock,
-              FlutterViewUpdateSemantics(expected_buffer, expected_strings));
-  platformViewAndroidDelegate->UpdateSemantics(update, actions);
+  delegate->UpdateSemantics(update, actions);
 }
 
 TEST(PlatformViewShell,
      UpdateSemanticsDoesFlutterViewUpdateCustomAccessibilityActions) {
   auto jni_mock = std::make_shared<JNIMock>();
-
-  PlatformViewAndroidDelegate* platformViewAndroidDelegate =
-      new PlatformViewAndroidDelegate(jni_mock);
+  auto delegate = std::make_unique<PlatformViewAndroidDelegate>(jni_mock);
 
   flutter::CustomAccessibilityActionUpdates actions;
   flutter::CustomAccessibilityAction action0;
@@ -91,11 +85,11 @@ TEST(PlatformViewShell,
   actions_buffer_int32[3] = expected_action_strings.size();
   expected_action_strings.push_back(action0.hint);
 
-  // Creates empty update.
-  flutter::SemanticsNodeUpdates update;
   EXPECT_CALL(*jni_mock, FlutterViewUpdateCustomAccessibilityActions(
                              expected_actions_buffer, expected_action_strings));
-  platformViewAndroidDelegate->UpdateSemantics(update, actions);
+  // Creates empty update.
+  flutter::SemanticsNodeUpdates update;
+  delegate->UpdateSemantics(update, actions);
 }
 
 }  // namespace testing

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h"
 #include "flutter/shell/platform/android/jni/jni_mock.h"
+#include "flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -13,7 +13,8 @@ namespace testing {
 TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
   auto jni_mock = std::make_shared<JNIMock>();
 
-  PlatformViewAndroidDelegate* platformViewAndroidDelegate = new PlatformViewAndroidDelegate(jni_mock);
+  PlatformViewAndroidDelegate* platformViewAndroidDelegate =
+      new PlatformViewAndroidDelegate(jni_mock);
 
   flutter::SemanticsNodeUpdates update;
   flutter::SemanticsNode node0;
@@ -39,12 +40,12 @@ TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
   buffer_float32[position++] = (float)node0.scrollPosition;
   buffer_float32[position++] = (float)node0.scrollExtentMax;
   buffer_float32[position++] = (float)node0.scrollExtentMin;
-  buffer_int32[position++] = expected_strings.size(); // node0.label
+  buffer_int32[position++] = expected_strings.size();  // node0.label
   expected_strings.push_back(node0.label);
-  buffer_int32[position++] = -1; // node0.value
-  buffer_int32[position++] = -1; // node0.increasedValue
-  buffer_int32[position++] = -1; // node0.decreasedValue
-  buffer_int32[position++] = -1; // node0.hint
+  buffer_int32[position++] = -1;  // node0.value
+  buffer_int32[position++] = -1;  // node0.increasedValue
+  buffer_int32[position++] = -1;  // node0.decreasedValue
+  buffer_int32[position++] = -1;  // node0.hint
   buffer_int32[position++] = node0.textDirection;
   buffer_float32[position++] = node0.rect.left();
   buffer_float32[position++] = node0.rect.top();
@@ -52,20 +53,24 @@ TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateSemantics) {
   buffer_float32[position++] = node0.rect.bottom();
   node0.transform.getColMajor(&buffer_float32[position]);
   position += 16;
-  buffer_int32[position++] = 0; // node0.childrenInTraversalOrder.size();
-  buffer_int32[position++] = 0; // node0.customAccessibilityActions.size();
-  EXPECT_CALL(*jni_mock, FlutterViewUpdateSemantics(expected_buffer, expected_strings));
+  buffer_int32[position++] = 0;  // node0.childrenInTraversalOrder.size();
+  buffer_int32[position++] = 0;  // node0.customAccessibilityActions.size();
+  EXPECT_CALL(*jni_mock,
+              FlutterViewUpdateSemantics(expected_buffer, expected_strings));
 
   // Creates empty custom actions.
   flutter::CustomAccessibilityActionUpdates actions;
-  EXPECT_CALL(*jni_mock, FlutterViewUpdateSemantics(expected_buffer, expected_strings));
+  EXPECT_CALL(*jni_mock,
+              FlutterViewUpdateSemantics(expected_buffer, expected_strings));
   platformViewAndroidDelegate->UpdateSemantics(update, actions);
 }
 
-TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateCustomAccessibilityActions) {
+TEST(PlatformViewShell,
+     UpdateSemanticsDoesFlutterViewUpdateCustomAccessibilityActions) {
   auto jni_mock = std::make_shared<JNIMock>();
 
-  PlatformViewAndroidDelegate* platformViewAndroidDelegate = new PlatformViewAndroidDelegate(jni_mock);
+  PlatformViewAndroidDelegate* platformViewAndroidDelegate =
+      new PlatformViewAndroidDelegate(jni_mock);
 
   flutter::CustomAccessibilityActionUpdates actions;
   flutter::CustomAccessibilityAction action0;
@@ -77,7 +82,7 @@ TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateCustomAccessibilityA
 
   std::vector<uint8_t> expected_actions_buffer(16);
   int32_t* actions_buffer_int32 =
-    reinterpret_cast<int32_t*>(&expected_actions_buffer[0]);
+      reinterpret_cast<int32_t*>(&expected_actions_buffer[0]);
   std::vector<std::string> expected_action_strings;
   actions_buffer_int32[0] = action0.id;
   actions_buffer_int32[1] = action0.overrideId;
@@ -88,7 +93,8 @@ TEST(PlatformViewShell, UpdateSemanticsDoesFlutterViewUpdateCustomAccessibilityA
 
   // Creates empty update.
   flutter::SemanticsNodeUpdates update;
-  EXPECT_CALL(*jni_mock, FlutterViewUpdateCustomAccessibilityActions(expected_actions_buffer, expected_action_strings));
+  EXPECT_CALL(*jni_mock, FlutterViewUpdateCustomAccessibilityActions(
+                             expected_actions_buffer, expected_action_strings));
   platformViewAndroidDelegate->UpdateSemantics(update, actions);
 }
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -137,6 +137,7 @@ def RunCCTests(build_dir, filter):
     # https://github.com/google/googletest/issues/2490
     RunEngineExecutable(build_dir, 'android_external_view_embedder_unittests', filter, shuffle_flags)
     RunEngineExecutable(build_dir, 'jni_unittests', filter, shuffle_flags)
+    RunEngineExecutable(build_dir, 'platform_view_android_delegate_unittests', filter, shuffle_flags)
 
   RunEngineExecutable(build_dir, 'ui_unittests', filter, shuffle_flags)
 


### PR DESCRIPTION
## Description

The android platform view sends the the wrong string list to the jni. This pr fixes it

## Related Issues

fixes https://github.com/flutter/flutter/issues/60926

## Tests

I added the following tests:

see files
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
