### PR TITLE
convert zircon and fuchsia to null-safety

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/fuchsia/lib/fuchsia.dart
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/lib/fuchsia.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 library fuchsia;
 
 import 'dart:io';
@@ -14,25 +13,25 @@ import 'dart:zircon';
 
 // TODO: refactors this incomingServices instead
 @pragma('vm:entry-point')
-Handle _environment;
+Handle? _environment;
 
 @pragma('vm:entry-point')
-Handle _outgoingServices;
+Handle? _outgoingServices;
 
 @pragma('vm:entry-point')
-Handle _viewRef;
+Handle? _viewRef;
 
 class MxStartupInfo {
   // TODO: refactor Handle to a Channel
   // https://github.com/flutter/flutter/issues/49439
   static Handle takeEnvironment() {
-    if (_outgoingServices == null && Platform.isFuchsia) {
+    if (_environment == null && Platform.isFuchsia) {
       throw Exception(
           'Attempting to call takeEnvironment more than once per process');
     }
-    Handle handle = _environment;
+    final handle = _environment;
     _environment = null;
-    return handle;
+    return handle!;
   }
 
   // TODO: refactor Handle to a Channel
@@ -42,9 +41,9 @@ class MxStartupInfo {
       throw Exception(
           'Attempting to call takeOutgoingServices more than once per process');
     }
-    Handle handle = _outgoingServices;
+    final handle = _outgoingServices;
     _outgoingServices = null;
-    return handle;
+    return handle!;
   }
 
   // TODO: refactor Handle to a ViewRef
@@ -54,9 +53,9 @@ class MxStartupInfo {
       throw Exception(
           'Attempting to call takeViewRef more than once per process');
     }
-    Handle handle = _viewRef;
+    final handle = _viewRef;
     _viewRef = null;
-    return handle;
+    return handle!;
   }
 }
 

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 part of zircon;
 
 // ignore_for_file: native_function_body_in_non_sdk_code

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_waiter.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_waiter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 part of zircon;
 
 // ignore_for_file: native_function_body_in_non_sdk_code

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 part of zircon;
 
 // ignore_for_file: native_function_body_in_non_sdk_code
@@ -16,12 +15,12 @@ class _Namespace { // ignore: unused_element
   // Library private variable set by the embedder used to cache the
   // namespace (as an fdio_ns_t*).
   @pragma('vm:entry-point')
-  static int _namespace; // ignore: unused_field
+  static int? _namespace; // ignore: unused_field
 }
 
 /// An exception representing an error returned as an zx_status_t.
 class ZxStatusException implements Exception {
-  final String message;
+  final String? message;
   final int status;
 
   ZxStatusException(this.status, [this.message]);
@@ -35,6 +34,9 @@ class ZxStatusException implements Exception {
   }
 }
 
