### PR TITLE
Allow access to a zircon handle's koid

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
@@ -22,6 +22,8 @@ class Handle extends NativeFieldWrapperClass2 {
 
   int get handle native 'Handle_handle';
 
+  int get koid native 'Handle_koid';
+
   @override
   String toString() => 'Handle($handle)';
 

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.cc
@@ -151,6 +151,7 @@ void Handle::ScheduleCallback(tonic::DartPersistentValue callback,
 
 #define FOR_EACH_BINDING(V) \
   V(Handle, handle)         \
+  V(Handle, koid)           \
   V(Handle, is_valid)       \
   V(Handle, Close)          \
   V(Handle, AsyncWait)      \

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h
@@ -51,6 +51,13 @@ class Handle : public fml::RefCountedThreadSafe<Handle>,
 
   zx_handle_t handle() const { return handle_; }
 
+  zx_koid_t koid() const {
+    zx_info_handle_basic_t info;
+    zx_status_t status = zx_object_get_info(
+        handle_, ZX_INFO_HANDLE_BASIC, &info, sizeof(info), nullptr, nullptr);
+    return status == ZX_OK ? info.koid : ZX_KOID_INVALID;
+  }
+
   zx_status_t Close();
 
   fml::RefPtr<HandleWaiter> AsyncWait(zx_signals_t signals,

--- a/shell/platform/fuchsia/dart-pkg/zircon/test/handle_test.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/test/handle_test.dart
@@ -24,4 +24,16 @@ void main() {
     final Handle duplicate = handle.duplicate(ZX.RIGHT_SAME_RIGHTS);
     expect(duplicate.isValid, isFalse);
   });
+
+  test('handle and its duplicate have same koid', () {
+    final HandlePairResult pair = System.eventpairCreate();
+    expect(pair.status, equals(ZX.OK));
+    expect(pair.first.isValid, isTrue);
+    expect(pair.second.isValid, isTrue);
+
+    final Handle duplicate = pair.first.duplicate(ZX.RIGHT_SAME_RIGHTS);
+    expect(duplicate.isValid, isTrue);
+
+    expect(pair.first.koid, duplicate.koid);
+  });
 }


### PR DESCRIPTION
## Description

A zircon handle is associated with a koid, kernal object identifier.
Whereas the handle can be duplicated, koid is unique. Two distinct
handles can point to the same kernal object, if their koids are
the same.

This change adds access to koid for a Handle object.

## Tests

Adds a unittest for koid
