### PR TITLE
Disable session_connection_unittests

### DIFF
--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -194,6 +194,7 @@ echo "$(date) START:flutter_runner_tests ----------------------------"
     -f flutter_aot_runner-0.far    \
     -f flutter_runner_scenic_tests-0.far  \
     -t flutter_runner_scenic_tests \
+    -a "--gtest_filter=-SessionConnectionTest.*:CalculateNextLatchPointTest.*" \
     --identity-file $pkey \
     --timeout-seconds $test_timeout_seconds \
     --packages-directory packages


### PR DESCRIPTION
Disabling this test until we get the logs to figure out what services are having a hard time launching.

Bug: https://github.com/flutter/flutter/issues/61463
