### PR TITLE
Fix lint errors in vulkan directory.

### DIFF
--- a/vulkan/BUILD.gn
+++ b/vulkan/BUILD.gn
@@ -11,7 +11,10 @@ config("vulkan_config") {
     include_dirs += [ "$fuchsia_sdk_root/vulkan/include" ]
     defines += [ "VK_USE_PLATFORM_FUCHSIA=1" ]
   } else {
-    include_dirs += [ "//third_party/vulkan/src" ]
+    include_dirs += [
+      "//third_party/vulkan/src",
+      "//third_party/vulkan/include",
+    ]
   }
 }
 

--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_application.h"
 
@@ -15,7 +14,7 @@
 namespace vulkan {
 
 VulkanApplication::VulkanApplication(
-    VulkanProcTable& p_vk,
+    VulkanProcTable& p_vk,  // NOLINT
     const std::string& application_name,
     std::vector<std::string> enabled_extensions,
     uint32_t application_version,

--- a/vulkan/vulkan_application.h
+++ b/vulkan/vulkan_application.h
@@ -24,7 +24,7 @@ class VulkanProcTable;
 /// create a VkInstance (with debug reporting optionally enabled).
 class VulkanApplication {
  public:
-  VulkanApplication(VulkanProcTable& vk,
+  VulkanApplication(VulkanProcTable& vk,  // NOLINT
                     const std::string& application_name,
                     std::vector<std::string> enabled_extensions,
                     uint32_t application_version = VK_MAKE_VERSION(1, 0, 0),

--- a/vulkan/vulkan_backbuffer.cc
+++ b/vulkan/vulkan_backbuffer.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_backbuffer.h"
 

--- a/vulkan/vulkan_command_buffer.cc
+++ b/vulkan/vulkan_command_buffer.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_command_buffer.h"
 

--- a/vulkan/vulkan_debug_report.cc
+++ b/vulkan/vulkan_debug_report.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_debug_report.h"
 
@@ -192,8 +191,9 @@ VulkanDebugReport::VulkanDebugReport(
   }
 
   VkDebugReportFlagsEXT flags = kVulkanErrorFlags;
-  if (ValidationLayerInfoMessagesEnabled())
+  if (ValidationLayerInfoMessagesEnabled()) {
     flags |= kVulkanInfoFlags;
+  }
   const VkDebugReportCallbackCreateInfoEXT create_info = {
       .sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CREATE_INFO_EXT,
       .pNext = nullptr,

--- a/vulkan/vulkan_device.cc
+++ b/vulkan/vulkan_device.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_device.h"
 

--- a/vulkan/vulkan_handle.cc
+++ b/vulkan/vulkan_handle.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_handle.h"
 

--- a/vulkan/vulkan_image.cc
+++ b/vulkan/vulkan_image.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_image.h"
 

--- a/vulkan/vulkan_interface.cc
+++ b/vulkan/vulkan_interface.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_interface.h"
 

--- a/vulkan/vulkan_native_surface.cc
+++ b/vulkan/vulkan_native_surface.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_native_surface.h"
 

--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_proc_table.h"
 

--- a/vulkan/vulkan_surface.cc
+++ b/vulkan/vulkan_surface.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_surface.h"
 
@@ -11,8 +10,8 @@
 namespace vulkan {
 
 VulkanSurface::VulkanSurface(
-    VulkanProcTable& p_vk,
-    VulkanApplication& application,
+    VulkanProcTable& p_vk,           // NOLINT
+    VulkanApplication& application,  // NOLINT
     std::unique_ptr<VulkanNativeSurface> native_surface)
     : vk(p_vk),
       application_(application),

--- a/vulkan/vulkan_utilities.cc
+++ b/vulkan/vulkan_utilities.cc
@@ -1,7 +1,6 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
 
 #include "vulkan_utilities.h"
 #include "flutter/fml/build_config.h"


### PR DESCRIPTION
## Description

This fixes lint errors in the vulkan directory.  This might be a little more controversial, but the reason that the lints were failing here was because of an include path problem that I think I solved.

There's one heinous hack in here.  It's totally safe, but see if you can spot it...