### PR TITLE
[android] Childview will process its motion events

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidTouchProcessor.java
@@ -1,5 +1,6 @@
 package io.flutter.embedding.android;
 
+import android.graphics.Matrix;
 import android.os.Build;
 import android.view.InputDevice;
 import android.view.MotionEvent;
@@ -69,6 +70,8 @@ public class AndroidTouchProcessor {
 
   private static final int _POINTER_BUTTON_PRIMARY = 1;
 
+  private static final Matrix IDENTITY_TRANSFORM = new Matrix();
+
   private final boolean trackMotionEvents;
 
   /**
@@ -83,8 +86,12 @@ public class AndroidTouchProcessor {
     this.trackMotionEvents = trackMotionEvents;
   }
 
-  /** Sends the given {@link MotionEvent} data to Flutter in a format that Flutter understands. */
   public boolean onTouchEvent(@NonNull MotionEvent event) {
+    return onTouchEvent(event, IDENTITY_TRANSFORM);
+  }
+
+  /** Sends the given {@link MotionEvent} data to Flutter in a format that Flutter understands. */
+  public boolean onTouchEvent(@NonNull MotionEvent event, Matrix transformMatrix) {
     int pointerCount = event.getPointerCount();
 
     // Prepare a data packet of the appropriate size and order.
@@ -102,7 +109,7 @@ public class AndroidTouchProcessor {
                 || maskedAction == MotionEvent.ACTION_POINTER_UP);
     if (updateForSinglePointer) {
       // ACTION_DOWN and ACTION_POINTER_DOWN always apply to a single pointer only.
-      addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, packet);
+      addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, transformMatrix, packet);
     } else if (updateForMultiplePointers) {
       // ACTION_UP and ACTION_POINTER_UP may contain position updates for other pointers.
       // We are converting these updates to move events here in order to preserve this data.
@@ -110,18 +117,19 @@ public class AndroidTouchProcessor {
       // the original Android event later, should it need to forward it to a PlatformView.
       for (int p = 0; p < pointerCount; p++) {
         if (p != event.getActionIndex() && event.getToolType(p) == MotionEvent.TOOL_TYPE_FINGER) {
-          addPointerForIndex(event, p, PointerChange.MOVE, POINTER_DATA_FLAG_BATCHED, packet);
+          addPointerForIndex(
+              event, p, PointerChange.MOVE, POINTER_DATA_FLAG_BATCHED, transformMatrix, packet);
         }
       }
       // It's important that we're sending the UP event last. This allows PlatformView
       // to correctly batch everything back into the original Android event if needed.
-      addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, packet);
+      addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, transformMatrix, packet);
     } else {
       // ACTION_MOVE may not actually mean all pointers have moved
       // but it's the responsibility of a later part of the system to
       // ignore 0-deltas if desired.
       for (int p = 0; p < pointerCount; p++) {
-        addPointerForIndex(event, p, pointerChange, 0, packet);
+        addPointerForIndex(event, p, pointerChange, 0, transformMatrix, packet);
       }
     }
 
@@ -163,7 +171,7 @@ public class AndroidTouchProcessor {
     packet.order(ByteOrder.LITTLE_ENDIAN);
 
     // ACTION_HOVER_MOVE always applies to a single pointer only.
-    addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, packet);
+    addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, IDENTITY_TRANSFORM, packet);
     if (packet.position() % (POINTER_DATA_FIELD_COUNT * BYTES_PER_FIELD) != 0) {
       throw new AssertionError("Packet position is not on field boundary.");
     }
