### PR TITLE
Check the return value of `GetWebGLContext`

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -125,6 +125,10 @@ class Surface {
       // anti-aliased by setting their `Paint` object's `antialias` property.
       js.JsObject.jsify({'antialias': 0}),
     ]);
+    if (glContext == 0) {
+      throw CanvasKitError('Could not create a WebGL context.');
+    }
+
     _grContext =
         canvasKit.callMethod('MakeGrContext', <dynamic>[glContext]);
 


### PR DESCRIPTION
## Description

Checks that we actually got a WebGL context from `GetWebGLContext`.

## Related Issues

This should provide a better error message for when we can't create a WebGL context. This may help debug this issue: https://github.com/flutter/devtools/issues/2125#issuecomment-659029127

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
