### PR TITLE
[web] Enable canvas measurement by default

### DIFF
--- a/lib/web_ui/lib/src/engine/web_experiments.dart
+++ b/lib/web_ui/lib/src/engine/web_experiments.dart
@@ -31,7 +31,7 @@ class WebExperiments {
 
   static const bool _defaultUseCanvasText = const bool.fromEnvironment(
     'FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_TEXT',
-    defaultValue: false,
+    defaultValue: true,
   );
 
   bool _useCanvasText = _defaultUseCanvasText;

--- a/lib/web_ui/test/engine/web_experiments_test.dart
+++ b/lib/web_ui/test/engine/web_experiments_test.dart
@@ -9,6 +9,8 @@ import 'dart:js_util' as js_util;
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 
+const bool _defaultUseCanvasText = true;
+
 void main() {
   setUp(() {
     WebExperiments.ensureInitialized();
@@ -19,7 +21,7 @@ void main() {
   });
 
   test('default web experiment values', () {
-    expect(WebExperiments.instance.useCanvasText, false);
+    expect(WebExperiments.instance.useCanvasText, _defaultUseCanvasText);
   });
 
   test('can turn on/off web experiments', () {
@@ -31,36 +33,36 @@ void main() {
 
     WebExperiments.instance.updateExperiment('useCanvasText', null);
     // Goes back to default value.
-    expect(WebExperiments.instance.useCanvasText, false);
+    expect(WebExperiments.instance.useCanvasText, _defaultUseCanvasText);
   });
 
   test('ignores unknown experiments', () {
-    expect(WebExperiments.instance.useCanvasText, false);
+    expect(WebExperiments.instance.useCanvasText, _defaultUseCanvasText);
     WebExperiments.instance.updateExperiment('foobarbazqux', true);
-    expect(WebExperiments.instance.useCanvasText, false);
+    expect(WebExperiments.instance.useCanvasText, _defaultUseCanvasText);
     WebExperiments.instance.updateExperiment('foobarbazqux', false);
-    expect(WebExperiments.instance.useCanvasText, false);
+    expect(WebExperiments.instance.useCanvasText, _defaultUseCanvasText);
   });
 
   test('can reset web experiments', () {
-    WebExperiments.instance.updateExperiment('useCanvasText', true);
+    WebExperiments.instance.updateExperiment('useCanvasText', false);
     WebExperiments.instance.reset();
-    expect(WebExperiments.instance.useCanvasText, false);
+    expect(WebExperiments.instance.useCanvasText, _defaultUseCanvasText);
 
-    WebExperiments.instance.updateExperiment('useCanvasText', true);
+    WebExperiments.instance.updateExperiment('useCanvasText', false);
     WebExperiments.instance.updateExperiment('foobarbazqux', true);
     WebExperiments.instance.reset();
-    expect(WebExperiments.instance.useCanvasText, false);
+    expect(WebExperiments.instance.useCanvasText, _defaultUseCanvasText);
   });
 
   test('js interop also works', () {
-    expect(WebExperiments.instance.useCanvasText, false);
+    expect(WebExperiments.instance.useCanvasText, _defaultUseCanvasText);
 
     expect(() => jsUpdateExperiment('useCanvasText', true), returnsNormally);
     expect(WebExperiments.instance.useCanvasText, true);
 
     expect(() => jsUpdateExperiment('useCanvasText', null), returnsNormally);
-    expect(WebExperiments.instance.useCanvasText, false);
+    expect(WebExperiments.instance.useCanvasText, _defaultUseCanvasText);
   });
 
   test('js interop throws on wrong type', () {

--- a/lib/web_ui/test/golden_tests/engine/scuba.dart
+++ b/lib/web_ui/test/golden_tests/engine/scuba.dart
@@ -116,8 +116,10 @@ void testEachCanvas(String description, CanvasTest body,
   test('$description (dom)', () {
     try {
       TextMeasurementService.initialize(rulerCacheCapacity: 2);
+      WebExperiments.instance.useCanvasText = false;
       return body(DomCanvas());
     } finally {
+      WebExperiments.instance.useCanvasText = null;
       TextMeasurementService.clearCache();
     }
   });
@@ -125,8 +127,10 @@ void testEachCanvas(String description, CanvasTest body,
     test('$description (houdini)', () {
       try {
         TextMeasurementService.initialize(rulerCacheCapacity: 2);
+        WebExperiments.instance.useCanvasText = false;
         return body(HoudiniCanvas(bounds));
       } finally {
+        WebExperiments.instance.useCanvasText = null;
         TextMeasurementService.clearCache();
       }
     });


### PR DESCRIPTION
## Description

Turn on canvas text measurement by default.

If, for any reason, one wants to opt-out, this is the flag to do it:
```
flutter run -d web-server --release --dart-define=FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_TEXT=false
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/33523
Fixes https://github.com/flutter/flutter/issues/45932
Fixes https://github.com/flutter/flutter/issues/53244
Fixes https://github.com/flutter/flutter/issues/55627
Fixes https://github.com/flutter/flutter/issues/60397

## Tests

There are many tests that cover this in:
- `test/text/measurement_test.dart`
- `test/paragraph_test.dart`