### PR TITLE
Fix lint errors in lib/ui

### DIFF
--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/canvas.h"
 
@@ -77,9 +76,11 @@ fml::RefPtr<Canvas> Canvas::Create(PictureRecorder* recorder,
                                    double top,
                                    double right,
                                    double bottom) {
-  if (!recorder)
+  if (!recorder) {
     Dart_ThrowException(
         ToDart("Canvas constructor called with non-genuine PictureRecorder."));
+    return nullptr;
+  }
   fml::RefPtr<Canvas> canvas = fml::MakeRefCounted<Canvas>(
       recorder->BeginRecording(SkRect::MakeLTRB(left, top, right, bottom)));
   recorder->set_canvas(canvas);
@@ -91,15 +92,17 @@ Canvas::Canvas(SkCanvas* canvas) : canvas_(canvas) {}
 Canvas::~Canvas() {}
 
 void Canvas::save() {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->save();
 }
 
 void Canvas::saveLayerWithoutBounds(const Paint& paint,
                                     const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->saveLayer(nullptr, paint.paint());
 }
 
@@ -109,51 +112,59 @@ void Canvas::saveLayer(double left,
                        double bottom,
                        const Paint& paint,
                        const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   SkRect bounds = SkRect::MakeLTRB(left, top, right, bottom);
   canvas_->saveLayer(&bounds, paint.paint());
 }
 
 void Canvas::restore() {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->restore();
 }
 
 int Canvas::getSaveCount() {
-  if (!canvas_)
+  if (!canvas_) {
     return 0;
+  }
   return canvas_->getSaveCount();
 }
 
 void Canvas::translate(double dx, double dy) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->translate(dx, dy);
 }
 
 void Canvas::scale(double sx, double sy) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->scale(sx, sy);
 }
 
 void Canvas::rotate(double radians) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->rotate(radians * 180.0 / M_PI);
 }
 
 void Canvas::skew(double sx, double sy) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->skew(sx, sy);
 }
 
 void Canvas::transform(const tonic::Float64List& matrix4) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->concat(ToSkMatrix(matrix4));
 }
 
@@ -163,31 +174,37 @@ void Canvas::clipRect(double left,
                       double bottom,
                       SkClipOp clipOp,
                       bool doAntiAlias) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->clipRect(SkRect::MakeLTRB(left, top, right, bottom), clipOp,
                     doAntiAlias);
 }
 
 void Canvas::clipRRect(const RRect& rrect, bool doAntiAlias) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->clipRRect(rrect.sk_rrect, doAntiAlias);
 }
 
 void Canvas::clipPath(const CanvasPath* path, bool doAntiAlias) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
-  if (!path)
+  }
+  if (!path) {
     Dart_ThrowException(
         ToDart("Canvas.clipPath called with non-genuine Path."));
+    return;
+  }
   external_allocation_size_ += path->path().approximateBytesUsed();
   canvas_->clipPath(path->path(), doAntiAlias);
 }
 
 void Canvas::drawColor(SkColor color, SkBlendMode blend_mode) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->drawColor(color, blend_mode);
 }
 
@@ -197,14 +214,16 @@ void Canvas::drawLine(double x1,
                       double y2,
                       const Paint& paint,
                       const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->drawLine(x1, y1, x2, y2, *paint.paint());
 }
 
 void Canvas::drawPaint(const Paint& paint, const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->drawPaint(*paint.paint());
 }
 
@@ -214,16 +233,18 @@ void Canvas::drawRect(double left,
                       double bottom,
                       const Paint& paint,
                       const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->drawRect(SkRect::MakeLTRB(left, top, right, bottom), *paint.paint());
 }
 
 void Canvas::drawRRect(const RRect& rrect,
                        const Paint& paint,
                        const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->drawRRect(rrect.sk_rrect, *paint.paint());
 }
 
@@ -231,8 +252,9 @@ void Canvas::drawDRRect(const RRect& outer,
                         const RRect& inner,
                         const Paint& paint,
                         const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->drawDRRect(outer.sk_rrect, inner.sk_rrect, *paint.paint());
 }
 
@@ -242,8 +264,9 @@ void Canvas::drawOval(double left,
                       double bottom,
                       const Paint& paint,
                       const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->drawOval(SkRect::MakeLTRB(left, top, right, bottom), *paint.paint());
 }
 
@@ -252,8 +275,9 @@ void Canvas::drawCircle(double x,
                         double radius,
                         const Paint& paint,
                         const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->drawCircle(x, y, radius, *paint.paint());
 }
 
@@ -266,8 +290,9 @@ void Canvas::drawArc(double left,
                      bool useCenter,
                      const Paint& paint,
                      const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
   canvas_->drawArc(SkRect::MakeLTRB(left, top, right, bottom),
                    startAngle * 180.0 / M_PI, sweepAngle * 180.0 / M_PI,
                    useCenter, *paint.paint());
@@ -276,11 +301,14 @@ void Canvas::drawArc(double left,
 void Canvas::drawPath(const CanvasPath* path,
                       const Paint& paint,
                       const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
-  if (!path)
+  }
+  if (!path) {
     Dart_ThrowException(
         ToDart("Canvas.drawPath called with non-genuine Path."));
+    return;
+  }
   external_allocation_size_ += path->path().approximateBytesUsed();
   canvas_->drawPath(path->path(), *paint.paint());
 }
@@ -290,11 +318,14 @@ void Canvas::drawImage(const CanvasImage* image,
                        double y,
                        const Paint& paint,
                        const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
-  if (!image)
+  }
+  if (!image) {
     Dart_ThrowException(
         ToDart("Canvas.drawImage called with non-genuine Image."));
+    return;
+  }
   external_allocation_size_ += image->GetAllocationSize();
   canvas_->drawImage(image->image(), x, y, paint.paint());
 }
