### PR TITLE
Handle glfwGetPrimaryMonitor returning nullptr

### DIFF
--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -185,7 +185,7 @@ static FlutterDesktopMessage ConvertToDesktopMessage(
 static double GetScreenCoordinatesPerInch() {
   auto* primary_monitor = glfwGetPrimaryMonitor();
   if (primary_monitor == nullptr) {
-    return kDpPerInch; 
+    return kDpPerInch;
   }
   auto* primary_monitor_mode = glfwGetVideoMode(primary_monitor);
   int primary_monitor_width_mm;

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -184,6 +184,9 @@ static FlutterDesktopMessage ConvertToDesktopMessage(
 // that a screen coordinate is one dp.
 static double GetScreenCoordinatesPerInch() {
   auto* primary_monitor = glfwGetPrimaryMonitor();
+  if (primary_monitor == nullptr) {
+    return kDpPerInch; 
+  }
   auto* primary_monitor_mode = glfwGetVideoMode(primary_monitor);
   int primary_monitor_width_mm;
   glfwGetMonitorPhysicalSize(primary_monitor, &primary_monitor_width_mm,


### PR DESCRIPTION
## Description

[glfwGetPrimaryMonitor](https://www.glfw.org/docs/3.3/group__monitor.html#ga721867d84c6d18d6790d64d2847ca0b1) may return NULL in non-error cases when no monitor is found. This started to happen recently with an update to the linux distribution, see internal b/162545223.

Handling this case avoids a crash and instead assumes a pixel density.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
