### PR TITLE
add a named constructor to FrameTiming

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -92,6 +92,18 @@ class FrameTiming {
   FrameTiming(List<int> timestamps)
       : assert(timestamps.length == FramePhase.values.length), _timestamps = timestamps;
 
+  /// Construct [FrameTiming] with given timestamp in micrseconds.
+  ///
+  /// TODO(CareF): This is part of #20229. Remove back to default constructor
+  /// after #20229 lands and corresponding framwork PRs land.
+  FrameTiming.fromTimeStamps({
+    int? vsyncStart,
+    required int buildStart,
+    required int buildFinish,
+    required int rasterStart,
+    required int rasterFinish
+  }) : _timestamps = <int>[buildStart, buildFinish, rasterStart, rasterFinish];
+
   /// This is a raw timestamp in microseconds from some epoch. The epoch in all
   /// [FrameTiming] is the same, but it may not match [DateTime]'s epoch.
   int timestampInMicroseconds(FramePhase phase) => _timestamps[phase.index];

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -94,15 +94,25 @@ class FrameTiming {
 
   /// Construct [FrameTiming] with given timestamp in micrseconds.
   ///
+  /// This constructor is used for unit test only. Real [FrameTiming]s should
+  /// be retrieved from [Window.onReportTimings].
+  ///
   /// TODO(CareF): This is part of #20229. Remove back to default constructor
   /// after #20229 lands and corresponding framwork PRs land.
-  FrameTiming.fromTimeStamps({
+  factory FrameTiming.fromTimeStamps({
     int? vsyncStart,
     required int buildStart,
     required int buildFinish,
     required int rasterStart,
     required int rasterFinish
-  }) : _timestamps = <int>[buildStart, buildFinish, rasterStart, rasterFinish];
+  }) {
+    return FrameTiming(<int>[
+      buildStart,
+      buildFinish,
+      rasterStart,
+      rasterFinish
+    ]);
+  }
 
   /// This is a raw timestamp in microseconds from some epoch. The epoch in all
   /// [FrameTiming] is the same, but it may not match [DateTime]'s epoch.

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1033,6 +1033,18 @@ class FrameTiming {
       : assert(timestamps.length == FramePhase.values.length),
         _timestamps = timestamps;
 
+  /// Construct [FrameTiming] with given timestamp in micrseconds.
+  ///
+  /// TODO(CareF): This is part of #20229. Remove back to default constructor
+  /// after #20229 lands and corresponding framwork PRs land.
+  FrameTiming.fromTimeStamps({
+    int? vsyncStart,
+    required int buildStart,
+    required int buildFinish,
+    required int rasterStart,
+    required int rasterFinish
+  }) : _timestamps = <int>[buildStart, buildFinish, rasterStart, rasterFinish];
+
   /// This is a raw timestamp in microseconds from some epoch. The epoch in all
   /// [FrameTiming] is the same, but it may not match [DateTime]'s epoch.
   int timestampInMicroseconds(FramePhase phase) => _timestamps[phase.index];

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1035,6 +1035,9 @@ class FrameTiming {
 
   /// Construct [FrameTiming] with given timestamp in micrseconds.
   ///
+  /// This constructor is used for unit test only. Real [FrameTiming]s should
+  /// be retrieved from [Window.onReportTimings].
+  ///
   /// TODO(CareF): This is part of #20229. Remove back to default constructor
   /// after #20229 lands and corresponding framwork PRs land.
   FrameTiming.fromTimeStamps({


### PR DESCRIPTION
## Description

This is part of #20229 to introduce/sync the change between engine and framework PR

## Related Issues

flutter/flutter#62689

## Tests

N/A. This change will be moved to default change after everything lands. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
