### PR TITLE
Release the AccessibilityBridge when destroying a legacy FlutterView

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -432,6 +432,7 @@ public class FlutterView extends SurfaceView
     if (!isAttached()) return;
 
     getHolder().removeCallback(mSurfaceCallback);
+    releaseAccessibilityNodeProvider();
 
     mNativeView.destroy();
     mNativeView = null;
@@ -749,9 +750,7 @@ public class FlutterView extends SurfaceView
   @Override
   protected void onDetachedFromWindow() {
     super.onDetachedFromWindow();
-
-    mAccessibilityNodeProvider.release();
-    mAccessibilityNodeProvider = null;
+    releaseAccessibilityNodeProvider();
   }
 
   // TODO(mattcarroll): Confer with Ian as to why we need this method. Delete if possible, otherwise
@@ -773,6 +772,13 @@ public class FlutterView extends SurfaceView
       // the a11y
       // tree.
       return null;
+    }
+  }
+
+  private void releaseAccessibilityNodeProvider() {
+    if (mAccessibilityNodeProvider != null) {
+      mAccessibilityNodeProvider.release();
+      mAccessibilityNodeProvider = null;
     }
   }
 


### PR DESCRIPTION
The legacy io.flutter.view.FlutterView class was releasing the
AccessibilityBridge in its override of View.onDetachedFromWindow.
However, onDetachedFromWindow is called after the activity onDestroy
lifecycle event which typically calls FlutterView.destroy.  If the
AccessibilityBridge listener is invoked after FlutterView.destroy, then
its calls to Flutter engine JNI APIs will fail.

This change will release the AccessibilityBridge and remove the listener
before FlutterView.destroy detaches from the engine.

Fixes https://github.com/flutter/flutter/issues/63555