### PR TITLE
[CanvasKit] Mark used SkPictures so they aren't deleted on the next frame.

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/canvas.dart
@@ -169,7 +169,7 @@ class CkCanvas {
   }
 
   void drawPicture(CkPicture picture) {
-    skCanvas.drawPicture(picture._skPicture);
+    skCanvas.drawPicture(picture.skiaObject.skiaObject);
   }
 
   void drawPoints(CkPaint paint, ui.PointMode pointMode,

--- a/lib/web_ui/lib/src/engine/compositor/picture.dart
+++ b/lib/web_ui/lib/src/engine/compositor/picture.dart
@@ -5,13 +5,11 @@
 part of engine;
 
 class CkPicture implements ui.Picture {
-  final SkPicture _skPicture;
-  final SkiaObject skiaObject;
+  final SkiaObject<SkPicture> skiaObject;
   final ui.Rect? cullRect;
 
   CkPicture(SkPicture picture, this.cullRect)
-    : _skPicture = picture,
-      skiaObject = SkPictureSkiaObject(picture);
+      : skiaObject = SkPictureSkiaObject(picture);
 
   @override
   int get approximateBytesUsed => 0;
@@ -23,7 +21,8 @@ class CkPicture implements ui.Picture {
 
   @override
   Future<ui.Image> toImage(int width, int height) {
-    throw UnsupportedError('Picture.toImage not yet implemented for CanvasKit and HTML');
+    throw UnsupportedError(
+        'Picture.toImage not yet implemented for CanvasKit and HTML');
   }
 }
 


### PR DESCRIPTION
## Description

Makes sure that whenever an `SkPicture` is used, we move it to the front of the cache so it isn't deleted when we clear the cache.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61886

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
