### PR TITLE
adding support for ios custom action overrides when switch control is enabled

### DIFF
--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -50,6 +50,9 @@ const int kScrollableSemanticsActions =
     static_cast<int32_t>(SemanticsAction::kScrollUp) |
     static_cast<int32_t>(SemanticsAction::kScrollDown);
 
+const int kCustomSemanticsActions =
+    static_cast<int32_t>(SemanticsAction::kCustomAction);
+
 /// C/C++ representation of `SemanticsFlags` defined in
 /// `lib/ui/semantics.dart`.
 ///\warning This must match the `SemanticsFlags` enum in

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1228,7 +1228,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   platformView->SetSemanticsEnabled(true);
   platformView->SetAccessibilityFeatures(flags);
 #else
-  bool enabled = UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning();
+  _switchControlEnabled = UIAccessibilityIsSwitchControlRunning();
+  bool enabled = _switchControlEnabled || UIAccessibilityIsVoiceOverRunning();
   if (enabled)
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kAccessibleNavigation);
   platformView->SetSemanticsEnabled(enabled || UIAccessibilityIsSpeakScreenEnabled());

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -26,6 +26,9 @@ extern NSNotificationName const FlutterViewControllerShowHomeIndicator;
 @interface FlutterViewController ()
 
 @property(nonatomic, readonly) BOOL isPresentingViewController;