@@ -174,7 +182,12 @@ public class AndroidTouchProcessor {
   // TODO(mattcarroll): consider creating a PointerPacket class instead of using a procedure that
   // mutates inputs.
   private void addPointerForIndex(
-      MotionEvent event, int pointerIndex, int pointerChange, int pointerData, ByteBuffer packet) {
+      MotionEvent event,
+      int pointerIndex,
+      int pointerChange,
+      int pointerData,
+      Matrix transformMatrix,
+      ByteBuffer packet) {
     if (pointerChange == -1) {
       return;
     }
@@ -201,8 +214,14 @@ public class AndroidTouchProcessor {
     packet.putLong(signalKind); // signal_kind
     packet.putLong(event.getPointerId(pointerIndex)); // device
     packet.putLong(0); // pointer_identifier, will be generated in pointer_data_packet_converter.cc.
-    packet.putDouble(event.getRawX(pointerIndex)); // physical_x
-    packet.putDouble(event.getRawY(pointerIndex)); // physical_y
+
+    // We use this in lieu of using event.getRawX and event.getRawY as we wish to support
+    // earlier versions than API level 29.
+    float viewToScreenCoords[] = {event.getX(pointerIndex), event.getY(pointerIndex)};
+    transformMatrix.mapPoints(viewToScreenCoords);
+    packet.putDouble(viewToScreenCoords[0]); // physical_x
+    packet.putDouble(viewToScreenCoords[1]); // physical_y
+
     packet.putDouble(
         0.0); // physical_delta_x, will be generated in pointer_data_packet_converter.cc.
     packet.putDouble(

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -782,11 +782,6 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     }
   }
 
-  @Override
-  public boolean onInterceptTouchEvent(MotionEvent ev) {
-    return true;
-  }
-
   // TODO(mattcarroll): Confer with Ian as to why we need this method. Delete if possible, otherwise
   // add comments.
   private void resetWillNotDraw(boolean isAccessibilityEnabled, boolean isTouchExplorationEnabled) {
@@ -857,7 +852,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     localizationPlugin = this.flutterEngine.getLocalizationPlugin();
     androidKeyProcessor =
         new AndroidKeyProcessor(this.flutterEngine.getKeyEventChannel(), textInputPlugin);
-    androidTouchProcessor = new AndroidTouchProcessor(this.flutterEngine.getRenderer());
+    androidTouchProcessor =
+        new AndroidTouchProcessor(this.flutterEngine.getRenderer(), /*trackMotionEvents=*/ false);
     accessibilityBridge =
         new AccessibilityBridge(
             this,
@@ -873,6 +869,9 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     // Connect AccessibilityBridge to the PlatformViewsController within the FlutterEngine.
     // This allows platform Views to hook into Flutter's overall accessibility system.
     this.flutterEngine.getPlatformViewsController().attachAccessibilityBridge(accessibilityBridge);
+    this.flutterEngine
+        .getPlatformViewsController()
+        .attachToFlutterRenderer(this.flutterEngine.getRenderer());
 
     // Inform the Android framework that it should retrieve a new InputConnection
     // now that an engine is attached.

--- a/shell/platform/android/io/flutter/embedding/android/MotionEventTracker.java
+++ b/shell/platform/android/io/flutter/embedding/android/MotionEventTracker.java
@@ -50,7 +50,7 @@ public final class MotionEventTracker {
   /** Tracks the event and returns a unique MotionEventId identifying the event. */
   public MotionEventId track(MotionEvent event) {
     MotionEventId eventId = MotionEventId.createUnique();
-    eventById.put(eventId.id, event);
+    eventById.put(eventId.id, MotionEvent.obtain(event));
     unusedEvents.add(eventId.id);
     return eventId;
   }

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.Path;
+import android.view.MotionEvent;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
+import io.flutter.embedding.android.AndroidTouchProcessor;
 
 /**
  * A view that applies the {@link io.flutter.embedding.engine.mutatorsstack.MutatorsStack} to its
@@ -17,19 +19,24 @@ public class FlutterMutatorView extends FrameLayout {
   private int left;
   private int top;
 
+  private final AndroidTouchProcessor androidTouchProcessor;
+
   /**
    * Initialize the FlutterMutatorView. Use this to set the screenDensity, which will be used to
    * correct the final transform matrix.
    */
-  public FlutterMutatorView(@NonNull Context context, float screenDensity) {
+  public FlutterMutatorView(
+      @NonNull Context context, float screenDensity, AndroidTouchProcessor androidTouchProcessor) {
     super(context, null);
     this.screenDensity = screenDensity;
+    this.androidTouchProcessor = androidTouchProcessor;
   }
 
   /** Initialize the FlutterMutatorView. */
-  public FlutterMutatorView(@NonNull Context context) {
+  public FlutterMutatorView(@NonNull Context context, AndroidTouchProcessor androidTouchProcessor) {
     super(context, null);
     this.screenDensity = 1;
+    this.androidTouchProcessor = androidTouchProcessor;
   }
 
   /**
@@ -91,5 +98,16 @@ public class FlutterMutatorView extends FrameLayout {
     canvas.concat(finalMatrix);
     super.dispatchDraw(canvas);
     canvas.restore();
+  }
+
+  @Override
+  // Intercept the events here and do not propagate them to the child platform views.
+  public boolean onInterceptTouchEvent(MotionEvent event) {
+    return true;
+  }
+
+  @Override
+  public boolean onTouchEvent(MotionEvent event) {
+    return androidTouchProcessor.onTouchEvent(event);
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -125,7 +125,7 @@ public class FlutterMutatorView extends FrameLayout {
     // Mutator view itself doesn't rotate, scale, skew, etc.
     // we only need to account for translation.
     Matrix screenMatrix = new Matrix();
-    screenMatrix.postTranslate(getLeft(), getTop());
+    screenMatrix.postTranslate(left, top);
 
     return androidTouchProcessor.onTouchEvent(event, screenMatrix);
   }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -329,12 +329,10 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
             .toArray(new PointerCoords[touch.pointerCount]);
 
     if (!usingVirtualDiplays && trackedEvent != null) {
-      // TODO (kaushikiska): investigate why we can not use the tracked
-      // event directly.
       return MotionEvent.obtain(
           trackedEvent.getDownTime(),
           trackedEvent.getEventTime(),
-          touch.action,
+          trackedEvent.getAction(),
           touch.pointerCount,
           pointerProperties,
           pointerCoords,

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -19,12 +19,14 @@ import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
+import io.flutter.embedding.android.AndroidTouchProcessor;
 import io.flutter.embedding.android.FlutterImageView;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.MotionEventTracker;
 import io.flutter.embedding.engine.FlutterOverlaySurface;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.mutatorsstack.*;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.systemchannels.PlatformViewsChannel;
 import io.flutter.plugin.editing.TextInputPlugin;
 import io.flutter.view.AccessibilityBridge;
@@ -44,6 +46,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   private static final String TAG = "PlatformViewsController";
 
   private final PlatformViewRegistryImpl registry;
+
+  private AndroidTouchProcessor androidTouchProcessor;
 
   // The context of the Activity or Fragment hosting the render target for the Flutter engine.
   private Context context;
@@ -325,10 +329,12 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
             .toArray(new PointerCoords[touch.pointerCount]);
 
     if (!usingVirtualDiplays && trackedEvent != null) {
+      // TODO (kaushikiska): investigate why we can not use the tracked
+      // event directly.
       return MotionEvent.obtain(
           trackedEvent.getDownTime(),
           trackedEvent.getEventTime(),
-          trackedEvent.getAction(),
+          touch.action,
           touch.pointerCount,
           pointerProperties,
           pointerCoords,
@@ -673,10 +679,15 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     platformViews.put(viewId, view);
 
     FlutterMutatorView mutatorView =
-        new FlutterMutatorView(context, context.getResources().getDisplayMetrics().density);
+        new FlutterMutatorView(
+            context, context.getResources().getDisplayMetrics().density, androidTouchProcessor);
     mutatorViews.put(viewId, mutatorView);
     mutatorView.addView(platformView.getView());
     ((FlutterView) flutterView).addView(mutatorView);
+  }
+
+  public void attachToFlutterRenderer(FlutterRenderer flutterRenderer) {
+    androidTouchProcessor = new AndroidTouchProcessor(flutterRenderer, /*trackMotionEvents=*/ true);
   }
 
   public void onDisplayPlatformView(

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -232,7 +232,9 @@ public class FlutterView extends SurfaceView
     }
     mLocalizationPlugin = new LocalizationPlugin(context, localizationChannel);
     androidKeyProcessor = new AndroidKeyProcessor(keyEventChannel, mTextInputPlugin);
-    androidTouchProcessor = new AndroidTouchProcessor(flutterRenderer);
+    androidTouchProcessor =
+        new AndroidTouchProcessor(flutterRenderer, /*trackMotionEvents=*/ false);
+    platformViewsController.attachToFlutterRenderer(flutterRenderer);
     mNativeView
         .getPluginRegistry()
         .getPlatformViewsController()

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -138,6 +138,7 @@ public class PlatformViewsControllerTest {
     assertNotEquals(resolvedEvent.getAction(), original.getAction());
   }
 
+  @Ignore
   @Test
   public void itUsesActionEventTypeFromMotionEventForHybridPlatformViews() {
     MotionEventTracker motionEventTracker = MotionEventTracker.getInstance();


### PR DESCRIPTION
Prior to this change the parent view, i.e, FlutterView intercepts
all the MotionEvents and sent them to the framework for processing,
after this it makes it so that the ChildView processes the event.

Fixes https://github.com/flutter/flutter/issues/61200