### PR TITLE
Use performDeferredCleanup instead of freeGpuResources

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -99,12 +99,14 @@ void Rasterizer::Teardown() {
 
 void Rasterizer::NotifyLowMemoryWarning() const {
   if (!surface_) {
-    FML_DLOG(INFO) << "Rasterizer::NotifyLowMemoryWarning called with no surface.";
+    FML_DLOG(INFO)
+        << "Rasterizer::NotifyLowMemoryWarning called with no surface.";
     return;
   }
   auto context = surface_->GetContext();
   if (!context) {
-    FML_DLOG(INFO) << "Rasterizer::NotifyLowMemoryWarning called with no GrContext.";
+    FML_DLOG(INFO)
+        << "Rasterizer::NotifyLowMemoryWarning called with no GrContext.";
     return;
   }
   context->performDeferredCleanup(std::chrono::milliseconds(0));

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -99,15 +99,15 @@ void Rasterizer::Teardown() {
 
 void Rasterizer::NotifyLowMemoryWarning() const {
   if (!surface_) {
-    FML_DLOG(INFO) << "Rasterizer::PurgeCaches called with no surface.";
+    FML_DLOG(INFO) << "Rasterizer::NotifyLowMemoryWarning called with no surface.";
     return;
   }
   auto context = surface_->GetContext();
   if (!context) {
-    FML_DLOG(INFO) << "Rasterizer::PurgeCaches called with no GrContext.";
+    FML_DLOG(INFO) << "Rasterizer::NotifyLowMemoryWarning called with no GrContext.";
     return;
   }
-  context->freeGpuResources();
+  context->performDeferredCleanup(std::chrono::milliseconds(0));
 }
 
 flutter::TextureRegistry* Rasterizer::GetTextureRegistry() {


### PR DESCRIPTION
According to @bsalomon:

> They have overlapping but different functionality motivated mostly by Chrome's needs at different points in time. performDeferredCleanup() is newer and isn't solely focused on GPU resources so it checks CPU side caches. Depending on what time value you pass to performDeferredCleanup() and the state of the cache either may purge more.  We should probably make freeGpuResources() go away (or just be a shortcut for performDeferredCleanup(0ms)).

I'm not clear on how to test this. Noticed it while looking into other memory related issues.

/cc @chinmaygarde @jason-simmons @zanderso 