### PR TITLE
Add virtual destructors to ByteStream*

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/byte_buffer_streams.h
+++ b/shell/platform/common/cpp/client_wrapper/byte_buffer_streams.h
@@ -23,6 +23,8 @@ class ByteBufferStreamReader : public ByteStreamReader {
   explicit ByteBufferStreamReader(const uint8_t* bytes, size_t size)
       : bytes_(bytes), size_(size) {}
 
+  virtual ~ByteBufferStreamReader() = default;
+
   // |ByteStreamReader|
   uint8_t ReadByte() override {
     if (location_ >= size_) {
@@ -68,6 +70,8 @@ class ByteBufferStreamWriter : public ByteStreamWriter {
       : bytes_(buffer) {
     assert(buffer);
   }
+
+  virtual ~ByteBufferStreamWriter() = default;
 
   // |ByteStreamWriter|
   void WriteByte(uint8_t byte) { bytes_->push_back(byte); }

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/byte_streams.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/byte_streams.h
@@ -12,6 +12,9 @@ namespace flutter {
 // An interface for a class that reads from a byte stream.
 class ByteStreamReader {
  public:
+  explicit ByteStreamReader() = default;
+  virtual ~ByteStreamReader() = default;
+
   // Reads and returns the next byte from the stream.
   virtual uint8_t ReadByte() = 0;
 
@@ -48,6 +51,9 @@ class ByteStreamReader {
 // An interface for a class that writes to a byte stream.
 class ByteStreamWriter {
  public:
+  explicit ByteStreamWriter() = default;
+  virtual ~ByteStreamWriter() = default;
+
   // Writes |byte| to the stream.
   virtual void WriteByte(uint8_t byte) = 0;
 


### PR DESCRIPTION
## Description

Fixes the lack of virtual destructors in the ByteStream* interfaces classes in the C++ client wrapper.

## Related Issues

None.

## Tests

I added the following tests: None; evaluation of warning flags will follow shortly.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
