### PR TITLE
Fix iOS Keyboard stuck as UIKeyboardTypeNamePhonePad

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -461,7 +461,6 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 
   self.secureTextEntry = [configuration[kSecureTextEntry] boolValue];
   self.keyboardType = ToUIKeyboardType(inputType);
-  self.keyboardType = UIKeyboardTypeNamePhonePad;
   self.returnKeyType = ToUIReturnKeyType(configuration[kInputAction]);
   self.autocapitalizationType = ToUITextAutoCapitalizationType(configuration);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -451,6 +451,20 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotEqual([inputView performSelector:@selector(font)], nil);
 }
 
+- (void)testKeyboardType {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [config setValue:@{@"name" : @"TextInputType.url"} forKey:@"inputType"];
+  [self setClientId:123 configuration:config];
+
+  // Find all the FlutterTextInputViews we created.
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+
+  FlutterTextInputView* inputView = inputFields[0];
+
+  // Verify keyboardType is set to the value specified in config.
+  XCTAssertEqual(inputView.keyboardType, UIKeyboardTypeURL);
+}
+
 - (void)testAutocorrectionPromptRectAppears {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithFrame:CGRectZero];
   inputView.textInputDelegate = engine;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -145,6 +145,9 @@ FLUTTER_ASSERT_ARC
   // Verify secureTextEntry is set to the correct value.
   XCTAssertTrue(inputView.secureTextEntry);
 
+  // Verify keyboardType is set to the default value.
+  XCTAssertEqual(inputView.keyboardType, UIKeyboardTypeDefault);
+
   // We should have only ever created one FlutterTextInputView.
   XCTAssertEqual(inputFields.count, 1);
 


### PR DESCRIPTION
## Description

Fixes the iOS keyboard being stuck as UIKeyboardTypeNamePhonePad.  Seems to be a line I should have caught in review [here](https://github.com/flutter/engine/pull/18643/files#diff-5f6e08941b895f0f7dc37f41f34501f1R464).

## Related Issues

Closes https://github.com/flutter/flutter/issues/62659

## Tests

I added the following tests:

  * Make sure that a FlutterTextInputView gets the default value for keyboardType.
