### PR TITLE
This makes the lint script use multiprocessing to speed it up.

### DIFF
--- a/ci/bin/lint.dart
+++ b/ci/bin/lint.dart
@@ -7,267 +7,11 @@
 
 import 'dart:async' show Completer;
 import 'dart:convert' show jsonDecode, utf8, LineSplitter;
-import 'dart:io'
-    show
-        File,
-        Process,
-        ProcessResult,
-        ProcessException,
-        exit,
-        Directory,
-        FileSystemEntity,
-        Platform,
-        stderr,
-        stdout;
+import 'dart:io' show File, exit, Directory, FileSystemEntity, Platform, stderr;
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
-
-Platform defaultPlatform = Platform();
-
-/// Exception class for when a process fails to run, so we can catch
-/// it and provide something more readable than a stack trace.
-class ProcessRunnerException implements Exception {
-  ProcessRunnerException(this.message, {this.result});
-
-  final String message;
-  final ProcessResult result;
-
-  int get exitCode => result?.exitCode ?? -1;
-
-  @override
-  String toString() {
-    String output = runtimeType.toString();
-    output += ': $message';
-    final String stderr = (result?.stderr ?? '') as String;
-    if (stderr.isNotEmpty) {
-      output += ':\n$stderr';
-    }
-    return output;
-  }
-}
-
-class ProcessRunnerResult {
-  const ProcessRunnerResult(this.exitCode, this.stdout, this.stderr, this.output);
-  final int exitCode;
-  final List<int> stdout;
-  final List<int> stderr;
-  final List<int> output;
-}
-
-/// A helper class for classes that want to run a process, optionally have the
-/// stderr and stdout reported as the process runs, and capture the stdout
-/// properly without dropping any.
-class ProcessRunner {
-  ProcessRunner({
-    this.defaultWorkingDirectory,
-  });
-
-  /// Sets the default directory used when `workingDirectory` is not specified
-  /// to [runProcess].
-  final Directory defaultWorkingDirectory;
-
-  /// The environment to run processes with.
-  Map<String, String> environment = Map<String, String>.from(Platform.environment);
-
-  /// Run the command and arguments in `commandLine` as a sub-process from
-  /// `workingDirectory` if set, or the [defaultWorkingDirectory] if not. Uses
-  /// [Directory.current] if [defaultWorkingDirectory] is not set.
-  ///
-  /// Set `failOk` if [runProcess] should not throw an exception when the
-  /// command completes with a a non-zero exit code.
-  Future<ProcessRunnerResult> runProcess(
-    List<String> commandLine, {
-    Directory workingDirectory,
-    bool printOutput = false,
-    bool failOk = false,
-    Stream<List<int>> stdin,
-  }) async {
-    workingDirectory ??= defaultWorkingDirectory ?? Directory.current;
-    if (printOutput) {
-      stderr.write('Running "${commandLine.join(' ')}" in ${workingDirectory.path}.\n');
-    }
-    final List<int> stdoutOutput = <int>[];
-    final List<int> stderrOutput = <int>[];
-    final List<int> combinedOutput = <int>[];
-    final Completer<void> stdoutComplete = Completer<void>();
-    final Completer<void> stderrComplete = Completer<void>();
-    final Completer<void> stdinComplete = Completer<void>();
-
-    Process process;
-    Future<int> allComplete() async {
-      if (stdin != null) {
-        await stdinComplete.future;
-        await process?.stdin?.close();
-      }
-      await stderrComplete.future;
-      await stdoutComplete.future;
-      return process?.exitCode ?? Future<int>.value(0);
-    }
-
-    try {
-      process = await Process.start(
-        commandLine.first,
-        commandLine.sublist(1),
-        workingDirectory: workingDirectory.absolute.path,
-        environment: environment,
-        runInShell: false,
-      );
-      if (stdin != null) {
-        stdin.listen((List<int> data) {
-          process?.stdin?.add(data);
-        }, onDone: () async => stdinComplete.complete());
-      }
-      process.stdout.listen(
-        (List<int> event) {
-          stdoutOutput.addAll(event);
-          combinedOutput.addAll(event);
-          if (printOutput) {
-            stdout.add(event);
-          }
-        },
-        onDone: () async => stdoutComplete.complete(),
-      );
-      process.stderr.listen(
-        (List<int> event) {
-          stderrOutput.addAll(event);
-          combinedOutput.addAll(event);
-          if (printOutput) {
-            stderr.add(event);
-          }
-        },
-        onDone: () async => stderrComplete.complete(),
-      );
-    } on ProcessException catch (e) {
-      final String message = 'Running "${commandLine.join(' ')}" in ${workingDirectory.path} '
-          'failed with:\n${e.toString()}';
-      throw ProcessRunnerException(message);
-    } on ArgumentError catch (e) {
-      final String message = 'Running "${commandLine.join(' ')}" in ${workingDirectory.path} '
-          'failed with:\n${e.toString()}';
-      throw ProcessRunnerException(message);
-    }
-
-    final int exitCode = await allComplete();
-    if (exitCode != 0 && !failOk) {
-      final String message =
-          'Running "${commandLine.join(' ')}" in ${workingDirectory.path} failed';
-      throw ProcessRunnerException(
-        message,
-        result: ProcessResult(
-            0, exitCode, null, 'exited with code $exitCode\n${utf8.decode(combinedOutput)}'),
-      );
-    }
-    return ProcessRunnerResult(exitCode, stdoutOutput, stderrOutput, combinedOutput);
-  }
-}
-
-class WorkerJob {
-  WorkerJob(
-    this.name,
-    this.args, {
-    this.workingDirectory,
-    this.printOutput = false,
-  });
-
-  /// The name of the job.
-  final String name;
-
-  /// The arguments for the process, including the command name as args[0].
-  final List<String> args;
-
-  /// The working directory that the command should be executed in.
-  final Directory workingDirectory;
-
-  /// Whether or not this command should print it's stdout when it runs.
-  final bool printOutput;
-
-  @override
-  String toString() {
-    return args.join(' ');
-  }
-}
-
-/// A pool of worker processes that will keep [numWorkers] busy until all of the
-/// (presumably single-threaded) processes are finished.
-class ProcessPool {
-  ProcessPool({int numWorkers}) : numWorkers = numWorkers ?? Platform.numberOfProcessors;
-
-  ProcessRunner processRunner = ProcessRunner();
-  int numWorkers;
-  List<WorkerJob> pendingJobs = <WorkerJob>[];
-  List<WorkerJob> failedJobs = <WorkerJob>[];
-  Map<WorkerJob, Future<List<int>>> inProgressJobs = <WorkerJob, Future<List<int>>>{};
-  Map<WorkerJob, ProcessRunnerResult> completedJobs = <WorkerJob, ProcessRunnerResult>{};
-  Completer<Map<WorkerJob, ProcessRunnerResult>> completer =
-      Completer<Map<WorkerJob, ProcessRunnerResult>>();
-
-  void _printReport() {
-    final int totalJobs = completedJobs.length + inProgressJobs.length + pendingJobs.length;
-    final String percent =
-        totalJobs == 0 ? '100' : ((100 * completedJobs.length) ~/ totalJobs).toString().padLeft(3);
-    final String completed = completedJobs.length.toString().padLeft(3);
-    final String total = totalJobs.toString().padRight(3);
-    final String inProgress = inProgressJobs.length.toString().padLeft(2);
-    final String pending = pendingJobs.length.toString().padLeft(3);
-    stdout.write('Jobs: $percent% done, $completed/$total completed, $inProgress in '
-        'progress, $pending pending.  \r');
-  }
-
-  Future<List<int>> _scheduleJob(WorkerJob job) async {
-    final Completer<List<int>> jobDone = Completer<List<int>>();
-    final List<int> output = <int>[];
-    try {
-      completedJobs[job] = await processRunner.runProcess(
-        job.args,
-        workingDirectory: job.workingDirectory,
-        printOutput: job.printOutput,
-      );
-    } catch (e) {
-      failedJobs.add(job);
-      if (e is ProcessRunnerException) {
-        print(e.toString());
-        print('${utf8.decode(output)}');
-      } else {
-        print('\nJob $job failed: $e');
-      }
-    } finally {
-      inProgressJobs.remove(job);
-      if (pendingJobs.isNotEmpty) {
-        final WorkerJob newJob = pendingJobs.removeAt(0);
-        inProgressJobs[newJob] = _scheduleJob(newJob);
-      } else {
-        if (inProgressJobs.isEmpty) {
-          completer.complete(completedJobs);
-        }
-      }
-      jobDone.complete(output);
-      _printReport();
-    }
-    return jobDone.future;
-  }
-
-  Future<Map<WorkerJob, ProcessRunnerResult>> startWorkers(List<WorkerJob> jobs) async {
-    assert(inProgressJobs.isEmpty);
-    assert(failedJobs.isEmpty);
-    assert(completedJobs.isEmpty);
-    if (jobs.isEmpty) {
-      return <WorkerJob, ProcessRunnerResult>{};
-    }
-    pendingJobs = jobs;
-    for (int i = 0; i < numWorkers; ++i) {
-      if (pendingJobs.isEmpty) {
-        break;
-      }
-      final WorkerJob job = pendingJobs.removeAt(0);
-      inProgressJobs[job] = _scheduleJob(job);
-    }
-    return completer.future.then((Map<WorkerJob, ProcessRunnerResult> result) {
-      stdout.flush();
-      return result;
-    });
-  }
-}
+import 'package:process_runner/process_runner.dart';
 
 String _linterOutputHeader = '''
 ┌──────────────────────────┐
@@ -313,20 +57,33 @@ bool containsAny(File file, Iterable<File> queries) {
   return queries.where((File query) => path.equals(query.path, file.path)).isNotEmpty;
 }
 
-/// Returns a list of all files with current changes or differ from `master`.
+/// Returns a list of all non-deleted files which differ from the nearest
+/// merge-base with `master`. If it can't find a fork point, uses the default
+/// merge-base.
 Future<List<File>> getListOfChangedFiles(Directory repoPath) async {
   final ProcessRunner processRunner = ProcessRunner(defaultWorkingDirectory: repoPath);
-  String branch = 'upstream/master';
-  final ProcessResult fetchResult = Process.runSync('git', <String>['fetch', 'upstream', 'master']);
+  final ProcessRunnerResult fetchResult = await processRunner.runProcess(
+    <String>['git', 'fetch', 'upstream', 'master'],
+    failOk: true,
+  );
   if (fetchResult.exitCode != 0) {
-    branch = 'origin/master';
-    Process.runSync('git', <String>['fetch', 'origin', 'master']);
+    await processRunner.runProcess(<String>['git', 'fetch', 'origin', 'master']);
   }
   final Set<String> result = <String>{};
-  final ProcessRunnerResult diffResult = await processRunner.runProcess(
-      <String>['git', 'diff', '--name-only', '--diff-filter=ACMRT', if (branch.isNotEmpty) branch]);
-
-  result.addAll(utf8.decode(diffResult.stdout).split('\n').where(isNonEmptyString));
+  ProcessRunnerResult mergeBaseResult = await processRunner.runProcess(
+      <String>['git', 'merge-base', '--fork-point', 'FETCH_HEAD', 'HEAD'],
+      failOk: true);
+  if (mergeBaseResult.exitCode != 0) {
+    if (verbose) {
+      stderr.writeln("Didn't find a fork point, falling back to default merge base.");
+    }
+    mergeBaseResult = await processRunner
+        .runProcess(<String>['git', 'merge-base', 'FETCH_HEAD', 'HEAD'], failOk: false);
+  }
+  final String mergeBase = mergeBaseResult.stdout.trim();
+  final ProcessRunnerResult masterResult = await processRunner
+      .runProcess(<String>['git', 'diff', '--name-only', '--diff-filter=ACMRT', mergeBase]);
+  result.addAll(masterResult.stdout.split('\n').where(isNonEmptyString));
   return result.map<File>((String filePath) => File(path.join(repoPath.path, filePath))).toList();
 }
 
@@ -348,29 +105,29 @@ File buildFileAsRepoFile(String buildFile, Directory repoPath) {
   return result;
 }
 
-Future<bool> shouldIgnoreFile(File file) async {
+Future<String> shouldIgnoreFile(File file) async {
   if (path.split(file.path).contains('third_party')) {
-    return true;
+    return 'third_party';
   } else {
-    final RegExp exp = RegExp(r'//.*FLUTTER_NOLINT');
+    final RegExp exp = RegExp(r'//\s*FLUTTER_NOLINT');
     await for (String line
         in file.openRead().transform(utf8.decoder).transform(const LineSplitter())) {
       if (exp.hasMatch(line)) {
-        return true;
+        return 'FLUTTER_NOLINT';
       } else if (line.isNotEmpty && line[0] != '\n' && line[0] != '/') {
         // Quick out once we find a line that isn't empty or a comment.  The
         // FLUTTER_NOLINT must show up before the first real code.
-        return false;
+        return '';
       }
     }
-    return false;
+    return '';
   }
 }
 
-void _usage(ArgParser parser) {
+void _usage(ArgParser parser, {int exitCode = 1}) {
   stderr.writeln('lint.dart [--help] [--lint-all] [--verbose] [--diff-branch]');
   stderr.writeln(parser.usage);
-  exit(0);
+  exit(exitCode);
 }
 
 bool verbose = false;
@@ -394,20 +151,32 @@ void main(List<String> arguments) async {
   verbose = options['verbose'] as bool;
 
   if (options['help'] as bool) {
+    _usage(parser, exitCode: 0);
+  }
+
+  if (!options.wasParsed('compile-commands')) {
+    stderr.writeln('ERROR: The --compile-commands argument is requried.');
+    _usage(parser);
+  }
+
+  if (!options.wasParsed('repo')) {
+    stderr.writeln('ERROR: The --repo argument is requried.');
     _usage(parser);
   }
 
   final File buildCommandsPath = File(options['compile-commands'] as String);
   if (!buildCommandsPath.existsSync()) {
-    stderr.writeln("Build commands path ${buildCommandsPath.absolute.path} doesn't exist.");
+    stderr.writeln("ERROR: Build commands path ${buildCommandsPath.absolute.path} doesn't exist.");
     _usage(parser);
   }
 
   final Directory repoPath = Directory(options['repo'] as String);
   if (!repoPath.existsSync()) {
-    stderr.writeln("Repo path ${repoPath.absolute.path} doesn't exist.");
+    stderr.writeln("ERROR: Repo path ${repoPath.absolute.path} doesn't exist.");
     _usage(parser);
   }
+
+  print(_linterOutputHeader);
 
   final String checksArg = options.wasParsed('checks') ? options['checks'] as String : '';
   final String checks = checksArg.isNotEmpty ? '--checks=$checksArg' : '--config=';
@@ -439,37 +208,47 @@ void main(List<String> arguments) async {
   final List<Command> changedFileBuildCommands =
       buildCommands.where((Command x) => containsAny(x.file, changedFiles)).toList();
 
+  if (changedFileBuildCommands.isEmpty) {
+    print('No changed files that have build commands associated with them '
+        'were found.');
+    exit(0);
+  }
+
   if (verbose) {
     print('Found ${changedFileBuildCommands.length} files that have build '
         'commands associated with them and can be lint checked.');
   }
 
-  print(_linterOutputHeader);
   int exitCode = 0;
   final List<WorkerJob> jobs = <WorkerJob>[];
   for (Command command in changedFileBuildCommands) {
-    if (!(await shouldIgnoreFile(command.file))) {
+    final String relativePath = path.relative(command.file.path, from: repoPath.parent.path);
+    final String ignoreReason = await shouldIgnoreFile(command.file);
+    if (ignoreReason.isEmpty) {
       final String tidyArgs = calcTidyArgs(command);
       final List<String> args = <String>[command.file.path, checks, '--'];
       args.addAll(tidyArgs?.split(' ') ?? <String>[]);
-      print('🔶 linting ${command.file}');
-      jobs.add(WorkerJob(command.file.path, <String>[tidyPath, ...args],
-          workingDirectory: command.directory));
+      print('🔶 linting $relativePath');
+      jobs.add(WorkerJob(
+        <String>[tidyPath, ...args],
+        workingDirectory: command.directory,
+        name: 'clang-tidy on ${command.file.path}',
+      ));
     } else {
-      print('🔷 ignoring ${command.file}');
+      print('🔷 ignoring $relativePath ($ignoreReason)');
     }
   }
   final ProcessPool pool = ProcessPool();
-  final Map<WorkerJob, ProcessRunnerResult> results = await pool.startWorkers(jobs);
-  print('\n');
-  for (final WorkerJob job in results.keys) {
-    if (results[job].stdout.isEmpty) {
+
+  await for (final WorkerJob job in pool.startWorkers(jobs)) {
+    if (job.result.stdout.isEmpty) {
       continue;
     }
     print('❌ Failures for ${job.name}:');
-    print(utf8.decode(results[job].stdout));
+    print(job.result.stdout);
     exitCode = 1;
   }
+  print('\n');
   if (exitCode == 0) {
     print('No lint problems found.');
   }

--- a/ci/lint.dart
+++ b/ci/lint.dart
@@ -5,17 +5,279 @@
 ///
 /// User environment variable FLUTTER_LINT_ALL to run on all files.
 
+// @dart = 2.9
+
+import 'dart:async' show Completer;
+import 'dart:convert' show jsonDecode, utf8, LineSplitter;
 import 'dart:io'
     show
         File,
         Process,
         ProcessResult,
+        ProcessException,
         exit,
         Directory,
         FileSystemEntity,
-        Platform;
-import 'dart:convert' show jsonDecode, utf8, LineSplitter;
-import 'dart:async' show Completer;
+        Platform,
+        stderr,
+        stdout;
+
+Platform defaultPlatform = Platform();
+
+/// Exception class for when a process fails to run, so we can catch
+/// it and provide something more readable than a stack trace.
+class ProcessRunnerException implements Exception {
+  ProcessRunnerException(this.message, {this.result});
+
+  final String message;
+  final ProcessResult? result;
+
+  int get exitCode => result?.exitCode ?? -1;
+
+  @override
+  String toString() {
+    String output = runtimeType.toString();
+    output += ': $message';
+    final String stderr = (result?.stderr ?? '') as String;
+    if (stderr.isNotEmpty) {
+      output += ':\n$stderr';
+    }
+    return output;
+  }
+}
+
+class ProcessRunnerResult {
+  const ProcessRunnerResult(
+      this.exitCode, this.stdout, this.stderr, this.output);
+  final int exitCode;
+  final List<int> stdout;
+  final List<int> stderr;
+  final List<int> output;
+}
+
+/// A helper class for classes that want to run a process, optionally have the
+/// stderr and stdout reported as the process runs, and capture the stdout
+/// properly without dropping any.
+class ProcessRunner {
+  ProcessRunner({
+    this.defaultWorkingDirectory,
+  });
+
+  /// Sets the default directory used when `workingDirectory` is not specified
+  /// to [runProcess].
+  final Directory? defaultWorkingDirectory;
+
+  /// The environment to run processes with.
+  Map<String, String> environment =
+      Map<String, String>.from(Platform.environment);
+
+  /// Run the command and arguments in `commandLine` as a sub-process from
+  /// `workingDirectory` if set, or the [defaultWorkingDirectory] if not. Uses
+  /// [Directory.current] if [defaultWorkingDirectory] is not set.
+  ///
+  /// Set `failOk` if [runProcess] should not throw an exception when the
+  /// command completes with a a non-zero exit code.
+  Future<ProcessRunnerResult> runProcess(
+    List<String> commandLine, {
+    Directory? workingDirectory,
+    bool printOutput = true,
+    bool failOk = false,
+    Stream<List<int>>? stdin,
+  }) async {
+    workingDirectory ??= defaultWorkingDirectory ?? Directory.current;
+    if (printOutput) {
+      stderr.write(
+          'Running "${commandLine.join(' ')}" in ${workingDirectory.path}.\n');
+    }
+    final List<int> stdoutOutput = <int>[];
+    final List<int> stderrOutput = <int>[];
+    final List<int> combinedOutput = <int>[];
+    final Completer<void> stdoutComplete = Completer<void>();
+    final Completer<void> stderrComplete = Completer<void>();
+    final Completer<void> stdinComplete = Completer<void>();
+
+    Process? process;
+    Future<int> allComplete() async {
+      if (stdin != null) {
+        await stdinComplete.future;
+        await process?.stdin.close();
+      }
+      await stderrComplete.future;
+      await stdoutComplete.future;
+      return process?.exitCode ?? Future<int>.value(0);
+    }
+
+    try {
+      process = await Process.start(
+        commandLine.first,
+        commandLine.sublist(1),
+        workingDirectory: workingDirectory.absolute.path,
+        environment: environment,
+        runInShell: false,
+      );
+      if (stdin != null) {
+        stdin.listen((List<int> data) {
+          process?.stdin.add(data);
+        }, onDone: () async => stdinComplete.complete());
+      }
+      process.stdout.listen(
+        (List<int> event) {
+          stdoutOutput.addAll(event);
+          combinedOutput.addAll(event);
+          if (printOutput) {
+            stdout.add(event);
+          }
+        },
+        onDone: () async => stdoutComplete.complete(),
+      );
+      process.stderr.listen(
+        (List<int> event) {
+          stderrOutput.addAll(event);
+          combinedOutput.addAll(event);
+          if (printOutput) {
+            stderr.add(event);
+          }
+        },
+        onDone: () async => stderrComplete.complete(),
+      );
+    } on ProcessException catch (e) {
+      final String message =
+          'Running "${commandLine.join(' ')}" in ${workingDirectory.path} '
+          'failed with:\n${e.toString()}';
+      throw ProcessRunnerException(message);
+    } on ArgumentError catch (e) {
+      final String message =
+          'Running "${commandLine.join(' ')}" in ${workingDirectory.path} '
+          'failed with:\n${e.toString()}';
+      throw ProcessRunnerException(message);
+    }
+
+    final int exitCode = await allComplete();
+    if (exitCode != 0 && !failOk) {
+      final String message =
+          'Running "${commandLine.join(' ')}" in ${workingDirectory.path} failed';
+      throw ProcessRunnerException(
+        message,
+        result: ProcessResult(0, exitCode, null, 'exited with code $exitCode\n${utf8.decode(combinedOutput)}'),
+      );
+    }
+    return ProcessRunnerResult(
+        exitCode, stdoutOutput, stderrOutput, combinedOutput);
+  }
+}
+
+class WorkerJob {
+  WorkerJob(
+    this.name,
+    this.args, {
+    this.workingDirectory,
+    this.printOutput = false,
+  });
+
+  /// The name of the job.
+  final String name;
+
+  /// The arguments for the process, including the command name as args[0].
+  final List<String> args;
+
+  /// The working directory that the command should be executed in.
+  final Directory? workingDirectory;
+
+  /// Whether or not this command should print it's stdout when it runs.
+  final bool printOutput;
+
+  @override
+  String toString() {
+    return args.join(' ');
+  }
+}
+
+/// A pool of worker processes that will keep [numWorkers] busy until all of the
+/// (presumably single-threaded) processes are finished.
+class ProcessPool {
+  ProcessPool({int? numWorkers})
+      : numWorkers = numWorkers ?? Platform.numberOfProcessors;
+
+  ProcessRunner processRunner = ProcessRunner();
+  int numWorkers;
+  List<WorkerJob> pendingJobs = <WorkerJob>[];
+  List<WorkerJob> failedJobs = <WorkerJob>[];
+  Map<WorkerJob, Future<List<int>>> inProgressJobs =
+      <WorkerJob, Future<List<int>>>{};
+  Map<WorkerJob, ProcessRunnerResult> completedJobs =
+      <WorkerJob, ProcessRunnerResult>{};
+  Completer<Map<WorkerJob, ProcessRunnerResult>> completer =
+      Completer<Map<WorkerJob, ProcessRunnerResult>>();
+
+  void _printReport() {
+    final int totalJobs =
+        completedJobs.length + inProgressJobs.length + pendingJobs.length;
+    final String percent = totalJobs == 0
+        ? '100'
+        : ((100 * completedJobs.length) ~/ totalJobs).toString().padLeft(3);
+    final String completed = completedJobs.length.toString().padLeft(3);
+    final String total = totalJobs.toString().padRight(3);
+    final String inProgress = inProgressJobs.length.toString().padLeft(2);
+    final String pending = pendingJobs.length.toString().padLeft(3);
+    stdout.write(
+        'Jobs: $percent% done, $completed/$total completed, $inProgress in progress, $pending pending.  \r');
+  }
+
+  Future<List<int>> _scheduleJob(WorkerJob job) async {
+    final Completer<List<int>> jobDone = Completer<List<int>>();
+    final List<int> output = <int>[];
+    try {
+      completedJobs[job] = await processRunner.runProcess(
+        job.args,
+        workingDirectory: job.workingDirectory,
+        printOutput: job.printOutput,
+      );
+    } catch (e) {
+      failedJobs.add(job);
+      if (e is ProcessRunnerException) {
+        print(e.toString());
+        print('${utf8.decode(output)}');
+      } else {
+        print('\nJob $job failed: $e');
+      }
+    } finally {
+      inProgressJobs.remove(job);
+      if (pendingJobs.isNotEmpty) {
+        final WorkerJob newJob = pendingJobs.removeAt(0);
+        inProgressJobs[newJob] = _scheduleJob(newJob);
+      } else {
+        if (inProgressJobs.isEmpty) {
+          completer.complete(completedJobs);
+        }
+      }
+      jobDone.complete(output);
+      _printReport();
+    }
+    return jobDone.future;
+  }
+
+  Future<Map<WorkerJob, ProcessRunnerResult>> startWorkers(
+      List<WorkerJob> jobs) async {
+    assert(inProgressJobs.isEmpty);
+    assert(failedJobs.isEmpty);
+    assert(completedJobs.isEmpty);
+    if (jobs.isEmpty) {
+      return <WorkerJob, ProcessRunnerResult>{};
+    }
+    pendingJobs = jobs;
+    for (int i = 0; i < numWorkers; ++i) {
+      if (pendingJobs.isEmpty) {
+        break;
+      }
+      final WorkerJob job = pendingJobs.removeAt(0);
+      inProgressJobs[job] = _scheduleJob(job);
+    }
+    return completer.future.then((Map<WorkerJob, ProcessRunnerResult> result) {
+      stdout.flush();
+      return result;
+    });
+  }
+}
 
 String _linterOutputHeader = '''┌──────────────────────────┐
 │ Engine Clang Tidy Linter │
