### PR TITLE
Remove duplicated try builder for luci tasks

### DIFF
--- a/ci/dev/try_builders.json
+++ b/ci/dev/try_builders.json
@@ -33,10 +33,6 @@
          "repo":"engine"
       },
       {
-         "name":"Mac Host Engine",
-         "repo":"engine"
-      },
-      {
          "name":"Mac iOS Engine",
          "repo":"engine"
       },


### PR DESCRIPTION
## Description

There have been two `Mac Host Engine` entries for a while, which means every engine commits have been triggering duplicated try runs for this builder. This will be a waste of resources.

One example:
<img width="814" alt="Screen Shot 2020-08-11 at 10 28 04 AM" src="https://user-images.githubusercontent.com/54558023/89928945-65b6c480-dbbd-11ea-83d5-612682f2f015.png">

This PR removes that.
