### PR TITLE
don't throw error for the new autofill request

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1152,6 +1152,11 @@ class TextEditingChannel {
         // Since autofill UI is a part of the browser, web engine does not need to utilize this method.
         break;
 
+      case 'TextInput.finishAutofillContext':
+        // TODO: Handle saving autofill information on web.
+        // https://github.com/flutter/flutter/issues/59378
+        break;
+
       default:
         throw StateError(
             'Unsupported method call on the flutter/textinput channel: ${call.method}');

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1153,7 +1153,7 @@ class TextEditingChannel {
         break;
 
       case 'TextInput.finishAutofillContext':
-        // TODO: Handle saving autofill information on web.
+        // TODO(nurhan): Handle saving autofill information on web.
         // https://github.com/flutter/flutter/issues/59378
         break;
 


### PR DESCRIPTION
PR: https://github.com/flutter/flutter/pull/58731/files is adding a new TextInput platform message to Flutter framework.

Related to: https://github.com/flutter/flutter/issues/59378