### PR TITLE
fix clipped and transformed content in HTML clip

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 4fb2ce1ea4b3a0bd48b01d7b3724be87244964d6
+revision: f26d68c3596eece3d40112e9dff01dc55d9bae97

--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -965,7 +965,9 @@ List<html.Element> _clipContent(List<_SaveClipEntry> clipStack,
         ..height = '${roundRect.bottom - clipOffsetY}px';
       setElementTransform(curElement, newClipTransform.storage);
     } else if (entry.path != null) {
-      curElement.style.transform = matrix4ToCssTransform(newClipTransform);
+      curElement.style
+        ..transform = matrix4ToCssTransform(newClipTransform)
+        ..transformOrigin = '0 0 0';
       String svgClipPath = createSvgClipDef(curElement as html.HtmlElement, entry.path!);
       final html.Element clipElement =
           html.Element.html(svgClipPath, treeSanitizer: _NullTreeSanitizer());


### PR DESCRIPTION
## Description

Apply `transform-origin: 0 0 0` to the clipping element. Otherwise, we get wrong transform on the clipped content.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61691

## Tests

I added the following tests:

Added a new test in `canvas_draw_image_golden_test.dart`, which reproduces this issue.
This change requires a new golden: https://github.com/flutter/goldens/pull/103