### PR TITLE
Fix font sorting problem due to iOS 14 fonts being broader

### DIFF
--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -204,31 +204,39 @@ std::shared_ptr<minikin::FontFamily> FontCollection::FindFontFamilyInManagers(
 
 void FontCollection::SortSkTypefaces(
     std::vector<sk_sp<SkTypeface>>& sk_typefaces) {
-  std::sort(sk_typefaces.begin(), sk_typefaces.end(),
-            [](const sk_sp<SkTypeface>& a, const sk_sp<SkTypeface>& b) {
-              SkFontStyle a_style = a->fontStyle();
-              SkFontStyle b_style = b->fontStyle();
+  std::sort(
+      sk_typefaces.begin(), sk_typefaces.end(),
+      [](const sk_sp<SkTypeface>& a, const sk_sp<SkTypeface>& b) {
+        SkFontStyle a_style = a->fontStyle();
+        SkFontStyle b_style = b->fontStyle();
 
-              if (a_style.width() != b_style.width()) {
-                // If a family name query is so generic it ends up bringing in
-                // fonts of multiple widths (e.g. condensed, expanded), opt to
-                // be conservative and select the most standard width.
-                //
-                // If a specific width is desired, it should be be narrowed down
-                // via the family name.
-                //
-                // The font weights are also sorted lightest to heaviest but
-                // Flutter APIs have the weight specified to narrow it down
-                // later. The width ordering here is more consequential since
-                // TextStyle doesn't have letter width APIs.
-                return std::abs(a_style.width() - SkFontStyle::kNormal_Width) <
-                       std::abs(b_style.width() - SkFontStyle::kNormal_Width);
-              } else {
-                return (a_style.weight() != b_style.weight())
-                           ? a_style.weight() < b_style.weight()
-                           : a_style.slant() < b_style.slant();
-              }
-            });
+        int a_delta = std::abs(a_style.width() - SkFontStyle::kNormal_Width);
+        int b_delta = std::abs(b_style.width() - SkFontStyle::kNormal_Width);
+
+        if (a_delta != b_delta) {
+          // If a family name query is so generic it ends up bringing in fonts
+          // of multiple widths (e.g. condensed, expanded), opt to be
+          // conservative and select the most standard width.
+          //
+          // If a specific width is desired, it should be be narrowed down via
+          // the family name.
+          //
+          // The font weights are also sorted lightest to heaviest but Flutter
+          // APIs have the weight specified to narrow it down later. The width
+          // ordering here is more consequential since TextStyle doesn't have
+          // letter width APIs.
+          return a_delta < b_delta;
+        } else if (a_style.width() != b_style.width()) {
+          // However, if the 2 fonts are equidistant from the "normal" width,
+          // just arbitrarily but consistently return the more condensed font.
+          return a_style.width() < b_style.width();
+        } else if (a_style.weight() != b_style.weight()) {
+          return a_style.weight() < b_style.weight();
+        } else {
+          return a_style.slant() < b_style.slant();
+        }
+        // Use a cascade of conditions so results are consistent each time.
+      });
 }
 
 std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -223,11 +223,12 @@ std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
     }
   }
 
