### PR TITLE
Reland "Add preliminary Windows arm64 plumbing"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -107,7 +107,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'fe3b46e595e7ce1350e11aa0c90365976051f4a3',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '292ac4889262c39710958a9984f9d89b125fbe80',
 
    # Fuchsia compatibility
    #

--- a/tools/gn
+++ b/tools/gn
@@ -38,6 +38,9 @@ def get_out_dir(args):
     if args.linux_cpu is not None:
       target_dir.append(args.linux_cpu)
 
+    if args.windows_cpu != 'x64':
+      target_dir.append(args.windows_cpu)
+
     if args.target_os == 'fuchsia' and args.fuchsia_cpu is not None:
       target_dir.append(args.fuchsia_cpu)
 
@@ -163,6 +166,8 @@ def to_gn_args(args):
       gn_args['target_cpu'] = args.linux_cpu
     elif args.target_os == 'fuchsia':
       gn_args['target_cpu'] = args.fuchsia_cpu
+    elif args.target_os == 'win':
+      gn_args['target_cpu'] = args.windows_cpu
     else:
         # Building host artifacts
         gn_args['target_cpu'] = 'x64'
@@ -172,7 +177,7 @@ def to_gn_args(args):
       raise Exception('--interpreter is no longer needed on any supported platform.')
     gn_args['dart_target_arch'] = gn_args['target_cpu']
 
-    if sys.platform.startswith(('cygwin', 'win')):
+    if sys.platform.startswith(('cygwin', 'win')) and args.target_os != 'win':
       if 'target_cpu' in gn_args:
         gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
@@ -297,7 +302,7 @@ def parse_args(args):
   parser.add_argument('--full-dart-debug', default=False, action='store_true', help='Implies --dart-debug ' +
       'and also disables optimizations in the Dart VM making it easier to step through VM code in the debugger.')
 
-  parser.add_argument('--target-os', type=str, choices=['android', 'ios', 'linux', 'fuchsia'])
+  parser.add_argument('--target-os', type=str, choices=['android', 'ios', 'linux', 'fuchsia', 'win'])
   parser.add_argument('--android', dest='target_os', action='store_const', const='android')
   parser.add_argument('--android-cpu', type=str, choices=['arm', 'x64', 'x86', 'arm64'], default='arm')
   parser.add_argument('--ios', dest='target_os', action='store_const', const='ios')
@@ -306,6 +311,7 @@ def parse_args(args):
   parser.add_argument('--fuchsia', dest='target_os', action='store_const', const='fuchsia')
   parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm'])
   parser.add_argument('--fuchsia-cpu', type=str, choices=['x64', 'arm64'], default = 'x64')
+  parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64'], default = 'x64')
   parser.add_argument('--arm-float-abi', type=str, choices=['hard', 'soft', 'softfp'])
 
   parser.add_argument('--goma', default=True, action='store_true')


### PR DESCRIPTION
Reverts flutter/engine#20236

The LUCI recipe issue should have already been fixed by @christopherfujino 

Try to trigger the LUCI tests with this as the "retry" button is somehow disabled for https://ci.chromium.org/p/flutter/builders/prod/Linux%20Fuchsia/4755 even if I logged in.