### PR TITLE
remove obsolete check on FlutterPlatformViewsController::OnCreate

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -916,6 +916,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlay
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -171,6 +171,7 @@ source_set("ios_test_flutter_mrc") {
   ]
   sources = [
     "framework/Source/FlutterEnginePlatformViewTest.mm",
+    "framework/Source/FlutterPlatformViewsTest.mm",
     "framework/Source/accessibility_bridge_test.mm",
   ]
   deps = [

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -122,15 +122,6 @@ void FlutterPlatformViewsController::OnMethodCall(FlutterMethodCall* call, Flutt
 }
 
 void FlutterPlatformViewsController::OnCreate(FlutterMethodCall* call, FlutterResult& result) {
-  if (!flutter_view_.get()) {
-    // Right now we assume we have a reference to FlutterView when creating a new view.
-    // TODO(amirh): support this by setting the reference to FlutterView when it becomes available.
-    // https://github.com/flutter/flutter/issues/23787
-    result([FlutterError errorWithCode:@"create_failed"
-                               message:@"can't create a view on a headless engine"
-                               details:nil]);
-    return;
-  }
   NSDictionary<NSString*, id>* args = [call arguments];
 
   long viewId = [args[@"id"] longValue];

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -272,6 +272,7 @@ PostPrerollResult FlutterPlatformViewsController::PostPrerollAction(
 void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(
     int view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
+  FML_DCHECK(flutter_view_);
   picture_recorders_[view_id] = std::make_unique<SkPictureRecorder>();
 
   auto rtree_factory = RTreeFactory();
@@ -398,6 +399,7 @@ void FlutterPlatformViewsController::ApplyMutators(const MutatorsStack& mutators
 
 void FlutterPlatformViewsController::CompositeWithParams(int view_id,
                                                          const EmbeddedViewParams& params) {
+  FML_DCHECK(flutter_view_);
   CGRect frame = CGRectMake(0, 0, params.sizePoints().width(), params.sizePoints().height());
   UIView* touchInterceptor = touch_interceptors_[view_id].get();
   touchInterceptor.layer.transform = CATransform3DIdentity;
@@ -420,6 +422,7 @@ void FlutterPlatformViewsController::CompositeWithParams(int view_id,
 }
 
 SkCanvas* FlutterPlatformViewsController::CompositeEmbeddedView(int view_id) {
+  FML_DCHECK(flutter_view_);
   // TODO(amirh): assert that this is running on the platform thread once we support the iOS
   // embedded views thread configuration.
 
@@ -463,6 +466,7 @@ SkRect FlutterPlatformViewsController::GetPlatformViewRect(int view_id) {
 bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
                                                  std::shared_ptr<IOSContext> ios_context,
                                                  std::unique_ptr<SurfaceFrame> frame) {
+  FML_DCHECK(flutter_view_);
   if (merge_threads_) {
     // Threads are about to be merged, we drop everything from this frame
     // and possibly resubmit the same layer tree in the next frame.
@@ -569,6 +573,7 @@ bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
 }
 
 void FlutterPlatformViewsController::BringLayersIntoView(LayersMap layer_map) {
+  FML_DCHECK(flutter_view_);
   UIView* flutter_view = flutter_view_.get();
   auto zIndex = 0;
   // Clear the `active_composition_order_`, which will be populated down below.
@@ -610,6 +615,7 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewsController::GetLay
     SkRect rect,
     int64_t view_id,
     int64_t overlay_id) {
+  FML_DCHECK(flutter_view_);
   std::shared_ptr<FlutterPlatformViewLayer> layer = layer_pool_->GetLayer(gr_context, ios_context);
 
   UIView* overlay_view_wrapper = layer->overlay_view_wrapper.get();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -272,7 +272,6 @@ PostPrerollResult FlutterPlatformViewsController::PostPrerollAction(
 void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(
     int view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
-  FML_DCHECK(flutter_view_);
   picture_recorders_[view_id] = std::make_unique<SkPictureRecorder>();
 
   auto rtree_factory = RTreeFactory();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -1,0 +1,146 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <XCTest/XCTest.h>
+
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
+#import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
+#import "third_party/ocmock/Source/OCMock/OCMock.h"
+
+FLUTTER_ASSERT_NOT_ARC
+@class FlutterPlatformViewsTestMockPlatformView;
+static FlutterPlatformViewsTestMockPlatformView* gMockPlatformView = nil;
+
+@interface FlutterPlatformViewsTestMockPlatformView : UIView
+@end
+@implementation FlutterPlatformViewsTestMockPlatformView
+
+- (instancetype)init {
+  self = [super init];
+  if (self) {
+    gMockPlatformView = self;
+  }
+  return self;
+}
+
+- (void)dealloc {
+  gMockPlatformView = nil;
+  [super dealloc];
+}
+
+@end
+
+@interface FlutterPlatformViewsTestMockFlutterPlatformView : NSObject <FlutterPlatformView>
+@property(nonatomic, strong) UIView* view;
+@end
+
+@implementation FlutterPlatformViewsTestMockFlutterPlatformView
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _view = [[FlutterPlatformViewsTestMockPlatformView alloc] init];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [_view release];
+  _view = nil;
+  [super dealloc];
+}
+
+@end
+
+@interface FlutterPlatformViewsTestMockFlutterPlatformFactory
+    : NSObject <FlutterPlatformViewFactory>
+@end
+
+@implementation FlutterPlatformViewsTestMockFlutterPlatformFactory
+- (NSObject<FlutterPlatformView>*)createWithFrame:(CGRect)frame
+                                   viewIdentifier:(int64_t)viewId
+                                        arguments:(id _Nullable)args {
+  return [[[FlutterPlatformViewsTestMockFlutterPlatformView alloc] init] autorelease];
+}
+
+@end
+
+namespace flutter {
+namespace {
+class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::Delegate {
+  void OnPlatformViewCreated(std::unique_ptr<Surface> surface) override {}
+  void OnPlatformViewDestroyed() override {}
+  void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) override {}
+  void OnPlatformViewSetViewportMetrics(const ViewportMetrics& metrics) override {}
+  void OnPlatformViewDispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) override {}
+  void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
+  }
+  void OnPlatformViewDispatchSemanticsAction(int32_t id,
+                                             SemanticsAction action,
+                                             std::vector<uint8_t> args) override {}
+  void OnPlatformViewSetSemanticsEnabled(bool enabled) override {}
+  void OnPlatformViewSetAccessibilityFeatures(int32_t flags) override {}
+  void OnPlatformViewRegisterTexture(std::shared_ptr<Texture> texture) override {}
+  void OnPlatformViewUnregisterTexture(int64_t texture_id) override {}
+  void OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) override {}
+
+  std::unique_ptr<std::vector<std::string>> ComputePlatformViewResolvedLocale(
+      const std::vector<std::string>& supported_locale_data) override {
+    std::unique_ptr<std::vector<std::string>> out = std::make_unique<std::vector<std::string>>();
+    return out;
+  }
+};
+
+}  // namespace
+}  // namespace flutter
+
+namespace {
+fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
+  auto thread = std::make_unique<fml::Thread>(name);
+  auto runner = thread->GetTaskRunner();
+  return runner;
+}
+}  // namespace
+
+@interface FlutterPlatformViewsTest : XCTestCase
+@end
+
+@implementation FlutterPlatformViewsTest
+
+- (void)testCanCreatePlatformViewWithoutFlutterView {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("FlutterPlatformViewsTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*task_runners=*/runners);
+
+  auto flutterPlatformViewsController = std::make_unique<flutter::FlutterPlatformViewsController>();
+
+  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
+      [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
+  flutterPlatformViewsController->RegisterViewFactory(
+      factory, @"MockFlutterPlatformView",
+      FlutterPlatformViewGestureRecognizersBlockingPolicyEager);
+  FlutterResult result = ^(id result) {
+  };
+  flutterPlatformViewsController->OnMethodCall(
+      [FlutterMethodCall
+          methodCallWithMethodName:@"create"
+                         arguments:@{@"id" : @2, @"viewType" : @"MockFlutterPlatformView"}],
+      result);
+
+  XCTAssertNotNil(gMockPlatformView);
+
+  flutterPlatformViewsController->Reset();
+}
+
+@end


### PR DESCRIPTION
## Description

When initially landed (https://github.com/flutter/engine/commit/92944f72fb4ea63fefb598efa79bef5aa8ca3f26), this check made sense. After https://github.com/flutter/engine/pull/9075 we no longer need to touch the flutter_view_ directly in OnCreate.

A recent change to lifecycle logic means that we sometimes get these calls (particularly on application relaunch for reasons I don't grasp) in different orders sometimes. Specifically, we no longer let `viewDidLayoutSubviews` create the surface _unless_ the application is active - and sometimes get to that point (it's called before applicationBecameActive).

I'm not able to make this fail in local app that actually calls it in this order. I have to think about how to test this.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/23787	
Fixes https://github.com/flutter/flutter/issues/61584

## Tests

I added the following tests:

Test that we can successfully create a platform view without a flutter_view_.
