### PR TITLE
fix ios layout change cause the accessibility focus to jump randomly.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -453,6 +453,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 - (void)accessibilityElementDidBecomeFocused {
   if (![self isAccessibilityBridgeAlive])
     return;
+  [self bridge]->AccessibilityFocusDidChange([self uid]);
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden) ||
       [self node].HasFlag(flutter::SemanticsFlags::kIsHeader)) {
     [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -33,7 +33,7 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
     SemanticsActionObservation observation(id, action);
     observations.push_back(observation);
   }
-  void AccessibilityFocusDidChange(int32_t focused_id) override {}
+  void AccessibilityFocusDidChange(int32_t id) override {}
   FlutterPlatformViewsController* GetPlatformViewsController() const override { return nil; }
   std::vector<SemanticsActionObservation> observations;
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -33,6 +33,7 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
     SemanticsActionObservation observation(id, action);
     observations.push_back(observation);
   }
+  void AccessibilityFocusDidChange(int32_t focused_id) override {}
   FlutterPlatformViewsController* GetPlatformViewsController() const override { return nil; }
   std::vector<SemanticsActionObservation> observations;
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -61,7 +61,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   void DispatchSemanticsAction(int32_t id,
                                flutter::SemanticsAction action,
                                std::vector<uint8_t> args) override;
-  void AccessibilityFocusDidChange(int32_t focused_id) override;
+  void AccessibilityFocusDidChange(int32_t id) override;
 
   UIView<UITextInput>* textInputView() override;
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -61,6 +61,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   void DispatchSemanticsAction(int32_t id,
                                flutter::SemanticsAction action,
                                std::vector<uint8_t> args) override;
+  void AccessibilityFocusDidChange(int32_t focused_id) override;
 
   UIView<UITextInput>* textInputView() override;
 
@@ -83,6 +84,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   FlutterViewController* view_controller_;
   PlatformViewIOS* platform_view_;
   FlutterPlatformViewsController* platform_views_controller_;
+  int32_t last_focused_semantics_object_id_;
   fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;
   fml::WeakPtrFactory<AccessibilityBridge> weak_factory_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -67,8 +67,8 @@ UIView<UITextInput>* AccessibilityBridge::textInputView() {
   return [[platform_view_->GetOwnerViewController().get().engine textInputPlugin] textInputView];
 }
 