+/// Users of the [_Result] subclasses should check the status before
+/// trying to read any data. Attempting to use a value stored in a result
+/// when the status in not OK will result in an exception.
 class _Result {
   final int status;
   const _Result(this.status);
@@ -42,78 +44,107 @@ class _Result {
 
 @pragma('vm:entry-point')
 class HandleResult extends _Result {
-  final Handle handle;
+  final Handle? _handle;
+  Handle get handle => _handle!;
+
   @pragma('vm:entry-point')
-  const HandleResult(final int status, [this.handle]) : super(status);
+  const HandleResult(final int status, [this._handle]) : super(status);
   @override
-  String toString() => 'HandleResult(status=$status, handle=$handle)';
+  String toString() => 'HandleResult(status=$status, handle=$_handle)';
 }
 
 @pragma('vm:entry-point')
 class HandlePairResult extends _Result {
-  final Handle first;
-  final Handle second;
+  final Handle? _first;
+  final Handle? _second;
+
+  Handle get first => _first!;
+  Handle get second => _second!;
+
   @pragma('vm:entry-point')
-  const HandlePairResult(final int status, [this.first, this.second])
+  const HandlePairResult(final int status, [this._first, this._second])
       : super(status);
   @override
   String toString() =>
-      'HandlePairResult(status=$status, first=$first, second=$second)';
+      'HandlePairResult(status=$status, first=$_first, second=$_second)';
 }
 
 @pragma('vm:entry-point')
 class ReadResult extends _Result {
-  final ByteData bytes;
-  final int numBytes;
-  final List<Handle> handles;
+  final ByteData? _bytes;
+  final int? _numBytes;
+  final List<Handle>? _handles;
+
+  ByteData get bytes => _bytes!;
+  int get numBytes => _numBytes!;
+  List<Handle> get handles => _handles!;
+
   @pragma('vm:entry-point')
-  const ReadResult(final int status, [this.bytes, this.numBytes, this.handles])
+  const ReadResult(final int status, [this._bytes, this._numBytes, this._handles])
       : super(status);
-  Uint8List bytesAsUint8List() =>
-      bytes.buffer.asUint8List(bytes.offsetInBytes, numBytes);
+
+  /// Returns the bytes as a Uint8List. If status != OK this will throw
+  /// an exception.
+  Uint8List bytesAsUint8List() {
+    return _bytes!.buffer.asUint8List(_bytes!.offsetInBytes, _numBytes!);
+  }
+
+  /// Returns the bytes as a String. If status != OK this will throw
+  /// an exception.
   String bytesAsUTF8String() => utf8.decode(bytesAsUint8List());
+
   @override
   String toString() =>
-      'ReadResult(status=$status, bytes=$bytes, numBytes=$numBytes, handles=$handles)';
+      'ReadResult(status=$status, bytes=$_bytes, numBytes=$_numBytes, handles=$_handles)';
 }
 
 @pragma('vm:entry-point')
 class WriteResult extends _Result {
-  final int numBytes;
+  final int? _numBytes;
+  int get numBytes => _numBytes!;
+
   @pragma('vm:entry-point')
-  const WriteResult(final int status, [this.numBytes]) : super(status);
+  const WriteResult(final int status, [this._numBytes]) : super(status);
   @override
-  String toString() => 'WriteResult(status=$status, numBytes=$numBytes)';
+  String toString() => 'WriteResult(status=$status, numBytes=$_numBytes)';
 }
 
 @pragma('vm:entry-point')
 class GetSizeResult extends _Result {
-  final int size;
+  final int? _size;
+  int get size => _size!;
+
   @pragma('vm:entry-point')
-  const GetSizeResult(final int status, [this.size]) : super(status);
+  const GetSizeResult(final int status, [this._size]) : super(status);
   @override
-  String toString() => 'GetSizeResult(status=$status, size=$size)';
+  String toString() => 'GetSizeResult(status=$status, size=$_size)';
 }
 
 @pragma('vm:entry-point')
 class FromFileResult extends _Result {
-  final Handle handle;
-  final int numBytes;
+  final Handle? _handle;
+  final int? _numBytes;
+
+  Handle get handle => _handle!;
+  int get numBytes => _numBytes!;
+
   @pragma('vm:entry-point')
-  const FromFileResult(final int status, [this.handle, this.numBytes])
+  const FromFileResult(final int status, [this._handle, this._numBytes])
       : super(status);
   @override
   String toString() =>
-      'FromFileResult(status=$status, handle=$handle, numBytes=$numBytes)';
+      'FromFileResult(status=$status, handle=$_handle, numBytes=$_numBytes)';
 }
 
 @pragma('vm:entry-point')
 class MapResult extends _Result {
-  final Uint8List data;
+  final Uint8List? _data;
+  Uint8List get data => _data!;
+
   @pragma('vm:entry-point')
-  const MapResult(final int status, [this.data]) : super(status);
+  const MapResult(final int status, [this._data]) : super(status);
   @override
-  String toString() => 'MapResult(status=$status, data=$data)';
+  String toString() => 'MapResult(status=$status, data=$_data)';
 }
 
 @pragma('vm:entry-point')

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/zircon.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/zircon.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 library zircon;
 
 import 'dart:convert' show utf8;

--- a/shell/platform/fuchsia/dart_runner/embedder/builtin.dart
+++ b/shell/platform/fuchsia/dart_runner/embedder/builtin.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 library fuchsia_builtin;
 
 import 'dart:async';
@@ -25,7 +24,7 @@ class _Logger {
 }
 
 @pragma('vm:entry-point')
-String _rawScript;
+late String _rawScript;
 
 Uri _scriptUri() {
   if (_rawScript.startsWith('http:') ||

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -21,7 +21,7 @@ compile_platform("kernel_platform_files") {
 
   args = [
     "--enable-experiment=non-nullable",
-    "--nnbd-weak",
+    "--nnbd-agnostic",
 
     # TODO(dartbug.com/36342): enable bytecode for core libraries when performance of bytecode
     # pipeline is on par with default pipeline and continuously tracked.

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -21,7 +21,7 @@ compile_platform("kernel_platform_files") {
 
   args = [
     "--enable-experiment=non-nullable",
-    "--nnbd-weak",
+    "--nnbd-agnostic",
 
     # TODO(dartbug.com/36342): enable bytecode for core libraries when performance of bytecode
     # pipeline is on par with default pipeline and continuously tracked.


### PR DESCRIPTION
## Description

Changes the `--nnbd-weak` flag to `--nnbd-agnostic` and migrates the native zircon and fuchsia packages to be null safe. This will allow us to start using nullability features inside of fuchsia.

## Related Issues

fxb/55746

## Tests

Tested by rolling the changes manually into the fuchsia tree and running the workstation product. Change works with the current state of not having the nullability experiment enabled as well as later adding it and writing a simple library which uses nullability annotations.