### PR TITLE
Update the Fuchsia toolchains on Mac and Linux to latest.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -510,7 +510,10 @@ deps = {
   },
 
    # Get the SDK from https://chrome-infra-packages.appspot.com/p/fuchsia/sdk/core at the 'latest' tag
-   # Get the toolchain from https://chrome-infra-packages.appspot.com/p/fuchsia/clang at the 'goma' tag
+   # Get the toolchain from https://chrome-infra-packages.appspot.com/p/fuchsia/third_party/clang at the 'integration' tag
+   # This is update by the following autorollers:
+   # Mac: https://autoroll.skia.org/r/fuchsia-mac-toolchain-flutter-engine
+   # Linux: https://autoroll.skia.org/r/fuchsia-linux-toolchain-flutter-engine
 
    'src/fuchsia/sdk/mac': {
      'packages': [
@@ -525,8 +528,8 @@ deps = {
    'src/fuchsia/toolchain/mac': {
      'packages': [
        {
-        'package': 'fuchsia/clang/mac-amd64',
-        'version': 'OzTZOKkICT0yD82Dbx0jvVn5hN5eOSi6ByVTDseE7i0C'
+        'package': 'fuchsia/third_party/clang/mac-amd64',
+        'version': 'hr7o2cD0tpLLUtC2ifLXCvi3nlGL2dyErXFuxbSpjEcC'
        }
      ],
      'condition': 'host_os == "mac"',
@@ -545,8 +548,8 @@ deps = {
    'src/fuchsia/toolchain/linux': {
      'packages': [
        {
-        'package': 'fuchsia/clang/linux-amd64',
-        'version': 'OT6p30bQQhyCzRSy7xPsSbZ88J3PWOnneenkMZ0j7kIC'
+        'package': 'fuchsia/third_party/clang/linux-amd64',
+        'version': 'E7w1U9ii_0fi-8y4UowsFj1PB7_vwZiiqhesG6a_sygC'
        }
      ],
      'condition': 'host_os == "linux"',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 08da629cc55657469fbc030dd104af1f
+Signature: 61f65fcbc3f78429ee7aaae866aa9960
 
 UNUSED LICENSES:
 

--- a/tools/fuchsia/clang.gni
+++ b/tools/fuchsia/clang.gni
@@ -5,7 +5,7 @@
 declare_args() {
   # The default clang toolchain provided by the prebuilt. This variable is
   # additionally consumed by the Go toolchain.
-  clang_base = rebase_path("//fuchsia/toolchain/$host_os/lib")
+  clang_base = rebase_path("//fuchsia/toolchain/$host_os")
 }
 
 if (current_cpu == "arm64") {
@@ -15,18 +15,3 @@ if (current_cpu == "arm64") {
 } else {
   assert(false, "CPU not supported")
 }
-
-if (is_fuchsia) {
-  clang_target = "${clang_cpu}-fuchsia"
-} else if (is_linux) {
-  clang_target = "${clang_cpu}-linux-gnu"
-} else if (is_mac) {
-  clang_target = "${clang_cpu}-apple-darwin"
-} else {
-  assert(false, "OS not supported")
-}
-
-clang_manifest = rebase_path("$clang_base/${clang_target}.manifest")
-clang_manifest_json = exec_script("//flutter/tools/fuchsia/parse_manifest.py",
-                                  [ "--input=${clang_manifest}" ],
-                                  "json")

--- a/tools/fuchsia/fuchsia_libs.gni
+++ b/tools/fuchsia/fuchsia_libs.gni
@@ -47,18 +47,15 @@ common_libs = [
   # This is a hack, and we can migrate to a better way soon.
   {
     name = "libc++.so.2"
-    path = rebase_path(
-            "$clang_base/${clang_manifest_json.md5_33bfe15b05ada4ed326fbc33adb39b95}")
+    path = rebase_path("$clang_base/lib/$clang_cpu-unknown-fuchsia/c++")
   },
   {
     name = "libc++abi.so.1"
-    path = rebase_path(
-            "$clang_base/${clang_manifest_json.md5_916c01a85e3353f124776599819ecb1c}")
+    path = rebase_path("$clang_base/lib/$clang_cpu-unknown-fuchsia/c++")
   },
   {
     name = "libunwind.so.1"
-    path = rebase_path(
-            "$clang_base/${clang_manifest_json.md5_beb70f40d525448b39ea87d9f5811e56}")
+    path = rebase_path("$clang_base/lib/$clang_cpu-unknown-fuchsia/c++")
   },
 ]
 

--- a/tools/gn
+++ b/tools/gn
@@ -433,7 +433,7 @@ def main(argv):
     try:
       contents = subprocess.check_output(compile_cmd_gen_cmd, cwd=SRC_ROOT)
     except subprocess.CalledProcessError as exc:
-      print "Failed to run ninja: ", exc.returncode, exc.output
+      print "Failed to run ninja when attempting to create the compile_commands.json manifest: ", exc.returncode, exc.output
       sys.exit(1)
     compile_commands = open('%s/out/compile_commands.json' % SRC_ROOT, 'w+')
     compile_commands.write(contents)


### PR DESCRIPTION
This needs a buildroot update pending in https://github.com/flutter/buildroot/pull/394.

The toolchains were being updated by an autoroller. The location the autoroller looked at for new toolchains is no longer being updated. This caused the toolchains to be stuck on revisions that are about 9 months old at this time. The autorollers have been updated in https://skia-review.googlesource.com/c/buildbot/+/306357 but the change in the path necessitates a manual update. This update must also address any build breakages caused by the newer compiler version.

Towards fixing https://github.com/flutter/flutter/issues/63581