### PR TITLE
Only create raster_thread_merge when explicitly requested by the embedding platform

### DIFF
--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -60,7 +60,7 @@ const std::vector<std::shared_ptr<Mutator>>::const_iterator MutatorsStack::End()
   return vector_.end();
 };
 
-bool ExternalViewEmbedder::SupportDynamicThreadMerging() {
+bool ExternalViewEmbedder::SupportsDynamicThreadMerging() {
   return false;
 }
 

--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -60,4 +60,8 @@ const std::vector<std::shared_ptr<Mutator>>::const_iterator MutatorsStack::End()
   return vector_.end();
 };
 
+bool ExternalViewEmbedder::SupportDynamicThreadMerging() {
+  return false;
+}
+
 }  // namespace flutter

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -266,6 +266,10 @@ class ExternalViewEmbedder {
   // sets the stage for the next pre-roll.
   virtual void CancelFrame() = 0;
 
+  // Indicates the begining of a frame.
+  //
+  // The `raster_thread_merger` will be null if |SupportDynamicThreadMerging|
+  // returns false.
   virtual void BeginFrame(
       SkISize frame_size,
       GrDirectContext* context,
@@ -306,10 +310,18 @@ class ExternalViewEmbedder {
   // A new frame on the platform thread starts immediately. If the GPU thread
   // still has some task running, there could be two frames being rendered
   // concurrently, which causes undefined behaviors.
+  //
+  // The `raster_thread_merger` will be null if |SupportDynamicThreadMerging|
+  // returns false.
   virtual void EndFrame(
       bool should_resubmit_frame,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {}
 
+  // Whether the embedder should support dynamic thread merging.
+  //
+  // Returning `true` results a |RasterThreadMerger| instance to be created.
+  // * See also |BegineFrame| and |EndFrame| for getting the
+  // |RasterThreadMerger| instance.
   virtual bool SupportDynamicThreadMerging();
 
   FML_DISALLOW_COPY_AND_ASSIGN(ExternalViewEmbedder);

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -268,7 +268,7 @@ class ExternalViewEmbedder {
 
   // Indicates the begining of a frame.
   //
-  // The `raster_thread_merger` will be null if |SupportDynamicThreadMerging|
+  // The `raster_thread_merger` will be null if |SupportsDynamicThreadMerging|
   // returns false.
   virtual void BeginFrame(
       SkISize frame_size,
@@ -311,7 +311,7 @@ class ExternalViewEmbedder {
   // still has some task running, there could be two frames being rendered
   // concurrently, which causes undefined behaviors.
   //
-  // The `raster_thread_merger` will be null if |SupportDynamicThreadMerging|
+  // The `raster_thread_merger` will be null if |SupportsDynamicThreadMerging|
   // returns false.
   virtual void EndFrame(
       bool should_resubmit_frame,
@@ -322,7 +322,7 @@ class ExternalViewEmbedder {
   // Returning `true` results a |RasterThreadMerger| instance to be created.
   // * See also |BegineFrame| and |EndFrame| for getting the
   // |RasterThreadMerger| instance.
-  virtual bool SupportDynamicThreadMerging();
+  virtual bool SupportsDynamicThreadMerging();
 
   FML_DISALLOW_COPY_AND_ASSIGN(ExternalViewEmbedder);
 

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -310,6 +310,8 @@ class ExternalViewEmbedder {
       bool should_resubmit_frame,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {}
 
+  virtual bool SupportDynamicThreadMerging();
+
   FML_DISALLOW_COPY_AND_ASSIGN(ExternalViewEmbedder);
 
 };  // ExternalViewEmbedder

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -82,7 +82,7 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
   // TODO(sanjayc77): https://github.com/flutter/flutter/issues/53179. Add
   // support for raster thread merger for Fuchsia.
   if (surface_->GetExternalViewEmbedder() &&
-      surface_->GetExternalViewEmbedder()->SupportDynamicThreadMerging()) {
+      surface_->GetExternalViewEmbedder()->SupportsDynamicThreadMerging()) {
     const auto platform_id =
         task_runners_.GetPlatformTaskRunner()->GetTaskQueueId();
     const auto gpu_id = task_runners_.GetRasterTaskRunner()->GetTaskQueueId();

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -81,7 +81,8 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
 #if !defined(OS_FUCHSIA)
   // TODO(sanjayc77): https://github.com/flutter/flutter/issues/53179. Add
   // support for raster thread merger for Fuchsia.
-  if (surface_->GetExternalViewEmbedder()) {
+  if (surface_->GetExternalViewEmbedder() &&
+      surface_->GetExternalViewEmbedder()->SupportDynamicThreadMerging()) {
     const auto platform_id =
         task_runners_.GetPlatformTaskRunner()->GetTaskQueueId();
     const auto gpu_id = task_runners_.GetRasterTaskRunner()->GetTaskQueueId();

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -53,4 +53,8 @@ SkCanvas* ShellTestExternalViewEmbedder::GetRootCanvas() {
   return nullptr;
 }
 
+bool ShellTestExternalViewEmbedder::SupportDynamicThreadMerging() {
+  return true;
+}
+
 }  // namespace flutter

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -53,7 +53,7 @@ SkCanvas* ShellTestExternalViewEmbedder::GetRootCanvas() {
   return nullptr;
 }
 
-bool ShellTestExternalViewEmbedder::SupportDynamicThreadMerging() {
+bool ShellTestExternalViewEmbedder::SupportsDynamicThreadMerging() {
   return support_thread_merging_;
 }
 

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -45,7 +45,7 @@ void ShellTestExternalViewEmbedder::SubmitFrame(
 void ShellTestExternalViewEmbedder::EndFrame(
     bool should_resubmit_frame,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
-  end_frame_call_back_(should_resubmit_frame);
+  end_frame_call_back_(should_resubmit_frame, raster_thread_merger);
 }
 
 // |ExternalViewEmbedder|
@@ -54,7 +54,7 @@ SkCanvas* ShellTestExternalViewEmbedder::GetRootCanvas() {
 }
 
 bool ShellTestExternalViewEmbedder::SupportDynamicThreadMerging() {
-  return true;
+  return support_thread_merging_;
 }
 
 }  // namespace flutter

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -15,12 +15,15 @@ namespace flutter {
 ///
 class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
  public:
-  using EndFrameCallBack = std::function<void(bool)>;
+  using EndFrameCallBack =
+      std::function<void(bool, fml::RefPtr<fml::RasterThreadMerger>)>;
 
   ShellTestExternalViewEmbedder(const EndFrameCallBack& end_frame_call_back,
-                                PostPrerollResult post_preroll_result)
+                                PostPrerollResult post_preroll_result,
+                                bool support_thread_merging)
       : end_frame_call_back_(end_frame_call_back),
-        post_preroll_result_(post_preroll_result) {}
+        post_preroll_result_(post_preroll_result),
+        support_thread_merging_(support_thread_merging) {}
 
   ~ShellTestExternalViewEmbedder() = default;
 
@@ -67,6 +70,8 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
 
   const EndFrameCallBack end_frame_call_back_;
   const PostPrerollResult post_preroll_result_;
+
+  bool support_thread_merging_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTestExternalViewEmbedder);
 };

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -66,7 +66,7 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
   SkCanvas* GetRootCanvas() override;
 
   // |ExternalViewEmbedder|
-  bool SupportDynamicThreadMerging() override;
+  bool SupportsDynamicThreadMerging() override;
 
   const EndFrameCallBack end_frame_call_back_;
   const PostPrerollResult post_preroll_result_;

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -62,6 +62,9 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
   // |ExternalViewEmbedder|
   SkCanvas* GetRootCanvas() override;
 
+  // |ExternalViewEmbedder|
+  bool SupportDynamicThreadMerging() override;
+
   const EndFrameCallBack end_frame_call_back_;
   const PostPrerollResult post_preroll_result_;
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -478,18 +478,69 @@ TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
 #if !defined(OS_FUCHSIA)
 // TODO(sanjayc77): https://github.com/flutter/flutter/issues/53179. Add
 // support for raster thread merger for Fuchsia.
+TEST_F(ShellTest, ExternalEmbedderNoThreadMerger) {
+  auto settings = CreateSettingsForFixture();
+  fml::AutoResetWaitableEvent endFrameLatch;
+  bool end_frame_called = false;
+  auto end_frame_callback =
+      [&](bool should_resubmit_frame,
+          fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
+        ASSERT_TRUE(raster_thread_merger.get() == nullptr);
+        ASSERT_FALSE(should_resubmit_frame);
+        end_frame_called = true;
+        endFrameLatch.Signal();
+      };
+  auto external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
+      end_frame_callback, PostPrerollResult::kResubmitFrame, false);
+  auto shell = CreateShell(std::move(settings), GetTaskRunnersForFixture(),
+                           false, external_view_embedder);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+
+  RunEngine(shell.get(), std::move(configuration));
+
+  LayerTreeBuilder builder = [&](std::shared_ptr<ContainerLayer> root) {
+    SkPictureRecorder recorder;
+    SkCanvas* recording_canvas =
+        recorder.beginRecording(SkRect::MakeXYWH(0, 0, 80, 80));
+    recording_canvas->drawRect(SkRect::MakeXYWH(0, 0, 80, 80),
+                               SkPaint(SkColor4f::FromColor(SK_ColorRED)));
+    auto sk_picture = recorder.finishRecordingAsPicture();
+    fml::RefPtr<SkiaUnrefQueue> queue = fml::MakeRefCounted<SkiaUnrefQueue>(
+        this->GetCurrentTaskRunner(), fml::TimeDelta::FromSeconds(0));
+    auto picture_layer = std::make_shared<PictureLayer>(
+        SkPoint::Make(10, 10),
+        flutter::SkiaGPUObject<SkPicture>({sk_picture, queue}), false, false);
+    root->Add(picture_layer);
+  };
+
+  PumpOneFrame(shell.get(), 100, 100, builder);
+  endFrameLatch.Wait();
+
+  ASSERT_TRUE(end_frame_called);
+
+  DestroyShell(std::move(shell));
+}
+
 TEST_F(ShellTest,
        ExternalEmbedderEndFrameIsCalledWhenPostPrerollResultIsResubmit) {
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent endFrameLatch;
   bool end_frame_called = false;
-  auto end_frame_callback = [&](bool should_resubmit_frame) {
-    ASSERT_TRUE(should_resubmit_frame);
-    end_frame_called = true;
-    endFrameLatch.Signal();
-  };
+  auto end_frame_callback =
+      [&](bool should_resubmit_frame,
+          fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
+        ASSERT_TRUE(raster_thread_merger.get() != nullptr);
+        ASSERT_TRUE(should_resubmit_frame);
+        end_frame_called = true;
+        endFrameLatch.Signal();
+      };
   auto external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(
-      end_frame_callback, PostPrerollResult::kResubmitFrame);
+      end_frame_callback, PostPrerollResult::kResubmitFrame, true);
   auto shell = CreateShell(std::move(settings), GetTaskRunnersForFixture(),
                            false, external_view_embedder);
 

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -295,4 +295,9 @@ void AndroidExternalViewEmbedder::EndFrame(
   }
 }
 
+// |ExternalViewEmbedder|
+bool AndroidExternalViewEmbedder::SupportsDynamicThreadMerging() {
+  return true;
+}
+
 }  // namespace flutter

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -70,6 +70,8 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
       bool should_resubmit_frame,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
+  bool SupportsDynamicThreadMerging() override;
+
   // Gets the rect based on the device pixel ratio of a platform view displayed
   // on the screen.
   SkRect GetViewRect(int view_id) const;

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -556,5 +556,13 @@ TEST(AndroidExternalViewEmbedder, DestroyOverlayLayersOnSizeChange) {
                        raster_thread_merger);
 }
 
+TEST(AndroidExternalViewEmbedder, SupportsDynamicThreadMerging) {
+  auto jni_mock = std::make_shared<JNIMock>();
+
+  auto embedder =
+      std::make_unique<AndroidExternalViewEmbedder>(nullptr, jni_mock, nullptr);
+  ASSERT_TRUE(embedder->SupportDynamicThreadMerging(), true);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -561,7 +561,7 @@ TEST(AndroidExternalViewEmbedder, SupportsDynamicThreadMerging) {
 
   auto embedder =
       std::make_unique<AndroidExternalViewEmbedder>(nullptr, jni_mock, nullptr);
-  ASSERT_TRUE(embedder->SupportDynamicThreadMerging(), true);
+  ASSERT_TRUE(embedder->SupportsDynamicThreadMerging());
 }
 
 }  // namespace testing

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -89,7 +89,7 @@ class IOSSurface : public ExternalViewEmbedder {
                 fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
   // |ExternalViewEmbedder|
-  bool SupportDynamicThreadMerging() override;
+  bool SupportsDynamicThreadMerging() override;
 
  public:
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurface);

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -88,6 +88,9 @@ class IOSSurface : public ExternalViewEmbedder {
   void EndFrame(bool should_resubmit_frame,
                 fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
+  // |ExternalViewEmbedder|
+  bool SupportDynamicThreadMerging() override;
+
  public:
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurface);
 };

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -155,4 +155,9 @@ void IOSSurface::EndFrame(bool should_resubmit_frame,
   return platform_views_controller_->EndFrame(should_resubmit_frame, raster_thread_merger);
 }
 
+// |ExternalViewEmbedder|
+bool IOSSurface::SupportDynamicThreadMerging() {
+  return true;
+}
+
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -156,7 +156,7 @@ void IOSSurface::EndFrame(bool should_resubmit_frame,
 }
 
 // |ExternalViewEmbedder|
-bool IOSSurface::SupportDynamicThreadMerging() {
+bool IOSSurface::SupportsDynamicThreadMerging() {
   return true;
 }
 


### PR DESCRIPTION
## Description

Currently, we create raster_thread_merger when there is an external embedder. This is no entirely necessary as some platforms don't need raster_thread_merger. This PR makes the embedding platform ask for support raster_thread_merger_ explicitly. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/38844

## Tests

I added the following tests:

ShellTest::ExternalEmbedderNoThreadMerger

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
