### PR TITLE
Do not access members after calling ClearDartWrapper

### DIFF
--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -486,10 +486,10 @@ void Canvas::drawShadow(const CanvasPath* path,
 }
 
 void Canvas::Invalidate() {
+  canvas_ = nullptr;
   if (dart_wrapper()) {
     ClearDartWrapper();
   }
-  canvas_ = nullptr;
 }
 
 }  // namespace flutter

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -37,8 +37,8 @@ Dart_Handle CanvasImage::toByteData(int format, Dart_Handle callback) {
 }
 
 void CanvasImage::dispose() {
-  ClearDartWrapper();
   image_.reset();
+  ClearDartWrapper();
 }
 
 size_t CanvasImage::GetAllocationSize() const {

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -56,8 +56,8 @@ Dart_Handle Picture::toImage(uint32_t width,
 }
 
 void Picture::dispose() {
-  ClearDartWrapper();
   picture_.reset();
+  ClearDartWrapper();
 }
 
 size_t Picture::GetAllocationSize() const {


### PR DESCRIPTION
ClearDartWrapper drops Dart's reference to the wrappable object,
which may cause the object to be deleted.

Fixes https://github.com/flutter/flutter/issues/63578