### PR TITLE
[iOS TextInput] Fixes selection clamping & composing range change logic

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -538,8 +538,8 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
       composingRange.length > 0 ? [FlutterTextRange rangeWithNSRange:composingRange] : nil;
   needsEditingStateUpdate =
       needsEditingStateUpdate ||
-      (newMarkedRange == nil ? self.markedTextRange != nil
-                             : ![newMarkedRange isEqualTo:(FlutterTextRange*)self.markedTextRange]);
+      (!newMarkedRange ? self.markedTextRange != nil
+                       : ![newMarkedRange isEqualTo:(FlutterTextRange*)self.markedTextRange]);
   self.markedTextRange = newMarkedRange;
 
   NSRange selectedRange = [self clampSelectionFromBase:[state[@"selectionBase"] intValue]
@@ -547,8 +547,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
                                                forText:self.text];
 
   NSRange oldSelectedRange = [(FlutterTextRange*)self.selectedTextRange range];
-  if (selectedRange.location != oldSelectedRange.location ||
-      selectedRange.length != oldSelectedRange.length) {
+  if (!NSEqualRanges(selectedRange, oldSelectedRange)) {
     needsEditingStateUpdate = YES;
     [self.inputDelegate selectionWillChange:self];
 
@@ -571,7 +570,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 // Extracts the selection information from the editing state dictionary.
 //
 // The state may contain an invalid selection, such as when no selection was
-// explicitly set in the framework (-1, -1). This is handled here by setting the
+// explicitly set in the framework. This is handled here by setting the
 // selection to (0,0). In contrast, Android handles this situation by
 // clearing the selection, but the result in both cases is that the cursor
 // is placed at the beginning of the field.
@@ -579,8 +578,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
                            extent:(int)selectionExtent
                           forText:(NSString*)text {
   int loc = MIN(selectionBase, selectionExtent);
-  NSUInteger len = ABS(selectionExtent - selectionBase);
-  // returns (0, 0) when the start or the end of the selection is less than 0.
+  int len = ABS(selectionExtent - selectionBase);
   return loc < 0 ? NSMakeRange(0, 0)
                  : [self clampSelection:NSMakeRange(loc, len) forText:self.text];
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -537,35 +537,22 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   FlutterTextRange* newMarkedRange =
       composingRange.length > 0 ? [FlutterTextRange rangeWithNSRange:composingRange] : nil;
   needsEditingStateUpdate =
-      needsEditingStateUpdate || newMarkedRange == nil
-          ? self.markedTextRange == nil
-          : [newMarkedRange isEqualTo:(FlutterTextRange*)self.markedTextRange];
+      needsEditingStateUpdate ||
+      (newMarkedRange == nil ? self.markedTextRange != nil
+                             : ![newMarkedRange isEqualTo:(FlutterTextRange*)self.markedTextRange]);
   self.markedTextRange = newMarkedRange;
 
-  NSInteger selectionBase = [state[@"selectionBase"] intValue];
-  NSInteger selectionExtent = [state[@"selectionExtent"] intValue];
-  NSRange selectedRange = [self clampSelection:NSMakeRange(MIN(selectionBase, selectionExtent),
-                                                           ABS(selectionBase - selectionExtent))
-                                       forText:self.text];
+  NSRange selectedRange = [self clampSelectionFromBase:[state[@"selectionBase"] intValue]
+                                                extent:[state[@"selectionExtent"] intValue]
+                                               forText:self.text];
+
   NSRange oldSelectedRange = [(FlutterTextRange*)self.selectedTextRange range];
   if (selectedRange.location != oldSelectedRange.location ||
       selectedRange.length != oldSelectedRange.length) {
     needsEditingStateUpdate = YES;
     [self.inputDelegate selectionWillChange:self];
 
-    // The state may contain an invalid selection, such as when no selection was
-    // explicitly set in the framework. This is handled here by setting the
-    // selection to (0,0). In contrast, Android handles this situation by
-    // clearing the selection, but the result in both cases is that the cursor
-    // is placed at the beginning of the field.
-    bool selectionBaseIsValid = selectionBase > 0 && selectionBase <= ((NSInteger)self.text.length);
-    bool selectionExtentIsValid =
-        selectionExtent > 0 && selectionExtent <= ((NSInteger)self.text.length);
-    if (selectionBaseIsValid && selectionExtentIsValid) {
-      [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:selectedRange]];
-    } else {
-      [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 0)]];
-    }
+    [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:selectedRange]];
 
     _selectionAffinity = _kTextAffinityDownstream;
     if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
