### PR TITLE
add explicit and auto-detecting renderer options

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/shader.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/shader.dart
@@ -81,7 +81,7 @@ class CkGradientLinear extends CkShader implements ui.Gradient {
 
   @override
   SkShader createDefault() {
-    assert(experimentalUseSkia);
+    assert(useCanvasKit);
 
     return canvasKit.SkShader.MakeLinearGradient(
       toSkPoint(from),
@@ -109,7 +109,7 @@ class CkGradientRadial extends CkShader implements ui.Gradient {
 
   @override
   SkShader createDefault() {
-    assert(experimentalUseSkia);
+    assert(useCanvasKit);
 
     return canvasKit.SkShader.MakeRadialGradient(
       toSkPoint(center),
@@ -141,7 +141,7 @@ class CkGradientConical extends CkShader implements ui.Gradient {
 
   @override
   SkShader createDefault() {
-    assert(experimentalUseSkia);
+    assert(useCanvasKit);
     return canvasKit.SkShader.MakeTwoPointConicalGradient(
       toSkPoint(focal),
       focalRadius,

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -45,7 +45,7 @@ class DomRenderer {
   html.MetaElement? _viewportMeta;
 
   /// The canvaskit script, downloaded from a CDN. Only created if
-  /// [experimentalUseSkia] is set to true.
+  /// [useCanvasKit] is set to true.
   html.ScriptElement? get canvasKitScript => _canvasKitScript;
   html.ScriptElement? _canvasKitScript;
 
@@ -436,7 +436,7 @@ flt-glass-pane * {
       });
     }
 
-    if (experimentalUseSkia) {
+    if (useCanvasKit) {
       _canvasKitScript?.remove();
       _canvasKitScript = html.ScriptElement();
       _canvasKitScript!.src = canvasKitBaseUrl + 'canvaskit.js';

--- a/lib/web_ui/lib/src/engine/html/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shader.dart
@@ -116,7 +116,7 @@ class GradientRadial extends EngineGradient {
 
   @override
   Object createPaintStyle(html.CanvasRenderingContext2D? ctx) {
-    if (!experimentalUseSkia) {
+    if (!useCanvasKit) {
       if (tileMode != ui.TileMode.clamp) {
         throw UnimplementedError(
             'TileMode not supported in GradientRadial shader');

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -588,7 +588,7 @@ class EngineWindow extends ui.Window {
         return;
 
       case 'flutter/platform_views':
-        if (experimentalUseSkia) {
+        if (useCanvasKit) {
           rasterizer!.surface.viewEmbedder.handlePlatformViewCall(data, callback);
         } else {
           ui.handlePlatformViewCall(data!, callback!);
@@ -721,7 +721,7 @@ class EngineWindow extends ui.Window {
 
   @override
   void render(ui.Scene scene) {
-    if (experimentalUseSkia) {
+    if (useCanvasKit) {
       final LayerScene layerScene = scene as LayerScene;
       rasterizer!.draw(layerScene.layerTree);
     } else {
@@ -731,7 +731,7 @@ class EngineWindow extends ui.Window {
   }
 
   @visibleForTesting
-  late Rasterizer? rasterizer = experimentalUseSkia ? Rasterizer(Surface(HtmlViewEmbedder())) : null;
+  late Rasterizer? rasterizer = useCanvasKit ? Rasterizer(Surface(HtmlViewEmbedder())) : null;
 }
 
 bool _handleWebTestEnd2EndMessage(MethodCodec codec, ByteData? data) {

--- a/lib/web_ui/lib/src/ui/canvas.dart
+++ b/lib/web_ui/lib/src/ui/canvas.dart
@@ -76,7 +76,7 @@ class Vertices {
     List<Color>? colors,
     List<int>? indices,
   }) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkVertices(mode, positions,
           textureCoordinates: textureCoordinates,
           colors: colors,
@@ -112,7 +112,7 @@ class Vertices {
     Int32List? colors,
     Uint16List? indices,
   }) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkVertices.raw(mode, positions,
           textureCoordinates: textureCoordinates,
           colors: colors,
@@ -133,7 +133,7 @@ abstract class PictureRecorder {
   /// [Canvas] and begin recording, pass this [PictureRecorder] to the
   /// [Canvas] constructor.
   factory PictureRecorder() {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkPictureRecorder();
     } else {
       return engine.EnginePictureRecorder();
@@ -176,7 +176,7 @@ abstract class PictureRecorder {
 /// managed by the [save], [saveLayer], and [restore] methods.
 abstract class Canvas {
   factory Canvas(PictureRecorder recorder, [Rect? cullRect]) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CanvasKitCanvas(recorder, cullRect);
     } else {
       return engine.SurfaceCanvas(recorder as engine.EnginePictureRecorder, cullRect);

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -113,7 +113,7 @@ abstract class PhysicalShapeEngineLayer implements EngineLayer {}
 abstract class SceneBuilder {
   /// Creates an empty [SceneBuilder] object.
   factory SceneBuilder() {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.LayerSceneBuilder();
     } else {
       return engine.SurfaceSceneBuilder();

--- a/lib/web_ui/lib/src/ui/initialization.dart
+++ b/lib/web_ui/lib/src/ui/initialization.dart
@@ -30,13 +30,13 @@ Future<void> _initializePlatform({
 
   // This needs to be after `webOnlyInitializeEngine` because that is where the
   // canvaskit script is added to the page.
-  if (engine.experimentalUseSkia) {
+  if (engine.useCanvasKit) {
     await engine.initializeCanvasKit();
   }
 
   assetManager ??= const engine.AssetManager();
   await webOnlySetAssetManager(assetManager);
-  if (engine.experimentalUseSkia) {
+  if (engine.useCanvasKit) {
     await engine.skiaFontCollection.ensureFontsLoaded();
   } else {
     await _fontCollection!.ensureFontsLoaded();
@@ -64,7 +64,7 @@ Future<void> webOnlySetAssetManager(engine.AssetManager assetManager) async {
 
   _assetManager = assetManager;
 
-  if (engine.experimentalUseSkia) {
+  if (engine.useCanvasKit) {
     engine.ensureSkiaFontCollectionInitialized();
   } else {
     _fontCollection ??= engine.FontCollection();
@@ -73,14 +73,14 @@ Future<void> webOnlySetAssetManager(engine.AssetManager assetManager) async {
 
 
   if (_assetManager != null) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       await engine.skiaFontCollection.registerFonts(_assetManager!);
     } else {
       await _fontCollection!.registerFonts(_assetManager!);
     }
   }
 
-  if (debugEmulateFlutterTesterEnvironment && !engine.experimentalUseSkia) {
+  if (debugEmulateFlutterTesterEnvironment && !engine.useCanvasKit) {
     _fontCollection!.debugRegisterTestFonts();
   }
 }

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -904,7 +904,7 @@ abstract class Paint {
   /// Constructs an empty [Paint] object with all fields initialized to
   /// their defaults.
   factory Paint() =>
-      engine.experimentalUseSkia ? engine.CkPaint() : engine.SurfacePaint();
+      engine.useCanvasKit ? engine.CkPaint() : engine.SurfacePaint();
 
   /// Whether to dither the output when drawing images.
   ///
@@ -1097,7 +1097,7 @@ abstract class Gradient extends Shader {
     List<double>? colorStops,
     TileMode tileMode = TileMode.clamp,
     Float64List? matrix4,
-  ]) => engine.experimentalUseSkia
+  ]) => engine.useCanvasKit
     ? engine.CkGradientLinear(from, to, colors, colorStops, tileMode, matrix4)
     : engine.GradientLinear(from, to, colors, colorStops, tileMode, matrix4);
 
@@ -1146,7 +1146,7 @@ abstract class Gradient extends Shader {
     final Float32List? matrix32 =
         matrix4 != null ? engine.toMatrix32(matrix4) : null;
     if (focal == null || (focal == center && focalRadius == 0.0)) {
-      return engine.experimentalUseSkia
+      return engine.useCanvasKit
         ? engine.CkGradientRadial(
           center, radius, colors, colorStops, tileMode, matrix32)
         : engine.GradientRadial(
@@ -1154,7 +1154,7 @@ abstract class Gradient extends Shader {
     } else {
       assert(center != Offset.zero ||
           focal != Offset.zero); // will result in exception(s) in Skia side
-      return engine.experimentalUseSkia
+      return engine.useCanvasKit
         ? engine.CkGradientConical(focal, focalRadius, center, radius, colors,
           colorStops, tileMode, matrix32)
         : engine.GradientConical(focal, focalRadius, center, radius, colors,
@@ -1196,7 +1196,7 @@ abstract class Gradient extends Shader {
     double startAngle = 0.0,
     double endAngle = math.pi * 2,
     Float64List? matrix4,
-  ]) => engine.experimentalUseSkia
+  ]) => engine.useCanvasKit
     ? engine.CkGradientSweep(center, colors, colorStops, tileMode, startAngle,
           endAngle, matrix4 != null ? engine.toMatrix32(matrix4) : null)
     : engine.GradientSweep(center, colors, colorStops, tileMode, startAngle,
@@ -1441,7 +1441,7 @@ enum FilterQuality {
 class ImageFilter {
   /// Creates an image filter that applies a Gaussian blur.
   factory ImageFilter.blur({double sigmaX = 0.0, double sigmaY = 0.0}) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY);
     }
     return engine.EngineImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY);
@@ -1591,7 +1591,7 @@ String? _instantiateImageCodec(
   int? rowBytes,
   PixelFormat? format,
 }) {
-  if (engine.experimentalUseSkia) {
+  if (engine.useCanvasKit) {
     if (width == null) {
       engine.skiaInstantiateImageCodec(list, callback);
     } else {
@@ -1617,7 +1617,7 @@ String? _instantiateImageCodecFromUrl(
     Uri uri,
     engine.WebOnlyImageCodecChunkCallback? chunkCallback,
     engine.Callback<Codec> callback) {
-  if (engine.experimentalUseSkia) {
+  if (engine.useCanvasKit) {
     engine.skiaInstantiateWebImageCodec(
         uri.toString(), callback, chunkCallback);
     return null;
@@ -1850,7 +1850,7 @@ class ImageShader extends Shader {
   /// be null.
   factory ImageShader(
       Image image, TileMode tmx, TileMode tmy, Float64List matrix4) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkImageShader(image, tmx, tmy, matrix4);
     }
     throw UnsupportedError('ImageShader not implemented for web platform.');

--- a/lib/web_ui/lib/src/ui/path.dart
+++ b/lib/web_ui/lib/src/ui/path.dart
@@ -25,7 +25,7 @@ part of ui;
 abstract class Path {
   /// Create a new empty [Path] object.
   factory Path() {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkPath();
     } else {
       return engine.SurfacePath();
@@ -37,7 +37,7 @@ abstract class Path {
   /// This copy is fast and does not require additional memory unless either
   /// the `source` path or the path returned by this constructor are modified.
   factory Path.from(Path source) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkPath.from(source as engine.CkPath);
     } else {
       return engine.SurfacePath.from(source as engine.SurfacePath);
@@ -271,7 +271,7 @@ abstract class Path {
   static Path combine(PathOperation operation, Path path1, Path path2) {
     assert(path1 != null); // ignore: unnecessary_null_comparison
     assert(path2 != null); // ignore: unnecessary_null_comparison
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkPath.combine(operation, path1, path2);
     }
     throw UnimplementedError();

--- a/lib/web_ui/lib/src/ui/text.dart
+++ b/lib/web_ui/lib/src/ui/text.dart
@@ -557,7 +557,7 @@ abstract class TextStyle {
     List<Shadow>? shadows,
     List<FontFeature>? fontFeatures,
   }) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkTextStyle(
           color: color,
           decoration: decoration,
@@ -676,7 +676,7 @@ abstract class ParagraphStyle {
     String? ellipsis,
     Locale? locale,
   }) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkParagraphStyle(
         textAlign: textAlign,
         textDirection: textDirection,
@@ -1484,7 +1484,7 @@ abstract class ParagraphBuilder {
   /// Creates a [ParagraphBuilder] object, which is used to create a
   /// [Paragraph].
   factory ParagraphBuilder(ParagraphStyle style) {
-    if (engine.experimentalUseSkia) {
+    if (engine.useCanvasKit) {
       return engine.CkParagraphBuilder(style);
     } else {
       return engine.EngineParagraphBuilder(style as engine.EngineParagraphStyle);
@@ -1581,7 +1581,7 @@ abstract class ParagraphBuilder {
 /// * `fontFamily`: The family name used to identify the font in text styles.
 ///  If this is not provided, then the family name will be extracted from the font file.
 Future<void> loadFontFromList(Uint8List list, {String? fontFamily}) {
-  if (engine.experimentalUseSkia) {
+  if (engine.useCanvasKit) {
     return engine.skiaFontCollection.loadFontFromList(list, fontFamily: fontFamily).then(
         (_) => engine.sendFontChangeMessage()
     );

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -25,7 +25,7 @@ void testMain() {
     });
 
     test('Using CanvasKit', () {
-      expect(experimentalUseSkia, true);
+      expect(useCanvasKit, true);
     });
 
     _blendModeTests();

--- a/lib/web_ui/test/canvaskit/path_metrics_test.dart
+++ b/lib/web_ui/test/canvaskit/path_metrics_test.dart
@@ -22,7 +22,7 @@ void testMain() {
     });
 
     test('Using CanvasKit', () {
-      expect(experimentalUseSkia, true);
+      expect(useCanvasKit, true);
     });
 
     test(CkPathMetrics, () {


### PR DESCRIPTION
## Description

Support three modes:

- Always use the HTML renderer
- Always use the CanvasKit renderer
- Automatically pick the renderer based on browser/OS combination

Proposal: https://docs.google.com/document/d/1aY0iU16wf_sdT7nwfpjgT-IatHNfF3slTiYHKmxcIog

## Related Issues

https://github.com/flutter/flutter/issues/64092
