### PR TITLE
re-enable integration tests. increase sdk version.

### DIFF
--- a/lib/web_ui/dev/driver_version.yaml
+++ b/lib/web_ui/dev/driver_version.yaml
@@ -2,6 +2,8 @@
 ## Map for driver versions to use for each browser version.
 ## See: https://chromedriver.chromium.org/downloads
 chrome:
+  85: '85.0.4183.38'
+  84: '84.0.4147.30'
   83: '83.0.4103.39'
   81: '81.0.4044.69'
   80: '80.0.3987.106'

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -128,17 +128,13 @@ class TestCommand extends Command<bool> with ArgUtils {
       case TestTypesRequested.unit:
         return runUnitTests();
       case TestTypesRequested.integration:
-        // TODO(nurhan): Stop running all integration tests for now.
-        // Related to: https://github.com/flutter/flutter/issues/62146
-        return true; // runIntegrationTests();
+        return runIntegrationTests();
       case TestTypesRequested.all:
         // TODO(nurhan): https://github.com/flutter/flutter/issues/53322
         // TODO(nurhan): Expand browser matrix for felt integration tests.
         if (runAllTests && (isChrome || isSafariOnMacOS || isFirefox)) {
           bool unitTestResult = await runUnitTests();
-          // TODO(nurhan): Stop running all integration tests for now.
-          // Related to: https://github.com/flutter/flutter/issues/62146
-          bool integrationTestResult = true; // await runIntegrationTests();
+          bool integrationTestResult = await runIntegrationTests();
           if (integrationTestResult != unitTestResult) {
             print('Tests run. Integration tests passed: $integrationTestResult '
                 'unit tests passed: $unitTestResult');

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: ui
 publish_to: none
 
 environment:
-  sdk: ">=2.9.0-0 <3.0.0"
+  sdk: ">=2.10.0-0 <3.0.0"
 
 dependencies:
   meta: 1.1.8


### PR DESCRIPTION
Both trees are green now:
https://ci.chromium.org/p/flutter/g/framework/console
https://ci.chromium.org/p/flutter/g/engine/console

Re-enable integration tests.
Increase sdk version, so vscode analysis works in sync with @2.10 annotations.
Add new driver versions since Chrome upgraded to 84 (previously LGTM'ed in PR: https://github.com/flutter/engine/pull/20007)