@@ -579,6 +566,23 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 
   // For consistency with Android behavior, send an update to the framework if anything changed.
   return needsEditingStateUpdate;
+}
+
+// Extracts the selection information from the editing state dictionary.
+//
+// The state may contain an invalid selection, such as when no selection was
+// explicitly set in the framework (-1, -1). This is handled here by setting the
+// selection to (0,0). In contrast, Android handles this situation by
+// clearing the selection, but the result in both cases is that the cursor
+// is placed at the beginning of the field.
+- (NSRange)clampSelectionFromBase:(int)selectionBase
+                           extent:(int)selectionExtent
+                          forText:(NSString*)text {
+  int loc = MIN(selectionBase, selectionExtent);
+  NSUInteger len = ABS(selectionExtent - selectionBase);
+  // returns (0, 0) when the start or the end of the selection is less than 0.
+  return loc < 0 ? NSMakeRange(0, 0)
+                 : [self clampSelection:NSMakeRange(loc, len) forText:self.text];
 }
 
 - (NSRange)clampSelection:(NSRange)range forText:(NSString*)text {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -64,23 +64,6 @@ FLUTTER_ASSERT_ARC
                              }];
 }
 
-- (void)commitAutofillContextAndVerify {
-  FlutterMethodCall* methodCall =
-      [FlutterMethodCall methodCallWithMethodName:@"TextInput.finishAutofillContext"
-                                        arguments:@YES];
-  [textInputPlugin handleMethodCall:methodCall
-                             result:^(id _Nullable result){
-                             }];
-
-  XCTAssertEqual(self.viewsVisibleToAutofill.count,
-                 [textInputPlugin.activeView isVisibleToAutofill] ? 1 : 0);
-  XCTAssertNotEqual(textInputPlugin.textInputView, nil);
-  // The active view should still be installed so it doesn't get
-  // deallocated.
-  XCTAssertEqual(self.installedInputViews.count, 1);
-  XCTAssertEqual(textInputPlugin.autofillContext.count, 0);
-}
-
 - (NSMutableDictionary*)mutableTemplateCopy {
   if (!_template) {
     _template = @{
@@ -97,22 +80,6 @@ FLUTTER_ASSERT_ARC
   return [_template mutableCopy];
 }
 
-- (NSMutableDictionary*)mutablePasswordTemplateCopy {
-  if (!_passwordTemplate) {
-    _passwordTemplate = @{
-      @"inputType" : @{@"name" : @"TextInuptType.text"},
-      @"keyboardAppearance" : @"Brightness.light",
-      @"obscureText" : @YES,
-      @"inputAction" : @"TextInputAction.unspecified",
-      @"smartDashesType" : @"0",
-      @"smartQuotesType" : @"0",
-      @"autocorrect" : @YES
-    };
-  }
-
-  return [_passwordTemplate mutableCopy];
-}
-
 - (NSArray<FlutterTextInputView*>*)installedInputViews {
   UIWindow* keyWindow =
       [[[UIApplication sharedApplication] windows]
@@ -122,11 +89,6 @@ FLUTTER_ASSERT_ARC
   return [keyWindow.subviews
       filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"self isKindOfClass: %@",
                                                                    [FlutterTextInputView class]]];
-}
-
-- (NSArray<FlutterTextInputView*>*)viewsVisibleToAutofill {
-  return [self.installedInputViews
-      filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isVisibleToAutofill == YES"]];
 }
 
 #pragma mark - Tests
@@ -161,6 +123,86 @@ FLUTTER_ASSERT_ARC
   XCTAssert(inputView.autofillId.length > 0);
 }
 
+- (void)testKeyboardType {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [config setValue:@{@"name" : @"TextInputType.url"} forKey:@"inputType"];
+  [self setClientId:123 configuration:config];
+
+  // Find all the FlutterTextInputViews we created.
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+
+  FlutterTextInputView* inputView = inputFields[0];
+
+  // Verify keyboardType is set to the value specified in config.
+  XCTAssertEqual(inputView.keyboardType, UIKeyboardTypeURL);
+}
+
+- (void)testAutocorrectionPromptRectAppears {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithFrame:CGRectZero];
+  inputView.textInputDelegate = engine;
+  [inputView firstRectForRange:[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)]];
+
+  // Verify behavior.
+  OCMVerify([engine showAutocorrectionPromptRectForStart:0 end:1 withClient:0]);
+}
+
+- (void)testTextRangeFromPositionMatchesUITextViewBehavior {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithFrame:CGRectZero];
+  FlutterTextPosition* fromPosition = [[FlutterTextPosition alloc] initWithIndex:2];
+  FlutterTextPosition* toPosition = [[FlutterTextPosition alloc] initWithIndex:0];
+
+  FlutterTextRange* flutterRange = (FlutterTextRange*)[inputView textRangeFromPosition:fromPosition
+                                                                            toPosition:toPosition];
+  NSRange range = flutterRange.range;
+
+  XCTAssertEqual(range.location, 0);
+  XCTAssertEqual(range.length, 2);
+}
+
+- (void)testNoZombies {
+  // Regression test for https://github.com/flutter/flutter/issues/62501.
+  FlutterSecureTextInputView* passwordView = [[FlutterSecureTextInputView alloc] init];
+
+  @autoreleasepool {
+    // Initialize the lazy textField.
+    [passwordView.textField description];
+  }
+  XCTAssert([[passwordView.textField description] containsString:@"TextField"]);
+}
+
+#pragma mark - EditingState tests
+
+- (void)testUITextInputCallsUpdateEditingStateOnce {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
+  inputView.textInputDelegate = engine;
+
+  __block int updateCount = 0;
+  OCMStub([engine updateEditingClient:0 withState:[OCMArg isNotNil]])
+      .andDo(^(NSInvocation* invocation) {
+        updateCount++;
+      });
+
+  [inputView insertText:@"text to insert"];
+  // Update the framework exactly once.
+  XCTAssertEqual(updateCount, 1);
+
+  [inputView deleteBackward];
+  XCTAssertEqual(updateCount, 2);
+
+  inputView.selectedTextRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)];
+  XCTAssertEqual(updateCount, 3);
+
+  [inputView replaceRange:[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)]
+                 withText:@"replace text"];
+  XCTAssertEqual(updateCount, 4);
+
+  [inputView setMarkedText:@"marked text" selectedRange:NSMakeRange(0, 1)];
+  XCTAssertEqual(updateCount, 5);
+
+  [inputView unmarkText];
+  XCTAssertEqual(updateCount, 6);
+}
+
 - (void)testTextChangesTriggerUpdateEditingClient {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
   inputView.textInputDelegate = engine;
@@ -171,11 +213,9 @@ FLUTTER_ASSERT_ARC
 
   // Text changes trigger update.
   XCTAssertTrue([inputView setTextInputState:@{@"text" : @"AFTER"}]);
-  // OCMVerify([engine updateEditingClient:0 withState:[OCMArg isNotNil]]);
 
   // Don't send anything if there's nothing new.
   XCTAssertFalse([inputView setTextInputState:@{@"text" : @"AFTER"}]);
-  // OCMReject([engine updateEditingClient:0 withState:[OCMArg any]]);
 }
 
 - (void)testSelectionChangeTriggersUpdateEditingClient {
@@ -189,23 +229,19 @@ FLUTTER_ASSERT_ARC
   BOOL shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"SELECTION", @"selectionBase" : @0, @"selectionExtent" : @3}];
   XCTAssertTrue(shouldUpdate);
