### PR TITLE
[null-safety] update use of dot packages to package_config.json

### DIFF
--- a/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
@@ -23,7 +23,7 @@ template("generate_dart_profiler_symbols") {
 
     script = "dart_profiler_symbols.dart"
 
-    packages = rebase_path("//third_party/dart/.packages")
+    packages = rebase_path("//third_party/dart/.dart_tool/package_config.json")
 
     args = [
       "--nm",

--- a/tools/const_finder/BUILD.gn
+++ b/tools/const_finder/BUILD.gn
@@ -13,7 +13,6 @@ application_snapshot("const_finder") {
   inputs = [
     "bin/main.dart",
     "lib/const_finder.dart",
-    ".packages",
     ".dart_tool/package_config.json",
   ]
 

--- a/tools/fuchsia/dart_kernel.gni
+++ b/tools/fuchsia/dart_kernel.gni
@@ -21,7 +21,8 @@ template("dart_kernel") {
     gen_kernel_script = "//third_party/dart/pkg/vm/bin/gen_kernel.dart"
     platform_dill = "$root_out_dir/dart_runner_patched_sdk/platform_strong.dill"
 
-    dot_packages = rebase_path("//third_party/dart/.packages")
+    dot_packages =
+        rebase_path("//third_party/dart/.dart_tool/package_config.json")
 
     inputs = [
       platform_dill,


### PR DESCRIPTION
## Description

Work towards https://github.com/flutter/flutter/issues/60999

All usage of .packages must eventually be replace with package_config.json to support language versioning.