### PR TITLE
[embedder] Add FBO callback that takes frame info

### DIFF
--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -60,7 +60,7 @@ bool ShellTestPlatformViewGL::GLContextPresent() {
 }
 
 // |GPUSurfaceGLDelegate|
-intptr_t ShellTestPlatformViewGL::GLContextFBO() const {
+intptr_t ShellTestPlatformViewGL::GLContextFBO(GLFrameInfo frame_info) const {
   return gl_surface_.GetFramebuffer();
 }
 

--- a/shell/common/shell_test_platform_view_gl.h
+++ b/shell/common/shell_test_platform_view_gl.h
@@ -56,7 +56,7 @@ class ShellTestPlatformViewGL : public ShellTestPlatformView,
   bool GLContextPresent() override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO() const override;
+  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
   GLProcResolver GetGLProcResolver() const override;

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -191,6 +191,9 @@ bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
     return true;
   }
 
+  GLFrameInfo frame_info = {.width = static_cast<uint32_t>(size.width()),
+                            .height = static_cast<uint32_t>(size.height())};
+
   // We need to do some updates.
   TRACE_EVENT0("flutter", "UpdateSurfacesSize");
 
@@ -205,9 +208,9 @@ bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
   sk_sp<SkSurface> onscreen_surface;
 
   onscreen_surface =