+
+@property(nonatomic, readonly) BOOL switchControlEnabled;
+
 - (fml::WeakPtr<FlutterViewController>)getWeakPtr;
 - (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
 - (FlutterRestorationPlugin*)restorationPlugin;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
@@ -60,6 +60,11 @@ constexpr int32_t kRootNodeId = 0;
 @property(nonatomic, strong) NSArray<SemanticsObject*>* children;
 
 /**
+ * Accessibility actions for this object
+ */
+@property(nonatomic, strong) NSArray<FlutterCustomAccessibilityAction*>* customSemanticsActions;
+
+/**
  * Used if this SemanticsObject is for a platform view.
  */
 @property(strong, nonatomic) FlutterPlatformViewSemanticsContainer* platformViewSemanticsContainer;
@@ -112,6 +117,13 @@ constexpr int32_t kRootNodeId = 0;
  * The uid of the action defined by the flutter application.
  */
 @property(nonatomic) int32_t uid;
+
+/**
+ * The semantics action the custom action overrides.
+ *
+ * If this custom action does not override any existing semantics action, this should be -1
+ */
+@property(nonatomic) int32_t overrideActionId;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -84,8 +84,10 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   //
   // If the parent is nil, this function use the root SemanticsObject as the parent.
   SemanticsObject* FindFirstFocusable(SemanticsObject* parent);
-  void VisitObjectsRecursivelyAndRemove(SemanticsObject* object,
-                                        NSMutableArray<NSNumber*>* doomed_uids);
+  void MarkAttendanceAndSetCustomActions(
+      SemanticsObject* object,
+      NSMutableArray<NSNumber*>* doomed_uids,
+      std::unordered_map<int32_t, FlutterCustomAccessibilityAction*> inherited_overrides);
   void HandleEvent(NSDictionary<NSString*, id>* annotatedEvent);
 
   FlutterViewController* view_controller_;
@@ -100,6 +102,8 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   fml::WeakPtrFactory<AccessibilityBridge> weak_factory_;
   int32_t previous_route_id_;
   std::unordered_map<int32_t, flutter::CustomAccessibilityAction> actions_;
+  std::unordered_map<int32_t, std::vector<FlutterCustomAccessibilityAction*>>
+      action_overrides_of_semantics_objects_;
   std::vector<int32_t> previous_routes_;
   std::unique_ptr<IosDelegate> ios_delegate_;
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -176,6 +176,17 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
 
   SemanticsObject* root = objects_.get()[@(kRootNodeId)];
 
+  NSMutableArray<NSNumber*>* doomed_uids = [NSMutableArray arrayWithArray:[objects_.get() allKeys]];
+  if (root) {
+    std::unordered_map<int32_t, FlutterCustomAccessibilityAction*> initial_overrides;
+    MarkAttendanceAndSetCustomActions(root, doomed_uids, initial_overrides);
+  }
+  [objects_ removeObjectsForKeys:doomed_uids];
+
+  for (NSNumber* uid in doomed_uids) {
+    action_overrides_of_semantics_objects_.erase([uid intValue]);
+  }
+
   bool routeChanged = false;
   SemanticsObject* lastAdded = nil;
 
@@ -215,17 +226,6 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     }
   } else {
     view_controller_.view.accessibilityElements = nil;
-  }
-
-  NSMutableArray<NSNumber*>* doomed_uids = [NSMutableArray arrayWithArray:[objects_.get() allKeys]];
-  if (root) {
-    std::unordered_map<int32_t, FlutterCustomAccessibilityAction*> initial_overrides;
-    MarkAttendanceAndSetCustomActions(root, doomed_uids, initial_overrides);
-  }
-  [objects_ removeObjectsForKeys:doomed_uids];
-
-  for (NSNumber* uid in doomed_uids) {
-    action_overrides_of_semantics_objects_.erase([uid intValue]);
   }
 
   if (!ios_delegate_->IsFlutterViewControllerPresentingModalViewController(view_controller_)) {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -9,6 +9,7 @@
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 
@@ -1282,7 +1283,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
   OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
-  std::string label = "some label";
+  OCMStub([mockFlutterViewController switchControlEnabled]).andReturn(YES);
 
   __block auto bridge =
       std::make_unique<flutter::AccessibilityBridge>(/*view_controller=*/mockFlutterViewController,
@@ -1293,33 +1294,42 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       [mockFlutterView setAccessibilityElements:[OCMArg checkWithBlock:^BOOL(NSArray* value) {
                          SemanticsObjectContainer* container = value[0];
                          SemanticsObject* root = container.semanticsObject;
-                         if (![root.accessibilityLabel isEqual:@"root"])
+                         if (![root.accessibilityLabel isEqual:@"root"]) {
                            return NO;
+                         }
                          // An action override should not present in the
                          // original object.
-                         if ([root.accessibilityCustomActions count] != 0)
+                         if ([root.accessibilityCustomActions count] != 0) {
                            return NO;
+                         }
                          SemanticsObject* node1 = root.children[0];
-                         if (![node1.accessibilityLabel isEqual:@"node 1"])
+                         if (![node1.accessibilityLabel isEqual:@"node 1"]) {
                            return NO;
+                         }
                          FlutterCustomAccessibilityAction* firstAction =
                              (FlutterCustomAccessibilityAction*)node1.accessibilityCustomActions[0];
-                         if (firstAction.uid != 14)
+                         if (firstAction.uid != 14) {
                            return NO;
-                         if (![firstAction.name isEqual:@"some action"])
+                         }
+                         if (![firstAction.name isEqual:@"some action"]) {
                            return NO;
-                         if (firstAction.target != node1)
+                         }
+                         if (firstAction.target != node1) {
                            return NO;
+                         }
                          FlutterCustomAccessibilityAction* secondAction =
                              (FlutterCustomAccessibilityAction*)node1.accessibilityCustomActions[1];
-                         if (secondAction.uid != 13)
+                         if (secondAction.uid != 13) {
                            return NO;
-                         if (![secondAction.name isEqual:@"some override"])
+                         }
+                         if (![secondAction.name isEqual:@"some override"]) {
                            return NO;
+                         }
                          // An inherited action override should targets
                          // the original object.
-                         if (secondAction.target != root)
+                         if (secondAction.target != root) {
                            return NO;
+                         }
                          return YES;
                        }]]);
 


### PR DESCRIPTION
## Description

The framework counter part https://github.com/flutter/flutter/pull/82746

The custom action overrides will now be support in ios in favor of adding fake switch control. There is currently no available api to turn on native switch control(scrolling for example) for UIView. We have to workaround it by adding custom actions to imitate those native switch control. This pr makes accessibility bridge in ios to accept custom action overrides for existing semantics action. If it receive such overrides, it will add the imitating custom action into all of its children but itself.

## Related Issues

https://github.com/flutter/flutter/issues/37974

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
