### PR TITLE
Use option --no-sound-null-safety instead of --no-null-safety

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -185,7 +185,7 @@ def SnapshotTest(build_dir, dart_file, kernel_file_output, verbose_dart_snapshot
     dart,
     frontend_server,
     '--enable-experiment=non-nullable',
-    '--no-null-safety',
+    '--no-sound-null-safety',
     '--sdk-root',
     flutter_patched_sdk,
     '--incremental',


### PR DESCRIPTION
Use option `--no-sound-null-safety` instead of `--no-null-safety `as the option `--null-safety` is being renamed to `--sound-null-safety` by the Dart team.