-      WrapOnscreenSurface(context_.get(),            // GL context
-                          size,                      // root surface size
-                          delegate_->GLContextFBO()  // window FBO ID
+      WrapOnscreenSurface(context_.get(),  // GL context
+                          size,            // root surface size
+                          delegate_->GLContextFBO(frame_info)  // window FBO ID
       );
 
   if (onscreen_surface == nullptr) {
@@ -287,13 +290,17 @@ bool GPUSurfaceGL::PresentSurface(SkCanvas* canvas) {
     auto current_size =
         SkISize::Make(onscreen_surface_->width(), onscreen_surface_->height());
 
+    GLFrameInfo frame_info = {
+        .width = static_cast<uint32_t>(current_size.width()),
+        .height = static_cast<uint32_t>(current_size.height())};
+
     // The FBO has changed, ask the delegate for the new FBO and do a surface
     // re-wrap.
-    auto new_onscreen_surface =
-        WrapOnscreenSurface(context_.get(),            // GL context
-                            current_size,              // root surface size
-                            delegate_->GLContextFBO()  // window FBO ID
-        );
+    auto new_onscreen_surface = WrapOnscreenSurface(
+        context_.get(),                      // GL context
+        current_size,                        // root surface size
+        delegate_->GLContextFBO(frame_info)  // window FBO ID
+    );
 
     if (!new_onscreen_surface) {
       return false;

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -191,9 +191,6 @@ bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
     return true;
   }
 
-  GLFrameInfo frame_info = {.width = static_cast<uint32_t>(size.width()),
-                            .height = static_cast<uint32_t>(size.height())};
-
   // We need to do some updates.
   TRACE_EVENT0("flutter", "UpdateSurfacesSize");
 
@@ -207,6 +204,8 @@ bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
 
   sk_sp<SkSurface> onscreen_surface;
 
+  GLFrameInfo frame_info = {static_cast<uint32_t>(size.width()),
+                            static_cast<uint32_t>(size.height())};
   onscreen_surface =
       WrapOnscreenSurface(context_.get(),  // GL context
                           size,            // root surface size
@@ -290,9 +289,8 @@ bool GPUSurfaceGL::PresentSurface(SkCanvas* canvas) {
     auto current_size =
         SkISize::Make(onscreen_surface_->width(), onscreen_surface_->height());
 
-    GLFrameInfo frame_info = {
-        .width = static_cast<uint32_t>(current_size.width()),
-        .height = static_cast<uint32_t>(current_size.height())};
+    GLFrameInfo frame_info = {static_cast<uint32_t>(current_size.width()),
+                              static_cast<uint32_t>(current_size.height())};
 
     // The FBO has changed, ask the delegate for the new FBO and do a surface
     // re-wrap.

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -14,6 +14,11 @@
 
 namespace flutter {
 
+struct GLFrameInfo {
+  uint32_t width;
+  uint32_t height;
+};
+
 class GPUSurfaceGLDelegate : public GPUSurfaceDelegate {
  public:
   ~GPUSurfaceGLDelegate() override;
@@ -33,13 +38,13 @@ class GPUSurfaceGLDelegate : public GPUSurfaceDelegate {
   virtual bool GLContextPresent() = 0;
 
   // The ID of the main window bound framebuffer. Typically FBO0.
-  virtual intptr_t GLContextFBO() const = 0;
+  virtual intptr_t GLContextFBO(GLFrameInfo frame_info) const = 0;
 
   // The rendering subsystem assumes that the ID of the main window bound
   // framebuffer remains constant throughout. If this assumption in incorrect,
   // embedders are required to return true from this method. In such cases,
-  // GLContextFBO() will be called again to acquire the new FBO ID for rendering
-  // subsequent frames.
+  // GLContextFBO(frame_info) will be called again to acquire the new FBO ID for
+  // rendering subsequent frames.
   virtual bool GLContextFBOResetAfterPresent() const;
 
   // Indicates whether or not the surface supports pixel readback as used in

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -14,6 +14,8 @@
 
 namespace flutter {
 
+// A structure to represent the frame information which is passed to the
+// embedder when requesting a frame buffer object.
 struct GLFrameInfo {
   uint32_t width;
   uint32_t height;

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -115,7 +115,7 @@ bool AndroidSurfaceGL::GLContextPresent() {
   return onscreen_surface_->SwapBuffers();
 }
 
-intptr_t AndroidSurfaceGL::GLContextFBO() const {
+intptr_t AndroidSurfaceGL::GLContextFBO(GLFrameInfo frame_info) const {
   FML_DCHECK(IsValid());
   // The default window bound framebuffer on Android.
   return 0;

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -59,7 +59,7 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   bool GLContextPresent() override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO() const override;
+  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;

--- a/shell/platform/android/surface/android_surface_mock.cc
+++ b/shell/platform/android/surface/android_surface_mock.cc
@@ -18,7 +18,7 @@ bool AndroidSurfaceMock::GLContextPresent() {
   return true;
 }
 
-intptr_t AndroidSurfaceMock::GLContextFBO() const {
+intptr_t AndroidSurfaceMock::GLContextFBO(GLFrameInfo frame_info) const {
   return 0;
 }
 

--- a/shell/platform/android/surface/android_surface_mock.h
+++ b/shell/platform/android/surface/android_surface_mock.h
@@ -48,7 +48,7 @@ class AndroidSurfaceMock final : public GPUSurfaceGLDelegate,
   bool GLContextPresent() override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO() const override;
+  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -43,7 +43,7 @@ class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
   bool GLContextPresent() override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO() const override;
+  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
   bool SurfaceSupportsReadback() const override;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -44,7 +44,7 @@ std::unique_ptr<Surface> IOSSurfaceGL::CreateGPUSurface(GrDirectContext* gr_cont
 }
 
 // |GPUSurfaceGLDelegate|
-intptr_t IOSSurfaceGL::GLContextFBO() const {
+intptr_t IOSSurfaceGL::GLContextFBO(GLFrameInfo frame_info) const {
   return IsValid() ? render_target_->GetFramebuffer() : GL_NONE;
 }
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -93,8 +93,19 @@ static bool IsOpenGLRendererConfigValid(const FlutterRendererConfig* config) {
 
   if (SAFE_ACCESS(open_gl_config, make_current, nullptr) == nullptr ||
       SAFE_ACCESS(open_gl_config, clear_current, nullptr) == nullptr ||
-      SAFE_ACCESS(open_gl_config, present, nullptr) == nullptr ||
-      SAFE_ACCESS(open_gl_config, fbo_callback, nullptr) == nullptr) {
+      SAFE_ACCESS(open_gl_config, present, nullptr) == nullptr) {
+    return false;
+  }
+
+  bool fbo_callback_exists =
+      SAFE_ACCESS(open_gl_config, fbo_callback, nullptr) != nullptr;
+  bool fbo_with_frame_info_callback_exists =
+      SAFE_ACCESS(open_gl_config, fbo_with_frame_info_callback, nullptr) !=
+      nullptr;
+  // only one of these callbacks must exist.
+  if (fbo_callback_exists == fbo_with_frame_info_callback_exists) {
+    LOG_EMBEDDER_ERROR(kInternalInconsistency,
+                       "OpenGL fbo callback configuration was invalid.");
     return false;
   }
 
@@ -168,8 +179,18 @@ InferOpenGLPlatformViewCreationCallback(
     return ptr(user_data);
   };
 
-  auto gl_fbo_callback = [ptr = config->open_gl.fbo_callback,
-                          user_data]() -> intptr_t { return ptr(user_data); };
+  auto gl_fbo_callback =
+      [fbo_callback = config->open_gl.fbo_callback,
+       fbo_with_frame_info_callback =
+           config->open_gl.fbo_with_frame_info_callback,
+       user_data](flutter::GLFrameInfo frame_info) -> intptr_t {
+    if (fbo_callback) {
+      return fbo_callback(user_data);
+    } else {
+      return fbo_with_frame_info_callback(
+          user_data, {.width = frame_info.width, .height = frame_info.height});
+    }
+  };
 
   const FlutterOpenGLRendererConfig* open_gl_config = &config->open_gl;
   std::function<bool()> gl_make_resource_current_callback = nullptr;

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -185,7 +185,7 @@ InferOpenGLPlatformViewCreationCallback(
     if (fbo_callback) {
       return fbo_callback(user_data);
     } else {
-      FlutterFrameInfo frame_info;
+      FlutterFrameInfo frame_info = {};
       frame_info.struct_size = sizeof(FlutterFrameInfo);
       frame_info.size = {gl_frame_info.width, gl_frame_info.height};
       return fbo_with_frame_info_callback(user_data, &frame_info);

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -104,8 +104,6 @@ static bool IsOpenGLRendererConfigValid(const FlutterRendererConfig* config) {
       nullptr;
   // only one of these callbacks must exist.
   if (fbo_callback_exists == fbo_with_frame_info_callback_exists) {
-    LOG_EMBEDDER_ERROR(kInternalInconsistency,
-                       "OpenGL fbo callback configuration was invalid.");
     return false;
   }
 
@@ -183,12 +181,14 @@ InferOpenGLPlatformViewCreationCallback(
       [fbo_callback = config->open_gl.fbo_callback,
        fbo_with_frame_info_callback =
            config->open_gl.fbo_with_frame_info_callback,
-       user_data](flutter::GLFrameInfo frame_info) -> intptr_t {
+       user_data](flutter::GLFrameInfo gl_frame_info) -> intptr_t {
     if (fbo_callback) {
       return fbo_callback(user_data);
     } else {
-      return fbo_with_frame_info_callback(
-          user_data, {.width = frame_info.width, .height = frame_info.height});
+      FlutterFrameInfo frame_info;
+      frame_info.struct_size = sizeof(FlutterFrameInfo);
+      frame_info.size = {gl_frame_info.width, gl_frame_info.height};
+      return fbo_with_frame_info_callback(user_data, &frame_info);
     }
   };
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -306,15 +306,33 @@ typedef bool (*TextureFrameCallback)(void* /* user data */,
                                      FlutterOpenGLTexture* /* texture out */);
 typedef void (*VsyncCallback)(void* /* user data */, intptr_t /* baton */);
 
+/// A structure to represent the width and height.
 typedef struct {
-  /// The width of the surface that will be backed by the fbo.
+  double width;
+  double height;
+} FlutterSize;
+
+/// A structure to represent the width and height.
+///
+/// See: \ref FlutterSize when the value are not integers.
+typedef struct {
   uint32_t width;
-  /// The height of the surface that will be backed by the fbo.
   uint32_t height;
+} FlutterUIntSize;
+
+/// This information is passed to the embedder when requesting a frame buffer
+/// object.
+///
+/// See: \ref FlutterSoftwareRendererConfig.fbo_with_frame_info_callback.
+typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterFrameInfo).
+  size_t struct_size;
+  /// The size of the surface that will be backed by the fbo.
+  FlutterUIntSize size;
 } FlutterFrameInfo;
 
-typedef uint32_t (*FBOWithFrameInfoCallBack)(void* /* user data */,
-                                             FlutterFrameInfo /* frame info*/);
+typedef uint32_t (*UIntFrameInfoCallback)(void* /* user data */,
+                                          FlutterFrameInfo* /* frame info */);
 
 typedef struct {
   /// The size of this struct. Must be sizeof(FlutterOpenGLRendererConfig).
@@ -322,10 +340,11 @@ typedef struct {
   BoolCallback make_current;
   BoolCallback clear_current;
   BoolCallback present;
-  /// This is an optional callback. Exactly one of
-  /// `fbo_with_frame_info_callback` or `fbo_callback` must be provided. The
-  /// return value indicates the id of the frame buffer object that flutter will
-  /// obtain the gl surface from.
+  /// Specifying one (and only one) of the `fbo_callback` or
+  /// `fbo_with_frame_info_callback` is required. Specifying both is an error
+  /// and engine intialization will be terminated. The return value indicates
+  /// the id of the frame buffer object that flutter will obtain the gl surface
+  /// from.
   UIntCallback fbo_callback;
   /// This is an optional callback. Flutter will ask the emebdder to create a GL
   /// context current on a background thread. If the embedder is able to do so,
@@ -356,13 +375,14 @@ typedef struct {
   /// that external texture details can be supplied to the engine for subsequent
   /// composition.
   TextureFrameCallback gl_external_texture_frame_callback;
-  /// This is an optional callback. Exactly one of
-  /// `fbo_with_frame_info_callback` or `fbo_callback` must provided. The
-  /// return value indicates the id of the frame buffer object (fbo) that
-  /// flutter will obtain the gl surface from. When using this variant, the
-  /// embedder is passed a `FlutterFrameInfo` struct that indicates the
-  /// properties of the surface that flutter will acquire from the returned fbo.
-  FBOWithFrameInfoCallBack fbo_with_frame_info_callback;
+  /// Specifying one (and only one) of the `fbo_callback` or
+  /// `fbo_with_frame_info_callback` is required. Specifying both is an error
+  /// and engine intialization will be terminated. The return value indicates
+  /// the id of the frame buffer object (fbo) that flutter will obtain the gl
+  /// surface from. When using this variant, the embedder is passed a
+  /// `FlutterFrameInfo` struct that indicates the properties of the surface
+  /// that flutter will acquire from the returned fbo.
+  UIntFrameInfoCallback fbo_with_frame_info_callback;
 } FlutterOpenGLRendererConfig;
 
 typedef struct {
@@ -522,11 +542,6 @@ typedef struct {
   double x;
   double y;
 } FlutterPoint;
-
-typedef struct {
-  double width;
-  double height;
-} FlutterSize;
 
 typedef struct {
   FlutterRect rect;

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -331,8 +331,9 @@ typedef struct {
   FlutterUIntSize size;
 } FlutterFrameInfo;
 
-typedef uint32_t (*UIntFrameInfoCallback)(void* /* user data */,
-                                          FlutterFrameInfo* /* frame info */);
+typedef uint32_t (*UIntFrameInfoCallback)(
+    void* /* user data */,
+    const FlutterFrameInfo* /* frame info */);
 
 typedef struct {
   /// The size of this struct. Must be sizeof(FlutterOpenGLRendererConfig).

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -307,11 +307,25 @@ typedef bool (*TextureFrameCallback)(void* /* user data */,
 typedef void (*VsyncCallback)(void* /* user data */, intptr_t /* baton */);
 
 typedef struct {
+  /// The width of the surface that will be backed by the fbo.
+  uint32_t width;
+  /// The height of the surface that will be backed by the fbo.
+  uint32_t height;
+} FlutterFrameInfo;
+
+typedef uint32_t (*FBOWithFrameInfoCallBack)(void* /* user data */,
+                                             FlutterFrameInfo /* frame info*/);
+
+typedef struct {
   /// The size of this struct. Must be sizeof(FlutterOpenGLRendererConfig).
   size_t struct_size;
   BoolCallback make_current;
   BoolCallback clear_current;
   BoolCallback present;
+  /// This is an optional callback. Exactly one of
+  /// `fbo_with_frame_info_callback` or `fbo_callback` must be provided. The
+  /// return value indicates the id of the frame buffer object that flutter will
+  /// obtain the gl surface from.
   UIntCallback fbo_callback;
   /// This is an optional callback. Flutter will ask the emebdder to create a GL
   /// context current on a background thread. If the embedder is able to do so,
@@ -342,6 +356,13 @@ typedef struct {
   /// that external texture details can be supplied to the engine for subsequent
   /// composition.
   TextureFrameCallback gl_external_texture_frame_callback;
+  /// This is an optional callback. Exactly one of
+  /// `fbo_with_frame_info_callback` or `fbo_callback` must provided. The
+  /// return value indicates the id of the frame buffer object (fbo) that
+  /// flutter will obtain the gl surface from. When using this variant, the
+  /// embedder is passed a `FlutterFrameInfo` struct that indicates the
+  /// properties of the surface that flutter will acquire from the returned fbo.
+  FBOWithFrameInfoCallBack fbo_with_frame_info_callback;
 } FlutterOpenGLRendererConfig;
 
 typedef struct {

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -50,8 +50,8 @@ bool EmbedderSurfaceGL::GLContextPresent() {
 }
 
 // |GPUSurfaceGLDelegate|
-intptr_t EmbedderSurfaceGL::GLContextFBO() const {
-  return gl_dispatch_table_.gl_fbo_callback();
+intptr_t EmbedderSurfaceGL::GLContextFBO(GLFrameInfo frame_info) const {
+  return gl_dispatch_table_.gl_fbo_callback(frame_info);
 }
 
 // |GPUSurfaceGLDelegate|

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -19,7 +19,7 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
     std::function<bool(void)> gl_make_current_callback;           // required
     std::function<bool(void)> gl_clear_current_callback;          // required
     std::function<bool(void)> gl_present_callback;                // required
-    std::function<intptr_t(void)> gl_fbo_callback;                // required
+    std::function<intptr_t(GLFrameInfo)> gl_fbo_callback;         // required
     std::function<bool(void)> gl_make_resource_current_callback;  // optional
     std::function<SkMatrix(void)>
         gl_surface_transformation_callback;              // optional
@@ -59,7 +59,7 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   bool GLContextPresent() override;
 
   // |GPUSurfaceGLDelegate|
-  intptr_t GLContextFBO() const override;
+  intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
   bool GLContextFBOResetAfterPresent() const override;

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -35,8 +35,12 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
   opengl_renderer_config_.present = [](void* context) -> bool {
     return reinterpret_cast<EmbedderTestContext*>(context)->GLPresent();
   };
-  opengl_renderer_config_.fbo_callback = [](void* context) -> uint32_t {
-    return reinterpret_cast<EmbedderTestContext*>(context)->GLGetFramebuffer();
+  opengl_renderer_config_.fbo_with_frame_info_callback =
+      [](void* context, FlutterFrameInfo frame_info) -> uint32_t {
+    return reinterpret_cast<EmbedderTestContext*>(context)->GLGetFramebuffer({
+        .width = frame_info.width,
+        .height = frame_info.height,
+    });
   };
   opengl_renderer_config_.make_resource_current = [](void* context) -> bool {
     return reinterpret_cast<EmbedderTestContext*>(context)

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -36,12 +36,9 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
     return reinterpret_cast<EmbedderTestContext*>(context)->GLPresent();
   };
   opengl_renderer_config_.fbo_with_frame_info_callback =
-      [](void* context, FlutterFrameInfo* frame_info) -> uint32_t {
-    FlutterFrameInfo tmp;
-    tmp.struct_size = sizeof(FlutterFrameInfo);
-    tmp.size = frame_info->size;
+      [](void* context, const FlutterFrameInfo* frame_info) -> uint32_t {
     return reinterpret_cast<EmbedderTestContext*>(context)->GLGetFramebuffer(
-        tmp);
+        *frame_info);
   };
   opengl_renderer_config_.make_resource_current = [](void* context) -> bool {
     return reinterpret_cast<EmbedderTestContext*>(context)
@@ -119,14 +116,14 @@ void EmbedderConfigBuilder::SetOpenGLFBOCallBack() {
   // SetOpenGLRendererConfig must be called before this.
   FML_CHECK(renderer_config_.type == FlutterRendererType::kOpenGL);
   renderer_config_.open_gl.fbo_callback = [](void* context) -> uint32_t {
-    FlutterFrameInfo tmp;
+    FlutterFrameInfo frame_info = {};
     // fbo_callback doesn't use the frame size information, only
     // fbo_callback_with_frame_info does.
-    tmp.struct_size = sizeof(FlutterFrameInfo);
-    tmp.size.width = 0;
-    tmp.size.height = 0;
+    frame_info.struct_size = sizeof(FlutterFrameInfo);
+    frame_info.size.width = 0;
+    frame_info.size.height = 0;
     return reinterpret_cast<EmbedderTestContext*>(context)->GLGetFramebuffer(
-        tmp);
+        frame_info);
   };
 }
 

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -49,6 +49,12 @@ class EmbedderConfigBuilder {
 
   void SetOpenGLRendererConfig(SkISize surface_size);
 
+  // Used to explicitly set an `open_gl.fbo_callback`. Using this method will
+  // cause your test to fail since the ctor for this class sets
+  // `open_gl.fbo_callback_with_frame_info`. This method exists as a utility to
+  // explicitly test this behavior.
+  void SetOpenGLFBOCallBack();
+
   void SetAssetsPath();
 
   void SetSnapshots();

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -197,9 +197,14 @@ bool EmbedderTestContext::GLPresent() {
   return true;
 }
 
-uint32_t EmbedderTestContext::GLGetFramebuffer() {
+uint32_t EmbedderTestContext::GLGetFramebuffer(FlutterFrameInfo frame_info) {
   FML_CHECK(gl_surface_) << "GL surface must be initialized.";
+  gl_surface_fbo_frame_infos_.push_back(frame_info);
   return gl_surface_->GetFramebuffer();
+}
+
+std::vector<FlutterFrameInfo> EmbedderTestContext::GetGLFBOFrameInfos() {
+  return gl_surface_fbo_frame_infos_;
 }
 
 bool EmbedderTestContext::GLMakeResourceCurrent() {

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -79,6 +79,8 @@ class EmbedderTestContext {
 
   size_t GetSoftwareSurfacePresentCount() const;
 
+  std::vector<FlutterFrameInfo> GetGLFBOFrameInfos();
+
  private:
   // This allows the builder to access the hooks.
   friend class EmbedderConfigBuilder;
@@ -101,6 +103,7 @@ class EmbedderTestContext {
   std::unique_ptr<EmbedderTestCompositor> compositor_;
   NextSceneCallback next_scene_callback_;
   SkMatrix root_surface_transformation_;
+  std::vector<FlutterFrameInfo> gl_surface_fbo_frame_infos_;
   size_t gl_surface_present_count_ = 0;
   size_t software_surface_present_count_ = 0;
 
@@ -133,7 +136,7 @@ class EmbedderTestContext {
 
   bool GLPresent();
 
-  uint32_t GLGetFramebuffer();
+  uint32_t GLGetFramebuffer(FlutterFrameInfo frame_info);
 
   bool GLMakeResourceCurrent();
 

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -79,6 +79,7 @@ class EmbedderTestContext {
 
   size_t GetSoftwareSurfacePresentCount() const;
 
+  // Returns the frame information for all the frames that were rendered.
   std::vector<FlutterFrameInfo> GetGLFBOFrameInfos();
 
  private:

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4352,5 +4352,49 @@ TEST_F(EmbedderTest, CanLaunchAndShutdownWithAValidElfSource) {
   engine.reset();
 }
 
+TEST_F(EmbedderTest, FrameInfoContainsValidWidthAndHeight) {
+  auto& context = GetEmbedderContext();
+
+  EmbedderConfigBuilder builder(context);
+  builder.SetOpenGLRendererConfig(SkISize::Make(600, 1024));
+  builder.SetDartEntrypoint("push_frames_over_and_over");
+
+  const auto root_surface_transformation =
+      SkMatrix().preTranslate(0, 1024).preRotate(-90, 0, 0);
+
+  context.SetRootSurfaceTransformation(root_surface_transformation);
+
+  auto engine = builder.LaunchEngine();
+
+  // Send a window metrics events so frames may be scheduled.
+  FlutterWindowMetricsEvent event = {};
+  event.struct_size = sizeof(event);
+  event.width = 1024;
+  event.height = 600;
+  event.pixel_ratio = 1.0;
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
+            kSuccess);
+  ASSERT_TRUE(engine.is_valid());
+
+  constexpr size_t frames_expected = 10;
+  fml::CountDownLatch frame_latch(frames_expected);
+  size_t frames_seen = 0;
+  context.AddNativeCallback("SignalNativeTest",
+                            CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
+                              frames_seen++;
+                              frame_latch.CountDown();
+                            }));
+  frame_latch.Wait();
+
+  ASSERT_EQ(frames_expected, frames_seen);
+  ASSERT_EQ(context.GetGLFBOFrameInfos().size(), frames_seen);
+
+  for (FlutterFrameInfo frame_info : context.GetGLFBOFrameInfos()) {
+    // width and height are rotated by 90 deg
+    ASSERT_EQ(frame_info.width, event.height);
+    ASSERT_EQ(frame_info.height, event.width);
+  }
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4391,9 +4391,20 @@ TEST_F(EmbedderTest, FrameInfoContainsValidWidthAndHeight) {
 
   for (FlutterFrameInfo frame_info : context.GetGLFBOFrameInfos()) {
     // width and height are rotated by 90 deg
-    ASSERT_EQ(frame_info.width, event.height);
-    ASSERT_EQ(frame_info.height, event.width);
+    ASSERT_EQ(frame_info.size.width, event.height);
+    ASSERT_EQ(frame_info.size.height, event.width);
   }
+}
+
+TEST_F(EmbedderTest, MustNotRunWithBothFBOCallbacksSet) {
+  auto& context = GetEmbedderContext();
+
+  EmbedderConfigBuilder builder(context);
+  builder.SetOpenGLRendererConfig(SkISize::Make(600, 1024));
+  builder.SetOpenGLFBOCallBack();
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_FALSE(engine.is_valid());
 }
 
 }  // namespace testing


### PR DESCRIPTION
Flutter conflates the size of the frame that is rendered by the framework and the size of the render surface itself. While these are usually the same, this breaks down in cases where the render surface size is being updated constantly.

To this effect, we will be adding a variant of `fbo_callback` that takes a FrameInfo struct. `fbo_callback_with_frame_info`. FrameInfo will contain the size of the layer tree that Flutter plans on rendering to the FBO. This lets us create and return an FBO of the requested size along with any additional bookkeeping.

See EC-1 in [flutter.dev/go/double-buffered-window-resize](http://flutter.dev/go/double-buffered-window-resize) and https://github.com/flutter/flutter/issues/44136