### PR TITLE
Remove suppression of null-related warnings

### DIFF
--- a/lib/web_ui/analysis_options.yaml
+++ b/lib/web_ui/analysis_options.yaml
@@ -12,8 +12,6 @@ analyzer:
     missing_required_param: warning
     missing_return: warning
     native_function_body_in_non_sdk_code: ignore
-    unnecessary_non_null_assertion: ignore
-    unnecessary_null_comparison: ignore
     todo: ignore
 
 linter:

--- a/lib/web_ui/lib/src/engine/compositor/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/compositor/path_metrics.dart
@@ -13,7 +13,7 @@ class CkPathMetrics extends IterableBase<ui.PathMetric>
 
   /// The [CkPath.isEmpty] case is special-cased to avoid booting the WASM machinery just to find out there are no contours.
   @override
-  Iterator<ui.PathMetric> get iterator => _path.isEmpty! ? const CkPathMetricIteratorEmpty._() : CkContourMeasureIter(_path, _forceClosed);
+  Iterator<ui.PathMetric> get iterator => _path.isEmpty ? const CkPathMetricIteratorEmpty._() : CkContourMeasureIter(_path, _forceClosed);
 }
 
 class CkContourMeasureIter implements Iterator<ui.PathMetric> {

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -161,7 +161,7 @@ class Surface {
         return _makeSoftwareCanvasSurface(htmlCanvas);
       }
 
-      return CkSurface(skSurface!, _grContext, glContext);
+      return CkSurface(skSurface, _grContext, glContext);
     }
   }
 


### PR DESCRIPTION
Since https://github.com/dart-lang/sdk/issues/41905 has closed,
this CL removes the suppression of unnecessary_non_null_assertion
and unnecessary_null_comparison. It also removes few unnecessary
null assertions that were not being reported.

## Related Issues

Original issue that has been resolved: dart-lang/sdk#41905

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [N/A] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [No change in test failures] No, no existing tests failed, so this is *not* a breaking change.
