### PR TITLE
support init engine asynchronous

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -632,9 +632,7 @@ const TaskRunners& Shell::GetTaskRunners() const {
   return task_runners_;
 }
 
-fml::TaskRunnerAffineWeakPtr<Rasterizer> Shell::GetRasterizer() {
-  ensureInitialized();
-  ensureSetupped();
+fml::TaskRunnerAffineWeakPtr<Rasterizer> Shell::GetRasterizer() const{
   FML_DCHECK(is_setup_);
   return weak_rasterizer_;
 }

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -258,7 +258,7 @@ class Shell final : public PlatformView::Delegate,
   ///
   /// @return     A weak pointer to the rasterizer.
   ///
-  fml::TaskRunnerAffineWeakPtr<Rasterizer> GetRasterizer();
+  fml::TaskRunnerAffineWeakPtr<Rasterizer> GetRasterizer() const;
 
   //------------------------------------------------------------------------------
   /// @brief      Engines may only be accessed on the UI thread. This method is

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -515,9 +515,14 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                     std::move(settings),      // settings
                                     on_create_platform_view,  // platform view creation
                                     on_create_rasterizer,      // rasterizer creation
-                                    [self, entrypoint = entrypoint](bool initialized) {
+                                    [self, entrypoint = entrypoint,
+                                        profilerEnabled = profilerEnabled,
+                                        threadLabel = threadLabel](bool initialized) {
                                         if (initialized) {
                                           [self postInitialized];
+                                          if (profilerEnabled) {
+                                             [self startProfiler:threadLabel];
+                                           }
                                         } else {
                                           FML_LOG(ERROR) << "Could not start a shell FlutterEngine with entrypoint: " << entrypoint.UTF8String;
                                         }
@@ -536,9 +541,14 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                     std::move(settings),      // settings
                                     on_create_platform_view,  // platform view creation
                                     on_create_rasterizer,      // rasterizer creation
-                                    [self, entrypoint = entrypoint](bool initialized) {
+                                    [self, entrypoint = entrypoint,
+                                        profilerEnabled = profilerEnabled,
+                                        threadLabel = threadLabel](bool initialized) {
                                         if (initialized) {
                                           [self postInitialized];
+                                           if (profilerEnabled) {
+                                             [self startProfiler:threadLabel];
+                                           }
                                         } else {
                                           FML_LOG(ERROR) << "Could not start a shell FlutterEngine with entrypoint: " << entrypoint.UTF8String;
                                         }
@@ -558,9 +568,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     _publisher.reset([[FlutterObservatoryPublisher alloc] init]);
     [self maybeSetupPlatformViewChannels];
     _shell->GetIsGpuDisabledSyncSwitch()->SetSwitch(_isGpuDisabled ? true : false);
-    if (profilerEnabled) {
-      [self startProfiler:threadLabel];
-    }
 }
 
 - (BOOL)run {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -517,12 +517,9 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                     on_create_rasterizer,      // rasterizer creation
                                     [self, entrypoint = entrypoint,
                                         profilerEnabled = profilerEnabled,
-                                        threadLabel = threadLabel](bool initialized) {
+                                        threadLabel = [threadLabel copy]](bool initialized) {
                                         if (initialized) {
-                                          [self postInitialized];
-                                          if (profilerEnabled) {
-                                             [self startProfiler:threadLabel];
-                                           }
+                                          [self postInitialized:profilerEnabled threadLabel:threadLabel];
                                         } else {
                                           FML_LOG(ERROR) << "Could not start a shell FlutterEngine with entrypoint: " << entrypoint.UTF8String;
                                         }
@@ -542,13 +539,10 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                                     on_create_platform_view,  // platform view creation
                                     on_create_rasterizer,      // rasterizer creation
                                     [self, entrypoint = entrypoint,
-                                        profilerEnabled = profilerEnabled,
-                                        threadLabel = threadLabel](bool initialized) {
+                                        profilerEnabled,
+                                        threadLabel = [threadLabel copy]](bool initialized) {
                                         if (initialized) {
-                                          [self postInitialized];
-                                           if (profilerEnabled) {
-                                             [self startProfiler:threadLabel];
-                                           }
+                                          [self postInitialized:profilerEnabled threadLabel:threadLabel];
                                         } else {
                                           FML_LOG(ERROR) << "Could not start a shell FlutterEngine with entrypoint: " << entrypoint.UTF8String;
                                         }
@@ -559,7 +553,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   return _shell != nullptr;
 }
 
-- (void)postInitialized {
+- (void)postInitialized:(BOOL)profilerEnabled threadLabel:(NSString*)threadLabel {
     [self setupChannels];
     [self onLocaleUpdated:nil];
     if (!_platformViewsController) {
@@ -568,6 +562,9 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     _publisher.reset([[FlutterObservatoryPublisher alloc] init]);
     [self maybeSetupPlatformViewChannels];
     _shell->GetIsGpuDisabledSyncSwitch()->SetSwitch(_isGpuDisabled ? true : false);
+    if (profilerEnabled) {
+      [self startProfiler:threadLabel];
+    }
 }
 
 - (BOOL)run {


### PR DESCRIPTION
## Description

*In Engine initialization, we have to wait for all other threads ready, it has an opportunity to improve it, so I make this asynchronous.*

### Comparison

#### Before
![4C888FFB-440C-4314-874F-9F9AA6CC7337](https://user-images.githubusercontent.com/1678324/89971563-2efcaf00-dc8e-11ea-9ac0-04da0fab1580.png)

#### After
![2459FB6E-7F2C-41F7-B5C9-B1BEBDBC1E29](https://user-images.githubusercontent.com/1678324/89971570-38861700-dc8e-11ea-8811-fc2a75d6bffb.png)

#### Conclusion:
It's clearly show that it makes ui thread asynchronous , platform thread does't have to wait for it in engine initialization.
It may make about *200ms* time for platform thread.

## Related Issues

*[19641](https://github.com/flutter/engine/pull/19641?spm=ata.13261165.0.0.627f4f59iRUf3Z)*

This pr seems a little hackable, my solution seems a bit more sensible.

## Tests

I added the following tests:

*Go through all test cases*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
