### PR TITLE
[web] Implement support for WidgetSpan (aka paragraph placeholders)

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 059261eda15701d6db9458ffa79c7875f6f62cf2
+revision: f26d68c3596eece3d40112e9dff01dc55d9bae97

--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 4fb2ce1ea4b3a0bd48b01d7b3724be87244964d6
+revision: 059261eda15701d6db9458ffa79c7875f6f62cf2

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -448,6 +448,7 @@ class DomTextMeasurementService extends TextMeasurementService {
       alphabeticBaseline: alphabeticBaseline,
       ideographicBaseline: ideographicBaseline,
       lines: lines,
+      placeholderBoxes: ruler.measurePlaceholderBoxes(),
       textAlign: paragraph._textAlign,
       textDirection: paragraph._textDirection,
     );
@@ -498,6 +499,7 @@ class DomTextMeasurementService extends TextMeasurementService {
       alphabeticBaseline: alphabeticBaseline,
       ideographicBaseline: ideographicBaseline,
       lines: null,
+      placeholderBoxes: ruler.measurePlaceholderBoxes(),
       textAlign: paragraph._textAlign,
       textDirection: paragraph._textDirection,
     );
@@ -609,6 +611,7 @@ class CanvasTextMeasurementService extends TextMeasurementService {
       maxIntrinsicWidth: maxIntrinsicCalculator.value,
       width: constraints.width,
       lines: linesCalculator.lines,
+      placeholderBoxes: <ui.TextBox>[],
       textAlign: paragraph._textAlign,
       textDirection: paragraph._textDirection,
     );

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -176,6 +176,7 @@ class EngineParagraph implements ui.Paragraph {
     required ui.TextAlign textAlign,
     required ui.TextDirection textDirection,
     required ui.Paint? background,
+    required this.placeholderCount,
   })  : assert((plainText == null && paint == null) ||
             (plainText != null && paint != null)),
         _paragraphElement = paragraphElement,
@@ -193,6 +194,8 @@ class EngineParagraph implements ui.Paragraph {
   final ui.TextAlign _textAlign;
   final ui.TextDirection _textDirection;
   final SurfacePaint? _background;
+
+  final int placeholderCount;
 
   @visibleForTesting
   String? get plainText => _plainText;
@@ -485,6 +488,7 @@ class EngineParagraph implements ui.Paragraph {
       textAlign: _textAlign,
       textDirection: _textDirection,
       background: _background,
+      placeholderCount: placeholderCount,
     );
   }
 
@@ -1076,6 +1080,11 @@ class EngineParagraphBuilder implements ui.ParagraphBuilder {
     double? baselineOffset,
     ui.TextBaseline? baseline,
   }) {
+    // Require a baseline to be specified if using a baseline-based alignment.
+    assert((alignment == ui.PlaceholderAlignment.aboveBaseline ||
+            alignment == ui.PlaceholderAlignment.belowBaseline ||
+            alignment == ui.PlaceholderAlignment.baseline) ? baseline != null : true);
+
     _placeholderCount++;
     _placeholderScales.add(scale);
     _ops.add(ParagraphPlaceholder(
@@ -1263,6 +1272,7 @@ class EngineParagraphBuilder implements ui.ParagraphBuilder {
         textAlign: textAlign,
         textDirection: textDirection,
         background: cumulativeStyle._background,
+        placeholderCount: placeholderCount,
       );
     }
 
@@ -1317,6 +1327,7 @@ class EngineParagraphBuilder implements ui.ParagraphBuilder {
       textAlign: textAlign,
       textDirection: textDirection,
       background: cumulativeStyle._background,
+      placeholderCount: placeholderCount,
     );
   }
 
@@ -1366,6 +1377,7 @@ class EngineParagraphBuilder implements ui.ParagraphBuilder {
       textAlign: _paragraphStyle._effectiveTextAlign,
       textDirection: _paragraphStyle._effectiveTextDirection,
       background: null,
+      placeholderCount: placeholderCount,
     );
   }
 }

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -1083,7 +1083,7 @@ class EngineParagraphBuilder implements ui.ParagraphBuilder {
       height * scale,
       alignment,
       baselineOffset: (baselineOffset ?? height) * scale,
-      baseline: baseline,
+      baseline: baseline ?? ui.TextBaseline.alphabetic,
     ));
   }
 
@@ -1398,7 +1398,7 @@ class ParagraphPlaceholder {
   final double baselineOffset;
 
   /// Dictates whether to use alphabetic or ideographic baseline.
-  final ui.TextBaseline? baseline;
+  final ui.TextBaseline baseline;
 }
 
 /// Converts [fontWeight] to its CSS equivalent value.
