### PR TITLE
fixing cirrus flag issue

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def3cf0d380830f06687a89ea69c87344c5ade369700fe]
 
 web_shard_template: &WEB_SHARD_TEMPLATE
-  only_if: "changesInclude('.cirrus.yml', 'DEPS', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+  only_if: "changesInclude('tools/clone_flutter.sh', '.cirrus.yml', 'DEPS', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
   environment:
     # As of March 2020, the Web shards needed 16G of RAM and 4 CPUs to run all framework tests with goldens without flaking.
     CPU: 4

--- a/ci/format.sh
+++ b/ci/format.sh
@@ -40,7 +40,7 @@ else
 fi;
 
 
-BASE_SHA="$(git fetch $UPSTREAM master > /dev/null 2>&1 && \
+BASE_SHA="$(git fetch $UPSTREAM flutter-1.20-candidate.7 > /dev/null 2>&1 && \
            (git merge-base --fork-point FETCH_HEAD HEAD || git merge-base FETCH_HEAD HEAD))"
 # Disable glob matching otherwise a file in the current directory that matches
 # $CLANG_FILETYPES will cause git to query for that exact file instead of doing

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -19,14 +19,10 @@ cd $ENGINE_PATH/src/flutter
 # Special handling of release branches. We would like to run the tests against
 # the release branch of flutter.
 #
-# On presubmit, we can get the branch name from the `CIRRUS_BASE_BRANCH` flag.
-# During the commit tests the base branch value is empty, instead
-# `CIRRUS_BRANCH` has the correct branch name.
-ENGINE_BRANCH_NAME="$CIRRUS_BASE_BRANCH"
-if [[ -z "$CIRRUS_BASE_BRANCH" ]]; then
-  echo "Running post commit tests use CIRRUS_BRANCH instead."
-  ENGINE_BRANCH_NAME="$CIRRUS_BRANCH"
-fi
+# This is a shortcut for the release branch, since we didn't address this part
+# in LUCI yet.
+ENGINE_BRANCH_NAME="flutter-1.20-candidate.7"
+
 versionregex="^v[[:digit:]]+\."
 releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
 ON_RELEASE_BRANCH=false

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -23,20 +23,9 @@ cd $ENGINE_PATH/src/flutter
 # in LUCI yet.
 ENGINE_BRANCH_NAME="flutter-1.20-candidate.7"
 
-versionregex="^v[[:digit:]]+\."
-releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
-ON_RELEASE_BRANCH=false
+ON_RELEASE_BRANCH=true
+echo "release branch $ENGINE_BRANCH_NAME"
 echo "Engine on branch $ENGINE_BRANCH_NAME"
-if [[ $ENGINE_BRANCH_NAME =~ $versionregex || $ENGINE_BRANCH_NAME =~ $releasecandidateregex ]]
-then
-  echo "release branch $ENGINE_BRANCH_NAME"
-  ON_RELEASE_BRANCH=true
-fi
-
-# Get latest commit's time for the engine repo.
-# Use date based on local time otherwise timezones might get mixed.
-LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
-echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
 
 # Check if there is an argument added for repo location.
 # If not use the location that should be set by Cirrus/LUCI.
@@ -58,27 +47,5 @@ else
 fi
 
 # Clone the Flutter Framework.
-git clone https://github.com/flutter/flutter.git
+git clone https://github.com/flutter/flutter.git -b "$ENGINE_BRANCH_NAME"
 cd flutter
-
-FRAMEWORK_BRANCH_NAME=`git branch | grep '*' | cut -d ' ' -f2`
-if [[ "$ON_RELEASE_BRANCH" = true && ENGINE_BRANCH_NAME != FRAMEWORK_BRANCH_NAME ]]
-then
-  echo "For a release framework and engine should be on the same version."
-  echo "Switching branches on Framework to from $FRAMEWORK_BRANCH_NAME to $ENGINE_BRANCH_NAME"
-  # Switch to the same version branch with the engine.
-  # If same version branch does not exits, fail.
-  SWITCH_RESULT=`git checkout $ENGINE_BRANCH_NAME` || true
-  if [[ -z "$SWITCH_RESULT" ]]
-  then
-    echo "$ENGINE_BRANCH_NAME Branch not found on framework. Quit."
-    exit 1
-  fi
-fi
-
-# Get the time of the youngest commit older than engine commit.
-# Git log uses commit date not the author date.
-# Before makes the comparison considering the timezone as well.
-COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
-echo "Using the flutter/flutter commit $COMMIT_NO";
-git reset --hard $COMMIT_NO

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -16,8 +16,17 @@ fi
 # Go to the engine git repo to get the date of the latest commit.
 cd $ENGINE_PATH/src/flutter
 
-# Special handling of release branches.
-ENGINE_BRANCH_NAME=$CIRRUS_BASE_BRANCH
+# Special handling of release branches. We would like to run the tests against
+# the release branch of flutter.
+#
+# On presubmit, we can get the branch name from the `CIRRUS_BASE_BRANCH` flag.
+# During the commit tests the base branch value is empty, instead
+# `CIRRUS_BRANCH` has the correct branch name.
+ENGINE_BRANCH_NAME="$CIRRUS_BASE_BRANCH"
+if [[ -z "$CIRRUS_BASE_BRANCH" ]] then
+  echo "Running post commit tests use CIRRUS_BRANCH instead."
+  ENGINE_BRANCH_NAME="$CIRRUS_BRANCH"
+fi
 versionregex="^v[[:digit:]]+\."
 releasecandidateregex="^flutter-[[:digit:]]+\.[[:digit:]]+-candidate\.[[:digit:]]+$"
 ON_RELEASE_BRANCH=false

--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -23,7 +23,7 @@ cd $ENGINE_PATH/src/flutter
 # During the commit tests the base branch value is empty, instead
 # `CIRRUS_BRANCH` has the correct branch name.
 ENGINE_BRANCH_NAME="$CIRRUS_BASE_BRANCH"
-if [[ -z "$CIRRUS_BASE_BRANCH" ]] then
+if [[ -z "$CIRRUS_BASE_BRANCH" ]]; then
   echo "Running post commit tests use CIRRUS_BRANCH instead."
   ENGINE_BRANCH_NAME="$CIRRUS_BRANCH"
 fi


### PR DESCRIPTION
Using correct CIRRUS CI flag for getting the branch name.

This fix should have done long ago: https://github.com/flutter/engine/pull/18655/files somehow got forgotten sorry for the inconvenience.