-  std::sort(skia_typefaces.begin(), skia_typefaces.end(),
-            [](const sk_sp<SkTypeface>& a, const sk_sp<SkTypeface>& b) {
-              SkFontStyle a_style = a->fontStyle();
-              SkFontStyle b_style = b->fontStyle();
-              return (a_style.width() != b_style.width())
+  std::sort(
+      skia_typefaces.begin(), skia_typefaces.end(),
+      [](const sk_sp<SkTypeface>& a, const sk_sp<SkTypeface>& b) {
+        SkFontStyle a_style = a->fontStyle();
+        SkFontStyle b_style = b->fontStyle();
+        return (a_style.width() != b_style.width())
                    // If a family name query is so generic it ends up bringing
                    // in fonts of multiple widths (e.g. condensed, expanded),
                    // opt to be conservative and select the most standard width.
@@ -239,7 +240,7 @@ std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
                    : (a_style.weight() != b_style.weight())
                          ? a_style.weight() < b_style.weight()
                          : a_style.slant() < b_style.slant();
-            });
+      });
 
   std::vector<minikin::Font> minikin_fonts;
   for (const sk_sp<SkTypeface>& skia_typeface : skia_typefaces) {

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -232,9 +232,14 @@ std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
                    // If a family name query is so generic it ends up bringing
                    // in fonts of multiple widths (e.g. condensed, expanded),
                    // opt to be conservative and select the most standard width.
-
+                   //
                    // If a specific width is desired, it should be be narrowed
                    // down via the family name.
+                   //
+                   // The font weights are also sorted lightest to heaviest
+                   // but Flutter APIs have the weight specified to narrow it
+                   // down later. The width ordering here is more consequential
+                   // since TextStyle doesn't have letter width APIs.
                    ? std::abs(a_style.width() - SkFontStyle::kNormal_Width) <
                          std::abs(b_style.width() - SkFontStyle::kNormal_Width)
                    : (a_style.weight() != b_style.weight())

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -227,7 +227,16 @@ std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
             [](const sk_sp<SkTypeface>& a, const sk_sp<SkTypeface>& b) {
               SkFontStyle a_style = a->fontStyle();
               SkFontStyle b_style = b->fontStyle();
-              return (a_style.weight() != b_style.weight())
+              return (a_style.width() != b_style.width())
+                   // If a family name query is so generic it ends up bringing
+                   // in fonts of multiple widths (e.g. condensed, expanded),
+                   // opt to be conservative and select the most standard width.
+
+                   // If a specific width is desired, it should be be narrowed
+                   // down via the family name.
+                   ? std::abs(a_style.width() - SkFontStyle::kNormal_Width) <
+                         std::abs(b_style.width() - SkFontStyle::kNormal_Width)
+                   : (a_style.weight() != b_style.weight())
                          ? a_style.weight() < b_style.weight()
                          : a_style.slant() < b_style.slant();
             });

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -203,7 +203,7 @@ std::shared_ptr<minikin::FontFamily> FontCollection::FindFontFamilyInManagers(
 }
 
 void FontCollection::SortSkTypefaces(
-    std::vector<sk_sp<SkTypeface>> sk_typefaces) {
+    std::vector<sk_sp<SkTypeface>>& sk_typefaces) {
   std::sort(sk_typefaces.begin(), sk_typefaces.end(),
             [](const sk_sp<SkTypeface>& a, const sk_sp<SkTypeface>& b) {
               SkFontStyle a_style = a->fontStyle();

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -130,7 +130,7 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
   // Sorts in-place a group of SkTypeface from an SkTypefaceSet into a
   // reasonable order for future queries.
   FRIEND_TEST(FontCollectionTest, CheckSkTypefacesSorting);
-  static void SortSkTypefaces(std::vector<sk_sp<SkTypeface>> sk_typefaces);
+  static void SortSkTypefaces(std::vector<sk_sp<SkTypeface>>& sk_typefaces);
 
   const std::shared_ptr<minikin::FontFamily>& GetFallbackFontFamily(
       const sk_sp<SkFontMgr>& manager,

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -127,6 +127,11 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
       const sk_sp<SkFontMgr>& manager,
       const std::string& family_name);
 
+  // Sorts in-place a group of SkTypeface from an SkTypefaceSet into a
+  // reasonable order for future queries.
+  FRIEND_TEST(FontCollectionTest, CheckSkTypefacesSorting);
+  static void SortSkTypefaces(std::vector<sk_sp<SkTypeface>> sk_typefaces);
+
   const std::shared_ptr<minikin::FontFamily>& GetFallbackFontFamily(
       const sk_sp<SkFontMgr>& manager,
       const std::string& family_name);

--- a/third_party/txt/tests/font_collection_unittests.cc
+++ b/third_party/txt/tests/font_collection_unittests.cc
@@ -15,7 +15,6 @@
  */
 
 #include "flutter/fml/logging.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "third_party/skia/include/utils/SkCustomTypeface.h"
 #include "txt/font_collection.h"
@@ -34,64 +33,67 @@ void PopulateUserTypeface(SkCustomTypefaceBuilder* builder) {
   constexpr float upem = 200;
 
   {
-      SkFontMetrics metrics;
-      metrics.fFlags = 0;
-      metrics.fTop = -200;
-      metrics.fAscent = -150;
-      metrics.fDescent = 50;
-      metrics.fBottom = -75;
-      metrics.fLeading = 10;
-      metrics.fAvgCharWidth = 150;
-      metrics.fMaxCharWidth = 300;
-      metrics.fXMin = -20;
-      metrics.fXMax = 290;
-      metrics.fXHeight = -100;
-      metrics.fCapHeight = 0;
-      metrics.fUnderlineThickness = 5;
-      metrics.fUnderlinePosition = 2;
-      metrics.fStrikeoutThickness = 5;
-      metrics.fStrikeoutPosition = -50;
-      builder->setMetrics(metrics, 1.0f/upem);
-    }
+    SkFontMetrics metrics;
+    metrics.fFlags = 0;
+    metrics.fTop = -200;
+    metrics.fAscent = -150;
+    metrics.fDescent = 50;
+    metrics.fBottom = -75;
+    metrics.fLeading = 10;
+    metrics.fAvgCharWidth = 150;
+    metrics.fMaxCharWidth = 300;
+    metrics.fXMin = -20;
+    metrics.fXMax = 290;
+    metrics.fXHeight = -100;
+    metrics.fCapHeight = 0;
+    metrics.fUnderlineThickness = 5;
+    metrics.fUnderlinePosition = 2;
+    metrics.fStrikeoutThickness = 5;
+    metrics.fStrikeoutPosition = -50;
+    builder->setMetrics(metrics, 1.0f / upem);
+  }
 
-    const SkMatrix scale = SkMatrix::Scale(1.0f/upem, 1.0f/upem);
-    for (SkGlyphID index = 0; index <= 67; ++index) {
-      SkScalar width;
-      width = 100;
-      SkPath path;
-      path.addCircle(50, -50, 75);
+  const SkMatrix scale = SkMatrix::Scale(1.0f / upem, 1.0f / upem);
+  for (SkGlyphID index = 0; index <= 67; ++index) {
+    SkScalar width;
+    width = 100;
+    SkPath path;
+    path.addCircle(50, -50, 75);
 
-      builder->setGlyph(index, width/upem, path.makeTransform(scale));
-    }
+    builder->setGlyph(index, width / upem, path.makeTransform(scale));
+  }
 }
-}
+}  // namespace
 
 TEST(FontCollectionTest, CheckSkTypefacesSorting) {
   // We have to make a real SkTypeface here. Not all the structs from the
   // SkTypeface headers are fully declared to be able to gmock.
   // SkCustomTypefaceBuilder is the simplest way to get a simple SkTypeface.
   SkCustomTypefaceBuilder typefaceBuilder1;
-  typefaceBuilder1.setFontStyle(SkFontStyle(SkFontStyle::kThin_Weight, SkFontStyle::kExpanded_Width,
-                  SkFontStyle::kItalic_Slant));
+  typefaceBuilder1.setFontStyle(SkFontStyle(SkFontStyle::kThin_Weight,
+                                            SkFontStyle::kExpanded_Width,
+                                            SkFontStyle::kItalic_Slant));
   // For the purpose of this test, we need to fill this to make the SkTypeface
   // build but it doesn't matter. We only care about the SkFontStyle.
   PopulateUserTypeface(&typefaceBuilder1);
   sk_sp<SkTypeface> typeface1{typefaceBuilder1.detach()};
 
   SkCustomTypefaceBuilder typefaceBuilder2;
-  typefaceBuilder2.setFontStyle(SkFontStyle(SkFontStyle::kLight_Weight, SkFontStyle::kNormal_Width,
-                   SkFontStyle::kUpright_Slant));
+  typefaceBuilder2.setFontStyle(SkFontStyle(SkFontStyle::kLight_Weight,
+                                            SkFontStyle::kNormal_Width,
+                                            SkFontStyle::kUpright_Slant));
   PopulateUserTypeface(&typefaceBuilder2);
   sk_sp<SkTypeface> typeface2{typefaceBuilder2.detach()};
 
   SkCustomTypefaceBuilder typefaceBuilder3;
-  typefaceBuilder3.setFontStyle(SkFontStyle(SkFontStyle::kNormal_Weight, SkFontStyle::kNormal_Width,
-                  SkFontStyle::kUpright_Slant));
+  typefaceBuilder3.setFontStyle(SkFontStyle(SkFontStyle::kNormal_Weight,
+                                            SkFontStyle::kNormal_Width,
+                                            SkFontStyle::kUpright_Slant));
   PopulateUserTypeface(&typefaceBuilder3);
   sk_sp<SkTypeface> typeface3{typefaceBuilder3.detach()};
 
   std::vector<sk_sp<SkTypeface>> candidateTypefaces = {typeface1, typeface2,
-                                                    typeface3};
+                                                       typeface3};
 
   // This sorts the vector in-place.
   txt::FontCollection::SortSkTypefaces(candidateTypefaces);

