### PR TITLE
Make const_finder work with implemented and extended classes

### DIFF
--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -13,11 +13,11 @@ class _ConstVisitor extends RecursiveVisitor<void> {
     this.classLibraryUri,
     this.className,
   )  : assert(kernelFilePath != null),
-        assert(classLibraryUri != null),
-        assert(className != null),
-        _visitedInstances = <String>{},
-        constantInstances = <Map<String, dynamic>>[],
-        nonConstantLocations = <Map<String, dynamic>>[];
+       assert(classLibraryUri != null),
+       assert(className != null),
+       _visitedInstances = <String>{},
+       constantInstances = <Map<String, dynamic>>[],
+       nonConstantLocations = <Map<String, dynamic>>[];
 
   /// The path to the file to open.
   final String kernelFilePath;
@@ -35,11 +35,10 @@ class _ConstVisitor extends RecursiveVisitor<void> {
   // A cache of previously evaluated classes.
   static Map<Class, bool> _classHeirarchyCache = <Class, bool>{};
   bool _matches(Class node) {
-    if (node == null) {
-      return false;
-    }
-    if (_classHeirarchyCache[node] == true) {
-      return true;
+    assert(node != null);
+    final bool result = _classHeirarchyCache[node];
+    if (result != null) {
+      return result;
     }
     final bool exactMatch = node.name == className
         && node.enclosingLibrary.importUri.toString() == classLibraryUri;

--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -32,15 +32,20 @@ class _ConstVisitor extends RecursiveVisitor<void> {
   final List<Map<String, dynamic>> constantInstances;
   final List<Map<String, dynamic>> nonConstantLocations;
 
+  // A cache of previously evaluated classes.
+  static Map<Class, bool> _classHeirarchyCache = <Class, bool>{};
   bool _matches(Class node) {
     if (node == null) {
       return false;
     }
+    if (_classHeirarchyCache[node] == true) {
+      return true;
+    }
     final bool exactMatch = node.name == className
         && node.enclosingLibrary.importUri.toString() == classLibraryUri;
-    return exactMatch
-        || _matches(node.superclass)
-        || node.implementedTypes.any((Supertype implementedType) => _matches(implementedType.classNode));
+    _classHeirarchyCache[node] = exactMatch
+        || node.supers.any((Supertype supertype) => _matches(supertype.classNode));
+    return _classHeirarchyCache[node];
   }
 
   // Avoid visiting the same constant more than once.

--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -33,8 +33,14 @@ class _ConstVisitor extends RecursiveVisitor<void> {
   final List<Map<String, dynamic>> nonConstantLocations;
 
   bool _matches(Class node) {
-    return node.enclosingLibrary.importUri.toString() == classLibraryUri &&
-      node.name == className;
+    if (node == null) {
+      return false;
+    }
+    final bool exactMatch = node.name == className
+        && node.enclosingLibrary.importUri.toString() == classLibraryUri;
+    return exactMatch
+        || _matches(node.superclass)
+        || node.implementedTypes.any((Supertype implementedType) => _matches(implementedType.classNode));
   }
 
   // Avoid visiting the same constant more than once.

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -78,6 +78,21 @@ void _checkConsts() {
       'nonConstantLocations': <dynamic>[],
     }),
   );
+
+  final ConstFinder finder2 = ConstFinder(
+    kernelFilePath: constsDill,
+    classLibraryUri: 'package:const_finder_fixtures/target.dart',
+    className: 'MixedInTarget',
+  );
+  expect<String>(
+    jsonEncode(finder2.findInstances()),
+    jsonEncode(<String, dynamic>{
+      'constantInstances': <Map<String, dynamic>>[
+        <String, dynamic>{'val': '13'},
+      ],
+      'nonConstantLocations': <dynamic>[],
+    }),
+  );
 }
 
 void _checkNonConsts() {

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -71,6 +71,8 @@ void _checkConsts() {
         <String, dynamic>{'stringValue': '10', 'intValue': 10, 'targetValue': null},
         <String, dynamic>{'stringValue': '9', 'intValue': 9},
         <String, dynamic>{'stringValue': '7', 'intValue': 7, 'targetValue': null},
+        <String, dynamic>{'stringValue': '11', 'intValue': 11, 'targetValue': null},
+        <String, dynamic>{'stringValue': '12', 'intValue': 12, 'targetValue': null},
         <String, dynamic>{'stringValue': 'package', 'intValue':-1, 'targetValue': null},
       ],
       'nonConstantLocations': <dynamic>[],

--- a/tools/const_finder/test/fixtures/lib/consts.dart
+++ b/tools/const_finder/test/fixtures/lib/consts.dart
@@ -36,6 +36,9 @@ void main() {
   extendsTarget.hit();
   const ImplementsTarget implementsTarget = ImplementsTarget('12', 12, null);
   implementsTarget.hit();
+
+  const MixedInTarget mixedInTraget = MixedInTarget('13');
+  mixedInTraget.hit();
 }
 
 class IgnoreMe {

--- a/tools/const_finder/test/fixtures/lib/consts.dart
+++ b/tools/const_finder/test/fixtures/lib/consts.dart
@@ -31,6 +31,11 @@ void main() {
 
   final StaticConstInitializer staticConstMap = StaticConstInitializer();
   staticConstMap.useOne(1);
+
+  const ExtendsTarget extendsTarget = ExtendsTarget('11', 11, null);
+  extendsTarget.hit();
+  const ImplementsTarget implementsTarget = ImplementsTarget('12', 12, null);
+  implementsTarget.hit();
 }
 
 class IgnoreMe {

--- a/tools/const_finder/test/fixtures/lib/target.dart
+++ b/tools/const_finder/test/fixtures/lib/target.dart
@@ -34,3 +34,18 @@ class ImplementsTarget implements Target {
     print('ImplementsTarget - $stringValue $intValue');
   }
 }
+
+mixin MixableTarget {
+  String get val;
+
+  void hit() {
+    print(val);
+  }
+}
+
+class MixedInTarget with MixableTarget {
+  const MixedInTarget(this.val);
+
+  @override
+  final String val;
+}

--- a/tools/const_finder/test/fixtures/lib/target.dart
+++ b/tools/const_finder/test/fixtures/lib/target.dart
@@ -13,3 +13,24 @@ class Target {
     print('$stringValue $intValue');
   }
 }
+
+class ExtendsTarget extends Target {
+  const ExtendsTarget(String stringValue, int intValue, Target targetValue)
+      : super(stringValue, intValue, targetValue);
+}
+
+class ImplementsTarget implements Target {
+  const ImplementsTarget(this.stringValue, this.intValue, this.targetValue);
+
+  @override
+  final String stringValue;
+  @override
+  final int intValue;
+  @override
+  final Target targetValue;
+
+  @override
+  void hit() {
+    print('ImplementsTarget - $stringValue $intValue');
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/63920

Makes const finder work with extended/implemented IconData classes - which is how the Flutter Font Awesome package uses it.

Updates tests.

I noticed in here that this needs a null-safety migration - I can try to takea look at that in a separate PR.