### PR TITLE
Fixing synthesizing keys for multiple keys pressed down on flutter web

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -91,9 +91,9 @@ class Keyboard {
 
     final String timerKey = keyboardEvent.code!;
 
-    // Don't synthesize a keyup event for modifier keys because the browser always
-    // sends a keyup event for those.
-    if (!_isModifierKey(event)) {
+    // Don't synthesize a keyup event for modifier keys, or keys not affected by modifiers,
+    // because the browser always sends a keyup event for those.
+    if (!_isModifierKey(event) && _isAffectedByModifiers(event)) {
       // When the user enters a browser/system shortcut (e.g. `cmd+alt+i`) the
       // browser doesn't send a keyup for it. This puts the framework in a
       // corrupt state because it thinks the key was never released.
@@ -183,6 +183,13 @@ int _getMetaState(html.KeyboardEvent event) {
 bool _isModifierKey(html.KeyboardEvent event) {
   final String key = event.key!;
   return key == 'Meta' || key == 'Shift' || key == 'Alt' || key == 'Control';
+}
+
+/// Returns true if the [event] is been affects by any of the modifiers key
+///
+/// This is a strong indication that this key is been used for a shortcut
+bool _isAffectedByModifiers(html.KeyboardEvent event) {
+  return event.ctrlKey || event.shiftKey || event.altKey || event.metaKey;
 }
 
 void _noopCallback(ByteData? data) {}

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -91,9 +91,8 @@ class Keyboard {
 
     final String timerKey = keyboardEvent.code!;
 
-    // Don't synthesize a keyup event for modifier keys, or keys not affected by modifiers,
-    // because the browser always sends a keyup event for those.
-    if (!_isModifierKey(event) && _isAffectedByModifiers(event)) {
+    // Don't handle synthesizing a keyup event for modifier keys
+    if (!_isModifierKey(event)) {
       // When the user enters a browser/system shortcut (e.g. `cmd+alt+i`) the
       // browser doesn't send a keyup for it. This puts the framework in a
       // corrupt state because it thinks the key was never released.
@@ -103,7 +102,10 @@ class Keyboard {
       // event within a specific duration ([_keydownCancelDuration]) we assume
       // the user has released the key and we synthesize a keyup event.
       _keydownTimers[timerKey]?.cancel();
-      if (event.type == 'keydown') {
+
+      // Only keys affected by modifiers, require synthesizing
+      // because the browser always sends a keyup event otherwise
+      if (event.type == 'keydown' && _isAffectedByModifiers(event)) {
         _keydownTimers[timerKey] = Timer(_keydownCancelDuration, () {
           _keydownTimers.remove(timerKey);
           _synthesizeKeyup(event);

--- a/lib/web_ui/test/keyboard_test.dart
+++ b/lib/web_ui/test/keyboard_test.dart
@@ -406,7 +406,7 @@ void testMain() {
     );
 
     testFakeAsync(
-      'do not synthesize keyup when we receive repeat events',
+      'do not synthesize keyup when we receive repeat events under meta affect',
       (FakeAsync async) {
         Keyboard.initialize();
 
@@ -457,6 +457,7 @@ void testMain() {
             key: 'i',
             code: 'KeyI',
             repeat: true,
+            isMetaPressed: true,
           );
         }
 
@@ -468,7 +469,7 @@ void testMain() {
             'keymap': 'web',
             'key': 'i',
             'code': 'KeyI',
-            'metaState': 0x0,
+            'metaState': 0x08,
           });
         }
         messages.clear();
@@ -482,9 +483,41 @@ void testMain() {
             'keymap': 'web',
             'key': 'i',
             'code': 'KeyI',
-            'metaState': 0x0,
+            'metaState': 0x08,
           }
         ]);
+
+        Keyboard.instance.dispose();
+      },
+    );
+
+    testFakeAsync(
+      'do not synthesize keyup when keys are not affected by meta modifiers',
+      (FakeAsync async) {
+        Keyboard.initialize();
+
+        List<Map<String, dynamic>> messages = <Map<String, dynamic>>[];
+        ui.window.onPlatformMessage = (String channel, ByteData data,
+            ui.PlatformMessageResponseCallback callback) {
+          messages.add(const JSONMessageCodec().decodeMessage(data));
+        };
+
+        dispatchKeyboardEvent(
+          'keydown',
+          key: 'i',
+          code: 'KeyI',
+        );
+        dispatchKeyboardEvent(
+          'keydown',
+          key: 'o',
+          code: 'KeyO',
+        );
+        messages.clear();
+
+        // Wait for a long-enough period of time and no events
+        // should be synthesized
+        async.elapse(Duration(seconds: 3));
+        expect(messages, hasLength(0));
 
         Keyboard.instance.dispose();
       },

--- a/lib/web_ui/test/keyboard_test.dart
+++ b/lib/web_ui/test/keyboard_test.dart
@@ -406,7 +406,7 @@ void testMain() {
     );
 
     testFakeAsync(
-      'do not synthesize keyup when we receive repeat events under meta affect',
+      'do not synthesize keyup when we receive repeat events',
       (FakeAsync async) {
         Keyboard.initialize();
 
@@ -457,7 +457,6 @@ void testMain() {
             key: 'i',
             code: 'KeyI',
             repeat: true,
-            isMetaPressed: true,
           );
         }
 
@@ -469,23 +468,10 @@ void testMain() {
             'keymap': 'web',
             'key': 'i',
             'code': 'KeyI',
-            'metaState': 0x08,
+            'metaState': 0x0,
           });
         }
         messages.clear();
-
-        // When repeat events stop for a long-enough period of time, a keyup
-        // should be synthesized.
-        async.elapse(Duration(seconds: 3));
-        expect(messages, <Map<String, dynamic>>[
-          <String, dynamic>{
-            'type': 'keyup',
-            'keymap': 'web',
-            'key': 'i',
-            'code': 'KeyI',
-            'metaState': 0x08,
-          }
-        ]);
 
         Keyboard.instance.dispose();
       },


### PR DESCRIPTION
## Description

The current implementation of the keyboard on the web engine had a logic to automatically trigger keyup events, when repeat events stoped occurring for a time.

That works great when only one key is pressed down, but when two keys are being pressed down together, the first key will stop to send repeat events and only the last key been pressed down will send repeat events.

That was causing a strange behaviour, as a keyup event would be triggered, even if the key was still pressed down.

I did some investigation, and due to some comments on the code, I discovered that this logic that auto triggers keyup when repeat event cease, was created to prevent the framework be on a invalid state due to a keyup event not happening because the browser don't trigger keyups when a key is used on a browser/system shortcut. So my solution was built to that same idea, and I add a small new logic, that only synthesise keyup events when a key can be used in a shortcut, which is when a modifier (control, alt, shift or meta) key is pressed together.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/58727

## Tests

- `test/keyboard_test.dart`

## Checklist

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
