### PR TITLE
Create PlatformView instance right after method channel call from Dart

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -120,7 +120,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
                 "Trying to create a view with unknown direction value: "
                     + request.direction
                     + "(view id: "
-                    + viewId
+                    + request.viewId
                     + ")");
           }
 
@@ -130,14 +130,13 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
                 "Trying to create a platform view of unregistered type: " + request.viewType);
           }
 
-          final Object createParams = null;
+          Object createParams = null;
           if (request.params != null) {
             createParams = factory.getCreateArgsCodec().decodeMessage(request.params);
           }
 
-          final PlatformView platformView = factory.create(context, viewId, createParams);
+          final PlatformView platformView = factory.create(context, request.viewId, createParams);
           final View view = platformView.getView();
-
           if (view == null) {
             throw new IllegalStateException(
                 "PlatformView#getView() returned null, but an Android view reference was expected.");
@@ -146,7 +145,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
             throw new IllegalStateException(
                 "The Android view returned from PlatformView#getView() was already added to a parent view.");
           }
-          platformViews.put(viewId, view);
+          platformViews.put(request.viewId, view);
         }
 
         @Override

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -107,18 +107,51 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
         @Override
         public void createAndroidViewForPlatformView(
             @NonNull PlatformViewsChannel.PlatformViewCreationRequest request) {
-          // API level 19 is required for android.graphics.ImageReader.
+          // API level 19 is required for `android.graphics.ImageReader`.
           ensureValidAndroidVersion(Build.VERSION_CODES.KITKAT);
-          platformViewRequests.put(request.viewId, request);
+
+          if (request == null) {
+            throw new IllegalStateException(
+                "Platform view hasn't been initialized from the platform view channel.");
+          }
+
+          if (!validateDirection(request.direction)) {
+            throw new IllegalStateException(
+                "Trying to create a view with unknown direction value: "
+                    + request.direction
+                    + "(view id: "
+                    + viewId
+                    + ")");
+          }
+
+          final PlatformViewFactory factory = registry.getFactory(request.viewType);
+          if (factory == null) {
+            throw new IllegalStateException(
+                "Trying to create a platform view of unregistered type: " + request.viewType);
+          }
+
+          final Object createParams = null;
+          if (request.params != null) {
+            createParams = factory.getCreateArgsCodec().decodeMessage(request.params);
+          }
+
+          final PlatformView platformView = factory.create(context, viewId, createParams);
+          final View view = platformView.getView();
+
+          if (view == null) {
+            throw new IllegalStateException(
+                "PlatformView#getView() returned null, but an Android view reference was expected.");
+          }
+          if (view.getParent() != null) {
+            throw new IllegalStateException(
+                "The Android view returned from PlatformView#getView() was already added to a parent view.");
+          }
+          platformViews.put(viewId, view);
         }
 
         @Override
         public void disposeAndroidViewForPlatformView(int viewId) {
           // Hybrid view.
-          if (platformViewRequests.get(viewId) != null) {
-            platformViewRequests.remove(viewId);
-          }
-
           final View platformView = platformViews.get(viewId);
           if (platformView != null) {
             final FlutterMutatorView mutatorView = mutatorViews.get(viewId);
@@ -651,50 +684,15 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
 
   @VisibleForTesting
   void initializePlatformViewIfNeeded(int viewId) {
-    if (platformViews.get(viewId) != null) {
-      return;
-    }
-
-    PlatformViewsChannel.PlatformViewCreationRequest request = platformViewRequests.get(viewId);
-    if (request == null) {
+    final View view = platformViews.get(viewId);
+    if (view == null) {
       throw new IllegalStateException(
           "Platform view hasn't been initialized from the platform view channel.");
     }
-
-    if (!validateDirection(request.direction)) {
-      throw new IllegalStateException(
-          "Trying to create a view with unknown direction value: "
-              + request.direction
-              + "(view id: "
-              + viewId
-              + ")");
+    if (mutatorViews.get(viewId) != null) {
+      return;
     }
-
-    PlatformViewFactory factory = registry.getFactory(request.viewType);
-    if (factory == null) {
-      throw new IllegalStateException(
-          "Trying to create a platform view of unregistered type: " + request.viewType);
-    }
-
-    Object createParams = null;
-    if (request.params != null) {
-      createParams = factory.getCreateArgsCodec().decodeMessage(request.params);
-    }
-
-    PlatformView platformView = factory.create(context, viewId, createParams);
-    View view = platformView.getView();
-
-    if (view == null) {
-      throw new IllegalStateException(
-          "PlatformView#getView() returned null, but an Android view reference was expected.");
-    }
-    if (view.getParent() != null) {
-      throw new IllegalStateException(
-          "The Android view returned from PlatformView#getView() was already added to a parent view.");
-    }
-    platformViews.put(viewId, view);
-
-    FlutterMutatorView mutatorView =
+    final FlutterMutatorView mutatorView =
         new FlutterMutatorView(
             context, context.getResources().getDisplayMetrics().density, androidTouchProcessor);
     mutatorViews.put(viewId, mutatorView);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -79,7 +79,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   // it is associated with(e.g if a platform view creates other views in the same virtual display.
   private final HashMap<Context, View> contextToPlatformView;
 
-  private final SparseArray<PlatformViewsChannel.PlatformViewCreationRequest> platformViewRequests;
   private final SparseArray<View> platformViews;
   private final SparseArray<FlutterMutatorView> mutatorViews;
 
@@ -410,7 +409,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     currentFrameUsedOverlayLayerIds = new HashSet<>();
     currentFrameUsedPlatformViewIds = new HashSet<>();
 
-    platformViewRequests = new SparseArray<>();
     platformViews = new SparseArray<>();
     mutatorViews = new SparseArray<>();
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -109,11 +109,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
           // API level 19 is required for `android.graphics.ImageReader`.
           ensureValidAndroidVersion(Build.VERSION_CODES.KITKAT);
 
-          if (request == null) {
-            throw new IllegalStateException(
-                "Platform view hasn't been initialized from the platform view channel.");
-          }
-
           if (!validateDirection(request.direction)) {
             throw new IllegalStateException(
                 "Trying to create a view with unknown direction value: "

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.util.SparseArray;
 import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.SurfaceHolder;
@@ -518,7 +519,7 @@ public class PlatformViewsControllerTest {
 
   @Implements(FlutterJNI.class)
   public static class ShadowFlutterJNI {
-    private static Map<Integer, ByteBuffer> replies = new HashMap<>();
+    private static SparseArray<ByteBuffer> replies = new SparseArray<>();
 
     public ShadowFlutterJNI() {}
 
@@ -569,7 +570,7 @@ public class PlatformViewsControllerTest {
       replies.put(responseId, message);
     }
 
-    public static Map<Integer, ByteBuffer> getResponses() {
+    public static SparseArray<ByteBuffer> getResponses() {
       return replies;
     }
   }

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -28,7 +28,9 @@ import io.flutter.embedding.engine.systemchannels.KeyEventChannel;
 import io.flutter.embedding.engine.systemchannels.MouseCursorChannel;
 import io.flutter.embedding.engine.systemchannels.SettingsChannel;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
+import io.flutter.plugin.common.FlutterException;
 import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.common.StandardMethodCodec;
 import io.flutter.plugin.localization.LocalizationPlugin;
 import java.nio.ByteBuffer;
@@ -242,7 +244,29 @@ public class PlatformViewsControllerTest {
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class})
-  public void initializePlatformViewIfNeeded__throwsIfViewIsNull() {
+  public void createPlatformViewMessage__initializesAndroidView() {
+    PlatformViewsController platformViewsController = new PlatformViewsController();
+
+    int platformViewId = 0;
+    assertNull(platformViewsController.getPlatformViewById(platformViewId));
+
+    PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
+    PlatformView platformView = mock(PlatformView.class);
+    when(platformView.getView()).thenReturn(mock(View.class));
+    when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
+    platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
+
+    FlutterJNI jni = new FlutterJNI();
+    attach(jni, platformViewsController);
+
+    // Simulate create call from the framework.
+    createPlatformView(jni, platformViewsController, platformViewId, "testType");
+    verify(platformView, times(1)).getView();
+  }
+
+  @Test
+  @Config(shadows = {ShadowFlutterJNI.class})
+  public void createPlatformViewMessage__throwsIfViewIsNull() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -259,22 +283,28 @@ public class PlatformViewsControllerTest {
 
     // Simulate create call from the framework.
     createPlatformView(jni, platformViewsController, platformViewId, "testType");
+    assertEquals(ShadowFlutterJNI.getResponses().size(), 1);
 
+    final ByteBuffer responseBuffer = ShadowFlutterJNI.getResponses().get(0);
+    responseBuffer.rewind();
+
+    StandardMethodCodec methodCodec = new StandardMethodCodec(new StandardMessageCodec());
     try {
-      platformViewsController.initializePlatformViewIfNeeded(platformViewId);
-    } catch (Exception exception) {
-      assertTrue(exception instanceof IllegalStateException);
-      assertEquals(
-          exception.getMessage(),
-          "PlatformView#getView() returned null, but an Android view reference was expected.");
+      methodCodec.decodeEnvelope(responseBuffer);
+    } catch (FlutterException exception) {
+      assertTrue(
+          exception
+              .getMessage()
+              .contains(
+                  "PlatformView#getView() returned null, but an Android view reference was expected."));
       return;
     }
-    assertTrue(false);
+    assertFalse(true);
   }
 
   @Test
   @Config(shadows = {ShadowFlutterJNI.class})
-  public void initializePlatformViewIfNeeded__throwsIfViewHasParent() {
+  public void createPlatformViewMessage__throwsIfViewHasParent() {
     PlatformViewsController platformViewsController = new PlatformViewsController();
 
     int platformViewId = 0;
@@ -293,16 +323,23 @@ public class PlatformViewsControllerTest {
 
     // Simulate create call from the framework.
     createPlatformView(jni, platformViewsController, platformViewId, "testType");
+    assertEquals(ShadowFlutterJNI.getResponses().size(), 1);
+
+    final ByteBuffer responseBuffer = ShadowFlutterJNI.getResponses().get(0);
+    responseBuffer.rewind();
+
+    StandardMethodCodec methodCodec = new StandardMethodCodec(new StandardMessageCodec());
     try {
-      platformViewsController.initializePlatformViewIfNeeded(platformViewId);
-    } catch (Exception exception) {
-      assertTrue(exception instanceof IllegalStateException);
-      assertEquals(
-          exception.getMessage(),
-          "The Android view returned from PlatformView#getView() was already added to a parent view.");
+      methodCodec.decodeEnvelope(responseBuffer);
+    } catch (FlutterException exception) {
+      assertTrue(
+          exception
+              .getMessage()
+              .contains(
+                  "The Android view returned from PlatformView#getView() was already added to a parent view."));
       return;
     }
-    assertTrue(false);
+    assertFalse(true);
   }
 
   @Test
@@ -481,6 +518,7 @@ public class PlatformViewsControllerTest {
 
   @Implements(FlutterJNI.class)
   public static class ShadowFlutterJNI {
+    private static Map<Integer, ByteBuffer> replies = new HashMap<>();
 
     public ShadowFlutterJNI() {}
 
@@ -527,7 +565,13 @@ public class PlatformViewsControllerTest {
 
     @Implementation
     public void invokePlatformMessageResponseCallback(
-        int responseId, ByteBuffer message, int position) {}
+        int responseId, ByteBuffer message, int position) {
+      replies.put(responseId, message);
+    }
+
+    public static Map<Integer, ByteBuffer> getResponses() {
+      return replies;
+    }
   }
 
   @Implements(SurfaceView.class)


### PR DESCRIPTION
## Description

This makes the order of callback execution equivalent to the one in the virtual display code path.

## Related Issues

https://github.com/flutter/flutter/issues/63691

## Tests

I added the following tests: Unit tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
