### PR TITLE
Adds fuchsia node roles to accessibility bridge updates.

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -300,6 +300,7 @@ class SemanticsFlag {
   static const int _kIsReadOnlyIndex = 1 << 20;
   static const int _kIsFocusableIndex = 1 << 21;
   static const int _kIsLinkIndex = 1 << 22;
+  static const int _kIsSliderIndex = 1 << 23;
   // READ THIS: if you add a flag here, you MUST update the numSemanticsFlags
   // value in testing/dart/semantics_test.dart, or tests will fail.
 
@@ -354,6 +355,9 @@ class SemanticsFlag {
   /// Text fields are announced as such and allow text input via accessibility
   /// affordances.
   static const SemanticsFlag isTextField = SemanticsFlag._(_kIsTextFieldIndex);
+
+  /// Whether the semantic node represents a slider.
+  static const SemanticsFlag isSlider = SemanticsFlag._(_kIsSliderIndex);
 
   /// Whether the semantic node is read only.
   ///

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -79,6 +79,7 @@ enum class SemanticsFlags : int32_t {
   kIsReadOnly = 1 << 20,
   kIsFocusable = 1 << 21,
   kIsLink = 1 << 22,
+  kIsSlider = 1 << 23,
 };
 
 const int kScrollableSemanticsFlags =

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -115,6 +115,30 @@ fuchsia::accessibility::semantics::States AccessibilityBridge::GetNodeStates(
   return states;
 }
 
+fuchsia::accessibility::semantics::Role AccessibilityBridge::GetNodeRole(const flutter::SemanticsNode& node) const {
+  if (node.HasFlag(flutter::SemanticsFlags::kIsButton)) {
+    return fuchsia::accessibility::semantics::Role::BUTTON;
+  }
+  
+  if (node.HasFlag(flutter::SemanticsFlags::kIsHeader)) {
+    return fuchsia::accessibility::semantics::Role::HEADER;
+  }
+
+  if (node.HasFlag(flutter::SemanticsFlags::kIsImage)) {
+    return fuchsia::accessibility::semantics::Role::IMAGE;
+  }
+
+  if (node.HasFlag(flutter::SemanticsFlags::kIsTextField)) {
+    return fuchsia::accessibility::semantics::Role::TEXT_FIELD;
+  }
+
+  if (node.HasFlag(flutter::SemanticsFlags::kIsSlider)) {
+    return fuchsia::accessibility::semantics::Role::SLIDER;
+  }
+
+  return fuchsia::accessibility::semantics::Role::UNKNOWN;
+}
+
 std::unordered_set<int32_t> AccessibilityBridge::GetDescendants(
     int32_t node_id) const {
   std::unordered_set<int32_t> descendents;
@@ -227,6 +251,7 @@ void AccessibilityBridge::AddSemanticsNodeUpdate(
         .set_transform(GetNodeTransform(flutter_node))
         .set_attributes(GetNodeAttributes(flutter_node, &this_node_size))
         .set_states(GetNodeStates(flutter_node, &this_node_size))
+        .set_role(GetNodeRole(flutter_node))
         .set_child_ids(child_ids);
     this_node_size +=
         kNodeIdSize * flutter_node.childrenInTraversalOrder.size();

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.h
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.h
@@ -145,6 +145,11 @@ class AccessibilityBridge
       const flutter::SemanticsNode& node,
       size_t* additional_size) const;
 
+  // Derives the role for a Fuchsia semantics node from a Flutter semantics
+  // node.
+  fuchsia::accessibility::semantics::Role GetNodeRole(
+      const flutter::SemanticsNode& node) const;
+
   // Gets the set of reachable descendants from the given node id.
   std::unordered_set<int32_t> GetDescendants(int32_t node_id) const;
 

--- a/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
@@ -19,6 +19,18 @@
 
 namespace flutter_runner_test {
 
+namespace {
+
+void ExpectNodeHasRole(const fuchsia::accessibility::semantics::Node& node,
+                       const std::unordered_map<uint32_t, fuchsia::accessibility::semantics::Role> roles_by_node_id) {
+  ASSERT_TRUE(node.has_node_id());
+  ASSERT_NE(roles_by_node_id.find(node.node_id()), roles_by_node_id.end());
+  EXPECT_TRUE(node.has_role());
+  EXPECT_EQ(node.role(), roles_by_node_id.at(node.node_id()));
+}
+
+}  // namespace
+
 class AccessibilityBridgeTestDelegate
     : public flutter_runner::AccessibilityBridge::Delegate {
  public:
@@ -87,6 +99,67 @@ TEST_F(AccessibilityBridgeTest, EnableDisable) {
       accessibility_bridge_.release());
   listener->OnSemanticsModeChanged(true, nullptr);
   EXPECT_TRUE(accessibility_delegate_.enabled());
+}
+
+TEST_F(AccessibilityBridgeTest, UpdatesNodeRoles) {
+  flutter::SemanticsNodeUpdates updates;
+
+  flutter::SemanticsNode node0;
+  node0.id = 0;
+  node0.flags |= static_cast<int>(flutter::SemanticsFlags::kIsButton);
+  node0.childrenInTraversalOrder = {1, 2, 3, 4};
+  node0.childrenInHitTestOrder = {1, 2, 3, 4};
+  updates.emplace(0, node0);
+
+  flutter::SemanticsNode node1;
+  node1.id = 1;
+  node1.flags |= static_cast<int>(flutter::SemanticsFlags::kIsHeader);
+  node1.childrenInTraversalOrder = {};
+  node1.childrenInHitTestOrder = {};
+  updates.emplace(1, node1);
+
+  flutter::SemanticsNode node2;
+  node2.id = 2;
+  node2.flags |= static_cast<int>(flutter::SemanticsFlags::kIsImage);
+  node2.childrenInTraversalOrder = {};
+  node2.childrenInHitTestOrder = {};
+  updates.emplace(2, node2);
+
+  flutter::SemanticsNode node3;
+  node3.id = 3;
+  node3.flags |= static_cast<int>(flutter::SemanticsFlags::kIsTextField);
+  node3.childrenInTraversalOrder = {};
+  node3.childrenInHitTestOrder = {};
+  updates.emplace(3, node3);
+
+  flutter::SemanticsNode node4;
+  node4.childrenInTraversalOrder = {};
+  node4.childrenInHitTestOrder = {};
+  node4.id = 4;
+  node4.flags |= static_cast<int>(flutter::SemanticsFlags::kIsSlider);
+  updates.emplace(4, node4);
+
+  accessibility_bridge_->AddSemanticsNodeUpdate(std::move(updates));
+  RunLoopUntilIdle();
+
+  std::unordered_map<uint32_t, fuchsia::accessibility::semantics::Role>
+      roles_by_node_id = {
+        {0u, fuchsia::accessibility::semantics::Role::BUTTON},
+        {1u, fuchsia::accessibility::semantics::Role::HEADER},
+        {2u, fuchsia::accessibility::semantics::Role::IMAGE},
+        {3u, fuchsia::accessibility::semantics::Role::TEXT_FIELD},
+        {4u, fuchsia::accessibility::semantics::Role::SLIDER}};
+
+  EXPECT_EQ(0, semantics_manager_.DeleteCount());
+  EXPECT_EQ(1, semantics_manager_.UpdateCount());
+  EXPECT_EQ(1, semantics_manager_.CommitCount());
+  EXPECT_EQ(5U, semantics_manager_.LastUpdatedNodes().size());
+  for (const auto& node : semantics_manager_.LastUpdatedNodes()) {
+    ExpectNodeHasRole(node, roles_by_node_id);
+  }
+
+  EXPECT_FALSE(semantics_manager_.DeleteOverflowed());
+  EXPECT_FALSE(semantics_manager_.UpdateOverflowed());
 }
 
 TEST_F(AccessibilityBridgeTest, DeletesChildrenTransitively) {

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 /// Verifies Semantics flags and actions.
 void main() {
   // This must match the number of flags in lib/ui/semantics.dart
-  const int numSemanticsFlags = 23;
+  const int numSemanticsFlags = 24;
   test('SemanticsFlag.values refers to all flags.', () async {
     expect(SemanticsFlag.values.length, equals(numSemanticsFlags));
     for (int index = 0; index < numSemanticsFlags; ++index) {


### PR DESCRIPTION
## Description

This change ensures that flutter populates the roles field in accessibility bridge updates. It also adds a flag for flutter nodes to be marked as sliders.

## Related Issues

N/A

## Tests

I added the following tests:

* Unit test to verify that roles are populated in fuchsia semantics updates, and that they are correctly translated to fuchsia roles.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ X] I signed the [CLA].
- [ X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ X] I updated/added relevant documentation.
- [ X] All existing and new tests are passing.
- [ X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
