### PR TITLE
add dart vm args when initialize FlutterViewController with FlutterDa…

### DIFF
--- a/shell/platform/darwin/common/command_line.h
+++ b/shell/platform/darwin/common/command_line.h
@@ -8,9 +8,11 @@
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/macros.h"
 
+#import <Foundation/Foundation.h>
+
 namespace flutter {
 
-fml::CommandLine CommandLineFromNSProcessInfo();
+fml::CommandLine CommandLineFromNSProcessInfo(NSArray<NSString*>*);
 
 }  // namespace flutter
 

--- a/shell/platform/darwin/common/command_line.mm
+++ b/shell/platform/darwin/common/command_line.mm
@@ -8,11 +8,17 @@
 
 namespace flutter {
 
-fml::CommandLine CommandLineFromNSProcessInfo() {
+fml::CommandLine CommandLineFromNSProcessInfo(NSArray<NSString*>* dartVmArgs) {
   std::vector<std::string> args_vector;
 
   for (NSString* arg in [NSProcessInfo processInfo].arguments) {
     args_vector.emplace_back(arg.UTF8String);
+  }
+
+  if (dartVmArgs != nil) {
+    for (NSString* arg in dartVmArgs) {
+      args_vector.emplace_back(arg.UTF8String);
+    }
   }
 
   return fml::CommandLineFromIterators(args_vector.begin(), args_vector.end());

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -18,9 +18,19 @@ FLUTTER_EXPORT
 @interface FlutterDartProject : NSObject
 
 /**
+ * Initializes a Flutter Dart project with dart vm args, such as tracing startup args.
+ */
+- (instancetype)initWithDartVmArgs:(nullable NSArray<NSString*>*)args;
+
+/**
  * Initializes a Flutter Dart project from a bundle.
  */
-- (instancetype)initWithPrecompiledDartBundle:(nullable NSBundle*)bundle NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithPrecompiledDartBundle:(nullable NSBundle*)bundle;
+
+/**
+* Initializes a Flutter Dart project from a bundle with dart vm args, such as tracing startup args.
+*/
+- (instancetype)initWithPrecompiledDartBundle:(nullable NSBundle*)bundle dartVmArgs:(nullable NSArray<NSString*>*)args NS_DESIGNATED_INITIALIZER;
 
 /**
  * Unavailable - use `init` instead.

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -26,8 +26,8 @@ extern const intptr_t kPlatformStrongDillSize;
 
 static const char* kApplicationKernelSnapshotFileName = "kernel_blob.bin";
 
-static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
-  auto command_line = flutter::CommandLineFromNSProcessInfo();
+static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil, NSArray<NSString*>* dartVmArgs = nil) {
+  auto command_line = flutter::CommandLineFromNSProcessInfo(dartVmArgs);
 
   // Precedence:
   // 1. Settings from the specified NSBundle.
@@ -153,16 +153,24 @@ static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 #pragma mark - Override base class designated initializers
 
 - (instancetype)init {
-  return [self initWithPrecompiledDartBundle:nil];
+  return [self initWithPrecompiledDartBundle:nil dartVmArgs:nil];
+}
+
+- (instancetype)initWithDartVmArgs:(nullable NSArray<NSString*>*)args {
+  return [self initWithPrecompiledDartBundle:nil dartVmArgs:args];
+}
+
+- (instancetype)initWithPrecompiledDartBundle:(nullable NSBundle*)bundle {
+  return [self initWithPrecompiledDartBundle:bundle dartVmArgs:nil];
 }
 
 #pragma mark - Designated initializers
 
-- (instancetype)initWithPrecompiledDartBundle:(nullable NSBundle*)bundle {
+- (instancetype)initWithPrecompiledDartBundle:(nullable NSBundle*)bundle dartVmArgs:(nullable NSArray<NSString*>*)args {
   self = [super init];
 
   if (self) {
-    _settings = DefaultSettingsForProcess(bundle);
+    _settings = DefaultSettingsForProcess(bundle, args);
   }
 
   return self;


### PR DESCRIPTION
## Description

In Android we can use params `dartVmArgs` when construct FlutterEngine to pass some trace args down to flutter engine(e.g. `--trace-startup`), so we can catch the startup trace, however in iOS side , there is no way to pass this args.

I add the args passing through down to the engine in iOS.

