### PR TITLE
Fix dartdocs of dart:ui

### DIFF
--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -213,7 +213,7 @@ class ChannelBuffers {
   }
 }
 
-/// [ChannelBuffer]s that allow the storage of messages between the
+/// [ChannelBuffers] that allow the storage of messages between the
 /// Engine and the Framework.  Typically messages that can't be delivered
 /// are stored here until the Framework is able to process them.
 ///

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -605,7 +605,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// Therefore, when implementing a subclass of the [Layer] concept defined in
   /// the rendering layer of Flutter's framework, once this is called, there's
-  /// no need to call [addToScene] for its children layers.
+  /// no need to call [Layer.addToScene] for its children layers.
   ///
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   void addRetained(EngineLayer retainedLayer) {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1167,8 +1167,9 @@ class Paint {
   /// See also:
   ///
   ///  * [Canvas.saveLayer], which uses its [Paint]'s [blendMode] to composite
-  ///    the layer when [restore] is called.
-  ///  * [BlendMode], which discusses the user of [saveLayer] with [blendMode].
+  ///    the layer when [Canvas.restore] is called.
+  ///  * [BlendMode], which discusses the user of [Canvas.saveLayer] with
+  ///    [blendMode].
   BlendMode get blendMode {
     final int encoded = _data.getInt32(_kBlendModeOffset, _kFakeHostEndian);
     return BlendMode.values[encoded ^ _kBlendModeDefault];

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -56,7 +56,7 @@ enum PointerDeviceKind {
   unknown
 }
 
-/// The kind of [PointerDeviceKind.signal].
+/// The kind of pointer signal event.
 enum PointerSignalKind {
   /// The event is not associated with a pointer signal.
   none,

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -169,7 +169,7 @@ class SemanticsAction {
 
   /// A request that the node should be dismissed.
   ///
-  /// A [Snackbar], for example, may have a dismiss action to indicate to the
+  /// A [SnackBar], for example, may have a dismiss action to indicate to the
   /// user that it can be removed after it is no longer relevant. On Android,
   /// (with TalkBack) special hint text is spoken when focusing the node and
   /// a custom action is available in the local context menu. On iOS,

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1965,7 +1965,8 @@ class Paragraph extends NativeFieldWrapperClass2 {
 
   /// Returns a list of text boxes that enclose all placeholders in the paragraph.
   ///
-  /// The order of the boxes are in the same order as passed in through [addPlaceholder].
+  /// The order of the boxes are in the same order as passed in through
+  /// [ParagraphBuilder.addPlaceholder].
   ///
   /// Coordinates of the [TextBox] are relative to the upper-left corner of the paragraph,
   /// where positive y values indicate down.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -716,10 +716,11 @@ class Window {
   /// This value is calculated by taking
   /// `max(0.0, Window.viewPadding - Window.viewInsets)`. This will treat a
   /// system IME that increases the bottom inset as consuming that much of the
-  /// bottom padding. For example, on an iPhone X, [Window.padding.bottom] is
-  /// the same as [Window.viewPadding.bottom] when the soft keyboard is not
-  /// drawn (to account for the bottom soft button area), but will be `0.0` when
-  /// the soft keyboard is visible.
+  /// bottom padding. For example, on an iPhone X, [EdgeInsets.bottom] of
+  /// [Window.padding] is the same as [EdgeInsets.bottom] of
+  /// [Window.viewPadding] when the soft keyboard is not drawn (to account for
+  /// the bottom soft button area), but will be `0.0` when the soft keyboard is
+  /// visible.
   ///
   /// When this changes, [onMetricsChanged] is called.
   ///


### PR DESCRIPTION
## Description

Fixes unresolved references warnings for dartdocs of dart:ui.

## Related Issues

https://github.com/flutter/flutter/issues/31931

## Tests

I added the following tests:

n/a, doc change only

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
