### PR TITLE
Add a driver version for Chrome84 - Chrome 85

### DIFF
--- a/lib/web_ui/dev/driver_version.yaml
+++ b/lib/web_ui/dev/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  84: '84.0.4147.30'
   83: '83.0.4103.39'
   81: '81.0.4044.69'
   80: '80.0.3987.106'

--- a/lib/web_ui/dev/driver_version.yaml
+++ b/lib/web_ui/dev/driver_version.yaml
@@ -2,6 +2,7 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  85: '85.0.4183.38'
   84: '84.0.4147.30'
   83: '83.0.4103.39'
   81: '81.0.4044.69'


### PR DESCRIPTION
-- how we decide on the driver number --
Each chromeDriver84 can run with Chrome84 however there is recommended version on this page: https://chromedriver.chromium.org/downloads

