### PR TITLE
Wait for platform view to appear in iOS UI tests

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/UnobstructedPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/UnobstructedPlatformViewTests.m
@@ -25,7 +25,7 @@
   [app launch];
 
   XCUIElement* platform_view = app.textViews[@"platform_view[0]"];
-  XCTAssertTrue(platform_view.exists);
+  XCTAssertTrue([platform_view waitForExistenceWithTimeout:1.0]);
   XCTAssertEqual(platform_view.frame.origin.x, 25);
   XCTAssertEqual(platform_view.frame.origin.y, 25);
   XCTAssertEqual(platform_view.frame.size.width, 250);
@@ -47,7 +47,7 @@
   [app launch];
 
   XCUIElement* platform_view = app.textViews[@"platform_view[0]"];
-  XCTAssertTrue(platform_view.exists);
+  XCTAssertTrue([platform_view waitForExistenceWithTimeout:1.0]);
   XCTAssertEqual(platform_view.frame.origin.x, 25);
   XCTAssertEqual(platform_view.frame.origin.y, 25);
   XCTAssertEqual(platform_view.frame.size.width, 250);
@@ -72,7 +72,7 @@
   [app launch];
 
   XCUIElement* platform_view = app.textViews[@"platform_view[0]"];
-  XCTAssertTrue(platform_view.exists);
+  XCTAssertTrue([platform_view waitForExistenceWithTimeout:1.0]);
   XCTAssertEqual(platform_view.frame.origin.x, 25);
   XCTAssertEqual(platform_view.frame.origin.y, 25);
   XCTAssertEqual(platform_view.frame.size.width, 250);
@@ -100,7 +100,7 @@
   [app launch];
 
   XCUIElement* platform_view = app.textViews[@"platform_view[0]"];
-  XCTAssertTrue(platform_view.exists);
+  XCTAssertTrue([platform_view waitForExistenceWithTimeout:1.0]);
   XCTAssertEqual(platform_view.frame.origin.x, 25);
   XCTAssertEqual(platform_view.frame.origin.y, 25);
   XCTAssertEqual(platform_view.frame.size.width, 250);
@@ -129,7 +129,7 @@
   [app launch];
 
   XCUIElement* platform_view = app.textViews[@"platform_view[0]"];
-  XCTAssertTrue(platform_view.exists);
+  XCTAssertTrue([platform_view waitForExistenceWithTimeout:1.0]);
   XCTAssertEqual(platform_view.frame.origin.x, 25);
   XCTAssertEqual(platform_view.frame.origin.y, 25);
   XCTAssertEqual(platform_view.frame.size.width, 250);
@@ -163,7 +163,7 @@
   [app launch];
 
   XCUIElement* platform_view1 = app.textViews[@"platform_view[0]"];
-  XCTAssertTrue(platform_view1.exists);
+  XCTAssertTrue([platform_view1 waitForExistenceWithTimeout:1.0]);
   XCTAssertEqual(platform_view1.frame.origin.x, 25);
   XCTAssertEqual(platform_view1.frame.origin.y, 325);
   XCTAssertEqual(platform_view1.frame.size.width, 250);
@@ -193,7 +193,7 @@
   [app launch];
 
   XCUIElement* platform_view1 = app.textViews[@"platform_view[0]"];
-  XCTAssertTrue(platform_view1.exists);
+  XCTAssertTrue([platform_view1 waitForExistenceWithTimeout:1.0]);
   XCTAssertEqual(platform_view1.frame.origin.x, 25);
   XCTAssertEqual(platform_view1.frame.origin.y, 325);
   XCTAssertEqual(platform_view1.frame.size.width, 250);
@@ -235,7 +235,7 @@
   [app launch];
 
   XCUIElement* platform_view = app.textViews[@"platform_view[0]"];
-  XCTAssertTrue(platform_view.exists);
+  XCTAssertTrue([platform_view waitForExistenceWithTimeout:1.0]);
   XCTAssertEqual(platform_view.frame.origin.x, 25);
   XCTAssertEqual(platform_view.frame.origin.y, 25);
   XCTAssertEqual(platform_view.frame.size.width, 250);


### PR DESCRIPTION
## Description

Wait for the first platform view to appear before checking its existence.

## Related Issues

Tracking down `UnobstructedPlatformViewTests` flakiness
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8875114005149650384/+/steps/Scenario_App_Integration_Tests/0/stdout

## Tests
https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/magder_google.com/d01cc14044ea2ed114f001899bc2bc84c7f4c49270e3f407651a7b4935967ba8/+/annotations?server=chromium-swarm.appspot.com
