### PR TITLE
 Added GLFW error-callback into FlutterEmbedderGLFW

### DIFF
--- a/examples/glfw/FlutterEmbedderGLFW.cc
+++ b/examples/glfw/FlutterEmbedderGLFW.cc
@@ -125,6 +125,10 @@ void printUsage() {
             << std::endl;
 }
 
+void GLFW_ErrorCallback(int error, const char* description) {
+  std::cout << "GLFW Error: (" << error << ") " << description << std::endl;
+}
+
 int main(int argc, const char* argv[]) {
   if (argc != 3) {
     printUsage();
@@ -133,6 +137,8 @@ int main(int argc, const char* argv[]) {
 
   std::string project_path = argv[1];
   std::string icudtl_path = argv[2];
+
+  glfwSetErrorCallback(GLFW_ErrorCallback);
 
   int result = glfwInit();
   assert(result == GLFW_TRUE);


### PR DESCRIPTION
GLFW Error callback useful to clarify reasons of `glfwInit()` failure.

On some platforms/desktop environments may be really strange failure reasons, like (in my case): `Linux: Failed to initialize inotify: Too many open files`, so descriptive error messages helps to solve problem.