### PR TITLE
Wait before switching surfaces

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -975,7 +975,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * If the surface is rendered by a {@code FlutterImageView}. Then, calling this method will stop
+   * If the surface is rendered by a {@code FlutterImageView}, then calling this method will stop
    * rendering to a {@code FlutterImageView}, and render on the previous surface instead.
    *
    * @param onDone a callback called when Flutter UI is rendered on the previous surface. Use this
@@ -997,23 +997,23 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
       callSafely(onDone);
       return;
     }
-    final FlutterRenderer render = flutterEngine.getRenderer();
-    if (render == null) {
+    final FlutterRenderer renderer = flutterEngine.getRenderer();
+    if (renderer == null) {
       flutterImageView.detachFromRenderer();
       callSafely(onDone);
       return;
     }
     // Start rendering on the previous surface.
     // This surface is typically `FlutterSurfaceView` or `FlutterTextureView`.
-    renderSurface.attachToRenderer(render);
+    renderSurface.attachToRenderer(renderer);
 
     // Install a Flutter UI listener to wait until the first frame is rendered
     // in the new surface to call the `onDone` callback.
-    render.addIsDisplayingFlutterUiListener(
+    renderer.addIsDisplayingFlutterUiListener(
         new FlutterUiDisplayListener() {
           @Override
           public void onFlutterUiDisplayed() {
-            render.removeIsDisplayingFlutterUiListener(this);
+            renderer.removeIsDisplayingFlutterUiListener(this);
             callSafely(onDone);
             flutterImageView.detachFromRenderer();
           }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -957,6 +957,10 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
         getContext(), getWidth(), getHeight(), FlutterImageView.SurfaceKind.background);
   }
 
+  /**
+   * Converts the current render surface to a {@link FlutterImageView} if it's not one already.
+   * Otherwise, it resizes the {@link FlutterImageView} based on the current view size.
+   */
   public void convertToImageView() {
     renderSurface.pause();
 
@@ -975,8 +979,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * If the surface is rendered by a {@code FlutterImageView}, then calling this method will stop
-   * rendering to a {@code FlutterImageView}, and render on the previous surface instead.
+   * If the surface is rendered by a {@link FlutterImageView}, then calling this method will stop
+   * rendering to a {@link FlutterImageView}, and render on the previous surface instead.
    *
    * @param onDone a callback called when Flutter UI is rendered on the previous surface. Use this
    *     callback to perform cleanups. For example, destroy overlay surfaces.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -996,7 +996,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     // This surface is typically `FlutterSurfaceView` or `FlutterTextureView`.
     renderSurface.attachToRenderer(flutterEngine.getRenderer());
 
-    FlutterRenderer render = renderSurface.getAttachedRenderer();
+    final FlutterRenderer render = renderSurface.getAttachedRenderer();
     if (render == null) {
       flutterImageView.detachFromRenderer();
       callSafely(onDone);

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -45,7 +45,6 @@ import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.view.AccessibilityBridge;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Callable;
 
 /**
  * Displays a Flutter UI on an Android device.
@@ -985,7 +984,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
    * @param onDone a callback called when Flutter UI is rendered on the previous surface. Use this
    *     callback to perform cleanups. For example, destroy overlay surfaces.
    */
-  public void revertImageView(@NonNull Callable<Void> onDone) {
+  public void revertImageView(@NonNull Runnable onDone) {
     if (flutterImageView == null) {
       Log.v(TAG, "Tried to revert the image view, but no image view is used.");
       return;
@@ -998,13 +997,13 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     previousRenderSurface = null;
     if (flutterEngine == null) {
       flutterImageView.detachFromRenderer();
-      callSafely(onDone);
+      onDone.run();
       return;
     }
     final FlutterRenderer renderer = flutterEngine.getRenderer();
     if (renderer == null) {
       flutterImageView.detachFromRenderer();
-      callSafely(onDone);
+      onDone.run();
       return;
     }
     // Start rendering on the previous surface.
@@ -1018,7 +1017,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
           @Override
           public void onFlutterUiDisplayed() {
             renderer.removeIsDisplayingFlutterUiListener(this);
-            callSafely(onDone);
+            onDone.run();
             flutterImageView.detachFromRenderer();
           }
 
@@ -1027,14 +1026,6 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
             // no-op
           }
         });
-  }
-
-  private static void callSafely(@NonNull Callable<Void> onDone) {
-    try {
-      onDone.call();
-    } catch (Exception exception) {
-      Log.e(TAG, "onDone callback threw exception: " + exception.getMessage());
-    }
   }
 
   public void attachOverlaySurfaceToRender(FlutterImageView view) {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -122,7 +122,6 @@ public class FlutterJNI {
 
   private native boolean nativeGetIsSoftwareRenderingEnabled();
 
-  @VisibleForTesting
   @UiThread
   // TODO(mattcarroll): add javadocs
   public boolean getIsSoftwareRenderingEnabled() {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -90,7 +90,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
  *
  * <p>To invoke a native method that is not associated with a platform view, invoke it statically:
  *
- * <p>{@code bool enabled = FlutterJNI.nativeGetIsSoftwareRenderingEnabled(); }
+ * <p>{@code bool enabled = FlutterJNI.getIsSoftwareRenderingEnabled(); }
  */
 @Keep
 public class FlutterJNI {
@@ -120,9 +120,14 @@ public class FlutterJNI {
    */
   public static native void nativePrefetchDefaultFontManager();
 
-  // TODO(mattcarroll): add javadocs
+  private native boolean nativeGetIsSoftwareRenderingEnabled();
+
+  @VisibleForTesting
   @UiThread
-  public native boolean nativeGetIsSoftwareRenderingEnabled();
+  // TODO(mattcarroll): add javadocs
+  public boolean getIsSoftwareRenderingEnabled() {
+    return nativeGetIsSoftwareRenderingEnabled();
+  }
 
   @Nullable
   // TODO(mattcarroll): add javadocs
@@ -212,7 +217,12 @@ public class FlutterJNI {
   public void attachToNative(boolean isBackgroundView) {
     ensureRunningOnMainThread();
     ensureNotAttachedToNative();
-    nativePlatformViewId = nativeAttach(this, isBackgroundView);
+    nativePlatformViewId = performNativeAttach(this, isBackgroundView);
+  }
+
+  @VisibleForTesting
+  public long performNativeAttach(@NonNull FlutterJNI flutterJNI, boolean isBackgroundView) {
+    return nativeAttach(flutterJNI, isBackgroundView);
   }
 
   private native long nativeAttach(@NonNull FlutterJNI flutterJNI, boolean isBackgroundView);
@@ -279,7 +289,7 @@ public class FlutterJNI {
   @SuppressWarnings("unused")
   @VisibleForTesting
   @UiThread
-  void onFirstFrame() {
+  public void onFirstFrame() {
     ensureRunningOnMainThread();
 
     for (FlutterUiDisplayListener listener : flutterUiDisplayListeners) {

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -314,7 +314,7 @@ public class FlutterRenderer implements TextureRegistry {
 
   // TODO(mattcarroll): describe the native behavior that this invokes
   public boolean isSoftwareRenderingEnabled() {
-    return flutterJNI.nativeGetIsSoftwareRenderingEnabled();
+    return flutterJNI.getIsSoftwareRenderingEnabled();
   }
 
   // TODO(mattcarroll): describe the native behavior that this invokes

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -713,7 +713,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
       int width,
       int height,
       int viewWidth,
-      int ViewHeight,
+      int viewHeight,
       FlutterMutatorsStack mutatorsStack) {
     initializeRootImageViewIfNeeded();
     initializePlatformViewIfNeeded(viewId);
@@ -723,7 +723,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     mutatorView.setVisibility(View.VISIBLE);
     mutatorView.bringToFront();
 
-    FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(viewWidth, ViewHeight);
+    FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(viewWidth, viewHeight);
     View platformView = platformViews.get(viewId);
     platformView.setLayoutParams(layoutParams);
     platformView.bringToFront();
@@ -823,6 +823,14 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     }
   }
 
+  @VisibleForTesting
+  @TargetApi(19)
+  public FlutterOverlaySurface createOverlaySurface(@NonNull FlutterImageView imageView) {
+    final int id = nextOverlayLayerId++;
+    overlayLayerViews.put(id, imageView);
+    return new FlutterOverlaySurface(id, imageView.getSurface());
+  }
+
   @TargetApi(19)
   public FlutterOverlaySurface createOverlaySurface() {
     // Overlay surfaces have the same size as the background surface.
@@ -831,17 +839,12 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     // if the drawings they contain have a different tight bound.
     //
     // The final view size is determined when its frame is set.
-    FlutterImageView imageView =
+    return createOverlaySurface(
         new FlutterImageView(
             flutterView.getContext(),
             flutterView.getWidth(),
             flutterView.getHeight(),
-            FlutterImageView.SurfaceKind.overlay);
-
-    int id = nextOverlayLayerId++;
-    overlayLayerViews.put(id, imageView);
-
-    return new FlutterOverlaySurface(id, imageView.getSurface());
+            FlutterImageView.SurfaceKind.overlay));
   }
 
   public void destroyOverlaySurfaces() {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -764,7 +764,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           () -> {
             // Destroy overlay surfaces once the surface reversion is completed.
             finishFrame(false);
-            return null;
           });
       return;
     }

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -169,7 +169,7 @@ public class FlutterView extends SurfaceView
 
     dartExecutor = mNativeView.getDartExecutor();
     flutterRenderer = new FlutterRenderer(mNativeView.getFlutterJNI());
-    mIsSoftwareRenderingEnabled = mNativeView.getFlutterJNI().nativeGetIsSoftwareRenderingEnabled();
+    mIsSoftwareRenderingEnabled = mNativeView.getFlutterJNI().getIsSoftwareRenderingEnabled();
     mMetrics = new ViewportMetrics();
     mMetrics.devicePixelRatio = context.getResources().getDisplayMetrics().density;
     setFocusable(true);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -8,15 +8,29 @@ import static org.mockito.Mockito.*;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.view.MotionEvent;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewParent;
+import io.flutter.embedding.android.FlutterImageView;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.android.MotionEventTracker;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.FlutterOverlaySurface;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorView;
+import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
+import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
+import io.flutter.embedding.engine.systemchannels.KeyEventChannel;
+import io.flutter.embedding.engine.systemchannels.MouseCursorChannel;
+import io.flutter.embedding.engine.systemchannels.SettingsChannel;
+import io.flutter.embedding.engine.systemchannels.TextInputChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.StandardMethodCodec;
+import io.flutter.plugin.localization.LocalizationPlugin;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -27,6 +41,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowSurfaceView;
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
@@ -196,6 +213,7 @@ public class PlatformViewsControllerTest {
   }
 
   @Test
+  @Config(shadows = {ShadowFlutterJNI.class})
   public void getPlatformViewById__hybridComposition() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
@@ -223,6 +241,7 @@ public class PlatformViewsControllerTest {
   }
 
   @Test
+  @Config(shadows = {ShadowFlutterJNI.class})
   public void initializePlatformViewIfNeeded__throwsIfViewIsNull() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
@@ -254,6 +273,7 @@ public class PlatformViewsControllerTest {
   }
 
   @Test
+  @Config(shadows = {ShadowFlutterJNI.class})
   public void initializePlatformViewIfNeeded__throwsIfViewHasParent() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
@@ -286,6 +306,7 @@ public class PlatformViewsControllerTest {
   }
 
   @Test
+  @Config(shadows = {ShadowFlutterJNI.class})
   public void disposeAndroidView__hybridComposition() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
@@ -324,10 +345,72 @@ public class PlatformViewsControllerTest {
     assertTrue(androidView.getParent() instanceof FlutterMutatorView);
   }
 
+  @Test
+  @Config(shadows = {ShadowFlutterSurfaceView.class, ShadowFlutterJNI.class})
+  public void onEndFrame__destroysOverlaySurfaceAfterFrameOnFlutterSurfaceView() {
+    final PlatformViewsController platformViewsController = new PlatformViewsController();
+
+    final int platformViewId = 0;
+    assertNull(platformViewsController.getPlatformViewById(platformViewId));
+
+    final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
+    final PlatformView platformView = mock(PlatformView.class);
+    when(platformView.getView()).thenReturn(mock(View.class));
+    when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
+
+    platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
+
+    final FlutterJNI jni = new FlutterJNI();
+    jni.attachToNative(false);
+    attach(jni, platformViewsController);
+
+    jni.onFirstFrame();
+
+    // Simulate create call from the framework.
+    createPlatformView(jni, platformViewsController, platformViewId, "testType");
+
+    // Produce a frame that displays a platform view and an overlay surface.
+    platformViewsController.onBeginFrame();
+    platformViewsController.onDisplayPlatformView(
+        platformViewId,
+        /* x=*/ 0,
+        /* y=*/ 0,
+        /* width=*/ 10,
+        /* height=*/ 10,
+        /* viewWidth=*/ 10,
+        /* viewHeight=*/ 10,
+        /* mutatorsStack=*/ new FlutterMutatorsStack());
+
+    final FlutterImageView overlayImageView = mock(FlutterImageView.class);
+    when(overlayImageView.acquireLatestImage()).thenReturn(true);
+
+    final FlutterOverlaySurface overlaySurface =
+        platformViewsController.createOverlaySurface(overlayImageView);
+    platformViewsController.onDisplayOverlaySurface(
+        overlaySurface.getId(), /* x=*/ 0, /* y=*/ 0, /* width=*/ 10, /* height=*/ 10);
+
+    platformViewsController.onEndFrame();
+
+    // Simulate first frame from the framework.
+    jni.onFirstFrame();
+
+    verify(overlayImageView, never()).detachFromRenderer();
+
+    // Produce a frame that doesn't display platform views.
+    platformViewsController.onBeginFrame();
+    platformViewsController.onEndFrame();
+
+    verify(overlayImageView, never()).detachFromRenderer();
+
+    // Simulate first frame from the framework.
+    jni.onFirstFrame();
+    verify(overlayImageView, times(1)).detachFromRenderer();
+  }
+
   private static byte[] encodeMethodCall(MethodCall call) {
-    ByteBuffer buffer = StandardMethodCodec.INSTANCE.encodeMethodCall(call);
+    final ByteBuffer buffer = StandardMethodCodec.INSTANCE.encodeMethodCall(call);
     buffer.rewind();
-    byte[] dest = new byte[buffer.remaining()];
+    final byte[] dest = new byte[buffer.remaining()];
     buffer.get(dest);
     return dest;
   }
@@ -337,12 +420,13 @@ public class PlatformViewsControllerTest {
       PlatformViewsController platformViewsController,
       int platformViewId,
       String viewType) {
-    Map<String, Object> platformViewCreateArguments = new HashMap<>();
+    final Map<String, Object> platformViewCreateArguments = new HashMap<>();
     platformViewCreateArguments.put("hybrid", true);
     platformViewCreateArguments.put("id", platformViewId);
     platformViewCreateArguments.put("viewType", viewType);
     platformViewCreateArguments.put("direction", 0);
-    MethodCall platformCreateMethodCall = new MethodCall("create", platformViewCreateArguments);
+    final MethodCall platformCreateMethodCall =
+        new MethodCall("create", platformViewCreateArguments);
 
     jni.handlePlatformMessage(
         "flutter/platform_views", encodeMethodCall(platformCreateMethodCall), /*replyId=*/ 0);
@@ -350,22 +434,124 @@ public class PlatformViewsControllerTest {
 
   private static void disposePlatformView(
       FlutterJNI jni, PlatformViewsController platformViewsController, int platformViewId) {
-    Map<String, Object> platformViewDisposeArguments = new HashMap<>();
+
+    final Map<String, Object> platformViewDisposeArguments = new HashMap<>();
     platformViewDisposeArguments.put("hybrid", true);
     platformViewDisposeArguments.put("id", platformViewId);
-    MethodCall platformDisposeMethodCall = new MethodCall("dispose", platformViewDisposeArguments);
+
+    final MethodCall platformDisposeMethodCall =
+        new MethodCall("dispose", platformViewDisposeArguments);
 
     jni.handlePlatformMessage(
         "flutter/platform_views", encodeMethodCall(platformDisposeMethodCall), /*replyId=*/ 0);
   }
 
-  private void attach(FlutterJNI jni, PlatformViewsController platformViewsController) {
-    DartExecutor executor = new DartExecutor(jni, mock(AssetManager.class));
+  private static void attach(FlutterJNI jni, PlatformViewsController platformViewsController) {
+    final DartExecutor executor = new DartExecutor(jni, mock(AssetManager.class));
     executor.onAttachedToJNI();
 
-    Context context = RuntimeEnvironment.application.getApplicationContext();
+    final Context context = RuntimeEnvironment.application.getApplicationContext();
     platformViewsController.attach(context, null, executor);
 
-    platformViewsController.attachToView(mock(FlutterView.class));
+    final FlutterView view =
+        new FlutterView(context, FlutterView.RenderMode.surface) {
+          @Override
+          public FlutterImageView createImageView() {
+            final FlutterImageView view = mock(FlutterImageView.class);
+            when(view.acquireLatestImage()).thenReturn(true);
+            return mock(FlutterImageView.class);
+          }
+        };
+
+    view.layout(0, 0, 100, 100);
+
+    final FlutterEngine engine = mock(FlutterEngine.class);
+    when(engine.getRenderer()).thenReturn(new FlutterRenderer(jni));
+    when(engine.getMouseCursorChannel()).thenReturn(mock(MouseCursorChannel.class));
+    when(engine.getTextInputChannel()).thenReturn(mock(TextInputChannel.class));
+    when(engine.getSettingsChannel()).thenReturn(new SettingsChannel(executor));
+    when(engine.getPlatformViewsController()).thenReturn(platformViewsController);
+    when(engine.getLocalizationPlugin()).thenReturn(mock(LocalizationPlugin.class));
+    when(engine.getKeyEventChannel()).thenReturn(mock(KeyEventChannel.class));
+    when(engine.getAccessibilityChannel()).thenReturn(mock(AccessibilityChannel.class));
+
+    view.attachToFlutterEngine(engine);
+    platformViewsController.attachToView(view);
+  }
+
+  @Implements(FlutterJNI.class)
+  public static class ShadowFlutterJNI {
+
+    public ShadowFlutterJNI() {}
+
+    @Implementation
+    public boolean getIsSoftwareRenderingEnabled() {
+      return false;
+    }
+
+    @Implementation
+    public long performNativeAttach(FlutterJNI flutterJNI, boolean isBackgroundView) {
+      return 1;
+    }
+
+    @Implementation
+    public void dispatchPlatformMessage(
+        String channel, ByteBuffer message, int position, int responseId) {}
+
+    @Implementation
+    public void onSurfaceCreated(Surface surface) {}
+
+    @Implementation
+    public void onSurfaceDestroyed() {}
+
+    @Implementation
+    public void onSurfaceWindowChanged(Surface surface) {}
+
+    @Implementation
+    public void setViewportMetrics(
+        float devicePixelRatio,
+        int physicalWidth,
+        int physicalHeight,
+        int physicalPaddingTop,
+        int physicalPaddingRight,
+        int physicalPaddingBottom,
+        int physicalPaddingLeft,
+        int physicalViewInsetTop,
+        int physicalViewInsetRight,
+        int physicalViewInsetBottom,
+        int physicalViewInsetLeft,
+        int systemGestureInsetTop,
+        int systemGestureInsetRight,
+        int systemGestureInsetBottom,
+        int systemGestureInsetLeft) {}
+
+    @Implementation
+    public void invokePlatformMessageResponseCallback(
+        int responseId, ByteBuffer message, int position) {}
+  }
+
+  @Implements(SurfaceView.class)
+  public static class ShadowFlutterSurfaceView extends ShadowSurfaceView {
+    private final FakeSurfaceHolder holder = new FakeSurfaceHolder();
+
+    public static class FakeSurfaceHolder extends ShadowSurfaceView.FakeSurfaceHolder {
+      private final Surface surface = mock(Surface.class);
+
+      public Surface getSurface() {
+        return surface;
+      }
+
+      @Implementation
+      public void addCallback(SurfaceHolder.Callback callback) {
+        callback.surfaceCreated(this);
+      }
+    }
+
+    public ShadowFlutterSurfaceView() {}
+
+    @Implementation
+    public SurfaceHolder getHolder() {
+      return holder;
+    }
   }
 }


### PR DESCRIPTION
## Description

Once a platform view disappears, the embedding continues rendering the Flutter UI on `FlutterSurfaceView`. However, the embedding should wait for the first frame before displaying the `SurfaceView`.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/62455

## Tests

I added the following tests: Unit test

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
