### PR TITLE
Update to android 30r2 and roll buildroot

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -1,3 +1,4 @@
+
 # This file is automatically processed to create .DEPS.git which is the file
 # that gclient uses under git.
 #
@@ -105,7 +106,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'daaa47b0272463e5ec7e3b142201b0d5a330a35d',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'a6c0959d1ac8cdfe6f9ff87892bc4905a73699fe',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -105,7 +105,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '5c728e8691edf262d4355c2c900bc1f9631e2451',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'daaa47b0272463e5ec7e3b142201b0d5a330a35d',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -105,7 +105,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/garyqian/buildroot.git' + '@' + '5c728e8691edf262d4355c2c900bc1f9631e2451',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '5c728e8691edf262d4355c2c900bc1f9631e2451',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -105,7 +105,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'b8d98f419b4c32eb1d575557d2c46e8c755ceac7',
+  'src': 'https://github.com/garyqian/buildroot.git' + '@' + '5c728e8691edf262d4355c2c900bc1f9631e2451',
 
    # Fuchsia compatibility
    #
@@ -425,7 +425,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/sdk/build-tools/${{platform}}',
-        'version': 'version:29.0.1'
+        'version': 'version:30.0.1'
        }
      ],
      'condition': 'download_android_deps',
@@ -436,7 +436,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/sdk/platform-tools/${{platform}}',
-        'version': 'version:29.0.2'
+        'version': 'version:30.0.4'
        }
      ],
      'condition': 'download_android_deps',
@@ -447,7 +447,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/sdk/platforms',
-        'version': 'version:29r1'
+        'version': 'version:30r2'
        }
      ],
      'condition': 'download_android_deps',

--- a/DEPS
+++ b/DEPS
@@ -1,4 +1,3 @@
-
 # This file is automatically processed to create .DEPS.git which is the file
 # that gclient uses under git.
 #

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -345,7 +345,7 @@ def RunJavaTests(filter, android_variant='android_debug_unopt'):
 
   embedding_deps_dir = os.path.join(buildroot_dir, 'third_party', 'android_embedding_dependencies', 'lib')
   classpath = map(str, [
-    os.path.join(buildroot_dir, 'third_party', 'android_tools', 'sdk', 'platforms', 'android-29', 'android.jar'),
+    os.path.join(buildroot_dir, 'third_party', 'android_tools', 'sdk', 'platforms', 'android-30', 'android.jar'),
     os.path.join(embedding_deps_dir, '*'), # Wildcard for all jars in the directory
     os.path.join(android_out_dir, 'flutter.jar'),
     os.path.join(android_out_dir, 'robolectric_tests.jar')

--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -7,7 +7,7 @@ screenshots {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/56597

This upgrades to default to building with Android 30. Also uses platform-tools 30.0.4 and build-tools 30.0.1