### PR TITLE
Fix failing Dart analyzer checks in the web UI tests

### DIFF
--- a/lib/web_ui/test/golden_tests/engine/linear_gradient_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/linear_gradient_golden_test.dart
@@ -19,8 +19,7 @@ void main() async {
 
   // Commit a recording canvas to a bitmap, and compare with the expected
   Future<void> _checkScreenshot(RecordingCanvas rc, String fileName,
-      {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
-        bool write = false}) async {
+      {Rect region = const Rect.fromLTWH(0, 0, 500, 500)}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
     rc.endRecording();
     rc.apply(engineCanvas, screenRect);

--- a/lib/web_ui/test/golden_tests/engine/path_metrics_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/path_metrics_test.dart
@@ -22,8 +22,7 @@ void main() async {
 
   // Commit a recording canvas to a bitmap, and compare with the expected
   Future<void> _checkScreenshot(RecordingCanvas rc, String fileName,
-      {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
-      bool write = false}) async {
+      {Rect region = const Rect.fromLTWH(0, 0, 500, 500)}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
     rc.endRecording();
     rc.apply(engineCanvas, screenRect);

--- a/lib/web_ui/test/golden_tests/engine/path_transform_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/path_transform_test.dart
@@ -20,8 +20,7 @@ void main() async {
   // Commit a recording canvas to a bitmap, and compare with the expected
   Future<void> _checkScreenshot(RecordingCanvas rc, String fileName,
       {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
-      double maxDiffRatePercent = null,
-      bool write = false}) async {
+      double maxDiffRatePercent = null}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
     rc.endRecording();
     rc.apply(engineCanvas, screenRect);


### PR DESCRIPTION
The "Linux Web Engine" LUCI builder is currently red due to errors in the "web engine analysis" step
