### PR TITLE
Support decimal information on the TextInputType

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -16,7 +16,7 @@ abstract class EngineInputType {
   static EngineInputType fromName(String name, {bool isDecimal = false}) {
     switch (name) {
       case 'TextInputType.number':
-      return isDecimal ? decimal : number;
+        return isDecimal ? decimal : number;
       case 'TextInputType.phone':
         return phone;
       case 'TextInputType.emailAddress':

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 part of engine;
 
 /// Various types of inputs used in text fields.
@@ -14,10 +13,10 @@ part of engine;
 abstract class EngineInputType {
   const EngineInputType();
 
-  static EngineInputType fromName(String name) {
+  static EngineInputType fromName(String name, {bool isDecimal = false}) {
     switch (name) {
       case 'TextInputType.number':
-        return number;
+      return isDecimal ? decimal : number;
       case 'TextInputType.phone':
         return phone;
       case 'TextInputType.emailAddress':
@@ -37,6 +36,9 @@ abstract class EngineInputType {
 
   /// Numeric input type.
   static const NumberInputType number = NumberInputType();
+
+  /// Decimal input type.
+  static const DecimalInputType decimal = DecimalInputType();
 
   /// Phone number input type.
   static const PhoneInputType phone = PhoneInputType();
@@ -89,11 +91,24 @@ class TextInputType extends EngineInputType {
 }
 
 /// Numeric input type.
+///
+/// Input keyboard with only the digits 0–9.
 class NumberInputType extends EngineInputType {
   const NumberInputType();
 
   @override
   final String inputmodeAttribute = 'numeric';
+}
+
+/// Decimal input type.
+///
+/// Input keyboard with containing the digits 0–9 and a decimal separator.
+/// Seperator can be `.`, `,` depending on the locale.
+class DecimalInputType extends EngineInputType {
+  const DecimalInputType();
+
+  @override
+  final String inputmodeAttribute = 'decimal';
 }
 
 /// Phone number input type.

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -435,7 +435,9 @@ class InputConfiguration {
   InputConfiguration.fromFrameworkMessage(
       Map<String, dynamic> flutterInputConfiguration)
       : inputType = EngineInputType.fromName(
-            flutterInputConfiguration['inputType']['name']),
+            flutterInputConfiguration['inputType']['name'],
+            isDecimal:
+                flutterInputConfiguration['inputType']['decimal'] ?? false),
         inputAction = flutterInputConfiguration['inputAction'],
         obscureText = flutterInputConfiguration['obscureText'],
         autocorrect = flutterInputConfiguration['autocorrect'],


### PR DESCRIPTION
InputConfiguration contains information on TextInputType. For numeric types the keyboard can only be set to show decimal keyboard using `TextInputType.numberWithOptions(decimal: true)` 

This PR adds support for using decimal information sent with the InputConfiguration.

Screenshots for numeric and decimal keyboards:
<img width="415" alt="Screen Shot 2020-07-10 at 4 26 36 PM" src="https://user-images.githubusercontent.com/50856934/87211813-251f0f00-c2d0-11ea-96e6-c7a2d92e46c7.png">
<img width="425" alt="Screen Shot 2020-07-10 at 4 26 45 PM" src="https://user-images.githubusercontent.com/50856934/87211816-294b2c80-c2d0-11ea-85cc-2166d65fd3c3.png">


fixes: https://github.com/flutter/flutter/issues/60426