-void AccessibilityBridge::AccessibilityFocusDidChange(int32_t focused_id) {
-  last_focused_semantics_object_id_ = focused_id;
+void AccessibilityBridge::AccessibilityFocusDidChange(int32_t id) {
+  last_focused_semantics_object_id_ = id;
 }
 
 void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -195,16 +195,14 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
   } else if (layoutChanged) {
     // Tries to refocus the previous focused semantics object to avoid random jumps.
     ios_delegate_->PostAccessibilityNotification(
-      UIAccessibilityLayoutChangedNotification,
-      [objects_.get() objectForKey:@(last_focused_semantics_object_id_)]
-    );
+        UIAccessibilityLayoutChangedNotification,
+        [objects_.get() objectForKey:@(last_focused_semantics_object_id_)]);
   }
   if (scrollOccured) {
     // Tries to refocus the previous focused semantics object to avoid random jumps.
     ios_delegate_->PostAccessibilityNotification(
-      UIAccessibilityPageScrolledNotification,
-      [objects_.get() objectForKey:@(last_focused_semantics_object_id_)]
-    );
+        UIAccessibilityPageScrolledNotification,
+        [objects_.get() objectForKey:@(last_focused_semantics_object_id_)]);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -41,6 +41,7 @@ AccessibilityBridge::AccessibilityBridge(FlutterViewController* view_controller,
     : view_controller_(view_controller),
       platform_view_(platform_view),
       platform_views_controller_(platform_views_controller),
+      last_focused_semantics_object_id_(0),
       objects_([[NSMutableDictionary alloc] init]),
       weak_factory_(this),
       previous_route_id_(0),
@@ -64,6 +65,10 @@ AccessibilityBridge::~AccessibilityBridge() {
 
 UIView<UITextInput>* AccessibilityBridge::textInputView() {
   return [[platform_view_->GetOwnerViewController().get().engine textInputPlugin] textInputView];
+}
+
+void AccessibilityBridge::AccessibilityFocusDidChange(int32_t focused_id) {
+  last_focused_semantics_object_id_ = focused_id;
 }
 
 void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
@@ -188,12 +193,18 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
                                                    [lastAdded routeFocusObject]);
     }
   } else if (layoutChanged) {
-    // TODO(goderbauer): figure out which node to focus next.
-    ios_delegate_->PostAccessibilityNotification(UIAccessibilityLayoutChangedNotification, nil);
+    // Tries to refocus the previous focused semantics object to avoid random jumps.
+    ios_delegate_->PostAccessibilityNotification(
+      UIAccessibilityLayoutChangedNotification,
+      [objects_.get() objectForKey:@(last_focused_semantics_object_id_)]
+    );
   }
   if (scrollOccured) {
-    // TODO(tvolkert): provide meaningful string (e.g. "page 2 of 5")
-    ios_delegate_->PostAccessibilityNotification(UIAccessibilityPageScrolledNotification, @"");
+    // Tries to refocus the previous focused semantics object to avoid random jumps.
+    ios_delegate_->PostAccessibilityNotification(
+      UIAccessibilityPageScrolledNotification,
+      [objects_.get() objectForKey:@(last_focused_semantics_object_id_)]
+    );
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
@@ -24,6 +24,7 @@ class AccessibilityBridgeIos {
   virtual void DispatchSemanticsAction(int32_t id,
                                        flutter::SemanticsAction action,
                                        std::vector<uint8_t> args) = 0;
+  virtual void AccessibilityFocusDidChange(int32_t focused_id) = 0;
   virtual FlutterPlatformViewsController* GetPlatformViewsController() const = 0;
 };
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
@@ -24,7 +24,13 @@ class AccessibilityBridgeIos {
   virtual void DispatchSemanticsAction(int32_t id,
                                        flutter::SemanticsAction action,
                                        std::vector<uint8_t> args) = 0;
-  virtual void AccessibilityFocusDidChange(int32_t focused_id) = 0;
+  /**
+   * A callback that is called after the accessibility focus has moved to a new
+   * SemanticObject.
+   *
+   * The input id is the uid of the newly focused SemanticObject.
+   */
+  virtual void AccessibilityFocusDidChange(int32_t id) = 0;
   virtual FlutterPlatformViewsController* GetPlatformViewsController() const = 0;
 };
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -326,7 +326,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                  UIAccessibilityScreenChangedNotification);
 }
 
