### PR TITLE
Stop using custom version for Dart SDK

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -183,9 +183,6 @@ def to_gn_args(args):
       if sys.platform.startswith(('cygwin', 'win')):
         gn_args['dart_use_fallback_root_certificates'] = True
 
-
-    gn_args['dart_custom_version_for_pub'] = 'flutter'
-
     # Make sure host_cpu matches the bit width of target_cpu on x86.
     if gn_args['target_cpu'] == 'x86':
       gn_args['host_cpu'] = 'x86'

--- a/tools/gn
+++ b/tools/gn
@@ -183,6 +183,9 @@ def to_gn_args(args):
       if sys.platform.startswith(('cygwin', 'win')):
         gn_args['dart_use_fallback_root_certificates'] = True
 
+    gn_args['dart_custom_version_for_pub'] = 'flutter'
+    gn_args['dart_version_git_info'] = False
+
     # Make sure host_cpu matches the bit width of target_cpu on x86.
     if gn_args['target_cpu'] == 'x86':
       gn_args['host_cpu'] = 'x86'


### PR DESCRIPTION
## Description

This PR adds `gn_args['dart_version_git_info'] = False`, which will remove the dependency our Dart SDK build has on upstream git tags in determining its version to report. This was one of the underlying causes of https://github.com/flutter/flutter/issues/62146.

Engine version of this https://dart-review.googlesource.com/c/sdk/+/155681. After that CL is rolled into the engine, the flag would be a no-op anyway, but this PR allows the change to be cherry-picked to Flutter release branches.

## Related Issues

Fixes https://github.com/dart-lang/sdk/issues/42820, would have prevented https://github.com/flutter/flutter/issues/62146

Note: this was initially added to fix https://github.com/flutter/flutter/issues/14751