### PR TITLE
[web] Cache line break property lookups

### DIFF
--- a/lib/web_ui/lib/src/engine/text/unicode_range.dart
+++ b/lib/web_ui/lib/src/engine/text/unicode_range.dart
@@ -107,7 +107,7 @@ int? getCodePoint(String text, int index) {
 /// has. The properties are then used to decide word boundaries, line break
 /// opportunities, etc.
 class UnicodePropertyLookup<P> {
-  const UnicodePropertyLookup(this.ranges, this.defaultProperty);
+  UnicodePropertyLookup(this.ranges, this.defaultProperty);
 
   /// Creates a [UnicodePropertyLookup] from packed line break data.
   factory UnicodePropertyLookup.fromPackedData(
@@ -129,6 +129,9 @@ class UnicodePropertyLookup<P> {
   /// known range.
   final P defaultProperty;
 
+  /// Cache for lookup results.
+  final Map<int, P> _cache = <int, P>{};
+
   /// Take a [text] and an [index], and returns the property of the character
   /// located at that [index].
   ///
@@ -147,8 +150,16 @@ class UnicodePropertyLookup<P> {
       return defaultProperty;
     }
 
+    final P? cacheHit = _cache[char];
+    if (cacheHit != null) {
+      return cacheHit;
+    }
+
     final int rangeIndex = _binarySearch(char);
-    return rangeIndex == -1 ? defaultProperty : ranges[rangeIndex].property;
+    final P result = rangeIndex == -1 ? defaultProperty : ranges[rangeIndex].property;
+    // Cache the result.
+    _cache[char] = result;
+    return result;
   }
 
   int _binarySearch(int value) {


### PR DESCRIPTION
## Description

The list of line break properties is really long, and even with binary search, it takes time to find the right property 

Performance gains in the `text_canvas_color_grid` benchmark:

- Text layout: ~12%
- Draw frame: 2%-3%

## Related Issues

- https://github.com/flutter/flutter/issues/59339

## Tests

Relying on the extensive tests in `test/text/line_breaker_test.dart` to ensure there are no regressions.