### PR TITLE
[null-safety] fix real failures

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/compositor/path_metrics.dart
@@ -13,7 +13,7 @@ class CkPathMetrics extends IterableBase<ui.PathMetric>
 
   /// The [CkPath.isEmpty] case is special-cased to avoid booting the WASM machinery just to find out there are no contours.
   @override
-  Iterator<ui.PathMetric> get iterator => _path.isEmpty! ? const CkPathMetricIteratorEmpty._() : CkContourMeasureIter(_path, _forceClosed);
+  Iterator<ui.PathMetric> get iterator => _path.isEmpty ? const CkPathMetricIteratorEmpty._() : CkContourMeasureIter(_path, _forceClosed);
 }
 
 class CkContourMeasureIter implements Iterator<ui.PathMetric> {

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -160,7 +160,7 @@ class Surface {
         return _makeSoftwareCanvasSurface(htmlCanvas);
       }
 
-      return CkSurface(skSurface!, _grContext, glContext);
+      return CkSurface(skSurface, _grContext, glContext);
     }
   }
 


### PR DESCRIPTION
## Description

These seem like real failures:

```
[INFO] build_web_compilers:entrypoint on test/hash_codes_test.dart:Dart2Js finished with:

packages/ui/src/engine/compositor/path_metrics.dart:16:49:
Warning: Operand of null-aware operation '!' has type 'bool' which excludes null.
  Iterator<ui.PathMetric> get iterator => _path.isEmpty! ? const CkPathMetricIteratorEmpty._() : CkContourMeasureIter(_path, _forceClosed);
                                                ^
packages/ui/src/engine/compositor/surface.dart:163:24:
Warning: Operand of null-aware operation '!' has type 'SkSurface' which excludes null.
 - 'SkSurface' is from 'package:ui/src/engine.dart' ('packages/ui/src/engine.dart').
      return CkSurface(skSurface!, _grContext, glContext);
                       ^
Compiled 10,872,741 characters Dart to 851,076 characters JavaScript in 6.97 seconds
Dart file test/hash_codes_test.dart compiled to JavaScript: test/hash_codes_test.dart.js

[INFO] build_web_compilers:entrypoint on test/rect_test.dart:Running dart2js with --no-minify --disable-inlining --enable-asserts --enable-experiment=non-nullable --no-sound-null-safety --packages=.dart_tool/package_config.json -otest/text/line_breaker_test.dart.js test/text/line_breaker_test.dart

[INFO] 3m 20s elapsed, 1860/1876 actions completed.
[INFO] 3m 22s elapsed, 1860/1876 actions completed.
[INFO] build_web_compilers:entrypoint on test/locale_test.dart:Dart2Js finished with:

packages/ui/src/engine/compositor/path_metrics.dart:16:49:
Warning: Operand of null-aware operation '!' has type 'bool' which excludes null.
  Iterator<ui.PathMetric> get iterator => _path.isEmpty! ? const CkPathMetricIteratorEmpty._() : CkContourMeasureIter(_path, _forceClosed);
                                                ^
packages/ui/src/engine/compositor/surface.dart:163:24:
Warning: Operand of null-aware operation '!' has type 'SkSurface' which excludes null.
 - 'SkSurface' is from 'package:ui/src/engine.dart' ('packages/ui/src/engine.dart').
      return CkSurface(skSurface!, _grContext, glContext);
                       ^
Compiled 10,871,168 characters Dart to 854,693 characters JavaScript in 7.16 seconds
Dart file test/locale_test.dart compiled to JavaScript: test/locale_test.dart.js
```