### PR TITLE
Added unit tests to the engine.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -600,6 +600,7 @@ FILE: ../../../flutter/shell/common/canvas_spy.h
 FILE: ../../../flutter/shell/common/canvas_spy_unittests.cc
 FILE: ../../../flutter/shell/common/engine.cc
 FILE: ../../../flutter/shell/common/engine.h
+FILE: ../../../flutter/shell/common/engine_unittests.cc
 FILE: ../../../flutter/shell/common/fixtures/shell_test.dart
 FILE: ../../../flutter/shell/common/fixtures/shelltest_screenshot.png
 FILE: ../../../flutter/shell/common/input_events_unittests.cc

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -116,7 +116,7 @@ bool RuntimeController::IsRootIsolateRunning() const {
 
 std::unique_ptr<RuntimeController> RuntimeController::Clone() const {
   return std::unique_ptr<RuntimeController>(new RuntimeController(
-      client_,                     //
+      client_,                      //
       vm_,                          //
       isolate_snapshot_,            //
       task_runners_,                //

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -16,6 +16,9 @@
 
 namespace flutter {
 
+RuntimeController::RuntimeController(RuntimeDelegate& client, TaskRunners p_task_runners)
+    : client_(client), vm_(nullptr), task_runners_(p_task_runners) {}
+
 RuntimeController::RuntimeController(
     RuntimeDelegate& p_client,
     DartVM* p_vm,
@@ -113,7 +116,7 @@ bool RuntimeController::IsRootIsolateRunning() const {
 
 std::unique_ptr<RuntimeController> RuntimeController::Clone() const {
   return std::unique_ptr<RuntimeController>(new RuntimeController(
-      client_,                      //
+      client_,                     //
       vm_,                          //
       isolate_snapshot_,            //
       task_runners_,                //

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -16,7 +16,8 @@
 
 namespace flutter {
 
-RuntimeController::RuntimeController(RuntimeDelegate& client, TaskRunners p_task_runners)
+RuntimeController::RuntimeController(RuntimeDelegate& client,
+                                     TaskRunners p_task_runners)
     : client_(client), vm_(nullptr), task_runners_(p_task_runners) {}
 
 RuntimeController::RuntimeController(

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -38,7 +38,7 @@ class Window;
 /// used by the engine to copy the currently accumulated window state so it can
 /// be referenced by the new runtime controller.
 ///
-class RuntimeController final : public PlatformConfigurationClient {
+class RuntimeController : public PlatformConfigurationClient {
  public:
   //----------------------------------------------------------------------------
   /// @brief      Creates a new instance of a runtime controller. This is
@@ -340,7 +340,7 @@ class RuntimeController final : public PlatformConfigurationClient {
   ///
   /// @return     True if root isolate running, False otherwise.
   ///
-  bool IsRootIsolateRunning() const;
+  virtual bool IsRootIsolateRunning() const;
 
   //----------------------------------------------------------------------------
   /// @brief      Dispatch the specified platform message to running root
@@ -351,7 +351,7 @@ class RuntimeController final : public PlatformConfigurationClient {
   /// @return     If the message was dispatched to the running root isolate.
   ///             This may fail is an isolate is not running.
   ///
-  bool DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message);
+  virtual bool DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message);
 
   //----------------------------------------------------------------------------
   /// @brief      Dispatch the specified pointer data message to the running
@@ -439,6 +439,10 @@ class RuntimeController final : public PlatformConfigurationClient {
   ///             indicates if one is specified by the root isolate.
   ///
   std::pair<bool, uint32_t> GetRootIsolateReturnCode();
+
+ protected:
+  /// Constructor for Mocks.
+  RuntimeController(RuntimeDelegate& client, TaskRunners p_task_runners);
 
  private:
   struct Locale {

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -258,6 +258,7 @@ if (enable_unittests) {
     sources = [
       "animator_unittests.cc",
       "canvas_spy_unittests.cc",
+      "engine_unittests.cc",
       "input_events_unittests.cc",
       "persistent_cache_unittests.cc",
       "pipeline_unittests.cc",
@@ -268,6 +269,7 @@ if (enable_unittests) {
     deps = [
       "//flutter/assets",
       "//flutter/shell/version",
+      "//third_party/googletest:gmock",
     ]
 
     public_deps_legacy_and_next = [ ":shell_test_fixture_sources" ]

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -28,6 +28,13 @@
 
 namespace flutter {
 
+static constexpr char kAssetChannel[] = "flutter/assets";
+static constexpr char kLifecycleChannel[] = "flutter/lifecycle";
+static constexpr char kNavigationChannel[] = "flutter/navigation";
+static constexpr char kLocalizationChannel[] = "flutter/localization";
+static constexpr char kSettingsChannel[] = "flutter/settings";
+static constexpr char kIsolateChannel[] = "flutter/isolate";
+
 Engine::Engine(
     Delegate& delegate,
     const PointerDataDispatcherMaker& dispatcher_maker,

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -28,12 +28,26 @@
 
 namespace flutter {
 
-static constexpr char kAssetChannel[] = "flutter/assets";
-static constexpr char kLifecycleChannel[] = "flutter/lifecycle";
-static constexpr char kNavigationChannel[] = "flutter/navigation";
-static constexpr char kLocalizationChannel[] = "flutter/localization";
-static constexpr char kSettingsChannel[] = "flutter/settings";
-static constexpr char kIsolateChannel[] = "flutter/isolate";
+Engine::Engine(
+    Delegate& delegate,
+    const PointerDataDispatcherMaker& dispatcher_maker,
+    std::shared_ptr<fml::ConcurrentTaskRunner> image_decoder_task_runner,
+    TaskRunners task_runners,
+    Settings settings,
+    std::unique_ptr<Animator> animator,
+    fml::WeakPtr<IOManager> io_manager,
+    std::unique_ptr<RuntimeController> runtime_controller)
+    : delegate_(delegate),
+      settings_(std::move(settings)),
+      animator_(std::move(animator)),
+      runtime_controller_(std::move(runtime_controller)),
+      activity_running_(true),
+      have_surface_(false),
+      image_decoder_(task_runners, image_decoder_task_runner, io_manager),
+      task_runners_(std::move(task_runners)),
+      weak_factory_(this) {
+  pointer_data_dispatcher_ = dispatcher_maker(*this);
+}
 
 Engine::Engine(Delegate& delegate,
                const PointerDataDispatcherMaker& dispatcher_maker,
@@ -46,19 +60,14 @@ Engine::Engine(Delegate& delegate,
                fml::WeakPtr<IOManager> io_manager,
                fml::RefPtr<SkiaUnrefQueue> unref_queue,
                fml::WeakPtr<SnapshotDelegate> snapshot_delegate)
-    : delegate_(delegate),
-      settings_(std::move(settings)),
-      animator_(std::move(animator)),
-      activity_running_(true),
-      have_surface_(false),
-      image_decoder_(task_runners,
-                     vm.GetConcurrentWorkerTaskRunner(),
-                     io_manager),
-      task_runners_(std::move(task_runners)),
-      weak_factory_(this) {
-  // Runtime controller is initialized here because it takes a reference to this
-  // object as its delegate. The delegate may be called in the constructor and
-  // we want to be fully initilazed by that point.
+    : Engine(delegate,
+             dispatcher_maker,
+             vm.GetConcurrentWorkerTaskRunner(),
+             task_runners,
+             settings,
+             std::move(animator),
+             io_manager,
+             nullptr) {
   runtime_controller_ = std::make_unique<RuntimeController>(
       *this,                        // runtime delegate
       &vm,                          // VM
@@ -76,8 +85,6 @@ Engine::Engine(Delegate& delegate,
       settings_.isolate_shutdown_callback,   // isolate shutdown callback
       settings_.persistent_isolate_data      // persistent isolate data
   );
-
-  pointer_data_dispatcher_ = dispatcher_maker(*this);
 }
 
 Engine::~Engine() = default;
@@ -291,31 +298,7 @@ void Engine::SetViewportMetrics(const ViewportMetrics& metrics) {
 }
 
 void Engine::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
-  std::string channel = message->channel();
-  if (channel == kLifecycleChannel) {
-    if (HandleLifecyclePlatformMessage(message.get())) {
-      return;
-    }
-  } else if (channel == kLocalizationChannel) {
-    if (HandleLocalizationPlatformMessage(message.get())) {
-      return;
-    }
-  } else if (channel == kSettingsChannel) {
-    HandleSettingsPlatformMessage(message.get());
-    return;
-  } else if (!runtime_controller_->IsRootIsolateRunning() &&
-             channel == kNavigationChannel) {
-    // If there's no runtime_, we may still need to set the initial route.
-    HandleNavigationPlatformMessage(std::move(message));
-    return;
-  }
-
-  if (runtime_controller_->IsRootIsolateRunning() &&
-      runtime_controller_->DispatchPlatformMessage(std::move(message))) {
-    return;
-  }
-
-  FML_DLOG(WARNING) << "Dropping platform message on channel: " << channel;
+  DispatchPlatformMessage(message, runtime_controller_.get());
 }
 
 bool Engine::HandleLifecyclePlatformMessage(PlatformMessage* message) {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -777,13 +777,6 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   const std::string& InitialRoute() const { return initial_route_; }
 
  private:
-  static constexpr char kAssetChannel[] = "flutter/assets";
-  static constexpr char kLifecycleChannel[] = "flutter/lifecycle";
-  static constexpr char kNavigationChannel[] = "flutter/navigation";
-  static constexpr char kLocalizationChannel[] = "flutter/localization";
-  static constexpr char kSettingsChannel[] = "flutter/settings";
-  static constexpr char kIsolateChannel[] = "flutter/isolate";
-
   Engine::Delegate& delegate_;
   const Settings settings_;
   std::unique_ptr<Animator> animator_;

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -678,41 +678,6 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   void DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message);
 
   //----------------------------------------------------------------------------
-  /// @brief      A version of `DispatchPlatformMessage` that allows delegating
-  ///             to a RuntimeControllerProxy.  You probably want the other
-  ///             `DispatchPlatformMessage` unless you are writing tests.
-  ///
-  template <typename RuntimeControllerProxy>
-  void DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message,
-                               RuntimeControllerProxy runtime_controller) {
-    std::string channel = message->channel();
-    if (channel == kLifecycleChannel) {
-      if (HandleLifecyclePlatformMessage(message.get())) {
-        return;
-      }
-    } else if (channel == kLocalizationChannel) {
-      if (HandleLocalizationPlatformMessage(message.get())) {
-        return;
-      }
-    } else if (channel == kSettingsChannel) {
-      HandleSettingsPlatformMessage(message.get());
-      return;
-    } else if (!runtime_controller->IsRootIsolateRunning() &&
-               channel == kNavigationChannel) {
-      // If there's no runtime_, we may still need to set the initial route.
-      HandleNavigationPlatformMessage(std::move(message));
-      return;
-    }
-
-    if (runtime_controller->IsRootIsolateRunning() &&
-        runtime_controller->DispatchPlatformMessage(std::move(message))) {
-      return;
-    }
-
-    FML_DLOG(WARNING) << "Dropping platform message on channel: " << channel;
-  }
-
-  //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder has sent it a pointer
   ///             data packet. A pointer data packet may contain multiple
   ///             input events. This call originates in the platform view and

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -12,6 +12,12 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
+// This is a hack to get gmock working on windows until a fix lands for:
+// https://github.com/google/googletest/issues/2490
+#undef GTEST_STRINGIFY_
+#define GTEST_STRINGIFY_HELPER_(name, ...) #name
+#define GTEST_STRINGIFY_(...) GTEST_STRINGIFY_HELPER_(__VA_ARGS__,)
+
 namespace flutter {
 
 namespace {

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -16,7 +16,7 @@
 // https://github.com/google/googletest/issues/2490
 #undef GTEST_STRINGIFY_
 #define GTEST_STRINGIFY_HELPER_(name, ...) #name
-#define GTEST_STRINGIFY_(...) GTEST_STRINGIFY_HELPER_(__VA_ARGS__,)
+#define GTEST_STRINGIFY_(...) GTEST_STRINGIFY_HELPER_(__VA_ARGS__, )
 
 namespace flutter {
 

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -12,78 +12,53 @@
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"
 
-// This is a hack to get gmock working on windows until a fix lands for:
+///\note Deprecated MOCK_METHOD macros used until this issue is resolved:
 // https://github.com/google/googletest/issues/2490
-#undef GTEST_STRINGIFY_
-#define GTEST_STRINGIFY_HELPER_(name, ...) #name
-#define GTEST_STRINGIFY_(...) GTEST_STRINGIFY_HELPER_(__VA_ARGS__, )
 
 namespace flutter {
 
 namespace {
 class MockDelegate : public Engine::Delegate {
-  MOCK_METHOD(void,
-              OnEngineUpdateSemantics,
-              (SemanticsNodeUpdates, CustomAccessibilityActionUpdates),
-              (override));
-  MOCK_METHOD(void,
-              OnEngineHandlePlatformMessage,
-              (fml::RefPtr<PlatformMessage>),
-              (override));
-  MOCK_METHOD(void, OnPreEngineRestart, (), (override));
-  MOCK_METHOD(void,
-              UpdateIsolateDescription,
-              (const std::string, int64_t),
-              (override));
-  MOCK_METHOD(void, SetNeedsReportTimings, (bool), (override));
-
-  MOCK_METHOD(std::unique_ptr<std::vector<std::string>>,
-              ComputePlatformResolvedLocale,
-              (const std::vector<std::string>&),
-              (override));
+  MOCK_METHOD2(OnEngineUpdateSemantics,
+               void(SemanticsNodeUpdates, CustomAccessibilityActionUpdates));
+  MOCK_METHOD1(OnEngineHandlePlatformMessage,
+               void(fml::RefPtr<PlatformMessage>));
+  MOCK_METHOD0(OnPreEngineRestart, void());
+  MOCK_METHOD2(UpdateIsolateDescription, void(const std::string, int64_t));
+  MOCK_METHOD1(SetNeedsReportTimings, void(bool));
+  MOCK_METHOD1(ComputePlatformResolvedLocale,
+               std::unique_ptr<std::vector<std::string>>(
+                   const std::vector<std::string>&));
 };
 
 class MockResponse : public PlatformMessageResponse {
  public:
-  MOCK_METHOD(void, Complete, (std::unique_ptr<fml::Mapping> data), (override));
-  MOCK_METHOD(void, CompleteEmpty, (), (override));
+  MOCK_METHOD1(Complete, void(std::unique_ptr<fml::Mapping> data));
+  MOCK_METHOD0(CompleteEmpty, void());
 };
 
 class MockRuntimeDelegate : public RuntimeDelegate {
  public:
-  MOCK_METHOD(std::string, DefaultRouteName, (), (override));
-  MOCK_METHOD(void, ScheduleFrame, (bool), (override));
-  MOCK_METHOD(void, Render, (std::unique_ptr<flutter::LayerTree>), (override));
-  MOCK_METHOD(void,
-              UpdateSemantics,
-              (SemanticsNodeUpdates, CustomAccessibilityActionUpdates),
-              (override));
-  MOCK_METHOD(void,
-              HandlePlatformMessage,
-              (fml::RefPtr<PlatformMessage>),
-              (override));
-  MOCK_METHOD(FontCollection&, GetFontCollection, (), (override));
-  MOCK_METHOD(void,
-              UpdateIsolateDescription,
-              (const std::string, int64_t),
-              (override));
-  MOCK_METHOD(void, SetNeedsReportTimings, (bool), (override));
-
-  MOCK_METHOD(std::unique_ptr<std::vector<std::string>>,
-              ComputePlatformResolvedLocale,
-              (const std::vector<std::string>&),
-              (override));
+  MOCK_METHOD0(DefaultRouteName, std::string());
+  MOCK_METHOD1(ScheduleFrame, void(bool));
+  MOCK_METHOD1(Render, void(std::unique_ptr<flutter::LayerTree>));
+  MOCK_METHOD2(UpdateSemantics,
+               void(SemanticsNodeUpdates, CustomAccessibilityActionUpdates));
+  MOCK_METHOD1(HandlePlatformMessage, void(fml::RefPtr<PlatformMessage>));
+  MOCK_METHOD0(GetFontCollection, FontCollection&());
+  MOCK_METHOD2(UpdateIsolateDescription, void(const std::string, int64_t));
+  MOCK_METHOD1(SetNeedsReportTimings, void(bool));
+  MOCK_METHOD1(ComputePlatformResolvedLocale,
+               std::unique_ptr<std::vector<std::string>>(
+                   const std::vector<std::string>&));
 };
 
 class MockRuntimeController : public RuntimeController {
  public:
   MockRuntimeController(RuntimeDelegate& client, TaskRunners p_task_runners)
       : RuntimeController(client, p_task_runners) {}
-  MOCK_METHOD(bool, IsRootIsolateRunning, (), (override, const));
-  MOCK_METHOD(bool,
-              DispatchPlatformMessage,
-              (fml::RefPtr<PlatformMessage>),
-              (override));
+  MOCK_CONST_METHOD0(IsRootIsolateRunning, bool());
+  MOCK_METHOD1(DispatchPlatformMessage, bool(fml::RefPtr<PlatformMessage>));
 };
 
 fml::RefPtr<PlatformMessage> MakePlatformMessage(

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -1,0 +1,216 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+// FLUTTER_NOLINT
+
+#include "flutter/runtime/dart_vm_lifecycle.h"
+#include "flutter/shell/common/engine.h"
+#include "flutter/shell/common/thread_host.h"
+#include "flutter/testing/testing.h"
+#include "gmock/gmock.h"
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/writer.h"
+
+namespace flutter {
+
+namespace {
+class MockDelegate : public Engine::Delegate {
+  MOCK_METHOD(void,
+              OnEngineUpdateSemantics,
+              (SemanticsNodeUpdates, CustomAccessibilityActionUpdates),
+              (override));
+  MOCK_METHOD(void,
+              OnEngineHandlePlatformMessage,
+              (fml::RefPtr<PlatformMessage>),
+              (override));
+  MOCK_METHOD(void, OnPreEngineRestart, (), (override));
+  MOCK_METHOD(void,
+              UpdateIsolateDescription,
+              (const std::string, int64_t),
+              (override));
+  MOCK_METHOD(void, SetNeedsReportTimings, (bool), (override));
+
+  MOCK_METHOD(std::unique_ptr<std::vector<std::string>>,
+              ComputePlatformResolvedLocale,
+              (const std::vector<std::string>&),
+              (override));
+};
+
+class MockResponse : public PlatformMessageResponse {
+ public:
+  MOCK_METHOD(void, Complete, (std::unique_ptr<fml::Mapping> data), (override));
+  MOCK_METHOD(void, CompleteEmpty, (), (override));
+};
+
+class MockRuntimeController {
+ public:
+  MOCK_METHOD(bool, IsRootIsolateRunning, ());
+  MOCK_METHOD(bool, DispatchPlatformMessage, (fml::RefPtr<PlatformMessage>));
+};
+
+fml::RefPtr<PlatformMessage> MakePlatformMessage(
+    const std::string& channel,
+    const std::map<std::string, std::string>& values,
+    fml::RefPtr<PlatformMessageResponse> response) {
+  rapidjson::Document document;
+  auto& allocator = document.GetAllocator();
+  document.SetObject();
+
+  for (const auto& pair : values) {
+    rapidjson::Value key(pair.first.c_str(), strlen(pair.first.c_str()),
+                         allocator);
+    rapidjson::Value value(pair.second.c_str(), strlen(pair.second.c_str()),
+                           allocator);
+    document.AddMember(key, value, allocator);
+  }
+
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  document.Accept(writer);
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
+
+  fml::RefPtr<PlatformMessage> message = fml::MakeRefCounted<PlatformMessage>(
+      channel, std::vector<uint8_t>(data, data + buffer.GetSize()), response);
+  return message;
+}
+
+class EngineTest : public ::testing::Test {
+ public:
+  EngineTest()
+      : thread_host_("EngineTest",
+                     ThreadHost::Type::Platform | ThreadHost::Type::IO |
+                         ThreadHost::Type::UI | ThreadHost::Type::GPU),
+        task_runners_({
+            "EngineTest",
+            thread_host_.platform_thread->GetTaskRunner(),  // platform
+            thread_host_.raster_thread->GetTaskRunner(),    // raster
+            thread_host_.ui_thread->GetTaskRunner(),        // ui
+            thread_host_.io_thread->GetTaskRunner()         // io
+        }) {}
+
+  void PostUITaskSync(const std::function<void()>& function) {
+    fml::AutoResetWaitableEvent latch;
+    task_runners_.GetUITaskRunner()->PostTask([&] {
+      function();
+      latch.Signal();
+    });
+    latch.Wait();
+  }
+
+ protected:
+  void SetUp() override {
+    dispatcher_maker_ = [](PointerDataDispatcher::Delegate&) {
+      return nullptr;
+    };
+  }
+
+  MockDelegate delegate_;
+  PointerDataDispatcherMaker dispatcher_maker_;
+  ThreadHost thread_host_;
+  TaskRunners task_runners_;
+  Settings settings_;
+  std::unique_ptr<Animator> animator_;
+  fml::WeakPtr<IOManager> io_manager_;
+  std::unique_ptr<RuntimeController> runtime_controller_;
+  std::shared_ptr<fml::ConcurrentTaskRunner> image_decoder_task_runner_;
+};
+}  // namespace
+
+TEST_F(EngineTest, Create) {
+  PostUITaskSync([this] {
+    auto engine = std::make_unique<Engine>(
+        /*delegate=*/delegate_,
+        /*dispatcher_maker=*/dispatcher_maker_,
+        /*image_decoder_task_runner=*/image_decoder_task_runner_,
+        /*task_runners=*/task_runners_,
+        /*settings=*/settings_,
+        /*animator=*/std::move(animator_),
+        /*io_manager=*/io_manager_,
+        /*runtime_controller=*/std::move(runtime_controller_));
+    EXPECT_TRUE(engine);
+  });
+}
+
+TEST_F(EngineTest, DispatchPlatformMessageUnknown) {
+  PostUITaskSync([this] {
+    auto engine = std::make_unique<Engine>(
+        /*delegate=*/delegate_,
+        /*dispatcher_maker=*/dispatcher_maker_,
+        /*image_decoder_task_runner=*/image_decoder_task_runner_,
+        /*task_runners=*/task_runners_,
+        /*settings=*/settings_,
+        /*animator=*/std::move(animator_),
+        /*io_manager=*/io_manager_,
+        /*runtime_controller=*/std::move(runtime_controller_));
+
+    fml::RefPtr<PlatformMessageResponse> response =
+        fml::MakeRefCounted<MockResponse>();
+    fml::RefPtr<PlatformMessage> message =
+        fml::MakeRefCounted<PlatformMessage>("foo", response);
+    MockRuntimeController mock_runtime_controller;
+    EXPECT_CALL(mock_runtime_controller, IsRootIsolateRunning())
+        .WillRepeatedly(::testing::Return(false));
+    engine->DispatchPlatformMessage(message, &mock_runtime_controller);
+  });
+}
+
+TEST_F(EngineTest, DispatchPlatformMessageInitialRoute) {
+  PostUITaskSync([this] {
+    auto engine = std::make_unique<Engine>(
+        /*delegate=*/delegate_,
+        /*dispatcher_maker=*/dispatcher_maker_,
+        /*image_decoder_task_runner=*/image_decoder_task_runner_,
+        /*task_runners=*/task_runners_,
+        /*settings=*/settings_,
+        /*animator=*/std::move(animator_),
+        /*io_manager=*/io_manager_,
+        /*runtime_controller=*/std::move(runtime_controller_));
+
+    fml::RefPtr<PlatformMessageResponse> response =
+        fml::MakeRefCounted<MockResponse>();
+    std::map<std::string, std::string> values{
+        {"method", "setInitialRoute"},
+        {"args", "test_initial_route"},
+    };
+    fml::RefPtr<PlatformMessage> message =
+        MakePlatformMessage("flutter/navigation", values, response);
+    MockRuntimeController mock_runtime_controller;
+    EXPECT_CALL(mock_runtime_controller, IsRootIsolateRunning())
+        .WillRepeatedly(::testing::Return(false));
+    engine->DispatchPlatformMessage(message, &mock_runtime_controller);
+    EXPECT_EQ(engine->InitialRoute(), "test_initial_route");
+  });
+}
+
+TEST_F(EngineTest, DispatchPlatformMessageInitialRouteIgnored) {
+  PostUITaskSync([this] {
+    auto engine = std::make_unique<Engine>(
+        /*delegate=*/delegate_,
+        /*dispatcher_maker=*/dispatcher_maker_,
+        /*image_decoder_task_runner=*/image_decoder_task_runner_,
+        /*task_runners=*/task_runners_,
+        /*settings=*/settings_,
+        /*animator=*/std::move(animator_),
+        /*io_manager=*/io_manager_,
+        /*runtime_controller=*/std::move(runtime_controller_));
+
+    fml::RefPtr<PlatformMessageResponse> response =
+        fml::MakeRefCounted<MockResponse>();
+    std::map<std::string, std::string> values{
+        {"method", "setInitialRoute"},
+        {"args", "test_initial_route"},
+    };
+    fml::RefPtr<PlatformMessage> message =
+        MakePlatformMessage("flutter/navigation", values, response);
+    MockRuntimeController mock_runtime_controller;
+    EXPECT_CALL(mock_runtime_controller, IsRootIsolateRunning())
+        .WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(mock_runtime_controller, DispatchPlatformMessage(::testing::_))
+        .WillRepeatedly(::testing::Return(true));
+    engine->DispatchPlatformMessage(message, &mock_runtime_controller);
+    EXPECT_EQ(engine->InitialRoute(), "");
+  });
+}
+
+}  // namespace flutter


### PR DESCRIPTION
## Description

Added tests to the Engine, previously there were none.  The tests that were added were for the benefit of https://github.com/flutter/engine/pull/20193

In order to make messages testable without incurring a performance cost I had to factor out one method to be templated so that we can delegate RuntimeController methods elsewhere.

## Related Issues

https://github.com/flutter/engine/pull/20193

## Tests

EngineTest

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
