### PR TITLE
Add support for playing alert sound on MacOS

### DIFF
--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -80,6 +80,7 @@ source_set("flutter_framework_source") {
   cflags_objcc = [ "-fobjc-arc" ]
 
   libs = [
+    "AudioToolbox.framework",
     "Cocoa.framework",
     "CoreVideo.framework",
   ]

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -80,7 +80,6 @@ source_set("flutter_framework_source") {
   cflags_objcc = [ "-fobjc-arc" ]
 
   libs = [
-    "AudioToolbox.framework",
     "Cocoa.framework",
     "CoreVideo.framework",
   ]

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -146,7 +146,7 @@ struct KeyboardState {
 - (void)sendInitialSettings;
 
 /**
- * Responsds to updates in the user settings and passes this data to the engine.
+ * Responds to updates in the user settings and passes this data to the engine.
  */
 - (void)onSettingsChanged:(NSNotification*)notification;
 
@@ -154,6 +154,12 @@ struct KeyboardState {
  * Handles messages received from the Flutter engine on the _*Channel channels.
  */
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
+
+/**
+ * Plays a system sound. |soundType| specifies which system sound to play. Valid
+ * values can be found in the SystemSoundType enum in the services SDK package.
+ */
+- (void)playSystemSound:(NSString*)soundType;
 
 /**
  * Reads the data from the clipboard. |format| specifies the media type of the

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -15,8 +15,6 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
 #import "flutter/shell/platform/embedder/embedder.h"
 
-#include <AudioToolbox/AudioToolbox.h>
-
 namespace {
 
 /// Clipboard plain text format.
@@ -507,7 +505,7 @@ static void CommonInit(FlutterViewController* controller) {
 
 - (void)playSystemSound:(NSString*)soundType {
   if ([soundType isEqualToString:@"SystemSoundType.alert"]) {
-    AudioServicesPlayAlertSound(kSystemSoundID_UserPreferredAlert);
+    NSBeep();
   }
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -15,6 +15,8 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
 #import "flutter/shell/platform/embedder/embedder.h"
 
+#include <AudioToolbox/AudioToolbox.h>
+
 namespace {
 
 /// Clipboard plain text format.
@@ -490,6 +492,9 @@ static void CommonInit(FlutterViewController* controller) {
   if ([call.method isEqualToString:@"SystemNavigator.pop"]) {
     [NSApp terminate:self];
     result(nil);
+  } else if ([call.method isEqualToString:@"SystemSound.play"]) {
+    [self playSystemSound:call.arguments];
+    result(nil);
   } else if ([call.method isEqualToString:@"Clipboard.getData"]) {
     result([self getClipboardData:call.arguments]);
   } else if ([call.method isEqualToString:@"Clipboard.setData"]) {
@@ -497,6 +502,12 @@ static void CommonInit(FlutterViewController* controller) {
     result(nil);
   } else {
     result(FlutterMethodNotImplemented);
+  }
+}
+
+- (void)playSystemSound:(NSString*)soundType {
+  if ([soundType isEqualToString:@"SystemSoundType.alert"]) {
+    AudioServicesPlayAlertSound(kSystemSoundID_UserPreferredAlert);
   }
 }
 


### PR DESCRIPTION
## Description

This enables the system alert to be played via the `SystemSound.play(SystemSoundType.alert)` API.

## Related Issues

https://github.com/flutter/flutter/issues/62143

## Checklist

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
