### PR TITLE
Turn off failing XCTest attachment collection

### DIFF
--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      systemAttachmentLifetime = "keepNever">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/xcshareddata/xcschemes/Scenarios.xcscheme
+++ b/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/xcshareddata/xcschemes/Scenarios.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      systemAttachmentLifetime = "keepNever">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
@@ -66,7 +66,8 @@ static const NSInteger kSecondsToWaitForPlatformView = 30;
     [self addAttachment:goldenAttachment];
 
     XCTFail(@"Goldens to not match. Follow the steps in the "
-            @"README update golden named %@ if needed.", golden.goldenName);
+            @"README to update golden named %@ if needed.",
+            golden.goldenName);
   }
 }
 @end

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
@@ -48,22 +48,25 @@ static const NSInteger kSecondsToWaitForPlatformView = 30;
   GoldenImage* golden = self.manager.goldenImage;
 
   XCUIScreenshot* screenshot = [[XCUIScreen mainScreen] screenshot];
-  XCTAttachment* attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
-  attachment.name = @"new_golden";
-  attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
-  [self addAttachment:attachment];
-
-  if (golden.image) {
-    XCTAttachment* goldenAttachment = [XCTAttachment attachmentWithImage:golden.image];
-    attachment.name = @"current_golden";
-    goldenAttachment.lifetime = XCTAttachmentLifetimeKeepAlways;
-    [self addAttachment:goldenAttachment];
-  } else {
+  if (!golden.image) {
+    XCTAttachment* attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
+    attachment.name = @"new_golden";
+    attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+    [self addAttachment:attachment];
     XCTFail(@"This test will fail - no golden named %@ found. Follow the steps in the "
             @"README to add a new golden.",
             golden.goldenName);
   }
 
-  XCTAssertTrue([golden compareGoldenToImage:screenshot.image]);
+  if (![golden compareGoldenToImage:screenshot.image]) {
+    XCTAttachment* goldenAttachment;
+    goldenAttachment = [XCTAttachment attachmentWithImage:golden.image];
+    goldenAttachment.name = @"current_golden";
+    goldenAttachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+    [self addAttachment:goldenAttachment];
+
+    XCTFail(@"Goldens to not match. Follow the steps in the "
+            @"README update golden named %@ if needed.", golden.goldenName);
+  }
 }
 @end


### PR DESCRIPTION
## Description

Turn off XCUITest attachment collection in iOS tests, which by default get saved for failing tests.  This is failing in Xcode 11.x on the command line, and the logs are mostly spew from that, which hides other failures:
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8875129688297197088/+/steps/Scenario_App_Integration_Tests/0/stdout
```
Details:  Error writing attachment data to file /Users/swarming/Library/Developer/Xcode/DerivedData/Scenarios-efgskbqbyxwwrrfdsxqpswpwbbkb/Logs/Test/Test-Scenarios-2020.07.10_14-50-15--0700.xcresult/Staging/1_Test/Attachments/new_golden_1_EC3183D7-0D02-4773-9B7C-D3A58744B8ED.png: Error Domain=NSCocoaErrorDomain Code=4 "The folder “new_golden_1_EC3183D7-0D02-4773-9B7C-D3A58744B8ED.png” doesn’t exist." UserInfo={NSFilePath=/Users/swarming/Library/Developer/Xcode/DerivedData/Scenarios-efgskbqbyxwwrrfdsxqpswpwbbkb/Logs/Test/Test-Scenarios-2020.07.10_14-50-15--0700.xcresult/Staging/1_Test/Attachments/new_golden_1_EC3183D7-0D02-4773-9B7C-D3A58744B8ED.png, NSUserStringVariant=Folder, NSUnderlyingError=0x7f838c7b0d90 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
Object:   <IDESchemeActionTestAttachment: 0x7f838c7b0180>
Method:   -_savePayload:
Thread:   <NSThread: 0x7f838c4153b0>{number = 1, name = main}
Please file a bug at https://feedbackassistant.apple.com with this warning message and any useful information you can provide.
2020-07-10 14:51:55.769 xcodebuild[39107:576449] [MT] DVTAssertions: Warning in /Library/Caches/com.apple.xbs/Sources/IDEFrameworks/IDEFrameworks-14936/IDEFoundation/ProjectModel/ActionRecords/IDESchemeActionTestAttachment.m:218
Details:  Error writing attachment data to file /Users/swarming/Library/Developer/Xcode/DerivedData/Scenarios-efgskbqbyxwwrrfdsxqpswpwbbkb/Logs/Test/Test-Scenarios-2020.07.10_14-50-15--0700.xcresult/Staging/1_Test/Attachments/public.png_1_C171348C-EE13-4736-B74E-74772B51A566.png: Error Domain=NSCocoaErrorDomain Code=4 "The folder “public.png_1_C171348C-EE13-4736-B74E-74772B51A566.png” doesn’t exist." UserInfo={NSFilePath=/Users/swarming/Library/Developer/Xcode/DerivedData/Scenarios-efgskbqbyxwwrrfdsxqpswpwbbkb/Logs/Test/Test-Scenarios-2020.07.10_14-50-15--0700.xcresult/Staging/1_Test/Attachments/public.png_1_C171348C-EE13-4736-B74E-74772B51A566.png, NSUserStringVariant=Folder, NSUnderlyingError=0x7f834c613480 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
Object:   <IDESchemeActionTestAttachment: 0x7f836c4e8c00>
Method:   -_savePayload:
Thread:   <NSThread: 0x7f838c4153b0>{number = 1, name = main}
Please file a bug at https://feedbackassistant.apple.com with this warning message and any useful information you can provide.
    . testPlatformView (4.035 seconds)
```

<img width="894" alt="Screen Shot 2020-07-10 at 4 54 40 PM" src="https://user-images.githubusercontent.com/682784/87213657-57823980-c2db-11ea-8c70-f4f7f4a01d1d.png">

Additionally, only save goldens attachments when either the comparison golden isn't found, or the screenshot doesn't match the golden.  Do not save attachments when the test passes.

## Related Issues

Found as part of flutter/flutter#61267 investigation.

## Tests

https://ci.chromium.org/swarming/task/4d638c548f418810?server=chromium-swarm.appspot.com