### PR TITLE
Add null checks for CanvasElement attributes

### DIFF
--- a/lib/web_ui/lib/src/engine/html/surface_stats.dart
+++ b/lib/web_ui/lib/src/engine/html/surface_stats.dart
@@ -291,8 +291,8 @@ void _debugPrintSurfaceStats(PersistedScene scene, int frameNumber) {
     final int pixelCount = canvasElements
         .cast<html.CanvasElement>()
         .map<int>((html.CanvasElement e) {
-      final int pixels = e.width * e.height;
-      canvasInfo.writeln('    - ${e.width} x ${e.height} = $pixels pixels');
+      final int pixels = e.width! * e.height!;
+      canvasInfo.writeln('    - ${e.width!} x ${e.height!} = $pixels pixels');
       return pixels;
     }).fold(0, (int total, int pixels) => total + pixels);
     final double physicalScreenWidth =


### PR DESCRIPTION
Changes in processing compatibility info in dart:html requires
these getters to be null-checked.

## Description

`CanvasElement` attributes will be changed to be potentially nullable (see https://dart-review.googlesource.com/c/sdk/+/155844), so they are null-checked.

## Related Issues

No new issue for this, but related to the original process in https://github.com/dart-lang/sdk/issues/41905.

## Tests

No tests added.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.