### PR TITLE
Fix Implments typo

### DIFF
--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -20,14 +20,14 @@ static void fl_renderer_x11_dispose(GObject* object) {
   G_OBJECT_CLASS(fl_renderer_x11_parent_class)->dispose(object);
 }
 
-// Implments FlRenderer::get_visual.
+// Implements FlRenderer::get_visual.
 static GdkVisual* fl_renderer_x11_get_visual(FlRenderer* renderer,
                                              GdkScreen* screen,
                                              EGLint visual_id) {
   return gdk_x11_screen_lookup_visual(GDK_X11_SCREEN(screen), visual_id);
 }
 
-// Implments FlRenderer::create_surface.
+// Implements FlRenderer::create_surface.
 static EGLSurface fl_renderer_x11_create_surface(FlRenderer* renderer,
                                                  EGLDisplay display,
                                                  EGLConfig config) {

--- a/shell/platform/linux/fl_string_codec.cc
+++ b/shell/platform/linux/fl_string_codec.cc
@@ -14,7 +14,7 @@ struct _FlStringCodec {
 
 G_DEFINE_TYPE(FlStringCodec, fl_string_codec, fl_message_codec_get_type())
 
-// Implments FlMessageCodec::encode_message.
+// Implements FlMessageCodec::encode_message.
 static GBytes* fl_string_codec_encode_message(FlMessageCodec* codec,
                                               FlValue* value,
                                               GError** error) {
@@ -29,7 +29,7 @@ static GBytes* fl_string_codec_encode_message(FlMessageCodec* codec,
   return g_bytes_new(text, strlen(text));
 }
 
-// Implments FlMessageCodec::decode_message.
+// Implements FlMessageCodec::decode_message.
 static FlValue* fl_string_codec_decode_message(FlMessageCodec* codec,
                                                GBytes* message,
                                                GError** error) {


### PR DESCRIPTION
## Description

Fix comment typo.

## Related Issues

No issues, trivial fix.

## Tests

No tests changed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
