### PR TITLE
Send locale information in the macOS embedding

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -14,9 +14,28 @@
 #import "flutter/shell/platform/embedder/embedder.h"
 
 /**
+ * Constructs and returns a FlutterLocale struct corresponding to |locale|, which must outlive
+ * the returned struct.
+ */
+static FlutterLocale FlutterLocaleFromNSLocale(NSLocale* locale) {
+  FlutterLocale flutterLocale = {};
+  flutterLocale.struct_size = sizeof(FlutterLocale);
+  flutterLocale.language_code = [[locale objectForKey:NSLocaleLanguageCode] UTF8String];
+  flutterLocale.country_code = [[locale objectForKey:NSLocaleCountryCode] UTF8String];
+  flutterLocale.script_code = [[locale objectForKey:NSLocaleScriptCode] UTF8String];
+  flutterLocale.variant_code = [[locale objectForKey:NSLocaleVariantCode] UTF8String];
+  return flutterLocale;
+}
+
+/**
  * Private interface declaration for FlutterEngine.
  */
 @interface FlutterEngine () <FlutterBinaryMessenger>
+
+/**
+ * Sends the list of user-preferred locales to the Flutter engine.
+ */
+- (void)sendUserLocales;
 
 /**
  * Called by the engine to make the context the engine should draw into current.
@@ -181,6 +200,12 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   _textures = [[NSMutableDictionary alloc] init];
   _allowHeadlessExecution = allowHeadlessExecution;
 
+  NSNotificationCenter* notificationCenter = [NSNotificationCenter defaultCenter];
+  [notificationCenter addObserver:self
+                         selector:@selector(sendUserLocales)
+                             name:NSCurrentLocaleDidChangeNotification
+                           object:nil];
+
   return self;
 }
 
@@ -254,6 +279,7 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
     return NO;
   }
 
+  [self sendUserLocales];
   [self updateWindowMetrics];
   return YES;
 }
@@ -313,6 +339,29 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
 }
 
 #pragma mark - Private methods
+
+- (void)sendUserLocales {
+  if (!self.running) {
+    return;
+  }
+
+  // Create a list of FlutterLocales corresponding to the preferred languages.
+  NSMutableArray<NSLocale*>* locales = [NSMutableArray array];
+  std::vector<FlutterLocale> flutterLocales;
+  flutterLocales.reserve(locales.count);
+  for (NSString* localeID in [NSLocale preferredLanguages]) {
+    NSLocale* locale = [[NSLocale alloc] initWithLocaleIdentifier:localeID];
+    [locales addObject:locale];
+    flutterLocales.push_back(FlutterLocaleFromNSLocale(locale));
+  }
+  // Convert to a list of pointers, and send to the engine.
+  std::vector<const FlutterLocale*> flutterLocaleList;
+  flutterLocaleList.reserve(flutterLocales.size());
+  std::transform(
+      flutterLocales.begin(), flutterLocales.end(), std::back_inserter(flutterLocaleList),
+      [](const auto& arg) -> const auto* { return &arg; });
+  FlutterEngineUpdateLocales(_engine, flutterLocaleList.data(), flutterLocaleList.size());
+}
 
 - (bool)engineCallbackOnMakeCurrent {
   if (!_mainOpenGLContext) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -303,6 +303,7 @@ static void CommonInit(FlutterViewController* controller) {
   }
   // Send the initial user settings such as brightness and text scale factor
   // to the engine.
+  // TODO(stuartmorgan): Move this logic to FlutterEngine.
   [self sendInitialSettings];
   return YES;
 }


### PR DESCRIPTION
## Description

Queries the system list of user-preferred languages, and sends it to the
engine just after starting it up, as well as after any OS locale change.

## Related Issues

macOS portion of https://github.com/flutter/flutter/issues/45152

## Tests

I added the following tests: None; there is not yet a framework for unit testing the macOS embedding with a stub engine API. Tests will be backfilled when that is implemented.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