@@ -1625,12 +1625,14 @@ html.Element _createPlaceholderElement({
     ..display = 'inline-block'
     ..width = '${placeholder.width}px'
     ..height = '${placeholder.height}px'
-    ..verticalAlign = _getCssPlaceholderAlignment(placeholder);
+    ..verticalAlign = _placeholderAlignmentToCssVerticalAlign(placeholder);
 
   return element;
 }
 
-String _getCssPlaceholderAlignment(ParagraphPlaceholder placeholder) {
+String _placeholderAlignmentToCssVerticalAlign(
+  ParagraphPlaceholder placeholder,
+) {
   // For more details about the vertical-align CSS property, see:
   // - https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
   switch (placeholder.alignment) {

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -632,6 +632,10 @@ class ParagraphRuler {
     assert(!_debugIsDisposed);
     assert(_paragraph != null);
 
+    if (_paragraph!.placeholderCount == 0) {
+      return const <ui.TextBox>[];
+    }
+
     final List<html.Element> placeholderElements =
         constrainedDimensions._element.querySelectorAll('.$_placeholderClass');
     final List<ui.TextBox> boxes = <ui.TextBox>[];

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -628,6 +628,27 @@ class ParagraphRuler {
     );
   }
 
+  List<ui.TextBox> measurePlaceholderBoxes() {
+    assert(!_debugIsDisposed);
+    assert(_paragraph != null);
+
+    final List<html.Element> placeholderElements =
+        constrainedDimensions._element.querySelectorAll('.$_placeholderClass');
+    final List<ui.TextBox> boxes = <ui.TextBox>[];
+
+    for (final html.Element element in placeholderElements) {
+      final html.Rectangle<num> rect = element.getBoundingClientRect();
+      boxes.add(ui.TextBox.fromLTRBD(
+        rect.left as double,
+        rect.top as double,
+        rect.right as double,
+        rect.bottom as double,
+        _paragraph!._textDirection,
+      ));
+    }
+    return boxes;
+  }
+
   /// Returns text position in a paragraph that contains multiple
   /// nested spans given an offset.
   int hitTest(ui.ParagraphConstraints constraints, ui.Offset offset) {
@@ -905,6 +926,8 @@ class MeasurementResult {
   /// of each laid out line.
   final List<EngineLineMetrics>? lines;
 
+  final List<ui.TextBox> placeholderBoxes;
+
   /// The text align value of the paragraph.
   final ui.TextAlign textAlign;
 
@@ -923,6 +946,7 @@ class MeasurementResult {
     required this.alphabeticBaseline,
     required this.ideographicBaseline,
     required this.lines,
+    required this.placeholderBoxes,
     required ui.TextAlign? textAlign,
     required ui.TextDirection? textDirection,
   })  : assert(constraintWidth != null), // ignore: unnecessary_null_comparison

--- a/lib/web_ui/test/golden_tests/engine/text_placeholders_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/text_placeholders_test.dart
@@ -1,0 +1,73 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.6
+// import 'package:image/image.dart';
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart';
+
+import 'scuba.dart';
+
+typedef PaintTest = void Function(RecordingCanvas recordingCanvas);
+
+void main() async {
+  final EngineScubaTester scuba = await EngineScubaTester.initialize(
+    viewportSize: const Size(600, 600),
+  );
+
+  setUpStableTestFonts();
+
+  testEachCanvas('draws paragraphs with placeholders', (EngineCanvas canvas) {
+    final Rect screenRect = const Rect.fromLTWH(0, 0, 600, 600);
+    final RecordingCanvas recordingCanvas = RecordingCanvas(screenRect);
+
+    Offset offset = Offset.zero;
+    for (PlaceholderAlignment alignment in PlaceholderAlignment.values) {
+      _paintTextWithPlaceholder(recordingCanvas, offset, alignment);
+      offset = offset.translate(0.0, 80.0);
+    }
+    recordingCanvas.endRecording();
+    recordingCanvas.apply(canvas, screenRect);
+    return scuba.diffCanvasScreenshot(canvas, 'text_with_placeholders');
+  }, bSkipHoudini: true);
+}
+
+const Color black = Color(0xFF000000);
+const Color blue = Color(0xFF0000FF);
+const Color red = Color(0xFFFF0000);
+
+const Size placeholderSize = Size(80.0, 50.0);
+
+void _paintTextWithPlaceholder(
+  RecordingCanvas canvas,
+  Offset offset,
+  PlaceholderAlignment alignment,
+) {
+  // First let's draw the paragraph.
+  final Paragraph paragraph = _createParagraphWithPlaceholder(alignment);
+  canvas.drawParagraph(paragraph, offset);
+
+  // Then fill the placeholders.
+  final TextBox placeholderBox = paragraph.getBoxesForPlaceholders().single;
+  canvas.drawRect(
+    placeholderBox.toRect().shift(offset),
+    Paint()..color = red,
+  );
+}
+
+Paragraph _createParagraphWithPlaceholder(PlaceholderAlignment alignment) {
+  final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
+  builder
+      .pushStyle(TextStyle(color: black, fontFamily: 'Roboto', fontSize: 14));
+  builder.addText('Lorem ipsum');
+  builder.addPlaceholder(
+    placeholderSize.width,
+    placeholderSize.height,
+    alignment,
+    baselineOffset: 40.0,
+  );
+  builder.pushStyle(TextStyle(color: blue));
+  builder.addText('dolor sit amet, consectetur.');
+  return builder.build()..layout(ParagraphConstraints(width: 200.0));
+}

--- a/lib/web_ui/test/golden_tests/engine/text_placeholders_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/text_placeholders_test.dart
@@ -66,8 +66,9 @@ Paragraph _createParagraphWithPlaceholder(PlaceholderAlignment alignment) {
     placeholderSize.height,
     alignment,
     baselineOffset: 40.0,
+    baseline: TextBaseline.alphabetic,
   );
-  builder.pushStyle(TextStyle(color: blue));
+  builder.pushStyle(TextStyle(color: blue, fontFamily: 'Roboto', fontSize: 14));
   builder.addText('dolor sit amet, consectetur.');
   return builder.build()..layout(ParagraphConstraints(width: 200.0));
 }


### PR DESCRIPTION
## Description

Add support for `WidgetSpan` in flutter web.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/42086
Fixes https://github.com/flutter/flutter/issues/62749

## Tests

I added the following tests:

- `test/golden_tests/engine/text_placeholders_test.dart` ([goldens](https://github.com/flutter/goldens/pull/102))