-- (void)testAnnouncesLayoutChangeWithNilIfLastFocusIsRemoved{
+- (void)testAnnouncesLayoutChangeWithNilIfLastFocusIsRemoved {
   flutter::MockDelegate mock_delegate;
   auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
   flutter::TaskRunners runners(/*label=*/self.name.UTF8String,

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -306,7 +306,6 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
 
   flutter::SemanticsNode route_node;
   route_node.id = 1;
-  route_node.label = label;
   route_node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute) |
                      static_cast<int32_t>(flutter::SemanticsFlags::kNamesRoute);
   route_node.label = "route";
@@ -325,6 +324,207 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   XCTAssertEqualObjects([focusObject accessibilityLabel], @"route");
   XCTAssertEqual([accessibility_notifications[0][@"notification"] unsignedIntValue],
                  UIAccessibilityScreenChangedNotification);
+}
+
+- (void)testAnnouncesLayoutChangeWithNilIfLastFocusIsRemoved{
+  flutter::MockDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*task_runners=*/runners);
+  id mockFlutterView = OCMClassMock([FlutterView class]);
+
+  NSMutableArray<NSDictionary<NSString*, id>*>* accessibility_notifications =
+      [[[NSMutableArray alloc] init] autorelease];
+  auto ios_delegate = std::make_unique<flutter::MockIosDelegate>();
+  ios_delegate->on_PostAccessibilityNotification_ =
+      [accessibility_notifications](UIAccessibilityNotifications notification, id argument) {
+        [accessibility_notifications addObject:@{
+          @"notification" : @(notification),
+          @"argument" : argument ? argument : [NSNull null],
+        }];
+      };
+  __block auto bridge =
+      std::make_unique<flutter::AccessibilityBridge>(/*view=*/mockFlutterView,
+                                                     /*platform_view=*/platform_view.get(),
+                                                     /*platform_views_controller=*/nil,
+                                                     /*ios_delegate=*/std::move(ios_delegate));
+
+  flutter::CustomAccessibilityActionUpdates actions;
+  flutter::SemanticsNodeUpdates first_update;
+
+  flutter::SemanticsNode route_node;
+  route_node.id = 1;
+  route_node.label = "route";
+  first_update[route_node.id] = route_node;
+  flutter::SemanticsNode root_node;
+  root_node.id = kRootNodeId;
+  root_node.label = "root";
+  root_node.childrenInTraversalOrder = {1};
+  root_node.childrenInHitTestOrder = {1};
+  first_update[root_node.id] = root_node;
+  bridge->UpdateSemantics(/*nodes=*/first_update, /*actions=*/actions);
+
+  XCTAssertEqual([accessibility_notifications count], 0ul);
+  // Simulates the focusing on the node 1.
+  bridge->AccessibilityFocusDidChange(1);
+
+  flutter::SemanticsNodeUpdates second_update;
+  // Simulates the removal of the node 1
+  flutter::SemanticsNode new_root_node;
+  new_root_node.id = kRootNodeId;
+  new_root_node.label = "root";
+  second_update[root_node.id] = new_root_node;
+  bridge->UpdateSemantics(/*nodes=*/second_update, /*actions=*/actions);
+  NSNull* focusObject = accessibility_notifications[0][@"argument"];
+  // The node 1 was removed, so the bridge will set the focus object to nil.
+  XCTAssertEqual(focusObject, [NSNull null]);
+  XCTAssertEqual([accessibility_notifications[0][@"notification"] unsignedIntValue],
+                 UIAccessibilityLayoutChangedNotification);
+}
+
+- (void)testAnnouncesLayoutChangeWithLastFocused {
+  flutter::MockDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*task_runners=*/runners);
+  id mockFlutterView = OCMClassMock([FlutterView class]);
+
+  NSMutableArray<NSDictionary<NSString*, id>*>* accessibility_notifications =
+      [[[NSMutableArray alloc] init] autorelease];
+  auto ios_delegate = std::make_unique<flutter::MockIosDelegate>();
+  ios_delegate->on_PostAccessibilityNotification_ =
+      [accessibility_notifications](UIAccessibilityNotifications notification, id argument) {
+        [accessibility_notifications addObject:@{
+          @"notification" : @(notification),
+          @"argument" : argument ? argument : [NSNull null],
+        }];
+      };
+  __block auto bridge =
+      std::make_unique<flutter::AccessibilityBridge>(/*view=*/mockFlutterView,
+                                                     /*platform_view=*/platform_view.get(),
+                                                     /*platform_views_controller=*/nil,
+                                                     /*ios_delegate=*/std::move(ios_delegate));
+
+  flutter::CustomAccessibilityActionUpdates actions;
+  flutter::SemanticsNodeUpdates first_update;
+
+  flutter::SemanticsNode node_one;
+  node_one.id = 1;
+  node_one.label = "route1";
+  first_update[node_one.id] = node_one;
+  flutter::SemanticsNode node_two;
+  node_two.id = 2;
+  node_two.label = "route2";
+  first_update[node_two.id] = node_two;
+  flutter::SemanticsNode root_node;
+  root_node.id = kRootNodeId;
+  root_node.label = "root";
+  root_node.childrenInTraversalOrder = {1, 2};
+  root_node.childrenInHitTestOrder = {1, 2};
+  first_update[root_node.id] = root_node;
+  bridge->UpdateSemantics(/*nodes=*/first_update, /*actions=*/actions);
+
+  XCTAssertEqual([accessibility_notifications count], 0ul);
+  // Simulates the focusing on the node 1.
+  bridge->AccessibilityFocusDidChange(1);
+
+  flutter::SemanticsNodeUpdates second_update;
+  // Simulates the removal of the node 2.
+  flutter::SemanticsNode new_root_node;
+  new_root_node.id = kRootNodeId;
+  new_root_node.label = "root";
+  new_root_node.childrenInTraversalOrder = {1};
+  new_root_node.childrenInHitTestOrder = {1};
+  second_update[root_node.id] = new_root_node;
+  bridge->UpdateSemantics(/*nodes=*/second_update, /*actions=*/actions);
+  SemanticsObject* focusObject = accessibility_notifications[0][@"argument"];
+  // Since we have focused on the node 1 right before the layout changed, the bridge should refocus
+  // the node 1.
+  XCTAssertEqual([focusObject uid], 1);
+  XCTAssertEqual([accessibility_notifications[0][@"notification"] unsignedIntValue],
+                 UIAccessibilityLayoutChangedNotification);
+}
+
+- (void)testAnnouncesScrollChangeWithLastFocused {
+  flutter::MockDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*task_runners=*/runners);
+  id mockFlutterView = OCMClassMock([FlutterView class]);
+
+  NSMutableArray<NSDictionary<NSString*, id>*>* accessibility_notifications =
+      [[[NSMutableArray alloc] init] autorelease];
+  auto ios_delegate = std::make_unique<flutter::MockIosDelegate>();
+  ios_delegate->on_PostAccessibilityNotification_ =
+      [accessibility_notifications](UIAccessibilityNotifications notification, id argument) {
+        [accessibility_notifications addObject:@{
+          @"notification" : @(notification),
+          @"argument" : argument ? argument : [NSNull null],
+        }];
+      };
+  __block auto bridge =
+      std::make_unique<flutter::AccessibilityBridge>(/*view=*/mockFlutterView,
+                                                     /*platform_view=*/platform_view.get(),
+                                                     /*platform_views_controller=*/nil,
+                                                     /*ios_delegate=*/std::move(ios_delegate));
+
+  flutter::CustomAccessibilityActionUpdates actions;
+  flutter::SemanticsNodeUpdates first_update;
+
+  flutter::SemanticsNode node_one;
+  node_one.id = 1;
+  node_one.label = "route1";
+  node_one.scrollPosition = 0.0;
+  first_update[node_one.id] = node_one;
+  flutter::SemanticsNode root_node;
+  root_node.id = kRootNodeId;
+  root_node.label = "root";
+  root_node.childrenInTraversalOrder = {1};
+  root_node.childrenInHitTestOrder = {1};
+  first_update[root_node.id] = root_node;
+  bridge->UpdateSemantics(/*nodes=*/first_update, /*actions=*/actions);
+
+  // The first update will trigger a scroll announcement, but we are not interested in it.
+  [accessibility_notifications removeAllObjects];
+
+  // Simulates the focusing on the node 1.
+  bridge->AccessibilityFocusDidChange(1);
+
+  flutter::SemanticsNodeUpdates second_update;
+  // Simulates the scrolling on the node 1.
+  flutter::SemanticsNode new_node_one;
+  new_node_one.id = 1;
+  new_node_one.label = "route1";
+  new_node_one.scrollPosition = 1.0;
+  second_update[new_node_one.id] = new_node_one;
+  bridge->UpdateSemantics(/*nodes=*/second_update, /*actions=*/actions);
+  SemanticsObject* focusObject = accessibility_notifications[0][@"argument"];
+  // Since we have focused on the node 1 right before the scrolling, the bridge should refocus the
+  // node 1.
+  XCTAssertEqual([focusObject uid], 1);
+  XCTAssertEqual([accessibility_notifications[0][@"notification"] unsignedIntValue],
+                 UIAccessibilityPageScrolledNotification);
 }
 
 - (void)testAnnouncesIgnoresRouteChangesWhenModal {


### PR DESCRIPTION
## Description

We always passes nil to layoutchange announcement and scroll announcement, this make ios to decide what to focus next by itself, and the result is unpredictable.

This pr makes accessibility bridge in ios to cache the last focused semantics object and attempt to refocus the same id after layout change or scroll to prevent a sudden jump in accessibility focus.

This is corresponding to the second problem i mentioned in https://github.com/flutter/flutter/issues/62549#issuecomment-666731900

## Related Issues

https://github.com/flutter/flutter/issues/62549

## Tests

I added the following tests:

See files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
