### PR TITLE
Add CPU-only rendering mode for CanvasKit as a fallback

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/initialization.dart
+++ b/lib/web_ui/lib/src/engine/compositor/initialization.dart
@@ -9,6 +9,10 @@ part of engine;
 const bool experimentalUseSkia =
     bool.fromEnvironment('FLUTTER_WEB_USE_SKIA', defaultValue: false);
 
+// If set to true, forces CPU-only rendering (i.e. no WebGL).
+const bool canvasKitForceCpuOnly =
+    bool.fromEnvironment('FLUTTER_WEB_CANVASKIT_FORCE_CPU_ONLY', defaultValue: false);
+
 /// The URL to use when downloading the CanvasKit script and associated wasm.
 ///
 /// When CanvasKit pushes a new release to NPM, update this URL to reflect the

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -180,7 +180,7 @@ class Surface {
     if (_surface!.context != null) {
       canvasKit.callMethod('setCurrentContext', <int?>[_surface!.context]);
     }
-    _surface!.getCanvas().flush();
+    _surface!.flush();
     return true;
   }
 }
@@ -198,6 +198,11 @@ class CkSurface {
     return CkCanvas(
       _jsObjectWrapper.unwrapSkCanvas(skCanvas),
     );
+  }
+
+  /// Flushes the graphics to be rendered on screen.
+  void flush() {
+    _surface.callMethod('flush');
   }
 
   int? get context => _glContext;

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -127,14 +127,14 @@ class Surface {
       return _makeSoftwareCanvasSurface(htmlCanvas);
     } else {
       // Try WebGL first.
-      final int? glContext = canvasKit.callMethod('GetWebGLContext', <dynamic>[
+      final int glContext = canvasKit.callMethod('GetWebGLContext', <dynamic>[
         htmlCanvas,
         // Default to no anti-aliasing. Paint commands can be explicitly
         // anti-aliased by setting their `Paint` object's `antialias` property.
         js.JsObject.jsify({'antialias': 0}),
       ]);
 
-      if (glContext == null) {
+      if (glContext == 0) {
         return _makeSoftwareCanvasSurface(htmlCanvas);
       }
 
@@ -166,6 +166,7 @@ class Surface {
   }
 
   CkSurface _makeSoftwareCanvasSurface(html.CanvasElement htmlCanvas) {
+    print('WARNING: failed to initialize WebGL. Falling back to CPU-only rendering.');
     return CkSurface(
       canvasKit.callMethod('MakeSWCanvasSurface', <dynamic>[
         htmlCanvas,

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -142,7 +142,7 @@ class Surface {
           canvasKit.callMethod('MakeGrContext', <dynamic>[glContext]);
 
       if (_grContext == null) {
-        return _makeSoftwareCanvasSurface(htmlCanvas);
+        throw CanvasKitError('Failed to initialize CanvasKit. CanvasKit.MakeGrContext returned null.');
       }
 
       // Set the cache byte limit for this grContext, if not specified it will use
@@ -165,8 +165,13 @@ class Surface {
     }
   }
 
+  static bool _didWarnAboutWebGlInitializationFailure = false;
+
   CkSurface _makeSoftwareCanvasSurface(html.CanvasElement htmlCanvas) {
-    print('WARNING: failed to initialize WebGL. Falling back to CPU-only rendering.');
+    if (!_didWarnAboutWebGlInitializationFailure) {
+      html.window.console.warn('WARNING: failed to initialize WebGL. Falling back to CPU-only rendering.');
+      _didWarnAboutWebGlInitializationFailure = true;
+    }
     return CkSurface(
       canvasKit.callMethod('MakeSWCanvasSurface', <dynamic>[
         htmlCanvas,


### PR DESCRIPTION
## Description

Some browsers do not support WebGL. In that case fallback to CPU-only rendering mode, which is slower but consistent with the GPU version of CanvasKit.

## Related Issues

https://github.com/flutter/devtools/issues/2125
