### PR TITLE
Remove null check for layer_tree pointer in `Animator::Render`

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -172,13 +172,13 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
 }
 
 void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
-  if (dimension_change_pending_ &&
-      layer_tree->frame_size() != last_layer_tree_size_) {
-    dimension_change_pending_ = false;
-  }
-  last_layer_tree_size_ = layer_tree->frame_size();
-
   if (layer_tree) {
+    if (dimension_change_pending_ &&
+        layer_tree->frame_size() != last_layer_tree_size_) {
+      dimension_change_pending_ = false;
+    }
+    last_layer_tree_size_ = layer_tree->frame_size();
+
     // Note the frame time for instrumentation.
     layer_tree->RecordBuildTime(last_frame_begin_time_,
                                 last_frame_target_time_);

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -179,8 +179,7 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
   last_layer_tree_size_ = layer_tree->frame_size();
 
   // Note the frame time for instrumentation.
-  layer_tree->RecordBuildTime(last_frame_begin_time_,
-                              last_frame_target_time_);
+  layer_tree->RecordBuildTime(last_frame_begin_time_, last_frame_target_time_);
 
   // Commit the pending continuation.
   bool result = producer_continuation_.Complete(std::move(layer_tree));

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -172,17 +172,15 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
 }
 
 void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
-  if (layer_tree) {
-    if (dimension_change_pending_ &&
-        layer_tree->frame_size() != last_layer_tree_size_) {
-      dimension_change_pending_ = false;
-    }
-    last_layer_tree_size_ = layer_tree->frame_size();
-
-    // Note the frame time for instrumentation.
-    layer_tree->RecordBuildTime(last_frame_begin_time_,
-                                last_frame_target_time_);
+  if (dimension_change_pending_ &&
+      layer_tree->frame_size() != last_layer_tree_size_) {
+    dimension_change_pending_ = false;
   }
+  last_layer_tree_size_ = layer_tree->frame_size();
+
+  // Note the frame time for instrumentation.
+  layer_tree->RecordBuildTime(last_frame_begin_time_,
+                              last_frame_target_time_);
 
   // Commit the pending continuation.
   bool result = producer_continuation_.Complete(std::move(layer_tree));


### PR DESCRIPTION
## Description

Moves `Animator::Render` invoke of `layer_tree` to `null` protected `if` statement. 

## Related Issues

fixes flutter/flutter#62600

## Tests

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
