### PR TITLE
Remove android view from the Mutator stack

### DIFF
--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -337,7 +337,6 @@ public class PlatformViewsControllerTest {
       PlatformViewsController platformViewsController,
       int platformViewId,
       String viewType) {
-    // Simulate create call from the framework.
     Map<String, Object> platformViewCreateArguments = new HashMap<>();
     platformViewCreateArguments.put("hybrid", true);
     platformViewCreateArguments.put("id", platformViewId);
@@ -351,7 +350,6 @@ public class PlatformViewsControllerTest {
 
   private static void disposePlatformView(
       FlutterJNI jni, PlatformViewsController platformViewsController, int platformViewId) {
-    // Simulate create call from the framework.
     Map<String, Object> platformViewDisposeArguments = new HashMap<>();
     platformViewDisposeArguments.put("hybrid", true);
     platformViewDisposeArguments.put("id", platformViewId);
@@ -362,12 +360,12 @@ public class PlatformViewsControllerTest {
   }
 
   private void attach(FlutterJNI jni, PlatformViewsController platformViewsController) {
-    AssetManager assetManager = mock(AssetManager.class);
-    Context context = RuntimeEnvironment.application.getApplicationContext();
-
-    DartExecutor executor = new DartExecutor(jni, assetManager);
+    DartExecutor executor = new DartExecutor(jni, mock(AssetManager.class));
     executor.onAttachedToJNI();
+
+    Context context = RuntimeEnvironment.application.getApplicationContext();
     platformViewsController.attach(context, null, executor);
+
     platformViewsController.attachToView(mock(FlutterView.class));
   }
 }

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -1,26 +1,20 @@
 package io.flutter.plugin.platform;
 
 import static io.flutter.embedding.engine.systemchannels.PlatformViewsChannel.PlatformViewTouch;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.*;
 
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewParent;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.MotionEventTracker;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorView;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.StandardMethodCodec;
 import java.nio.ByteBuffer;
@@ -208,33 +202,18 @@ public class PlatformViewsControllerTest {
     int platformViewId = 0;
     assertNull(platformViewsController.getPlatformViewById(platformViewId));
 
-    FlutterJNI jni = new FlutterJNI();
-    AssetManager assetManager = mock(AssetManager.class);
-    Context context = RuntimeEnvironment.application.getApplicationContext();
-
-    DartExecutor executor = new DartExecutor(jni, assetManager);
-    executor.onAttachedToJNI();
-    platformViewsController.attach(context, null, executor);
-    platformViewsController.attachToView(mock(FlutterView.class));
-
     PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
     PlatformView platformView = mock(PlatformView.class);
     View androidView = mock(View.class);
     when(platformView.getView()).thenReturn(androidView);
     when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
-
     platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
 
-    // Simulate create call from the framework.
-    Map<String, Object> platformViewCreateArguments = new HashMap<>();
-    platformViewCreateArguments.put("hybrid", true);
-    platformViewCreateArguments.put("id", platformViewId);
-    platformViewCreateArguments.put("viewType", "testType");
-    platformViewCreateArguments.put("direction", 0);
-    MethodCall platformCreateMethodCall = new MethodCall("create", platformViewCreateArguments);
+    FlutterJNI jni = new FlutterJNI();
+    attach(jni, platformViewsController);
 
-    jni.handlePlatformMessage(
-        "flutter/platform_views", encodeMethodCall(platformCreateMethodCall), /*replyId=*/ 0);
+    // Simulate create call from the framework.
+    createPlatformView(jni, platformViewsController, platformViewId, "testType");
 
     platformViewsController.initializePlatformViewIfNeeded(platformViewId);
 
@@ -243,11 +222,152 @@ public class PlatformViewsControllerTest {
     assertEquals(resultAndroidView, androidView);
   }
 
+  @Test
+  public void initializePlatformViewIfNeeded__throwsIfViewIsNull() {
+    PlatformViewsController platformViewsController = new PlatformViewsController();
+
+    int platformViewId = 0;
+    assertNull(platformViewsController.getPlatformViewById(platformViewId));
+
+    PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
+    PlatformView platformView = mock(PlatformView.class);
+    when(platformView.getView()).thenReturn(null);
+    when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
+    platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
+
+    FlutterJNI jni = new FlutterJNI();
+    attach(jni, platformViewsController);
+
+    // Simulate create call from the framework.
+    createPlatformView(jni, platformViewsController, platformViewId, "testType");
+
+    try {
+      platformViewsController.initializePlatformViewIfNeeded(platformViewId);
+    } catch (Exception exception) {
+      assertTrue(exception instanceof IllegalStateException);
+      assertEquals(
+          exception.getMessage(),
+          "PlatformView#getView() returned null, but an Android view reference was expected.");
+      return;
+    }
+    assertTrue(false);
+  }
+
+  @Test
+  public void initializePlatformViewIfNeeded__throwsIfViewHasParent() {
+    PlatformViewsController platformViewsController = new PlatformViewsController();
+
+    int platformViewId = 0;
+    assertNull(platformViewsController.getPlatformViewById(platformViewId));
+
+    PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
+    PlatformView platformView = mock(PlatformView.class);
+    View androidView = mock(View.class);
+    when(androidView.getParent()).thenReturn(mock(ViewParent.class));
+    when(platformView.getView()).thenReturn(androidView);
+    when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
+    platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
+
+    FlutterJNI jni = new FlutterJNI();
+    attach(jni, platformViewsController);
+
+    // Simulate create call from the framework.
+    createPlatformView(jni, platformViewsController, platformViewId, "testType");
+    try {
+      platformViewsController.initializePlatformViewIfNeeded(platformViewId);
+    } catch (Exception exception) {
+      assertTrue(exception instanceof IllegalStateException);
+      assertEquals(
+          exception.getMessage(),
+          "The Android view returned from PlatformView#getView() was already added to a parent view.");
+      return;
+    }
+    assertTrue(false);
+  }
+
+  @Test
+  public void disposeAndroidView__hybridComposition() {
+    PlatformViewsController platformViewsController = new PlatformViewsController();
+
+    int platformViewId = 0;
+    assertNull(platformViewsController.getPlatformViewById(platformViewId));
+
+    PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
+    PlatformView platformView = mock(PlatformView.class);
+
+    Context context = RuntimeEnvironment.application.getApplicationContext();
+    View androidView = new View(context);
+
+    when(platformView.getView()).thenReturn(androidView);
+    when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
+    platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
+
+    FlutterJNI jni = new FlutterJNI();
+    attach(jni, platformViewsController);
+
+    // Simulate create call from the framework.
+    createPlatformView(jni, platformViewsController, platformViewId, "testType");
+    platformViewsController.initializePlatformViewIfNeeded(platformViewId);
+
+    assertNotNull(androidView.getParent());
+    assertTrue(androidView.getParent() instanceof FlutterMutatorView);
+
+    // Simulate dispose call from the framework.
+    disposePlatformView(jni, platformViewsController, platformViewId);
+    assertNull(androidView.getParent());
+
+    // Simulate create call from the framework.
+    createPlatformView(jni, platformViewsController, platformViewId, "testType");
+    platformViewsController.initializePlatformViewIfNeeded(platformViewId);
+
+    assertNotNull(androidView.getParent());
+    assertTrue(androidView.getParent() instanceof FlutterMutatorView);
+  }
+
   private static byte[] encodeMethodCall(MethodCall call) {
     ByteBuffer buffer = StandardMethodCodec.INSTANCE.encodeMethodCall(call);
     buffer.rewind();
     byte[] dest = new byte[buffer.remaining()];
     buffer.get(dest);
     return dest;
+  }
+
+  private static void createPlatformView(
+      FlutterJNI jni,
+      PlatformViewsController platformViewsController,
+      int platformViewId,
+      String viewType) {
+    // Simulate create call from the framework.
+    Map<String, Object> platformViewCreateArguments = new HashMap<>();
+    platformViewCreateArguments.put("hybrid", true);
+    platformViewCreateArguments.put("id", platformViewId);
+    platformViewCreateArguments.put("viewType", viewType);
+    platformViewCreateArguments.put("direction", 0);
+    MethodCall platformCreateMethodCall = new MethodCall("create", platformViewCreateArguments);
+
+    jni.handlePlatformMessage(
+        "flutter/platform_views", encodeMethodCall(platformCreateMethodCall), /*replyId=*/ 0);
+  }
+
+  private static void disposePlatformView(
+      FlutterJNI jni, PlatformViewsController platformViewsController, int platformViewId) {
+    // Simulate create call from the framework.
+    Map<String, Object> platformViewDisposeArguments = new HashMap<>();
+    platformViewDisposeArguments.put("hybrid", true);
+    platformViewDisposeArguments.put("id", platformViewId);
+    MethodCall platformDisposeMethodCall = new MethodCall("dispose", platformViewDisposeArguments);
+
+    jni.handlePlatformMessage(
+        "flutter/platform_views", encodeMethodCall(platformDisposeMethodCall), /*replyId=*/ 0);
+  }
+
+  private void attach(FlutterJNI jni, PlatformViewsController platformViewsController) {
+    AssetManager assetManager = mock(AssetManager.class);
+    Context context = RuntimeEnvironment.application.getApplicationContext();
+
+    DartExecutor executor = new DartExecutor(jni, assetManager);
+    executor.onAttachedToJNI();
+    platformViewsController.attach(context, null, executor);
+    platformViewsController.attachToView(mock(FlutterView.class));
   }
 }


### PR DESCRIPTION
## Description

The view should be removed from the mutator stack view since the Android view system doesn't allow to add a view to a `ViewGroup` if it's already in a parent `ViewGroup`.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/62079

## Tests

I added the following tests: 3 unit tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
