### PR TITLE
Fix invalid selection handling in text plugins

### DIFF
--- a/shell/platform/glfw/text_input_plugin.cc
+++ b/shell/platform/glfw/text_input_plugin.cc
@@ -187,9 +187,13 @@ void TextInputPlugin::HandleMethodCall(
                     "Selection base/extent values invalid.");
       return;
     }
-    active_model_->SetEditingState(selection_base->value.GetInt(),
-                                   selection_extent->value.GetInt(),
-                                   text->value.GetString());
+    // Flutter uses -1/-1 for invalid; translate that to 0/0 for the model.
+    int base = selection_base->value.GetInt();
+    int extent = selection_extent->value.GetInt();
+    if (base == -1 && extent == -1) {
+      base = extent = 0;
+    }
+    active_model_->SetEditingState(base, extent, text->value.GetString());
   } else {
     result->NotImplemented();
     return;

--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -4,11 +4,11 @@
 
 #include "flutter/shell/platform/linux/fl_text_input_plugin.h"
 
+#include <gtk/gtk.h>
+
 #include "flutter/shell/platform/common/cpp/text_input_model.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_json_method_codec.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_method_channel.h"
-
-#include <gtk/gtk.h>
 
 static constexpr char kChannelName[] = "flutter/textinput";
 
@@ -190,6 +190,10 @@ static FlMethodResponse* set_editing_state(FlTextInputPlugin* self,
       fl_value_get_int(fl_value_lookup_string(args, kSelectionBaseKey));
   int64_t selection_extent =
       fl_value_get_int(fl_value_lookup_string(args, kSelectionExtentKey));
+  // Flutter uses -1/-1 for invalid; translate that to 0/0 for the model.
+  if (selection_base == -1 && selection_extent == -1) {
+    selection_base = selection_extent = 0;
+  }
 
   self->text_model->SetEditingState(selection_base, selection_extent, text);
 

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -189,9 +189,13 @@ void TextInputPlugin::HandleMethodCall(
                     "Selection base/extent values invalid.");
       return;
     }
-    active_model_->SetEditingState(selection_base->value.GetInt(),
-                                   selection_extent->value.GetInt(),
-                                   text->value.GetString());
+    // Flutter uses -1/-1 for invalid; translate that to 0/0 for the model.
+    int base = selection_base->value.GetInt();
+    int extent = selection_extent->value.GetInt();
+    if (base == -1 && extent == -1) {
+      base = extent = 0;
+    }
+    active_model_->SetEditingState(base, extent, text->value.GetString());
   } else {
     result->NotImplemented();
     return;


### PR DESCRIPTION
## Description

The Windows, Linux, and GLFW embeddings (which all share a common code
ancestry) pass TextInput.setEditingState selection base and extents
straight through to the shared text model class. The model expects those
values to be valid, but the framework sends -1/-1 for "invalid"
selections, which happen for some empty text cases (e.g.,
TextFieldController.clear()).

This translates those invalid selection values to an empty selection at
the start of the string, as expected by the model.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/59140

## Tests

I added the following tests: None; test frameworks don't yet exist for this layer of the desktop embeddings.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
