### PR TITLE
Adds fuchsia node roles to accessibility bridge updates.

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -300,8 +300,12 @@ class SemanticsFlag {
   static const int _kIsReadOnlyIndex = 1 << 20;
   static const int _kIsFocusableIndex = 1 << 21;
   static const int _kIsLinkIndex = 1 << 22;
+  static const int _kIsSliderIndex = 1 << 23;
   // READ THIS: if you add a flag here, you MUST update the numSemanticsFlags
-  // value in testing/dart/semantics_test.dart, or tests will fail.
+  // value in testing/dart/semantics_test.dart, or tests will fail. Also,
+  // please update the Flag enum in
+  // flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java,
+  // and the SemanticsFlag class in lib/web_ui/lib/src/ui/semantics.dart.
 
   const SemanticsFlag._(this.index) : assert(index != null); // ignore: unnecessary_null_comparison
 
@@ -354,6 +358,9 @@ class SemanticsFlag {
   /// Text fields are announced as such and allow text input via accessibility
   /// affordances.
   static const SemanticsFlag isTextField = SemanticsFlag._(_kIsTextFieldIndex);
+
+  /// Whether the semantic node represents a slider.
+  static const SemanticsFlag isSlider = SemanticsFlag._(_kIsSliderIndex);
 
   /// Whether the semantic node is read only.
   ///
@@ -551,7 +558,8 @@ class SemanticsFlag {
     _kIsReadOnlyIndex: isReadOnly,
     _kIsFocusableIndex: isFocusable,
     _kIsLinkIndex: isLink,
-  };
+    _kIsSliderIndex: isSlider,
+};
 
   @override
   String toString() {
@@ -602,6 +610,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.isFocusable';
       case _kIsLinkIndex:
         return 'SemanticsFlag.isLink';
+      case _kIsSliderIndex:
+        return 'SemanticsFlag.isSlider';
     }
     assert(false, 'Unhandled index: $index');
     return '';

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -79,6 +79,7 @@ enum class SemanticsFlags : int32_t {
   kIsReadOnly = 1 << 20,
   kIsFocusable = 1 << 21,
   kIsLink = 1 << 22,
+  kIsSlider = 1 << 23,
 };
 
 const int kScrollableSemanticsFlags =

--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -156,6 +156,7 @@ class SemanticsFlag {
   static const int _kIsReadOnlyIndex = 1 << 20;
   static const int _kIsFocusableIndex = 1 << 21;
   static const int _kIsLinkIndex = 1 << 22;
+  static const int _kIsSliderIndex = 1 << 23;
 
   const SemanticsFlag._(this.index) : assert(index != null); // ignore: unnecessary_null_comparison
   final int index;
@@ -182,12 +183,14 @@ class SemanticsFlag {
   static const SemanticsFlag isToggled = SemanticsFlag._(_kIsToggledIndex);
   static const SemanticsFlag hasImplicitScrolling = SemanticsFlag._(_kHasImplicitScrollingIndex);
   static const SemanticsFlag isMultiline = SemanticsFlag._(_kIsMultilineIndex);
+  static const SemanticsFlag isSlider = SemanticsFlag._(_kIsSliderIndex);
   static const Map<int, SemanticsFlag> values = <int, SemanticsFlag>{
     _kHasCheckedStateIndex: hasCheckedState,
     _kIsCheckedIndex: isChecked,
     _kIsSelectedIndex: isSelected,
     _kIsButtonIndex: isButton,
     _kIsLinkIndex: isLink,
+    _kIsSliderIndex: isSlider,
     _kIsTextFieldIndex: isTextField,
     _kIsFocusableIndex: isFocusable,
     _kIsFocusedIndex: isFocused,

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -115,6 +115,31 @@ fuchsia::accessibility::semantics::States AccessibilityBridge::GetNodeStates(
   return states;
 }
 
+fuchsia::accessibility::semantics::Role AccessibilityBridge::GetNodeRole(
+    const flutter::SemanticsNode& node) const {
+  if (node.HasFlag(flutter::SemanticsFlags::kIsButton)) {
+    return fuchsia::accessibility::semantics::Role::BUTTON;
+  }
+
+  if (node.HasFlag(flutter::SemanticsFlags::kIsHeader)) {
+    return fuchsia::accessibility::semantics::Role::HEADER;
+  }
+
+  if (node.HasFlag(flutter::SemanticsFlags::kIsImage)) {
+    return fuchsia::accessibility::semantics::Role::IMAGE;
+  }
+
+  if (node.HasFlag(flutter::SemanticsFlags::kIsTextField)) {
+    return fuchsia::accessibility::semantics::Role::TEXT_FIELD;
+  }
+
+  if (node.HasFlag(flutter::SemanticsFlags::kIsSlider)) {
+    return fuchsia::accessibility::semantics::Role::SLIDER;
+  }
+
+  return fuchsia::accessibility::semantics::Role::UNKNOWN;
+}
+
 std::unordered_set<int32_t> AccessibilityBridge::GetDescendants(
     int32_t node_id) const {
   std::unordered_set<int32_t> descendents;
@@ -227,6 +252,7 @@ void AccessibilityBridge::AddSemanticsNodeUpdate(
         .set_transform(GetNodeTransform(flutter_node))
         .set_attributes(GetNodeAttributes(flutter_node, &this_node_size))
         .set_states(GetNodeStates(flutter_node, &this_node_size))
+        .set_role(GetNodeRole(flutter_node))
         .set_child_ids(child_ids);
     this_node_size +=
         kNodeIdSize * flutter_node.childrenInTraversalOrder.size();

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.h
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.h
@@ -145,6 +145,11 @@ class AccessibilityBridge
       const flutter::SemanticsNode& node,
       size_t* additional_size) const;
 
+  // Derives the role for a Fuchsia semantics node from a Flutter semantics
+  // node.
+  fuchsia::accessibility::semantics::Role GetNodeRole(
+      const flutter::SemanticsNode& node) const;
+
   // Gets the set of reachable descendants from the given node id.
   std::unordered_set<int32_t> GetDescendants(int32_t node_id) const;
 

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 /// Verifies Semantics flags and actions.
 void main() {
   // This must match the number of flags in lib/ui/semantics.dart
-  const int numSemanticsFlags = 23;
+  const int numSemanticsFlags = 24;
   test('SemanticsFlag.values refers to all flags.', () async {
     expect(SemanticsFlag.values.length, equals(numSemanticsFlags));
     for (int index = 0; index < numSemanticsFlags; ++index) {


### PR DESCRIPTION
## Description

This change adds a semantics flag to mark slider UI elements, and modifies the fuchsia accessibility bridge to populate the fuchsia node role.

## Related Issues

N/A

## Tests

I added the following tests:

Accessibility bridge unit test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
