### PR TITLE
[macOS] Refactor resizing logic to FlutterWindowController

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1025,6 +1025,8 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterView.
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterView.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/module.modulemap
 FILE: ../../../flutter/shell/platform/embedder/assets/EmbedderInfo.plist

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -62,6 +62,8 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterView.mm",
     "framework/Source/FlutterViewController.mm",
     "framework/Source/FlutterViewController_Internal.h",
+    "framework/Source/FlutterWindowController.h",
+    "framework/Source/FlutterWindowController.mm",
   ]
 
   sources += _flutter_framework_headers

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -3,16 +3,7 @@
 // found in the LICENSE file.
 
 #import <Cocoa/Cocoa.h>
-
-/**
- * Listener for view resizing.
- */
-@protocol FlutterViewReshapeListener <NSObject>
-/**
- * Called when the view's backing store changes size.
- */
-- (void)viewDidReshape:(nonnull NSView*)view;
-@end
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h"
 
 /**
  * View capable of acting as a rendering target and input source for the Flutter

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -39,11 +39,6 @@
   return YES;
 }
 
-- (void)reshape {
-  [super reshape];
-  [_reshapeListener viewDidReshape:self];
-}
-
 - (BOOL)acceptsFirstResponder {
   return YES;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -194,6 +194,9 @@ struct KeyboardState {
 
   // A method channel for miscellaneous platform functionality.
   FlutterMethodChannel* _platformChannel;
+
+  // Handler for window size changes.
+  FlutterWindowController* _windowController;
 }
 
 @dynamic view;
@@ -255,6 +258,11 @@ static void CommonInit(FlutterViewController* controller) {
     [self launchEngine];
   }
   [self listenForMetaModifiedKeyUpEvents];
+}
+
+- (void)viewDidAppear {
+  [super viewDidAppear];
+  _windowController = [[FlutterWindowController alloc] initWithView:self.view reshapeListener:self];
 }
 
 - (void)viewWillDisappear {

--- a/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERWINDOWCONTROLLER_H_
+#define SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERWINDOWCONTROLLER_H_
+
+#import <Cocoa/Cocoa.h>
+
+/**
+ * Listener for view resizing.
+ */
+@protocol FlutterViewReshapeListener <NSObject>
+/**
+ * Called when the view's backing store changes size or the view bounds change.
+ */
+- (void)viewDidReshape:(nonnull NSView*)view;
+@end
+
+/**
+ * Window controller for the main application window.
+ */
+@interface FlutterWindowController : NSObject <NSWindowDelegate> {
+ @private
+  __weak NSView* _view;
+  __weak id<FlutterViewReshapeListener> _reshapeListener;
+}
+
+- (nullable id)initWithView:(nonnull NSView*)view
+            reshapeListener:(nonnull id<FlutterViewReshapeListener>)reshapeListener;
+
+@end
+
+#endif  // SHELL_PLATFORM_DARWIN_MACOS_FRAMEWORK_SOURCE_FLUTTERWINDOWCONTROLLER_H_

--- a/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterWindowController.mm
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterWindowController.h"
+
+@implementation FlutterWindowController
+
+- (id)initWithView:(nonnull NSView*)view
+    reshapeListener:(nonnull id<FlutterViewReshapeListener>)reshapeListener {
+  _view = view;
+  [view.window setDelegate:self];
+  _reshapeListener = reshapeListener;
+  return self;
+}
+
+#pragma mark - NSWindowDelegate overrides.
+
+- (NSSize)windowWillResize:(NSWindow*)sender toSize:(NSSize)frameSize {
+  [_reshapeListener viewDidReshape:_view];
+  return frameSize;
+}
+
+- (void)windowDidResize:(NSNotification*)notification {
+  // Calls to windowWillResize:toSize: are not matched evenly with calls to windowDidResize: because
+  // the former is NOT called in the event that you are setting the window's size with
+  // setContentSize: or setFrame:, but windowDidResize: is. Hence we need to update the  viewport
+  // metrics on windowDidResize as well.
+  [_reshapeListener viewDidReshape:_view];
+}
+
+@end


### PR DESCRIPTION
Prior to this change we rely on NSOpenGlView's reshape to trigger resize
this change makes it so that we rely on the notifications received by
the window containing the FlutterView instead.

This change lets us then use windowWillResize and windowDidResize life
cycle methods to control the rendering before during and after resizing
the window.

There is expected to be no behavior change.

This is done as one of the steps to address https://github.com/flutter/flutter/issues/44136