### PR TITLE
CanvasKit: switch to non-overloaded arcTo methods

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/compositor/canvaskit_api.dart
@@ -973,11 +973,20 @@ class SkPath {
   external void addRect(
     SkRect rect,
   );
-  external void arcTo(
+  external void arcToOval(
     SkRect oval,
     double startAngleDegrees,
     double sweepAngleDegrees,
     bool forceMoveTo,
+  );
+  external void arcToRotated(
+    double radiusX,
+    double radiusY,
+    double rotation,
+    bool useSmallArc,
+    bool counterClockWise,
+    double x,
+    double y,
   );
   external void close();
   external void conicTo(
@@ -1054,21 +1063,6 @@ class SkPath {
     double pers0,
     double pers1,
     double pers2,
-  );
-}
-
-/// A different view on [SkPath] used to overload [SkPath.arcTo].
-// TODO(yjbanov): this is a hack to get around https://github.com/flutter/flutter/issues/61305
-@JS()
-class SkPathArcToPointOverload {
-  external void arcTo(
-    double radiusX,
-    double radiusY,
-    double rotation,
-    bool useSmallArc,
-    bool counterClockWise,
-    double x,
-    double y,
   );
 }
 

--- a/lib/web_ui/lib/src/engine/compositor/path.dart
+++ b/lib/web_ui/lib/src/engine/compositor/path.dart
@@ -116,7 +116,7 @@ class CkPath implements ui.Path {
   void arcTo(
       ui.Rect rect, double startAngle, double sweepAngle, bool forceMoveTo) {
     const double toDegrees = 180.0 / math.pi;
-    _skPath.arcTo(
+    _skPath.arcToOval(
       toSkRect(rect),
       startAngle * toDegrees,
       sweepAngle * toDegrees,
@@ -130,7 +130,7 @@ class CkPath implements ui.Path {
       double rotation = 0.0,
       bool largeArc = false,
       bool clockwise = true}) {
-    (_skPath as SkPathArcToPointOverload).arcTo(
+    _skPath.arcToRotated(
       radius.x,
       radius.y,
       rotation,

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -602,7 +602,7 @@ void _pathTests() {
   });
 
   test('arcTo', () {
-    path.arcTo(
+    path.arcToOval(
       SkRect(fLeft: 1, fTop: 2, fRight: 3, fBottom: 4),
       5,
       40,
@@ -611,7 +611,7 @@ void _pathTests() {
   });
 
   test('overloaded arcTo (used for arcToPoint)', () {
-    (path as SkPathArcToPointOverload).arcTo(
+    path.arcToRotated(
       1,
       2,
       3,


### PR DESCRIPTION
## Description

Switch to the non-overloaded variants of `arcTo` methods. This removes awkward JS-interop bindings and probably improves performance a little because `arguments` no longer need to be dynamically destructured.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61305

## Tests

Covered by existing tests.
