### PR TITLE
Enable iOS plumbing for network security and add tests

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -920,6 +920,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryM
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -208,6 +208,7 @@ shared_library("ios_test_flutter") {
   ]
   sources = [
     "framework/Source/FlutterBinaryMessengerRelayTest.mm",
+    "framework/Source/FlutterDartProjectTest.mm",
     "framework/Source/FlutterEngineTest.mm",
     "framework/Source/FlutterPluginAppLifeCycleDelegateTest.m",
     "framework/Source/FlutterTextInputPluginTest.m",

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProjectTest.mm
@@ -1,0 +1,85 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <XCTest/XCTest.h>
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h"
+
+FLUTTER_ASSERT_ARC
+
+@interface FlutterDartProjectTest : XCTestCase
+@end
+
+@implementation FlutterDartProjectTest
+
+- (void)setUp {
+}
+
+- (void)tearDown {
+}
+
+- (void)testMainBundleSettingsAreCorrectlyParsed {
+  NSBundle* mainBundle = [NSBundle mainBundle];
+  NSDictionary* appTransportSecurity =
+      [mainBundle objectForInfoDictionaryKey:@"NSAppTransportSecurity"];
+  XCTAssertTrue([FlutterDartProject allowsArbitraryLoads:appTransportSecurity]);
+  XCTAssertEqualObjects(
+      @"[[\"invalid-site.com\",true,false],[\"sub.invalid-site.com\",false,false]]",
+      [FlutterDartProject domainNetworkPolicy:appTransportSecurity]);
+}
+
+- (void)testEmptySettingsAreCorrect {
+  XCTAssertFalse([FlutterDartProject allowsArbitraryLoads:[[NSDictionary alloc] init]]);
+  XCTAssertEqualObjects(@"", [FlutterDartProject domainNetworkPolicy:[[NSDictionary alloc] init]]);
+}
+
+- (void)testAllowsArbitraryLoads {
+  XCTAssertFalse([FlutterDartProject allowsArbitraryLoads:@{@"NSAllowsArbitraryLoads" : @false}]);
+  XCTAssertTrue([FlutterDartProject allowsArbitraryLoads:@{@"NSAllowsArbitraryLoads" : @true}]);
+}
+
+- (void)testProperlyFormedExceptionDomains {
+  NSDictionary* domainInfoOne = @{
+    @"NSIncludesSubdomains" : @false,
+    @"NSExceptionAllowsInsecureHTTPLoads" : @true,
+    @"NSExceptionMinimumTLSVersion" : @"4.0"
+  };
+  NSDictionary* domainInfoTwo = @{
+    @"NSIncludesSubdomains" : @true,
+    @"NSExceptionAllowsInsecureHTTPLoads" : @false,
+    @"NSExceptionMinimumTLSVersion" : @"4.0"
+  };
+  NSDictionary* domainInfoThree = @{
+    @"NSIncludesSubdomains" : @false,
+    @"NSExceptionAllowsInsecureHTTPLoads" : @true,
+    @"NSExceptionMinimumTLSVersion" : @"4.0"
+  };
+  NSDictionary* exceptionDomains = @{
+    @"domain.name" : domainInfoOne,
+    @"sub.domain.name" : domainInfoTwo,
+    @"sub.two.domain.name" : domainInfoThree
+  };
+  NSDictionary* appTransportSecurity = @{@"NSExceptionDomains" : exceptionDomains};
+  XCTAssertEqualObjects(@"[[\"domain.name\",false,true],[\"sub.domain.name\",true,false],"
+                        @"[\"sub.two.domain.name\",false,true]]",
+                        [FlutterDartProject domainNetworkPolicy:appTransportSecurity]);
+}
+
+- (void)testExceptionDomainsWithMissingInfo {
+  NSDictionary* domainInfoOne = @{@"NSExceptionMinimumTLSVersion" : @"4.0"};
+  NSDictionary* domainInfoTwo = @{
+    @"NSIncludesSubdomains" : @true,
+  };
+  NSDictionary* domainInfoThree = @{};
+  NSDictionary* exceptionDomains = @{
+    @"domain.name" : domainInfoOne,
+    @"sub.domain.name" : domainInfoTwo,
+    @"sub.two.domain.name" : domainInfoThree
+  };
+  NSDictionary* appTransportSecurity = @{@"NSExceptionDomains" : exceptionDomains};
+  XCTAssertEqualObjects(@"[[\"domain.name\",false,false],[\"sub.domain.name\",true,false],"
+                        @"[\"sub.two.domain.name\",false,false]]",
+                        [FlutterDartProject domainNetworkPolicy:appTransportSecurity]);
+}
+
+@end

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
@@ -23,6 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
                                               libraryOrNil:(nullable NSString*)dartLibraryOrNil;
 
 + (NSString*)flutterAssetsName:(NSBundle*)bundle;
++ (NSString*)domainNetworkPolicy:(NSDictionary*)appTransportSecurity;
++ (bool)allowsArbitraryLoads:(NSDictionary*)appTransportSecurity;
 
 /**
  * The embedder can specify data that the isolate can request synchronously on launch. Engines

--- a/testing/ios/IosUnitTests/App/Info.plist
+++ b/testing/ios/IosUnitTests/App/Info.plist
@@ -24,6 +24,26 @@
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+                <key>NSExceptionDomains</key>
+		<dict>
+			<key>invalid-site.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>sub.invalid-site.com</key>
+                        <dict>
+                                <key>NSThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+                                <false/>
+                        </dict>
+		</dict>
+	</dict>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
This is a continuation of https://github.com/flutter/engine/pull/20218. Copy pasted its description. This PR adds tests for the iOS code.

The feature is still disabled. We will enable it after the announcement is made.

## Description

Starting API 28[1] and iOS 9[2], insecure connections are banned on native platform by default. Flutter, on the other hand, uses Dart VM's HTTP implementation which integrates with Sockets directly. This circumvents the security features on the platform and allows insecure connections.

We attempted to clamp the HTTP connections with a previous PR but this was deemed inadequate because it was ignoring platform level configuration leaving it up to users to allow insecure connections in Dart code via zones. (https://github.com/flutter/engine/pull/17653).

This PR effectively reverts the aforementioned PR and replaces it with a new set of embedder configurations I have added to Dart VM via https://dart-review.googlesource.com/c/sdk/+/154180. With these new settings we can convert iOS and Android network configuration into Dart network configuration. This allows embedder to start the Dart isolate with an immutable network policy derived from the platform configuration.

## Related Issues

https://github.com/flutter/flutter/issues/54448

## Tests

The biggest code change is how Android parses `ApplicationInfo`. Previously all this was scattered in the loader. I pulled it out and added parsing for the network configuration. I have added unit tests for these classes.

I would love to add a couple of end-to-end tests as well on Android and iOS but I am unsure how to do so. **Please advise**.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [x] Primary discussion at go/disable-http-flutter-dd and https://github.com/dart-lang/sdk/issues/40548.
   - [x] I got input from the developer relations team, specifically from: @RedBrogdon 
   - [x] I wrote a migration guide: https://github.com/flutter/website/pull/4458

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
