### PR TITLE
Add missing reply in C++ MethodChannel unit test

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/method_channel_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/method_channel_unittests.cc
@@ -67,6 +67,7 @@ TEST(MethodChannelTest, Registration) {
         // result.
         EXPECT_EQ(call.method_name(), method_name);
         EXPECT_NE(result, nullptr);
+        result->Success();
       });
   EXPECT_EQ(messenger.last_message_handler_channel(), channel_name);
   EXPECT_NE(messenger.last_message_handler(), nullptr);


### PR DESCRIPTION
## Description

The test handler wasn't replying, which logged an error message during
the unit test.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/62560

## Tests

I added the following tests: N/A; it's fixing unit test code.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
