### PR TITLE
[tonic] Log stack trace for unhandles exceptions

### DIFF
--- a/third_party/tonic/common/log.cc
+++ b/third_party/tonic/common/log.cc
@@ -22,8 +22,9 @@ void Log(const char* format, ...) {
   int result = vsnprintf(nullptr, 0, format, ap);
   va_end(ap);
 
-  if (result < 0)
+  if (result < 0) {
     return;
+  }
 
   int size = result + 1;
   std::unique_ptr<char[]> message(new char[size]);
@@ -31,8 +32,9 @@ void Log(const char* format, ...) {
   result = vsnprintf(message.get(), size, format, ap);
   va_end(ap);
 
-  if (result < 0)
+  if (result < 0) {
     return;
+  }
 
   if (log_handler) {
     log_handler(message.get());

--- a/third_party/tonic/logging/BUILD.gn
+++ b/third_party/tonic/logging/BUILD.gn
@@ -16,6 +16,7 @@ source_set("logging") {
 
   deps = [
     "../common",
+    "../converter",
   ]
 
   public_deps = [

--- a/third_party/tonic/logging/dart_error.cc
+++ b/third_party/tonic/logging/dart_error.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "tonic/logging/dart_error.h"
+#include "tonic/converter/dart_converter.h"
 
 #include "tonic/common/macros.h"
 
@@ -12,11 +13,18 @@ const char kInvalidArgument[] = "Invalid argument.";
 }  // namespace DartError
 
 bool LogIfError(Dart_Handle handle) {
-  if (Dart_IsError(handle)) {
+  if (Dart_IsUnhandledExceptionError(handle)) {
+    Dart_Handle stack_trace_handle = Dart_ErrorGetStackTrace(handle);
+    const std::string stack_trace =
+        tonic::StdStringFromDart(Dart_ToString(stack_trace_handle));
+    tonic::Log("Dart Unhandled Exception: %s", stack_trace.c_str());
+    return true;
+  } else if (Dart_IsError(handle)) {
     tonic::Log("Dart Error: %s", Dart_GetError(handle));
     return true;
+  } else {
+    return false;
   }
-  return false;
 }
 
 DartErrorHandleType GetErrorHandleType(Dart_Handle handle) {


### PR DESCRIPTION
Before this change, when we encounter an unhandles exception,
we see:

```
[00050.147083][37665][67367][klog] ERROR: [ERROR:flutter/shell/common/shell.cc(209)] Dart Error: Unhandled exception:
[00050.147087][37665][67367][klog] INFO: UnimplementedError
```

This doesn't help identify the root cause. Adding stack trace will help
the cause.