### PR TITLE
reducing the shard number to 8 for framework tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,8 +5,9 @@ web_shard_template: &WEB_SHARD_TEMPLATE
   environment:
     # As of March 2020, the Web shards needed 16G of RAM and 4 CPUs to run all framework tests with goldens without flaking.
     # The tests are encountering a flake in Chrome. Increasing the number of shards to decrease race conditions.
+    # Shard number kept at 8 for the engine since 12 shards exhausted the Cirrus limits.
     # https://github.com/flutter/flutter/issues/62510
-    WEB_SHARD_COUNT: 12
+    WEB_SHARD_COUNT: 8
     CPU: 4
     MEMORY: 16G
     CHROME_NO_SANDBOX: true
@@ -123,19 +124,7 @@ task:
     - name: web_tests-6-linux
       << : *WEB_SHARD_TEMPLATE
 
-    - name: web_tests-7-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-8-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-9-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-10-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-11_last-linux # last Web shard must end with _last
+    - name: web_tests-7_last-linux # last Web shard must end with _last
       << : *WEB_SHARD_TEMPLATE
 
     - name: build_test


### PR DESCRIPTION
For more context: https://github.com/flutter/engine/pull/20164#issuecomment-668741939