### PR TITLE
Add isPartiallyHidden SemanticsFlag, call showOnScreen when focused

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -300,6 +300,7 @@ class SemanticsFlag {
   static const int _kIsReadOnlyIndex = 1 << 20;
   static const int _kIsFocusableIndex = 1 << 21;
   static const int _kIsLinkIndex = 1 << 22;
+  static const int _kIsPartiallyHiddenIndex = 1 << 23;
   // READ THIS: if you add a flag here, you MUST update the numSemanticsFlags
   // value in testing/dart/semantics_test.dart, or tests will fail.
 
@@ -474,6 +475,25 @@ class SemanticsFlag {
   /// used to implement accessibility scrolling on iOS.
   static const SemanticsFlag isHidden = SemanticsFlag._(_kIsHiddenIndex);
 
+  /// Whether the semantics node is considered partially hidden.
+  ///
+  /// Elements with this flag are both partially hidden off screen and partially
+  /// visible on screen. They may be partially covered by other elements or
+  /// positioned partway outside of the visible area of a viewport.
+  ///
+  /// Partially hidden elements are brought fully on screen upon gaining
+  /// accessibility focus.
+  ///
+  /// This flag is different from [isHidden], since partially hidden elements
+  /// are still valid memebers of the semantics tree for all platforms.
+  /// 
+  /// Platforms should generally call [SemanticsAction.showOnScreen] when an
+  /// element with [isPartiallyHidden] receives accessibility focus, although
+  /// additional platform-specific considerations may be needed to ensure
+  /// this does not interfere with other actions, such as smooth scrolling
+  /// on Android.
+  static const SemanticsFlag isPartiallyHidden = SemanticsFlag._(_kIsPartiallyHiddenIndex);
+
   /// Whether the semantics node represents an image.
   ///
   /// Both TalkBack and VoiceOver will inform the user the semantics node
@@ -551,6 +571,7 @@ class SemanticsFlag {
     _kIsReadOnlyIndex: isReadOnly,
     _kIsFocusableIndex: isFocusable,
     _kIsLinkIndex: isLink,
+    _kIsPartiallyHiddenIndex: isPartiallyHidden,
   };
 
   @override
@@ -602,6 +623,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.isFocusable';
       case _kIsLinkIndex:
         return 'SemanticsFlag.isLink';
+      case _kIsPartiallyHiddenIndex:
+        return 'SemanticsFlag.isPartiallyHidden';
     }
     assert(false, 'Unhandled index: $index');
     return '';

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -79,6 +79,7 @@ enum class SemanticsFlags : int32_t {
   kIsReadOnly = 1 << 20,
   kIsFocusable = 1 << 21,
   kIsLink = 1 << 22,
+  kIsPartiallyHidden = 1 << 23,
 };
 
 const int kScrollableSemanticsFlags =

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -455,6 +455,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
     return;
   [self bridge]->AccessibilityFocusDidChange([self uid]);
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden) ||
+      [self node].HasFlag(flutter::SemanticsFlags::kIsPartiallyHidden) ||
       [self node].HasFlag(flutter::SemanticsFlags::kIsHeader)) {
     [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
   }

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 /// Verifies Semantics flags and actions.
 void main() {
   // This must match the number of flags in lib/ui/semantics.dart
-  const int numSemanticsFlags = 23;
+  const int numSemanticsFlags = 24;
   test('SemanticsFlag.values refers to all flags.', () async {
     expect(SemanticsFlag.values.length, equals(numSemanticsFlags));
     for (int index = 0; index < numSemanticsFlags; ++index) {


### PR DESCRIPTION
## Description

This is the engine side (Android and iOS) of changes required for [Proposal: New "isPartiallyHidden" Semantics Flag](https://github.com/flutter/flutter/issues/62931).

See related framework PR here: https://github.com/flutter/flutter/pull/63031

Please see **"Q&A -> Open questions"** at the bottom of ([#62931](https://github.com/flutter/flutter/issues/62931)), especially the two questions most relevant to the engine:

1. **Is it okay to add another entry to the SemanticsFlag bitflag for something relatively small like this?**

    1. Currently we are working with 32 bit integer flags ([semantics\_node.h](https://github.com/flutter/engine/blob/7a022774c285b2354520b6c679cc9161f4f9fe7a/lib/ui/semantics/semantics_node.h#L57)), is it possible to upgrade this to 64 if we run out?

        1. It looks like there may be [problems with the web platform](https://api.dart.dev/stable/2.9.0/dart-core/int-class.html): "bitwise operators truncate their operands to 32-bit integers when compiled to JavaScript."

2. **Neither TalkBack nor VoiceOver will scroll to show a newly focused element if the element was focused by a tap, rather than a horizontal swipe. Should we mimic this, or "enhance" them to also scroll to elements focused via tap?**

    1. Perhaps users don't expect anything to move when tapping around, but they do when swiping? If so, this can be supported by:

        1. **Android:** ensuring `hoveredObject == null`.

        2. **iOS:** Unsure, TODO.


## Related Issues

Will fix issues for Android (https://github.com/flutter/flutter/issues/36307) and iOS (https://github.com/flutter/flutter/issues/61624) currently affecting `customer: money`.

## Tests

WIP/TODO

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change. 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