--- a/third_party/txt/tests/font_collection_unittests.cc
+++ b/third_party/txt/tests/font_collection_unittests.cc
@@ -16,11 +16,116 @@
 
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "third_party/skia/src/core/SkAdvancedTypefaceMetrics.h"
+#include "third_party/skia/src/core/SkScalerContext.h"
 #include "txt/font_collection.h"
 #include "txt_test_utils.h"
 
 namespace txt {
+
+// We don't really need a fixture but a class in a namespace is needed for
+// the FRIEND_TEST macro.
+class FontCollectionTest : public ::testing::Test {};
+
+class MockSkTypeface : public SkTypeface {
+  public:
+  MockSkTypeface();
+  MOCK_CONST_METHOD1(onMakeClone, sk_sp<SkTypeface>(const SkFontArguments&));
+  MOCK_CONST_METHOD2(onCreateScalerContext,
+                     SkScalerContext*(const SkScalerContextEffects&,
+                                      const SkDescriptor*));
+  MOCK_CONST_METHOD1(onFilterRec, void(SkScalerContextRec*));
+  MOCK_CONST_METHOD0(onGetAdvancedMetrics,
+                     std::unique_ptr<SkAdvancedTypefaceMetrics>());
+  MOCK_CONST_METHOD1(getPostScriptGlyphNames, void(SkString*));
+  MOCK_CONST_METHOD1(getGlyphToUnicodeMap, void(SkUnichar* dstArray));
+  MOCK_CONST_METHOD1(onOpenStream,
+                     std::unique_ptr<SkStreamAsset>(int* ttcIndex));
+  MOCK_CONST_METHOD2(
+      onGetVariationDesignPosition,
+      int(SkFontArguments::VariationPosition::Coordinate coordinates[],
+          int coordinateCount));
+  MOCK_CONST_METHOD2(onGetVariationDesignParameters,
+                     int(SkFontParameters::Variation::Axis parameters[],
+                         int parameterCount));
+  MOCK_CONST_METHOD2(onGetFontDescriptor,
+                     void(SkFontDescriptor*, bool* isLocal));
+  MOCK_CONST_METHOD3(onCharsToGlyphs,
+                     void(const SkUnichar* chars,
+                          int count,
+                          SkGlyphID glyphs[]));
+  MOCK_CONST_METHOD0(onCountGlyphs, int());
+  MOCK_CONST_METHOD0(onGetUPEM, int());
+  MOCK_CONST_METHOD3(onGetKerningPairAdjustments,
+                     bool(const SkGlyphID glyphs[],
+                          int count,
+                          int32_t adjustments[]));
+  MOCK_CONST_METHOD1(onGetFamilyName, void(SkString* familyName));
+  MOCK_CONST_METHOD0(onCreateFamilyNameIterator, SkTypeface::LocalizedStrings*());
+  MOCK_CONST_METHOD1(onGetTableTags, int(SkFontTableTag tags[]));
+  MOCK_CONST_METHOD4(
+      onGetTableData,
+      size_t(SkFontTableTag, size_t offset, size_t length, void* data));
+  MOCK_CONST_METHOD1(onCopyTableData, sk_sp<SkData>(SkFontTableTag));
+  MOCK_CONST_METHOD1(onComputeBounds, bool(SkRect*));
+  MOCK_CONST_METHOD0(onGetCTFontRef, void*());
+};
+
+TEST(FontCollectionTest, CheckSkTypefacesSorting) {
+  MockSkTypeface mockTypeface1;
+
+  sk_sp<SkTypeface> typeface1{SkTypeface::MakeFromName(
+      "Arial",
+      SkFontStyle(SkFontStyle::kThin_Weight, SkFontStyle::kExpanded_Width,
+                  SkFontStyle::kItalic_Slant))};
+  sk_sp<SkTypeface> typeface2{SkTypeface::MakeFromName(
+      "Arial",
+      SkFontStyle(SkFontStyle::kLight_Weight, SkFontStyle::kNormal_Width,
+                  SkFontStyle::kUpright_Slant))};
+  sk_sp<SkTypeface> typeface3{SkTypeface::MakeFromName(
+      "Arial",
+      SkFontStyle(SkFontStyle::kNormal_Weight, SkFontStyle::kNormal_Width,
+                  SkFontStyle::kUpright_Slant))};
+  std::vector<sk_sp<SkTypeface>> candidateTypefaces{typeface1, typeface2,
+                                                    typeface3};
+
+  ASSERT_EQ(candidateTypefaces[0]->fontStyle().weight(),
+            SkFontStyle::kThin_Weight);
+  ASSERT_EQ(candidateTypefaces[0]->fontStyle().width(),
+            SkFontStyle::kExpanded_Width);
+
+  ASSERT_EQ(candidateTypefaces[1]->fontStyle().weight(),
+            SkFontStyle::kLight_Weight);
+  ASSERT_EQ(candidateTypefaces[1]->fontStyle().width(),
+            SkFontStyle::kNormal_Width);
+
+  ASSERT_EQ(candidateTypefaces[2]->fontStyle().weight(),
+            SkFontStyle::kNormal_Weight);
+  ASSERT_EQ(candidateTypefaces[2]->fontStyle().width(),
+            SkFontStyle::kNormal_Width);
+
+  // This sorts the vector in-place.
+  txt::FontCollection::SortSkTypefaces(candidateTypefaces);
+  ASSERT_EQ(candidateTypefaces[0].get(), typeface1.get());
+  ASSERT_EQ(candidateTypefaces[1].get(), typeface2.get());
+
+  // ASSERT_EQ(candidateTypefaces[0]->fontStyle().weight(),
+  // SkFontStyle::kLight_Weight);
+  ASSERT_EQ(candidateTypefaces[0]->fontStyle().width(),
+            SkFontStyle::kNormal_Width);
+
+  ASSERT_EQ(candidateTypefaces[1]->fontStyle().weight(),
+            SkFontStyle::kNormal_Weight);
+  ASSERT_EQ(candidateTypefaces[1]->fontStyle().width(),
+            SkFontStyle::kNormal_Width);
+
+  ASSERT_EQ(candidateTypefaces[2]->fontStyle().weight(),
+            SkFontStyle::kThin_Weight);
+  ASSERT_EQ(candidateTypefaces[2]->fontStyle().width(),
+            SkFontStyle::kExpanded_Width);
+}
 
 #if 0
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/60013
The problem turned out way simpler than I expected. Despite it being officially deprecated, searching for font by font family name string is still working on iOS 14. We still have to fix it at some point but for now, the thing that got borked was searching for the broad family name such as `.AppleSystemUIFont`/`.SFUI-Regular` actually returns both condensed and normal widths of the fonts (the `kCTFontWidthTrait`). We weren't accounting for it in our sorting so we can end up with the narrower font. 

Didn't write tests yet. Would love a pointer for which file this might fit in (or whether I'd have to start something new)