### PR TITLE
add information collection for safari bots

### DIFF
--- a/lib/web_ui/dev/felt.dart
+++ b/lib/web_ui/dev/felt.dart
@@ -47,12 +47,17 @@ void main(List<String> args) async {
   } on ToolException catch (e) {
     io.stderr.writeln(e.message);
     exitCode = 1;
+  } on ProcessException catch (e) {
+    io.stderr.writeln('description: ${e.description}'
+        'executable: ${e.executable} ${e.arguments} '
+        'exit code: ${e.exitCode}');
+    exitCode = e.exitCode;
   } catch (e) {
     rethrow;
   } finally {
     await cleanup();
     // The exit code is changed by one of the branches.
-    if(exitCode != -1) {
+    if (exitCode != -1) {
       io.exit(exitCode);
     }
   }

--- a/lib/web_ui/dev/felt.dart
+++ b/lib/web_ui/dev/felt.dart
@@ -49,7 +49,8 @@ void main(List<String> args) async {
     exitCode = 1;
   } on ProcessException catch (e) {
     io.stderr.writeln('description: ${e.description}'
-        'executable: ${e.executable} ${e.arguments} '
+        'executable: ${e.executable} '
+        'arguments: ${e.arguments} '
         'exit code: ${e.exitCode}');
     exitCode = e.exitCode;
   } catch (e) {

--- a/lib/web_ui/dev/macos_info.dart
+++ b/lib/web_ui/dev/macos_info.dart
@@ -6,19 +6,17 @@ import 'dart:convert';
 import 'utils.dart';
 
 class MacOSInfo {
-  /// Default Safari Version.
-  String safariVersion = 'Safari 12';
-
   Future<void> collectInformation() async {
     final String systemProfileJson = await evalProcess(
         'system_profiler', ['SPApplicationsDataType', '-json']);
-    print('INFO: system_profiler run, information on Safari');
 
-    Map<String, dynamic> json = jsonDecode(systemProfileJson);
-    final List<dynamic> systemProfile = json.values.first;
+    final Map<String, dynamic> json =
+        jsonDecode(systemProfileJson) as Map<String, dynamic>;
+    final List<dynamic> systemProfile = json.values.first as List<dynamic>;
     for (int i = 0; i < systemProfile.length; i++) {
-      final Map<String, dynamic> application = systemProfile[i];
-      final String applicationName = application['_name'];
+      final Map<String, dynamic> application =
+          systemProfile[i] as Map<String, dynamic>;
+      final String applicationName = application['_name'] as String;
       if (applicationName.contains('Safari')) {
         print('application: $applicationName '
             'fullInfo: ${application.toString()}');

--- a/lib/web_ui/dev/macos_info.dart
+++ b/lib/web_ui/dev/macos_info.dart
@@ -6,13 +6,27 @@ import 'dart:convert';
 import 'utils.dart';
 
 class MacOSInfo {
-
   /// Print information collected from the operating system.
   ///
   /// Built in tools such as `system_profiler` and `defaults` are utilized.
   Future<void> printInformation() async {
-    await _printSafaridApplications();
-    await _printSafariDefaults();
+    try {
+      await _printSafaridApplications();
+    } catch (error) {
+      print('Error thrown while getting Safari Applications: $error');
+    }
+
+    try {
+      await _printSafariDefaults();
+    } catch (error) {
+      print('Error thrown while getting Safari defaults: $error');
+    }
+
+    try {
+      await _printUserLimits();
+    } catch (error) {
+      print('Error thrown while getting user limits defaults: $error');
+    }
   }
 
   /// Print information on applications in the system that contains string
@@ -41,5 +55,16 @@ class MacOSInfo {
         await evalProcess('/usr/bin/defaults', ['find', 'Safari']);
 
     print('Safari related defaults:\n $defaults');
+  }
+
+  /// Print user limits (file and process).
+  Future<void> _printUserLimits() async {
+    final String fileLimit = await evalProcess('ulimit', ['-n']);
+
+    print('MacOS file limit: $fileLimit');
+
+    final String processLimit = await evalProcess('ulimit', ['-u']);
+
+    print('MacOS process limit: $processLimit');
   }
 }

--- a/lib/web_ui/dev/macos_info.dart
+++ b/lib/web_ui/dev/macos_info.dart
@@ -11,7 +11,7 @@ class MacOSInfo {
   /// Built in tools such as `system_profiler` and `defaults` are utilized.
   Future<void> printInformation() async {
     try {
-      await _printSafaridApplications();
+      await _printSafariApplications();
     } catch (error) {
       print('Error thrown while getting Safari Applications: $error');
     }
@@ -31,7 +31,7 @@ class MacOSInfo {
 
   /// Print information on applications in the system that contains string
   /// `Safari`.
-  Future<void> _printSafaridApplications() async {
+  Future<void> _printSafariApplications() async {
     final String systemProfileJson = await evalProcess(
         'system_profiler', ['SPApplicationsDataType', '-json']);
 

--- a/lib/web_ui/dev/macos_info.dart
+++ b/lib/web_ui/dev/macos_info.dart
@@ -6,7 +6,18 @@ import 'dart:convert';
 import 'utils.dart';
 
 class MacOSInfo {
-  Future<void> collectInformation() async {
+
+  /// Print information collected from the operating system.
+  ///
+  /// Built in tools such as `system_profiler` and `defaults` are utilized.
+  Future<void> printInformation() async {
+    await _printSafaridApplications();
+    await _printSafariDefaults();
+  }
+
+  /// Print information on applications in the system that contains string
+  /// `Safari`.
+  Future<void> _printSafaridApplications() async {
     final String systemProfileJson = await evalProcess(
         'system_profiler', ['SPApplicationsDataType', '-json']);
 
@@ -20,8 +31,15 @@ class MacOSInfo {
       if (applicationName.contains('Safari')) {
         print('application: $applicationName '
             'fullInfo: ${application.toString()}');
-        print('version: ${application['version']}');
       }
     }
+  }
+
+  /// Print all the defaults in the system related to Safari.
+  Future<void> _printSafariDefaults() async {
+    final String defaults =
+        await evalProcess('/usr/bin/defaults', ['find', 'Safari']);
+
+    print('Safari related defaults:\n $defaults');
   }
 }

--- a/lib/web_ui/dev/macos_info.dart
+++ b/lib/web_ui/dev/macos_info.dart
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'dart:convert';
+
+import 'utils.dart';
+
+class MacOSInfo {
+  /// Default Safari Version.
+  String safariVersion = 'Safari 12';
+
+  Future<void> collectInformation() async {
+    final String systemProfileJson = await evalProcess(
+        'system_profiler', ['SPApplicationsDataType', '-json']);
+    print('INFO: system_profiler run, information on Safari');
+
+    Map<String, dynamic> json = jsonDecode(systemProfileJson);
+    final List<dynamic> systemProfile = json.values.first;
+    for (int i = 0; i < systemProfile.length; i++) {
+      final Map<String, dynamic> application = systemProfile[i];
+      final String applicationName = application['_name'];
+      if (applicationName.contains('Safari')) {
+        print('application: $applicationName '
+            'fullInfo: ${application.toString()}');
+        print('version: ${application['version']}');
+      }
+    }
+  }
+}

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -131,7 +131,7 @@ class TestCommand extends Command<bool> with ArgUtils {
       final MacOSInfo macOsInfo = new MacOSInfo();
       await macOsInfo.printInformation();
       /// Tests may fail on the CI, therefore exit test_runner.
-      if( isLuci) {
+      if (isLuci) {
         return true;
       }
     }

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -19,6 +19,7 @@ import 'package:simulators/simulator_manager.dart';
 import 'environment.dart';
 import 'exceptions.dart';
 import 'integration_tests_manager.dart';
+import 'macos_info.dart';
 import 'safari_installation.dart';
 import 'supported_browsers.dart';
 import 'test_platform.dart';
@@ -123,6 +124,13 @@ class TestCommand extends Command<bool> with ArgUtils {
 
     // Check the flags to see what type of integration tests are requested.
     testTypesRequested = findTestType();
+
+    if (isSafariOnMacOS) {
+      /// Collect information on the bot.
+      final MacOSInfo macOsInfo = new MacOSInfo();
+      await macOsInfo.collectInformation();
+      return true;
+    }
 
     switch (testTypesRequested) {
       case TestTypesRequested.unit:

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -16,6 +16,7 @@ import 'package:test_core/src/executable.dart'
     as test; // ignore: implementation_imports
 import 'package:simulators/simulator_manager.dart';
 
+import 'common.dart';
 import 'environment.dart';
 import 'exceptions.dart';
 import 'integration_tests_manager.dart';
@@ -128,8 +129,11 @@ class TestCommand extends Command<bool> with ArgUtils {
     if (isSafariOnMacOS) {
       /// Collect information on the bot.
       final MacOSInfo macOsInfo = new MacOSInfo();
-      await macOsInfo.collectInformation();
-      return true;
+      await macOsInfo.printInformation();
+      /// Tests may fail on the CI, therefore exit test_runner.
+      if( isLuci) {
+        return true;
+      }
     }
 
     switch (testTypesRequested) {


### PR DESCRIPTION
add information(application location, application version, other safari related application) collection for safari bots.

This change won't break the build, since Safari tests only run system_profiler to collect information and exit by returning true. 

relate issue: https://github.com/flutter/flutter/issues/58012