### PR TITLE
Create scenic session with view focuser

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -82,7 +82,9 @@ Engine::Engine(Delegate& delegate,
   fidl::InterfaceHandle<fuchsia::ui::scenic::Session> session;
   fidl::InterfaceHandle<fuchsia::ui::scenic::SessionListener> session_listener;
   auto session_listener_request = session_listener.NewRequest();
-  scenic->CreateSession(session.NewRequest(), session_listener.Bind());
+  fidl::InterfaceHandle<fuchsia::ui::views::Focuser> focuser;
+  scenic->CreateSession2(session.NewRequest(), session_listener.Bind(),
+                         focuser.NewRequest());
 
   // Grab the parent environment services. The platform view may want to access
   // some of these services.
@@ -139,6 +141,7 @@ Engine::Engine(Delegate& delegate,
            parent_environment_service_provider =
                std::move(parent_environment_service_provider),
            session_listener_request = std::move(session_listener_request),
+           focuser = std::move(focuser),
            on_session_listener_error_callback =
                std::move(on_session_listener_error_callback),
            on_session_metrics_change_callback =
@@ -161,6 +164,7 @@ Engine::Engine(Delegate& delegate,
                 std::move(runner_services),
                 std::move(parent_environment_service_provider),  // services
                 std::move(session_listener_request),  // session listener
+                std::move(focuser),
                 std::move(on_session_listener_error_callback),
                 std::move(on_session_metrics_change_callback),
                 std::move(on_session_size_change_hint_callback),

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -52,6 +52,7 @@ class PlatformView final : public flutter::PlatformView,
                    parent_environment_service_provider,
                fidl::InterfaceRequest<fuchsia::ui::scenic::SessionListener>
                    session_listener_request,
+               fidl::InterfaceHandle<fuchsia::ui::views::Focuser> focuser,
                fit::closure on_session_listener_error_callback,
                OnMetricsUpdate session_metrics_did_change_callback,
                OnSizeChangeHint session_size_change_hint_callback,
@@ -88,6 +89,7 @@ class PlatformView final : public flutter::PlatformView,
   // TODO(MI4-2490): remove once ViewRefControl is passed to Scenic and kept
   // alive there
   const fuchsia::ui::views::ViewRef view_ref_;
+  fuchsia::ui::views::FocuserPtr focuser_;
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
 
   fidl::Binding<fuchsia::ui::scenic::SessionListener> session_listener_binding_;


### PR DESCRIPTION

## Description

This change creates the scenic session with request to Focuser. The focuser is used to request focus to a view, given it's ViewRef. The call to requestFocus is made from PlatformView messages channel, which will be used from Flutter side by ChildView.

## Tests

Adds a PlatformView unittest for the requestFocus method.
