### PR TITLE
Re-enable logging.

### DIFF
--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -44,7 +44,7 @@ reboot() {
   ./fuchsia_ctl -d $device_name ssh \
        -c "log_listener --dump_logs yes" \
        --timeout-seconds $ssh_timeout_seconds \
-       --identity-file $pkey --log-file $3/log.txt
+       --identity-file $pkey --log-file ${ISOLATED_OUTDIR}/log.txt
 
   echo "$(date) START:REBOOT ------------------------------------------"
   # note: this will set an exit code of 255, which we can ignore.

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -37,14 +37,15 @@ else
 fi
 
 reboot() {
-  # TODO come up with better log collection strategy.
-  # https://github.com/flutter/flutter/issues/57273
-  # echo "Dumping system logs..."
-
   ./fuchsia_ctl -d $device_name ssh \
        -c "log_listener --dump_logs yes" \
        --timeout-seconds $ssh_timeout_seconds \
-       --identity-file $pkey --log-file ${ISOLATED_OUTDIR}/log.txt
+       --identity-file $pkey --log-file fuchsia_log.txt
+  # As we are not using recipes we don't have a way to know the location
+  # to upload the log to isolated. We are saving the log to a file to avoid dart
+  # hanging when running the process and then just using printing the content to
+  # the console.
+  cat fuchsia_log.txt
 
   echo "$(date) START:REBOOT ------------------------------------------"
   # note: this will set an exit code of 255, which we can ignore.

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -38,14 +38,17 @@ fi
 
 reboot() {
   ./fuchsia_ctl -d $device_name ssh \
-       -c "log_listener --dump_logs yes" \
+       -c "log_listener --dump_logs yes --file /tmp/log.txt" \
        --timeout-seconds $ssh_timeout_seconds \
-       --identity-file $pkey --log-file fuchsia_log.txt
+       --identity-file $pkey
   # As we are not using recipes we don't have a way to know the location
   # to upload the log to isolated. We are saving the log to a file to avoid dart
   # hanging when running the process and then just using printing the content to
   # the console.
-  cat fuchsia_log.txt
+  ./fuchsia_ctl -d $device_name ssh \
+       -c "cat /tmp/log.txt" \
+       --timeout-seconds $ssh_timeout_seconds \
+       --identity-file $pkey
 
   echo "$(date) START:REBOOT ------------------------------------------"
   # note: this will set an exit code of 255, which we can ignore.

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -44,7 +44,7 @@ reboot() {
   ./fuchsia_ctl -d $device_name ssh \
        -c "log_listener --dump_logs yes" \
        --timeout-seconds $ssh_timeout_seconds \
-       --identity-file $pkey
+       --identity-file $pkey --log-file $3/log.txt
 
   echo "$(date) START:REBOOT ------------------------------------------"
   # note: this will set an exit code of 255, which we can ignore.

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -41,10 +41,10 @@ reboot() {
   # https://github.com/flutter/flutter/issues/57273
   # echo "Dumping system logs..."
 
-  # ./fuchsia_ctl -d $device_name ssh \
-  #     -c "log_listener --dump_logs yes" \
-  #     --timeout-seconds $ssh_timeout_seconds \
-  #     --identity-file $pkey
+  ./fuchsia_ctl -d $device_name ssh \
+       -c "log_listener --dump_logs yes" \
+       --timeout-seconds $ssh_timeout_seconds \
+       --identity-file $pkey
 
   echo "$(date) START:REBOOT ------------------------------------------"
   # note: this will set an exit code of 255, which we can ignore.


### PR DESCRIPTION
## Description

fuchsia_ctl was updated to support processing the logs as a stream
instead of keeping them in the process.

## Related Issues

  flutter/flutter#57273

## Tests

I added the following tests:

N/A tests were added on fuchsia_ctl

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
