### PR TITLE
Fix loss of negative text selection ranges

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -214,14 +214,6 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
   return autofill == nil ? nil : autofill[@"uniqueIdentifier"];
 }
 
-// Read a signed integer from state into an unsigned integer. This is needed for
-// NSRange locations, which are unsigned integers, but are read in from signed
-// integers in state. These are -1 when there is no selection specified, but
-// they should be interpreted as 0 instead of overflowing.
-static NSUInteger readInt(NSInteger value) {
-  return value < 0 ? 0 : value;
-}
-
 #pragma mark - FlutterTextPosition
 
 @implementation FlutterTextPosition
@@ -342,8 +334,8 @@ static NSUInteger readInt(NSInteger value) {
     [self.text setString:newText];
   }
   BOOL needsEditingStateUpdate = textChanged;
-  NSUInteger composingBase = readInt([state[@"composingBase"] intValue]);
-  NSUInteger composingExtent = readInt([state[@"composingExtent"] intValue]);
+  NSInteger composingBase = [state[@"composingBase"] intValue];
+  NSInteger composingExtent = [state[@"composingExtent"] intValue];
   NSRange composingRange = [self clampSelection:NSMakeRange(MIN(composingBase, composingExtent),
                                                             ABS(composingBase - composingExtent))
                                         forText:self.text];
@@ -355,8 +347,8 @@ static NSUInteger readInt(NSInteger value) {
           : [newMarkedRange isEqualTo:(FlutterTextRange*)self.markedTextRange];
   self.markedTextRange = newMarkedRange;
 
-  NSUInteger selectionBase = readInt([state[@"selectionBase"] intValue]);
-  NSUInteger selectionExtent = readInt([state[@"selectionExtent"] intValue]);
+  NSInteger selectionBase = [state[@"selectionBase"] intValue];
+  NSInteger selectionExtent = [state[@"selectionExtent"] intValue];
   NSRange selectedRange = [self clampSelection:NSMakeRange(MIN(selectionBase, selectionExtent),
                                                            ABS(selectionBase - selectionExtent))
                                        forText:self.text];
@@ -365,7 +357,14 @@ static NSUInteger readInt(NSInteger value) {
       selectedRange.length != oldSelectedRange.length) {
     needsEditingStateUpdate = YES;
     [self.inputDelegate selectionWillChange:self];
-    [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:selectedRange]];
+    bool selectionBaseIsValid = selectionBase > 0 && selectionBase <= ((NSInteger)self.text.length);
+    bool selectionExtentIsValid =
+        selectionExtent > 0 && selectionExtent <= ((NSInteger)self.text.length);
+    if (selectionBaseIsValid && selectionExtentIsValid) {
+      [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:selectedRange]];
+    } else {
+      [self removeSelectedTextRangeLocal];
+    }
     _selectionAffinity = _kTextAffinityDownstream;
     if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
       _selectionAffinity = _kTextAffinityUpstream;
@@ -421,6 +420,13 @@ static NSUInteger readInt(NSInteger value) {
     }
     [oldSelectedRange release];
   }
+}
+
+// Clear the selected text range, without notifying the framework.
+- (void)removeSelectedTextRangeLocal {
+  UITextRange* oldSelectedRange = _selectedTextRange;
+  _selectedTextRange = nil;
+  [oldSelectedRange release];
 }
 
 - (void)setSelectedTextRange:(UITextRange*)selectedTextRange {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -214,6 +214,14 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
   return autofill == nil ? nil : autofill[@"uniqueIdentifier"];
 }
 
+// Read a signed integer from state into an unsigned integer. This is needed for
+// NSRange locations, which are unsigned integers, but are read in from signed
+// integers in state. These are -1 when there is no selection specified, but
+// they should be interpreted as 0 instead of overflowing.
+static NSUInteger readInt(NSInteger value) {
+  return value < 0 ? 0 : value;
+}
+
 #pragma mark - FlutterTextPosition
 
 @implementation FlutterTextPosition
@@ -334,8 +342,8 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
     [self.text setString:newText];
   }
   BOOL needsEditingStateUpdate = textChanged;
