### PR TITLE
fuchsia: Allow setting thread-name

### DIFF
--- a/fml/thread.cc
+++ b/fml/thread.cc
@@ -10,6 +10,8 @@
 
 #if defined(OS_WIN)
 #include <windows.h>
+#elif defined(OS_FUCHSIA)
+#include <lib/zx/thread.h>
 #else
 #include <pthread.h>
 #endif
@@ -70,11 +72,11 @@ void Thread::SetCurrentThreadName(const std::string& name) {
   if (name == "") {
     return;
   }
-#if OS_MACOSX
+#if defined(OS_MACOSX)
   pthread_setname_np(name.c_str());
-#elif OS_LINUX || OS_ANDROID
+#elif defined(OS_LINUX) || defined(OS_ANDROID)
   pthread_setname_np(pthread_self(), name.c_str());
-#elif OS_WIN
+#elif defined(OS_WIN)
   THREADNAME_INFO info;
   info.dwType = 0x1000;
   info.szName = name.c_str();
@@ -85,6 +87,8 @@ void Thread::SetCurrentThreadName(const std::string& name) {
                    reinterpret_cast<DWORD_PTR*>(&info));
   } __except (EXCEPTION_CONTINUE_EXECUTION) {
   }
+#elif defined(OS_FUCHSIA)
+  zx::thread::self()->set_property(ZX_PROP_NAME, name.c_str(), name.size());
 #else
   FML_DLOG(INFO) << "Could not set the thread name to '" << name
                  << "' on this platform.";


### PR DESCRIPTION
This aids debugging a lot, and the log currently has errors about failing to set the names for various threads