### PR TITLE
Migrating web_analysis from Cirrus to LUCI (PART 1)

### DIFF
--- a/lib/web_ui/dev/web_engine_analysis.sh
+++ b/lib/web_ui/dev/web_engine_analysis.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
+set -x
 
 # web_analysis: a command-line utility for running dart analyzer on Flutter Web
 # Engine. Used/Called by LUCI recipes:
 #
-# See: https://flutter.googlesource.com/recipes/+/refs/heads/master/recipes/web_engine.py#165
+# See: https://flutter.googlesource.com/recipes/+/refs/heads/master/recipes/web_engine.py
 
 echo "Engine path $ENGINE_PATH"
 

--- a/lib/web_ui/dev/web_engine_analysis.sh
+++ b/lib/web_ui/dev/web_engine_analysis.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# web_analysis: a command-line utility for running dart analyzer on Flutter Web
+# Engine. Used/Called by LUCI recipes:
+#
+# See: https://flutter.googlesource.com/recipes/+/refs/heads/master/recipes/web_engine.py#165
+
+echo "Engine path $ENGINE_PATH"
+
+DART_SDK_DIR="${ENGINE_PATH}/src/out/host_debug_unopt/dart-sdk"
+PUB_PATH="$DART_SDK_DIR/bin/pub"
+DART_ANALYZER_PATH="$DART_SDK_DIR/bin/dartanalyzer"
+
+echo "Running \`pub get\` in 'engine/src/flutter/lib/web_ui'"
+(cd "$WEB_UI_DIR"; $PUB_PATH get)
+
+echo "Running \`dartanalyzer\` in 'engine/src/flutter/lib/web_ui'"
+(cd "$WEB_UI_DIR"; $DART_ANALYZER_PATH --enable-experiment=non-nullable --fatal-warnings --fatal-hints dev/ lib/ test/ tool/)


### PR DESCRIPTION
adding a script for web_analysis for using from luci.

PART1: Add script to run web_analysis.
PART2: Change LUCI recipe to run web_analysis checks (Successful run example with the recipe change: https://chromium-swarm.appspot.com/task?id=4d631dfb7ab22610)
PART3: Cleanup this step from Cirrus file.