### PR TITLE
Wayland support on Linux/GTK platform

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1273,6 +1273,8 @@ FILE: ../../../flutter/shell/platform/linux/fl_renderer.cc
 FILE: ../../../flutter/shell/platform/linux/fl_renderer.h
 FILE: ../../../flutter/shell/platform/linux/fl_renderer_headless.cc
 FILE: ../../../flutter/shell/platform/linux/fl_renderer_headless.h
+FILE: ../../../flutter/shell/platform/linux/fl_renderer_wayland.cc
+FILE: ../../../flutter/shell/platform/linux/fl_renderer_wayland.h
 FILE: ../../../flutter/shell/platform/linux/fl_renderer_x11.cc
 FILE: ../../../flutter/shell/platform/linux/fl_renderer_x11.h
 FILE: ../../../flutter/shell/platform/linux/fl_standard_message_codec.cc

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -96,6 +96,7 @@ source_set("flutter_linux_sources") {
     "fl_plugin_registry.cc",
     "fl_renderer.cc",
     "fl_renderer_headless.cc",
+    "fl_renderer_wayland.cc",
     "fl_renderer_x11.cc",
     "fl_standard_message_codec.cc",
     "fl_standard_method_codec.cc",
@@ -119,6 +120,7 @@ source_set("flutter_linux") {
   configs += [
     "//flutter/shell/platform/linux/config:gtk",
     "//flutter/shell/platform/linux/config:egl",
+    "//flutter/shell/platform/linux/config:wayland-egl",
     "//third_party/khronos:khronos_headers",
   ]
 
@@ -162,7 +164,10 @@ executable("flutter_linux_unittests") {
 
   public_configs = [ "//flutter:config" ]
 
-  configs += [ "//flutter/shell/platform/linux/config:gtk" ]
+  configs += [
+    "//flutter/shell/platform/linux/config:gtk",
+    "//flutter/shell/platform/linux/config:wayland-egl"
+  ]
 
   # Set flag to allow public headers to be directly included (library users should not do this)
   defines = [ "FLUTTER_LINUX_COMPILATION" ]

--- a/shell/platform/linux/config/BUILD.gn
+++ b/shell/platform/linux/config/BUILD.gn
@@ -18,3 +18,7 @@ pkg_config("gtk") {
 pkg_config("egl") {
   packages = [ "egl" ]
 }
+
+pkg_config("wayland-egl") {
+  packages = [ "wayland-egl" ]
+}

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -117,6 +117,12 @@ GdkVisual* fl_renderer_get_visual(FlRenderer* self, GdkScreen* screen) {
   }
 }
 
+void fl_renderer_set_window(FlRenderer* self, GdkWindow* window) {
+  if (FL_RENDERER_GET_CLASS(self)->set_window) {
+    FL_RENDERER_GET_CLASS(self)->set_window(self, window);
+  }
+}
+
 gboolean fl_renderer_start(FlRenderer* self, GError** error) {
   FlRendererPrivate* priv =
       static_cast<FlRendererPrivate*>(fl_renderer_get_instance_private(self));

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -109,21 +109,8 @@ GdkVisual* fl_renderer_get_visual(FlRenderer* self, GdkScreen* screen) {
   FlRendererPrivate* priv =
       static_cast<FlRendererPrivate*>(fl_renderer_get_instance_private(self));
 
-  EGLint visual_id;
-  if (!eglGetConfigAttrib(priv->egl_display, priv->egl_config,
-                          EGL_NATIVE_VISUAL_ID, &visual_id)) {
-    g_warning("Failed to determine EGL configuration visual");
-    return nullptr;
-  }
-
-  GdkVisual* visual =
-      FL_RENDERER_GET_CLASS(self)->get_visual(self, screen, visual_id);
-  if (visual == nullptr) {
-    g_warning("Failed to find visual 0x%x", visual_id);
-    return nullptr;
-  }
-
-  return visual;
+  return FL_RENDERER_GET_CLASS(self)->get_visual(
+      self, screen, priv->egl_display, priv->egl_config);
 }
 
 gboolean fl_renderer_start(FlRenderer* self, GError** error) {

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -29,12 +29,12 @@ gboolean fl_renderer_setup(FlRenderer* self, GError** error) {
   FlRendererPrivate* priv =
       static_cast<FlRendererPrivate*>(fl_renderer_get_instance_private(self));
 
-  // Note the use of EGL_DEFAULT_DISPLAY rather than sharing an existing
+  // Note the creation of a new display rather than sharing an existing
   // display connection (e.g. an X11 connection from GTK). This is because
   // this EGL display is going to be accessed by a thread from Flutter. In the
   // case of GTK/X11 the display connection is not thread safe and this would
   // cause a crash.
-  priv->egl_display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  priv->egl_display = FL_RENDERER_GET_CLASS(self)->create_display(self);
 
   if (!eglInitialize(priv->egl_display, nullptr, nullptr)) {
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -105,25 +105,21 @@ gboolean fl_renderer_setup(FlRenderer* self, GError** error) {
   return TRUE;
 }
 
-GdkVisual* fl_renderer_get_visual(FlRenderer* self,
-                                  GdkScreen* screen,
-                                  GError** error) {
+GdkVisual* fl_renderer_get_visual(FlRenderer* self, GdkScreen* screen) {
   FlRendererPrivate* priv =
       static_cast<FlRendererPrivate*>(fl_renderer_get_instance_private(self));
 
   EGLint visual_id;
   if (!eglGetConfigAttrib(priv->egl_display, priv->egl_config,
                           EGL_NATIVE_VISUAL_ID, &visual_id)) {
-    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
-                "Failed to determine EGL configuration visual");
+    g_warning("Failed to determine EGL configuration visual");
     return nullptr;
   }
 
   GdkVisual* visual =
       FL_RENDERER_GET_CLASS(self)->get_visual(self, screen, visual_id);
   if (visual == nullptr) {
-    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
-                "Failed to find visual 0x%x", visual_id);
+    g_warning("Failed to find visual 0x%x", visual_id);
     return nullptr;
   }
 

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -141,6 +141,14 @@ gboolean fl_renderer_start(FlRenderer* self, GError** error) {
   return TRUE;
 }
 
+void fl_renderer_set_geometry(FlRenderer* self,
+                              GdkRectangle* geometry,
+                              gint scale) {
+  if (FL_RENDERER_GET_CLASS(self)->set_geometry) {
+    FL_RENDERER_GET_CLASS(self)->set_geometry(self, geometry, scale);
+  }
+}
+
 void* fl_renderer_get_proc_address(FlRenderer* self, const char* name) {
   return reinterpret_cast<void*>(eglGetProcAddress(name));
 }

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -93,11 +93,12 @@ gboolean fl_renderer_setup(FlRenderer* self, GError** error) {
   }
 
   if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+    EGLint egl_error = eglGetError();  // must be before egl_config_to_string()
     g_autofree gchar* config_string =
         egl_config_to_string(priv->egl_display, priv->egl_config);
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
                 "Failed to bind EGL OpenGL ES API using configuration (%s): %s",
-                config_string, egl_error_to_string(eglGetError()));
+                config_string, egl_error_to_string(egl_error));
     return FALSE;
   }
 
@@ -136,11 +137,12 @@ gboolean fl_renderer_start(FlRenderer* self, GError** error) {
   priv->egl_surface = FL_RENDERER_GET_CLASS(self)->create_surface(
       self, priv->egl_display, priv->egl_config);
   if (priv->egl_surface == EGL_NO_SURFACE) {
+    EGLint egl_error = eglGetError();  // must be before egl_config_to_string()
     g_autofree gchar* config_string =
         egl_config_to_string(priv->egl_display, priv->egl_config);
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
                 "Failed to create EGL surface using configuration (%s): %s",
-                config_string, egl_error_to_string(eglGetError()));
+                config_string, egl_error_to_string(egl_error));
     return FALSE;
   }
 
@@ -148,11 +150,12 @@ gboolean fl_renderer_start(FlRenderer* self, GError** error) {
   priv->egl_context = eglCreateContext(priv->egl_display, priv->egl_config,
                                        EGL_NO_CONTEXT, context_attributes);
   if (priv->egl_context == EGL_NO_CONTEXT) {
+    EGLint egl_error = eglGetError();  // must be before egl_config_to_string()
     g_autofree gchar* config_string =
         egl_config_to_string(priv->egl_display, priv->egl_config);
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
                 "Failed to create EGL context using configuration (%s): %s",
-                config_string, egl_error_to_string(eglGetError()));
+                config_string, egl_error_to_string(egl_error));
     return FALSE;
   }
 

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -109,8 +109,12 @@ GdkVisual* fl_renderer_get_visual(FlRenderer* self, GdkScreen* screen) {
   FlRendererPrivate* priv =
       static_cast<FlRendererPrivate*>(fl_renderer_get_instance_private(self));
 
-  return FL_RENDERER_GET_CLASS(self)->get_visual(
-      self, screen, priv->egl_display, priv->egl_config);
+  if (FL_RENDERER_GET_CLASS(self)->get_visual) {
+    return FL_RENDERER_GET_CLASS(self)->get_visual(
+        self, screen, priv->egl_display, priv->egl_config);
+  } else {
+    return nullptr;
+  }
 }
 
 gboolean fl_renderer_start(FlRenderer* self, GError** error) {

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -42,6 +42,10 @@ struct _FlRendererClass {
                            EGLDisplay display,
                            EGLConfig config);
 
+  // Virtual method called after a GDK window has been created
+  // Does not need to be implemented
+  void (*set_window)(FlRenderer* renderer, GdkWindow* window);
+
   // Virtual method called when Flutter needs a surface to render to.
   EGLSurface (*create_surface)(FlRenderer* renderer,
                                EGLDisplay display,
@@ -72,6 +76,15 @@ gboolean fl_renderer_setup(FlRenderer* self, GError** error);
  * Returns: a #GdkVisual or nullptr if a specific visual is not required.
  */
 GdkVisual* fl_renderer_get_visual(FlRenderer* self, GdkScreen* screen);
+
+/**
+ * fl_renderer_set_window:
+ * @renderer: an #FlRenderer.
+ * @window: the GDK Window this renderer will render to
+ *
+ * Set the window this renderer will use
+ */
+void fl_renderer_set_window(FlRenderer* self, GdkWindow* window);
 
 /**
  * fl_renderer_start:

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -69,9 +69,7 @@ gboolean fl_renderer_setup(FlRenderer* self, GError** error);
  *
  * Returns: a #GdkVisual.
  */
-GdkVisual* fl_renderer_get_visual(FlRenderer* self,
-                                  GdkScreen* screen,
-                                  GError** error);
+GdkVisual* fl_renderer_get_visual(FlRenderer* self, GdkScreen* screen);
 
 /**
  * fl_renderer_start:

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -51,6 +51,9 @@ struct _FlRendererClass {
   // Does not need to be implemented
   void (*set_window)(FlRenderer* renderer, GdkWindow* window);
 
+  // Virtual method to create a new EGL display
+  EGLDisplay (*create_display)(FlRenderer* renderer);
+
   // Virtual method called when Flutter needs a surface to render to.
   EGLSurfacePair (*create_surface)(FlRenderer* renderer,
                                    EGLDisplay display,

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -13,6 +13,11 @@
 
 G_BEGIN_DECLS
 
+struct EGLSurfacePair {
+  EGLSurface visible;
+  EGLSurface resource;
+};
+
 /**
  * FlRendererError:
  * Errors for #FlRenderer objects to set on failures.
@@ -47,9 +52,9 @@ struct _FlRendererClass {
   void (*set_window)(FlRenderer* renderer, GdkWindow* window);
 
   // Virtual method called when Flutter needs a surface to render to.
-  EGLSurface (*create_surface)(FlRenderer* renderer,
-                               EGLDisplay display,
-                               EGLConfig config);
+  EGLSurfacePair (*create_surface)(FlRenderer* renderer,
+                                   EGLDisplay display,
+                                   EGLConfig config);
 };
 
 /**

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -36,6 +36,7 @@ struct _FlRendererClass {
   GObjectClass parent_class;
 
   // Virtual method called to get the required visual
+  // Does not need to be implemented if the default visual will do
   GdkVisual* (*get_visual)(FlRenderer* renderer,
                            GdkScreen* screen,
                            EGLDisplay display,
@@ -68,7 +69,7 @@ gboolean fl_renderer_setup(FlRenderer* self, GError** error);
  *
  * Gets the visual required to render on.
  *
- * Returns: a #GdkVisual.
+ * Returns: a #GdkVisual or nullptr if a specific visual is not required.
  */
 GdkVisual* fl_renderer_get_visual(FlRenderer* self, GdkScreen* screen);
 

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -35,10 +35,11 @@ G_DECLARE_DERIVABLE_TYPE(FlRenderer, fl_renderer, FL, RENDERER, GObject)
 struct _FlRendererClass {
   GObjectClass parent_class;
 
-  // Virtual method called to get the visual that matches the given ID.
+  // Virtual method called to get the required visual
   GdkVisual* (*get_visual)(FlRenderer* renderer,
                            GdkScreen* screen,
-                           EGLint visual_id);
+                           EGLDisplay display,
+                           EGLConfig config);
 
   // Virtual method called when Flutter needs a surface to render to.
   EGLSurface (*create_surface)(FlRenderer* renderer,

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -58,6 +58,10 @@ struct _FlRendererClass {
   EGLSurfacePair (*create_surface)(FlRenderer* renderer,
                                    EGLDisplay display,
                                    EGLConfig config);
+
+  // Virtual method called when the EGL window needs to be resized.
+  // This is implmented by Wayland but not needed for X11
+  void (*set_geometry)(FlRenderer* self, GdkRectangle* geometry, gint scale);
 };
 
 /**
@@ -105,6 +109,15 @@ void fl_renderer_set_window(FlRenderer* self, GdkWindow* window);
  * Returns: %TRUE if successfully started.
  */
 gboolean fl_renderer_start(FlRenderer* self, GError** error);
+
+/**
+ * fl_renderer_set_geometry:
+ * @geometry: New size and position (unscaled) of the EGL window.
+ * @scale: Scale of the window.
+ */
+void fl_renderer_set_geometry(FlRenderer* self,
+                              GdkRectangle* geometry,
+                              gint scale);
 
 /**
  * fl_renderer_get_proc_address:

--- a/shell/platform/linux/fl_renderer_headless.cc
+++ b/shell/platform/linux/fl_renderer_headless.cc
@@ -10,10 +10,10 @@ struct _FlRendererHeadless {
 
 G_DEFINE_TYPE(FlRendererHeadless, fl_renderer_headless, fl_renderer_get_type())
 
-static EGLSurface fl_renderer_headless_create_surface(FlRenderer* renderer,
-                                                      EGLDisplay display,
-                                                      EGLConfig config) {
-  return EGL_NO_SURFACE;
+static EGLSurfacePair fl_renderer_headless_create_surface(FlRenderer* renderer,
+                                                          EGLDisplay display,
+                                                          EGLConfig config) {
+  return EGLSurfacePair{EGL_NO_SURFACE, EGL_NO_SURFACE};
 }
 
 static void fl_renderer_headless_class_init(FlRendererHeadlessClass* klass) {

--- a/shell/platform/linux/fl_renderer_wayland.cc
+++ b/shell/platform/linux/fl_renderer_wayland.cc
@@ -1,0 +1,179 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "fl_renderer_wayland.h"
+
+#include <wayland-egl-core.h>
+#include <string>
+
+static wl_registry* registry_global = nullptr;
+static wl_subcompositor* subcompositor_global = nullptr;
+
+static void registry_handle_global(void*,
+                                   wl_registry* registry,
+                                   uint32_t id,
+                                   const char* name,
+                                   uint32_t max_version) {
+  if (std::string{name} == std::string{wl_subcompositor_interface.name}) {
+    const wl_interface* interface = &wl_subcompositor_interface;
+    uint32_t version =
+        std::min(static_cast<uint32_t>(interface->version), max_version);
+    subcompositor_global = static_cast<wl_subcompositor*>(
+        wl_registry_bind(registry, id, interface, version));
+  }
+}
+
+static void registry_handle_global_remove(void*, wl_registry*, uint32_t) {}
+
+static const wl_registry_listener registry_listener = {
+    .global = registry_handle_global,
+    .global_remove = registry_handle_global_remove,
+};
+
+static void lazy_initialize_wayland_globals() {
+  if (registry_global)
+    return;
+
+  GdkWaylandDisplay* gdk_display =
+      GDK_WAYLAND_DISPLAY(gdk_display_get_default());
+  g_return_if_fail(gdk_display);
+
+  wl_display* display = gdk_wayland_display_get_wl_display(gdk_display);
+  registry_global = wl_display_get_registry(display);
+  wl_registry_add_listener(registry_global, &registry_listener, nullptr);
+  wl_display_roundtrip(display);
+}
+
+struct _FlRendererWayland {
+  FlRenderer parent_instance;
+
+  GdkWindow* toplevel_window;
+
+  struct {
+    wl_subsurface* subsurface;
+    wl_surface* surface;
+    wl_egl_window* egl_window;
+    GdkRectangle geometry;
+  } subsurface;
+
+  // The resource surface will not be mapped, but needs to be a wl_surface
+  // because ONLY window EGL surfaces are supported on Wayland
+  struct {
+    wl_surface* surface;
+    wl_egl_window* egl_window;
+  } resource;
+};
+
+G_DEFINE_TYPE(FlRendererWayland, fl_renderer_wayland, fl_renderer_get_type())
+
+static void fl_renderer_wayland_set_window(FlRenderer* renderer,
+                                           GdkWindow* window) {
+  FlRendererWayland* self = FL_RENDERER_WAYLAND(renderer);
+  g_return_if_fail(GDK_IS_WAYLAND_WINDOW(window));
+  self->toplevel_window = GDK_WAYLAND_WINDOW(window);
+}
+
+// Implements FlRenderer::create_display
+static EGLDisplay fl_renderer_wayland_create_display(FlRenderer* /*renderer*/) {
+  GdkWaylandDisplay* gdk_display =
+      GDK_WAYLAND_DISPLAY(gdk_display_get_default());
+  g_return_val_if_fail(gdk_display, nullptr);
+  return eglGetDisplay(gdk_wayland_display_get_wl_display(gdk_display));
+}
+
+static EGLSurfacePair fl_renderer_wayland_create_surface(FlRenderer* renderer,
+                                                         EGLDisplay egl_display,
+                                                         EGLConfig config) {
+  static const EGLSurfacePair null_result{EGL_NO_SURFACE, EGL_NO_SURFACE};
+
+  FlRendererWayland* self = FL_RENDERER_WAYLAND(renderer);
+
+  GdkWaylandDisplay* gdk_display =
+      GDK_WAYLAND_DISPLAY(gdk_display_get_default());
+  g_return_val_if_fail(gdk_display, null_result);
+
+  wl_compositor* compositor =
+      gdk_wayland_display_get_wl_compositor(gdk_display);
+  g_return_val_if_fail(compositor, null_result);
+
+  self->subsurface.surface = wl_compositor_create_surface(compositor);
+  self->resource.surface = wl_compositor_create_surface(compositor);
+  g_return_val_if_fail(self->subsurface.surface, null_result);
+  g_return_val_if_fail(self->resource.surface, null_result);
+  self->subsurface.geometry = GdkRectangle{0, 0, 1, 1};
+
+  self->subsurface.egl_window =
+      wl_egl_window_create(self->subsurface.surface, 1, 1);
+  self->resource.egl_window =
+      wl_egl_window_create(self->resource.surface, 1, 1);
+  g_return_val_if_fail(self->subsurface.egl_window, null_result);
+  g_return_val_if_fail(self->resource.egl_window, null_result);
+
+  EGLSurface visible = eglCreateWindowSurface(
+      egl_display, config, self->subsurface.egl_window, nullptr);
+  EGLSurface resource = eglCreateWindowSurface(
+      egl_display, config, self->resource.egl_window, nullptr);
+  g_return_val_if_fail(visible != EGL_NO_SURFACE, null_result);
+  g_return_val_if_fail(resource != EGL_NO_SURFACE, null_result);
+
+  lazy_initialize_wayland_globals();
+  g_return_val_if_fail(subcompositor_global, null_result);
+
+  wl_surface* toplevel_surface =
+      gdk_wayland_window_get_wl_surface(self->toplevel_window);
+  g_return_val_if_fail(toplevel_surface, null_result);
+
+  self->subsurface.subsurface = wl_subcompositor_get_subsurface(
+      subcompositor_global, self->subsurface.surface, toplevel_surface);
+  g_return_val_if_fail(self->subsurface.subsurface, null_result);
+  wl_subsurface_set_desync(self->subsurface.subsurface);
+  wl_subsurface_set_position(self->subsurface.subsurface, 0, 0);
+  wl_surface_commit(self->subsurface.surface);
+
+  // Give the subsurface an empty input region so the main surface gets input
+  wl_region* region = wl_compositor_create_region(compositor);
+  wl_surface_set_input_region(self->subsurface.surface, region);
+  wl_region_destroy(region);
+  wl_surface_commit(self->subsurface.surface);
+
+  return EGLSurfacePair{visible, resource};
+}
+
+static void fl_renderer_wayland_set_geometry(FlRenderer* renderer,
+                                             GdkRectangle* geometry,
+                                             gint scale) {
+  FlRendererWayland* self = FL_RENDERER_WAYLAND(renderer);
+
+  if (!self->subsurface.egl_window || !self->subsurface.surface) {
+    return;
+  }
+
+  if (geometry->x != self->subsurface.geometry.x ||
+      geometry->y != self->subsurface.geometry.y) {
+    wl_subsurface_set_position(self->subsurface.subsurface, geometry->x,
+                               geometry->y);
+  }
+
+  if (geometry->width != self->subsurface.geometry.width ||
+      geometry->height != self->subsurface.geometry.height) {
+    wl_egl_window_resize(self->subsurface.egl_window, geometry->width,
+                         geometry->height, 0, 0);
+  }
+
+  self->subsurface.geometry = *geometry;
+}
+
+static void fl_renderer_wayland_class_init(FlRendererWaylandClass* klass) {
+  FL_RENDERER_CLASS(klass)->set_window = fl_renderer_wayland_set_window;
+  FL_RENDERER_CLASS(klass)->create_display = fl_renderer_wayland_create_display;
+  FL_RENDERER_CLASS(klass)->create_surface = fl_renderer_wayland_create_surface;
+  FL_RENDERER_CLASS(klass)->set_geometry = fl_renderer_wayland_set_geometry;
+}
+
+static void fl_renderer_wayland_init(FlRendererWayland* self) {}
+
+FlRendererWayland* fl_renderer_wayland_new() {
+  return FL_RENDERER_WAYLAND(
+      g_object_new(fl_renderer_wayland_get_type(), nullptr));
+}

--- a/shell/platform/linux/fl_renderer_wayland.h
+++ b/shell/platform/linux/fl_renderer_wayland.h
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_WAYLAND_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_WAYLAND_H_
+
+#define WL_EGL_PLATFORM
+
+#include <gdk/gdkwayland.h>
+
+#include "flutter/shell/platform/linux/fl_renderer.h"
+
+G_BEGIN_DECLS
+
+G_DECLARE_FINAL_TYPE(FlRendererWayland,
+                     fl_renderer_wayland,
+                     FL,
+                     RENDERER_WAYLAND,
+                     FlRenderer)
+
+/**
+ * FlRendererWayland:
+ *
+ * #FlRendererWayland is an implementation of a #FlRenderer that renders to
+ * Wayland surfaces.
+ */
+
+/**
+ * fl_renderer_wayland_new:
+ *
+ * Create an object that allows Flutter to render to Wayland surfaces.
+ *
+ * Returns: a #FlRendererWayland
+ */
+FlRendererWayland* fl_renderer_wayland_new();
+
+G_END_DECLS
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_WAYLAND_H_

--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -49,6 +49,11 @@ static void fl_renderer_x11_set_window(FlRenderer* renderer,
   self->window = GDK_X11_WINDOW(g_object_ref(window));
 }
 
+// Implements FlRenderer::create_display
+static EGLDisplay fl_renderer_x11_create_display(FlRenderer* /*renderer*/) {
+  return eglGetDisplay(EGL_DEFAULT_DISPLAY);
+}
+
 // Implments FlRenderer::create_surface.
 static EGLSurfacePair fl_renderer_x11_create_surface(FlRenderer* renderer,
                                                      EGLDisplay display,
@@ -73,6 +78,7 @@ static void fl_renderer_x11_class_init(FlRendererX11Class* klass) {
   G_OBJECT_CLASS(klass)->dispose = fl_renderer_x11_dispose;
   FL_RENDERER_CLASS(klass)->get_visual = fl_renderer_x11_get_visual;
   FL_RENDERER_CLASS(klass)->set_window = fl_renderer_x11_set_window;
+  FL_RENDERER_CLASS(klass)->create_display = fl_renderer_x11_create_display;
   FL_RENDERER_CLASS(klass)->create_surface = fl_renderer_x11_create_surface;
 }
 

--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -23,8 +23,22 @@ static void fl_renderer_x11_dispose(GObject* object) {
 // Implments FlRenderer::get_visual.
 static GdkVisual* fl_renderer_x11_get_visual(FlRenderer* renderer,
                                              GdkScreen* screen,
-                                             EGLint visual_id) {
-  return gdk_x11_screen_lookup_visual(GDK_X11_SCREEN(screen), visual_id);
+                                             EGLDisplay display,
+                                             EGLConfig config) {
+  EGLint visual_id;
+  if (!eglGetConfigAttrib(display, config, EGL_NATIVE_VISUAL_ID, &visual_id)) {
+    g_warning("Failed to determine EGL configuration visual");
+    return nullptr;
+  }
+
+  GdkVisual* visual =
+      gdk_x11_screen_lookup_visual(GDK_X11_SCREEN(screen), visual_id);
+  if (visual == nullptr) {
+    g_warning("Failed to find visual 0x%x", visual_id);
+    return nullptr;
+  }
+
+  return visual;
 }
 
 // Implments FlRenderer::create_surface.

--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -41,6 +41,14 @@ static GdkVisual* fl_renderer_x11_get_visual(FlRenderer* renderer,
   return visual;
 }
 
+// Implements FlRenderer::set_window
+static void fl_renderer_x11_set_window(FlRenderer* renderer,
+                                       GdkWindow* window) {
+  FlRendererX11* self = FL_RENDERER_X11(renderer);
+  g_return_if_fail(GDK_IS_X11_WINDOW(window));
+  self->window = GDK_X11_WINDOW(g_object_ref(window));
+}
+
 // Implments FlRenderer::create_surface.
 static EGLSurface fl_renderer_x11_create_surface(FlRenderer* renderer,
                                                  EGLDisplay display,
@@ -53,6 +61,7 @@ static EGLSurface fl_renderer_x11_create_surface(FlRenderer* renderer,
 static void fl_renderer_x11_class_init(FlRendererX11Class* klass) {
   G_OBJECT_CLASS(klass)->dispose = fl_renderer_x11_dispose;
   FL_RENDERER_CLASS(klass)->get_visual = fl_renderer_x11_get_visual;
+  FL_RENDERER_CLASS(klass)->set_window = fl_renderer_x11_set_window;
   FL_RENDERER_CLASS(klass)->create_surface = fl_renderer_x11_create_surface;
 }
 
@@ -60,9 +69,4 @@ static void fl_renderer_x11_init(FlRendererX11* self) {}
 
 FlRendererX11* fl_renderer_x11_new() {
   return FL_RENDERER_X11(g_object_new(fl_renderer_x11_get_type(), nullptr));
-}
-
-void fl_renderer_x11_set_window(FlRendererX11* self, GdkX11Window* window) {
-  g_return_if_fail(FL_IS_RENDERER_X11(self));
-  self->window = GDK_X11_WINDOW(g_object_ref(window));
 }

--- a/shell/platform/linux/fl_renderer_x11.h
+++ b/shell/platform/linux/fl_renderer_x11.h
@@ -33,15 +33,6 @@ G_DECLARE_FINAL_TYPE(FlRendererX11,
  */
 FlRendererX11* fl_renderer_x11_new();
 
-/**
- * fl_renderer_x11_set_window:
- * @renderer: an #FlRendererX11.
- * @window: the X window being rendered to.
- *
- * Sets the X11 window that is being rendered to.
- */
-void fl_renderer_x11_set_window(FlRendererX11* renderer, GdkX11Window* window);
-
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_X11_H_

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -100,13 +100,14 @@ static gboolean fl_view_send_pointer_button_event(FlView* self,
 }
 
 // Updates the engine with the current window metrics.
-static void fl_view_send_window_metrics(FlView* self) {
+static void fl_view_geometry_changed(FlView* self) {
   GtkAllocation allocation;
   gtk_widget_get_allocation(GTK_WIDGET(self), &allocation);
   gint scale_factor = gtk_widget_get_scale_factor(GTK_WIDGET(self));
   fl_engine_send_window_metrics_event(
       self->engine, allocation.width * scale_factor,
       allocation.height * scale_factor, scale_factor);
+  fl_renderer_set_geometry(self->renderer, &allocation, scale_factor);
 }
 
 // Implements FlPluginRegistry::get_registrar_for_plugin.
@@ -175,7 +176,7 @@ static void fl_view_notify(GObject* object, GParamSpec* pspec) {
   FlView* self = FL_VIEW(object);
 
   if (strcmp(pspec->name, "scale-factor") == 0) {
-    fl_view_send_window_metrics(self);
+    fl_view_geometry_changed(self);
   }
 
   if (G_OBJECT_CLASS(fl_view_parent_class)->notify != nullptr)
@@ -255,7 +256,7 @@ static void fl_view_size_allocate(GtkWidget* widget,
                            allocation->height);
   }
 
-  fl_view_send_window_metrics(self);
+  fl_view_geometry_changed(self);
 }
 
 // Implements GtkWidget::button_press_event.

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -216,15 +216,19 @@ static void fl_view_realize(GtkWidget* widget) {
   window_attributes.width = allocation.width;
   window_attributes.height = allocation.height;
   window_attributes.wclass = GDK_INPUT_OUTPUT;
-  window_attributes.visual =
-      fl_renderer_get_visual(self->renderer, gtk_widget_get_screen(widget));
   window_attributes.event_mask =
       gtk_widget_get_events(widget) | GDK_EXPOSURE_MASK |
       GDK_POINTER_MOTION_MASK | GDK_BUTTON_PRESS_MASK |
       GDK_BUTTON_RELEASE_MASK | GDK_SCROLL_MASK | GDK_SMOOTH_SCROLL_MASK |
       GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK;
 
-  gint window_attributes_mask = GDK_WA_X | GDK_WA_Y | GDK_WA_VISUAL;
+  gint window_attributes_mask = GDK_WA_X | GDK_WA_Y;
+
+  window_attributes.visual =
+      fl_renderer_get_visual(self->renderer, gtk_widget_get_screen(widget));
+  if (window_attributes.visual) {
+    window_attributes_mask |= GDK_WA_VISUAL;
+  }
 
   GdkWindow* window =
       gdk_window_new(gtk_widget_get_parent_window(widget), &window_attributes,

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -9,11 +9,13 @@
 #include "flutter/shell/platform/linux/fl_mouse_cursor_plugin.h"
 #include "flutter/shell/platform/linux/fl_platform_plugin.h"
 #include "flutter/shell/platform/linux/fl_plugin_registrar_private.h"
+#include "flutter/shell/platform/linux/fl_renderer_wayland.h"
 #include "flutter/shell/platform/linux/fl_renderer_x11.h"
 #include "flutter/shell/platform/linux/fl_text_input_plugin.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_plugin_registry.h"
 
+#include <gdk/gdkwayland.h>
 #include <gdk/gdkx.h>
 
 static constexpr int kMicrosecondsPerMillisecond = 1000;
@@ -128,7 +130,13 @@ static void fl_view_plugin_registry_iface_init(
 static void fl_view_constructed(GObject* object) {
   FlView* self = FL_VIEW(object);
 
-  self->renderer = FL_RENDERER(fl_renderer_x11_new());
+  GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(self));
+  if (GDK_IS_X11_DISPLAY(display))
+    self->renderer = FL_RENDERER(fl_renderer_x11_new());
+  else if (GDK_IS_WAYLAND_DISPLAY(display))
+    self->renderer = FL_RENDERER(fl_renderer_wayland_new());
+  else
+    g_error("Unsupported GDK backend");
   self->engine = fl_engine_new(self->project, self->renderer);
 
   // Create system channel handlers.

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -216,8 +216,8 @@ static void fl_view_realize(GtkWidget* widget) {
   window_attributes.width = allocation.width;
   window_attributes.height = allocation.height;
   window_attributes.wclass = GDK_INPUT_OUTPUT;
-  window_attributes.visual = fl_renderer_get_visual(
-      self->renderer, gtk_widget_get_screen(widget), nullptr);
+  window_attributes.visual =
+      fl_renderer_get_visual(self->renderer, gtk_widget_get_screen(widget));
   window_attributes.event_mask =
       gtk_widget_get_events(widget) | GDK_EXPOSURE_MASK |
       GDK_POINTER_MOTION_MASK | GDK_BUTTON_PRESS_MASK |

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -25,7 +25,7 @@ struct _FlView {
   FlDartProject* project;
 
   // Rendering output.
-  FlRendererX11* renderer;
+  FlRenderer* renderer;
 
   // Engine running @project.
   FlEngine* engine;
@@ -127,8 +127,8 @@ static void fl_view_plugin_registry_iface_init(
 static void fl_view_constructed(GObject* object) {
   FlView* self = FL_VIEW(object);
 
-  self->renderer = fl_renderer_x11_new();
-  self->engine = fl_engine_new(self->project, FL_RENDERER(self->renderer));
+  self->renderer = FL_RENDERER(fl_renderer_x11_new());
+  self->engine = fl_engine_new(self->project, self->renderer);
 
   // Create system channel handlers.
   FlBinaryMessenger* messenger = fl_engine_get_binary_messenger(self->engine);
@@ -203,7 +203,7 @@ static void fl_view_realize(GtkWidget* widget) {
   gtk_widget_set_realized(widget, TRUE);
 
   g_autoptr(GError) error = nullptr;
-  if (!fl_renderer_setup(FL_RENDERER(self->renderer), &error))
+  if (!fl_renderer_setup(self->renderer, &error))
     g_warning("Failed to setup renderer: %s", error->message);
 
   GtkAllocation allocation;
@@ -217,7 +217,7 @@ static void fl_view_realize(GtkWidget* widget) {
   window_attributes.height = allocation.height;
   window_attributes.wclass = GDK_INPUT_OUTPUT;
   window_attributes.visual = fl_renderer_get_visual(
-      FL_RENDERER(self->renderer), gtk_widget_get_screen(widget), nullptr);
+      self->renderer, gtk_widget_get_screen(widget), nullptr);
   window_attributes.event_mask =
       gtk_widget_get_events(widget) | GDK_EXPOSURE_MASK |
       GDK_POINTER_MOTION_MASK | GDK_BUTTON_PRESS_MASK |
@@ -233,7 +233,8 @@ static void fl_view_realize(GtkWidget* widget) {
   gtk_widget_set_window(widget, window);
 
   fl_renderer_x11_set_window(
-      self->renderer, GDK_X11_WINDOW(gtk_widget_get_window(GTK_WIDGET(self))));
+      FL_RENDERER_X11(self->renderer),
+      GDK_X11_WINDOW(gtk_widget_get_window(GTK_WIDGET(self))));
 
   if (!fl_engine_start(self->engine, &error))
     g_warning("Failed to start Flutter engine: %s", error->message);

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -236,9 +236,7 @@ static void fl_view_realize(GtkWidget* widget) {
   gtk_widget_register_window(widget, window);
   gtk_widget_set_window(widget, window);
 
-  fl_renderer_x11_set_window(
-      FL_RENDERER_X11(self->renderer),
-      GDK_X11_WINDOW(gtk_widget_get_window(GTK_WIDGET(self))));
+  fl_renderer_set_window(self->renderer, window);
 
   if (!fl_engine_start(self->engine, &error))
     g_warning("Failed to start Flutter engine: %s", error->message);

--- a/shell/platform/linux/testing/mock_renderer.cc
+++ b/shell/platform/linux/testing/mock_renderer.cc
@@ -18,6 +18,11 @@ static GdkVisual* fl_mock_renderer_get_visual(FlRenderer* renderer,
   return static_cast<GdkVisual*>(g_object_new(GDK_TYPE_VISUAL, nullptr));
 }
 
+// Implements FlRenderer::create_display
+static EGLDisplay fl_mock_renderer_create_display(FlRenderer* /*renderer*/) {
+    return eglGetDisplay(EGL_DEFAULT_DISPLAY);
+}
+
 // Implements FlRenderer::create_surface.
 static EGLSurfacePair fl_mock_renderer_create_surface(FlRenderer* renderer,
                                                   EGLDisplay display,
@@ -32,6 +37,7 @@ static EGLSurfacePair fl_mock_renderer_create_surface(FlRenderer* renderer,
 
 static void fl_mock_renderer_class_init(FlMockRendererClass* klass) {
   FL_RENDERER_CLASS(klass)->get_visual = fl_mock_renderer_get_visual;
+  FL_RENDERER_CLASS(klass)->create_display = fl_mock_renderer_create_display;
   FL_RENDERER_CLASS(klass)->create_surface = fl_mock_renderer_create_surface;
 }
 

--- a/shell/platform/linux/testing/mock_renderer.cc
+++ b/shell/platform/linux/testing/mock_renderer.cc
@@ -19,10 +19,15 @@ static GdkVisual* fl_mock_renderer_get_visual(FlRenderer* renderer,
 }
 
 // Implements FlRenderer::create_surface.
-static EGLSurface fl_mock_renderer_create_surface(FlRenderer* renderer,
+static EGLSurfacePair fl_mock_renderer_create_surface(FlRenderer* renderer,
                                                   EGLDisplay display,
                                                   EGLConfig config) {
-  return eglCreateWindowSurface(display, config, 0, nullptr);
+  EGLSurface visible = eglCreateWindowSurface(display, config, 0, nullptr);
+  const EGLint attribs[] = {EGL_WIDTH, 1,
+                            EGL_HEIGHT, 1,
+                            EGL_NONE};
+  EGLSurface resource = eglCreatePbufferSurface(display, config, attribs);
+  return EGLSurfacePair{visible, resource};
 }
 
 static void fl_mock_renderer_class_init(FlMockRendererClass* klass) {

--- a/shell/platform/linux/testing/mock_renderer.cc
+++ b/shell/platform/linux/testing/mock_renderer.cc
@@ -13,7 +13,8 @@ G_DEFINE_TYPE(FlMockRenderer, fl_mock_renderer, fl_renderer_get_type())
 // Implements FlRenderer::get_visual.
 static GdkVisual* fl_mock_renderer_get_visual(FlRenderer* renderer,
                                               GdkScreen* screen,
-                                              EGLint visual_id) {
+                                              EGLDisplay display,
+                                              EGLConfig config) {
   return static_cast<GdkVisual*>(g_object_new(GDK_TYPE_VISUAL, nullptr));
 }
 


### PR DESCRIPTION
## Description

Adds native Wayland support to the Linux/GTK shell. Because it's not possible to get GTK's internal `EGLSurface` (or make additional `EGLSurface`s for a single `wl_surface`), we have to create a new subsurface for Flutter to render to. This subsurface is positioned and resized by us to cover the required area of the window, and it's given an empty input region so events fall through to the GTK widget below. Based on original work from @robert-ancell.

## Related Issues

https://github.com/flutter/flutter/issues/57932

## Tests

None (there aren't currently any tests of the Linux rendering code, and adding them would require some way to mock GTK, libwayland and EGL)

## Checklist

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [?] I signed the [CLA]. *(I'm with Canonical, have we signed it company-wide? Or do I need to do something individually?)*
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