@@ -310,11 +341,14 @@ void Canvas::drawImageRect(const CanvasImage* image,
                            double dst_bottom,
                            const Paint& paint,
                            const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
-  if (!image)
+  }
+  if (!image) {
     Dart_ThrowException(
         ToDart("Canvas.drawImageRect called with non-genuine Image."));
+    return;
+  }
   SkRect src = SkRect::MakeLTRB(src_left, src_top, src_right, src_bottom);
   SkRect dst = SkRect::MakeLTRB(dst_left, dst_top, dst_right, dst_bottom);
   external_allocation_size_ += image->GetAllocationSize();
@@ -333,11 +367,14 @@ void Canvas::drawImageNine(const CanvasImage* image,
                            double dst_bottom,
                            const Paint& paint,
                            const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
-  if (!image)
+  }
+  if (!image) {
     Dart_ThrowException(
         ToDart("Canvas.drawImageNine called with non-genuine Image."));
+    return;
+  }
   SkRect center =
       SkRect::MakeLTRB(center_left, center_top, center_right, center_bottom);
   SkIRect icenter;
@@ -348,11 +385,14 @@ void Canvas::drawImageNine(const CanvasImage* image,
 }
 
 void Canvas::drawPicture(Picture* picture) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
-  if (!picture)
+  }
+  if (!picture) {
     Dart_ThrowException(
         ToDart("Canvas.drawPicture called with non-genuine Picture."));
+    return;
+  }
   external_allocation_size_ += picture->GetAllocationSize();
   canvas_->drawPicture(picture->picture().get());
 }
@@ -361,8 +401,9 @@ void Canvas::drawPoints(const Paint& paint,
                         const PaintData& paint_data,
                         SkCanvas::PointMode point_mode,
                         const tonic::Float32List& points) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
+  }
 
   static_assert(sizeof(SkPoint) == sizeof(float) * 2,
                 "SkPoint doesn't use floats.");
@@ -377,11 +418,14 @@ void Canvas::drawVertices(const Vertices* vertices,
                           SkBlendMode blend_mode,
                           const Paint& paint,
                           const PaintData& paint_data) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
-  if (!vertices)
+  }
+  if (!vertices) {
     Dart_ThrowException(
         ToDart("Canvas.drawVertices called with non-genuine Vertices."));
+    return;
+  }
   external_allocation_size_ += vertices->GetAllocationSize();
   canvas_->drawVertices(vertices->vertices(), blend_mode, *paint.paint());
 }
