### PR TITLE
Use the GrDirectContext factories instead of deprecated GrContext ones

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -31,7 +31,7 @@ void CompositorContext::EndFrame(ScopedFrame& frame,
 }
 
 std::unique_ptr<CompositorContext::ScopedFrame> CompositorContext::AcquireFrame(
-    GrContext* gr_context,
+    GrDirectContext* gr_context,
     SkCanvas* canvas,
     ExternalViewEmbedder* view_embedder,
     const SkMatrix& root_surface_transformation,
@@ -45,7 +45,7 @@ std::unique_ptr<CompositorContext::ScopedFrame> CompositorContext::AcquireFrame(
 
 CompositorContext::ScopedFrame::ScopedFrame(
     CompositorContext& context,
-    GrContext* gr_context,
+    GrDirectContext* gr_context,
     SkCanvas* canvas,
     ExternalViewEmbedder* view_embedder,
     const SkMatrix& root_surface_transformation,

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -15,7 +15,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/raster_thread_merger.h"
 #include "third_party/skia/include/core/SkCanvas.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -40,7 +40,7 @@ class CompositorContext {
   class ScopedFrame {
    public:
     ScopedFrame(CompositorContext& context,
-                GrContext* gr_context,
+                GrDirectContext* gr_context,
                 SkCanvas* canvas,
                 ExternalViewEmbedder* view_embedder,
                 const SkMatrix& root_surface_transformation,
@@ -62,14 +62,14 @@ class CompositorContext {
 
     bool surface_supports_readback() { return surface_supports_readback_; }
 
-    GrContext* gr_context() const { return gr_context_; }
+    GrDirectContext* gr_context() const { return gr_context_; }
 
     virtual RasterStatus Raster(LayerTree& layer_tree,
                                 bool ignore_raster_cache);
 
    private:
     CompositorContext& context_;
-    GrContext* gr_context_;
+    GrDirectContext* gr_context_;
     SkCanvas* canvas_;
     ExternalViewEmbedder* view_embedder_;
     const SkMatrix& root_surface_transformation_;
@@ -85,7 +85,7 @@ class CompositorContext {
   virtual ~CompositorContext();
 
   virtual std::unique_ptr<ScopedFrame> AcquireFrame(
-      GrContext* gr_context,
+      GrDirectContext* gr_context,
       SkCanvas* canvas,
       ExternalViewEmbedder* view_embedder,
       const SkMatrix& root_surface_transformation,

--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -6,7 +6,7 @@
 
 namespace flutter {
 
-void ExternalViewEmbedder::SubmitFrame(GrContext* context,
+void ExternalViewEmbedder::SubmitFrame(GrDirectContext* context,
                                        std::unique_ptr<SurfaceFrame> frame) {
   frame->Submit();
 };

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -268,7 +268,7 @@ class ExternalViewEmbedder {
 
   virtual void BeginFrame(
       SkISize frame_size,
-      GrContext* context,
+      GrDirectContext* context,
       double device_pixel_ratio,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) = 0;
 
@@ -295,7 +295,7 @@ class ExternalViewEmbedder {
   // This method can mutate the root Skia canvas before submitting the frame.
   //
   // It can also allocate frames for overlay surfaces to compose hybrid views.
-  virtual void SubmitFrame(GrContext* context,
+  virtual void SubmitFrame(GrDirectContext* context,
                            std::unique_ptr<SurfaceFrame> frame);
 
   // This method provides the embedder a way to do additional tasks after

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -44,7 +44,7 @@ enum Clip { none, hardEdge, antiAlias, antiAliasWithSaveLayer };
 
 struct PrerollContext {
   RasterCache* raster_cache;
-  GrContext* gr_context;
+  GrDirectContext* gr_context;
   ExternalViewEmbedder* view_embedder;
   MutatorsStack& mutators_stack;
   SkColorSpace* dst_color_space;
@@ -121,7 +121,7 @@ class Layer {
     // layers.
     SkCanvas* internal_nodes_canvas;
     SkCanvas* leaf_nodes_canvas;
-    GrContext* gr_context;
+    GrDirectContext* gr_context;
     ExternalViewEmbedder* view_embedder;
     const Stopwatch& raster_time;
     const Stopwatch& ui_time;

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -15,7 +15,7 @@
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -89,7 +89,7 @@ static bool IsPictureWorthRasterizing(SkPicture* picture,
 
 /// @note Procedure doesn't copy all closures.
 static std::unique_ptr<RasterCacheResult> Rasterize(
-    GrContext* context,
+    GrDirectContext* context,
     const SkMatrix& ctm,
     SkColorSpace* dst_color_space,
     bool checkerboard,
@@ -126,7 +126,7 @@ static std::unique_ptr<RasterCacheResult> Rasterize(
 
 std::unique_ptr<RasterCacheResult> RasterCache::RasterizePicture(
     SkPicture* picture,
-    GrContext* context,
+    GrDirectContext* context,
     const SkMatrix& ctm,
     SkColorSpace* dst_color_space,
     bool checkerboard) const {
@@ -177,7 +177,7 @@ std::unique_ptr<RasterCacheResult> RasterCache::RasterizeLayer(
       });
 }
 
-bool RasterCache::Prepare(GrContext* context,
+bool RasterCache::Prepare(GrDirectContext* context,
                           SkPicture* picture,
                           const SkMatrix& transformation_matrix,
                           SkColorSpace* dst_color_space,

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -72,7 +72,7 @@ class RasterCache {
    */
   virtual std::unique_ptr<RasterCacheResult> RasterizePicture(
       SkPicture* picture,
-      GrContext* context,
+      GrDirectContext* context,
       const SkMatrix& ctm,
       SkColorSpace* dst_color_space,
       bool checkerboard) const;
@@ -134,7 +134,7 @@ class RasterCache {
   // 3. The picture is accessed too few times
   // 4. There are too many pictures to be cached in the current frame.
   //    (See also kDefaultPictureCacheLimitPerFrame.)
-  bool Prepare(GrContext* context,
+  bool Prepare(GrDirectContext* context,
                SkPicture* picture,
                const SkMatrix& transformation_matrix,
                SkColorSpace* dst_color_space,

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -214,7 +214,7 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
   // |ExternalViewEmbedder|
   void BeginFrame(
       SkISize frame_size,
-      GrContext* context,
+      GrDirectContext* context,
       double device_pixel_ratio,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override {}
 

--- a/flow/skia_gpu_object.h
+++ b/flow/skia_gpu_object.h
@@ -12,7 +12,7 @@
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/task_runner.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -37,7 +37,7 @@ class SkiaUnrefQueue : public fml::RefCountedThreadSafe<SkiaUnrefQueue> {
   bool drain_pending_;
   fml::WeakPtr<GrContext> context_;
 
-  // The `GrContext* context` is only used for signaling Skia to
+  // The `GrDirectContext* context` is only used for signaling Skia to
   // performDeferredCleanup. It can be nullptr when such signaling is not needed
   // (e.g., in unit tests).
   SkiaUnrefQueue(fml::RefPtr<fml::TaskRunner> task_runner,

--- a/flow/surface.h
+++ b/flow/surface.h
@@ -27,7 +27,7 @@ class Surface {
 
   virtual SkMatrix GetRootTransformation() const = 0;
 
-  virtual GrContext* GetContext() = 0;
+  virtual GrDirectContext* GetContext() = 0;
 
   virtual flutter::ExternalViewEmbedder* GetExternalViewEmbedder();
 

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -15,7 +15,7 @@ MockRasterCacheResult::MockRasterCacheResult(SkIRect device_rect)
 
 std::unique_ptr<RasterCacheResult> MockRasterCache::RasterizePicture(
     SkPicture* picture,
-    GrContext* context,
+    GrDirectContext* context,
     const SkMatrix& ctm,
     SkColorSpace* dst_color_space,
     bool checkerboard) const {

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -46,7 +46,7 @@ class MockRasterCache : public RasterCache {
  public:
   std::unique_ptr<RasterCacheResult> RasterizePicture(
       SkPicture* picture,
-      GrContext* context,
+      GrDirectContext* context,
       const SkMatrix& ctm,
       SkColorSpace* dst_color_space,
       bool checkerboard) const override;

--- a/flow/testing/mock_texture.cc
+++ b/flow/testing/mock_texture.cc
@@ -12,7 +12,7 @@ MockTexture::MockTexture(int64_t textureId) : Texture(textureId) {}
 void MockTexture::Paint(SkCanvas& canvas,
                         const SkRect& bounds,
                         bool freeze,
-                        GrContext* context,
+                        GrDirectContext* context,
                         SkFilterQuality filter_quality) {
   paint_calls_.emplace_back(
       PaintCall{canvas, bounds, freeze, context, filter_quality});

--- a/flow/testing/mock_texture.h
+++ b/flow/testing/mock_texture.h
@@ -20,7 +20,7 @@ class MockTexture : public Texture {
     SkCanvas& canvas;
     SkRect bounds;
     bool freeze;
-    GrContext* context;
+    GrDirectContext* context;
     SkFilterQuality filter_quality;
   };
 
@@ -30,7 +30,7 @@ class MockTexture : public Texture {
   void Paint(SkCanvas& canvas,
              const SkRect& bounds,
              bool freeze,
-             GrContext* context,
+             GrDirectContext* context,
              SkFilterQuality filter_quality) override;
 
   void OnGrContextCreated() override { gr_context_created_ = true; }

--- a/flow/texture.h
+++ b/flow/texture.h
@@ -11,6 +11,8 @@
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 
+class GrDirectContext;
+
 namespace flutter {
 
 class Texture {
@@ -22,7 +24,7 @@ class Texture {
   virtual void Paint(SkCanvas& canvas,
                      const SkRect& bounds,
                      bool freeze,
-                     GrContext* context,
+                     GrDirectContext* context,
                      SkFilterQuality quality) = 0;
 
   // Called from raster thread.

--- a/lib/ui/io_manager.h
+++ b/lib/ui/io_manager.h
@@ -8,19 +8,19 @@
 #include "flutter/flow/skia_gpu_object.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/synchronization/sync_switch.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
-// Interface for methods that manage access to the resource GrContext and Skia
-// unref queue.  Meant to be implemented by the owner of the resource GrContext,
-// i.e. the shell's IOManager.
+// Interface for methods that manage access to the resource GrDirectContext and
+// Skia unref queue.  Meant to be implemented by the owner of the resource
+// GrDirectContext, i.e. the shell's IOManager.
 class IOManager {
  public:
   virtual ~IOManager() = default;
 
   virtual fml::WeakPtr<IOManager> GetWeakIOManager() const = 0;
 
-  virtual fml::WeakPtr<GrContext> GetResourceContext() const = 0;
+  virtual fml::WeakPtr<GrDirectContext> GetResourceContext() const = 0;
 
   virtual fml::RefPtr<flutter::SkiaUnrefQueue> GetSkiaUnrefQueue() const = 0;
 

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -28,9 +28,10 @@ class TestIOManager final : public IOManager {
       : gl_surface_(SkISize::Make(1, 1)),
         gl_context_(has_gpu_context ? gl_surface_.CreateGrContext() : nullptr),
         weak_gl_context_factory_(
-            has_gpu_context ? std::make_unique<fml::WeakPtrFactory<GrContext>>(
-                                  gl_context_.get())
-                            : nullptr),
+            has_gpu_context
+                ? std::make_unique<fml::WeakPtrFactory<GrDirectContext>>(
+                      gl_context_.get())
+                : nullptr),
         unref_queue_(fml::MakeRefCounted<SkiaUnrefQueue>(
             task_runner,
             fml::TimeDelta::FromNanoseconds(0))),
@@ -59,9 +60,9 @@ class TestIOManager final : public IOManager {
   }
 
   // |IOManager|
-  fml::WeakPtr<GrContext> GetResourceContext() const override {
+  fml::WeakPtr<GrDirectContext> GetResourceContext() const override {
     return weak_gl_context_factory_ ? weak_gl_context_factory_->GetWeakPtr()
-                                    : fml::WeakPtr<GrContext>{};
+                                    : fml::WeakPtr<GrDirectContext>{};
   }
 
   // |IOManager|
@@ -79,8 +80,9 @@ class TestIOManager final : public IOManager {
 
  private:
   TestGLSurface gl_surface_;
-  sk_sp<GrContext> gl_context_;
-  std::unique_ptr<fml::WeakPtrFactory<GrContext>> weak_gl_context_factory_;
+  sk_sp<GrDirectContext> gl_context_;
+  std::unique_ptr<fml::WeakPtrFactory<GrDirectContext>>
+      weak_gl_context_factory_;
   fml::RefPtr<SkiaUnrefQueue> unref_queue_;
   fml::WeakPtr<TestIOManager> weak_prototype_;
   fml::RefPtr<fml::TaskRunner> runner_;

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -54,7 +54,7 @@ void InvokeDataCallback(std::unique_ptr<DartPersistentValue> callback,
 
 sk_sp<SkImage> ConvertToRasterUsingResourceContext(
     sk_sp<SkImage> image,
-    GrContext* resource_context) {
+    GrDirectContext* resource_context) {
   sk_sp<SkSurface> surface;
   SkImageInfo surface_info = SkImageInfo::MakeN32Premul(image->dimensions());
   if (resource_context) {
@@ -86,7 +86,7 @@ void ConvertImageToRaster(sk_sp<SkImage> image,
                           std::function<void(sk_sp<SkImage>)> encode_task,
                           fml::RefPtr<fml::TaskRunner> raster_task_runner,
                           fml::RefPtr<fml::TaskRunner> io_task_runner,
-                          GrContext* resource_context,
+                          GrDirectContext* resource_context,
                           fml::WeakPtr<SnapshotDelegate> snapshot_delegate) {
   // Check validity of the image.
   if (image == nullptr) {
@@ -213,7 +213,7 @@ void EncodeImageAndInvokeDataCallback(
     fml::RefPtr<fml::TaskRunner> ui_task_runner,
     fml::RefPtr<fml::TaskRunner> raster_task_runner,
     fml::RefPtr<fml::TaskRunner> io_task_runner,
-    GrContext* resource_context,
+    GrDirectContext* resource_context,
     fml::WeakPtr<SnapshotDelegate> snapshot_delegate) {
   auto callback_task = fml::MakeCopyable(
       [callback = std::move(callback)](sk_sp<SkData> encoded) mutable {

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -20,7 +20,7 @@
 #include "flutter/lib/ui/painting/image_decoder.h"
 #include "flutter/lib/ui/snapshot_delegate.h"
 #include "third_party/dart/runtime/include/dart_api.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/tonic/dart_microtask_queue.h"
 #include "third_party/tonic/dart_persistent_value.h"
 #include "third_party/tonic/dart_state.h"

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -14,7 +14,7 @@
 #include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/viewport_metrics.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/tonic/dart_persistent_value.h"
 
 namespace tonic {

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -82,7 +82,7 @@ void PlatformView::NotifyDestroyed() {
   delegate_.OnPlatformViewDestroyed();
 }
 
-sk_sp<GrContext> PlatformView::CreateResourceContext() const {
+sk_sp<GrDirectContext> PlatformView::CreateResourceContext() const {
   FML_DLOG(WARNING) << "This platform does not setup the resource "
                        "context on the IO thread for async texture uploads.";
   return nullptr;

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -21,7 +21,7 @@
 #include "flutter/shell/common/pointer_data_dispatcher.h"
 #include "flutter/shell/common/vsync_waiter.h"
 #include "third_party/skia/include/core/SkSize.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -427,7 +427,7 @@ class PlatformView {
   ///             main render thread GPU context. May be `nullptr` in case such
   ///             a context cannot be created.
   ///
-  virtual sk_sp<GrContext> CreateResourceContext() const;
+  virtual sk_sp<GrDirectContext> CreateResourceContext() const;
 
   //----------------------------------------------------------------------------
   /// @brief      Used by the shell to notify the embedder that the resource

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -488,7 +488,7 @@ static sk_sp<SkData> ScreenshotLayerTreeAsPicture(
   return recorder.finishRecordingAsPicture()->serialize(&procs);
 }
 
-static sk_sp<SkSurface> CreateSnapshotSurface(GrContext* surface_context,
+static sk_sp<SkSurface> CreateSnapshotSurface(GrDirectContext* surface_context,
                                               const SkISize& size) {
   const auto image_info = SkImageInfo::MakeN32Premul(
       size.width(), size.height(), SkColorSpace::MakeSRGB());
@@ -509,7 +509,7 @@ static sk_sp<SkSurface> CreateSnapshotSurface(GrContext* surface_context,
 sk_sp<SkData> Rasterizer::ScreenshotLayerTreeAsImage(
     flutter::LayerTree* tree,
     flutter::CompositorContext& compositor_context,
-    GrContext* surface_context,
+    GrDirectContext* surface_context,
     bool compressed) {
   // Attempt to create a snapshot surface depending on whether we have access to
   // a valid GPU rendering context.
@@ -589,7 +589,8 @@ Rasterizer::Screenshot Rasterizer::ScreenshotLastLayerTree(
 
   sk_sp<SkData> data = nullptr;
 
-  GrContext* surface_context = surface_ ? surface_->GetContext() : nullptr;
+  GrDirectContext* surface_context =
+      surface_ ? surface_->GetContext() : nullptr;
 
   switch (type) {
     case ScreenshotType::SkiaPicture:
@@ -648,7 +649,7 @@ void Rasterizer::SetResourceCacheMaxBytes(size_t max_bytes, bool from_user) {
     return;
   }
 
-  GrContext* context = surface_->GetContext();
+  GrDirectContext* context = surface_->GetContext();
   if (context) {
     int max_resources;
     context->getResourceCacheLimits(&max_resources, nullptr);
@@ -660,7 +661,7 @@ std::optional<size_t> Rasterizer::GetResourceCacheMaxBytes() const {
   if (!surface_) {
     return std::nullopt;
   }
-  GrContext* context = surface_->GetContext();
+  GrDirectContext* context = surface_->GetContext();
   if (context) {
     size_t max_bytes;
     context->getResourceCacheLimits(nullptr, &max_bytes);

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -458,7 +458,7 @@ class Rasterizer final : public SnapshotDelegate {
   sk_sp<SkData> ScreenshotLayerTreeAsImage(
       flutter::LayerTree* tree,
       flutter::CompositorContext& compositor_context,
-      GrContext* surface_context,
+      GrDirectContext* surface_context,
       bool compressed);
 
   sk_sp<SkImage> DoMakeRasterSnapshot(

--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -11,7 +11,7 @@
 
 namespace flutter {
 
-sk_sp<GrContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
+sk_sp<GrDirectContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
     GrBackend backend,
     sk_sp<const GrGLInterface> gl_interface) {
   if (backend != GrBackend::kOpenGL_GrBackend) {
@@ -40,7 +40,7 @@ sk_sp<GrContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
   options.fPreferExternalImagesOverES3 = true;
 
 #if !OS_FUCHSIA
-  if (auto context = GrContext::MakeGL(gl_interface, options)) {
+  if (auto context = GrDirectContext::MakeGL(gl_interface, options)) {
     // Do not cache textures created by the image decoder.  These textures
     // should be deleted when they are no longer referenced by an SkImage.
     context->setResourceCacheLimits(0, 0);
@@ -52,14 +52,15 @@ sk_sp<GrContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
 }
 
 ShellIOManager::ShellIOManager(
-    sk_sp<GrContext> resource_context,
+    sk_sp<GrDirectContext> resource_context,
     std::shared_ptr<fml::SyncSwitch> is_gpu_disabled_sync_switch,
     fml::RefPtr<fml::TaskRunner> unref_queue_task_runner)
     : resource_context_(std::move(resource_context)),
       resource_context_weak_factory_(
-          resource_context_ ? std::make_unique<fml::WeakPtrFactory<GrContext>>(
-                                  resource_context_.get())
-                            : nullptr),
+          resource_context_
+              ? std::make_unique<fml::WeakPtrFactory<GrDirectContext>>(
+                    resource_context_.get())
+              : nullptr),
       unref_queue_(fml::MakeRefCounted<flutter::SkiaUnrefQueue>(
           std::move(unref_queue_task_runner),
           fml::TimeDelta::FromMilliseconds(8),
@@ -83,7 +84,7 @@ ShellIOManager::~ShellIOManager() {
 }
 
 void ShellIOManager::NotifyResourceContextAvailable(
-    sk_sp<GrContext> resource_context) {
+    sk_sp<GrDirectContext> resource_context) {
   // The resource context needs to survive as long as we have Dart objects
   // referencing. We shouldn't ever need to replace it if we have one - unless
   // we've somehow shut down the Dart VM and started a new one fresh.
@@ -92,12 +93,14 @@ void ShellIOManager::NotifyResourceContextAvailable(
   }
 }
 
-void ShellIOManager::UpdateResourceContext(sk_sp<GrContext> resource_context) {
+void ShellIOManager::UpdateResourceContext(
+    sk_sp<GrDirectContext> resource_context) {
   resource_context_ = std::move(resource_context);
   resource_context_weak_factory_ =
-      resource_context_ ? std::make_unique<fml::WeakPtrFactory<GrContext>>(
-                              resource_context_.get())
-                        : nullptr;
+      resource_context_
+          ? std::make_unique<fml::WeakPtrFactory<GrDirectContext>>(
+                resource_context_.get())
+          : nullptr;
 }
 
 fml::WeakPtr<ShellIOManager> ShellIOManager::GetWeakPtr() {
@@ -105,10 +108,10 @@ fml::WeakPtr<ShellIOManager> ShellIOManager::GetWeakPtr() {
 }
 
 // |IOManager|
-fml::WeakPtr<GrContext> ShellIOManager::GetResourceContext() const {
+fml::WeakPtr<GrDirectContext> ShellIOManager::GetResourceContext() const {
   return resource_context_weak_factory_
              ? resource_context_weak_factory_->GetWeakPtr()
-             : fml::WeakPtr<GrContext>();
+             : fml::WeakPtr<GrDirectContext>();
 }
 
 // |IOManager|

--- a/shell/common/shell_io_manager.h
+++ b/shell/common/shell_io_manager.h
@@ -11,20 +11,20 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/lib/ui/io_manager.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
 class ShellIOManager final : public IOManager {
  public:
-  // Convenience methods for platforms to create a GrContext used to supply to
-  // the IOManager. The platforms may create the context themselves if they so
-  // desire.
-  static sk_sp<GrContext> CreateCompatibleResourceLoadingContext(
+  // Convenience methods for platforms to create a GrDirectContext used to
+  // supply to the IOManager. The platforms may create the context themselves if
+  // they so desire.
+  static sk_sp<GrDirectContext> CreateCompatibleResourceLoadingContext(
       GrBackend backend,
       sk_sp<const GrGLInterface> gl_interface);
 
-  ShellIOManager(sk_sp<GrContext> resource_context,
+  ShellIOManager(sk_sp<GrDirectContext> resource_context,
                  std::shared_ptr<fml::SyncSwitch> is_gpu_disabled_sync_switch,
                  fml::RefPtr<fml::TaskRunner> unref_queue_task_runner);
 
@@ -33,13 +33,13 @@ class ShellIOManager final : public IOManager {
   // This method should be called when a resource_context first becomes
   // available. It is safe to call multiple times, and will only update
   // the held resource context if it has not already been set.
-  void NotifyResourceContextAvailable(sk_sp<GrContext> resource_context);
+  void NotifyResourceContextAvailable(sk_sp<GrDirectContext> resource_context);
 
   // This method should be called if you want to force the IOManager to
   // update its resource context reference. It should not be called
   // if there are any Dart objects that have a reference to the old
   // resource context, but may be called if the Dart VM is restarted.
-  void UpdateResourceContext(sk_sp<GrContext> resource_context);
+  void UpdateResourceContext(sk_sp<GrDirectContext> resource_context);
 
   fml::WeakPtr<ShellIOManager> GetWeakPtr();
 
@@ -47,7 +47,7 @@ class ShellIOManager final : public IOManager {
   fml::WeakPtr<IOManager> GetWeakIOManager() const override;
 
   // |IOManager|
-  fml::WeakPtr<GrContext> GetResourceContext() const override;
+  fml::WeakPtr<GrDirectContext> GetResourceContext() const override;
 
   // |IOManager|
   fml::RefPtr<flutter::SkiaUnrefQueue> GetSkiaUnrefQueue() const override;
@@ -57,8 +57,8 @@ class ShellIOManager final : public IOManager {
 
  private:
   // Resource context management.
-  sk_sp<GrContext> resource_context_;
-  std::unique_ptr<fml::WeakPtrFactory<GrContext>>
+  sk_sp<GrDirectContext> resource_context_;
+  std::unique_ptr<fml::WeakPtrFactory<GrDirectContext>>
       resource_context_weak_factory_;
 
   // Unref queue management.

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -8,7 +8,7 @@ void ShellTestExternalViewEmbedder::CancelFrame() {}
 // |ExternalViewEmbedder|
 void ShellTestExternalViewEmbedder::BeginFrame(
     SkISize frame_size,
-    GrContext* context,
+    GrDirectContext* context,
     double device_pixel_ratio,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {}
 
@@ -36,7 +36,7 @@ SkCanvas* ShellTestExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
 
 // |ExternalViewEmbedder|
 void ShellTestExternalViewEmbedder::SubmitFrame(
-    GrContext* context,
+    GrDirectContext* context,
     std::unique_ptr<SurfaceFrame> frame) {
   frame->Submit();
 }

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -31,7 +31,7 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
   // |ExternalViewEmbedder|
   void BeginFrame(
       SkISize frame_size,
-      GrContext* context,
+      GrDirectContext* context,
       double device_pixel_ratio,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
@@ -51,7 +51,7 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
   SkCanvas* CompositeEmbeddedView(int view_id) override;
 
   // |ExternalViewEmbedder|
-  void SubmitFrame(GrContext* context,
+  void SubmitFrame(GrDirectContext* context,
                    std::unique_ptr<SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -113,10 +113,11 @@ bool ShellTestPlatformViewVulkan::OffScreenSurface::CreateSkiaGrContext() {
   PersistentCache::MarkStrategySet();
   options.fPersistentCache = PersistentCache::GetCacheForProcess();
 
-  sk_sp<GrContext> context = GrContext::MakeVulkan(backend_context, options);
+  sk_sp<GrDirectContext> context =
+      GrDirectContext::MakeVulkan(backend_context, options);
 
   if (context == nullptr) {
-    FML_DLOG(ERROR) << "Failed to create GrContext";
+    FML_DLOG(ERROR) << "Failed to create GrDirectContext";
     return false;
   }
 
@@ -179,7 +180,7 @@ ShellTestPlatformViewVulkan::OffScreenSurface::AcquireFrame(
                                         std::move(callback));
 }
 
-GrContext* ShellTestPlatformViewVulkan::OffScreenSurface::GetContext() {
+GrDirectContext* ShellTestPlatformViewVulkan::OffScreenSurface::GetContext() {
   return context_.get();
 }
 

--- a/shell/common/shell_test_platform_view_vulkan.h
+++ b/shell/common/shell_test_platform_view_vulkan.h
@@ -45,7 +45,7 @@ class ShellTestPlatformViewVulkan : public ShellTestPlatformView {
     SkMatrix GetRootTransformation() const override;
 
     // |Surface|
-    GrContext* GetContext() override;
+    GrDirectContext* GetContext() override;
 
     flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
@@ -56,7 +56,7 @@ class ShellTestPlatformViewVulkan : public ShellTestPlatformView {
         shell_test_external_view_embedder_;
     std::unique_ptr<vulkan::VulkanApplication> application_;
     std::unique_ptr<vulkan::VulkanDevice> logical_device_;
-    sk_sp<GrContext> context_;
+    sk_sp<GrDirectContext> context_;
 
     bool CreateSkiaGrContext();
     bool CreateSkiaBackendContext(GrVkBackendContext* context);

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -945,7 +945,7 @@ class MockTexture : public Texture {
   void Paint(SkCanvas& canvas,
              const SkRect& bounds,
              bool freeze,
-             GrContext* context,
+             GrDirectContext* context,
              SkFilterQuality filter_quality) override {}
 
   void OnGrContextCreated() override {}

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -66,7 +66,7 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate,
   // A similar work-around is also used in shell/common/io_manager.cc.
   options.fDisableGpuYUVConversion = true;
 
-  auto context = GrContext::MakeGL(delegate_->GetGLInterface(), options);
+  auto context = GrDirectContext::MakeGL(delegate_->GetGLInterface(), options);
 
   if (context == nullptr) {
     FML_LOG(ERROR) << "Failed to setup Skia Gr context.";
@@ -93,7 +93,7 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate,
   delegate_->GLContextClearCurrent();
 }
 
-GPUSurfaceGL::GPUSurfaceGL(sk_sp<GrContext> gr_context,
+GPUSurfaceGL::GPUSurfaceGL(sk_sp<GrDirectContext> gr_context,
                            GPUSurfaceGLDelegate* delegate,
                            bool render_to_surface)
     : delegate_(delegate),
@@ -120,7 +120,7 @@ GPUSurfaceGL::~GPUSurfaceGL() {
   auto context_switch = delegate_->GLContextMakeCurrent();
   if (!context_switch->GetResult()) {
     FML_LOG(ERROR) << "Could not make the context current to destroy the "
-                      "GrContext resources.";
+                      "GrDirectContext resources.";
     return;
   }
 
@@ -138,7 +138,7 @@ bool GPUSurfaceGL::IsValid() {
   return valid_;
 }
 
-static SkColorType FirstSupportedColorType(GrContext* context,
+static SkColorType FirstSupportedColorType(GrDirectContext* context,
                                            GrGLenum* format) {
 #define RETURN_IF_RENDERABLE(x, y)                 \
   if (context->colorTypeSupportedAsSurface((x))) { \
@@ -151,7 +151,7 @@ static SkColorType FirstSupportedColorType(GrContext* context,
   return kUnknown_SkColorType;
 }
 
-static sk_sp<SkSurface> WrapOnscreenSurface(GrContext* context,
+static sk_sp<SkSurface> WrapOnscreenSurface(GrDirectContext* context,
                                             const SkISize& size,
                                             intptr_t fbo) {
   GrGLenum format;
@@ -322,7 +322,7 @@ sk_sp<SkSurface> GPUSurfaceGL::AcquireRenderSurface(
 }
 
 // |Surface|
-GrContext* GPUSurfaceGL::GetContext() {
+GrDirectContext* GPUSurfaceGL::GetContext() {
   return context_.get();
 }
 

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -14,7 +14,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -22,8 +22,8 @@ class GPUSurfaceGL : public Surface {
  public:
   GPUSurfaceGL(GPUSurfaceGLDelegate* delegate, bool render_to_surface);
 
-  // Creates a new GL surface reusing an existing GrContext.
-  GPUSurfaceGL(sk_sp<GrContext> gr_context,
+  // Creates a new GL surface reusing an existing GrDirectContext.
+  GPUSurfaceGL(sk_sp<GrDirectContext> gr_context,
                GPUSurfaceGLDelegate* delegate,
                bool render_to_surface);
 
@@ -40,7 +40,7 @@ class GPUSurfaceGL : public Surface {
   SkMatrix GetRootTransformation() const override;
 
   // |Surface|
-  GrContext* GetContext() override;
+  GrDirectContext* GetContext() override;
 
   // |Surface|
   flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
@@ -50,7 +50,7 @@ class GPUSurfaceGL : public Surface {
 
  private:
   GPUSurfaceGLDelegate* delegate_;
-  sk_sp<GrContext> context_;
+  sk_sp<GrDirectContext> context_;
   sk_sp<SkSurface> onscreen_surface_;
   bool context_owner_;
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an

--- a/shell/gpu/gpu_surface_metal.h
+++ b/shell/gpu/gpu_surface_metal.h
@@ -11,7 +11,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/gpu/gpu_surface_delegate.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 @class CAMetalLayer;
 
@@ -21,7 +21,7 @@ class GPUSurfaceMetal : public Surface {
  public:
   GPUSurfaceMetal(GPUSurfaceDelegate* delegate,
                   fml::scoped_nsobject<CAMetalLayer> layer,
-                  sk_sp<GrContext> context,
+                  sk_sp<GrDirectContext> context,
                   fml::scoped_nsprotocol<id<MTLCommandQueue>> command_queue);
 
   // |Surface|
@@ -30,7 +30,7 @@ class GPUSurfaceMetal : public Surface {
  private:
   GPUSurfaceDelegate* delegate_;
   fml::scoped_nsobject<CAMetalLayer> layer_;
-  sk_sp<GrContext> context_;
+  sk_sp<GrDirectContext> context_;
   fml::scoped_nsprotocol<id<MTLCommandQueue>> command_queue_;
   GrMTLHandle next_drawable_ = nullptr;
 
@@ -44,7 +44,7 @@ class GPUSurfaceMetal : public Surface {
   SkMatrix GetRootTransformation() const override;
 
   // |Surface|
-  GrContext* GetContext() override;
+  GrDirectContext* GetContext() override;
 
   // |Surface|
   flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;

--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -18,7 +18,7 @@ namespace flutter {
 
 GPUSurfaceMetal::GPUSurfaceMetal(GPUSurfaceDelegate* delegate,
                                  fml::scoped_nsobject<CAMetalLayer> layer,
-                                 sk_sp<GrContext> context,
+                                 sk_sp<GrDirectContext> context,
                                  fml::scoped_nsprotocol<id<MTLCommandQueue>> command_queue)
     : delegate_(delegate),
       layer_(std::move(layer)),
@@ -118,7 +118,7 @@ SkMatrix GPUSurfaceMetal::GetRootTransformation() const {
 }
 
 // |Surface|
-GrContext* GPUSurfaceMetal::GetContext() {
+GrDirectContext* GPUSurfaceMetal::GetContext() {
   return context_.get();
 }
 

--- a/shell/gpu/gpu_surface_software.cc
+++ b/shell/gpu/gpu_surface_software.cc
@@ -82,7 +82,7 @@ SkMatrix GPUSurfaceSoftware::GetRootTransformation() const {
 }
 
 // |Surface|
-GrContext* GPUSurfaceSoftware::GetContext() {
+GrDirectContext* GPUSurfaceSoftware::GetContext() {
   // There is no GrContext associated with a software surface.
   return nullptr;
 }

--- a/shell/gpu/gpu_surface_software.h
+++ b/shell/gpu/gpu_surface_software.h
@@ -29,7 +29,7 @@ class GPUSurfaceSoftware : public Surface {
   SkMatrix GetRootTransformation() const override;
 
   // |Surface|
-  GrContext* GetContext() override;
+  GrDirectContext* GetContext() override;
 
   // |Surface|
   flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -63,7 +63,7 @@ SkMatrix GPUSurfaceVulkan::GetRootTransformation() const {
   return matrix;
 }
 
-GrContext* GPUSurfaceVulkan::GetContext() {
+GrDirectContext* GPUSurfaceVulkan::GetContext() {
   return window_.GetSkiaGrContext();
 }
 

--- a/shell/gpu/gpu_surface_vulkan.h
+++ b/shell/gpu/gpu_surface_vulkan.h
@@ -34,7 +34,7 @@ class GPUSurfaceVulkan : public Surface {
   SkMatrix GetRootTransformation() const override;
 
   // |Surface|
-  GrContext* GetContext() override;
+  GrDirectContext* GetContext() override;
 
   // |Surface|
   flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -36,7 +36,7 @@ void AndroidExternalTextureGL::MarkNewFrameAvailable() {
 void AndroidExternalTextureGL::Paint(SkCanvas& canvas,
                                      const SkRect& bounds,
                                      bool freeze,
-                                     GrContext* context,
+                                     GrDirectContext* context,
                                      SkFilterQuality filter_quality) {
   if (state_ == AttachmentState::detached) {
     return;

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -24,7 +24,7 @@ class AndroidExternalTextureGL : public flutter::Texture {
   void Paint(SkCanvas& canvas,
              const SkRect& bounds,
              bool freeze,
-             GrContext* context,
+             GrDirectContext* context,
              SkFilterQuality filter_quality) override;
 
   void OnGrContextCreated() override;

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -43,7 +43,7 @@ bool AndroidSurfaceGL::IsValid() const {
 }
 
 std::unique_ptr<Surface> AndroidSurfaceGL::CreateGPUSurface(
-    GrContext* gr_context) {
+    GrDirectContext* gr_context) {
   if (gr_context) {
     return std::make_unique<GPUSurfaceGL>(sk_ref_sp(gr_context), this, true);
   }

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -31,7 +31,8 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   bool IsValid() const override;
 
   // |AndroidSurface|
-  std::unique_ptr<Surface> CreateGPUSurface(GrContext* gr_context) override;
+  std::unique_ptr<Surface> CreateGPUSurface(
+      GrDirectContext* gr_context) override;
 
   // |AndroidSurface|
   void TeardownOnScreenContext() override;

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -65,7 +65,7 @@ bool AndroidSurfaceSoftware::ResourceContextClearCurrent() {
 }
 
 std::unique_ptr<Surface> AndroidSurfaceSoftware::CreateGPUSurface(
-    GrContext* gr_context) {
+    GrDirectContext* gr_context) {
   if (!IsValid()) {
     return nullptr;
   }

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -34,7 +34,8 @@ class AndroidSurfaceSoftware final : public AndroidSurface,
   bool ResourceContextClearCurrent() override;
 
   // |AndroidSurface|
-  std::unique_ptr<Surface> CreateGPUSurface(GrContext* gr_context) override;
+  std::unique_ptr<Surface> CreateGPUSurface(
+      GrDirectContext* gr_context) override;
 
   // |AndroidSurface|
   void TeardownOnScreenContext() override;

--- a/shell/platform/android/android_surface_vulkan.cc
+++ b/shell/platform/android/android_surface_vulkan.cc
@@ -33,7 +33,7 @@ void AndroidSurfaceVulkan::TeardownOnScreenContext() {
 }
 
 std::unique_ptr<Surface> AndroidSurfaceVulkan::CreateGPUSurface(
-    GrContext* gr_context) {
+    GrDirectContext* gr_context) {
   if (!IsValid()) {
     return nullptr;
   }

--- a/shell/platform/android/android_surface_vulkan.h
+++ b/shell/platform/android/android_surface_vulkan.h
@@ -29,7 +29,8 @@ class AndroidSurfaceVulkan : public AndroidSurface,
   bool IsValid() const override;
 
   // |AndroidSurface|
-  std::unique_ptr<Surface> CreateGPUSurface(GrContext* gr_context) override;
+  std::unique_ptr<Surface> CreateGPUSurface(
+      GrDirectContext* gr_context) override;
 
   // |AndroidSurface|
   void TeardownOnScreenContext() override;

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -73,7 +73,7 @@ SkRect AndroidExternalViewEmbedder::GetViewRect(int view_id) const {
 
 // |ExternalViewEmbedder|
 void AndroidExternalViewEmbedder::SubmitFrame(
-    GrContext* context,
+    GrDirectContext* context,
     std::unique_ptr<SurfaceFrame> frame) {
   TRACE_EVENT0("flutter", "AndroidExternalViewEmbedder::SubmitFrame");
 
@@ -185,7 +185,7 @@ void AndroidExternalViewEmbedder::SubmitFrame(
 
 // |ExternalViewEmbedder|
 std::unique_ptr<SurfaceFrame>
-AndroidExternalViewEmbedder::CreateSurfaceIfNeeded(GrContext* context,
+AndroidExternalViewEmbedder::CreateSurfaceIfNeeded(GrDirectContext* context,
                                                    int64_t view_id,
                                                    sk_sp<SkPicture> picture,
                                                    const SkRect& rect) {
@@ -257,7 +257,7 @@ void AndroidExternalViewEmbedder::Reset() {
 // |ExternalViewEmbedder|
 void AndroidExternalViewEmbedder::BeginFrame(
     SkISize frame_size,
-    GrContext* context,
+    GrDirectContext* context,
     double device_pixel_ratio,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
   Reset();

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -45,7 +45,7 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |ExternalViewEmbedder|
-  void SubmitFrame(GrContext* context,
+  void SubmitFrame(GrDirectContext* context,
                    std::unique_ptr<SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|
@@ -58,7 +58,7 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
   // |ExternalViewEmbedder|
   void BeginFrame(
       SkISize frame_size,
-      GrContext* context,
+      GrDirectContext* context,
       double device_pixel_ratio,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
@@ -132,7 +132,7 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // Creates a Surface when needed or recycles an existing one.
   // Finally, draws the picture on the frame's canvas.
-  std::unique_ptr<SurfaceFrame> CreateSurfaceIfNeeded(GrContext* context,
+  std::unique_ptr<SurfaceFrame> CreateSurfaceIfNeeded(GrDirectContext* context,
                                                       int64_t view_id,
                                                       sk_sp<SkPicture> picture,
                                                       const SkRect& rect);

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -12,7 +12,7 @@
 #include "flutter/shell/platform/android/surface/android_surface_mock.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 namespace testing {
@@ -31,7 +31,7 @@ class SurfaceMock : public Surface {
 
   MOCK_METHOD(SkMatrix, GetRootTransformation, (), (const, override));
 
-  MOCK_METHOD(GrContext*, GetContext, (), (override));
+  MOCK_METHOD(GrDirectContext*, GetContext, (), (override));
 
   MOCK_METHOD(flutter::ExternalViewEmbedder*,
               GetExternalViewEmbedder,
@@ -260,7 +260,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame) {
       std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
-  auto gr_context = GrContext::MakeMock(nullptr);
+  auto gr_context = GrDirectContext::MakeMock(nullptr);
   auto frame_size = SkISize::Make(1000, 1000);
   auto surface_factory =
       [gr_context, window, frame_size](
@@ -479,7 +479,7 @@ TEST(AndroidExternalViewEmbedder, DestroyOverlayLayersOnSizeChange) {
       std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
-  auto gr_context = GrContext::MakeMock(nullptr);
+  auto gr_context = GrDirectContext::MakeMock(nullptr);
   auto frame_size = SkISize::Make(1000, 1000);
   auto surface_factory =
       [gr_context, window, frame_size](

--- a/shell/platform/android/external_view_embedder/surface_pool.cc
+++ b/shell/platform/android/external_view_embedder/surface_pool.cc
@@ -20,7 +20,7 @@ SurfacePool::SurfacePool() = default;
 SurfacePool::~SurfacePool() = default;
 
 std::shared_ptr<OverlayLayer> SurfacePool::GetLayer(
-    GrContext* gr_context,
+    GrDirectContext* gr_context,
     std::shared_ptr<AndroidContext> android_context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
     const AndroidSurface::Factory& surface_factory) {

--- a/shell/platform/android/external_view_embedder/surface_pool.h
+++ b/shell/platform/android/external_view_embedder/surface_pool.h
@@ -52,7 +52,7 @@ class SurfacePool {
   // Finally, it marks the layer as used. That is, it increments
   // `available_layer_index_`.
   std::shared_ptr<OverlayLayer> GetLayer(
-      GrContext* gr_context,
+      GrDirectContext* gr_context,
       std::shared_ptr<AndroidContext> android_context,
       std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
       const AndroidSurface::Factory& surface_factory);

--- a/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
+++ b/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
@@ -9,7 +9,7 @@
 #include "flutter/shell/platform/android/surface/android_surface_mock.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 namespace testing {
@@ -20,7 +20,7 @@ using ::testing::Return;
 TEST(SurfacePool, GetLayer__AllocateOneLayer) {
   auto pool = std::make_unique<SurfacePool>();
 
-  auto gr_context = GrContext::MakeMock(nullptr);
+  auto gr_context = GrDirectContext::MakeMock(nullptr);
   auto android_context =
       std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
@@ -51,7 +51,7 @@ TEST(SurfacePool, GetLayer__AllocateOneLayer) {
 TEST(SurfacePool, GetUnusedLayers) {
   auto pool = std::make_unique<SurfacePool>();
 
-  auto gr_context = GrContext::MakeMock(nullptr);
+  auto gr_context = GrDirectContext::MakeMock(nullptr);
   auto android_context =
       std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
@@ -84,7 +84,7 @@ TEST(SurfacePool, GetUnusedLayers) {
 TEST(SurfacePool, GetLayer__Recycle) {
   auto pool = std::make_unique<SurfacePool>();
 
-  auto gr_context_1 = GrContext::MakeMock(nullptr);
+  auto gr_context_1 = GrDirectContext::MakeMock(nullptr);
   auto jni_mock = std::make_shared<JNIMock>();
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
   EXPECT_CALL(*jni_mock, FlutterViewCreateOverlaySurface())
@@ -95,7 +95,7 @@ TEST(SurfacePool, GetLayer__Recycle) {
   auto android_context =
       std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
-  auto gr_context_2 = GrContext::MakeMock(nullptr);
+  auto gr_context_2 = GrDirectContext::MakeMock(nullptr);
   auto surface_factory =
       [gr_context_1, gr_context_2, window](
           std::shared_ptr<AndroidContext> android_context,
@@ -130,7 +130,7 @@ TEST(SurfacePool, GetLayer__Recycle) {
 TEST(SurfacePool, GetLayer__AllocateTwoLayers) {
   auto pool = std::make_unique<SurfacePool>();
 
-  auto gr_context = GrContext::MakeMock(nullptr);
+  auto gr_context = GrDirectContext::MakeMock(nullptr);
   auto android_context =
       std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
@@ -172,7 +172,7 @@ TEST(SurfacePool, DestroyLayers) {
   EXPECT_CALL(*jni_mock, FlutterViewDestroyOverlaySurfaces()).Times(0);
   pool->DestroyLayers(jni_mock);
 
-  auto gr_context = GrContext::MakeMock(nullptr);
+  auto gr_context = GrDirectContext::MakeMock(nullptr);
   auto android_context =
       std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -420,11 +420,11 @@ std::unique_ptr<Surface> PlatformViewAndroid::CreateRenderingSurface() {
 }
 
 // |PlatformView|
-sk_sp<GrContext> PlatformViewAndroid::CreateResourceContext() const {
+sk_sp<GrDirectContext> PlatformViewAndroid::CreateResourceContext() const {
   if (!android_surface_) {
     return nullptr;
   }
-  sk_sp<GrContext> resource_context;
+  sk_sp<GrDirectContext> resource_context;
   if (android_surface_->ResourceContextMakeCurrent()) {
     // TODO(chinmaygarde): Currently, this code depends on the fact that only
     // the OpenGL surface will be able to make a resource context current. If

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -105,7 +105,7 @@ class PlatformViewAndroid final : public PlatformView {
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |PlatformView|
-  sk_sp<GrContext> CreateResourceContext() const override;
+  sk_sp<GrDirectContext> CreateResourceContext() const override;
 
   // |PlatformView|
   void ReleaseResourceContext() const override;

--- a/shell/platform/android/surface/android_surface.h
+++ b/shell/platform/android/surface/android_surface.h
@@ -27,7 +27,7 @@ class AndroidSurface {
   virtual void TeardownOnScreenContext() = 0;
 
   virtual std::unique_ptr<Surface> CreateGPUSurface(
-      GrContext* gr_context = nullptr) = 0;
+      GrDirectContext* gr_context = nullptr) = 0;
 
   virtual bool OnScreenSurfaceResize(const SkISize& size) = 0;
 

--- a/shell/platform/android/surface/android_surface_mock.h
+++ b/shell/platform/android/surface/android_surface_mock.h
@@ -24,7 +24,7 @@ class AndroidSurfaceMock final : public GPUSurfaceGLDelegate,
 
   MOCK_METHOD(std::unique_ptr<Surface>,
               CreateGPUSurface,
-              (GrContext * gr_context),
+              (GrDirectContext * gr_context),
               (override));
 
   MOCK_METHOD(bool, OnScreenSurfaceResize, (const SkISize& size), (override));

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -22,7 +22,7 @@
 namespace flutter {
 
 std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewLayerPool::GetLayer(
-    GrContext* gr_context,
+    GrDirectContext* gr_context,
     std::shared_ptr<IOSContext> ios_context) {
   if (available_layer_index_ >= layers_.size()) {
     std::shared_ptr<FlutterPlatformViewLayer> layer;
@@ -462,7 +462,7 @@ SkRect FlutterPlatformViewsController::GetPlatformViewRect(int view_id) {
   );
 }
 
-bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
+bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
                                                  std::shared_ptr<IOSContext> ios_context,
                                                  std::unique_ptr<SurfaceFrame> frame) {
   FML_DCHECK(flutter_view_);
@@ -608,7 +608,7 @@ void FlutterPlatformViewsController::EndFrame(
 }
 
 std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewsController::GetLayer(
-    GrContext* gr_context,
+    GrDirectContext* gr_context,
     std::shared_ptr<IOSContext> ios_context,
     sk_sp<SkPicture> picture,
     SkRect rect,

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -78,7 +78,7 @@ struct FlutterPlatformViewLayer {
   // The GrContext that is currently used by the overlay surfaces.
   // We track this to know when the GrContext for the Flutter app has changed
   // so we can update the overlay with the new context.
-  GrContext* gr_context;
+  GrDirectContext* gr_context;
 };
 
 // This class isn't thread safe.
@@ -89,7 +89,7 @@ class FlutterPlatformViewLayerPool {
 
   // Gets a layer from the pool if available, or allocates a new one.
   // Finally, it marks the layer as used. That is, it increments `available_layer_index_`.
-  std::shared_ptr<FlutterPlatformViewLayer> GetLayer(GrContext* gr_context,
+  std::shared_ptr<FlutterPlatformViewLayer> GetLayer(GrDirectContext* gr_context,
                                                      std::shared_ptr<IOSContext> ios_context);
 
   // Gets the layers in the pool that aren't currently used.
@@ -162,7 +162,7 @@ class FlutterPlatformViewsController {
   // Discards all platform views instances and auxiliary resources.
   void Reset();
 
-  bool SubmitFrame(GrContext* gr_context,
+  bool SubmitFrame(GrDirectContext* gr_context,
                    std::shared_ptr<IOSContext> ios_context,
                    std::unique_ptr<SurfaceFrame> frame);
 
@@ -290,7 +290,7 @@ class FlutterPlatformViewsController {
   bool merge_threads_ = false;
   // Allocates a new FlutterPlatformViewLayer if needed, draws the pixels within the rect from
   // the picture on the layer's canvas.
-  std::shared_ptr<FlutterPlatformViewLayer> GetLayer(GrContext* gr_context,
+  std::shared_ptr<FlutterPlatformViewLayer> GetLayer(GrDirectContext* gr_context,
                                                      std::shared_ptr<IOSContext> ios_context,
                                                      sk_sp<SkPicture> picture,
                                                      SkRect rect,

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -13,7 +13,7 @@
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h"
 #include "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -58,12 +58,12 @@ class IOSContext {
   ///             asynchronously and collect resources that are no longer needed
   ///             on the render task runner.
   ///
-  /// @attention  Client rendering APIs for which a GrContext cannot be realized
+  /// @attention  Client rendering APIs for which a GrDirectContext cannot be realized
   ///             (software rendering), this method will always return null.
   ///
   /// @return     A non-null Skia context on success. `nullptr` on failure.
   ///
-  virtual sk_sp<GrContext> CreateResourceContext() = 0;
+  virtual sk_sp<GrDirectContext> CreateResourceContext() = 0;
 
   //----------------------------------------------------------------------------
   /// @brief      When using client rendering APIs whose contexts need to be
@@ -75,7 +75,7 @@ class IOSContext {
   ///             bindings (anything that is not OpenGL) will always return
   ///             `true`.
   ///
-  /// @attention  Client rendering APIs for which a GrContext cannot be created
+  /// @attention  Client rendering APIs for which a GrDirectContext cannot be created
   ///             (software rendering) will always return `false`.
   ///
   /// @attention  This binds the on-screen context to the current thread. To

--- a/shell/platform/darwin/ios/ios_context_gl.h
+++ b/shell/platform/darwin/ios/ios_context_gl.h
@@ -30,7 +30,7 @@ class IOSContextGL final : public IOSContext {
   fml::scoped_nsobject<EAGLContext> resource_context_;
 
   // |IOSContext|
-  sk_sp<GrContext> CreateResourceContext() override;
+  sk_sp<GrDirectContext> CreateResourceContext() override;
 
   // |IOSContext|
   std::unique_ptr<GLContextResult> MakeCurrent() override;

--- a/shell/platform/darwin/ios/ios_context_gl.mm
+++ b/shell/platform/darwin/ios/ios_context_gl.mm
@@ -32,7 +32,7 @@ std::unique_ptr<IOSRenderTargetGL> IOSContextGL::CreateRenderTarget(
 }
 
 // |IOSContext|
-sk_sp<GrContext> IOSContextGL::CreateResourceContext() {
+sk_sp<GrDirectContext> IOSContextGL::CreateResourceContext() {
   if (![EAGLContext setCurrentContext:resource_context_.get()]) {
     FML_DLOG(INFO) << "Could not make resource context current on IO thread. Async texture uploads "
                       "will be disabled. On Simulators, this is expected.";

--- a/shell/platform/darwin/ios/ios_context_metal.h
+++ b/shell/platform/darwin/ios/ios_context_metal.h
@@ -11,7 +11,7 @@
 #include "flutter/fml/platform/darwin/cf_utils.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/platform/darwin/ios/ios_context.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -27,20 +27,20 @@ class IOSContextMetal final : public IOSContext {
 
   fml::scoped_nsprotocol<id<MTLCommandQueue>> GetResourceCommandQueue() const;
 
-  sk_sp<GrContext> GetMainContext() const;
+  sk_sp<GrDirectContext> GetMainContext() const;
 
-  sk_sp<GrContext> GetResourceContext() const;
+  sk_sp<GrDirectContext> GetResourceContext() const;
 
  private:
   fml::scoped_nsprotocol<id<MTLDevice>> device_;
   fml::scoped_nsprotocol<id<MTLCommandQueue>> main_queue_;
-  sk_sp<GrContext> main_context_;
-  sk_sp<GrContext> resource_context_;
+  sk_sp<GrDirectContext> main_context_;
+  sk_sp<GrDirectContext> resource_context_;
   fml::CFRef<CVMetalTextureCacheRef> texture_cache_;
   bool is_valid_ = false;
 
   // |IOSContext|
-  sk_sp<GrContext> CreateResourceContext() override;
+  sk_sp<GrDirectContext> CreateResourceContext() override;
 
   // |IOSContext|
   std::unique_ptr<GLContextResult> MakeCurrent() override;

--- a/shell/platform/darwin/ios/ios_context_metal.mm
+++ b/shell/platform/darwin/ios/ios_context_metal.mm
@@ -40,9 +40,11 @@ IOSContextMetal::IOSContextMetal() {
   const auto& context_options = CreateMetalGrContextOptions();
 
   // Skia expect arguments to `MakeMetal` transfer ownership of the reference in for release later
-  // when the GrContext is collected.
-  main_context_ = GrContext::MakeMetal([device_ retain], [main_queue_ retain], context_options);
-  resource_context_ = GrContext::MakeMetal([device_ retain], [main_queue_ retain], context_options);
+  // when the GrDirectContext is collected.
+  main_context_ =
+      GrDirectContext::MakeMetal([device_ retain], [main_queue_ retain], context_options);
+  resource_context_ =
+      GrDirectContext::MakeMetal([device_ retain], [main_queue_ retain], context_options);
 
   if (!main_context_ || !resource_context_) {
     FML_DLOG(ERROR) << "Could not create Skia Metal contexts.";
@@ -82,16 +84,16 @@ fml::scoped_nsprotocol<id<MTLCommandQueue>> IOSContextMetal::GetResourceCommandQ
   return main_queue_;
 }
 
-sk_sp<GrContext> IOSContextMetal::GetMainContext() const {
+sk_sp<GrDirectContext> IOSContextMetal::GetMainContext() const {
   return main_context_;
 }
 
-sk_sp<GrContext> IOSContextMetal::GetResourceContext() const {
+sk_sp<GrDirectContext> IOSContextMetal::GetResourceContext() const {
   return resource_context_;
 }
 
 // |IOSContext|
-sk_sp<GrContext> IOSContextMetal::CreateResourceContext() {
+sk_sp<GrDirectContext> IOSContextMetal::CreateResourceContext() {
   return resource_context_;
 }
 

--- a/shell/platform/darwin/ios/ios_context_software.h
+++ b/shell/platform/darwin/ios/ios_context_software.h
@@ -18,7 +18,7 @@ class IOSContextSoftware final : public IOSContext {
   ~IOSContextSoftware();
 
   // |IOSContext|
-  sk_sp<GrContext> CreateResourceContext() override;
+  sk_sp<GrDirectContext> CreateResourceContext() override;
 
   // |IOSContext|
   std::unique_ptr<GLContextResult> MakeCurrent() override;

--- a/shell/platform/darwin/ios/ios_context_software.mm
+++ b/shell/platform/darwin/ios/ios_context_software.mm
@@ -12,7 +12,7 @@ IOSContextSoftware::IOSContextSoftware() = default;
 IOSContextSoftware::~IOSContextSoftware() = default;
 
 // |IOSContext|
-sk_sp<GrContext> IOSContextSoftware::CreateResourceContext() {
+sk_sp<GrDirectContext> IOSContextSoftware::CreateResourceContext() {
   return nullptr;
 }
 

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -30,7 +30,7 @@ class IOSExternalTextureGL final : public Texture {
   void Paint(SkCanvas& canvas,
              const SkRect& bounds,
              bool freeze,
-             GrContext* context,
+             GrDirectContext* context,
              SkFilterQuality filter_quality) override;
 
   // |Texture|

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -11,6 +11,7 @@
 #include "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -63,7 +64,7 @@ bool IOSExternalTextureGL::NeedUpdateTexture(bool freeze) {
 void IOSExternalTextureGL::Paint(SkCanvas& canvas,
                                  const SkRect& bounds,
                                  bool freeze,
-                                 GrContext* context,
+                                 GrDirectContext* context,
                                  SkFilterQuality filter_quality) {
   EnsureTextureCacheExists();
   if (NeedUpdateTexture(freeze)) {

--- a/shell/platform/darwin/ios/ios_external_texture_metal.h
+++ b/shell/platform/darwin/ios/ios_external_texture_metal.h
@@ -38,7 +38,7 @@ class IOSExternalTextureMetal final : public Texture {
   void Paint(SkCanvas& canvas,
              const SkRect& bounds,
              bool freeze,
-             GrContext* context,
+             GrDirectContext* context,
              SkFilterQuality filter_quality) override;
 
   // |Texture|
@@ -54,7 +54,7 @@ class IOSExternalTextureMetal final : public Texture {
   void OnTextureUnregistered() override;
 
   sk_sp<SkImage> WrapExternalPixelBuffer(fml::CFRef<CVPixelBufferRef> pixel_buffer,
-                                         GrContext* context) const;
+                                         GrDirectContext* context) const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSExternalTextureMetal);
 };

--- a/shell/platform/darwin/ios/ios_external_texture_metal.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_metal.mm
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/logging.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/mtl/GrMtlTypes.h"
 
 namespace flutter {
@@ -26,7 +27,7 @@ IOSExternalTextureMetal::~IOSExternalTextureMetal() = default;
 void IOSExternalTextureMetal::Paint(SkCanvas& canvas,
                                     const SkRect& bounds,
                                     bool freeze,
-                                    GrContext* context,
+                                    GrDirectContext* context,
                                     SkFilterQuality filter_quality) {
   const bool needs_updated_texture = (!freeze && texture_frame_available_) || !external_image_;
 
@@ -59,7 +60,7 @@ void IOSExternalTextureMetal::Paint(SkCanvas& canvas,
 
 sk_sp<SkImage> IOSExternalTextureMetal::WrapExternalPixelBuffer(
     fml::CFRef<CVPixelBufferRef> pixel_buffer,
-    GrContext* context) const {
+    GrDirectContext* context) const {
   if (!pixel_buffer) {
     return nullptr;
   }

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -40,12 +40,12 @@ class IOSSurface : public ExternalViewEmbedder {
 
   virtual void UpdateStorageSizeIfNecessary() = 0;
 
-  // Creates a GPU surface. If no GrContext is supplied and the rendering mode
+  // Creates a GPU surface. If no GrDirectContext is supplied and the rendering mode
   // supports one, a new one will be created; otherwise, the software backend
   // will be used.
   //
-  // If a GrContext is supplied, creates a secondary surface.
-  virtual std::unique_ptr<Surface> CreateGPUSurface(GrContext* gr_context = nullptr) = 0;
+  // If a GrDirectContext is supplied, creates a secondary surface.
+  virtual std::unique_ptr<Surface> CreateGPUSurface(GrDirectContext* gr_context = nullptr) = 0;
 
  protected:
   IOSSurface(std::shared_ptr<IOSContext> ios_context,
@@ -63,7 +63,7 @@ class IOSSurface : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void BeginFrame(SkISize frame_size,
-                  GrContext* context,
+                  GrDirectContext* context,
                   double device_pixel_ratio,
                   fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
@@ -82,7 +82,7 @@ class IOSSurface : public ExternalViewEmbedder {
   SkCanvas* CompositeEmbeddedView(int view_id) override;
 
   // |ExternalViewEmbedder|
-  void SubmitFrame(GrContext* context, std::unique_ptr<SurfaceFrame> frame) override;
+  void SubmitFrame(GrDirectContext* context, std::unique_ptr<SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|
   void EndFrame(bool should_resubmit_frame,

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -95,7 +95,7 @@ void IOSSurface::CancelFrame() {
 
 // |ExternalViewEmbedder|
 void IOSSurface::BeginFrame(SkISize frame_size,
-                            GrContext* context,
+                            GrDirectContext* context,
                             double device_pixel_ratio,
                             fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
   TRACE_EVENT0("flutter", "IOSSurface::BeginFrame");
@@ -135,7 +135,7 @@ SkCanvas* IOSSurface::CompositeEmbeddedView(int view_id) {
 }
 
 // |ExternalViewEmbedder|
-void IOSSurface::SubmitFrame(GrContext* context, std::unique_ptr<SurfaceFrame> frame) {
+void IOSSurface::SubmitFrame(GrDirectContext* context, std::unique_ptr<SurfaceFrame> frame) {
   TRACE_EVENT0("flutter", "IOSSurface::SubmitFrame");
   FML_CHECK(platform_views_controller_ != nullptr);
   bool submitted =

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -31,7 +31,7 @@ class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
   void UpdateStorageSizeIfNecessary() override;
 
   // |IOSSurface|
-  std::unique_ptr<Surface> CreateGPUSurface(GrContext* gr_context) override;
+  std::unique_ptr<Surface> CreateGPUSurface(GrDirectContext* gr_context) override;
 
   // |GPUSurfaceGLDelegate|
   std::unique_ptr<GLContextResult> GLContextMakeCurrent() override;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -36,7 +36,7 @@ void IOSSurfaceGL::UpdateStorageSizeIfNecessary() {
 }
 
 // |IOSSurface|
-std::unique_ptr<Surface> IOSSurfaceGL::CreateGPUSurface(GrContext* gr_context) {
+std::unique_ptr<Surface> IOSSurfaceGL::CreateGPUSurface(GrDirectContext* gr_context) {
   if (gr_context) {
     return std::make_unique<GPUSurfaceGL>(sk_ref_sp(gr_context), this, true);
   }

--- a/shell/platform/darwin/ios/ios_surface_metal.h
+++ b/shell/platform/darwin/ios/ios_surface_metal.h
@@ -33,7 +33,7 @@ class IOSSurfaceMetal final : public IOSSurface, public GPUSurfaceDelegate {
   void UpdateStorageSizeIfNecessary() override;
 
   // |IOSSurface|
-  std::unique_ptr<Surface> CreateGPUSurface(GrContext* gr_context) override;
+  std::unique_ptr<Surface> CreateGPUSurface(GrDirectContext* gr_context) override;
 
   // |GPUSurfaceDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -43,7 +43,7 @@ void IOSSurfaceMetal::UpdateStorageSizeIfNecessary() {
 }
 
 // |IOSSurface|
-std::unique_ptr<Surface> IOSSurfaceMetal::CreateGPUSurface(GrContext* /* unused */) {
+std::unique_ptr<Surface> IOSSurfaceMetal::CreateGPUSurface(GrDirectContext* /* unused */) {
   auto metal_context = CastToMetalContext(GetContext());
 
   return std::make_unique<GPUSurfaceMetal>(this,    // Metal surface delegate

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -31,7 +31,7 @@ class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDel
   void UpdateStorageSizeIfNecessary() override;
 
   // |IOSSurface|
-  std::unique_ptr<Surface> CreateGPUSurface(GrContext* gr_context = nullptr) override;
+  std::unique_ptr<Surface> CreateGPUSurface(GrDirectContext* gr_context = nullptr) override;
 
   // |GPUSurfaceSoftwareDelegate|
   sk_sp<SkSurface> AcquireBackingStore(const SkISize& size) override;

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -33,7 +33,7 @@ void IOSSurfaceSoftware::UpdateStorageSizeIfNecessary() {
   // Android oddities.
 }
 
-std::unique_ptr<Surface> IOSSurfaceSoftware::CreateGPUSurface(GrContext* gr_context) {
+std::unique_ptr<Surface> IOSSurfaceSoftware::CreateGPUSurface(GrDirectContext* gr_context) {
   if (!IsValid()) {
     return nullptr;
   }

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -31,7 +31,7 @@ namespace flutter {
  * The shell provides and requests for UI related data and this PlatformView subclass fulfills
  * it with iOS specific capabilities. As an example, the iOS embedding (the `FlutterEngine` and the
  * `FlutterViewController`) sends pointer data to the shell and receives the shell's request for a
- * Skia GrContext and supplies it.
+ * Skia GrDirectContext and supplies it.
  *
  * Despite the name "view", this class is unrelated to UIViews on iOS and doesn't have the same
  * lifecycle. It's a long lived bridge owned by the `FlutterEngine` and can be attached and
@@ -138,7 +138,7 @@ class PlatformViewIOS final : public PlatformView {
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |PlatformView|
-  sk_sp<GrContext> CreateResourceContext() const override;
+  sk_sp<GrDirectContext> CreateResourceContext() const override;
 
   // |PlatformView|
   void SetAccessibilityFeatures(int32_t flags) override;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -138,7 +138,7 @@ std::unique_ptr<Surface> PlatformViewIOS::CreateRenderingSurface() {
 }
 
 // |PlatformView|
-sk_sp<GrContext> PlatformViewIOS::CreateResourceContext() const {
+sk_sp<GrDirectContext> PlatformViewIOS::CreateResourceContext() const {
   return ios_context_->CreateResourceContext();
 }
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -310,7 +310,7 @@ InferPlatformViewCreationCallback(
 }
 
 static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
-    GrContext* context,
+    GrDirectContext* context,
     const FlutterBackingStoreConfig& config,
     const FlutterOpenGLTexture* texture) {
   GrGLTextureInfo texture_info;
@@ -350,7 +350,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
 }
 
 static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
-    GrContext* context,
+    GrDirectContext* context,
     const FlutterBackingStoreConfig& config,
     const FlutterOpenGLFramebuffer* framebuffer) {
   GrGLFramebufferInfo framebuffer_info = {};
@@ -389,7 +389,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
 }
 
 static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
-    GrContext* context,
+    GrDirectContext* context,
     const FlutterBackingStoreConfig& config,
     const FlutterSoftwareBackingStore* software) {
   const auto image_info =
@@ -427,7 +427,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
 static std::unique_ptr<flutter::EmbedderRenderTarget>
 CreateEmbedderRenderTarget(const FlutterCompositor* compositor,
                            const FlutterBackingStoreConfig& config,
-                           GrContext* context) {
+                           GrDirectContext* context) {
   FlutterBackingStore backing_store = {};
   backing_store.struct_size = sizeof(backing_store);
 
@@ -517,7 +517,7 @@ InferExternalViewEmbedderFromArgs(const FlutterCompositor* compositor) {
 
   flutter::EmbedderExternalViewEmbedder::CreateRenderTargetCallback
       create_render_target_callback =
-          [captured_compositor](GrContext* context, const auto& config) {
+          [captured_compositor](GrDirectContext* context, const auto& config) {
             return CreateEmbedderRenderTarget(&captured_compositor, config,
                                               context);
           };
@@ -1005,7 +1005,7 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
                     nullptr) != nullptr) {
       external_texture_callback =
           [ptr = open_gl_config->gl_external_texture_frame_callback, user_data](
-              int64_t texture_identifier, GrContext* context,
+              int64_t texture_identifier, GrDirectContext* context,
               const SkISize& size) -> sk_sp<SkImage> {
         FlutterOpenGLTexture texture = {};
 

--- a/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -21,11 +21,11 @@ EmbedderExternalTextureGL::~EmbedderExternalTextureGL() = default;
 void EmbedderExternalTextureGL::Paint(SkCanvas& canvas,
                                       const SkRect& bounds,
                                       bool freeze,
-                                      GrContext* context,
+                                      GrDirectContext* context,
                                       SkFilterQuality filter_quality) {
   if (auto image = external_texture_callback_(
           Id(),                                           //
-          canvas.getGrContext(),                          //
+          context,                                        //
           SkISize::Make(bounds.width(), bounds.height())  //
           )) {
     last_image_ = image;

--- a/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/shell/platform/embedder/embedder_external_texture_gl.h
@@ -14,8 +14,10 @@ namespace flutter {
 
 class EmbedderExternalTextureGL : public flutter::Texture {
  public:
-  using ExternalTextureCallback = std::function<
-      sk_sp<SkImage>(int64_t texture_identifier, GrContext*, const SkISize&)>;
+  using ExternalTextureCallback =
+      std::function<sk_sp<SkImage>(int64_t texture_identifier,
+                                   GrDirectContext*,
+                                   const SkISize&)>;
 
   EmbedderExternalTextureGL(int64_t texture_identifier,
                             const ExternalTextureCallback& callback);
@@ -30,7 +32,7 @@ class EmbedderExternalTextureGL : public flutter::Texture {
   void Paint(SkCanvas& canvas,
              const SkRect& bounds,
              bool freeze,
-             GrContext* context,
+             GrDirectContext* context,
              SkFilterQuality filter_quality) override;
 
   // |flutter::Texture|

--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -8,7 +8,7 @@
 
 #include "flutter/shell/platform/embedder/embedder_layers.h"
 #include "flutter/shell/platform/embedder/embedder_render_target.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -49,7 +49,7 @@ void EmbedderExternalViewEmbedder::CancelFrame() {
 // |ExternalViewEmbedder|
 void EmbedderExternalViewEmbedder::BeginFrame(
     SkISize frame_size,
-    GrContext* context,
+    GrDirectContext* context,
     double device_pixel_ratio,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
   Reset();
@@ -132,7 +132,7 @@ static FlutterBackingStoreConfig MakeBackingStoreConfig(
 
 // |ExternalViewEmbedder|
 void EmbedderExternalViewEmbedder::SubmitFrame(
-    GrContext* context,
+    GrDirectContext* context,
     std::unique_ptr<SurfaceFrame> frame) {
   auto [matched_render_targets, pending_keys] =
       render_target_cache_.GetExistingTargetsInCache(pending_views_);

--- a/shell/platform/embedder/embedder_external_view_embedder.h
+++ b/shell/platform/embedder/embedder_external_view_embedder.h
@@ -30,7 +30,7 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
  public:
   using CreateRenderTargetCallback =
       std::function<std::unique_ptr<EmbedderRenderTarget>(
-          GrContext* context,
+          GrDirectContext* context,
           const FlutterBackingStoreConfig& config)>;
   using PresentCallback =
       std::function<bool(const std::vector<const FlutterLayer*>& layers)>;
@@ -75,7 +75,7 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
   // |ExternalViewEmbedder|
   void BeginFrame(
       SkISize frame_size,
-      GrContext* context,
+      GrDirectContext* context,
       double device_pixel_ratio,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
@@ -91,7 +91,7 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
   SkCanvas* CompositeEmbeddedView(int view_id) override;
 
   // |ExternalViewEmbedder|
-  void SubmitFrame(GrContext* context,
+  void SubmitFrame(GrDirectContext* context,
                    std::unique_ptr<SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|

--- a/shell/platform/embedder/embedder_surface.h
+++ b/shell/platform/embedder/embedder_surface.h
@@ -21,7 +21,7 @@ class EmbedderSurface {
 
   virtual std::unique_ptr<Surface> CreateGPUSurface() = 0;
 
-  virtual sk_sp<GrContext> CreateResourceContext() const = 0;
+  virtual sk_sp<GrDirectContext> CreateResourceContext() const = 0;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderSurface);

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -90,7 +90,7 @@ std::unique_ptr<Surface> EmbedderSurfaceGL::CreateGPUSurface() {
 }
 
 // |EmbedderSurface|
-sk_sp<GrContext> EmbedderSurfaceGL::CreateResourceContext() const {
+sk_sp<GrDirectContext> EmbedderSurfaceGL::CreateResourceContext() const {
   auto callback = gl_dispatch_table_.gl_make_resource_current_callback;
   if (callback && callback()) {
     if (auto context = ShellIOManager::CreateCompatibleResourceLoadingContext(

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -47,7 +47,7 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   std::unique_ptr<Surface> CreateGPUSurface() override;
 
   // |EmbedderSurface|
-  sk_sp<GrContext> CreateResourceContext() const override;
+  sk_sp<GrDirectContext> CreateResourceContext() const override;
 
   // |GPUSurfaceGLDelegate|
   std::unique_ptr<GLContextResult> GLContextMakeCurrent() override;

--- a/shell/platform/embedder/embedder_surface_software.cc
+++ b/shell/platform/embedder/embedder_surface_software.cc
@@ -5,7 +5,7 @@
 #include "flutter/shell/platform/embedder/embedder_surface_software.h"
 
 #include "flutter/fml/trace_event.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -43,7 +43,7 @@ std::unique_ptr<Surface> EmbedderSurfaceSoftware::CreateGPUSurface() {
 }
 
 // |EmbedderSurface|
-sk_sp<GrContext> EmbedderSurfaceSoftware::CreateResourceContext() const {
+sk_sp<GrDirectContext> EmbedderSurfaceSoftware::CreateResourceContext() const {
   return nullptr;
 }
 

--- a/shell/platform/embedder/embedder_surface_software.h
+++ b/shell/platform/embedder/embedder_surface_software.h
@@ -39,7 +39,7 @@ class EmbedderSurfaceSoftware final : public EmbedderSurface,
   std::unique_ptr<Surface> CreateGPUSurface() override;
 
   // |EmbedderSurface|
-  sk_sp<GrContext> CreateResourceContext() const override;
+  sk_sp<GrDirectContext> CreateResourceContext() const override;
 
   // |GPUSurfaceSoftwareDelegate|
   sk_sp<SkSurface> AcquireBackingStore(const SkISize& size) override;

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -74,7 +74,7 @@ std::unique_ptr<Surface> PlatformViewEmbedder::CreateRenderingSurface() {
 }
 
 // |PlatformView|
-sk_sp<GrContext> PlatformViewEmbedder::CreateResourceContext() const {
+sk_sp<GrDirectContext> PlatformViewEmbedder::CreateResourceContext() const {
   if (embedder_surface_ == nullptr) {
     FML_LOG(ERROR) << "Embedder surface was null.";
     return nullptr;

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -76,7 +76,7 @@ class PlatformViewEmbedder final : public PlatformView {
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |PlatformView|
-  sk_sp<GrContext> CreateResourceContext() const override;
+  sk_sp<GrDirectContext> CreateResourceContext() const override;
 
   // |PlatformView|
   std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;

--- a/shell/platform/embedder/tests/embedder_test_compositor.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor.cc
@@ -12,7 +12,7 @@ namespace flutter {
 namespace testing {
 
 EmbedderTestCompositor::EmbedderTestCompositor(SkISize surface_size,
-                                               sk_sp<GrContext> context)
+                                               sk_sp<GrDirectContext> context)
     : surface_size_(surface_size), context_(context) {
   FML_CHECK(!surface_size_.isEmpty()) << "Surface size must not be empty";
   FML_CHECK(context_);

--- a/shell/platform/embedder/tests/embedder_test_compositor.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor.h
@@ -10,7 +10,7 @@
 #include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 namespace testing {
@@ -23,7 +23,7 @@ class EmbedderTestCompositor {
     kSoftwareBuffer,
   };
 
-  EmbedderTestCompositor(SkISize surface_size, sk_sp<GrContext> context);
+  EmbedderTestCompositor(SkISize surface_size, sk_sp<GrDirectContext> context);
 
   ~EmbedderTestCompositor();
 
@@ -38,7 +38,7 @@ class EmbedderTestCompositor {
 
   using PlatformViewRendererCallback =
       std::function<sk_sp<SkImage>(const FlutterLayer& layer,
-                                   GrContext* context)>;
+                                   GrDirectContext* context)>;
   void SetPlatformViewRendererCallback(
       const PlatformViewRendererCallback& callback);
 
@@ -75,7 +75,7 @@ class EmbedderTestCompositor {
 
  private:
   const SkISize surface_size_;
-  sk_sp<GrContext> context_;
+  sk_sp<GrDirectContext> context_;
   RenderTargetType type_ = RenderTargetType::kOpenGLFramebuffer;
   PlatformViewRendererCallback platform_view_renderer_callback_;
   bool present_callback_is_one_shot_ = false;

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -1023,7 +1023,7 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToSoftwareBuffer) {
 }
 
 static sk_sp<SkSurface> CreateRenderSurface(const FlutterLayer& layer,
-                                            GrContext* context) {
+                                            GrDirectContext* context) {
   const auto image_info =
       SkImageInfo::MakeN32Premul(layer.size.width, layer.size.height);
   auto surface = context ? SkSurface::MakeRenderTarget(
@@ -1260,7 +1260,8 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownScene) {
       });
 
   context.GetCompositor().SetPlatformViewRendererCallback(
-      [&](const FlutterLayer& layer, GrContext* context) -> sk_sp<SkImage> {
+      [&](const FlutterLayer& layer,
+          GrDirectContext* context) -> sk_sp<SkImage> {
         auto surface = CreateRenderSurface(layer, context);
         auto canvas = surface->getCanvas();
         FML_CHECK(canvas != nullptr);
@@ -1432,7 +1433,7 @@ TEST_F(EmbedderTest,
       });
 
   context.GetCompositor().SetPlatformViewRendererCallback(
-      [&](const FlutterLayer& layer, GrContext*
+      [&](const FlutterLayer& layer, GrDirectContext*
           /* don't use because software compositor */) -> sk_sp<SkImage> {
         auto surface = CreateRenderSurface(
             layer, nullptr /* null because software compositor */);
@@ -1748,7 +1749,8 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderWithPlatformLayerOnBottom) {
       });
 
   context.GetCompositor().SetPlatformViewRendererCallback(
-      [&](const FlutterLayer& layer, GrContext* context) -> sk_sp<SkImage> {
+      [&](const FlutterLayer& layer,
+          GrDirectContext* context) -> sk_sp<SkImage> {
         auto surface = CreateRenderSurface(layer, context);
         auto canvas = surface->getCanvas();
         FML_CHECK(canvas != nullptr);
@@ -1917,7 +1919,8 @@ TEST_F(EmbedderTest,
       });
 
   context.GetCompositor().SetPlatformViewRendererCallback(
-      [&](const FlutterLayer& layer, GrContext* context) -> sk_sp<SkImage> {
+      [&](const FlutterLayer& layer,
+          GrDirectContext* context) -> sk_sp<SkImage> {
         auto surface = CreateRenderSurface(layer, context);
         auto canvas = surface->getCanvas();
         FML_CHECK(canvas != nullptr);
@@ -2219,7 +2222,8 @@ TEST_F(EmbedderTest, CanRenderGradientWithCompositorOnNonRootLayer) {
       });
 
   context.GetCompositor().SetPlatformViewRendererCallback(
-      [&](const FlutterLayer& layer, GrContext* context) -> sk_sp<SkImage> {
+      [&](const FlutterLayer& layer,
+          GrDirectContext* context) -> sk_sp<SkImage> {
         auto surface = CreateRenderSurface(layer, context);
         auto canvas = surface->getCanvas();
         FML_CHECK(canvas != nullptr);
@@ -2329,7 +2333,8 @@ TEST_F(EmbedderTest, CanRenderGradientWithCompositorOnNonRootLayerWithXform) {
       });
 
   context.GetCompositor().SetPlatformViewRendererCallback(
-      [&](const FlutterLayer& layer, GrContext* context) -> sk_sp<SkImage> {
+      [&](const FlutterLayer& layer,
+          GrDirectContext* context) -> sk_sp<SkImage> {
         auto surface = CreateRenderSurface(layer, context);
         auto canvas = surface->getCanvas();
         FML_CHECK(canvas != nullptr);
@@ -2991,7 +2996,8 @@ TEST_F(EmbedderTest, VerifyB143464703WithSoftwareBackend) {
       });
 
   context.GetCompositor().SetPlatformViewRendererCallback(
-      [](const FlutterLayer& layer, GrContext* context) -> sk_sp<SkImage> {
+      [](const FlutterLayer& layer,
+         GrDirectContext* context) -> sk_sp<SkImage> {
         auto surface = CreateRenderSurface(
             layer, nullptr /* null because software compositor */);
         auto canvas = surface->getCanvas();

--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -5,6 +5,7 @@
 #include "compositor_context.h"
 
 #include "flutter/flow/layers/layer_tree.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter_runner {
 
@@ -112,7 +113,7 @@ CompositorContext::~CompositorContext() {
 
 std::unique_ptr<flutter::CompositorContext::ScopedFrame>
 CompositorContext::AcquireFrame(
-    GrContext* gr_context,
+    GrDirectContext* gr_context,
     SkCanvas* canvas,
     flutter::ExternalViewEmbedder* view_embedder,
     const SkMatrix& root_surface_transformation,

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -49,7 +49,7 @@ class CompositorContext final : public flutter::CompositorContext {
 
   // |flutter::CompositorContext|
   std::unique_ptr<ScopedFrame> AcquireFrame(
-      GrContext* gr_context,
+      GrDirectContext* gr_context,
       SkCanvas* canvas,
       flutter::ExternalViewEmbedder* view_embedder,
       const SkMatrix& root_surface_transformation,

--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -35,7 +35,7 @@ std::unique_ptr<flutter::SurfaceFrame> Surface::AcquireFrame(
 }
 
 // |flutter::Surface|
-GrContext* Surface::GetContext() {
+GrDirectContext* Surface::GetContext() {
   return nullptr;
 }
 

--- a/shell/platform/fuchsia/flutter/surface.h
+++ b/shell/platform/fuchsia/flutter/surface.h
@@ -33,7 +33,7 @@ class Surface final : public flutter::Surface {
       const SkISize& size) override;
 
   // |flutter::Surface|
-  GrContext* GetContext() override;
+  GrDirectContext* GetContext() override;
 
   // |flutter::Surface|
   SkMatrix GetRootTransformation() const override;

--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -13,7 +13,7 @@
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/gpu/GrBackendSemaphore.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter_runner {
 
@@ -104,7 +104,7 @@ bool CreateVulkanImage(vulkan::VulkanProvider& vulkan_provider,
 }
 
 VulkanSurface::VulkanSurface(vulkan::VulkanProvider& vulkan_provider,
-                             sk_sp<GrContext> context,
+                             sk_sp<GrDirectContext> context,
                              scenic::Session* session,
                              const SkISize& size)
     : vulkan_provider_(vulkan_provider), session_(session), wait_(this) {
@@ -226,7 +226,7 @@ bool VulkanSurface::CreateFences() {
   return true;
 }
 
-bool VulkanSurface::AllocateDeviceMemory(sk_sp<GrContext> context,
+bool VulkanSurface::AllocateDeviceMemory(sk_sp<GrDirectContext> context,
                                          const SkISize& size,
                                          zx::vmo& exported_vmo) {
   if (size.isEmpty()) {
@@ -323,7 +323,7 @@ bool VulkanSurface::AllocateDeviceMemory(sk_sp<GrContext> context,
                           image_create_info, memory_reqs);
 }
 
-bool VulkanSurface::SetupSkiaSurface(sk_sp<GrContext> context,
+bool VulkanSurface::SetupSkiaSurface(sk_sp<GrDirectContext> context,
                                      const SkISize& size,
                                      SkColorType color_type,
                                      const VkImageCreateInfo& image_create_info,
@@ -407,7 +407,7 @@ sk_sp<SkSurface> VulkanSurface::GetSkiaSurface() const {
   return valid_ ? sk_surface_ : nullptr;
 }
 
-bool VulkanSurface::BindToImage(sk_sp<GrContext> context,
+bool VulkanSurface::BindToImage(sk_sp<GrDirectContext> context,
                                 VulkanImage vulkan_image) {
   FML_DCHECK(vulkan_image.vk_memory_requirements.size <=
              vk_memory_info_.allocationSize);

--- a/shell/platform/fuchsia/flutter/vulkan_surface.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.h
@@ -48,7 +48,7 @@ class VulkanSurface final
     : public flutter::SceneUpdateContext::SurfaceProducerSurface {
  public:
   VulkanSurface(vulkan::VulkanProvider& vulkan_provider,
-                sk_sp<GrContext> context,
+                sk_sp<GrDirectContext> context,
                 scenic::Session* session,
                 const SkISize& size);
 
@@ -117,7 +117,7 @@ class VulkanSurface final
   // than or equal the amount of memory contained in |vk_memory_|. Returns
   // whether the swap was successful.  The |VulkanSurface| will become invalid
   // if the swap was not successful.
-  bool BindToImage(sk_sp<GrContext> context, VulkanImage vulkan_image);
+  bool BindToImage(sk_sp<GrDirectContext> context, VulkanImage vulkan_image);
 
   // Flutter may retain a |VulkanSurface| for a |flutter::Layer| subtree to
   // improve the performance. The |retained_key_| identifies which layer subtree
@@ -162,11 +162,11 @@ class VulkanSurface final
                      zx_status_t status,
                      const zx_packet_signal_t* signal);
 
-  bool AllocateDeviceMemory(sk_sp<GrContext> context,
+  bool AllocateDeviceMemory(sk_sp<GrDirectContext> context,
                             const SkISize& size,
                             zx::vmo& exported_vmo);
 
-  bool SetupSkiaSurface(sk_sp<GrContext> context,
+  bool SetupSkiaSurface(sk_sp<GrDirectContext> context,
                         const SkISize& size,
                         SkColorType color_type,
                         const VkImageCreateInfo& image_create_info,

--- a/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "flutter/fml/trace_event.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter_runner {
 
@@ -22,7 +22,7 @@ std::string ToString(const SkISize& size) {
 }  // namespace
 
 VulkanSurfacePool::VulkanSurfacePool(vulkan::VulkanProvider& vulkan_provider,
-                                     sk_sp<GrContext> context,
+                                     sk_sp<GrDirectContext> context,
                                      scenic::Session* scenic_session)
     : vulkan_provider_(vulkan_provider),
       context_(std::move(context)),

--- a/shell/platform/fuchsia/flutter/vulkan_surface_pool.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_pool.h
@@ -21,7 +21,7 @@ class VulkanSurfacePool final {
   static constexpr int kMaxSurfaceAge = 3;
 
   VulkanSurfacePool(vulkan::VulkanProvider& vulkan_provider,
-                    sk_sp<GrContext> context,
+                    sk_sp<GrDirectContext> context,
                     scenic::Session* scenic_session);
 
   ~VulkanSurfacePool();
@@ -59,7 +59,7 @@ class VulkanSurfacePool final {
   };
 
   vulkan::VulkanProvider& vulkan_provider_;
-  sk_sp<GrContext> context_;
+  sk_sp<GrDirectContext> context_;
   scenic::Session* scenic_session_;
   std::vector<std::unique_ptr<VulkanSurface>> available_surfaces_;
   std::unordered_map<uintptr_t, std::unique_ptr<VulkanSurface>>

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -14,7 +14,7 @@
 #include "flutter/fml/trace_event.h"
 #include "third_party/skia/include/gpu/GrBackendSemaphore.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkExtensions.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
@@ -138,10 +138,10 @@ bool VulkanSurfaceProducer::Initialize(scenic::Session* scenic_session) {
                      countof(device_extensions), device_extensions);
   backend_context.fVkExtensions = &vk_extensions;
 
-  context_ = GrContext::MakeVulkan(backend_context);
+  context_ = GrDirectContext::MakeVulkan(backend_context);
 
   if (context_ == nullptr) {
-    FML_LOG(ERROR) << "Failed to create GrContext.";
+    FML_LOG(ERROR) << "Failed to create GrDirectContext.";
     return false;
   }
 

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
@@ -66,7 +66,7 @@ class VulkanSurfaceProducer final
             width_change_factor, height_change_factor);
   }
 
-  GrContext* gr_context() { return context_.get(); }
+  GrDirectContext* gr_context() { return context_.get(); }
 
  private:
   // VulkanProvider
@@ -86,7 +86,7 @@ class VulkanSurfaceProducer final
   fml::RefPtr<vulkan::VulkanProcTable> vk_;
   std::unique_ptr<vulkan::VulkanApplication> application_;
   std::unique_ptr<vulkan::VulkanDevice> logical_device_;
-  sk_sp<GrContext> context_;
+  sk_sp<GrDirectContext> context_;
   std::unique_ptr<VulkanSurfacePool> surface_pool_;
   bool valid_ = false;
 

--- a/testing/test_gl_surface.cc
+++ b/testing/test_gl_surface.cc
@@ -248,17 +248,15 @@ void* TestGLSurface::GetProcAddress(const char* name) const {
   return reinterpret_cast<void*>(symbol);
 }
 
-sk_sp<GrContext> TestGLSurface::GetGrContext() {
+sk_sp<GrDirectContext> TestGLSurface::GetGrContext() {
   if (context_) {
     return context_;
   }
 
-  context_ = CreateGrContext();
-
-  return context_;
+  return CreateGrContext();
 }
 
-sk_sp<GrContext> TestGLSurface::CreateGrContext() {
+sk_sp<GrDirectContext> TestGLSurface::CreateGrContext() {
   if (!MakeCurrent()) {
     return nullptr;
   }
@@ -290,7 +288,7 @@ sk_sp<GrContext> TestGLSurface::CreateGrContext() {
     return nullptr;
   }
 
-  context_ = GrContext::MakeGL(interface);
+  context_ = GrDirectContext::MakeGL(interface);
   return context_;
 }
 

--- a/testing/test_gl_surface.h
+++ b/testing/test_gl_surface.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 
 #include "flutter/fml/macros.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 namespace testing {
@@ -35,9 +35,9 @@ class TestGLSurface {
 
   sk_sp<SkSurface> GetOnscreenSurface();
 
-  sk_sp<GrContext> GetGrContext();
+  sk_sp<GrDirectContext> GetGrContext();
 
-  sk_sp<GrContext> CreateGrContext();
+  sk_sp<GrDirectContext> CreateGrContext();
 
   sk_sp<SkImage> GetRasterSurfaceSnapshot();
 
@@ -56,7 +56,7 @@ class TestGLSurface {
   EGLContext offscreen_context_;
   EGLSurface onscreen_surface_;
   EGLSurface offscreen_surface_;
-  sk_sp<GrContext> context_;
+  sk_sp<GrDirectContext> context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TestGLSurface);
 };

--- a/testing/test_metal_surface.cc
+++ b/testing/test_metal_surface.cc
@@ -35,7 +35,7 @@ bool TestMetalSurface::IsValid() const {
   return impl_ ? impl_->IsValid() : false;
 }
 
-sk_sp<GrContext> TestMetalSurface::GetGrContext() const {
+sk_sp<GrDirectContext> TestMetalSurface::GetGrContext() const {
   return impl_ ? impl_->GetGrContext() : nullptr;
 }
 

--- a/testing/test_metal_surface.h
+++ b/testing/test_metal_surface.h
@@ -8,7 +8,7 @@
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -27,7 +27,7 @@ class TestMetalSurface {
 
   virtual bool IsValid() const;
 
-  virtual sk_sp<GrContext> GetGrContext() const;
+  virtual sk_sp<GrDirectContext> GetGrContext() const;
 
   virtual sk_sp<SkSurface> GetSurface() const;
 

--- a/testing/test_metal_surface_impl.h
+++ b/testing/test_metal_surface_impl.h
@@ -19,14 +19,14 @@ class TestMetalSurfaceImpl : public TestMetalSurface {
 
  private:
   bool is_valid_ = false;
-  sk_sp<GrContext> context_;
+  sk_sp<GrDirectContext> context_;
   sk_sp<SkSurface> surface_;
 
   // |TestMetalSurface|
   bool IsValid() const override;
 
   // |TestMetalSurface|
-  sk_sp<GrContext> GetGrContext() const override;
+  sk_sp<GrDirectContext> GetGrContext() const override;
 
   // |TestMetalSurface|
   sk_sp<SkSurface> GetSurface() const override;

--- a/testing/test_metal_surface_impl.mm
+++ b/testing/test_metal_surface_impl.mm
@@ -54,7 +54,7 @@ TestMetalSurfaceImpl::TestMetalSurfaceImpl(SkISize surface_size) {
     return;
   }
 
-  auto skia_context = GrContext::MakeMetal(device.get(), command_queue.get());
+  auto skia_context = GrDirectContext::MakeMetal(device.get(), command_queue.get());
 
   if (skia_context) {
     // Skia wants ownership of the device and queue. If a context was created,
@@ -63,7 +63,7 @@ TestMetalSurfaceImpl::TestMetalSurfaceImpl(SkISize surface_size) {
     FML_ALLOW_UNUSED_LOCAL(device.release());
     FML_ALLOW_UNUSED_LOCAL(command_queue.release());
   } else {
-    FML_LOG(ERROR) << "Could not create the GrContext from the Metal Device "
+    FML_LOG(ERROR) << "Could not create the GrDirectContext from the Metal Device "
                       "and command queue.";
     return;
   }
@@ -108,7 +108,7 @@ bool TestMetalSurfaceImpl::IsValid() const {
   return is_valid_;
 }
 // |TestMetalSurface|
-sk_sp<GrContext> TestMetalSurfaceImpl::GetGrContext() const {
+sk_sp<GrDirectContext> TestMetalSurfaceImpl::GetGrContext() const {
   return IsValid() ? context_ : nullptr;
 }
 // |TestMetalSurface|

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -5,7 +5,7 @@
 #include "vulkan_swapchain.h"
 
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 #include "vulkan_backbuffer.h"
 #include "vulkan_device.h"
@@ -39,7 +39,7 @@ static std::vector<FormatInfo> DesiredFormatInfos() {
 VulkanSwapchain::VulkanSwapchain(const VulkanProcTable& p_vk,
                                  const VulkanDevice& device,
                                  const VulkanSurface& surface,
-                                 GrContext* skia_context,
+                                 GrDirectContext* skia_context,
                                  std::unique_ptr<VulkanSwapchain> old_swapchain,
                                  uint32_t queue_family_index)
     : vk(p_vk),
@@ -208,7 +208,7 @@ SkISize VulkanSwapchain::GetSize() const {
 }
 
 sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(
-    GrContext* gr_context,
+    GrDirectContext* gr_context,
     VkImage image,
     const SkISize& size,
     SkColorType color_type,
@@ -246,7 +246,7 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(
   );
 }
 
-bool VulkanSwapchain::CreateSwapchainImages(GrContext* skia_context,
+bool VulkanSwapchain::CreateSwapchainImages(GrDirectContext* skia_context,
                                             SkColorType color_type,
                                             sk_sp<SkColorSpace> color_space) {
   std::vector<VkImage> images = GetImages();

--- a/vulkan/vulkan_swapchain.h
+++ b/vulkan/vulkan_swapchain.h
@@ -28,7 +28,7 @@ class VulkanSwapchain {
   VulkanSwapchain(const VulkanProcTable& vk,
                   const VulkanDevice& device,
                   const VulkanSurface& surface,
-                  GrContext* skia_context,
+                  GrDirectContext* skia_context,
                   std::unique_ptr<VulkanSwapchain> old_swapchain,
                   uint32_t queue_family_index);
 
@@ -77,11 +77,11 @@ class VulkanSwapchain {
 
   std::vector<VkImage> GetImages() const;
 
-  bool CreateSwapchainImages(GrContext* skia_context,
+  bool CreateSwapchainImages(GrDirectContext* skia_context,
                              SkColorType color_type,
                              sk_sp<SkColorSpace> color_space);
 
-  sk_sp<SkSurface> CreateSkiaSurface(GrContext* skia_context,
+  sk_sp<SkSurface> CreateSkiaSurface(GrDirectContext* skia_context,
                                      VkImage image,
                                      const SkISize& size,
                                      SkColorType color_type,

--- a/vulkan/vulkan_swapchain_stub.cc
+++ b/vulkan/vulkan_swapchain_stub.cc
@@ -1,6 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+// FLUTTER_NOLINT
 
 #include "vulkan_swapchain.h"
 

--- a/vulkan/vulkan_swapchain_stub.cc
+++ b/vulkan/vulkan_swapchain_stub.cc
@@ -9,7 +9,7 @@ namespace vulkan {
 VulkanSwapchain::VulkanSwapchain(const VulkanProcTable& p_vk,
                                  const VulkanDevice& device,
                                  const VulkanSurface& surface,
-                                 GrContext* skia_context,
+                                 GrDirectContext* skia_context,
                                  std::unique_ptr<VulkanSwapchain> old_swapchain,
                                  uint32_t queue_family_index) {}
 

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -8,7 +8,7 @@
 #include <memory>
 #include <string>
 
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "vulkan_application.h"
 #include "vulkan_device.h"
 #include "vulkan_native_surface.h"
@@ -75,7 +75,7 @@ VulkanWindow::VulkanWindow(fml::RefPtr<VulkanProcTable> proc_table,
     return;
   }
 
-  // Create the Skia GrContext.
+  // Create the Skia GrDirectContext.
 
   if (!CreateSkiaGrContext()) {
     FML_DLOG(INFO) << "Could not create Skia context.";
@@ -98,7 +98,7 @@ bool VulkanWindow::IsValid() const {
   return valid_;
 }
 
-GrContext* VulkanWindow::GetSkiaGrContext() {
+GrDirectContext* VulkanWindow::GetSkiaGrContext() {
   return skia_gr_context_.get();
 }
 
@@ -109,7 +109,7 @@ bool VulkanWindow::CreateSkiaGrContext() {
     return false;
   }
 
-  sk_sp<GrContext> context = GrContext::MakeVulkan(backend_context);
+  sk_sp<GrDirectContext> context = GrDirectContext::MakeVulkan(backend_context);
 
   if (context == nullptr) {
     return false;

--- a/vulkan/vulkan_window.h
+++ b/vulkan/vulkan_window.h
@@ -15,7 +15,7 @@
 #include "third_party/skia/include/core/SkRefCnt.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
 #include "vulkan_proc_table.h"
 
@@ -39,7 +39,7 @@ class VulkanWindow {
 
   bool IsValid() const;
 
-  GrContext* GetSkiaGrContext();
+  GrDirectContext* GetSkiaGrContext();
 
   sk_sp<SkSurface> AcquireSurface();
 
@@ -52,7 +52,7 @@ class VulkanWindow {
   std::unique_ptr<VulkanDevice> logical_device_;
   std::unique_ptr<VulkanSurface> surface_;
   std::unique_ptr<VulkanSwapchain> swapchain_;
-  sk_sp<GrContext> skia_gr_context_;
+  sk_sp<GrDirectContext> skia_gr_context_;
 
   bool CreateSkiaGrContext();
 


### PR DESCRIPTION
This is part of a larger effort to expose the difference between GrDirectContext, which runs on the GPU thread and can directly perform operations like uploading textures, and GrRecordingContext, which can only queue up work to be delivered to the GrDirectContext later.

Over time, GrContext will be replaced by:
- GrDirectContext in cases where we know that we have the GPU access / with functions that require it.
- GrRecordingContext in cases where we aren't sure / with functions that do not need to perform such actions.
  - In practice, since Flutter plumbs the context around on its own (say, instead of using `SkCanvas->recordingContext`,) we pretty much have the direct context handy at all times.

Rough outline of what's going on is [here](https://docs.google.com/presentation/d/1JvhLYu-4Kb5J1TW5ahTMfzI-kSyl0csd6fSbQLWi3os/edit#slide=id.g4d734dd84e_0_0). The key is SkDeferredDisplayLists – when dealing with them, which Flutter does not presently, the GrContext is actually incapable of talking to the GPU because it's not on the GPU's thread. Right now, the internal GrDDLContext you get just stubs off functionality that it can't perform, but this won't scale – we need to reveal this distinction to users so they can be clear about what's allowed and what's not.