### PR TITLE
[web] Address platform changes in the integration tests. Part 1

### DIFF
--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -409,6 +409,7 @@ String getBlockedTestsListMapKey(String browser) =>
 /// Note that integration tests are only running on chrome for now.
 const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
   'chrome-linux': [
+    'target_platform_android_e2e.dart',
     'target_platform_ios_e2e.dart',
     'target_platform_macos_e2e.dart',
   ],
@@ -422,6 +423,7 @@ const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
     'image_loading_e2e.dart',
   ],
   'firefox-linux': [
+    'target_platform_android_e2e.dart',
     'target_platform_ios_e2e.dart',
     'target_platform_macos_e2e.dart',
   ],


### PR DESCRIPTION
The way platform is chosen in Flutter has changed recently.

Now linux is recognized as a separate platform and linux machines does not return "android" as the platform anymore.

Therefore we need to stop running android tests on linux desktop web test runners.

As Part2, I'll add another test for linux platform.