### PR TITLE
Missing default focus when navigating to a page with no SemanticsNode that sets namesRoute:true

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1548,6 +1548,17 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     AccessibilityEvent event =
         obtainAccessibilityEvent(route.id, AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
     String routeName = route.getRouteName();
+    if (routeName == null) {
+      // The routeName will be null when there is no semantics node that represnets namesRoute in
+      // the scopeRoute. The TYPE_WINDOW_STATE_CHANGED only works the route name is not null and not
+      // empty. Gives it a while space will make it focus the first semantics node without
+      // pronouncing any word.
+      //
+      // The other way to trigger a focus change is to send a TYPE_VIEW_FOCUSED to the
+      // rootAccessibilityView. However, it is less predictable which semantics node it will focus
+      // next.
+      routeName = " ";
+    }
     event.getText().add(routeName);
     sendAccessibilityEvent(event);
   }

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1551,7 +1551,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     if (routeName == null) {
       // The routeName will be null when there is no semantics node that represnets namesRoute in
       // the scopeRoute. The TYPE_WINDOW_STATE_CHANGED only works the route name is not null and not
-      // empty. Gives it a while space will make it focus the first semantics node without
+      // empty. Gives it a whitespace will make it focus the first semantics node without
       // pronouncing any word.
       //
       // The other way to trigger a focus change is to send a TYPE_VIEW_FOCUSED to the

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -20,7 +20,6 @@ import android.view.ViewParent;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
-import android.util.Log;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.platform.PlatformViewsAccessibilityDelegate;
 import java.nio.ByteBuffer;

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -141,7 +141,7 @@ public class AccessibilityBridgeTest {
     when(mockRootView.getContext()).thenReturn(context);
     when(context.getPackageName()).thenReturn("test");
     AccessibilityBridge accessibilityBridge =
-            setUpBridge(mockRootView, mockManager, mockViewEmbedder);
+        setUpBridge(mockRootView, mockManager, mockViewEmbedder);
     ViewParent mockParent = mock(ViewParent.class);
     when(mockRootView.getParent()).thenReturn(mockParent);
     when(mockManager.isEnabled()).thenReturn(true);
@@ -157,15 +157,14 @@ public class AccessibilityBridgeTest {
     accessibilityBridge.updateSemantics(testSemanticsUpdate.buffer, testSemanticsUpdate.strings);
 
     ArgumentCaptor<AccessibilityEvent> eventCaptor =
-            ArgumentCaptor.forClass(AccessibilityEvent.class);
+        ArgumentCaptor.forClass(AccessibilityEvent.class);
     verify(mockParent, times(2))
-            .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
     AccessibilityEvent event = eventCaptor.getAllValues().get(0);
     assertEquals(event.getEventType(), AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
     List<CharSequence> sentences = event.getText();
     assertEquals(sentences.size(), 1);
     assertEquals(sentences.get(0).toString(), " ");
-
   }
 
   @Test


### PR DESCRIPTION
## Description

Add whitespace string when there is no namesRoute

## Related Issues

Fixes https://github.com/flutter/flutter/issues/63685

## Tests

I added the following tests:
see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
