### PR TITLE
Add Surface::GetContext() support on Fuchsia

### DIFF
--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -42,6 +42,10 @@ class CompositorContext final : public flutter::CompositorContext {
     return &session_connection_.scene_update_context();
   }
 
+  GrDirectContext* GetGrContext() {
+    return session_connection_.vulkan_surface_producer()->gr_context();
+  }
+
  private:
   const std::string debug_label_;
   scenic::ViewRefPair view_ref_pair_;

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -83,6 +83,8 @@ class Engine final {
 
   flutter::ExternalViewEmbedder* GetViewEmbedder();
 
+  GrDirectContext* GetGrContext();
+
   FML_DISALLOW_COPY_AND_ASSIGN(Engine);
 };
 

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -96,6 +96,7 @@ PlatformView::PlatformView(
     OnCreateView on_create_view_callback,
     OnDestroyView on_destroy_view_callback,
     OnGetViewEmbedder on_get_view_embedder_callback,
+    OnGetGrContext on_get_gr_context_callback,
     zx_handle_t vsync_event_handle,
     FlutterRunnerProductConfiguration product_config)
     : flutter::PlatformView(delegate, std::move(task_runners)),
@@ -111,6 +112,7 @@ PlatformView::PlatformView(
       on_create_view_callback_(std::move(on_create_view_callback)),
       on_destroy_view_callback_(std::move(on_destroy_view_callback)),
       on_get_view_embedder_callback_(std::move(on_get_view_embedder_callback)),
+      on_get_gr_context_callback_(std::move(on_get_gr_context_callback)),
       ime_client_(this),
       vsync_event_handle_(vsync_event_handle),
       product_config_(product_config) {
@@ -581,7 +583,8 @@ std::unique_ptr<flutter::Surface> PlatformView::CreateRenderingSurface() {
   // surface is setup once during platform view setup and returned to the
   // shell on the initial (and only) |NotifyCreated| call.
   auto view_embedder = on_get_view_embedder_callback_();
-  return std::make_unique<Surface>(debug_label_, view_embedder);
+  auto gr_context = on_get_gr_context_callback_();
+  return std::make_unique<Surface>(debug_label_, view_embedder, gr_context);
 }
 
 // |flutter::PlatformView|

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -31,6 +31,7 @@ using OnEnableWireframe = fit::function<void(bool)>;
 using OnCreateView = fit::function<void(int64_t, bool, bool)>;
 using OnDestroyView = fit::function<void(int64_t)>;
 using OnGetViewEmbedder = fit::function<flutter::ExternalViewEmbedder*()>;
+using OnGetGrContext = fit::function<GrDirectContext*()>;
 
 // The per engine component residing on the platform thread is responsible for
 // all platform specific integrations.
@@ -60,6 +61,7 @@ class PlatformView final : public flutter::PlatformView,
                OnCreateView on_create_view_callback,
                OnDestroyView on_destroy_view_callback,
                OnGetViewEmbedder on_get_view_embedder_callback,
+               OnGetGrContext on_get_gr_context_callback,
                zx_handle_t vsync_event_handle,
                FlutterRunnerProductConfiguration product_config);
   PlatformView(flutter::PlatformView::Delegate& delegate,
@@ -100,6 +102,7 @@ class PlatformView final : public flutter::PlatformView,
   OnCreateView on_create_view_callback_;
   OnDestroyView on_destroy_view_callback_;
   OnGetViewEmbedder on_get_view_embedder_callback_;
+  OnGetGrContext on_get_gr_context_callback_;
 
   int current_text_input_client_ = 0;
   fidl::Binding<fuchsia::ui::input::InputMethodEditorClient> ime_client_;

--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -14,8 +14,11 @@
 namespace flutter_runner {
 
 Surface::Surface(std::string debug_label,
-                 flutter::ExternalViewEmbedder* view_embedder)
-    : debug_label_(std::move(debug_label)), view_embedder_(view_embedder) {}
+                 flutter::ExternalViewEmbedder* view_embedder,
+                 GrDirectContext* gr_context)
+    : debug_label_(std::move(debug_label)),
+      view_embedder_(view_embedder),
+      gr_context_(gr_context) {}
 
 Surface::~Surface() = default;
 
@@ -36,7 +39,7 @@ std::unique_ptr<flutter::SurfaceFrame> Surface::AcquireFrame(
 
 // |flutter::Surface|
 GrDirectContext* Surface::GetContext() {
-  return nullptr;
+  return gr_context_;
 }
 
 static zx_status_t DriverWatcher(int dirfd,

--- a/shell/platform/fuchsia/flutter/surface.h
+++ b/shell/platform/fuchsia/flutter/surface.h
@@ -16,7 +16,8 @@ namespace flutter_runner {
 class Surface final : public flutter::Surface {
  public:
   Surface(std::string debug_label,
-          flutter::ExternalViewEmbedder* view_embedder);
+          flutter::ExternalViewEmbedder* view_embedder,
+          GrDirectContext* gr_context);
 
   ~Surface() override;
 
@@ -24,6 +25,7 @@ class Surface final : public flutter::Surface {
   const bool valid_ = CanConnectToDisplay();
   const std::string debug_label_;
   flutter::ExternalViewEmbedder* view_embedder_;
+  GrDirectContext* gr_context_;
 
   // |flutter::Surface|
   bool IsValid() override;


### PR DESCRIPTION
This improves raster cache control from apps and enables
GPU acceleration for some offscreen workloads that would
fallback to software.

Test: PlatformViewTests.GetGrContextTest