### PR TITLE
[null-safety] fix isolate launch with --null_assertions

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -235,7 +235,7 @@ void _runMainZoned(Function startMainIsolateFunction,
     }, (Object error, StackTrace stackTrace) {
       _reportUnhandledException(error.toString(), stackTrace.toString());
     });
-  }, null);
+  }, args);
 }
 
 void _reportUnhandledException(String error, String stackTrace) native 'Window_reportUnhandledException';


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/61770

Currently _runMainZoned is passing `null` as the second argument to the startMainIsolateFunction. This is ultimately retrieved from isolate_patch.dart: https://github.com/dart-lang/sdk/blob/master/sdk/lib/_internal/vm/lib/isolate_patch.dart#L232

This function defines a non-null args, causing a null-assertion failure when hooks passes a null.