### PR TITLE
Implement our own WebGL version detection

### DIFF
--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -159,3 +159,32 @@ bool get isDesktop => _desktopOperatingSystems.contains(operatingSystem);
 /// See [_desktopOperatingSystems].
 /// See [isDesktop].
 bool get isMobile => !isDesktop;
+
+int? _cachedWebGLVersion;
+
+/// The highest WebGL version supported by the current browser, or -1 if WebGL
+/// is not supported.
+int get webGLVersion => _cachedWebGLVersion ?? (_cachedWebGLVersion = _detectWebGLVersion());
+
+/// Detects the highest WebGL version supported by the current browser, or
+/// -1 if WebGL is not supported.
+///
+/// Chrome reports that `WebGL2RenderingContext` is available even when WebGL 2 is
+/// disabled due hardware-specific issues. This happens, for example, on Chrome on
+/// Moto E5. Therefore checking for the presence of `WebGL2RenderingContext` or
+/// using the current [browserEngine] is insufficient.
+///
+/// Our CanvasKit backend is affected due to: https://github.com/emscripten-core/emscripten/issues/11819
+int _detectWebGLVersion() {
+  final html.CanvasElement canvas = html.CanvasElement(
+    width: 1,
+    height: 1,
+  );
+  if (canvas.getContext('webgl2') != null) {
+    return 2;
+  }
+  if (canvas.getContext('webgl') != null) {
+    return 1;
+  }
+  return -1;
+}

--- a/lib/web_ui/lib/src/engine/compositor/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/compositor/canvaskit_api.dart
@@ -111,6 +111,8 @@ class SkColorSpace {}
 class SkWebGLContextOptions {
   external factory SkWebGLContextOptions({
     required int anitalias,
+    // WebGL version: 1 or 2.
+    required int majorVersion,
   });
 }
 

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -123,7 +123,7 @@ class Surface {
       ..height = '${logicalSize.height.ceil()}px';
 
     htmlElement = htmlCanvas;
-    if (canvasKitForceCpuOnly) {
+    if (webGLVersion == -1 || canvasKitForceCpuOnly) {
       return _makeSoftwareCanvasSurface(htmlCanvas);
     } else {
       // Try WebGL first.
@@ -133,6 +133,7 @@ class Surface {
           // Default to no anti-aliasing. Paint commands can be explicitly
           // anti-aliased by setting their `Paint` object's `antialias` property.
           anitalias: 0,
+          majorVersion: webGLVersion,
         ),
       );
 

--- a/lib/web_ui/lib/src/engine/surface/render_vertices.dart
+++ b/lib/web_ui/lib/src/engine/surface/render_vertices.dart
@@ -163,8 +163,7 @@ class _WebGlRenderer implements _GlRenderer {
     }
     _GlContext gl =
         _OffscreenCanvas.createGlContext(widthInPixels, heightInPixels)!;
-    final bool isWebKit = (browserEngine == BrowserEngine.webkit);
-    _GlProgram glProgram = isWebKit
+    _GlProgram glProgram = webGLVersion == 1
         ? gl.useAndCacheProgram(
             _vertexShaderTriangleEs1, _fragmentShaderTriangleEs1)!
         : gl.useAndCacheProgram(


### PR DESCRIPTION
## Description

Implement our own WebGL version detection.

CanvasKit was affected because of an issue in Emscripten (filed as https://github.com/emscripten-core/emscripten/issues/11819).

HTML backend (`drawVertices`) was affected because we relied on `browserEngine` to detect WebGL 2 support.

## Tests

This is already covered by existing tests. The WebGL 1 fallback should be covered by running the existing tests in Safari.
