### PR TITLE
Remove migrated format and lint steps from the cirrus file

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -111,14 +111,7 @@ task:
     - name: web_tests-3_last-linux # last Web shard must end with _last
       << : *WEB_SHARD_TEMPLATE
 
-    - name: format_and_dart_test
-      format_script: |
-        cd $ENGINE_PATH/src/flutter
-        ./ci/format.sh
+    - name: build_test
       build_script: |
         cd $ENGINE_PATH/src/flutter
         ./ci/build.sh
-    - name: lint_test
-      lint_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/ci/lint.sh


### PR DESCRIPTION
We migrated these steps yesterday, they are working without any issues in LUCI now:

https://ci.chromium.org/p/flutter/builders/prod/Linux%20Web%20Engine/968
https://ci.chromium.org/p/flutter/builders/prod/Linux%20Host%20Engine/6028

Fixes: https://github.com/flutter/flutter/issues/61654