### PR TITLE
[web] Include trailing spaces in text box measurements

### DIFF
--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -435,7 +435,7 @@ class DomTextMeasurementService extends TextMeasurementService {
               _excludeTrailing(text, 0, text.length, _newlinePredicate),
           hardBreak: true,
           width: lineWidth,
-          widthWithSpaces: lineWidth,
+          widthWithTrailingSpaces: lineWidth,
           left: alignOffset,
           lineNumber: 0,
         ),
@@ -805,7 +805,7 @@ class LinesCalculator {
               _excludeTrailing(_text!, _chunkStart, chunkEnd, _newlinePredicate),
           hardBreak: false,
           width: widthOfResultingLine,
-          widthWithSpaces: widthOfResultingLine,
+          widthWithTrailingSpaces: widthOfResultingLine,
           left: alignOffset,
           lineNumber: lines.length,
         ));
@@ -860,7 +860,7 @@ class LinesCalculator {
     );
     final int lineNumber = lines.length;
     final double lineWidth = measureSubstring(_lineStart, endWithoutSpace);
-    final double lineWidthWithSpaces =
+    final double lineWidthWithTrailingSpaces =
         measureSubstring(_lineStart, endWithoutNewlines);
     final double alignOffset = _calculateAlignOffsetForLine(
       paragraph: _paragraph,
@@ -874,7 +874,7 @@ class LinesCalculator {
       endIndexWithoutNewlines: endWithoutNewlines,
       hardBreak: isHardBreak,
       width: lineWidth,
-      widthWithSpaces: lineWidthWithSpaces,
+      widthWithTrailingSpaces: lineWidthWithTrailingSpaces,
       left: alignOffset,
       lineNumber: lineNumber,
     );

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -435,6 +435,7 @@ class DomTextMeasurementService extends TextMeasurementService {
               _excludeTrailing(text, 0, text.length, _newlinePredicate),
           hardBreak: true,
           width: lineWidth,
+          widthWithSpaces: lineWidth,
           left: alignOffset,
           lineNumber: 0,
         ),
@@ -804,6 +805,7 @@ class LinesCalculator {
               _excludeTrailing(_text!, _chunkStart, chunkEnd, _newlinePredicate),
           hardBreak: false,
           width: widthOfResultingLine,
+          widthWithSpaces: widthOfResultingLine,
           left: alignOffset,
           lineNumber: lines.length,
         ));
@@ -858,6 +860,8 @@ class LinesCalculator {
     );
     final int lineNumber = lines.length;
     final double lineWidth = measureSubstring(_lineStart, endWithoutSpace);
+    final double lineWidthWithSpaces =
+        measureSubstring(_lineStart, endWithoutNewlines);
     final double alignOffset = _calculateAlignOffsetForLine(
       paragraph: _paragraph,
       lineWidth: lineWidth,
@@ -870,6 +874,7 @@ class LinesCalculator {
       endIndexWithoutNewlines: endWithoutNewlines,
       hardBreak: isHardBreak,
       width: lineWidth,
+      widthWithSpaces: lineWidthWithSpaces,
       left: alignOffset,
       lineNumber: lineNumber,
     );

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -21,7 +21,8 @@ class EngineLineMetrics implements ui.LineMetrics {
   })  : displayText = null,
         startIndex = -1,
         endIndex = -1,