-  // OCMVerify([engine updateEditingClient:1 withState:[OCMArg isNotNil]]);
 
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"SELECTION", @"selectionBase" : @1, @"selectionExtent" : @3}];
   XCTAssertTrue(shouldUpdate);
-  // OCMVerify([engine updateEditingClient:1 withState:[OCMArg isNotNil]]);
 
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"SELECTION", @"selectionBase" : @1, @"selectionExtent" : @2}];
   XCTAssertTrue(shouldUpdate);
-  // OCMVerify([engine updateEditingClient:1 withState:[OCMArg isNotNil]]);
 
   // Don't send anything if there's nothing new.
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"SELECTION", @"selectionBase" : @1, @"selectionExtent" : @2}];
   XCTAssertFalse(shouldUpdate);
-  // OCMReject([engine updateEditingClient:1 withState:[OCMArg any]]);
 }
 
 - (void)testComposingChangeTriggersUpdateEditingClient {
@@ -220,23 +256,19 @@ FLUTTER_ASSERT_ARC
   BOOL shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"COMPOSING", @"composingBase" : @0, @"composingExtent" : @3}];
   XCTAssertTrue(shouldUpdate);
-  // OCMVerify([engine updateEditingClient:1 withState:[OCMArg isNotNil]]);
 
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"COMPOSING", @"composingBase" : @1, @"composingExtent" : @3}];
   XCTAssertTrue(shouldUpdate);
