### PR TITLE
integration tests for linux platform check

### DIFF
--- a/e2etests/web/regular_integration_tests/lib/target_platform_main.dart
+++ b/e2etests/web/regular_integration_tests/lib/target_platform_main.dart
@@ -41,6 +41,11 @@ class MyHomePage extends StatelessWidget {
                 'I am running on Android',
                 key: Key('androidKey'),
               ),
+            if (defaultTargetPlatform == TargetPlatform.linux)
+              const Text(
+                'I am running on Linux',
+                key: Key('linuxKey'),
+              ),
           ],
         ),
       ),

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
@@ -24,5 +24,8 @@ void main() {
 
         final Finder androidFinder = find.byKey(const Key('androidKey'));
         expect(androidFinder, findsNothing);
+
+        final Finder linuxFinder = find.byKey(const Key('linuxKey'));
+        expect(linuxFinder, findsNothing);
       });
 }

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_linux_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_linux_e2e.dart
@@ -11,7 +11,7 @@ import 'package:e2e/e2e.dart';
 void main() {
   E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
 
-  testWidgets('Should detect android platform when running on android device',
+  testWidgets('Should detect linux platform when running on linux machine',
           (WidgetTester tester) async {
         app.main();
         await tester.pumpAndSettle();
@@ -23,9 +23,9 @@ void main() {
         expect(iOSFinder, findsNothing);
 
         final Finder androidFinder = find.byKey(const Key('androidKey'));
-        expect(androidFinder, findsOneWidget);
+        expect(androidFinder, findsNothing);
 
         final Finder linuxFinder = find.byKey(const Key('linuxKey'));
-        expect(linuxFinder, findsNothing);
+        expect(linuxFinder, findsOneWidget);
       });
 }

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_linux_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_linux_e2e_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:e2e/e2e_driver.dart' as e2e;
+
+Future<void> main() async => e2e.main();

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
@@ -24,5 +24,8 @@ void main() {
 
         final Finder androidFinder = find.byKey(const Key('androidKey'));
         expect(androidFinder, findsNothing);
+
+        final Finder linuxFinder = find.byKey(const Key('linuxKey'));
+        expect(linuxFinder, findsNothing);
       });
 }

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -414,11 +414,13 @@ const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
     'target_platform_macos_e2e.dart',
   ],
   'chrome-macos': [
+    'target_platform_linux_e2e.dart',
     'target_platform_ios_e2e.dart',
     'target_platform_android_e2e.dart',
   ],
   'safari-macos': [
     'target_platform_ios_e2e.dart',
+    'target_platform_linux_e2e.dart',
     'target_platform_android_e2e.dart',
     'image_loading_e2e.dart',
   ],
@@ -428,6 +430,7 @@ const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
     'target_platform_macos_e2e.dart',
   ],
   'firefox-macos': [
+    'target_platform_linux_e2e.dart',
     'target_platform_android_e2e.dart',
     'target_platform_ios_e2e.dart',
   ],

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -409,6 +409,7 @@ String getBlockedTestsListMapKey(String browser) =>
 /// Note that integration tests are only running on chrome for now.
 const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
   'chrome-linux': [
+    'target_platform_linux_e2e.dart',
     'target_platform_android_e2e.dart',
     'target_platform_ios_e2e.dart',
     'target_platform_macos_e2e.dart',
@@ -426,6 +427,7 @@ const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
   ],
   'firefox-linux': [
     'target_platform_android_e2e.dart',
+    'target_platform_linux_e2e.dart',
     'target_platform_ios_e2e.dart',
     'target_platform_macos_e2e.dart',
   ],

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -334,7 +334,7 @@ class ChromeIntegrationArguments extends IntegrationArguments {
       '--$mode',
       '--browser-name=chrome',
       if (isLuci) '--chrome-binary=${preinstalledChromeExecutable()}',
-      if (isLuci) '--headless',
+      if (isLuci) '--no-headless',
       '--local-engine=host_debug_unopt',
     ];
   }
@@ -409,7 +409,6 @@ String getBlockedTestsListMapKey(String browser) =>
 /// Note that integration tests are only running on chrome for now.
 const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
   'chrome-linux': [
-    'target_platform_linux_e2e.dart',
     'target_platform_android_e2e.dart',
     'target_platform_ios_e2e.dart',
     'target_platform_macos_e2e.dart',
@@ -427,7 +426,6 @@ const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
   ],
   'firefox-linux': [
     'target_platform_android_e2e.dart',
-    'target_platform_linux_e2e.dart',
     'target_platform_ios_e2e.dart',
     'target_platform_macos_e2e.dart',
   ],


### PR DESCRIPTION
(Marked as draft since tree is still red.)

I'm adding a test for linux platform. Linux target platform is recently added: https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/foundation/_platform_web.dart#L41