### PR TITLE
Allow custom CanvasKit URL

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/initialization.dart
+++ b/lib/web_ui/lib/src/engine/compositor/initialization.dart
@@ -17,7 +17,10 @@ const bool canvasKitForceCpuOnly =
 /// When CanvasKit pushes a new release to NPM, update this URL to reflect the
 /// most recent version. For example, if CanvasKit releases version 0.34.0 to
 /// NPM, update this URL to `https://unpkg.com/canvaskit-wasm@0.34.0/bin/`.
-const String canvasKitBaseUrl = 'https://unpkg.com/canvaskit-wasm@0.16.2/bin/';
+const String canvasKitBaseUrl = String.fromEnvironment(
+  'FLUTTER_WEB_CANVASKIT_URL',
+  defaultValue: 'https://unpkg.com/canvaskit-wasm@0.16.2/bin/',
+);
 
 /// Initialize CanvasKit.
 ///


### PR DESCRIPTION
## Description

Allow custom CanvasKit URL via `FLUTTER_WEB_CANVASKIT_URL` environment variable.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/51424
Related to https://github.com/flutter/flutter/issues/61610