-  // OCMVerify([engine updateEditingClient:1 withState:[OCMArg isNotNil]]);
 
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"COMPOSING", @"composingBase" : @1, @"composingExtent" : @2}];
   XCTAssertTrue(shouldUpdate);
-  // OCMVerify([engine updateEditingClient:1 withState:[OCMArg isNotNil]]);
 
   // Don't send anything if there's nothing new.
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"COMPOSING", @"composingBase" : @1, @"composingExtent" : @2}];
   XCTAssertFalse(shouldUpdate);
-  // OCMReject([engine updateEditingClient:1 withState:[OCMArg any]]);
 }
 
 - (void)testUpdateEditingClientNegativeSelection {
@@ -328,13 +360,54 @@ FLUTTER_ASSERT_ARC
     @"selectionExtent" : @9999
   }];
   [inputView updateEditingState];
-
   OCMVerify([engine updateEditingClient:0
                               withState:[OCMArg checkWithBlock:^BOOL(NSDictionary* state) {
                                 return ([state[@"selectionBase"] intValue]) == 9 &&
                                        ([state[@"selectionExtent"] intValue] == 9);
                               }]]);
 }
+
+#pragma mark - Autofill - Utilities
+
+- (NSMutableDictionary*)mutablePasswordTemplateCopy {
+  if (!_passwordTemplate) {
+    _passwordTemplate = @{
+      @"inputType" : @{@"name" : @"TextInuptType.text"},
+      @"keyboardAppearance" : @"Brightness.light",
+      @"obscureText" : @YES,
+      @"inputAction" : @"TextInputAction.unspecified",
+      @"smartDashesType" : @"0",
+      @"smartQuotesType" : @"0",
+      @"autocorrect" : @YES
+    };
+  }
+
+  return [_passwordTemplate mutableCopy];
+}
+
+- (NSArray<FlutterTextInputView*>*)viewsVisibleToAutofill {
+  return [self.installedInputViews
+      filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"isVisibleToAutofill == YES"]];
+}
+
+- (void)commitAutofillContextAndVerify {
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"TextInput.finishAutofillContext"
+                                        arguments:@YES];
+  [textInputPlugin handleMethodCall:methodCall
+                             result:^(id _Nullable result){
+                             }];
+
+  XCTAssertEqual(self.viewsVisibleToAutofill.count,
+                 [textInputPlugin.activeView isVisibleToAutofill] ? 1 : 0);
+  XCTAssertNotEqual(textInputPlugin.textInputView, nil);
+  // The active view should still be installed so it doesn't get
+  // deallocated.
+  XCTAssertEqual(self.installedInputViews.count, 1);
+  XCTAssertEqual(textInputPlugin.autofillContext.count, 0);
+}
+
+#pragma mark - Autofill - Tests
 
 - (void)testAutofillContext {
   NSMutableDictionary* field1 = self.mutableTemplateCopy;
@@ -537,81 +610,4 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotEqual([inputView performSelector:@selector(font)], nil);
 }
 
