### PR TITLE
Remove xcpretty from unit tests to see full output on test failures

### DIFF
--- a/testing/ios/IosUnitTests/run_tests.sh
+++ b/testing/ios/IosUnitTests/run_tests.sh
@@ -8,15 +8,9 @@ if [ $# -eq 1 ]; then
   FLUTTER_ENGINE=$1
 fi
 
-PRETTY="cat"
-if which xcpretty; then
-  PRETTY="xcpretty"
-fi
-
 set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme IosUnitTests \
   -destination 'platform=iOS Simulator,name=iPhone 8' \
   test \
-  FLUTTER_ENGINE=$FLUTTER_ENGINE | $PRETTY
-
+  FLUTTER_ENGINE=$FLUTTER_ENGINE
 popd

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -8,11 +8,6 @@ if [ $# -eq 1 ]; then
   FLUTTER_ENGINE=$1
 fi
 
-PRETTY="cat"
-if which xcpretty; then
-  PRETTY="xcpretty"
-fi
-
 cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd
 
 # Delete after LUCI push.
@@ -24,6 +19,5 @@ set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme Scenarios \
   -destination 'platform=iOS Simulator,name=iPhone 8' \
   test \
-  FLUTTER_ENGINE=$FLUTTER_ENGINE | $PRETTY
-
+  FLUTTER_ENGINE=$FLUTTER_ENGINE
 popd


### PR DESCRIPTION
## Description

Remove `xcpretty` from iOS unit tests so all the too-verbose Xcode output can be examined on test failure.

## Related Issues

May help track down https://github.com/flutter/flutter/issues/61267.

## Testing
https://ci.chromium.org/swarming/task/4d54338aef495110?server=chromium-swarm.appspot.com