### PR TITLE
Use weak references instead of resurrection, if available

### DIFF
--- a/lib/web_ui/dev/browser_lock.yaml
+++ b/lib/web_ui/dev/browser_lock.yaml
@@ -1,11 +1,11 @@
 chrome:
   # It seems Chrome can't always release from the same build for all operating
   # systems, so we specify per-OS build number.
-  # Note: 768962 binary is for Chrome Version 84. Driver for Chrome version 83
+  # Note: 741412 binary is for Chrome Version 82. Driver for Chrome version 83
   # is not working with chrome.binary option.
-  Linux: 768968
-  Mac: 768968
-  Win: 768975
+  Linux: 741412
+  Mac: 735194
+  Win: 735105
 firefox:
   version: '72.0'
 edge:

--- a/lib/web_ui/dev/browser_lock.yaml
+++ b/lib/web_ui/dev/browser_lock.yaml
@@ -1,11 +1,11 @@
 chrome:
   # It seems Chrome can't always release from the same build for all operating
   # systems, so we specify per-OS build number.
-  # Note: 741412 binary is for Chrome Version 82. Driver for Chrome version 83
+  # Note: 768962 binary is for Chrome Version 84. Driver for Chrome version 83
   # is not working with chrome.binary option.
-  Linux: 741412
-  Mac: 735194
-  Win: 735105
+  Linux: 768968
+  Mac: 768968
+  Win: 768975
 firefox:
   version: '72.0'
 edge:

--- a/lib/web_ui/lib/src/engine/compositor/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/compositor/color_filter.dart
@@ -6,7 +6,7 @@
 part of engine;
 
 /// A [ui.ColorFilter] backed by Skia's [CkColorFilter].
-class CkColorFilter extends ResurrectableSkiaObject<SkColorFilter> {
+class CkColorFilter extends ManagedSkiaObject<SkColorFilter> {
   final EngineColorFilter _engineFilter;
 
   CkColorFilter.mode(EngineColorFilter filter) : _engineFilter = filter;

--- a/lib/web_ui/lib/src/engine/compositor/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/compositor/image_filter.dart
@@ -8,7 +8,7 @@ part of engine;
 /// The CanvasKit implementation of [ui.ImageFilter].
 ///
 /// Currently only supports `blur`.
-class CkImageFilter extends ResurrectableSkiaObject<SkImageFilter> implements ui.ImageFilter {
+class CkImageFilter extends ManagedSkiaObject<SkImageFilter> implements ui.ImageFilter {
   CkImageFilter.blur({double sigmaX = 0.0, double sigmaY = 0.0})
       : _sigmaX = sigmaX,
         _sigmaY = sigmaY;

--- a/lib/web_ui/lib/src/engine/compositor/mask_filter.dart
+++ b/lib/web_ui/lib/src/engine/compositor/mask_filter.dart
@@ -6,7 +6,7 @@
 part of engine;
 
 /// The CanvasKit implementation of [ui.MaskFilter].
-class CkMaskFilter extends ResurrectableSkiaObject<SkMaskFilter> {
+class CkMaskFilter extends ManagedSkiaObject<SkMaskFilter> {
   CkMaskFilter.blur(ui.BlurStyle blurStyle, double sigma)
       : _blurStyle = blurStyle,
         _sigma = sigma;

--- a/lib/web_ui/lib/src/engine/compositor/painting.dart
+++ b/lib/web_ui/lib/src/engine/compositor/painting.dart
@@ -9,7 +9,7 @@ part of engine;
 ///
 /// This class is backed by a Skia object that must be explicitly
 /// deleted to avoid a memory leak. This is done by extending [SkiaObject].
-class CkPaint extends ResurrectableSkiaObject<SkPaint> implements ui.Paint {
+class CkPaint extends ManagedSkiaObject<SkPaint> implements ui.Paint {
   CkPaint();
 
   static const ui.Color _defaultPaintColor = ui.Color(0xFF000000);

--- a/lib/web_ui/lib/src/engine/compositor/picture.dart
+++ b/lib/web_ui/lib/src/engine/compositor/picture.dart
@@ -32,6 +32,6 @@ class SkPictureSkiaObject extends OneShotSkiaObject<SkPicture> {
 
   @override
   void delete() {
-    rawSkiaObject?.delete();
+    rawSkiaObject.delete();
   }
 }

--- a/lib/web_ui/lib/src/engine/compositor/text.dart
+++ b/lib/web_ui/lib/src/engine/compositor/text.dart
@@ -216,7 +216,7 @@ SkFontStyle toSkFontStyle(ui.FontWeight? fontWeight, ui.FontStyle? fontStyle) {
   return style;
 }
 
-class CkParagraph extends ResurrectableSkiaObject<SkParagraph>
+class CkParagraph extends ManagedSkiaObject<SkParagraph>
     implements ui.Paragraph {
   CkParagraph(
       this._initialParagraph, this._paragraphStyle, this._paragraphCommands);

--- a/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
+++ b/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
@@ -21,12 +21,22 @@ void main() {
 
 void _tests() {
   SkiaObjects.maximumCacheSize = 4;
+  bool originalBrowserSupportsFinalizationRegistry;
 
   setUpAll(() async {
     await ui.webOnlyInitializePlatform();
+
+    // Pretend the browser does not support FinalizationRegistry so we can test the
+    // resurrection logic.
+    originalBrowserSupportsFinalizationRegistry = browserSupportsFinalizationRegistry;
+    browserSupportsFinalizationRegistry = false;
   });
 
-  group(ResurrectableSkiaObject, () {
+  tearDownAll(() {
+    browserSupportsFinalizationRegistry = originalBrowserSupportsFinalizationRegistry;
+  });
+
+  group(ManagedSkiaObject, () {
     test('implements create, cache, delete, resurrect, delete lifecycle', () {
       int addPostFrameCallbackCount = 0;
 
@@ -152,7 +162,7 @@ class TestOneShotSkiaObject extends OneShotSkiaObject<SkPaint> {
   }
 }
 
-class TestSkiaObject extends ResurrectableSkiaObject<SkPaint> {
+class TestSkiaObject extends ManagedSkiaObject<SkPaint> {
   int createDefaultCount = 0;
   int resurrectCount = 0;
   int deleteCount = 0;


### PR DESCRIPTION
## Description

- Use weak references (`FinalizationRegistry`) in browsers that support it, instead of resurrecting objects.
- Update test Chromium version to one that supports weak refs.

## Related Issues

https://github.com/flutter/flutter/issues/60401

## Tests

I changed the existing `skia_objects_cache_test.dart` to pretend that weak refs are not supported. I'm not sure how to test the weak ref logic because GC kicks in in unpredictable times.