### PR TITLE
Update Dart to version 2.10

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -41,7 +41,7 @@ vars = {
   'dart_args_tag': '1.6.0',
   'dart_boringssl_gen_rev': '429ccb1877f7987a6f3988228bc2440e61293499',
   'dart_boringssl_rev': '4dfd5af70191b068aebe567b8e29ce108cee85ce',
-  'dart_collection_rev': '80f5b6de8a8d8d584732a71bb59912da3e44883b',
+  'dart_collection_rev': '583693680fc067e34ca5b72503df25e8b80579f9',
   'dart_dart2js_info_tag': '0.6.0',
   'dart_dart_style_tag': '1.3.6',
   'dart_http_retry_tag': '0.1.1',
@@ -49,7 +49,6 @@ vars = {
   'dart_intl_tag': '0.16.1',
   'dart_linter_tag': '0.1.117',
   'dart_oauth2_tag': '1.6.0',
-  'dart_pedantic_tag': 'v1.9.0',
   'dart_protobuf_rev': '3746c8fd3f2b0147623a8e3db89c3ff4330de760',
   'dart_pub_rev': '04b054b62cc437cf23451785fdc50e49cd9de139',
   'dart_pub_semver_tag': 'v1.4.4',
@@ -61,15 +60,13 @@ vars = {
   'dart_shelf_static_rev': 'v0.2.8',
   'dart_shelf_tag': '0.7.3+3',
   'dart_shelf_web_socket_tag': '0.2.2+3',
-  'dart_source_map_stack_trace_tag': '2.0.0',
-  'dart_source_span_tag': '1.7.0',
   'dart_sse_tag': 'e5cf68975e8e87171a3dc297577aa073454a91dc',
-  'dart_stack_trace_tag': '56811dbb2530d823b764fe167ec335879a4adb32',
+  'dart_stack_trace_tag': 'd3813ca0a77348e0faf0d6af0cc17913e36afa39',
   'dart_stagehand_tag': 'v3.3.9',
-  'dart_stream_channel_tag': '70433d577be02c48cb16d72d65654f3b4d82c6ed',
+  'dart_stream_channel_tag': 'c446774fd077c9bdbd6235a7aadc661ef60a9727',
   'dart_test_reflective_loader_tag': '0.1.9',
   'dart_tflite_native_rev': '3c777c40608a2a9f1427bfe0028ab48e7116b4c1',
-  'dart_typed_data_tag': '0c369b73a9b7ebf042c06512951bfe5b52b84a5f',
+  'dart_typed_data_tag': 'f94fc57b8e8c0e4fe4ff6cfd8290b94af52d3719',
   'dart_usage_tag': '3.4.0',
   'dart_watcher_rev': 'fc3c9aae5d31d707b3013b42634dde8d8a1161b4',
 
@@ -171,13 +168,13 @@ deps = {
    Var('dart_git') + '/args.git' + '@' + Var('dart_args_tag'),
 
   'src/third_party/dart/third_party/pkg/async':
-   Var('dart_git') + '/async.git@6b90f4557f330e1ead021f501ee7f1d8b0e77815',
+   Var('dart_git') + '/async.git@128c461a97dbdbd9336ba000ba5a5c02e79b8651',
 
   'src/third_party/dart/third_party/pkg/bazel_worker':
    Var('dart_git') + '/bazel_worker.git@26680d5e249b249c7216ab2fed0ac8ed4ee285c5',
 
   'src/third_party/dart/third_party/pkg/boolean_selector':
-   Var('dart_git') + '/boolean_selector.git@1309eabed510cc3b7536fd4367d39b97ebee3d69',
+   Var('dart_git') + '/boolean_selector.git@665e6921ab246569420376f827bff4585dff0b14',
 
   'src/third_party/dart/third_party/pkg/charcode':
    Var('dart_git') + '/charcode.git@af1e2d59a9c383da94f99ea51dac4b93fb0626c4',
@@ -207,7 +204,7 @@ deps = {
    Var('dart_git') + '/ffi.git@454ab0f9ea6bd06942a983238d8a6818b1357edb',
 
   'src/third_party/dart/third_party/pkg/fixnum':
-   Var('dart_git') + '/fixnum.git@9b38f49f6679654d66a363e69e48173cca07e882',
+   Var('dart_git') + '/fixnum.git@300c3f025e94a72b7b6770e15f76a4de15f77668',
 
   'src/third_party/dart/third_party/pkg/glob':
    Var('dart_git') + '/glob.git@e9f4e6b7ae8abe5071461cf8f47191bb19cf7ef6',
@@ -246,7 +243,7 @@ deps = {
    Var('dart_git') + '/markdown.git@dd150bb64c5f3b41d31f20f399ae2a855f7f8c00',
 
   'src/third_party/dart/third_party/pkg/matcher':
-   Var('dart_git') + '/matcher.git@8f8d965933c94a489b1a39e20d558a32841bfa5b',
+   Var('dart_git') + '/matcher.git@9cae8faa7868bf3a88a7ba45eb0bd128e66ac515',
 
   'src/third_party/dart/third_party/pkg/mime':
    Var('dart_git') + '/mime.git@179b5e6a88f4b63f36dc1b8fcbc1e83e5e0cd3a7',
@@ -261,13 +258,13 @@ deps = {
    Var('dart_git') + '/oauth2.git' + '@' + Var('dart_oauth2_tag'),
 
   'src/third_party/dart/third_party/pkg/path':
-   Var('dart_git') + '/path.git@4f3bb71843fe5493ba490828a1721821d7b33746',
+   Var('dart_git') + '/path.git@62ecd5a78ffe5734d14ed0df76d20309084cd04a',
 
   'src/third_party/dart/third_party/pkg/pedantic':
-   Var('dart_git') + '/pedantic.git' + '@' + Var('dart_pedantic_tag'),
+   Var('dart_git') + '/pedantic.git@24b38df72430d7e21cb4257828580becb9a39c72',
 
   'src/third_party/dart/third_party/pkg/pool':
-   Var('dart_git') + '/pool.git@86fbb2cde9bbc66c8d159909d2f65a5981ea5b50',
+   Var('dart_git') + '/pool.git@eedbd5fde84f9a1a8da643b475305a81841da599',
 
   'src/third_party/dart/third_party/pkg/protobuf':
    Var('dart_git') + '/protobuf.git' + '@' + Var('dart_protobuf_rev'),
@@ -300,13 +297,13 @@ deps = {
    Var('dart_git') + '/shelf_web_socket.git' + '@' + Var('dart_shelf_web_socket_tag'),
 
   'src/third_party/dart/third_party/pkg/source_map_stack_trace':
-   Var('dart_git') + '/source_map_stack_trace.git' + '@' + Var('dart_source_map_stack_trace_tag'),
+   Var('dart_git') + '/source_map_stack_trace.git@1c3026f69d9771acf2f8c176a1ab750463309cce',
 
   'src/third_party/dart/third_party/pkg/source_maps':
-   Var('dart_git') + '/source_maps.git@87b4fd9027378bbd51b02e9d7df794eee8a82b7a',
+   Var('dart_git') + '/source_maps.git@53eb92ccfe6e64924054f83038a534b959b12b3e',
 
   'src/third_party/dart/third_party/pkg/source_span':
-   Var('dart_git') + '/source_span.git' + '@' + Var('dart_source_span_tag'),
+   Var('dart_git') + '/source_span.git@94833d6cbf4552ebe5d2aa6714acecd93834e53a',
 
   'src/third_party/dart/third_party/pkg/sse':
    Var('dart_git') + '/sse.git' + '@' + Var('dart_sse_tag'),
@@ -321,13 +318,13 @@ deps = {
    Var('dart_git') + '/stream_channel.git' + '@' + Var('dart_stream_channel_tag'),
 
   'src/third_party/dart/third_party/pkg/string_scanner':
-   Var('dart_git') + '/string_scanner.git@a918e7371af6b6e73bfd534ff9da6084741c1f99',
+   Var('dart_git') + '/string_scanner.git@1b63e6e5db5933d7be0a45da6e1129fe00262734',
 
   'src/third_party/dart/third_party/pkg/term_glyph':
-   Var('dart_git') + '/term_glyph.git@b3da31e9684a99cfe5f192b89914492018b44da7',
+   Var('dart_git') + '/term_glyph.git@6a0f9b6fb645ba75e7a00a4e20072678327a0347',
 
   'src/third_party/dart/third_party/pkg/test':
-   Var('dart_git') + '/test.git@718fe6f93c4655208460f28e89d887c5ef4144c5',
+   Var('dart_git') + '/test.git@c6b3fe63eda87da1687580071cad1eefd575f851',
 
   'src/third_party/dart/third_party/pkg/test_reflective_loader':
    Var('dart_git') + '/test_reflective_loader.git' + '@' + Var('dart_test_reflective_loader_tag'),
@@ -357,7 +354,7 @@ deps = {
    Var('dart_git') + '/package_config.git@9c586d04bd26fef01215fd10e7ab96a3050cfa64',
 
   'src/third_party/dart/tools/sdks':
-   {'packages': [{'version': 'version:2.9.0-21.0.dev', 'package': 'dart/dart-sdk/${{platform}}'}], 'dep_type': 'cipd'},
+   {'packages': [{'version': 'version:2.10.0-0.2-preview', 'package': 'dart/dart-sdk/${{platform}}'}], 'dep_type': 'cipd'},
 
   # WARNING: end of dart dependencies list that is cleaned up automatically - see create_updated_flutter_deps.py.
 

--- a/lib/ui/annotations.dart
+++ b/lib/ui/annotations.dart
@@ -4,7 +4,7 @@
 
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -4,7 +4,7 @@
 
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/isolate_name_server.dart
+++ b/lib/ui/isolate_name_server.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/lerp.dart
+++ b/lib/ui/lerp.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -4,7 +4,7 @@
 
 // TODO(dnfield): remove unused_element ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/plugins.dart
+++ b/lib/ui/plugins.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -9,7 +9,7 @@
 /// This library exposes the lowest-level services that Flutter frameworks use
 /// to bootstrap applications, such as classes for driving the input, graphics
 /// text, layout, and rendering subsystems.
-// @dart = 2.9
+// @dart = 2.10
 library dart.ui;
 
 import 'dart:_internal' hide Symbol; // ignore: unused_import

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of dart.ui;
 
 /// Signature of callbacks that have no arguments and return no data.

--- a/lib/web_ui/lib/src/ui/annotations.dart
+++ b/lib/web_ui/lib/src/ui/annotations.dart
@@ -4,7 +4,7 @@
 
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 // TODO(dnfield): Update this if/when we default this to on in the tool,

--- a/lib/web_ui/lib/src/ui/canvas.dart
+++ b/lib/web_ui/lib/src/ui/canvas.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// Defines how a list of points is interpreted when drawing a set of points.

--- a/lib/web_ui/lib/src/ui/channel_buffers.dart
+++ b/lib/web_ui/lib/src/ui/channel_buffers.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// A saved platform message for a channel with its callback.

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// An opaque object representing a composited scene.

--- a/lib/web_ui/lib/src/ui/geometry.dart
+++ b/lib/web_ui/lib/src/ui/geometry.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// Base class for [Size] and [Offset], which are both ways to describe

--- a/lib/web_ui/lib/src/ui/hash_codes.dart
+++ b/lib/web_ui/lib/src/ui/hash_codes.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 class _HashEnd { const _HashEnd(); }

--- a/lib/web_ui/lib/src/ui/initialization.dart
+++ b/lib/web_ui/lib/src/ui/initialization.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// Initializes the platform.

--- a/lib/web_ui/lib/src/ui/lerp.dart
+++ b/lib/web_ui/lib/src/ui/lerp.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// Linearly interpolate between two numbers.

--- a/lib/web_ui/lib/src/ui/natives.dart
+++ b/lib/web_ui/lib/src/ui/natives.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 // Corelib 'print' implementation.

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 // ignore: unused_element, Used in Shader assert.

--- a/lib/web_ui/lib/src/ui/path.dart
+++ b/lib/web_ui/lib/src/ui/path.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// A complex, one-dimensional subset of a plane.

--- a/lib/web_ui/lib/src/ui/path_metrics.dart
+++ b/lib/web_ui/lib/src/ui/path_metrics.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// An iterable collection of [PathMetric] objects describing a [Path].

--- a/lib/web_ui/lib/src/ui/pointer.dart
+++ b/lib/web_ui/lib/src/ui/pointer.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// How the pointer has changed since the last report.

--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// The possible actions that can be conveyed from the operating system

--- a/lib/web_ui/lib/src/ui/test_embedding.dart
+++ b/lib/web_ui/lib/src/ui/test_embedding.dart
@@ -4,7 +4,7 @@
 
 // TODO(flutter_web): the Web-only API below need to be cleaned up.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// Used to track when the platform is initialized. This ensures the test fonts

--- a/lib/web_ui/lib/src/ui/text.dart
+++ b/lib/web_ui/lib/src/ui/text.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 // Synced 2019-05-30T14:20:57.833907.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// Whether to slant the glyphs in the font

--- a/lib/web_ui/lib/src/ui/tile_mode.dart
+++ b/lib/web_ui/lib/src/ui/tile_mode.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// Defines what happens at the edge of the gradient.

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 // Synced 2019-05-30T14:20:57.841444.
 
-// @dart = 2.9
+// @dart = 2.10
 part of ui;
 
 /// Signature of callbacks that have no arguments and return no data.

--- a/lib/web_ui/lib/ui.dart
+++ b/lib/web_ui/lib/ui.dart
@@ -5,7 +5,7 @@
 /// This library defines the web equivalent of the native dart:ui.
 ///
 /// All types in this library are public.
-// @dart = 2.9
+// @dart = 2.10
 library ui;
 
 import 'dart:async';

--- a/tools/const_finder/.dart_tool/package_config.json
+++ b/tools/const_finder/.dart_tool/package_config.json
@@ -17,7 +17,7 @@
       "name": "meta",
       "rootUri": "../../../../third_party/dart/pkg/meta",
       "packageUri": "lib",
-      "languageVersion": "2.9"
+      "languageVersion": "2.10"
     },
     {
       "name": "args",
@@ -29,7 +29,7 @@
       "name": "path",
       "rootUri": "../../../../third_party/dart/third_party/pkg/path",
       "packageUri": "lib",
-      "languageVersion": "2.0"
+      "languageVersion": "2.10"
     }
   ]
 }


### PR DESCRIPTION
Null-safety for opted-in packages is now triggered by language
version 2.10, not language version 2.9

## Description

These are the patches that will be needed when rolling Dart in Flutter engine, since Dart has
now changed its version to 2.10.  This PR should be a resource for whoever is doing the roll.
It should not be landed prior to doing the roll.
I am a Google employee, so the CLA is not needed/automatically signed.
