### PR TITLE
Add preliminary Windows arm64 plumbing

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -107,7 +107,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'fe3b46e595e7ce1350e11aa0c90365976051f4a3',
+  'src': 'https://github.com/stuartmorgan/buildroot.git' + '@' + 'e5a04629f9e171099b15925749eda68f807e4d0c',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -107,7 +107,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/stuartmorgan/buildroot.git' + '@' + 'e5a04629f9e171099b15925749eda68f807e4d0c',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '292ac4889262c39710958a9984f9d89b125fbe80',
 
    # Fuchsia compatibility
    #

--- a/tools/gn
+++ b/tools/gn
@@ -38,6 +38,9 @@ def get_out_dir(args):
     if args.linux_cpu is not None:
       target_dir.append(args.linux_cpu)
 
+    if args.windows_cpu is not None:
+      target_dir.append(args.windows_cpu)
+
     if args.target_os == 'fuchsia' and args.fuchsia_cpu is not None:
       target_dir.append(args.fuchsia_cpu)
 
@@ -163,6 +166,8 @@ def to_gn_args(args):
       gn_args['target_cpu'] = args.linux_cpu
     elif args.target_os == 'fuchsia':
       gn_args['target_cpu'] = args.fuchsia_cpu
+    elif args.target_os == 'win':
+      gn_args['target_cpu'] = args.windows_cpu
     else:
         # Building host artifacts
         gn_args['target_cpu'] = 'x64'
@@ -172,7 +177,7 @@ def to_gn_args(args):
       raise Exception('--interpreter is no longer needed on any supported platform.')
     gn_args['dart_target_arch'] = gn_args['target_cpu']
 
-    if sys.platform.startswith(('cygwin', 'win')):
+    if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
       if 'target_cpu' in gn_args:
         gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
@@ -297,7 +302,7 @@ def parse_args(args):
   parser.add_argument('--full-dart-debug', default=False, action='store_true', help='Implies --dart-debug ' +
       'and also disables optimizations in the Dart VM making it easier to step through VM code in the debugger.')
 
-  parser.add_argument('--target-os', type=str, choices=['android', 'ios', 'linux', 'fuchsia'])
+  parser.add_argument('--target-os', type=str, choices=['android', 'ios', 'linux', 'fuchsia', 'win'])
   parser.add_argument('--android', dest='target_os', action='store_const', const='android')
   parser.add_argument('--android-cpu', type=str, choices=['arm', 'x64', 'x86', 'arm64'], default='arm')
   parser.add_argument('--ios', dest='target_os', action='store_const', const='ios')
@@ -306,6 +311,7 @@ def parse_args(args):
   parser.add_argument('--fuchsia', dest='target_os', action='store_const', const='fuchsia')
   parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm'])
   parser.add_argument('--fuchsia-cpu', type=str, choices=['x64', 'arm64'], default = 'x64')
+  parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64'], default = 'x64')
   parser.add_argument('--arm-float-abi', type=str, choices=['hard', 'soft', 'softfp'])
 
   parser.add_argument('--goma', default=True, action='store_true')

--- a/tools/gn
+++ b/tools/gn
@@ -38,7 +38,7 @@ def get_out_dir(args):
     if args.linux_cpu is not None:
       target_dir.append(args.linux_cpu)
 
-    if args.windows_cpu is not None:
+    if args.windows_cpu != 'x64':
       target_dir.append(args.windows_cpu)
 
     if args.target_os == 'fuchsia' and args.fuchsia_cpu is not None:


### PR DESCRIPTION
## Description

- Rolls buildroot to pick up
  https://github.com/flutter/buildroot/pull/389
- Adds support to the gn wrapper for setting the traget CPU on Windows

Attempting to generate Windows arm64 GN files will currently fail, due
to lack of arm64 support for an OpenGL test support target, but this
sets the foundation, and makes experimentation easier.

## Related Issues

Part of https://github.com/flutter/flutter/issues/62597

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
