### PR TITLE
Save current screenshot as attachment in scenarios test

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
@@ -59,11 +59,11 @@ static const NSInteger kSecondsToWaitForPlatformView = 30;
   }
 
   if (![golden compareGoldenToImage:screenshot.image]) {
-    XCTAttachment* goldenAttachment;
-    goldenAttachment = [XCTAttachment attachmentWithImage:golden.image];
-    goldenAttachment.name = @"current_golden";
-    goldenAttachment.lifetime = XCTAttachmentLifetimeKeepAlways;
-    [self addAttachment:goldenAttachment];
+    XCTAttachment* screenshotAttachment;
+    screenshotAttachment = [XCTAttachment attachmentWithImage:screenshot.image];
+    screenshotAttachment.name = @"test_screenshot";
+    screenshotAttachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+    [self addAttachment:screenshotAttachment];
 
     XCTFail(@"Goldens to not match. Follow the steps in the "
             @"README to update golden named %@ if needed.",

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
@@ -61,7 +61,7 @@ static const NSInteger kSecondsToWaitForPlatformView = 30;
   if (![golden compareGoldenToImage:screenshot.image]) {
     XCTAttachment* screenshotAttachment;
     screenshotAttachment = [XCTAttachment attachmentWithImage:screenshot.image];
-    screenshotAttachment.name = @"test_screenshot";
+    screenshotAttachment.name = golden.goldenName;
     screenshotAttachment.lifetime = XCTAttachmentLifetimeKeepAlways;
     [self addAttachment:screenshotAttachment];
 


### PR DESCRIPTION
## Description

When the Scenarios iOS test fails, save the screenshot of what it looked like during the test, not the already-saved golden.

## Checklist
- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*