### PR TITLE
[fuchsia] Fix use-after-free due to raster cache

### DIFF
--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -106,7 +106,9 @@ void CompositorContext::OnDestroyView(int64_t view_id) {
   session_connection_.scene_update_context().DestroyView(view_id);
 }
 
-CompositorContext::~CompositorContext() = default;
+CompositorContext::~CompositorContext() {
+  OnGrContextDestroyed();
+}
 
 std::unique_ptr<flutter::CompositorContext::ScopedFrame>
 CompositorContext::AcquireFrame(


### PR DESCRIPTION
Tear down Vulkan device and GrContext before raster cache