### PR TITLE
Fix acquireLatestImage exceeds maxImage and cause IllegalStateException.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -183,9 +183,13 @@ public class FlutterImageView extends View implements RenderSurface {
     //
     // To avoid exceptions, check if a new image can be acquired.
     if (pendingImages < imageReader.getMaxImages()) {
-      nextImage = imageReader.acquireLatestImage();
-      if (nextImage != null) {
-        pendingImages++;
+      try {
+        nextImage = imageReader.acquireLatestImage();
+        if (nextImage != null) {
+          pendingImages++;
+        }
+      } catch (IllegalStateException exception) {
+        // just bypass
       }
     }
     invalidate();


### PR DESCRIPTION
## Description

When using `PlatformViewLink` widget to wrap a native `WebView` in Android, in certain scenarios, the app will be crashed with following callstack.

#### Scenario
* launch a screen with PlatformViewLink` wrapped WebView, while it's loading the content, press HOME key on android device.
* It may crash the flutter app with around 30% to 60% percent crash rate.

>W/ImageReader_JNI(18777): Unable to acquire a buffer item, very likely client tried to acquire more than maxImages buffers E/flutter (18777): [ERROR:flutter/shell/platform/android/platform_view_android_jni_impl.cc(43)] java.lang.IllegalStateException: maxImages (3) has already been acquired, call #close before acquiring more. E/flutter (18777): at android.media.ImageReader.acquireNextImage(ImageReader.java:513) E/flutter (18777): at android.media.ImageReader.acquireLatestImage(ImageReader.java:397) E/flutter (18777): at io.flutter.embedding.android.FlutterImageView.acquireLatestImage(FlutterImageView.java:186) E/flutter (18777): at io.flutter.embedding.android.FlutterView.acquireLatestImageViewFrame(FlutterView.java:1039) E/flutter (18777): at io.flutter.plugin.platform.PlatformViewsController.onEndFrame(PlatformViewsController.java:780) E/flutter (18777): at io.flutter.embedding.engine.FlutterJNI.onEndFrame(FlutterJNI.java:856) E/flutter (18777): at android.os.MessageQueue.nativePollOnce(Native Method) E/flutter (18777): at android.os.MessageQueue.next(MessageQueue.java:336) E/flutter (18777): at android.os.Looper.loop(Looper.java:197) E/flutter (18777): at android.app.ActivityThread.main(ActivityThread.java:8016) E/flutter (18777): at java.lang.reflect.Method.invoke(Native Method) E/flutter (18777): at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493) E/flutter (18777): at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1076) E/flutter (18777): F/flutter (18777): [FATAL:flutter/shell/platform/android/platform_view_android_jni_impl.cc(1241)] Check failed: CheckException(env). F/libc (18777): Fatal signal 6 (SIGABRT), code -6 (SI_TKILL) in tid 18777 (twshopping.beta), pid 18777 (twshopping.beta)

Here's the official document for `acquireLatestImage()` https://developer.android.com/reference/android/media/ImageReader#acquireLatestImage()

It says that 
>This operation will fail by throwing an IllegalStateException if maxImages have been acquired with acquireNextImage() or acquireLatestImage(). 

So, I tried to catch `IllegalStateException` to prevent the native crash.
As for in what circumstances it will cause this scenario, since I am not so familiar with flutter/engine. It may need other's help to figure it out.

## Related Issues

Maybe related to the issue mentioned in 
https://github.com/flutter/engine/pull/19325/files#
https://github.com/flutter/engine/pull/19487/files



## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
