### PR TITLE
hasStrings on Android

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -432,6 +432,7 @@ action("robolectric_tests") {
     "test/io/flutter/embedding/engine/dart/DartExecutorTest.java",
     "test/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistryTest.java",
     "test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java",
+    "test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java",
     "test/io/flutter/embedding/engine/systemchannels/RestorationChannelTest.java",
     "test/io/flutter/external/FlutterLaunchTests.java",
     "test/io/flutter/plugin/common/StandardMessageCodecTest.java",

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -30,7 +30,7 @@ public class PlatformChannel {
   @Nullable private PlatformMessageHandler platformMessageHandler;
 
   @NonNull @VisibleForTesting
-  protected final MethodChannel.MethodCallHandler parsingMethodCallHandler =
+  public final MethodChannel.MethodCallHandler parsingMethodCallHandler =
       new MethodChannel.MethodCallHandler() {
         @Override
         public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -155,6 +155,14 @@ public class PlatformChannel {
                   result.success(null);
                   break;
                 }
+              case "Clipboard.hasStrings":
+                {
+                  boolean hasStrings = platformMessageHandler.clipboardHasStrings();
+                  JSONObject response = new JSONObject();
+                  response.put("value", hasStrings);
+                  result.success(response);
+                  break;
+                }
               default:
                 result.notImplemented();
                 break;
@@ -426,6 +434,11 @@ public class PlatformChannel {
      * {@code text}.
      */
     void setClipboardData(@NonNull String text);
+
+    /** The Flutter application would like to know if the clipboard currently contains a string
+     *  that can be pasted.
+     */
+    boolean clipboardHasStrings();
   }
 
   /** Types of sounds the Android OS can play on behalf of an application. */

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -30,7 +30,7 @@ public class PlatformChannel {
   @Nullable private PlatformMessageHandler platformMessageHandler;
 
   @NonNull @VisibleForTesting
-  public final MethodChannel.MethodCallHandler parsingMethodCallHandler =
+  final MethodChannel.MethodCallHandler parsingMethodCallHandler =
       new MethodChannel.MethodCallHandler() {
         @Override
         public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -435,8 +435,9 @@ public class PlatformChannel {
      */
     void setClipboardData(@NonNull String text);
 
-    /** The Flutter application would like to know if the clipboard currently contains a string
-     *  that can be pasted.
+    /**
+     * The Flutter application would like to know if the clipboard currently contains a string that
+     * can be pasted.
      */
     boolean clipboardHasStrings();
   }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -30,7 +30,8 @@ public class PlatformPlugin {
   private PlatformChannel.SystemChromeStyle currentTheme;
   private int mEnabledOverlays;
 
-  private final PlatformChannel.PlatformMessageHandler mPlatformMessageHandler =
+  @VisibleForTesting
+  final PlatformChannel.PlatformMessageHandler mPlatformMessageHandler =
       new PlatformChannel.PlatformMessageHandler() {
         @Override
         public void playSystemSound(@NonNull PlatformChannel.SoundType soundType) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -89,7 +89,9 @@ public class PlatformPlugin {
 
         @Override
         public boolean clipboardHasStrings() {
-          CharSequence data = PlatformPlugin.this.getClipboardData(PlatformChannel.ClipboardContentFormat.PLAIN_TEXT);
+          CharSequence data =
+              PlatformPlugin.this.getClipboardData(
+                  PlatformChannel.ClipboardContentFormat.PLAIN_TEXT);
           return data != null && data.length() > 0;
         }
       };

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -85,6 +85,12 @@ public class PlatformPlugin {
         public void setClipboardData(@NonNull String text) {
           PlatformPlugin.this.setClipboardData(text);
         }
+
+        @Override
+        public boolean clipboardHasStrings() {
+          CharSequence data = PlatformPlugin.this.getClipboardData(PlatformChannel.ClipboardContentFormat.PLAIN_TEXT);
+          return data != null && data.length() > 0;
+        }
       };
 
   public PlatformPlugin(Activity activity, PlatformChannel platformChannel) {

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -17,6 +17,7 @@ import io.flutter.embedding.engine.LocalizationPluginTest;
 import io.flutter.embedding.engine.RenderingComponentTest;
 import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistryTest;
 import io.flutter.embedding.engine.renderer.FlutterRendererTest;
+import io.flutter.embedding.engine.systemchannels.PlatformChannelTest;
 import io.flutter.embedding.engine.systemchannels.RestorationChannelTest;
 import io.flutter.external.FlutterLaunchTests;
 import io.flutter.plugin.common.StandardMessageCodecTest;
@@ -68,6 +69,7 @@ import test.io.flutter.embedding.engine.dart.DartExecutorTest;
   TextInputPluginTest.class,
   MouseCursorPluginTest.class,
   AccessibilityBridgeTest.class,
+  PlatformChannelTest.class,
   RestorationChannelTest.class,
 })
 /** Runs all of the unit tests listed in the {@code @SuiteClasses} annotation. */

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
@@ -1,0 +1,46 @@
+package io.flutter.embedding.engine.systemchannels;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.res.AssetManager;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.systemchannels.PlatformChannel;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class PlatformChannelTest {
+  @Test
+  public void platformChannel_hasStringsMessage() {
+    MethodChannel rawChannel = mock(MethodChannel.class);
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    DartExecutor dartExecutor = new DartExecutor(mockFlutterJNI, mock(AssetManager.class));
+    PlatformChannel fakePlatformChannel = new PlatformChannel(dartExecutor);
+    PlatformChannel.PlatformMessageHandler mockMessageHandler =
+        mock(PlatformChannel.PlatformMessageHandler.class);
+    fakePlatformChannel.setPlatformMessageHandler(mockMessageHandler);
+    Boolean returnValue = true;
+    when(mockMessageHandler.clipboardHasStrings()).thenReturn(returnValue);
+    MethodCall methodCall = new MethodCall("Clipboard.hasStrings", null);
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+    fakePlatformChannel.parsingMethodCallHandler.onMethodCall(methodCall, mockResult);
+
+    JSONObject expected = new JSONObject();
+    try {
+      expected.put("value", returnValue);
+    } catch (JSONException e) {
+    }
+    verify(mockResult).success(Matchers.refEq(expected));
+  }
+}

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/PlatformChannelTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import android.content.res.AssetManager;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import org.json.JSONException;

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -1,8 +1,8 @@
 package io.flutter.plugin.platform;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -14,22 +14,19 @@ import android.view.Window;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
-import io.flutter.embedding.engine.systemchannels.TextInputChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
-import java.util.HashMap;
-import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowClipboardManager;
 
-@Config(manifest = Config.NONE)
+@Config(manifest = Config.NONE, shadows = ShadowClipboardManager.class)
 @RunWith(RobolectricTestRunner.class)
 public class PlatformPluginTest {
   @Config(sdk = 16)
@@ -70,5 +67,24 @@ public class PlatformPluginTest {
     } catch (JSONException e) {
     }
     verify(mockResult).success(Matchers.refEq(expected));
+  }
+
+  @Test
+  public void platformPlugin_hasStrings() {
+    View fakeDecorView = mock(View.class);
+    Window fakeWindow = mock(Window.class);
+    when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
+    Activity fakeActivity = mock(Activity.class);
+    when(fakeActivity.getWindow()).thenReturn(fakeWindow);
+    PlatformChannel fakePlatformChannel = mock(PlatformChannel.class);
+    PlatformPlugin platformPlugin = new PlatformPlugin(fakeActivity, fakePlatformChannel);
+
+    ClipboardManager clipboardManager =
+        RuntimeEnvironment.application.getSystemService(ClipboardManager.class);
+    clipboardManager.setText("iamastring");
+    assertTrue(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
+
+    clipboardManager.setText("");
+    assertFalse(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
   }
 }

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -3,31 +3,21 @@ package io.flutter.plugin.platform;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import android.content.ClipboardManager;
 import android.content.Context;
-import android.content.res.AssetManager;
 import android.view.View;
 import android.view.Window;
-import io.flutter.embedding.engine.FlutterJNI;
-import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowClipboardManager;
 
-@Config(manifest = Config.NONE, shadows = ShadowClipboardManager.class)
+@Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public class PlatformPluginTest {
   @Config(sdk = 16)
@@ -46,29 +36,6 @@ public class PlatformPluginTest {
 
     // SELECTION_CLICK haptic response is only available on "LOLLIPOP" (21) and later.
     platformPlugin.vibrateHapticFeedback(PlatformChannel.HapticFeedbackType.SELECTION_CLICK);
-  }
-
-  @Test
-  public void platformPlugin_hasStringsMessage() {
-    MethodChannel rawChannel = mock(MethodChannel.class);
-    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
-    DartExecutor dartExecutor = new DartExecutor(mockFlutterJNI, mock(AssetManager.class));
-    PlatformChannel fakePlatformChannel = new PlatformChannel(dartExecutor);
-    PlatformChannel.PlatformMessageHandler mockMessageHandler =
-        mock(PlatformChannel.PlatformMessageHandler.class);
-    fakePlatformChannel.setPlatformMessageHandler(mockMessageHandler);
-    Boolean returnValue = true;
-    when(mockMessageHandler.clipboardHasStrings()).thenReturn(returnValue);
-    MethodCall methodCall = new MethodCall("Clipboard.hasStrings", null);
-    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
-    fakePlatformChannel.parsingMethodCallHandler.onMethodCall(methodCall, mockResult);
-
-    JSONObject expected = new JSONObject();
-    try {
-      expected.put("value", returnValue);
-    } catch (JSONException e) {
-    }
-    verify(mockResult).success(Matchers.refEq(expected));
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import android.app.Activity;
 import android.content.res.AssetManager;
 import android.content.ClipboardManager;
+import android.content.Context;
 import android.view.View;
 import android.view.Window;
 import io.flutter.embedding.engine.FlutterJNI;
@@ -71,16 +72,18 @@ public class PlatformPluginTest {
 
   @Test
   public void platformPlugin_hasStrings() {
+    ClipboardManager clipboardManager =
+        RuntimeEnvironment.application.getSystemService(ClipboardManager.class);
+
     View fakeDecorView = mock(View.class);
     Window fakeWindow = mock(Window.class);
     when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
     Activity fakeActivity = mock(Activity.class);
     when(fakeActivity.getWindow()).thenReturn(fakeWindow);
+    when(fakeActivity.getSystemService(Context.CLIPBOARD_SERVICE)).thenReturn(clipboardManager);
     PlatformChannel fakePlatformChannel = mock(PlatformChannel.class);
     PlatformPlugin platformPlugin = new PlatformPlugin(fakeActivity, fakePlatformChannel);
 
-    ClipboardManager clipboardManager =
-        RuntimeEnvironment.application.getSystemService(ClipboardManager.class);
     clipboardManager.setText("iamastring");
     assertTrue(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
 

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -1,15 +1,15 @@
 package io.flutter.plugin.platform;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
-import android.content.res.AssetManager;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.res.AssetManager;
 import android.view.View;
 import android.view.Window;
 import io.flutter.embedding.engine.FlutterJNI;
@@ -54,7 +54,8 @@ public class PlatformPluginTest {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     DartExecutor dartExecutor = new DartExecutor(mockFlutterJNI, mock(AssetManager.class));
     PlatformChannel fakePlatformChannel = new PlatformChannel(dartExecutor);
-    PlatformChannel.PlatformMessageHandler mockMessageHandler = mock(PlatformChannel.PlatformMessageHandler.class);
+    PlatformChannel.PlatformMessageHandler mockMessageHandler =
+        mock(PlatformChannel.PlatformMessageHandler.class);
     fakePlatformChannel.setPlatformMessageHandler(mockMessageHandler);
     Boolean returnValue = true;
     when(mockMessageHandler.clipboardHasStrings()).thenReturn(returnValue);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -1,15 +1,18 @@
 package io.flutter.plugin.platform;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
+import android.content.ClipboardManager;
 import android.view.View;
 import android.view.Window;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -31,5 +34,25 @@ public class PlatformPluginTest {
 
     // SELECTION_CLICK haptic response is only available on "LOLLIPOP" (21) and later.
     platformPlugin.vibrateHapticFeedback(PlatformChannel.HapticFeedbackType.SELECTION_CLICK);
+  }
+
+  @Test
+  public void platformPlugin_hasStrings() {
+    View fakeDecorView = mock(View.class);
+    Window fakeWindow = mock(Window.class);
+    when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
+    Activity fakeActivity = mock(Activity.class);
+    when(fakeActivity.getWindow()).thenReturn(fakeWindow);
+    PlatformChannel fakePlatformChannel = mock(PlatformChannel.class);
+    PlatformPlugin platformPlugin = new PlatformPlugin(fakeActivity, fakePlatformChannel);
+
+    ClipboardManager clipboardManager =
+        RuntimeEnvironment.application.getSystemService(ClipboardManager.class);
+    clipboardManager.setText("iamastring");
+
+    // TODO(justinmc): Can't do this because mPlatformMessageHandler is private.
+    // How can I send a message to the platform plugin?
+    //boolean hasStrings = platformPlugin.mPlatformMessageHandler.clipboardHasStrings();
+    //assertTrue(hasStrings);
   }
 }


### PR DESCRIPTION
## Description

Implementing hasStrings on Android, which was implemented in iOS in https://github.com/flutter/engine/pull/19859 for https://github.com/flutter/flutter/issues/60145.  The point is to allow iOS to decided if it can paste without actually reading the clipboard, but it was decided to add the same API to all other platforms as well.

## Related Issues

https://github.com/flutter/flutter/issues/60145

## Tests

I added the following tests:

  * Test that a mocked hasStrings can be called via method channel.
  * Test that hasStrings has the correct behavior when called directly.

## Breaking Change

No.