### PR TITLE
fix and re-enable SessionConnection unit tests

### DIFF
--- a/shell/platform/fuchsia/flutter/meta/flutter_runner_scenic_tests.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_runner_scenic_tests.cmx
@@ -14,6 +14,7 @@
       "fuchsia.sys.Environment",
       "fuchsia.sysmem.Allocator",
       "fuchsia.tracing.provider.Registry",
+      "fuchsia.ui.input.ImeService",
       "fuchsia.ui.policy.Presenter",
       "fuchsia.ui.scenic.Scenic",
       "fuchsia.vulkan.loader.Loader"

--- a/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
@@ -34,9 +34,20 @@ class SessionConnectionTest : public ::testing::Test {
     view_token_ = std::move(view_token);
 
     scenic_->CreateSession(session_.NewRequest(), session_listener_.Bind());
-    presenter_->PresentView(std::move(view_holder_token), nullptr);
+    presenter_->PresentOrReplaceView(std::move(view_holder_token), nullptr);
 
     FML_CHECK(zx::event::create(0, &vsync_event_) == ZX_OK);
+
+    // Ensure Scenic has had time to wake up before the test logic begins.
+    // TODO(61768) Find a better solution than sleeping periodically checking a condition.
+    int scenic_initialized = false;
+    scenic_->GetDisplayInfo(
+        [&scenic_initialized](fuchsia::ui::gfx::DisplayInfo display_info) {
+          scenic_initialized = true;
+        });
+    while (!scenic_initialized) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
   }
   // Warning: Initialization order matters here. |loop_| must be initialized
   // before |SetUp()| so that we have a dispatcher already initialized.

--- a/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/session_connection_unittests.cc
@@ -39,7 +39,8 @@ class SessionConnectionTest : public ::testing::Test {
     FML_CHECK(zx::event::create(0, &vsync_event_) == ZX_OK);
 
     // Ensure Scenic has had time to wake up before the test logic begins.
-    // TODO(61768) Find a better solution than sleeping periodically checking a condition.
+    // TODO(61768) Find a better solution than sleeping periodically checking a
+    // condition.
     int scenic_initialized = false;
     scenic_->GetDisplayInfo(
         [&scenic_initialized](fuchsia::ui::gfx::DisplayInfo display_info) {

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -194,7 +194,6 @@ echo "$(date) START:flutter_runner_tests ----------------------------"
     -f flutter_aot_runner-0.far    \
     -f flutter_runner_scenic_tests-0.far  \
     -t flutter_runner_scenic_tests \
-    -a "--gtest_filter=-SessionConnectionTest.*:CalculateNextLatchPointTest.*" \
     --identity-file $pkey \
     --timeout-seconds $test_timeout_seconds \
     --packages-directory packages


### PR DESCRIPTION
## Description

This change ensures Scenic is initialized before beginning the test
logic. This should fix the issue where the test starts running before or
during Scenic startup.

## Related Issues

https://github.com/flutter/flutter/issues/61463
