### PR TITLE
Remove unnecessary breaks after returns in lib/web_ui switch statements

### DIFF
--- a/lib/web_ui/lib/src/engine/surface/render_vertices.dart
+++ b/lib/web_ui/lib/src/engine/surface/render_vertices.dart
@@ -499,13 +499,10 @@ class _GlContext {
     switch (mode) {
       case ui.VertexMode.triangles:
         return kTriangles;
-        break;
       case ui.VertexMode.triangleFan:
         return kTriangleFan;
-        break;
       case ui.VertexMode.triangleStrip:
         return kTriangleStrip;
-        break;
     }
   }
 

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -1703,7 +1703,6 @@ String? textAlignToCssValue(ui.TextAlign? align, ui.TextDirection textDirection)
         case ui.TextDirection.rtl:
           return 'left';
       }
-      break;
     default: // including ui.TextAlign.start
       switch (textDirection) {
         case ui.TextDirection.ltr:
@@ -1711,7 +1710,6 @@ String? textAlignToCssValue(ui.TextAlign? align, ui.TextDirection textDirection)
         case ui.TextDirection.rtl:
           return 'right';
       }
-      break;
   }
 }
 


### PR DESCRIPTION
These are now flagged by the Dart analyzer.