### PR TITLE
Add flag to indicate whether the platform supports state restoration

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
@@ -89,7 +89,7 @@ public class RestorationChannelTest {
         ArgumentCaptor.forClass(MethodChannel.Result.class);
     Map<String, Object> expected2 = new HashMap<>();
     expected2.put("enabled", true);
-    expected2.put("data", null);
+    expected2.put("data", data);
     verify(rawChannel).invokeMethod(eq("push"), eq(expected2), resultCapture.capture());
     resultCapture.getValue().success(null);
     assertEquals(restorationChannel.getRestorationData(), data);

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import android.annotation.TargetApi;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import java.util.HashMap;
+import java.util.Map;
 import org.json.JSONException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,12 +53,15 @@ public class RestorationChannelTest {
 
     restorationChannel.setRestorationData(data);
     verify(rawChannel, times(0)).invokeMethod(any(), any());
-    verify(result).success(data);
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("enabled", true);
+    expected.put("data", data);
+    verify(result).success(expected);
 
     // Next get request is answered right away.
     MethodChannel.Result result2 = mock(MethodChannel.Result.class);
     argumentCaptor.getValue().onMethodCall(new MethodCall("get", null), result2);
-    verify(result2).success(data);
+    verify(result2).success(expected);
   }
 
   @Test
@@ -72,14 +77,20 @@ public class RestorationChannelTest {
 
     MethodChannel.Result result = mock(MethodChannel.Result.class);
     argumentCaptor.getValue().onMethodCall(new MethodCall("get", null), result);
-    verify(result).success(null);
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("enabled", true);
+    expected.put("data", null);
+    verify(result).success(expected);
 
     restorationChannel.setRestorationData(data);
     assertEquals(restorationChannel.getRestorationData(), null);
 
     ArgumentCaptor<MethodChannel.Result> resultCapture =
         ArgumentCaptor.forClass(MethodChannel.Result.class);
-    verify(rawChannel).invokeMethod(eq("push"), eq(data), resultCapture.capture());
+    Map<String, Object> expected2 = new HashMap<>();
+    expected2.put("enabled", true);
+    expected2.put("data", null);
+    verify(rawChannel).invokeMethod(eq("push"), eq(expected2), resultCapture.capture());
     resultCapture.getValue().success(null);
     assertEquals(restorationChannel.getRestorationData(), data);
   }

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -321,7 +321,7 @@ def EnsureIosTestsAreBuilt(ios_out_dir):
 
 def AssertExpectedJavaVersion():
   """Checks that the user has Java 8 which is the supported Java version for Android"""
-  EXPECTED_VERSION = '1.8'
+  EXPECTED_VERSION = '11.0.4'
   # `java -version` is output to stderr. https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4380614
   version_output = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
   match = bool(re.compile('version "%s' % EXPECTED_VERSION).search(version_output))

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -321,7 +321,7 @@ def EnsureIosTestsAreBuilt(ios_out_dir):
 
 def AssertExpectedJavaVersion():
   """Checks that the user has Java 8 which is the supported Java version for Android"""
-  EXPECTED_VERSION = '11.0.4'
+  EXPECTED_VERSION = '1.8'
   # `java -version` is output to stderr. https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4380614
   version_output = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
   match = bool(re.compile('version "%s' % EXPECTED_VERSION).search(version_output))


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/60375 gives platforms that don't support state restoration the chance to turn it off. This PR sets that flag to true on Android.

## Related Issues

#6827

## Tests

I added the following tests:

* Existing tests updated.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
