### PR TITLE
Make `Shell::Create` not blocking platform thread by asynchronously setup shell subsystems

### DIFF
--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -391,6 +391,8 @@ class Shell final : public PlatformView::Delegate,
                      >
       service_protocol_handlers_;
   bool is_setup_ = false;
+  std::future<bool> async_waiting_subsystems_;
+  std::queue<std::future<void>> pending_tasks_before_setup_;
   uint64_t next_pointer_flow_id_ = 0;
 
   bool first_frame_rasterized_ = false;


### PR DESCRIPTION
## Description
As the related issue refer, the application may be doing too much work on its main thread even in a simple hello_world demo.
That is because the creation of engine on the UI thread takes a noticeable time, and it is blocking the main thread in order to run `Shell::Setup` synchronously.
This PR breaks the main thread blocking, by introducing `std::async` to wait for the shell subsystems creation in a background thread. `Shell::Setup` will be executed when the subsystems are ready. Before shell is setup, calls to shell subsystem will be pushed into a pending tasks queue which would be run in sequence once the setup is done.
Code changes are mainly inside `Shell::CreateShellOnPlatformThread` and `Shell::Setup`.

## Related Issues
https://github.com/flutter/flutter/issues/40563 could be resolved by this PR.

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