@@ -394,12 +438,15 @@ void Canvas::drawAtlas(const Paint& paint,
                        const tonic::Int32List& colors,
                        SkBlendMode blend_mode,
                        const tonic::Float32List& cull_rect) {
-  if (!canvas_)
+  if (!canvas_) {
     return;
-  if (!atlas)
+  }
+  if (!atlas) {
     Dart_ThrowException(
         ToDart("Canvas.drawAtlas or Canvas.drawRawAtlas called with "
                "non-genuine Image."));
+    return;
+  }
 
   sk_sp<SkImage> skImage = atlas->image();
 
@@ -422,9 +469,11 @@ void Canvas::drawShadow(const CanvasPath* path,
                         SkColor color,
                         double elevation,
                         bool transparentOccluder) {
-  if (!path)
+  if (!path) {
     Dart_ThrowException(
         ToDart("Canvas.drawShader called with non-genuine Path."));
+    return;
+  }
   SkScalar dpr =
       UIDartState::Current()->window()->viewport_metrics().device_pixel_ratio;
   external_allocation_size_ += path->path().approximateBytesUsed();

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/mapping.h"
@@ -23,8 +22,8 @@ namespace testing {
 
 class TestIOManager final : public IOManager {
  public:
-  TestIOManager(fml::RefPtr<fml::TaskRunner> task_runner,
-                bool has_gpu_context = true)
+  explicit TestIOManager(fml::RefPtr<fml::TaskRunner> task_runner,
+                         bool has_gpu_context = true)
       : gl_surface_(SkISize::Make(1, 1)),
         gl_context_(has_gpu_context ? gl_surface_.CreateGrContext() : nullptr),
         weak_gl_context_factory_(

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/image_encoding.h"
 
@@ -237,11 +236,13 @@ void EncodeImageAndInvokeDataCallback(
 Dart_Handle EncodeImage(CanvasImage* canvas_image,
                         int format,
                         Dart_Handle callback_handle) {
-  if (!canvas_image)
+  if (!canvas_image) {
     return ToDart("encode called with non-genuine Image.");
+  }
 
-  if (!Dart_IsClosure(callback_handle))
+  if (!Dart_IsClosure(callback_handle)) {
     return ToDart("Callback must be a function.");
+  }
 
   ImageByteFormat image_format = static_cast<ImageByteFormat>(format);
 

--- a/lib/ui/painting/image_shader.cc
+++ b/lib/ui/painting/image_shader.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/image_shader.h"
 
@@ -42,6 +41,7 @@ void ImageShader::initWithImage(CanvasImage* image,
   if (!image) {
     Dart_ThrowException(
         ToDart("ImageShader constructor called with non-genuine Image."));
+    return;
   }
   SkMatrix sk_matrix = ToSkMatrix(matrix4);
   set_shader(UIDartState::CreateGPUObject(

--- a/lib/ui/painting/matrix.cc
+++ b/lib/ui/painting/matrix.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/matrix.h"
 
@@ -23,18 +22,20 @@ SkMatrix ToSkMatrix(const tonic::Float64List& matrix4) {
   SkMatrix sk_matrix;
   for (int i = 0; i < 9; ++i) {
     int matrix4_index = kSkMatrixIndexToMatrix4Index[i];
-    if (matrix4_index < matrix4.num_elements())
+    if (matrix4_index < matrix4.num_elements()) {
       sk_matrix[i] = matrix4[matrix4_index];
-    else
+    } else {
       sk_matrix[i] = 0.0;
+    }
   }
   return sk_matrix;
 }
 
 tonic::Float64List ToMatrix4(const SkMatrix& sk_matrix) {
   tonic::Float64List matrix4(Dart_NewTypedData(Dart_TypedData_kFloat64, 16));
-  for (int i = 0; i < 9; ++i)
+  for (int i = 0; i < 9; ++i) {
     matrix4[kSkMatrixIndexToMatrix4Index[i]] = sk_matrix[i];
+  }
   matrix4[10] = 1.0;  // Identity along the z axis.
   return matrix4;
 }

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/multi_frame_codec.h"
 
@@ -80,13 +79,14 @@ sk_sp<SkImage> MultiFrameCodec::State::GetNextFrameImage(
   SkBitmap bitmap = SkBitmap();
   SkImageInfo info = generator_->getInfo().makeColorType(kN32_SkColorType);
   if (info.alphaType() == kUnpremul_SkAlphaType) {
-    info = info.makeAlphaType(kPremul_SkAlphaType);
+    SkImageInfo updated = info.makeAlphaType(kPremul_SkAlphaType);
+    info = updated;
   }
   bitmap.allocPixels(info);
 
   SkCodec::Options options;
   options.fFrameIndex = nextFrameIndex_;
-  SkCodec::FrameInfo frameInfo;
+  SkCodec::FrameInfo frameInfo{0};
   generator_->getFrameInfo(nextFrameIndex_, &frameInfo);
   const int requiredFrameIndex = frameInfo.fRequiredFrame;
   if (requiredFrameIndex != SkCodec::kNoFrame) {
@@ -144,7 +144,7 @@ void MultiFrameCodec::State::GetNextFrameAndInvokeCallback(
   if (skImage) {
     fml::RefPtr<CanvasImage> image = CanvasImage::Create();
     image->set_image({skImage, std::move(unref_queue)});
-    SkCodec::FrameInfo skFrameInfo;
+    SkCodec::FrameInfo skFrameInfo{0};
     generator_->getFrameInfo(nextFrameIndex_, &skFrameInfo);
     frameInfo =
         fml::MakeRefCounted<FrameInfo>(std::move(image), skFrameInfo.fDuration);

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/paint.h"
 
@@ -68,8 +67,9 @@ enum MaskFilterType { Null, Blur };
 
 Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
   is_null_ = Dart_IsNull(paint_data);
-  if (is_null_)
+  if (is_null_) {
     return;
+  }
 
   Dart_Handle values[kObjectCount];
   if (!Dart_IsNull(paint_objects)) {
@@ -78,8 +78,10 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
     Dart_ListLength(paint_objects, &length);
 
     FML_CHECK(length == kObjectCount);
-    if (Dart_IsError(Dart_ListGetRange(paint_objects, 0, kObjectCount, values)))
+    if (Dart_IsError(
+            Dart_ListGetRange(paint_objects, 0, kObjectCount, values))) {
       return;
+    }
 
     Dart_Handle shader = values[kShaderIndex];
     if (!Dart_IsNull(shader)) {
@@ -123,28 +125,34 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
   }
 
   uint32_t style = uint_data[kStyleIndex];
-  if (style)
+  if (style) {
     paint_.setStyle(static_cast<SkPaint::Style>(style));
+  }
 
   float stroke_width = float_data[kStrokeWidthIndex];
-  if (stroke_width != 0.0)
+  if (stroke_width != 0.0) {
     paint_.setStrokeWidth(stroke_width);
+  }
 
   uint32_t stroke_cap = uint_data[kStrokeCapIndex];
-  if (stroke_cap)
+  if (stroke_cap) {
     paint_.setStrokeCap(static_cast<SkPaint::Cap>(stroke_cap));
+  }
 
   uint32_t stroke_join = uint_data[kStrokeJoinIndex];
-  if (stroke_join)
+  if (stroke_join) {
     paint_.setStrokeJoin(static_cast<SkPaint::Join>(stroke_join));
+  }
 
   float stroke_miter_limit = float_data[kStrokeMiterLimitIndex];
-  if (stroke_miter_limit != 0.0)
+  if (stroke_miter_limit != 0.0) {
     paint_.setStrokeMiter(stroke_miter_limit + kStrokeMiterLimitDefault);
+  }
 
   uint32_t filter_quality = uint_data[kFilterQualityIndex];
-  if (filter_quality)
+  if (filter_quality) {
     paint_.setFilterQuality(static_cast<SkFilterQuality>(filter_quality));
+  }
 
   if (uint_data[kInvertColorIndex]) {
     sk_sp<SkColorFilter> invert_filter =

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/path.h"
 
@@ -209,8 +208,10 @@ void CanvasPath::addRRect(const RRect& rrect) {
 }
 
 void CanvasPath::addPath(CanvasPath* path, double dx, double dy) {
-  if (!path)
+  if (!path) {
     Dart_ThrowException(ToDart("Path.addPath called with non-genuine Path."));
+    return;
+  }
   path_.addPath(path->path(), dx, dy, SkPath::kAppend_AddPathMode);
 }
 
@@ -221,6 +222,7 @@ void CanvasPath::addPathWithMatrix(CanvasPath* path,
   if (!path) {
     Dart_ThrowException(
         ToDart("Path.addPathWithMatrix called with non-genuine Path."));
+    return;
   }
 
   SkMatrix matrix = ToSkMatrix(matrix4);
@@ -231,9 +233,11 @@ void CanvasPath::addPathWithMatrix(CanvasPath* path,
 }
 
 void CanvasPath::extendWithPath(CanvasPath* path, double dx, double dy) {
-  if (!path)
+  if (!path) {
     Dart_ThrowException(
         ToDart("Path.extendWithPath called with non-genuine Path."));
+    return;
+  }
   path_.addPath(path->path(), dx, dy, SkPath::kExtend_AddPathMode);
 }
 
@@ -244,6 +248,7 @@ void CanvasPath::extendWithPathAndMatrix(CanvasPath* path,
   if (!path) {
     Dart_ThrowException(
         ToDart("Path.addPathWithMatrix called with non-genuine Path."));
+    return;
   }
 
   SkMatrix matrix = ToSkMatrix(matrix4);
@@ -288,7 +293,8 @@ tonic::Float32List CanvasPath::getBounds() {
 }
 
 bool CanvasPath::op(CanvasPath* path1, CanvasPath* path2, int operation) {
-  return Op(path1->path(), path2->path(), (SkPathOp)operation, &path_);
+  return Op(path1->path(), path2->path(), static_cast<SkPathOp>(operation),
+            &path_);
 }
 
 void CanvasPath::clone(Dart_Handle path_handle) {

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -82,7 +82,7 @@ Dart_Handle Picture::RasterizeToImage(sk_sp<SkPicture> picture,
   }
 
   auto* dart_state = UIDartState::Current();
-  auto image_callback = std::make_shared<tonic::DartPersistentValue>(
+  auto image_callback = std::make_unique<tonic::DartPersistentValue>(
       dart_state, raw_image_callback);
   auto unref_queue = dart_state->GetSkiaUnrefQueue();
   auto ui_task_runner = dart_state->GetTaskRunners().GetUITaskRunner();
@@ -96,7 +96,8 @@ Dart_Handle Picture::RasterizeToImage(sk_sp<SkPicture> picture,
 
   auto picture_bounds = SkISize::Make(width, height);
 
-  auto ui_task = fml::MakeCopyable([image_callback, unref_queue](
+  auto ui_task = fml::MakeCopyable([image_callback = std::move(image_callback),
+                                    unref_queue](
                                        sk_sp<SkImage> raster_image) mutable {
     auto dart_state = image_callback->dart_state().lock();
     if (!dart_state) {

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -1,9 +1,9 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/picture.h"
+#include <memory>
 
 #include "flutter/fml/make_copyable.h"
 #include "flutter/lib/ui/painting/canvas.h"
@@ -81,8 +81,6 @@ Dart_Handle Picture::RasterizeToImage(sk_sp<SkPicture> picture,
   }
 
   auto* dart_state = UIDartState::Current();
-  tonic::DartPersistentValue* image_callback =
-      new tonic::DartPersistentValue(dart_state, raw_image_callback);
   auto unref_queue = dart_state->GetSkiaUnrefQueue();
   auto ui_task_runner = dart_state->GetTaskRunners().GetUITaskRunner();
   auto raster_task_runner = dart_state->GetTaskRunners().GetRasterTaskRunner();
@@ -95,8 +93,11 @@ Dart_Handle Picture::RasterizeToImage(sk_sp<SkPicture> picture,
 
   auto picture_bounds = SkISize::Make(width, height);
 
-  auto ui_task = fml::MakeCopyable([image_callback, unref_queue](
+  auto ui_task = fml::MakeCopyable([raw_image_callback, dart_state,
+                                    unref_queue](
                                        sk_sp<SkImage> raster_image) mutable {
+    auto image_callback = std::make_unique<tonic::DartPersistentValue>(
+        dart_state, raw_image_callback);
     auto dart_state = image_callback->dart_state().lock();
     if (!dart_state) {
       // The root isolate could have died in the meantime.
@@ -117,8 +118,7 @@ Dart_Handle Picture::RasterizeToImage(sk_sp<SkPicture> picture,
     tonic::DartInvoke(image_callback->Get(), {raw_dart_image});
 
     // image_callback is associated with the Dart isolate and must be deleted
-    // on the UI thread
-    delete image_callback;
+    // on the UI thread. It gets deleted when it goes out of scope here.
   });
 
   // Kick things off on the raster rask runner.

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/picture_recorder.h"
 
@@ -44,8 +43,9 @@ SkCanvas* PictureRecorder::BeginRecording(SkRect bounds) {
 }
 
 fml::RefPtr<Picture> PictureRecorder::endRecording(Dart_Handle dart_picture) {
-  if (!canvas_)
+  if (!canvas_) {
     return nullptr;
+  }
 
   fml::RefPtr<Picture> picture =
       Picture::Create(dart_picture,

--- a/lib/ui/painting/rrect.cc
+++ b/lib/ui/painting/rrect.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/rrect.h"
 
@@ -9,7 +8,7 @@
 #include "third_party/tonic/logging/dart_error.h"
 #include "third_party/tonic/typed_data/typed_list.h"
 
-using namespace flutter;
+using flutter::RRect;
 
 namespace tonic {
 
@@ -21,8 +20,9 @@ RRect DartConverter<flutter::RRect>::FromDart(Dart_Handle value) {
 
   RRect result;
   result.is_null = true;
-  if (buffer.data() == nullptr)
+  if (buffer.data() == nullptr) {
     return result;
+  }
 
   SkVector radii[4] = {{buffer[4], buffer[5]},
                        {buffer[6], buffer[7]},

--- a/lib/ui/painting/vertices.cc
+++ b/lib/ui/painting/vertices.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/painting/vertices.h"
 #include "flutter/lib/ui/ui_dart_state.h"
@@ -16,14 +15,16 @@ namespace flutter {
 namespace {
 
 void DecodePoints(const tonic::Float32List& coords, SkPoint* points) {
-  for (int i = 0; i < coords.num_elements(); i += 2)
+  for (int i = 0; i < coords.num_elements(); i += 2) {
     points[i / 2] = SkPoint::Make(coords[i], coords[i + 1]);
+  }
 }
 
 template <typename T>
 void DecodeInts(const tonic::Int32List& ints, T* out) {
-  for (int i = 0; i < ints.num_elements(); i++)
+  for (int i = 0; i < ints.num_elements(); i++) {
     out[i] = ints[i];
+  }
 }
 
 }  // namespace
@@ -50,21 +51,25 @@ bool Vertices::init(Dart_Handle vertices_handle,
                     const tonic::Uint16List& indices) {
   UIDartState::ThrowIfUIOperationsProhibited();
   uint32_t builderFlags = 0;
-  if (texture_coordinates.data())
+  if (texture_coordinates.data()) {
     builderFlags |= SkVertices::kHasTexCoords_BuilderFlag;
-  if (colors.data())
+  }
+  if (colors.data()) {
     builderFlags |= SkVertices::kHasColors_BuilderFlag;
+  }
 
   SkVertices::Builder builder(vertex_mode, positions.num_elements() / 2,
                               indices.num_elements(), builderFlags);
 
-  if (!builder.isValid())
+  if (!builder.isValid()) {
     return false;
+  }
 
   // positions are required for SkVertices::Builder
   FML_DCHECK(positions.data());
-  if (positions.data())
+  if (positions.data()) {
     DecodePoints(positions, builder.positions());
+  }
 
   if (texture_coordinates.data()) {
     // SkVertices::Builder assumes equal numbers of elements

--- a/lib/ui/painting/vertices_unittests.cc
+++ b/lib/ui/painting/vertices_unittests.cc
@@ -1,8 +1,8 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
+#include <memory>
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/lib/ui/painting/vertices.h"
@@ -15,9 +15,9 @@ namespace flutter {
 namespace testing {
 
 TEST_F(ShellTest, VerticesAccuratelyReportsSize) {
-  fml::AutoResetWaitableEvent message_latch;
+  auto message_latch = std::make_shared<fml::AutoResetWaitableEvent>();
 
-  auto nativeValidateVertices = [&](Dart_NativeArguments args) {
+  auto nativeValidateVertices = [message_latch](Dart_NativeArguments args) {
     auto handle = Dart_GetNativeArgument(args, 0);
     intptr_t peer = 0;
     Dart_Handle result = Dart_GetNativeInstanceField(
@@ -29,7 +29,7 @@ TEST_F(ShellTest, VerticesAccuratelyReportsSize) {
     // macOS as of the test writing is 1441890ul. Just need to assert it's
     // big enough to get the Dart GC's attention.
     ASSERT_GT(vertices->GetAllocationSize(), 1300000ul);
-    message_latch.Signal();
+    message_latch->Signal();
   };
 
   Settings settings = CreateSettingsForFixture();
@@ -50,11 +50,11 @@ TEST_F(ShellTest, VerticesAccuratelyReportsSize) {
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("createVertices");
 
-  shell->RunEngine(std::move(configuration), [&](auto result) {
+  shell->RunEngine(std::move(configuration), [](auto result) {
     ASSERT_EQ(result, Engine::RunStatus::Success);
   });
 
-  message_latch.Wait();
+  message_latch->Wait();
   DestroyShell(std::move(shell), std::move(task_runners));
 }
 

--- a/lib/ui/text/asset_manager_font_provider.cc
+++ b/lib/ui/text/asset_manager_font_provider.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/text/asset_manager_font_provider.h"
 
@@ -97,8 +96,9 @@ void AssetManagerFontStyleSet::getStyle(int index,
 
 SkTypeface* AssetManagerFontStyleSet::createTypeface(int i) {
   size_t index = i;
-  if (index >= assets_.size())
+  if (index >= assets_.size()) {
     return nullptr;
+  }
 
   TypefaceAsset& asset = assets_[index];
   if (!asset.typeface) {
@@ -116,8 +116,9 @@ SkTypeface* AssetManagerFontStyleSet::createTypeface(int i) {
 
     // Ownership of the stream is transferred.
     asset.typeface = SkTypeface::MakeFromStream(std::move(stream));
-    if (!asset.typeface)
+    if (!asset.typeface) {
       return nullptr;
+    }
   }
 
   return SkRef(asset.typeface.get());

--- a/lib/ui/text/font_collection.cc
+++ b/lib/ui/text/font_collection.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/text/font_collection.h"
 
@@ -28,7 +27,7 @@ namespace flutter {
 
 namespace {
 
-void LoadFontFromList(tonic::Uint8List& font_data,
+void LoadFontFromList(tonic::Uint8List& font_data,  // NOLINT
                       Dart_Handle callback,
                       std::string family_name) {
   FontCollection& font_collection =
@@ -122,7 +121,7 @@ void FontCollection::RegisterFonts(
         continue;
       }
 
-      // TODO: Handle weights and styles.
+      // TODO(chinmaygarde): Handle weights and styles.
       font_provider->RegisterAsset(family_name->value.GetString(),
                                    font_asset->value.GetString());
     }

--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/text/paragraph.h"
 
@@ -90,8 +89,9 @@ void Paragraph::layout(double width) {
 
 void Paragraph::paint(Canvas* canvas, double x, double y) {
   SkCanvas* sk_canvas = canvas->canvas();
-  if (!sk_canvas)
+  if (!sk_canvas) {
     return;
+  }
   m_paragraph->Paint(sk_canvas, x, y);
 }
 
@@ -103,8 +103,8 @@ static tonic::Float32List EncodeTextBoxes(
   // text direction index.
   tonic::Float32List result(
       Dart_NewTypedData(Dart_TypedData_kFloat32, boxes.size() * 5));
-  unsigned long position = 0;
-  for (unsigned long i = 0; i < boxes.size(); i++) {
+  uint64_t position = 0;
+  for (uint64_t i = 0; i < boxes.size(); i++) {
     const txt::Paragraph::TextBox& box = boxes[i];
     result[position++] = box.rect.fLeft;
     result[position++] = box.rect.fTop;
@@ -173,8 +173,8 @@ tonic::Float64List Paragraph::computeLineMetrics() {
   // properties
   tonic::Float64List result(
       Dart_NewTypedData(Dart_TypedData_kFloat64, metrics.size() * 9));
-  unsigned long position = 0;
-  for (unsigned long i = 0; i < metrics.size(); i++) {
+  uint64_t position = 0;
+  for (uint64_t i = 0; i < metrics.size(); i++) {
     const txt::LineMetrics& line = metrics[i];
     result[position++] = static_cast<double>(line.hard_break);
     result[position++] = line.ascent;

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/text/paragraph_builder.h"
 
@@ -170,7 +169,7 @@ fml::RefPtr<ParagraphBuilder> ParagraphBuilder::create(
 // parameter passed directly.
 void decodeStrut(Dart_Handle strut_data,
                  const std::vector<std::string>& strut_font_families,
-                 txt::ParagraphStyle& paragraph_style) {
+                 txt::ParagraphStyle& paragraph_style) {  // NOLINT
   if (strut_data == Dart_Null()) {
     return;
   }
@@ -304,8 +303,9 @@ ParagraphBuilder::ParagraphBuilder(
 
 ParagraphBuilder::~ParagraphBuilder() = default;
 
-void decodeTextShadows(Dart_Handle shadows_data,
-                       std::vector<txt::TextShadow>& decoded_shadows) {
+void decodeTextShadows(
+    Dart_Handle shadows_data,
+    std::vector<txt::TextShadow>& decoded_shadows) {  // NOLINT
   decoded_shadows.clear();
 
   tonic::DartByteData byte_data(shadows_data);
@@ -329,7 +329,7 @@ void decodeTextShadows(Dart_Handle shadows_data,
 }
 
 void decodeFontFeatures(Dart_Handle font_features_data,
-                        txt::FontFeatures& font_features) {
+                        txt::FontFeatures& font_features) {  // NOLINT
   tonic::DartByteData byte_data(font_features_data);
   FML_CHECK(byte_data.length_in_bytes() % kBytesPerFontFeature == 0);
 
@@ -399,21 +399,26 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
 
   if (mask & (tsFontWeightMask | tsFontStyleMask | tsFontSizeMask |
               tsLetterSpacingMask | tsWordSpacingMask)) {
-    if (mask & tsFontWeightMask)
+    if (mask & tsFontWeightMask) {
       style.font_weight =
           static_cast<txt::FontWeight>(encoded[tsFontWeightIndex]);
+    }
 
-    if (mask & tsFontStyleMask)
+    if (mask & tsFontStyleMask) {
       style.font_style = static_cast<txt::FontStyle>(encoded[tsFontStyleIndex]);
+    }
 
-    if (mask & tsFontSizeMask)
+    if (mask & tsFontSizeMask) {
       style.font_size = fontSize;
+    }
 
-    if (mask & tsLetterSpacingMask)
+    if (mask & tsLetterSpacingMask) {
       style.letter_spacing = letterSpacing;
+    }
 
-    if (mask & tsWordSpacingMask)
+    if (mask & tsWordSpacingMask) {
       style.word_spacing = wordSpacing;
+    }
   }
 
   if (mask & tsHeightMask) {
@@ -464,8 +469,9 @@ void ParagraphBuilder::pop() {
 }
 
 Dart_Handle ParagraphBuilder::addText(const std::u16string& text) {
-  if (text.empty())
+  if (text.empty()) {
     return Dart_Null();
+  }
 
   // Use ICU to validate the UTF-16 input.  Calling u_strToUTF8 with a null
   // output buffer will return U_BUFFER_OVERFLOW_ERROR if the input is well
@@ -473,8 +479,9 @@ Dart_Handle ParagraphBuilder::addText(const std::u16string& text) {
   const UChar* text_ptr = reinterpret_cast<const UChar*>(text.data());
   UErrorCode error_code = U_ZERO_ERROR;
   u_strToUTF8(nullptr, 0, nullptr, text_ptr, text.size(), &error_code);
-  if (error_code != U_BUFFER_OVERFLOW_ERROR)
+  if (error_code != U_BUFFER_OVERFLOW_ERROR) {
     return tonic::ToDart("string is not well-formed UTF-16");
+  }
 
   m_paragraphBuilder->AddText(text);
 

--- a/lib/ui/ui_benchmarks.cc
+++ b/lib/ui/ui_benchmarks.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/benchmarking/benchmarking.h"
 #include "flutter/common/settings.h"
@@ -19,7 +18,8 @@ class Fixture : public testing::FixtureTest {
   void TestBody() override{};
 };
 
-static void BM_PlatformMessageResponseDartComplete(benchmark::State& state) {
+static void BM_PlatformMessageResponseDartComplete(
+    benchmark::State& state) {  // NOLINT
   ThreadHost thread_host("test",
                          ThreadHost::Type::Platform | ThreadHost::Type::GPU |
                              ThreadHost::Type::IO | ThreadHost::Type::UI);

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/ui_dart_state.h"
 
@@ -74,8 +73,9 @@ void UIDartState::ThrowIfUIOperationsProhibited() {
 
 void UIDartState::SetDebugName(const std::string debug_name) {
   debug_name_ = debug_name;
-  if (window_)
+  if (window_) {
     window_->client()->UpdateIsolateDescription(debug_name_, main_port_);
+  }
 }
 
 UIDartState* UIDartState::Current() {
@@ -84,8 +84,9 @@ UIDartState* UIDartState::Current() {
 
 void UIDartState::SetWindow(std::unique_ptr<Window> window) {
   window_ = std::move(window);
-  if (window_)
+  if (window_) {
     window_->client()->UpdateIsolateDescription(debug_name_, main_port_);
+  }
 }
 
 const TaskRunners& UIDartState::GetTaskRunners() const {

--- a/lib/ui/window/platform_message_response_dart.cc
+++ b/lib/ui/window/platform_message_response_dart.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/window/platform_message_response_dart.h"
 
@@ -29,16 +28,18 @@ PlatformMessageResponseDart::~PlatformMessageResponseDart() {
 }
 
 void PlatformMessageResponseDart::Complete(std::unique_ptr<fml::Mapping> data) {
-  if (callback_.is_empty())
+  if (callback_.is_empty()) {
     return;
+  }
   FML_DCHECK(!is_complete_);
   is_complete_ = true;
   ui_task_runner_->PostTask(fml::MakeCopyable(
       [callback = std::move(callback_), data = std::move(data)]() mutable {
         std::shared_ptr<tonic::DartState> dart_state =
             callback.dart_state().lock();
-        if (!dart_state)
+        if (!dart_state) {
           return;
+        }
         tonic::DartState::Scope scope(dart_state);
 
         Dart_Handle byte_buffer =
@@ -48,16 +49,18 @@ void PlatformMessageResponseDart::Complete(std::unique_ptr<fml::Mapping> data) {
 }
 
 void PlatformMessageResponseDart::CompleteEmpty() {
-  if (callback_.is_empty())
+  if (callback_.is_empty()) {
     return;
+  }
   FML_DCHECK(!is_complete_);
   is_complete_ = true;
   ui_task_runner_->PostTask(
       fml::MakeCopyable([callback = std::move(callback_)]() mutable {
         std::shared_ptr<tonic::DartState> dart_state =
             callback.dart_state().lock();
-        if (!dart_state)
+        if (!dart_state) {
           return;
+        }
         tonic::DartState::Scope scope(dart_state);
         tonic::DartInvoke(callback.Release(), {Dart_Null()});
       }));

--- a/lib/ui/window/pointer_data_packet_converter_unittests.cc
+++ b/lib/ui/window/pointer_data_packet_converter_unittests.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/window/pointer_data_packet_converter.h"
 #include "gtest/gtest.h"
@@ -9,7 +8,7 @@
 namespace flutter {
 namespace testing {
 
-void CreateSimulatedPointerData(PointerData& data,
+void CreateSimulatedPointerData(PointerData& data,  // NOLINT
                                 PointerData::Change change,
                                 int64_t device,
                                 double dx,
@@ -44,7 +43,7 @@ void CreateSimulatedPointerData(PointerData& data,
   data.scroll_delta_y = 0.0;
 }
 
-void CreateSimulatedMousePointerData(PointerData& data,
+void CreateSimulatedMousePointerData(PointerData& data,  // NOLINT
                                      PointerData::Change change,
                                      PointerData::SignalKind signal_kind,
                                      int64_t device,
@@ -82,7 +81,7 @@ void CreateSimulatedMousePointerData(PointerData& data,
   data.scroll_delta_y = scroll_delta_y;
 }
 
-void UnpackPointerPacket(std::vector<PointerData>& output,
+void UnpackPointerPacket(std::vector<PointerData>& output,  // NOLINT
                          std::unique_ptr<PointerDataPacket> packet) {
   size_t kBytesPerPointerData = kPointerDataFieldCount * kBytesPerField;
   auto buffer = packet->data();

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "flutter/lib/ui/window/window.h"
 
@@ -188,8 +187,9 @@ void Window::UpdateWindowMetrics(const ViewportMetrics& metrics) {
   viewport_metrics_ = metrics;
 
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
   tonic::LogIfError(tonic::DartInvokeField(
       library_.value(), "_updateWindowMetrics",
@@ -215,8 +215,9 @@ void Window::UpdateWindowMetrics(const ViewportMetrics& metrics) {
 
 void Window::UpdateLocales(const std::vector<std::string>& locales) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
   tonic::LogIfError(tonic::DartInvokeField(
       library_.value(), "_updateLocales",
@@ -227,8 +228,9 @@ void Window::UpdateLocales(const std::vector<std::string>& locales) {
 
 void Window::UpdateUserSettingsData(const std::string& data) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
 
   tonic::LogIfError(tonic::DartInvokeField(library_.value(),
@@ -240,8 +242,9 @@ void Window::UpdateUserSettingsData(const std::string& data) {
 
 void Window::UpdateLifecycleState(const std::string& data) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
   tonic::LogIfError(tonic::DartInvokeField(library_.value(),
                                            "_updateLifecycleState",
@@ -252,8 +255,9 @@ void Window::UpdateLifecycleState(const std::string& data) {
 
 void Window::UpdateSemanticsEnabled(bool enabled) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
   UIDartState::ThrowIfUIOperationsProhibited();
 
@@ -263,8 +267,9 @@ void Window::UpdateSemanticsEnabled(bool enabled) {
 
 void Window::UpdateAccessibilityFeatures(int32_t values) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
 
   tonic::LogIfError(tonic::DartInvokeField(library_.value(),
@@ -304,13 +309,15 @@ void Window::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
 
 void Window::DispatchPointerDataPacket(const PointerDataPacket& packet) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
 
   Dart_Handle data_handle = ToByteData(packet.data());
-  if (Dart_IsError(data_handle))
+  if (Dart_IsError(data_handle)) {
     return;
+  }
   tonic::LogIfError(tonic::DartInvokeField(
       library_.value(), "_dispatchPointerDataPacket", {data_handle}));
 }
@@ -319,14 +326,16 @@ void Window::DispatchSemanticsAction(int32_t id,
                                      SemanticsAction action,
                                      std::vector<uint8_t> args) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
 
   Dart_Handle args_handle = (args.empty()) ? Dart_Null() : ToByteData(args);
 
-  if (Dart_IsError(args_handle))
+  if (Dart_IsError(args_handle)) {
     return;
+  }
 
   tonic::LogIfError(tonic::DartInvokeField(
       library_.value(), "_dispatchSemanticsAction",
@@ -336,8 +345,9 @@ void Window::DispatchSemanticsAction(int32_t id,
 
 void Window::BeginFrame(fml::TimePoint frameTime) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
 
   int64_t microseconds = (frameTime - fml::TimePoint()).ToMicroseconds();
@@ -354,8 +364,9 @@ void Window::BeginFrame(fml::TimePoint frameTime) {
 
 void Window::ReportTimings(std::vector<int64_t> timings) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
 
   Dart_Handle data_handle =
@@ -378,11 +389,13 @@ void Window::ReportTimings(std::vector<int64_t> timings) {
 }
 
 void Window::CompletePlatformMessageEmptyResponse(int response_id) {
-  if (!response_id)
+  if (!response_id) {
     return;
+  }
   auto it = pending_responses_.find(response_id);
-  if (it == pending_responses_.end())
+  if (it == pending_responses_.end()) {
     return;
+  }
   auto response = std::move(it->second);
   pending_responses_.erase(it);
   response->CompleteEmpty();
@@ -390,11 +403,13 @@ void Window::CompletePlatformMessageEmptyResponse(int response_id) {
 
 void Window::CompletePlatformMessageResponse(int response_id,
                                              std::vector<uint8_t> data) {
-  if (!response_id)
+  if (!response_id) {
     return;
+  }
   auto it = pending_responses_.find(response_id);
-  if (it == pending_responses_.end())
+  if (it == pending_responses_.end()) {
     return;
+  }
   auto response = std::move(it->second);
   pending_responses_.erase(it);
   response->Complete(std::make_unique<fml::DataMapping>(std::move(data)));


### PR DESCRIPTION
## Description

This fixes all of the lint errors in lib/ui, except for a few (three, I think) where it would have changed the API, converting non-const references to pointers.  For those, I just did NOLINT on the particular line instead of ignoring the whole file.
