### PR TITLE
Fix NPE in PlatformViewsController.checkInputConnectionProxy

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -17,6 +17,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.embedding.android.AndroidTouchProcessor;
@@ -531,7 +532,12 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    * if the view was created in a platform view's VD, delegates the decision to the platform view's
    * {@link View#checkInputConnectionProxy(View)} method. Else returns false.
    */
-  public boolean checkInputConnectionProxy(View view) {
+  public boolean checkInputConnectionProxy(@Nullable View view) {
+    // View can be null on some devices
+    // See: https://github.com/flutter/flutter/issues/36517
+    if (view == null) {
+      return false;
+    }
     if (!contextToPlatformView.containsKey(view.getContext())) {
       return false;
     }

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -519,6 +519,13 @@ public class PlatformViewsControllerTest {
     assertEquals(flutterView.getChildCount(), 1);
   }
 
+  @Test
+  public void checkInputConnectionProxy__falseIfViewIsNull() {
+    final PlatformViewsController platformViewsController = new PlatformViewsController();
+    boolean shouldProxying = platformViewsController.checkInputConnectionProxy(null);
+    assertFalse(shouldProxying);
+  }
+
   private static byte[] encodeMethodCall(MethodCall call) {
     final ByteBuffer buffer = StandardMethodCodec.INSTANCE.encodeMethodCall(call);
     buffer.rewind();


### PR DESCRIPTION
## Description

Fix for possible NullPointerException in `PlatformViewsController.checkInputConnectionProxy`

## Related Issues

https://github.com/flutter/flutter/issues/36517

## Tests

I added the following tests:
`PlatformViewsControllerTest.checkInputConnectionProxy__falseIfViewIsNull`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
