### PR TITLE
fuchsia: Increase timeout for flaky test

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -586,7 +586,14 @@ TEST_F(ShellTest, ReportTimingsIsCalledSoonerInNonReleaseMode) {
 #else
   // Our batch time is 100ms. Hopefully the 500ms limit is relaxed enough to
   // make it not too flaky.
+  //
+  // TODO(https://github.com/flutter/flutter/issues/64087): Fuchsia uses a
+  // 2000ms timeout to handle slowdowns in FEMU.
+#if OS_FUCHSIA
+  ASSERT_TRUE(elapsed <= fml::TimeDelta::FromMilliseconds(2000));
+#else
   ASSERT_TRUE(elapsed <= fml::TimeDelta::FromMilliseconds(500));
+#endif
 #endif
 }
 


### PR DESCRIPTION
## Description

This test is flaky when running on the Fuchsia emulator.  Increase the timeout while we wait for the underlying Fuchsia issue to be fixed.

## Related Issues

https://github.com/flutter/flutter/issues/64087
https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=58532

## Tests

Ran tests on try bots:
https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/dworsham_google.com/64b40128fbc97928b1fe017b007220103d15cb88ec2dda3416172abcfd98c9a5/+/annotations?server=chromium-swarm.appspot.com

