### PR TITLE
Fix navigation message relay.

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -303,14 +303,16 @@ void Engine::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
   } else if (channel == kSettingsChannel) {
     HandleSettingsPlatformMessage(message.get());
     return;
-  } else if (channel == kNavigationChannel) {
-    // If there's no runtime_, we may still need to set the initial route.
-    HandleNavigationPlatformMessage(std::move(message));
-    return;
   }
 
   if (runtime_controller_->IsRootIsolateRunning() &&
       runtime_controller_->DispatchPlatformMessage(std::move(message))) {
+    return;
+  }
+
+  if (channel == kNavigationChannel) {
+    // If there's no runtime_, we may still need to set the initial route.
+    HandleNavigationPlatformMessage(std::move(message));
     return;
   }
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -303,16 +303,15 @@ void Engine::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
   } else if (channel == kSettingsChannel) {
     HandleSettingsPlatformMessage(message.get());
     return;
+  } else if (!runtime_controller_->IsRootIsolateRunning() &&
+             channel == kNavigationChannel) {
+    // If there's no runtime_, we may still need to set the initial route.
+    HandleNavigationPlatformMessage(std::move(message));
+    return;
   }
 
   if (runtime_controller_->IsRootIsolateRunning() &&
       runtime_controller_->DispatchPlatformMessage(std::move(message))) {
-    return;
-  }
-
-  if (channel == kNavigationChannel) {
-    // If there's no runtime_, we may still need to set the initial route.
-    HandleNavigationPlatformMessage(std::move(message));
     return;
   }
 


### PR DESCRIPTION
Partially reverts the change done in https://github.com/flutter/engine/pull/19981 to make sure back button works on Android. There's a problem with `std::move` which already existed in the old code if `DispatchPlatformMessage` returns false. Fixing that is out of scope for this PR. It would also be good to add tests for navigation channel.