### PR TITLE
Prevent that removeActivityResultListener() is causing an ConcurrentModificationException

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
@@ -686,7 +686,7 @@ class FlutterEnginePluginRegistry
     boolean onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
       boolean didConsumeResult = false;
       for (io.flutter.plugin.common.PluginRegistry.ActivityResultListener listener :
-          onActivityResultListeners) {
+          new HashSet<>(onActivityResultListeners)) {
         didConsumeResult =
             listener.onActivityResult(requestCode, resultCode, data) || didConsumeResult;
       }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
@@ -86,7 +86,7 @@ public class FlutterEnginePluginRegistryTest {
     registry.add(fakePlugin);
     registry.attachToActivity(activity, lifecycle);
 
-    // The binding is now available via `fakePlugin.binding`: Creat and add the listeners
+    // The binding is now available via `fakePlugin.binding`: Create and add the listeners
     FakeActivityResultListener listener1 =
         new FakeActivityResultListener(isFirstCall, fakePlugin.binding);
     FakeActivityResultListener listener2 =
@@ -100,6 +100,12 @@ public class FlutterEnginePluginRegistryTest {
 
     assertEquals(1, listener1.callCount);
     assertEquals(1, listener2.callCount);
+
+    // fire it again to check if the first called listener was removed
+    registry.onActivityResult(0, 0, intent);
+
+    // The order of the listeners in the HashSet is random: So just check the sum of calls
+    assertEquals(3, listener1.callCount + listener2.callCount);
   }
 
   private static class FakeFlutterPlugin implements FlutterPlugin {

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
@@ -121,12 +121,10 @@ public class FlutterEnginePluginRegistryTest {
     public ActivityPluginBinding binding;
 
     @Override
-    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-    }
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {}
 
     @Override
-    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    }
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
 
     @Override
     public void onAttachedToActivity(final ActivityPluginBinding binding) {
@@ -134,18 +132,13 @@ public class FlutterEnginePluginRegistryTest {
     }
 
     @Override
-    public void onDetachedFromActivityForConfigChanges() {
-
-    }
+    public void onDetachedFromActivityForConfigChanges() {}
 
     @Override
-    public void onReattachedToActivityForConfigChanges(final ActivityPluginBinding binding) {
-    }
+    public void onReattachedToActivityForConfigChanges(final ActivityPluginBinding binding) {}
 
     @Override
-    public void onDetachedFromActivity() {
-
-    }
+    public void onDetachedFromActivity() {}
   }
 
   private static class FakeActivityResultListener implements PluginRegistry.ActivityResultListener {
@@ -159,9 +152,10 @@ public class FlutterEnginePluginRegistryTest {
     }
 
     @Override
-    public boolean onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+    public boolean onActivityResult(
+        final int requestCode, final int resultCode, final Intent data) {
       callCount++;
-      if(isFirstCall.get()) {
+      if (isFirstCall.get()) {
         isFirstCall.set(false);
         binding.removeActivityResultListener(this);
       }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
@@ -130,7 +130,7 @@ public class FlutterEnginePluginRegistryTest {
 
     @Override
     public void onAttachedToActivity(final ActivityPluginBinding binding) {
-
+      this.binding = binding;
     }
 
     @Override
@@ -140,7 +140,6 @@ public class FlutterEnginePluginRegistryTest {
 
     @Override
     public void onReattachedToActivityForConfigChanges(final ActivityPluginBinding binding) {
-      this.binding = binding;
     }
 
     @Override

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
@@ -6,15 +6,24 @@ import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
+
 import androidx.annotation.NonNull;
+import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.embedding.engine.plugins.activity.ActivityAware;
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
+import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.platform.PlatformViewsController;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 // Run with Robolectric so that Log calls don't crash.
 @Config(manifest = Config.NONE)
@@ -58,6 +67,41 @@ public class FlutterEnginePluginRegistryTest {
     assertEquals(0, fakePlugin2.detachmentCallCount);
   }
 
+  @Test
+  public void activityResultListenerCanBeRemovedFromListener() {
+    Context context = mock(Context.class);
+
+    FlutterEngine flutterEngine = mock(FlutterEngine.class);
+    PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
+    when(flutterEngine.getPlatformViewsController()).thenReturn(platformViewsController);
+
+    FlutterLoader flutterLoader = mock(FlutterLoader.class);
+    Activity activity = mock(Activity.class);
+    Lifecycle lifecycle = mock(Lifecycle.class);
+    Intent intent = mock(Intent.class);
+    AtomicBoolean isFirstCall = new AtomicBoolean(true);
+
+    // setup the environment to get the required internal data
+    FlutterEnginePluginRegistry registry =
+            new FlutterEnginePluginRegistry(context, flutterEngine, flutterLoader);
+    FakeActivityAwareFlutterPlugin fakePlugin = new FakeActivityAwareFlutterPlugin();
+    registry.add(fakePlugin);
+    registry.attachToActivity(activity, lifecycle);
+
+    // The binding is now available via `fakePlugin.binding`: Creating now the listeners and add them
+    FakeActivityResultListener listener1 = new FakeActivityResultListener(isFirstCall, fakePlugin.binding);
+    FakeActivityResultListener listener2 = new FakeActivityResultListener(isFirstCall, fakePlugin.binding);
+
+    fakePlugin.binding.addActivityResultListener(listener1);
+    fakePlugin.binding.addActivityResultListener(listener2);
+
+    // fire the onActivityResult which should invoke both listeners
+    registry.onActivityResult(0, 0, intent);
+
+    assertEquals(1, listener1.callCount);
+    assertEquals(1, listener2.callCount);
+  }
+
   private static class FakeFlutterPlugin implements FlutterPlugin {
     public int attachmentCallCount = 0;
     public int detachmentCallCount = 0;
@@ -70,6 +114,59 @@ public class FlutterEnginePluginRegistryTest {
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
       detachmentCallCount += 1;
+    }
+  }
+
+  private static class FakeActivityAwareFlutterPlugin implements FlutterPlugin, ActivityAware {
+    public ActivityPluginBinding binding;
+
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+    }
+
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    }
+
+    @Override
+    public void onAttachedToActivity(final ActivityPluginBinding binding) {
+
+    }
+
+    @Override
+    public void onDetachedFromActivityForConfigChanges() {
+
+    }
+
+    @Override
+    public void onReattachedToActivityForConfigChanges(final ActivityPluginBinding binding) {
+      this.binding = binding;
+    }
+
+    @Override
+    public void onDetachedFromActivity() {
+
+    }
+  }
+
+  private static class FakeActivityResultListener implements PluginRegistry.ActivityResultListener {
+    public int callCount = 0;
+    private final AtomicBoolean isFirstCall;
+    private final ActivityPluginBinding binding;
+
+    public FakeActivityResultListener(AtomicBoolean isFirstCall, ActivityPluginBinding binding) {
+      this.isFirstCall = isFirstCall;
+      this.binding = binding;
+    }
+
+    @Override
+    public boolean onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+      callCount++;
+      if(isFirstCall.get()) {
+        isFirstCall.set(false);
+        binding.removeActivityResultListener(this);
+      }
+      return false;
     }
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEnginePluginRegistryTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-
 import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.engine.loader.FlutterLoader;
@@ -18,12 +17,11 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.platform.PlatformViewsController;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 // Run with Robolectric so that Log calls don't crash.
 @Config(manifest = Config.NONE)
@@ -83,14 +81,16 @@ public class FlutterEnginePluginRegistryTest {
 
     // setup the environment to get the required internal data
     FlutterEnginePluginRegistry registry =
-            new FlutterEnginePluginRegistry(context, flutterEngine, flutterLoader);
+        new FlutterEnginePluginRegistry(context, flutterEngine, flutterLoader);
     FakeActivityAwareFlutterPlugin fakePlugin = new FakeActivityAwareFlutterPlugin();
     registry.add(fakePlugin);
     registry.attachToActivity(activity, lifecycle);
 
-    // The binding is now available via `fakePlugin.binding`: Creating now the listeners and add them
-    FakeActivityResultListener listener1 = new FakeActivityResultListener(isFirstCall, fakePlugin.binding);
-    FakeActivityResultListener listener2 = new FakeActivityResultListener(isFirstCall, fakePlugin.binding);
+    // The binding is now available via `fakePlugin.binding`: Creat and add the listeners
+    FakeActivityResultListener listener1 =
+        new FakeActivityResultListener(isFirstCall, fakePlugin.binding);
+    FakeActivityResultListener listener2 =
+        new FakeActivityResultListener(isFirstCall, fakePlugin.binding);
 
     fakePlugin.binding.addActivityResultListener(listener1);
     fakePlugin.binding.addActivityResultListener(listener2);


### PR DESCRIPTION
## Description

This pull request will clone the list of `onActivityResultListeners` before iterating above the listeners, since the listener could call `removeActivityResultListener()` which will cause a `ConcurrentModificationException`.

## Hint

This is my first pull request on a Google repo, I read the docs, but likely that I missed some details so please be kind with me :-)

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from our [issue
database]. Indicate, which of these issues are resolved or fixed by this PR.
There should be at least one issue listed here. -->
This will fix the issues https://github.com/flutter/flutter/issues/61293 and https://github.com/rekire/autologin_plugin/issues/3

## Tests

I added the following tests:

<!--Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.-->

I added the test `FlutterEnginePluginRegistryTest.activityResultListenerCanBeRemovedFromListener`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
<!-- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes* -->

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
