### PR TITLE
ensure we do not double publish to CIPD

### DIFF
--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -10,6 +10,7 @@ import argparse
 import errno
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -174,6 +175,22 @@ def BuildBucket(runtime_mode, arch, product):
   CopyVulkanDepsToBucket(out_dir, deps_dir, arch)
   CopyIcuDepsToBucket(out_dir, deps_dir)
 
+def CheckCIPDPackageExists(package_name, tag):
+  '''Check to see if the current package/tag combo has been published'''
+  command = [
+    'cipd',
+    'search',
+    package_name,
+    '-tag',
+    tag,
+  ]
+  stdout = subprocess.check_output()
+  match = re.search(r'No matching instances\.', stdout)
+  if match:
+    return False
+  else:
+    return True
+
 
 def ProcessCIPDPackage(upload, engine_version):
   # Copy the CIPD YAML template from the source directory to be next to the bucket
@@ -181,7 +198,11 @@ def ProcessCIPDPackage(upload, engine_version):
   cipd_yaml = os.path.join(_script_dir, 'fuchsia.cipd.yaml')
   CopyFiles(cipd_yaml, os.path.join(_bucket_directory, 'fuchsia.cipd.yaml'))
 
-  if upload and IsLinux():
+  tag = 'git_revision:%s' % engine_version
+  already_exists = CheckCIPDPackageExists('flutter/fuchsia', tag)
+  if already_exists:
+    print('CIPD package already exists!')
+  if upload and IsLinux() and not already_exists:
     command = [
         'cipd', 'create', '-pkg-def', 'fuchsia.cipd.yaml', '-ref', 'latest',
         '-tag',

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -175,6 +175,7 @@ def BuildBucket(runtime_mode, arch, product):
   CopyVulkanDepsToBucket(out_dir, deps_dir, arch)
   CopyIcuDepsToBucket(out_dir, deps_dir)
 
+
 def CheckCIPDPackageExists(package_name, tag):
   '''Check to see if the current package/tag combo has been published'''
   command = [
@@ -184,7 +185,7 @@ def CheckCIPDPackageExists(package_name, tag):
     '-tag',
     tag,
   ]
-  stdout = subprocess.check_output()
+  stdout = subprocess.check_output(command)
   match = re.search(r'No matching instances\.', stdout)
   if match:
     return False
@@ -202,6 +203,7 @@ def ProcessCIPDPackage(upload, engine_version):
   already_exists = CheckCIPDPackageExists('flutter/fuchsia', tag)
   if already_exists:
     print('CIPD package already exists!')
+
   if upload and IsLinux() and not already_exists:
     command = [
         'cipd', 'create', '-pkg-def', 'fuchsia.cipd.yaml', '-ref', 'latest',

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -202,7 +202,7 @@ def ProcessCIPDPackage(upload, engine_version):
   tag = 'git_revision:%s' % engine_version
   already_exists = CheckCIPDPackageExists('flutter/fuchsia', tag)
   if already_exists:
-    print('CIPD package already exists!')
+    print('CIPD package flutter/fuchsia tag %s already exists!' % tag)
 
   if upload and IsLinux() and not already_exists:
     command = [

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -206,7 +206,7 @@ def ProcessCIPDPackage(upload, engine_version):
     command = [
         'cipd', 'create', '-pkg-def', 'fuchsia.cipd.yaml', '-ref', 'latest',
         '-tag',
-        'git_revision:%s' % engine_version
+        tag,
     ]
   else:
     command = [

--- a/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -72,11 +72,12 @@ def CheckCIPDPackageExists(package_name, tag):
 def ProcessCIPDPackage(upload, cipd_yaml, engine_version, out_dir, target_arch):
   _packaging_dir = GetPackagingDir(out_dir)
   tag = 'git_revision:%s' % engine_version
+  package_name = 'flutter/fuchsia-debug-symbols-%s' % target_arch
   already_exists = CheckCIPDPackageExists(
-    'flutter/fuchsia-debug-symbols-%s' % target_arch,
+    package_name,
     tag)
   if already_exists:
-    print('CIPD package already exists!')
+    print('CIPD package %s tag %s already exists!' % (package_name, tag))
 
   if upload and IsLinux() and not already_exists:
     command = [


### PR DESCRIPTION
## Description

CIPD will allow multiple package instances to be created with the same tag, but then subsequent downloading will fail. This change checks if the tag already exists first before publishing. cc @renyou 

## Related Issues

Related to https://github.com/flutter/flutter/issues/55082