-- (void)testKeyboardType {
-  NSDictionary* config = self.mutableTemplateCopy;
-  [config setValue:@{@"name" : @"TextInputType.url"} forKey:@"inputType"];
-  [self setClientId:123 configuration:config];
-
-  // Find all the FlutterTextInputViews we created.
-  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
-
-  FlutterTextInputView* inputView = inputFields[0];
-
-  // Verify keyboardType is set to the value specified in config.
-  XCTAssertEqual(inputView.keyboardType, UIKeyboardTypeURL);
-}
-
-- (void)testAutocorrectionPromptRectAppears {
-  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithFrame:CGRectZero];
-  inputView.textInputDelegate = engine;
-  [inputView firstRectForRange:[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)]];
-
-  // Verify behavior.
-  OCMVerify([engine showAutocorrectionPromptRectForStart:0 end:1 withClient:0]);
-}
-
-- (void)testTextRangeFromPositionMatchesUITextViewBehavior {
-  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithFrame:CGRectZero];
-  FlutterTextPosition* fromPosition = [[FlutterTextPosition alloc] initWithIndex:2];
-  FlutterTextPosition* toPosition = [[FlutterTextPosition alloc] initWithIndex:0];
-
-  FlutterTextRange* flutterRange = (FlutterTextRange*)[inputView textRangeFromPosition:fromPosition
-                                                                            toPosition:toPosition];
-  NSRange range = flutterRange.range;
-
-  XCTAssertEqual(range.location, 0);
-  XCTAssertEqual(range.length, 2);
-}
-
-- (void)testUITextInputCallsUpdateEditingStateOnce {
-  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
-  inputView.textInputDelegate = engine;
-
-  __block int updateCount = 0;
-  OCMStub([engine updateEditingClient:0 withState:[OCMArg isNotNil]])
-      .andDo(^(NSInvocation* invocation) {
-        updateCount++;
-      });
-
-  [inputView insertText:@"text to insert"];
-  // Update the framework exactly once.
-  XCTAssertEqual(updateCount, 1);
-
-  [inputView deleteBackward];
-  XCTAssertEqual(updateCount, 2);
-
-  inputView.selectedTextRange = [FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)];
-  XCTAssertEqual(updateCount, 3);
-
-  [inputView replaceRange:[FlutterTextRange rangeWithNSRange:NSMakeRange(0, 1)]
-                 withText:@"replace text"];
-  XCTAssertEqual(updateCount, 4);
-
-  [inputView setMarkedText:@"marked text" selectedRange:NSMakeRange(0, 1)];
-  XCTAssertEqual(updateCount, 5);
-
-  [inputView unmarkText];
-  XCTAssertEqual(updateCount, 6);
-}
-
-- (void)testNoZombies {
-  // Regression test for https://github.com/flutter/flutter/issues/62501.
-  FlutterSecureTextInputView* passwordView = [[FlutterSecureTextInputView alloc] init];
-
-  @autoreleasepool {
-    // Initialize the lazy textField.
-    [passwordView.textField description];
-  }
-  XCTAssert([[passwordView.textField description] containsString:@"TextField"]);
-}
 @end


### PR DESCRIPTION
## Description

- Fixes valid selection range (should include 0).
- Fixes composing range change logic
- Fixes some tests, regroups some of them

## Related Issues

Fixes https://github.com/flutter/flutter/issues/62992

## Tests

I added the following tests:

- testUpdateEditingClientSelectionClamping

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