@@ -26,19 +288,19 @@ https://github.com/flutter/flutter/wiki/Engine-Clang-Tidy-Linter
 ''';
 
 class Command {
-  String directory;
-  String command;
-  String file;
+  String directory = '';
+  String command = '';
+  String file = '';
 }
 
 Command parseCommand(Map<String, dynamic> map) {
   return Command()
-    ..directory = map['directory']
-    ..command = map['command']
-    ..file = map['file'];
+    ..directory = map['directory'] as String
+    ..command = map['command'] as String
+    ..file = map['file'] as String;
 }
 
-String calcTidyArgs(Command command) {
+String? calcTidyArgs(Command command) {
   String result = command.command;
   result = result.replaceAll(RegExp(r'\S*clang/bin/clang'), '');
   result = result.replaceAll(RegExp(r'-MF \S*'), '');
@@ -48,11 +310,12 @@ String calcTidyArgs(Command command) {
 String calcTidyPath(Command command) {
   final RegExp regex = RegExp(r'\S*clang/bin/clang');
   return regex
-      .stringMatch(command.command)
-      .replaceAll('clang/bin/clang', 'clang/bin/clang-tidy');
+          .stringMatch(command.command)
+          ?.replaceAll('clang/bin/clang', 'clang/bin/clang-tidy') ??
+      '';
 }
 
-bool isNonEmptyString(String str) => str.length > 0;
+bool isNonEmptyString(String str) => str.isNotEmpty;
 
 bool containsAny(String str, List<String> queries) {
   for (String query in queries) {
@@ -65,37 +328,40 @@ bool containsAny(String str, List<String> queries) {
 
 /// Returns a list of all files with current changes or differ from `master`.
 List<String> getListOfChangedFiles(String repoPath) {
-  final Set<String> result = Set<String>();
+  final Set<String> result = <String>{};
   final ProcessResult diffResult = Process.runSync(
-      'git', ['diff', '--name-only'],
+      'git', <String>['diff', '--name-only'],
       workingDirectory: repoPath);
   final ProcessResult diffCachedResult = Process.runSync(
-      'git', ['diff', '--cached', '--name-only'],
+      'git', <String>['diff', '--cached', '--name-only'],
       workingDirectory: repoPath);
 
   final ProcessResult fetchResult =
-      Process.runSync('git', ['fetch', 'upstream', 'master']);
+      Process.runSync('git', <String>['fetch', 'upstream', 'master']);
   if (fetchResult.exitCode != 0) {
-    Process.runSync('git', ['fetch', 'origin', 'master']);
+    Process.runSync('git', <String>['fetch', 'origin', 'master']);
   }
   final ProcessResult mergeBaseResult = Process.runSync(
-      'git', ['merge-base', '--fork-point', 'FETCH_HEAD', 'HEAD'],
+      'git', <String>['merge-base', '--fork-point', 'FETCH_HEAD', 'HEAD'],
       workingDirectory: repoPath);
-  final String mergeBase = mergeBaseResult.stdout.trim();
+  final String mergeBase = mergeBaseResult.stdout.trim() as String;
   final ProcessResult masterResult = Process.runSync(
-      'git', ['diff', '--name-only', mergeBase],
+      'git', <String>['diff', '--name-only', mergeBase],
       workingDirectory: repoPath);
-  result.addAll(diffResult.stdout.split('\n').where(isNonEmptyString));
-  result.addAll(diffCachedResult.stdout.split('\n').where(isNonEmptyString));
-  result.addAll(masterResult.stdout.split('\n').where(isNonEmptyString));
+  result.addAll(diffResult.stdout.split('\n').where(isNonEmptyString)
+      as Iterable<String>);
+  result.addAll(diffCachedResult.stdout.split('\n').where(isNonEmptyString)
+      as Iterable<String>);
+  result.addAll(masterResult.stdout.split('\n').where(isNonEmptyString)
+      as Iterable<String>);
   return result.toList();
 }
 
 Future<List<String>> dirContents(String repoPath) {
-  Directory dir = Directory(repoPath);
-  var files = <String>[];
-  var completer = new Completer<List<String>>();
-  var lister = dir.list(recursive: true);
+  final Directory dir = Directory(repoPath);
+  final List<String> files = <String>[];
+  final Completer<List<String>> completer = Completer<List<String>>();
+  final Stream<FileSystemEntity> lister = dir.list(recursive: true);
   lister.listen((FileSystemEntity file) => files.add(file.path),
       // should also register onError
       onDone: () => completer.complete(files));
@@ -113,7 +379,7 @@ Future<bool> shouldIgnoreFile(String path) async {
         .transform(const LineSplitter())) {
       if (exp.hasMatch(line)) {
         return true;
-      } else if (line.length > 0 && line[0] != '\n' && line[0] != '/') {
+      } else if (line.isNotEmpty && line[0] != '\n' && line[0] != '/') {
         // Quick out once we find a line that isn't empty or a comment.  The
         // FLUTTER_NOLINT must show up before the first real code.
         return false;
@@ -132,37 +398,48 @@ void main(List<String> arguments) async {
       Platform.environment['FLUTTER_LINT_ALL'] != null
           ? await dirContents(repoPath)
           : getListOfChangedFiles(repoPath);
+
   /// TODO(gaaclarke): Convert FLUTTER_LINT_ALL to a command-line flag and add
   /// `--verbose` flag.
 
   final List<dynamic> buildCommandMaps =
-      jsonDecode(await new File(buildCommandsPath).readAsString());
-  final List<Command> buildCommands =
-      buildCommandMaps.map((x) => parseCommand(x)).toList();
+      jsonDecode(await File(buildCommandsPath).readAsString()) as List<dynamic>;
+  final List<Command> buildCommands = buildCommandMaps
+      .map<Command>((dynamic x) => parseCommand(x as Map<String, dynamic>))
+      .toList();
   final Command firstCommand = buildCommands[0];
   final String tidyPath = calcTidyPath(firstCommand);
-  final List<Command> changedFileBuildCommands =
-      buildCommands.where((x) => containsAny(x.file, changedFiles)).toList();
+  assert(tidyPath.isNotEmpty);
+  final List<Command> changedFileBuildCommands = buildCommands
+      .where((Command x) => containsAny(x.file, changedFiles))
+      .toList();
 
   print(_linterOutputHeader);
   int exitCode = 0;
-  //TODO(aaclarke): Coalesce this into one call using the `-p` arguement.
+  final List<WorkerJob> jobs = <WorkerJob>[];
   for (Command command in changedFileBuildCommands) {
     if (!(await shouldIgnoreFile(command.file))) {
-      final String tidyArgs = calcTidyArgs(command);
-      final List<String> args = [command.file, checks, '--'];
-      args.addAll(tidyArgs.split(' '));
+      final String? tidyArgs = calcTidyArgs(command);
+      final List<String> args = <String>[command.file, checks, '--'];
+      args.addAll(tidyArgs?.split(' ') ?? <String>[]);
       print('🔶 linting ${command.file}');
-      final Process process = await Process.start(tidyPath, args,
-          workingDirectory: command.directory, runInShell: false);
-      process.stdout.transform(utf8.decoder).listen((data) {
-        print(data);
-        exitCode = 1;
-      });
-      await process.exitCode;
+      jobs.add(WorkerJob(command.file, <String>[tidyPath, ...args],
+          workingDirectory: Directory(command.directory)));
     } else {
       print('🔷 ignoring ${command.file}');
     }
+  }
+  final ProcessPool pool = ProcessPool();
+  final Map<WorkerJob, ProcessRunnerResult> results =
+      await pool.startWorkers(jobs);
+  print('\n');
+  for (final WorkerJob job in results.keys) {
+    if (results[job]!.stdout.isEmpty) {
+      continue;
+    }
+    print('❌ Failures for ${job.name}:');
+    print(utf8.decode(results[job]!.stdout));
+    exitCode = 1;
   }
   exit(exitCode);
 }

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -41,7 +41,7 @@ if [ ! -f "$COMPILE_COMMANDS" ]; then
 fi
 
 cd "$CI_DIR"
-exec dart \
+pub get && dart \
   bin/lint.dart \
   --compile-commands="$COMPILE_COMMANDS" \
   --repo="$SRC_DIR/flutter" \

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -2,9 +2,47 @@
 
 set -e
 
-COMPILE_COMMANDS="out/compile_commands.json"
-if [ ! -f $COMPILE_COMMANDS ]; then
-  ./flutter/tools/gn
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
+
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The returned filesystem path must be a format usable by Dart's URI parser,
+# since the Dart command line tool treats its argument as a file URI, not a
+# filename. For instance, multiple consecutive slashes should be reduced to a
+# single slash, since double-slashes indicate a URI "authority", and these are
+# supposed to be filenames. There is an edge case where this will return
+# multiple slashes: when the input resolves to the root directory. However, if
+# that were the case, we wouldn't be running this shell, so we don't do anything
+# about it.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -h "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
+PROG_NAME="$(follow_links "${BASH_SOURCE[0]}")"
+CI_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
+SRC_DIR="$(cd "$CI_DIR/../.."; pwd -P)"
+
+COMPILE_COMMANDS="$SRC_DIR/out/compile_commands.json"
+if [ ! -f "$COMPILE_COMMANDS" ]; then
+  (cd $SRC_DIR; ./flutter/tools/gn)
 fi
 
-dart --enable-experiment=non-nullable flutter/ci/lint.dart $COMPILE_COMMANDS flutter/ 
+cd "$CI_DIR"
+exec dart \
+  bin/lint.dart \
+  --compile-commands="$COMPILE_COMMANDS" \
+  --repo="$SRC_DIR/flutter" \
+  "$@"

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -7,4 +7,4 @@ if [ ! -f $COMPILE_COMMANDS ]; then
   ./flutter/tools/gn
 fi
 
-dart flutter/ci/lint.dart $COMPILE_COMMANDS flutter/
+dart --enable-experiment=non-nullable flutter/ci/lint.dart $COMPILE_COMMANDS flutter/ 

--- a/ci/pubspec.yaml
+++ b/ci/pubspec.yaml
@@ -3,6 +3,7 @@ name: ci_scripts
 dependencies:
   args: ^1.6.0
   path: ^1.7.0
+  process_runner: ^2.0.3
 
 environment:
   sdk: '>=2.8.0 <3.0.0'

--- a/ci/pubspec.yaml
+++ b/ci/pubspec.yaml
@@ -1,0 +1,7 @@
+name: ci_scripts
+
+dependencies:
+  args: ^1.6.0
+
+environment:
+  sdk: '>=2.8.0 <3.0.0'

--- a/ci/pubspec.yaml
+++ b/ci/pubspec.yaml
@@ -2,6 +2,7 @@ name: ci_scripts
 
 dependencies:
   args: ^1.6.0
+  path: ^1.7.0
 
 environment:
   sdk: '>=2.8.0 <3.0.0'

--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_application.h"
 
@@ -15,7 +14,7 @@
 namespace vulkan {
 
 VulkanApplication::VulkanApplication(
-    VulkanProcTable& p_vk,
+    VulkanProcTable& p_vk, // NOLINT
     const std::string& application_name,
     std::vector<std::string> enabled_extensions,
     uint32_t application_version,
@@ -36,7 +35,7 @@ VulkanApplication::VulkanApplication(
   // Configure extensions.
 
   if (enable_instance_debugging) {
-    enabled_extensions.emplace_back(VulkanDebugReport::DebugExtensionName());
+    enabled_extensions.emplace_back(VulkanDebugReport::DebugExtensionNamgie());
   }
 #if OS_FUCHSIA
   if (ExtensionSupported(supported_extensions,

--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -1,6 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+// FLUTTER_NOLINT
 
 #include "vulkan_application.h"
 
@@ -14,7 +15,7 @@
 namespace vulkan {
 
 VulkanApplication::VulkanApplication(
-    VulkanProcTable& p_vk, // NOLINT
+    VulkanProcTable& p_vk,
     const std::string& application_name,
     std::vector<std::string> enabled_extensions,
     uint32_t application_version,
@@ -35,7 +36,7 @@ VulkanApplication::VulkanApplication(
   // Configure extensions.
 
   if (enable_instance_debugging) {
-    enabled_extensions.emplace_back(VulkanDebugReport::DebugExtensionNamgie());
+    enabled_extensions.emplace_back(VulkanDebugReport::DebugExtensionName());
   }
 #if OS_FUCHSIA
   if (ExtensionSupported(supported_extensions,


### PR DESCRIPTION
## Description

I got tired of waiting for it to run, so I added some of the "worker" queue code that I wrote for the assets-for-api-docs generator.

I also tried out putting all the files in one call to clang-tidy with the `-p` argument, but that was still a lot slower because it runs them all on one core. This runs separate jobs for each file, simultaneously, and then reports the results at the end (associated with each file, of course).