### PR TITLE
Manual Skia roll to c91db040ad18b9cc3236e342e9acca020eaafd10

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -26,7 +26,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   # OCMock is for testing only so there is no google clone
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
-  'skia_revision': '5160e8caa226213c77b2a5f98908aa4eeee75ef5',
+  'skia_revision': 'c91db040ad18b9cc3236e342e9acca020eaafd10',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the
@@ -109,7 +109,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'a6103d43ed47c5cf91d47d614fe00a0665484fc5',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '6728d80355083a20ceecb6db1d73c16dee255a43',
 
    # Fuchsia compatibility
    #

--- a/ci/licenses_golden/licenses_skia
+++ b/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: e49c9c554a9e530ceeb05109f84c8c7b
+Signature: 964bda7fdf8851c2cd2d8d5274171bae
 
 UNUSED LICENSES:
 
@@ -5718,6 +5718,7 @@ ORIGIN: ../../../third_party/skia/fuzz/oss_fuzz/FuzzAPISVGCanvas.cpp + ../../../
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzAPISVGCanvas.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzSVG.cpp
+FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzSkRuntimeEffect.cpp
 ----------------------------------------------------------------------------------------------------
 Copyright 2020 Google, LLC
 

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 90e25fd2f6388bf92247eaf28caec993
+Signature: 592e745218e99a4be1e5207bf7ffe31f
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Requires rolling the buildroot to use Wuffs version 0.3