### PR TITLE
Fix RTTI check in EncodableValue

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/encodable_value.h
@@ -14,6 +14,23 @@
 #include <variant>
 #include <vector>
 
+// Unless overridden, attempt to detect the RTTI state from the compiler.
+#ifndef FLUTTER_ENABLE_RTTI
+#if defined(_MSC_VER)
+#ifdef _CPPRTTI
+#define FLUTTER_ENABLE_RTTI 1
+#endif
+#elif defined(__clang__)
+#if __has_feature(cxx_rtti)
+#define FLUTTER_ENABLE_RTTI 1
+#endif
+#elif defined(__GNUC__)
+#ifdef __GXX_RTTI
+#define FLUTTER_ENABLE_RTTI 1
+#endif
+#endif
+#endif  // #ifndef FLUTTER_ENABLE_RTTI
+
 namespace flutter {
 
 static_assert(sizeof(double) == 8, "EncodableValue requires a 64-bit double");
@@ -56,7 +73,7 @@ class CustomEncodableValue {
   operator std::any &() { return value_; }
   operator const std::any &() const { return value_; }
 
-#if __has_feature(cxx_rtti)
+#if defined(FLUTTER_ENABLE_RTTI) && FLUTTER_ENABLE_RTTI
   // Passthrough to std::any's type().
   const std::type_info& type() const noexcept { return value_.type(); }
 #endif


### PR DESCRIPTION
## Description

__has_feature(cxx_rtti) is a clang extension, but clients of this code
are mostly using the VS toolchain. This makes the RTTI check work with
more compilers.

## Related Issues

None.

## Tests

I added the following tests: None. Eventually this will be covered by e2e tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. 

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
