### PR TITLE
Makes IOS dispatch showOnCcreen action for header semantics nodes

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -452,7 +452,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 - (void)accessibilityElementDidBecomeFocused {
   if (![self isAccessibilityBridgeAlive])
     return;
-  if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden)) {
+  if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden) ||
+      [self node].HasFlag(flutter::SemanticsFlags::kIsHeader)) {
     [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
   }
   if ([self node].HasAction(flutter::SemanticsAction::kDidGainAccessibilityFocus)) {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -128,7 +128,7 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
 
 
-  // Handle initial setting of node with header
+  // Handle initial setting of node with header.
   flutter::SemanticsNode node;
   node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kIsHeader);
   node.label = "foo";
@@ -150,7 +150,7 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
 
 
-  // Handle initial setting of node with header
+  // Handle initial setting of node with hidden.
   flutter::SemanticsNode node;
   node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kIsHidden);
   node.label = "foo";

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -8,17 +8,36 @@ FLUTTER_ASSERT_ARC
 
 namespace flutter {
 namespace {
+
+class SemanticsActionObservation {
+ public:
+  SemanticsActionObservation(
+    int32_t observed_id,
+    SemanticsAction observed_action
+  ) : id(observed_id),
+      action(observed_action) { }
+
+  int32_t id;
+  SemanticsAction action;
+};
+
 class MockAccessibilityBridge : public AccessibilityBridgeIos {
  public:
-  MockAccessibilityBridge() { view_ = [[UIView alloc] init]; }
+  MockAccessibilityBridge() : observations({}) { view_ = [[UIView alloc] init]; }
   UIView* view() const override { return view_; }
   UIView<UITextInput>* textInputView() override { return nil; }
-  void DispatchSemanticsAction(int32_t id, SemanticsAction action) override {}
+  void DispatchSemanticsAction(int32_t id, SemanticsAction action) override {
+    SemanticsActionObservation observation(id, action);
+    observations.push_back(observation);
+  }
   void DispatchSemanticsAction(int32_t id,
                                SemanticsAction action,
-                               std::vector<uint8_t> args) override {}
+                               std::vector<uint8_t> args) override {
+    SemanticsActionObservation observation(id, action);
+    observations.push_back(observation);
+  }
   FlutterPlatformViewsController* GetPlatformViewsController() const override { return nil; }
-
+  std::vector<SemanticsActionObservation> observations;
  private:
   UIView* view_;
 };
@@ -100,6 +119,50 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   updatedNode.label = "foo";
   [object setSemanticsNode:&updatedNode];
   XCTAssertTrue([object nodeShouldTriggerAnnouncement:&node]);
+}
+
+- (void)testShouldDispatchShowOnScreenActionForHeader {
+  fml::WeakPtrFactory<flutter::MockAccessibilityBridge> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
+  SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
+
+
+  // Handle initial setting of node with header
+  flutter::SemanticsNode node;
+  node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kIsHeader);
+  node.label = "foo";
+
+  [object setSemanticsNode:&node];
+
+  // Simulate accessibility focus.
+  [object accessibilityElementDidBecomeFocused];
+
+  XCTAssertTrue(bridge->observations.size() == 1);
+  XCTAssertTrue(bridge->observations[0].id == 1);
+  XCTAssertTrue(bridge->observations[0].action == flutter::SemanticsAction::kShowOnScreen);
+}
+
+- (void)testShouldDispatchShowOnScreenActionForHidden {
+  fml::WeakPtrFactory<flutter::MockAccessibilityBridge> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
+  SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
+
+
+  // Handle initial setting of node with header
+  flutter::SemanticsNode node;
+  node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kIsHidden);
+  node.label = "foo";
+
+  [object setSemanticsNode:&node];
+
+  // Simulate accessibility focus.
+  [object accessibilityElementDidBecomeFocused];
+
+  XCTAssertTrue(bridge->observations.size() == 1);
+  XCTAssertTrue(bridge->observations[0].id == 1);
+  XCTAssertTrue(bridge->observations[0].action == flutter::SemanticsAction::kShowOnScreen);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -11,11 +11,8 @@ namespace {
 
 class SemanticsActionObservation {
  public:
-  SemanticsActionObservation(
-    int32_t observed_id,
-    SemanticsAction observed_action
-  ) : id(observed_id),
-      action(observed_action) { }
+  SemanticsActionObservation(int32_t observed_id, SemanticsAction observed_action)
+      : id(observed_id), action(observed_action) {}
 
   int32_t id;
   SemanticsAction action;
@@ -38,6 +35,7 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   }
   FlutterPlatformViewsController* GetPlatformViewsController() const override { return nil; }
   std::vector<SemanticsActionObservation> observations;
+
  private:
   UIView* view_;
 };
@@ -127,7 +125,6 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
   SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
 
-
   // Handle initial setting of node with header.
   flutter::SemanticsNode node;
   node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kIsHeader);
@@ -148,7 +145,6 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
       new flutter::MockAccessibilityBridge());
   fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
   SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
-
 
   // Handle initial setting of node with hidden.
   flutter::SemanticsNode node;


### PR DESCRIPTION
## Description
IOS relies on show on screen action to scroll the app during accessibility focus traversal. This pr makes sure the header always get scrolled if it is focused.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61360

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
