### PR TITLE
[null-safety] add null assertions to dart-flags allowlist

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -61,6 +61,7 @@ static const std::string gAllowedDartFlags[] = {
     "--trace-reload",
     "--trace-reload-verbose",
     "--write-service-info",
+    "--null_assertions",
 };
 // clang-format on
 


### PR DESCRIPTION
## Description

Will allow enabling the null-safety asserts flag for https://github.com/flutter/flutter/issues/61042

This won't work for desktop, since we can't pass args through.