-  NSInteger composingBase = [state[@"composingBase"] intValue];
-  NSInteger composingExtent = [state[@"composingExtent"] intValue];
+  NSUInteger composingBase = readInt([state[@"composingBase"] intValue]);
+  NSUInteger composingExtent = readInt([state[@"composingExtent"] intValue]);
   NSRange composingRange = [self clampSelection:NSMakeRange(MIN(composingBase, composingExtent),
                                                             ABS(composingBase - composingExtent))
                                         forText:self.text];
@@ -347,8 +355,8 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
           : [newMarkedRange isEqualTo:(FlutterTextRange*)self.markedTextRange];
   self.markedTextRange = newMarkedRange;
 
-  NSInteger selectionBase = [state[@"selectionBase"] intValue];
-  NSInteger selectionExtent = [state[@"selectionExtent"] intValue];
+  NSUInteger selectionBase = readInt([state[@"selectionBase"] intValue]);
+  NSUInteger selectionExtent = readInt([state[@"selectionExtent"] intValue]);
   NSRange selectedRange = [self clampSelection:NSMakeRange(MIN(selectionBase, selectionExtent),
                                                            ABS(selectionBase - selectionExtent))
                                        forText:self.text];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -363,7 +363,7 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
     if (selectionBaseIsValid && selectionExtentIsValid) {
       [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:selectedRange]];
     } else {
-      [self removeSelectedTextRangeLocal];
+      [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 0)]];
     }
     _selectionAffinity = _kTextAffinityDownstream;
     if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
@@ -420,13 +420,6 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
     }
     [oldSelectedRange release];
   }
-}
-
-// Clear the selected text range, without notifying the framework.
-- (void)removeSelectedTextRangeLocal {
-  UITextRange* oldSelectedRange = _selectedTextRange;
-  _selectedTextRange = nil;
-  [oldSelectedRange release];
 }
 
 - (void)setSelectedTextRange:(UITextRange*)selectedTextRange {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -357,6 +357,12 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
       selectedRange.length != oldSelectedRange.length) {
     needsEditingStateUpdate = YES;
     [self.inputDelegate selectionWillChange:self];
+
+    // The state may contain an invalid selection, such as when no selection was
+    // explicitly set in the framework. This is handled here by setting the
+    // selection to (0,0). In contrast, Android handles this situation by
+    // clearing the selection, but the result in both cases is that the cursor
+    // is placed at the beginning of the field.
     bool selectionBaseIsValid = selectionBase > 0 && selectionBase <= ((NSInteger)self.text.length);
     bool selectionExtentIsValid =
         selectionExtent > 0 && selectionExtent <= ((NSInteger)self.text.length);
@@ -365,6 +371,7 @@ static NSString* uniqueIdFromDictionary(NSDictionary* dictionary) {
     } else {
       [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 0)]];
     }
+
     _selectionAffinity = _kTextAffinityDownstream;
     if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
       _selectionAffinity = _kTextAffinityUpstream;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -147,6 +147,26 @@ FLUTTER_ASSERT_ARC
   OCMReject([engine updateEditingClient:0 withState:[OCMArg any]]);
 }
 
+- (void)testUpdateEditingClientNegativeSelection {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
+  inputView.textInputDelegate = engine;
+
+  [inputView.text setString:@"SELECTION"];
+  inputView.markedTextRange = nil;
+  inputView.selectedTextRange = nil;
+
+  [inputView setTextInputState:@{
+    @"text" : @"SELECTION",
+    @"selectionBase" : @-1,
+    @"selectionExtent" : @-1
+  }];
+  OCMVerify([engine updateEditingClient:0
+                              withState:[OCMArg checkWithBlock:^BOOL(NSDictionary* state) {
+                                return ([state[@"selectionBase"] intValue]) == 0 &&
+                                       ([state[@"selectionExtent"] intValue] == 0);
+                              }]]);
+}
+
 - (void)testAutofillInputViews {
   NSDictionary* template = @{
     @"inputType" : @{@"name" : @"TextInuptType.text"},


### PR DESCRIPTION
## Description

In the framework, changing the value of a TextEditingController to something with a selection of (-1, -1) was coming back from the engine as (length, length).  This was because of improper handling of signed and unsigned integers.  The -1 was being interpreted as a very large unsigned integer, which was then clamped to the length of the string.

This PR fixes the problem by reading negative selection range values as zero.

## Related Issues

Related to https://github.com/flutter/flutter/issues/61282

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Breaking Change

This is unlikely to break anything unless there is an iOS-only app (Android behaves correctly) that relies on this broken behavior.