### PR TITLE
FrameTiming build start timestamp fix and add vsync start timestamp

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -22,12 +22,17 @@ namespace flutter {
 
 class FrameTiming {
  public:
-  enum Phase {kVsyncStart, kBuildStart, kBuildFinish, kRasterStart,
-              kRasterFinish, kCount };
+  enum Phase {
+    kVsyncStart,
+    kBuildStart,
+    kBuildFinish,
+    kRasterStart,
+    kRasterFinish,
+    kCount
+  };
 
-  static constexpr Phase kPhases[kCount] = {kVsyncStart,
-                                            kBuildStart, kBuildFinish,
-                                            kRasterStart, kRasterFinish};
+  static constexpr Phase kPhases[kCount] = {
+      kVsyncStart, kBuildStart, kBuildFinish, kRasterStart, kRasterFinish};
 
   fml::TimePoint Get(Phase phase) const { return data_[phase]; }
   fml::TimePoint Set(Phase phase, fml::TimePoint value) {

--- a/common/settings.h
+++ b/common/settings.h
@@ -22,9 +22,11 @@ namespace flutter {
 
 class FrameTiming {
  public:
-  enum Phase { kBuildStart, kBuildFinish, kRasterStart, kRasterFinish, kCount };
+  enum Phase {kVsyncStart, kBuildStart, kBuildFinish, kRasterStart,
+              kRasterFinish, kCount };
 
-  static constexpr Phase kPhases[kCount] = {kBuildStart, kBuildFinish,
+  static constexpr Phase kPhases[kCount] = {kVsyncStart,
+                                            kBuildStart, kBuildFinish,
                                             kRasterStart, kRasterFinish};
 
   fml::TimePoint Get(Phase phase) const { return data_[phase]; }

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -21,8 +21,10 @@ LayerTree::LayerTree(const SkISize& frame_size,
       checkerboard_raster_cache_images_(false),
       checkerboard_offscreen_layers_(false) {}
 
-void LayerTree::RecordBuildTime(fml::TimePoint build_start,
+void LayerTree::RecordBuildTime(fml::TimePoint vsync_start,
+                                fml::TimePoint build_start,
                                 fml::TimePoint target_time) {
+  vsync_start_ = vsync_start;
   build_start_ = build_start;
   target_time_ = target_time;
   build_finish_ = fml::TimePoint::Now();

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -54,7 +54,12 @@ class LayerTree {
   float frame_physical_depth() const { return frame_physical_depth_; }
   float frame_device_pixel_ratio() const { return frame_device_pixel_ratio_; }
 
-  void RecordBuildTime(fml::TimePoint build_start, fml::TimePoint target_time);
+  void RecordBuildTime(fml::TimePoint vsync_start,
+                       fml::TimePoint build_start,
+                       fml::TimePoint target_time);
+  fml::TimePoint vsync_start() const { return vsync_start_; }
+  fml::TimeDelta vsync_overhead() const { return build_start_ - vsync_start_; }
+  fml::TimeDelta vsync_time() const { return build_finish_ - vsync_start_; }
   fml::TimePoint build_start() const { return build_start_; }
   fml::TimePoint build_finish() const { return build_finish_; }
   fml::TimeDelta build_time() const { return build_finish_ - build_start_; }
@@ -83,6 +88,7 @@ class LayerTree {
 
  private:
   std::shared_ptr<Layer> root_layer_;
+  fml::TimePoint vsync_start_;
   fml::TimePoint build_start_;
   fml::TimePoint build_finish_;
   fml::TimePoint target_time_;

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -59,7 +59,6 @@ class LayerTree {
                        fml::TimePoint target_time);
   fml::TimePoint vsync_start() const { return vsync_start_; }
   fml::TimeDelta vsync_overhead() const { return build_start_ - vsync_start_; }
-  fml::TimeDelta vsync_time() const { return build_finish_ - vsync_start_; }
   fml::TimePoint build_start() const { return build_start_; }
   fml::TimePoint build_finish() const { return build_finish_; }
   fml::TimeDelta build_time() const { return build_finish_ - build_start_; }

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -200,7 +200,7 @@ void _reportTimings(List<int> timings) {
   assert(timings.length % FramePhase.values.length == 0);
   final List<FrameTiming> frameTimings = <FrameTiming>[];
   for (int i = 0; i < timings.length; i += FramePhase.values.length) {
-    frameTimings.add(FrameTiming(timings.sublist(i, i + FramePhase.values.length)));
+    frameTimings.add(FrameTiming._(timings.sublist(i, i + FramePhase.values.length)));
   }
   _invoke1(window.onReportTimings, window._onReportTimingsZone, frameTimings);
 }

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -47,7 +47,7 @@ typedef _SetNeedsReportTimingsFunc = void Function(bool value);
 ///
 /// [FrameTiming] records a timestamp of each phase for performance analysis.
 enum FramePhase {
-  /// When the UI thread receives the vsync signal from the operating system.
+  /// The timestamp of the vsync signal given by the operating system.
   ///
   /// See also [FrameTiming.vsyncOverhead].
   vsyncStart,
@@ -150,15 +150,15 @@ class FrameTiming {
 
   /// The duration between receiving the vsync signal and starting building the
   /// frame.
-  Duration get vsyncOverhead => _rawDuration(FramePhase.vsyncStart) - _rawDuration(FramePhase.buildStart);
+  Duration get vsyncOverhead => _rawDuration(FramePhase.buildStart) - _rawDuration(FramePhase.vsyncStart);
 
-  /// The timespan between build start and raster finish.
+  /// The timespan between vsync start and raster finish.
   ///
   /// To achieve the lowest latency on an X fps display, this should not exceed
   /// 1000/X milliseconds.
   /// {@macro dart.ui.FrameTiming.fps_milliseconds}
   ///
-  /// See also [buildDuration] and [rasterDuration].
+  /// See also [vsyncOverhead], [buildDuration] and [rasterDuration].
   Duration get totalSpan => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.vsyncStart);
 
   final List<int> _timestamps;  // in microseconds

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -47,6 +47,11 @@ typedef _SetNeedsReportTimingsFunc = void Function(bool value);
 ///
 /// [FrameTiming] records a timestamp of each phase for performance analysis.
 enum FramePhase {
+  /// When the UI thread receives the vsync signal from the operating system.
+  ///
+  /// See also [FrameTiming.vsyncOverhead].
+  vsyncStart,
+
   /// When the UI thread starts building a frame.
   ///
   /// See also [FrameTiming.buildDuration].
@@ -143,6 +148,10 @@ class FrameTiming {
   /// {@macro dart.ui.FrameTiming.fps_milliseconds}
   Duration get rasterDuration => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.rasterStart);
 
+  /// The duration between receiving the vsync signal and starting building the
+  /// frame.
+  Duration get vsyncOverhead => _rawDuration(FramePhase.vsyncStart) - _rawDuration(FramePhase.buildStart);
+
   /// The timespan between build start and raster finish.
   ///
   /// To achieve the lowest latency on an X fps display, this should not exceed
@@ -150,7 +159,7 @@ class FrameTiming {
   /// {@macro dart.ui.FrameTiming.fps_milliseconds}
   ///
   /// See also [buildDuration] and [rasterDuration].
-  Duration get totalSpan => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.buildStart);
+  Duration get totalSpan => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.vsyncStart);
 
   final List<int> _timestamps;  // in microseconds
 

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -89,12 +89,32 @@ enum FramePhase {
 class FrameTiming {
   /// Construct [FrameTiming] with raw timestamps in microseconds.
   ///
+  /// This constructor is used for unit test only. Real [FrameTiming]s should
+  /// be retrieved from [Window.onReportTimings].
+  factory FrameTiming({
+    required int vsyncStart,
+    required int buildStart,
+    required int buildFinish,
+    required int rasterStart,
+    required int rasterFinish,
+  }) {
+    return FrameTiming._(<int>[
+      vsyncStart,
+      buildStart,
+      buildFinish,
+      rasterStart,
+      rasterFinish
+    ]);
+  }
+
+  /// Construct [FrameTiming] with raw timestamps in microseconds.
+  ///
   /// List [timestamps] must have the same number of elements as
   /// [FramePhase.values].
   ///
   /// This constructor is usually only called by the Flutter engine, or a test.
   /// To get the [FrameTiming] of your app, see [Window.onReportTimings].
-  FrameTiming(List<int> timestamps)
+  FrameTiming._(List<int> timestamps)
       : assert(timestamps.length == FramePhase.values.length), _timestamps = timestamps;
 
   /// Construct [FrameTiming] with given timestamp in micrseconds.
@@ -111,7 +131,9 @@ class FrameTiming {
     required int rasterStart,
     required int rasterFinish
   }) {
-    return FrameTiming(<int>[
+    return FrameTiming._(<int>[
+      // This is for temporarily backward compatiblilty.
+      vsyncStart ?? buildStart,
       buildStart,
       buildFinish,
       rasterStart,

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -167,7 +167,7 @@ class FrameTiming {
 
   @override
   String toString() {
-    return '$runtimeType(buildDuration: ${_formatMS(buildDuration)}, rasterDuration: ${_formatMS(rasterDuration)}, totalSpan: ${_formatMS(totalSpan)})';
+    return '$runtimeType(buildDuration: ${_formatMS(buildDuration)}, rasterDuration: ${_formatMS(rasterDuration)}, vsyncOverhead: ${_formatMS(vsyncOverhead)}, totalSpan: ${_formatMS(totalSpan)})';
   }
 }
 

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1121,7 +1121,7 @@ class FrameTiming {
 
   @override
   String toString() {
-    return '$runtimeType(buildDuration: ${_formatMS(buildDuration)}, rasterDuration: ${_formatMS(rasterDuration)}, totalSpan: ${_formatMS(totalSpan)})';
+    return '$runtimeType(buildDuration: ${_formatMS(buildDuration)}, rasterDuration: ${_formatMS(rasterDuration)}, vsyncOverhead: ${_formatMS(vsyncOverhead)}, totalSpan: ${_formatMS(totalSpan)})';
   }
 }
 

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1042,14 +1042,33 @@ enum FramePhase {
 class FrameTiming {
   /// Construct [FrameTiming] with raw timestamps in microseconds.
   ///
+  /// This constructor is used for unit test only. Real [FrameTiming]s should
+  /// be retrieved from [Window.onReportTimings].
+  factory FrameTiming({
+    required int vsyncStart,
+    required int buildStart,
+    required int buildFinish,
+    required int rasterStart,
+    required int rasterFinish,
+  }) {
+    return FrameTiming._(<int>[
+      vsyncStart,
+      buildStart,
+      buildFinish,
+      rasterStart,
+      rasterFinish
+    ]);
+  }
+
+  /// Construct [FrameTiming] with raw timestamps in microseconds.
+  ///
   /// List [timestamps] must have the same number of elements as
   /// [FramePhase.values].
   ///
   /// This constructor is usually only called by the Flutter engine, or a test.
   /// To get the [FrameTiming] of your app, see [Window.onReportTimings].
-  FrameTiming(List<int> timestamps)
-      : assert(timestamps.length == FramePhase.values.length),
-        _timestamps = timestamps;
+  FrameTiming._(List<int> timestamps)
+      : assert(timestamps.length == FramePhase.values.length), _timestamps = timestamps;
 
   /// Construct [FrameTiming] with given timestamp in micrseconds.
   ///
@@ -1058,13 +1077,22 @@ class FrameTiming {
   ///
   /// TODO(CareF): This is part of #20229. Remove back to default constructor
   /// after #20229 lands and corresponding framwork PRs land.
-  FrameTiming.fromTimeStamps({
+  factory FrameTiming.fromTimeStamps({
     int? vsyncStart,
     required int buildStart,
     required int buildFinish,
     required int rasterStart,
     required int rasterFinish
-  }) : _timestamps = <int>[buildStart, buildFinish, rasterStart, rasterFinish];
+  }) {
+    return FrameTiming._(<int>[
+      // This is for temporarily backward compatiblilty.
+      vsyncStart ?? buildStart,
+      buildStart,
+      buildFinish,
+      rasterStart,
+      rasterFinish
+    ]);
+  }
 
   /// This is a raw timestamp in microseconds from some epoch. The epoch in all
   /// [FrameTiming] is the same, but it may not match [DateTime]'s epoch.

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1005,7 +1005,7 @@ class IsolateNameServer {
 ///
 /// [FrameTiming] records a timestamp of each phase for performance analysis.
 enum FramePhase {
-  /// When the UI thread receives the vsync signal from the operating system.
+  /// The timestamp of the vsync signal given by the operating system.
   ///
   /// See also [FrameTiming.vsyncOverhead].
   vsyncStart,
@@ -1102,15 +1102,15 @@ class FrameTiming {
 
   /// The duration between receiving the vsync signal and starting building the
   /// frame.
-  Duration get vsyncOverhead => _rawDuration(FramePhase.vsyncStart) - _rawDuration(FramePhase.buildStart);
+  Duration get vsyncOverhead => _rawDuration(FramePhase.buildStart) - _rawDuration(FramePhase.vsyncStart);
 
-  /// The timespan between build start and raster finish.
+  /// The timespan between vsync start and raster finish.
   ///
   /// To achieve the lowest latency on an X fps display, this should not exceed
   /// 1000/X milliseconds.
   /// {@macro dart.ui.FrameTiming.fps_milliseconds}
   ///
-  /// See also [buildDuration] and [rasterDuration].
+  /// See also [vsyncOverhead], [buildDuration] and [rasterDuration].
   Duration get totalSpan =>
       _rawDuration(FramePhase.rasterFinish) -
       _rawDuration(FramePhase.vsyncStart);

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1005,6 +1005,11 @@ class IsolateNameServer {
 ///
 /// [FrameTiming] records a timestamp of each phase for performance analysis.
 enum FramePhase {
+  /// When the UI thread receives the vsync signal from the operating system.
+  ///
+  /// See also [FrameTiming.vsyncOverhead].
+  vsyncStart,
+
   /// When the UI thread starts building a frame.
   ///
   /// See also [FrameTiming.buildDuration].
@@ -1095,6 +1100,10 @@ class FrameTiming {
       _rawDuration(FramePhase.rasterFinish) -
       _rawDuration(FramePhase.rasterStart);
 
+  /// The duration between receiving the vsync signal and starting building the
+  /// frame.
+  Duration get vsyncOverhead => _rawDuration(FramePhase.vsyncStart) - _rawDuration(FramePhase.buildStart);
+
   /// The timespan between build start and raster finish.
   ///
   /// To achieve the lowest latency on an X fps display, this should not exceed
@@ -1104,7 +1113,7 @@ class FrameTiming {
   /// See also [buildDuration] and [rasterDuration].
   Duration get totalSpan =>
       _rawDuration(FramePhase.rasterFinish) -
-      _rawDuration(FramePhase.buildStart);
+      _rawDuration(FramePhase.vsyncStart);
 
   final List<int> _timestamps; // in microseconds
 

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -136,6 +136,9 @@ void Animator::BeginFrame(fml::TimePoint vsync_start_time,
 
   last_frame_begin_time_ = fml::TimePoint::Now();
   last_vsync_start_time_ = vsync_start_time;
+  fml::tracing::TraceEventAsyncComplete("flutter", "VsyncSchedulingOverhead",
+                                        last_frame_begin_time_,
+                                        last_frame_begin_time_);
   last_frame_target_time_ = frame_target_time;
   dart_frame_deadline_ = FxlToDartOrEarlier(frame_target_time);
   {

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -26,6 +26,7 @@ Animator::Animator(Delegate& delegate,
       task_runners_(std::move(task_runners)),
       waiter_(std::move(waiter)),
       last_frame_begin_time_(),
+      last_vsync_start_time_(),
       last_frame_target_time_(),
       dart_frame_deadline_(0),
 #if FLUTTER_SHELL_ENABLE_METAL
@@ -98,7 +99,7 @@ static int64_t FxlToDartOrEarlier(fml::TimePoint time) {
   return (time - fxl_now).ToMicroseconds() + dart_now;
 }
 
-void Animator::BeginFrame(fml::TimePoint frame_start_time,
+void Animator::BeginFrame(fml::TimePoint vsync_start_time,
                           fml::TimePoint frame_target_time) {
   TRACE_EVENT_ASYNC_END0("flutter", "Frame Request Pending", frame_number_++);
 
@@ -134,6 +135,7 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
   FML_DCHECK(producer_continuation_);
 
   last_frame_begin_time_ = fml::TimePoint::Now();
+  last_vsync_start_time_ = vsync_start_time;
   last_frame_target_time_ = frame_target_time;
   dart_frame_deadline_ = FxlToDartOrEarlier(frame_target_time);
   {
@@ -179,7 +181,9 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
   last_layer_tree_size_ = layer_tree->frame_size();
 
   // Note the frame time for instrumentation.
-  layer_tree->RecordBuildTime(last_frame_begin_time_, last_frame_target_time_);
+  layer_tree->RecordBuildTime(last_vsync_start_time_,
+                              last_frame_begin_time_,
+                              last_frame_target_time_);
 
   // Commit the pending continuation.
   bool result = producer_continuation_.Complete(std::move(layer_tree));
@@ -233,13 +237,13 @@ void Animator::RequestFrame(bool regenerate_layer_tree) {
 
 void Animator::AwaitVSync() {
   waiter_->AsyncWaitForVsync(
-      [self = weak_factory_.GetWeakPtr()](fml::TimePoint frame_start_time,
+      [self = weak_factory_.GetWeakPtr()](fml::TimePoint vsync_start_time,
                                           fml::TimePoint frame_target_time) {
         if (self) {
           if (self->CanReuseLastLayerTree()) {
             self->DrawLastLayerTree();
           } else {
-            self->BeginFrame(frame_start_time, frame_target_time);
+            self->BeginFrame(vsync_start_time, frame_target_time);
           }
         }
       });

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -133,7 +133,7 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
   // to service potential frame.
   FML_DCHECK(producer_continuation_);
 
-  last_frame_begin_time_ = frame_start_time;
+  last_frame_begin_time_ = fml::TimePoint::Now();
   last_frame_target_time_ = frame_target_time;
   dart_frame_deadline_ = FxlToDartOrEarlier(frame_target_time);
   {

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -137,7 +137,7 @@ void Animator::BeginFrame(fml::TimePoint vsync_start_time,
   last_frame_begin_time_ = fml::TimePoint::Now();
   last_vsync_start_time_ = vsync_start_time;
   fml::tracing::TraceEventAsyncComplete("flutter", "VsyncSchedulingOverhead",
-                                        last_frame_begin_time_,
+                                        last_vsync_start_time_,
                                         last_frame_begin_time_);
   last_frame_target_time_ = frame_target_time;
   dart_frame_deadline_ = FxlToDartOrEarlier(frame_target_time);
@@ -184,8 +184,7 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
   last_layer_tree_size_ = layer_tree->frame_size();
 
   // Note the frame time for instrumentation.
-  layer_tree->RecordBuildTime(last_vsync_start_time_,
-                              last_frame_begin_time_,
+  layer_tree->RecordBuildTime(last_vsync_start_time_, last_frame_begin_time_,
                               last_frame_target_time_);
 
   // Commit the pending continuation.

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -98,6 +98,7 @@ class Animator final {
   std::shared_ptr<VsyncWaiter> waiter_;
 
   fml::TimePoint last_frame_begin_time_;
+  fml::TimePoint last_vsync_start_time_;
   fml::TimePoint last_frame_target_time_;
   int64_t dart_frame_deadline_;
   fml::RefPtr<LayerTreePipeline> layer_tree_pipeline_;

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -290,6 +290,7 @@ RasterStatus Rasterizer::DoDraw(
 #if !defined(OS_FUCHSIA)
   const fml::TimePoint frame_target_time = layer_tree->target_time();
 #endif
+  timing.Set(FrameTiming::kVsyncStart, layer_tree->vsync_start());
   timing.Set(FrameTiming::kBuildStart, layer_tree->build_start());
   timing.Set(FrameTiming::kBuildFinish, layer_tree->build_finish());
   timing.Set(FrameTiming::kRasterStart, fml::TimePoint::Now());
@@ -382,7 +383,7 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
   // There is no way for the compositor to know how long the layer tree
   // construction took. Fortunately, the layer tree does. Grab that time
   // for instrumentation.
-  compositor_context_->ui_time().SetLapTime(layer_tree.build_time());
+  compositor_context_->ui_time().SetLapTime(layer_tree.vsync_time());
 
   auto* external_view_embedder = surface_->GetExternalViewEmbedder();
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -383,7 +383,7 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
   // There is no way for the compositor to know how long the layer tree
   // construction took. Fortunately, the layer tree does. Grab that time
   // for instrumentation.
-  compositor_context_->ui_time().SetLapTime(layer_tree.vsync_time());
+  compositor_context_->ui_time().SetLapTime(layer_tree.build_time());
 
   auto* external_view_embedder = surface_->GetExternalViewEmbedder();
 

--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -122,9 +122,6 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
         [callback, flow_identifier, frame_start_time, frame_target_time]() {
           FML_TRACE_EVENT("flutter", kVsyncTraceName, "StartTime",
                           frame_start_time, "TargetTime", frame_target_time);
-          fml::tracing::TraceEventAsyncComplete(
-              "flutter", "VsyncSchedulingOverhead", fml::TimePoint::Now(),
-              frame_start_time);
           callback(frame_start_time, frame_target_time);
           TRACE_FLOW_END("flutter", kVsyncFlowName, flow_identifier);
         },

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -22,8 +22,8 @@ void main() {
   });
 
   test('FrameTiming.toString has the correct format', () {
-    final FrameTiming timing = FrameTiming(<int>[1000, 8000, 9000, 19500]);
-    expect(timing.toString(), 'FrameTiming(buildDuration: 7.0ms, rasterDuration: 10.5ms, totalSpan: 18.5ms)');
+    final FrameTiming timing = FrameTiming(<int>[500, 1000, 8000, 9000, 19500]);
+    expect(timing.toString(), 'FrameTiming(buildDuration: 6.5ms, rasterDuration: 10.5ms, vsyncOverhead: 0.5ms, totalSpan: 18.5ms)');
   });
 
   test('computePlatformResolvedLocale basic', () {

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -23,7 +23,7 @@ void main() {
 
   test('FrameTiming.toString has the correct format', () {
     final FrameTiming timing = FrameTiming(<int>[500, 1000, 8000, 9000, 19500]);
-    expect(timing.toString(), 'FrameTiming(buildDuration: 6.5ms, rasterDuration: 10.5ms, vsyncOverhead: 0.5ms, totalSpan: 18.5ms)');
+    expect(timing.toString(), 'FrameTiming(buildDuration: 7.0ms, rasterDuration: 10.5ms, vsyncOverhead: 0.5ms, totalSpan: 19.0ms)');
   });
 
   test('computePlatformResolvedLocale basic', () {

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -22,7 +22,13 @@ void main() {
   });
 
   test('FrameTiming.toString has the correct format', () {
-    final FrameTiming timing = FrameTiming(<int>[500, 1000, 8000, 9000, 19500]);
+    final FrameTiming timing = FrameTiming(
+      vsyncStart: 500,
+      buildStart: 1000,
+      buildFinish: 8000,
+      rasterStart: 9000,
+      rasterFinish: 19500
+    );
     expect(timing.toString(), 'FrameTiming(buildDuration: 7.0ms, rasterDuration: 10.5ms, vsyncOverhead: 0.5ms, totalSpan: 19.0ms)');
   });
 


### PR DESCRIPTION
## Description

See flutter/flutter#62689
The original build_start time stamp is now vsync_start, and the current build time closer to what we get from timeline events. 

## Related Issues

fixes flutter/flutter#62689

## Tests

I modify the `'FrameTiming.toString has the correct format'` test in `testing/dart/window_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
