### PR TITLE
Final prep before Linux Wayland support

### DIFF
--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -10,6 +10,7 @@
 #include <gtk/gtk.h>
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_view.h"
 
 G_BEGIN_DECLS
 
@@ -40,18 +41,11 @@ struct _FlRendererClass {
    * Does not need to be implemented.
    */
   gboolean (*setup_window_attr)(FlRenderer* renderer,
-                                GtkWidget* widget,
                                 EGLDisplay egl_display,
                                 EGLConfig egl_config,
                                 GdkWindowAttr* window_attributes,
                                 gint* mask,
                                 GError** error);
-
-  /**
-   * Virtual method called after a GDK window has been created.
-   * This is called once. Does not need to be implemented.
-   */
-  void (*set_window)(FlRenderer* renderer, GdkWindow* window);
 
   /**
    * Virtual method to create a new EGL display.
@@ -88,7 +82,7 @@ struct _FlRendererClass {
 /**
  * fl_renderer_start:
  * @renderer: an #FlRenderer.
- * @widget: the widget Flutter is renderering to.
+ * @view: the #FlView widget this renderer is using.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  * to ignore.
  *
@@ -96,9 +90,15 @@ struct _FlRendererClass {
  *
  * Returns: %TRUE if successfully started.
  */
-gboolean fl_renderer_start(FlRenderer* renderer,
-                           GtkWidget* widget,
-                           GError** error);
+gboolean fl_renderer_start(FlRenderer* renderer, FlView* view, GError** error);
+
+/**
+ * fl_renderer_get_view:
+ * @renderer: an #FlRenderer.
+ *
+ * Returns the #FlView that is using the renderer.
+ */
+FlView* fl_renderer_get_view(FlRenderer* renderer);
 
 /**
  * fl_renderer_set_geometry:

--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -7,24 +7,13 @@
 
 struct _FlRendererX11 {
   FlRenderer parent_instance;
-
-  GdkX11Window* window;
 };
 
 G_DEFINE_TYPE(FlRendererX11, fl_renderer_x11, fl_renderer_get_type())
 
-static void fl_renderer_x11_dispose(GObject* object) {
-  FlRendererX11* self = FL_RENDERER_X11(object);
-
-  g_clear_object(&self->window);
-
-  G_OBJECT_CLASS(fl_renderer_x11_parent_class)->dispose(object);
-}
-
 // Implements FlRenderer::setup_window_attr.
 static gboolean fl_renderer_x11_setup_window_attr(
     FlRenderer* renderer,
-    GtkWidget* widget,
     EGLDisplay egl_display,
     EGLConfig egl_config,
     GdkWindowAttr* window_attributes,
@@ -38,10 +27,11 @@ static gboolean fl_renderer_x11_setup_window_attr(
     return FALSE;
   }
 
-  GdkX11Screen* screen = GDK_X11_SCREEN(gtk_widget_get_screen(widget));
+  GtkWidget* view_widget = GTK_WIDGET(fl_renderer_get_view(renderer));
+  GdkX11Screen* screen = GDK_X11_SCREEN(gtk_widget_get_screen(view_widget));
   if (!screen) {
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
-                "Widget is not on an X11 screen");
+                "View widget is not on an X11 screen");
     return FALSE;
   }
 
@@ -55,15 +45,6 @@ static gboolean fl_renderer_x11_setup_window_attr(
   *mask |= GDK_WA_VISUAL;
 
   return TRUE;
-}
-
-// Implements FlRenderer::set_window.
-static void fl_renderer_x11_set_window(FlRenderer* renderer,
-                                       GdkWindow* window) {
-  FlRendererX11* self = FL_RENDERER_X11(renderer);
-  g_return_if_fail(GDK_IS_X11_WINDOW(window));
-  g_assert_null(self->window);
-  self->window = GDK_X11_WINDOW(g_object_ref(window));
 }
 
 // Implements FlRenderer::create_display.
@@ -82,16 +63,17 @@ static gboolean fl_renderer_x11_create_surfaces(FlRenderer* renderer,
                                                 EGLSurface* visible,
                                                 EGLSurface* resource,
                                                 GError** error) {
-  FlRendererX11* self = FL_RENDERER_X11(renderer);
-
-  if (!self->window) {
-    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
-                "Can not create EGL surface: FlRendererX11::window not set");
+  GdkWindow* window =
+      gtk_widget_get_window(GTK_WIDGET(fl_renderer_get_view(renderer)));
+  if (!GDK_IS_X11_WINDOW(window)) {
+    g_set_error(
+        error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+        "Can not create EGL surface: view doesn't have an X11 GDK window");
     return FALSE;
   }
 
-  *visible = eglCreateWindowSurface(
-      display, config, gdk_x11_window_get_xid(self->window), nullptr);
+  *visible = eglCreateWindowSurface(display, config,
+                                    gdk_x11_window_get_xid(window), nullptr);
   if (*visible == EGL_NO_SURFACE) {
     EGLint egl_error = eglGetError();  // Must be before egl_config_to_string().
     g_autofree gchar* config_string = egl_config_to_string(display, config);
@@ -116,10 +98,8 @@ static gboolean fl_renderer_x11_create_surfaces(FlRenderer* renderer,
 }
 
 static void fl_renderer_x11_class_init(FlRendererX11Class* klass) {
-  G_OBJECT_CLASS(klass)->dispose = fl_renderer_x11_dispose;
   FL_RENDERER_CLASS(klass)->setup_window_attr =
       fl_renderer_x11_setup_window_attr;
-  FL_RENDERER_CLASS(klass)->set_window = fl_renderer_x11_set_window;
   FL_RENDERER_CLASS(klass)->create_display = fl_renderer_x11_create_display;
   FL_RENDERER_CLASS(klass)->create_surfaces = fl_renderer_x11_create_surfaces;
 }

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -208,7 +208,7 @@ static void fl_view_realize(GtkWidget* widget) {
 
   gtk_widget_set_realized(widget, TRUE);
 
-  if (!fl_renderer_start(self->renderer, widget, &error)) {
+  if (!fl_renderer_start(self->renderer, self, &error)) {
     g_warning("Failed to start Flutter renderer: %s", error->message);
     return;
   }


### PR DESCRIPTION
## Description
- Refactor and simplify the `FlRenderer` setup process (`fl_renderer_start()` is now the only relevant publicly facing method)
- Allow accessing a `FlView` from an `FlRenderer`. This view can be used as a widget, and from it you can get a window. This prevents a patchwork of sending widgets and windows to various functions at various times.
- Replace `get_visual()` with `setup_window_attr()`, which allows renderer implementations to customize window creation in a cleaner and more flexible way

After this is merged, all that's left is to add the `FlRendererWayland` file and Wayland support is good to go.

## Related Issues

https://github.com/flutter/flutter/issues/57932

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
