### PR TITLE
FlRenderer cleanup in preperation for Wayland support

### DIFF
--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -93,11 +93,12 @@ gboolean fl_renderer_setup(FlRenderer* self, GError** error) {
   }
 
   if (!eglBindAPI(EGL_OPENGL_ES_API)) {
+    EGLint egl_error = eglGetError();  // must be before egl_config_to_string().
     g_autofree gchar* config_string =
         egl_config_to_string(priv->egl_display, priv->egl_config);
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
                 "Failed to bind EGL OpenGL ES API using configuration (%s): %s",
-                config_string, egl_error_to_string(eglGetError()));
+                config_string, egl_error_to_string(egl_error));
     return FALSE;
   }
 
@@ -136,11 +137,12 @@ gboolean fl_renderer_start(FlRenderer* self, GError** error) {
   priv->egl_surface = FL_RENDERER_GET_CLASS(self)->create_surface(
       self, priv->egl_display, priv->egl_config);
   if (priv->egl_surface == EGL_NO_SURFACE) {
+    EGLint egl_error = eglGetError();  // must be before egl_config_to_string().
     g_autofree gchar* config_string =
         egl_config_to_string(priv->egl_display, priv->egl_config);
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
                 "Failed to create EGL surface using configuration (%s): %s",
-                config_string, egl_error_to_string(eglGetError()));
+                config_string, egl_error_to_string(egl_error));
     return FALSE;
   }
 
@@ -148,11 +150,12 @@ gboolean fl_renderer_start(FlRenderer* self, GError** error) {
   priv->egl_context = eglCreateContext(priv->egl_display, priv->egl_config,
                                        EGL_NO_CONTEXT, context_attributes);
   if (priv->egl_context == EGL_NO_CONTEXT) {
+    EGLint egl_error = eglGetError();  // must be before egl_config_to_string().
     g_autofree gchar* config_string =
         egl_config_to_string(priv->egl_display, priv->egl_config);
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
                 "Failed to create EGL context using configuration (%s): %s",
-                config_string, egl_error_to_string(eglGetError()));
+                config_string, egl_error_to_string(egl_error));
     return FALSE;
   }
 

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -25,7 +25,7 @@ struct _FlView {
   FlDartProject* project;
 
   // Rendering output.
-  FlRendererX11* renderer;
+  FlRenderer* renderer;
 
   // Engine running @project.
   FlEngine* engine;
@@ -127,8 +127,8 @@ static void fl_view_plugin_registry_iface_init(
 static void fl_view_constructed(GObject* object) {
   FlView* self = FL_VIEW(object);
 
-  self->renderer = fl_renderer_x11_new();
-  self->engine = fl_engine_new(self->project, FL_RENDERER(self->renderer));
+  self->renderer = FL_RENDERER(fl_renderer_x11_new());
+  self->engine = fl_engine_new(self->project, self->renderer);
 
   // Create system channel handlers.
   FlBinaryMessenger* messenger = fl_engine_get_binary_messenger(self->engine);
@@ -203,7 +203,7 @@ static void fl_view_realize(GtkWidget* widget) {
   gtk_widget_set_realized(widget, TRUE);
 
   g_autoptr(GError) error = nullptr;
-  if (!fl_renderer_setup(FL_RENDERER(self->renderer), &error))
+  if (!fl_renderer_setup(self->renderer, &error))
     g_warning("Failed to setup renderer: %s", error->message);
 
   GtkAllocation allocation;
@@ -217,7 +217,7 @@ static void fl_view_realize(GtkWidget* widget) {
   window_attributes.height = allocation.height;
   window_attributes.wclass = GDK_INPUT_OUTPUT;
   window_attributes.visual = fl_renderer_get_visual(
-      FL_RENDERER(self->renderer), gtk_widget_get_screen(widget), nullptr);
+      self->renderer, gtk_widget_get_screen(widget), nullptr);
   window_attributes.event_mask =
       gtk_widget_get_events(widget) | GDK_EXPOSURE_MASK |
       GDK_POINTER_MOTION_MASK | GDK_BUTTON_PRESS_MASK |
@@ -233,7 +233,8 @@ static void fl_view_realize(GtkWidget* widget) {
   gtk_widget_set_window(widget, window);
 
   fl_renderer_x11_set_window(
-      self->renderer, GDK_X11_WINDOW(gtk_widget_get_window(GTK_WIDGET(self))));
+      FL_RENDERER_X11(self->renderer),
+      GDK_X11_WINDOW(gtk_widget_get_window(GTK_WIDGET(self))));
 
   if (!fl_engine_start(self->engine, &error))
     g_warning("Failed to start Flutter engine: %s", error->message);


### PR DESCRIPTION
## Description

Clean up some minor problems in `FlRenderer` in preparation for adding Wayland support.

- Fix a problem where some errors were incorrectly showing `EGL_SUCCESS`. A successful EGL call was being made between the failed call and the diagnostic message. This calls `eglGetError()` earlier to handle that.
- Make `FlRenderer` hold a generic `FlRenderer`, rather than a `FlRendererX11`
- Remove a `GError` that was being ignored anyway

## Related Issues

https://github.com/flutter/flutter/issues/57932
Piece of my previous PR: https://github.com/flutter/engine/pull/19736

## Tests

None

## Checklist

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
