### PR TITLE
Populates fuchsia node actions in semantics updates.

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -115,6 +115,36 @@ fuchsia::accessibility::semantics::States AccessibilityBridge::GetNodeStates(
   return states;
 }
 
+std::vector<fuchsia::accessibility::semantics::Action>
+AccessibilityBridge::GetNodeActions(const flutter::SemanticsNode& node,
+                                    size_t* additional_size) const {
+  std::vector<fuchsia::accessibility::semantics::Action> node_actions;
+
+  if (node.HasAction(flutter::SemanticsAction::kTap)) {
+    node_actions.push_back(fuchsia::accessibility::semantics::Action::DEFAULT);
+  }
+  if (node.HasAction(flutter::SemanticsAction::kLongPress)) {
+    node_actions.push_back(
+        fuchsia::accessibility::semantics::Action::SECONDARY);
+  }
+  if (node.HasAction(flutter::SemanticsAction::kShowOnScreen)) {
+    node_actions.push_back(
+        fuchsia::accessibility::semantics::Action::SHOW_ON_SCREEN);
+  }
+  if (node.HasAction(flutter::SemanticsAction::kIncrease)) {
+    node_actions.push_back(
+        fuchsia::accessibility::semantics::Action::INCREMENT);
+  }
+  if (node.HasAction(flutter::SemanticsAction::kDecrease)) {
+    node_actions.push_back(
+        fuchsia::accessibility::semantics::Action::DECREMENT);
+  }
+
+  *additional_size +=
+      node_actions.size() * sizeof(fuchsia::accessibility::semantics::Action);
+  return node_actions;
+}
+
 std::unordered_set<int32_t> AccessibilityBridge::GetDescendants(
     int32_t node_id) const {
   std::unordered_set<int32_t> descendents;
@@ -227,6 +257,7 @@ void AccessibilityBridge::AddSemanticsNodeUpdate(
         .set_transform(GetNodeTransform(flutter_node))
         .set_attributes(GetNodeAttributes(flutter_node, &this_node_size))
         .set_states(GetNodeStates(flutter_node, &this_node_size))
+        .set_actions(GetNodeActions(flutter_node, &this_node_size))
         .set_child_ids(child_ids);
     this_node_size +=
         kNodeIdSize * flutter_node.childrenInTraversalOrder.size();

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.h
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.h
@@ -145,6 +145,12 @@ class AccessibilityBridge
       const flutter::SemanticsNode& node,
       size_t* additional_size) const;
 
+  // Derives the set of supported actions for a Fuchsia semantics node from
+  // a Flutter semantics node.
+  std::vector<fuchsia::accessibility::semantics::Action> GetNodeActions(
+      const flutter::SemanticsNode& node,
+      size_t* additional_size) const;
+
   // Gets the set of reachable descendants from the given node id.
   std::unordered_set<int32_t> GetDescendants(int32_t node_id) const;
 

--- a/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
@@ -237,6 +237,36 @@ TEST_F(AccessibilityBridgeTest, PopulatesHiddenState) {
   EXPECT_FALSE(semantics_manager_.UpdateOverflowed());
 }
 
+TEST_F(AccessibilityBridgeTest, PopulatesActions) {
+  flutter::SemanticsNode node0;
+  node0.id = 0;
+  node0.actions |= static_cast<int>(flutter::SemanticsAction::kTap);
+  node0.actions |= static_cast<int>(flutter::SemanticsAction::kLongPress);
+  node0.actions |= static_cast<int>(flutter::SemanticsAction::kShowOnScreen);
+  node0.actions |= static_cast<int>(flutter::SemanticsAction::kIncrease);
+  node0.actions |= static_cast<int>(flutter::SemanticsAction::kDecrease);
+
+  accessibility_bridge_->AddSemanticsNodeUpdate({{0, node0}});
+  RunLoopUntilIdle();
+
+  EXPECT_EQ(0, semantics_manager_.DeleteCount());
+  EXPECT_EQ(1, semantics_manager_.UpdateCount());
+  EXPECT_EQ(1, semantics_manager_.CommitCount());
+  EXPECT_EQ(1u, semantics_manager_.LastUpdatedNodes().size());
+  const auto& fuchsia_node = semantics_manager_.LastUpdatedNodes().at(0u);
+  EXPECT_EQ(fuchsia_node.actions().size(), 5u);
+  EXPECT_EQ(fuchsia_node.actions().at(0u),
+            fuchsia::accessibility::semantics::Action::DEFAULT);
+  EXPECT_EQ(fuchsia_node.actions().at(1u),
+            fuchsia::accessibility::semantics::Action::SECONDARY);
+  EXPECT_EQ(fuchsia_node.actions().at(2u),
+            fuchsia::accessibility::semantics::Action::SHOW_ON_SCREEN);
+  EXPECT_EQ(fuchsia_node.actions().at(3u),
+            fuchsia::accessibility::semantics::Action::INCREMENT);
+  EXPECT_EQ(fuchsia_node.actions().at(4u),
+            fuchsia::accessibility::semantics::Action::DECREMENT);
+}
+
 TEST_F(AccessibilityBridgeTest, TruncatesLargeLabel) {
   // Test that labels which are too long are truncated.
   flutter::SemanticsNode node0;


### PR DESCRIPTION
## Description

This change ensures that the accessibility bridge correctly specifies which semantics actions are available to each node in a semantics update.

## Related Issues

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=57668&q=owner%3Ame&can=2

## Tests

I added the following tests:

Added an accessibility bridge unit test verifying that semantics actions are translated correctly.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
