### PR TITLE
Migrate some Dart_WeakPersistentHandle uses to Dart_FinalizableHandle

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
@@ -423,9 +423,7 @@ struct SizedRegion {
   size_t size;
 };
 
-void System::VmoMapFinalizer(void* isolate_callback_data,
-                             Dart_WeakPersistentHandle handle,
-                             void* peer) {
+void System::VmoMapFinalizer(void* isolate_callback_data, void* peer) {
   SizedRegion* r = reinterpret_cast<SizedRegion*>(peer);
   zx_vmar_unmap(zx_vmar_root_self(), reinterpret_cast<uintptr_t>(r->region),
                 r->size);
@@ -453,9 +451,9 @@ Dart_Handle System::VmoMap(fml::RefPtr<Handle> vmo) {
   FML_DCHECK(!tonic::LogIfError(object));
 
   SizedRegion* r = new SizedRegion(data, size);
-  Dart_NewWeakPersistentHandle(object, reinterpret_cast<void*>(r),
-                               static_cast<intptr_t>(size) + sizeof(*r),
-                               System::VmoMapFinalizer);
+  Dart_NewFinalizableHandle(object, reinterpret_cast<void*>(r),
+                            static_cast<intptr_t>(size) + sizeof(*r),
+                            System::VmoMapFinalizer);
 
   return ConstructDartObject(kMapResult, ToDart(ZX_OK), object);
 }

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
@@ -69,9 +69,7 @@ class System : public fml::RefCountedThreadSafe<System>,
                                       fml::RefPtr<Handle> channel);
 
  private:
-  static void VmoMapFinalizer(void* isolate_callback_data,
-                              Dart_WeakPersistentHandle handle,
-                              void* peer);
+  static void VmoMapFinalizer(void* isolate_callback_data, void* peer);
 
   static zx::channel CloneChannelFromFileDescriptor(int fd);
 };

--- a/third_party/tonic/file_loader/file_loader.cc
+++ b/third_party/tonic/file_loader/file_loader.cc
@@ -195,9 +195,7 @@ Dart_Handle FileLoader::Import(Dart_Handle url) {
 }
 
 namespace {
-void MallocFinalizer(void* isolate_callback_data,
-                     Dart_WeakPersistentHandle handle,
-                     void* peer) {
+void MallocFinalizer(void* isolate_callback_data, void* peer) {
   free(peer);
 }
 }  // namespace
@@ -212,7 +210,7 @@ Dart_Handle FileLoader::Kernel(Dart_Handle url) {
   }
   result =
       Dart_NewExternalTypedData(Dart_TypedData_kUint8, buffer, buffer_size);
-  Dart_NewWeakPersistentHandle(result, buffer, buffer_size, MallocFinalizer);
+  Dart_NewFinalizableHandle(result, buffer, buffer_size, MallocFinalizer);
   return result;
 }
 


### PR DESCRIPTION
## Description

The PR is migrating some users of Dart_WeakPersistentHandle because the semantics of that is changing to be non-auto-deleting. See https://dart-review.googlesource.com/c/sdk/+/151525. This is the non-breaking change part of https://github.com/flutter/engine/pull/19843.

## Related Issues

https://github.com/dart-lang/sdk/issues/42312

## Tests

I did not write new tests but ran the existing tests on HHH infrastructure.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

This is the non-breaking change part of https://github.com/flutter/engine/pull/19843.

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