-        endIndexWithoutNewlines = -1;
+        endIndexWithoutNewlines = -1,
+        widthWithSpaces = width;
 
   EngineLineMetrics.withText(
     String this.displayText, {
@@ -30,6 +31,7 @@ class EngineLineMetrics implements ui.LineMetrics {
     required this.endIndexWithoutNewlines,
     required this.hardBreak,
     required this.width,
+    required this.widthWithSpaces,
     required this.left,
     required this.lineNumber,
   })  : assert(displayText != null), // ignore: unnecessary_null_comparison
@@ -79,6 +81,18 @@ class EngineLineMetrics implements ui.LineMetrics {
 
   @override
   final double width;
+
+  /// The full width of the line including all trailing space but not new lines.
+  ///
+  /// The difference between [width] and [widthWithSpaces] is that
+  /// [widthWithSpaces] includes trailing spaces in the width calculation
+  /// while [width] doesn't.
+  ///
+  /// For alignment purposes for example, the [width] property is the right one
+  /// to use because trailing spaces shouldn't affect the centering of text.
+  /// But for placing cursors in text fields, we do care about trailing
+  /// spaces so [widthWithSpaces] is more suitable.
+  final double widthWithSpaces;
 
   @override
   final double left;
@@ -453,7 +467,7 @@ class EngineParagraph implements ui.Paragraph {
     return ui.TextBox.fromLTRBD(
       line.left + widthBeforeBox,
       top,
-      line.left + line.width - widthAfterBox,
+      line.left + line.widthWithSpaces - widthAfterBox,
       top + _lineHeight,
       _textDirection,
     );

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -22,7 +22,7 @@ class EngineLineMetrics implements ui.LineMetrics {
         startIndex = -1,
         endIndex = -1,
         endIndexWithoutNewlines = -1,
-        widthWithSpaces = width;
+        widthWithTrailingSpaces = width;
 
   EngineLineMetrics.withText(
     String this.displayText, {
@@ -31,7 +31,7 @@ class EngineLineMetrics implements ui.LineMetrics {
     required this.endIndexWithoutNewlines,
     required this.hardBreak,
     required this.width,
-    required this.widthWithSpaces,
+    required this.widthWithTrailingSpaces,
     required this.left,
     required this.lineNumber,
   })  : assert(displayText != null), // ignore: unnecessary_null_comparison
@@ -84,15 +84,15 @@ class EngineLineMetrics implements ui.LineMetrics {
 
   /// The full width of the line including all trailing space but not new lines.
   ///
-  /// The difference between [width] and [widthWithSpaces] is that
-  /// [widthWithSpaces] includes trailing spaces in the width calculation
-  /// while [width] doesn't.
+  /// The difference between [width] and [widthWithTrailingSpaces] is that
+  /// [widthWithTrailingSpaces] includes trailing spaces in the width
+  /// calculation while [width] doesn't.
   ///
   /// For alignment purposes for example, the [width] property is the right one
   /// to use because trailing spaces shouldn't affect the centering of text.
   /// But for placing cursors in text fields, we do care about trailing
-  /// spaces so [widthWithSpaces] is more suitable.
-  final double widthWithSpaces;
+  /// spaces so [widthWithTrailingSpaces] is more suitable.
+  final double widthWithTrailingSpaces;
 
   @override
   final double left;
@@ -467,7 +467,7 @@ class EngineParagraph implements ui.Paragraph {
     return ui.TextBox.fromLTRBD(
       line.left + widthBeforeBox,
       top,
-      line.left + line.widthWithSpaces - widthAfterBox,
+      line.left + line.widthWithTrailingSpaces - widthAfterBox,
       top + _lineHeight,
       _textDirection,
     );

--- a/lib/web_ui/test/paragraph_test.dart
+++ b/lib/web_ui/test/paragraph_test.dart
@@ -801,6 +801,46 @@ void main() async {
     );
   });
 
+  testEachMeasurement('getBoxesForRange includes trailing spaces', () {
+    const String text = 'abcd abcde  ';
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+      fontFamily: 'Ahem',
+      fontStyle: FontStyle.normal,
+      fontWeight: FontWeight.normal,
+      fontSize: 10,
+    ));
+    builder.addText(text);
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: double.infinity));
+    expect(
+      paragraph.getBoxesForRange(0, text.length),
+      <TextBox>[
+        TextBox.fromLTRBD(0.0, 0.0, 120.0, 10.0, TextDirection.ltr),
+      ],
+    );
+  });
+
+  testEachMeasurement('getBoxesForRange multi-line includes trailing spaces', () {
+    const String text = 'abcd\nabcde  \nabc';
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+      fontFamily: 'Ahem',
+      fontStyle: FontStyle.normal,
+      fontWeight: FontWeight.normal,
+      fontSize: 10,
+    ));
+    builder.addText(text);
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: double.infinity));
+    expect(
+      paragraph.getBoxesForRange(0, text.length),
+      <TextBox>[
+        TextBox.fromLTRBD(0.0, 0.0, 40.0, 10.0, TextDirection.ltr),
+        TextBox.fromLTRBD(0.0, 10.0, 70.0, 20.0, TextDirection.ltr),
+        TextBox.fromLTRBD(0.0, 20.0, 30.0, 30.0, TextDirection.ltr),
+      ],
+    );
+  });
+
   test('longestLine', () {
     // [Paragraph.longestLine] is only supported by canvas-based measurement.
     WebExperiments.instance.useCanvasText = true;


### PR DESCRIPTION
## Description

In some situations, we need to ignore trailing spaces when measuring text width (e.g. centering a line of text). In other situations, we need to account for trailing spaces (e.g. placing cursors in text fields).

This PR achieves the latter by using a trailing-space-sensitive width when [measuring text boxes](https://github.com/flutter/engine/blob/fa16c3d0bacd7d9928bc4c61659989d07cbf2645/lib/web_ui/lib/src/engine/text/paragraph.dart#L372) in a paragraph. I verified that this matches the native engine's behavior. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/62758

## Tests

I added tests in:

- `test/paragraph_test.dart`.