### PR TITLE
Add Linux Wayland support

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1304,6 +1304,8 @@ FILE: ../../../flutter/shell/platform/linux/fl_renderer.cc
 FILE: ../../../flutter/shell/platform/linux/fl_renderer.h
 FILE: ../../../flutter/shell/platform/linux/fl_renderer_headless.cc
 FILE: ../../../flutter/shell/platform/linux/fl_renderer_headless.h
+FILE: ../../../flutter/shell/platform/linux/fl_renderer_wayland.cc
+FILE: ../../../flutter/shell/platform/linux/fl_renderer_wayland.h
 FILE: ../../../flutter/shell/platform/linux/fl_renderer_x11.cc
 FILE: ../../../flutter/shell/platform/linux/fl_renderer_x11.h
 FILE: ../../../flutter/shell/platform/linux/fl_standard_message_codec.cc

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -161,7 +161,7 @@ executable("flutter_linux_unittests") {
 
   configs += [
     "//flutter/shell/platform/linux/config:gtk",
-    "//flutter/shell/platform/linux/config:wayland-egl"
+    "//flutter/shell/platform/linux/config:wayland-egl",
   ]
 
   # Set flag to allow public headers to be directly included (library users should not do this)

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -94,6 +94,7 @@ source_set("flutter_linux_sources") {
     "fl_plugin_registry.cc",
     "fl_renderer.cc",
     "fl_renderer_headless.cc",
+    "fl_renderer_wayland.cc",
     "fl_renderer_x11.cc",
     "fl_standard_message_codec.cc",
     "fl_standard_method_codec.cc",
@@ -117,6 +118,7 @@ source_set("flutter_linux") {
   configs += [
     "//flutter/shell/platform/linux/config:gtk",
     "//flutter/shell/platform/linux/config:egl",
+    "//flutter/shell/platform/linux/config:wayland-egl",
     "//third_party/khronos:khronos_headers",
   ]
 
@@ -157,7 +159,10 @@ executable("flutter_linux_unittests") {
 
   public_configs = [ "//flutter:config" ]
 
-  configs += [ "//flutter/shell/platform/linux/config:gtk" ]
+  configs += [
+    "//flutter/shell/platform/linux/config:gtk",
+    "//flutter/shell/platform/linux/config:wayland-egl"
+  ]
 
   # Set flag to allow public headers to be directly included (library users should not do this)
   defines = [ "FLUTTER_LINUX_COMPILATION" ]

--- a/shell/platform/linux/config/BUILD.gn
+++ b/shell/platform/linux/config/BUILD.gn
@@ -18,3 +18,7 @@ pkg_config("gtk") {
 pkg_config("egl") {
   packages = [ "egl" ]
 }
+
+pkg_config("wayland-egl") {
+  packages = [ "wayland-egl" ]
+}

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -9,6 +9,7 @@
 #include <gtk/gtk.h>
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_view.h"
 
 G_BEGIN_DECLS
 
@@ -39,18 +40,11 @@ struct _FlRendererClass {
    * Does not need to be implemented.
    */
   gboolean (*setup_window_attr)(FlRenderer* renderer,
-                                GtkWidget* widget,
                                 EGLDisplay egl_display,
                                 EGLConfig egl_config,
                                 GdkWindowAttr* window_attributes,
                                 gint* mask,
                                 GError** error);
-
-  /**
-   * Virtual method called after a GDK window has been created.
-   * This is called once. Does not need to be implemented.
-   */
-  void (*set_window)(FlRenderer* renderer, GdkWindow* window);
 
   /**
    * Virtual method to create a new EGL display.
@@ -87,7 +81,7 @@ struct _FlRendererClass {
 /**
  * fl_renderer_start:
  * @renderer: an #FlRenderer.
- * @widget: the widget Flutter is renderering to.
+ * @view: the #FlView widget this renderer is using.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  * to ignore.
  *
@@ -95,9 +89,15 @@ struct _FlRendererClass {
  *
  * Returns: %TRUE if successfully started.
  */
-gboolean fl_renderer_start(FlRenderer* renderer,
-                           GtkWidget* widget,
-                           GError** error);
+gboolean fl_renderer_start(FlRenderer* renderer, FlView* view, GError** error);
+
+/**
+ * fl_renderer_get_view:
+ * @renderer: an #FlRenderer.
+ *
+ * Returns the #FlView that is using the renderer.
+ */
+FlView* fl_renderer_get_view(FlRenderer* renderer);
 
 /**
  * fl_renderer_set_geometry:

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -38,10 +38,21 @@ struct _FlRendererClass {
   /**
    * Virtual method called before creating a GdkWindow for the widget.
    * Does not need to be implemented.
+   * @renderer: an #FlRenderer.
+   * @widget: the widget being rendered on.
+   * @display: display to create surfaces on.
+   * @config: EGL configuration.
+   * @window_attributes: window attributes to modify.
+   * @mask: (out): the window mask to use.
+   * @error: (allow-none): #GError location to store the error occurring, or
+   * %NULL to ignore.
+   *
+   * Returns: %TRUE if the window is successfully set up.
    */
   gboolean (*setup_window_attr)(FlRenderer* renderer,
-                                EGLDisplay egl_display,
-                                EGLConfig egl_config,
+                                GtkWidget* widget,
+                                EGLDisplay display,
+                                EGLConfig config,
                                 GdkWindowAttr* window_attributes,
                                 gint* mask,
                                 GError** error);
@@ -54,7 +65,9 @@ struct _FlRendererClass {
   /**
    * Virtual method called when Flutter needs surfaces to render to.
    * @renderer: an #FlRenderer.
+   * @widget: the widget being rendered on.
    * @display: display to create surfaces on.
+   * @config: EGL configuration.
    * @visible: (out): the visible surface that is created.
    * @resource: (out): the resource surface that is created.
    * @error: (allow-none): #GError location to store the error occurring, or
@@ -63,6 +76,7 @@ struct _FlRendererClass {
    * Returns: %TRUE if both surfaces were created, %FALSE if there was an error.
    */
   gboolean (*create_surfaces)(FlRenderer* renderer,
+                              GtkWidget* widget,
                               EGLDisplay display,
                               EGLConfig config,
                               EGLSurface* visible,
@@ -81,7 +95,7 @@ struct _FlRendererClass {
 /**
  * fl_renderer_start:
  * @renderer: an #FlRenderer.
- * @view: the #FlView widget this renderer is using.
+ * @widget: the widget Flutter is renderering to.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  * to ignore.
  *
@@ -89,15 +103,9 @@ struct _FlRendererClass {
  *
  * Returns: %TRUE if successfully started.
  */
-gboolean fl_renderer_start(FlRenderer* renderer, FlView* view, GError** error);
-
-/**
- * fl_renderer_get_view:
- * @renderer: an #FlRenderer.
- *
- * Returns the #FlView that is using the renderer.
- */
-FlView* fl_renderer_get_view(FlRenderer* renderer);
+gboolean fl_renderer_start(FlRenderer* renderer,
+                           GtkWidget* widget,
+                           GError** error);
 
 /**
  * fl_renderer_set_geometry:

--- a/shell/platform/linux/fl_renderer_headless.cc
+++ b/shell/platform/linux/fl_renderer_headless.cc
@@ -11,6 +11,7 @@ struct _FlRendererHeadless {
 G_DEFINE_TYPE(FlRendererHeadless, fl_renderer_headless, fl_renderer_get_type())
 
 static gboolean fl_renderer_headless_create_surfaces(FlRenderer* renderer,
+                                                     GtkWidget* widget,
                                                      EGLDisplay display,
                                                      EGLConfig config,
                                                      EGLSurface* visible,

--- a/shell/platform/linux/fl_renderer_wayland.cc
+++ b/shell/platform/linux/fl_renderer_wayland.cc
@@ -121,16 +121,14 @@ static void fl_renderer_wayland_on_window_map(FlRendererWayland* self,
     return;
   }
 
-  GdkWaylandWindow* window = GDK_WAYLAND_WINDOW(
-      gtk_widget_get_window(gtk_widget_get_toplevel(widget)));
+  GdkWaylandWindow* window = GDK_WAYLAND_WINDOW(gtk_widget_get_window(widget));
   if (!window) {
-    g_error("fl_renderer_wayland_on_window_map: not a Wayland surface");
+    g_error("fl_renderer_wayland_on_window_map: not a Wayland window");
     return;
   }
   wl_surface* toplevel_surface = gdk_wayland_window_get_wl_surface(window);
   if (!toplevel_surface) {
-    g_error(
-        "fl_renderer_wayland_on_window_map: could not get toplevel wl_surface");
+    g_error("fl_renderer_wayland_on_window_map: could not get wl_surface");
     return;
   }
 

--- a/shell/platform/linux/fl_renderer_wayland.cc
+++ b/shell/platform/linux/fl_renderer_wayland.cc
@@ -1,0 +1,322 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#define WL_EGL_PLATFORM
+
+#include "fl_renderer_wayland.h"
+#include "flutter/shell/platform/linux/egl_utils.h"
+
+#include <gdk/gdkwayland.h>
+#include <wayland-egl-core.h>
+
+static void fl_renderer_wayland_on_window_map(GtkWidget* widget,
+                                              FlRendererWayland* self);
+static void fl_renderer_wayland_on_window_unmap(GtkWidget* widget,
+                                                FlRendererWayland* self);
+
+struct _FlRendererWayland {
+  FlRenderer parent_instance;
+
+  struct {
+    wl_subsurface* subsurface;
+    wl_surface* surface;
+    wl_egl_window* egl_window;
+    GdkRectangle geometry;
+    gint scale;
+  } subsurface;
+
+  // The resource surface will not be mapped, but needs to be a wl_surface
+  // because ONLY window EGL surfaces are supported on Wayland.
+  struct {
+    wl_surface* surface;
+    wl_egl_window* egl_window;
+  } resource;
+};
+
+static wl_registry* registry_global = nullptr;
+static wl_subcompositor* subcompositor_global = nullptr;
+
+// All globals in this array will be automatically bound in
+// registry_handle_global() if available.
+static struct {
+  void** global;
+  const wl_interface* interface;
+} globals[] = {{reinterpret_cast<void**>(&subcompositor_global),
+                &wl_subcompositor_interface}};
+
+// wl_registry.global callback.
+// Binds to all globals in the globals array.
+static void registry_handle_global(void*,
+                                   wl_registry* registry,
+                                   uint32_t id,
+                                   const char* name,
+                                   uint32_t max_version) {
+  for (unsigned i = 0; i < sizeof(globals) / sizeof(globals[0]); i++) {
+    const wl_interface* interface = globals[i].interface;
+    if (strcmp(name, interface->name) == 0) {
+      uint32_t version =
+          MIN(static_cast<uint32_t>(interface->version), max_version);
+      *globals[i].global = static_cast<wl_subcompositor*>(
+          wl_registry_bind(registry, id, interface, version));
+    }
+  }
+}
+
+// wl_registry.global_remove callback.
+// Can be safely ignored unless we bind to globals that might be removed.
+static void registry_handle_global_remove(void*, wl_registry*, uint32_t) {}
+
+static const wl_registry_listener registry_listener = {
+    .global = registry_handle_global,
+    .global_remove = registry_handle_global_remove,
+};
+
+// The first time this function is called, all Wayland globals are initialized
+// (which blocks for a round trip to the Wayland compositor).
+// Subsequent calls return immediately.
+static void lazy_initialize_wayland_globals() {
+  if (registry_global) {
+    return;
+  }
+
+  GdkWaylandDisplay* gdk_display =
+      GDK_WAYLAND_DISPLAY(gdk_display_get_default());
+  g_return_if_fail(gdk_display);
+
+  wl_display* display = gdk_wayland_display_get_wl_display(gdk_display);
+  registry_global = wl_display_get_registry(display);
+  wl_registry_add_listener(registry_global, &registry_listener, nullptr);
+  wl_display_roundtrip(display);
+}
+
+G_DEFINE_TYPE(FlRendererWayland, fl_renderer_wayland, fl_renderer_get_type())
+
+// Returns the GTK widget at the top of the view's widget hierarchy.
+static GtkWidget* fl_renderer_wayland_get_toplevel_widget(
+    FlRendererWayland* self) {
+  FlRenderer* renderer = FL_RENDERER(self);
+  return gtk_widget_get_toplevel(GTK_WIDGET(fl_renderer_get_view(renderer)));
+}
+
+// Implements GObject::dispose.
+static void fl_renderer_wayland_dispose(GObject* object) {
+  FlRendererWayland* self = FL_RENDERER_WAYLAND(object);
+
+  GtkWidget* toplevel = fl_renderer_wayland_get_toplevel_widget(self);
+  g_signal_handlers_disconnect_by_func(
+      G_OBJECT(toplevel), (gpointer)fl_renderer_wayland_on_window_map, self);
+  g_signal_handlers_disconnect_by_func(
+      G_OBJECT(toplevel), (gpointer)fl_renderer_wayland_on_window_unmap, self);
+
+  g_clear_pointer(&self->subsurface.subsurface, wl_subsurface_destroy);
+  g_clear_pointer(&self->subsurface.egl_window, wl_egl_window_destroy);
+  g_clear_pointer(&self->subsurface.surface, wl_surface_destroy);
+
+  g_clear_pointer(&self->resource.egl_window, wl_egl_window_destroy);
+  g_clear_pointer(&self->resource.surface, wl_surface_destroy);
+
+  G_OBJECT_CLASS(fl_renderer_wayland_parent_class)->dispose(object);
+}
+
+// Implements FlRenderer::create_display.
+static EGLDisplay fl_renderer_wayland_create_display(FlRenderer* /*renderer*/) {
+  GdkWaylandDisplay* gdk_display =
+      GDK_WAYLAND_DISPLAY(gdk_display_get_default());
+  g_return_val_if_fail(gdk_display, nullptr);
+  return eglGetDisplay(gdk_wayland_display_get_wl_display(gdk_display));
+}
+
+static void fl_renderer_wayland_on_window_map(GtkWidget* widget,
+                                              FlRendererWayland* self) {
+  if (self->subsurface.subsurface) {
+    g_error("fl_renderer_wayland_on_window_map: already has a subsurface");
+    return;
+  }
+
+  GdkWaylandDisplay* gdk_display =
+      GDK_WAYLAND_DISPLAY(gdk_display_get_default());
+
+  wl_compositor* compositor =
+      gdk_wayland_display_get_wl_compositor(gdk_display);
+
+  lazy_initialize_wayland_globals();
+  if (!subcompositor_global) {
+    g_error(
+        "fl_renderer_wayland_on_window_map: could not bind to "
+        "wl_subcompositor");
+    return;
+  }
+
+  GdkWaylandWindow* window = GDK_WAYLAND_WINDOW(
+      gtk_widget_get_window(fl_renderer_wayland_get_toplevel_widget(self)));
+  if (!window) {
+    g_error("fl_renderer_wayland_on_window_map: not a Wayland surface");
+    return;
+  }
+  wl_surface* toplevel_surface = gdk_wayland_window_get_wl_surface(window);
+  if (!toplevel_surface) {
+    g_error(
+        "fl_renderer_wayland_on_window_map: could not get toplevel wl_surface");
+    return;
+  }
+
+  self->subsurface.subsurface = wl_subcompositor_get_subsurface(
+      subcompositor_global, self->subsurface.surface, toplevel_surface);
+  if (!self->subsurface.subsurface) {
+    g_error("fl_renderer_wayland_on_window_map: could not create subsurface");
+    return;
+  }
+
+  wl_subsurface_set_desync(self->subsurface.subsurface);
+  wl_subsurface_set_position(self->subsurface.subsurface,
+                             self->subsurface.geometry.x,
+                             self->subsurface.geometry.y);
+
+  // Give the subsurface an empty input region so the main surface gets input.
+  wl_region* region = wl_compositor_create_region(compositor);
+  wl_surface_set_input_region(self->subsurface.surface, region);
+  wl_region_destroy(region);
+
+  wl_surface_commit(self->subsurface.surface);
+}
+
+static void fl_renderer_wayland_on_window_unmap(GtkWidget* widget,
+                                                FlRendererWayland* self) {
+  g_clear_pointer(&self->subsurface.subsurface, wl_subsurface_destroy);
+}
+
+// Implements FlRenderer::create_surfaces.
+static gboolean fl_renderer_wayland_create_surfaces(FlRenderer* renderer,
+                                                    EGLDisplay egl_display,
+                                                    EGLConfig config,
+                                                    EGLSurface* visible,
+                                                    EGLSurface* resource,
+                                                    GError** error) {
+  FlRendererWayland* self = FL_RENDERER_WAYLAND(renderer);
+
+  if (self->subsurface.surface || self->subsurface.egl_window ||
+      self->resource.surface || self->resource.egl_window) {
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "Surfaces already created");
+    return FALSE;
+  }
+
+  if (!GDK_IS_WAYLAND_DISPLAY(gdk_display_get_default())) {
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "Expected Wayland display");
+    return FALSE;
+  }
+  GdkWaylandDisplay* gdk_display =
+      GDK_WAYLAND_DISPLAY(gdk_display_get_default());
+
+  wl_compositor* compositor =
+      gdk_wayland_display_get_wl_compositor(gdk_display);
+  if (!compositor) {
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "No wl_compositor");
+    return FALSE;
+  }
+
+  // Make sure size and scale is not <= 0
+  self->subsurface.scale = MAX(self->subsurface.scale, 1);
+  self->subsurface.geometry.width = MAX(self->subsurface.geometry.width, 1);
+  self->subsurface.geometry.height = MAX(self->subsurface.geometry.height, 1);
+
+  self->subsurface.surface = wl_compositor_create_surface(compositor);
+  self->resource.surface = wl_compositor_create_surface(compositor);
+  if (!self->subsurface.surface || !self->resource.surface) {
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "Failed to create wl_surfaces");
+    return FALSE;
+  }
+  wl_surface_set_buffer_scale(self->subsurface.surface, self->subsurface.scale);
+
+  gint window_width = self->subsurface.geometry.width * self->subsurface.scale;
+  gint window_height =
+      self->subsurface.geometry.height * self->subsurface.scale;
+  self->subsurface.egl_window = wl_egl_window_create(
+      self->subsurface.surface, window_width, window_height);
+  self->resource.egl_window =
+      wl_egl_window_create(self->resource.surface, 1, 1);
+  if (!self->subsurface.egl_window || !self->resource.egl_window) {
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "Failed to create EGL windows");
+    return FALSE;
+  }
+
+  *visible = eglCreateWindowSurface(egl_display, config,
+                                    self->subsurface.egl_window, nullptr);
+  *resource = eglCreateWindowSurface(egl_display, config,
+                                     self->resource.egl_window, nullptr);
+  if (*visible == EGL_NO_SURFACE || *resource == EGL_NO_SURFACE) {
+    EGLint egl_error = eglGetError();  // must be before egl_config_to_string()
+    g_autofree gchar* config_string = egl_config_to_string(egl_display, config);
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "Failed to create EGL surfaces using configuration (%s): %s",
+                config_string, egl_error_to_string(egl_error));
+    return FALSE;
+  }
+
+  GtkWidget* toplevel = fl_renderer_wayland_get_toplevel_widget(self);
+  if (!toplevel) {
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "Renderer does not have a widget");
+    return FALSE;
+  }
+  g_signal_connect(toplevel, "map",
+                   G_CALLBACK(fl_renderer_wayland_on_window_map), self);
+  g_signal_connect(toplevel, "unmap",
+                   G_CALLBACK(fl_renderer_wayland_on_window_unmap), self);
+  if (gtk_widget_get_mapped(toplevel)) {
+    fl_renderer_wayland_on_window_map(toplevel, self);
+  }
+
+  return TRUE;
+}
+
+// Implements FlRenderer::set_geometry.
+static void fl_renderer_wayland_set_geometry(FlRenderer* renderer,
+                                             GdkRectangle* geometry,
+                                             gint scale) {
+  FlRendererWayland* self = FL_RENDERER_WAYLAND(renderer);
+
+  if (scale != self->subsurface.scale && self->subsurface.surface) {
+    wl_surface_set_buffer_scale(self->subsurface.surface, scale);
+  }
+
+  // NOTE: position is unscaled but size is scaled.
+
+  if ((geometry->x != self->subsurface.geometry.x ||
+       geometry->y != self->subsurface.geometry.y) &&
+      self->subsurface.subsurface) {
+    wl_subsurface_set_position(self->subsurface.subsurface, geometry->x,
+                               geometry->y);
+  }
+
+  if ((geometry->width != self->subsurface.geometry.width ||
+       geometry->height != self->subsurface.geometry.height ||
+       scale != self->subsurface.scale) &&
+      self->subsurface.egl_window) {
+    wl_egl_window_resize(self->subsurface.egl_window, geometry->width * scale,
+                         geometry->height * scale, 0, 0);
+  }
+
+  self->subsurface.geometry = *geometry;
+  self->subsurface.scale = scale;
+}
+
+static void fl_renderer_wayland_class_init(FlRendererWaylandClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = fl_renderer_wayland_dispose;
+  FL_RENDERER_CLASS(klass)->create_display = fl_renderer_wayland_create_display;
+  FL_RENDERER_CLASS(klass)->create_surfaces =
+      fl_renderer_wayland_create_surfaces;
+  FL_RENDERER_CLASS(klass)->set_geometry = fl_renderer_wayland_set_geometry;
+}
+
+static void fl_renderer_wayland_init(FlRendererWayland* self) {}
+
+FlRendererWayland* fl_renderer_wayland_new() {
+  return FL_RENDERER_WAYLAND(
+      g_object_new(fl_renderer_wayland_get_type(), nullptr));
+}

--- a/shell/platform/linux/fl_renderer_wayland.h
+++ b/shell/platform/linux/fl_renderer_wayland.h
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_WAYLAND_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_WAYLAND_H_
+
+#include "flutter/shell/platform/linux/fl_renderer.h"
+
+G_BEGIN_DECLS
+
+G_DECLARE_FINAL_TYPE(FlRendererWayland,
+                     fl_renderer_wayland,
+                     FL,
+                     RENDERER_WAYLAND,
+                     FlRenderer)
+
+/**
+ * FlRendererWayland:
+ *
+ * #FlRendererWayland is an implementation of a #FlRenderer that renders to
+ * Wayland surfaces.
+ */
+
+/**
+ * fl_renderer_wayland_new:
+ *
+ * Create an object that allows Flutter to render to Wayland surfaces.
+ *
+ * Returns: a #FlRendererWayland.
+ */
+FlRendererWayland* fl_renderer_wayland_new();
+
+G_END_DECLS
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_WAYLAND_H_

--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -14,21 +14,20 @@ G_DEFINE_TYPE(FlRendererX11, fl_renderer_x11, fl_renderer_get_type())
 // Implements FlRenderer::setup_window_attr.
 static gboolean fl_renderer_x11_setup_window_attr(
     FlRenderer* renderer,
-    EGLDisplay egl_display,
-    EGLConfig egl_config,
+    GtkWidget* widget,
+    EGLDisplay display,
+    EGLConfig config,
     GdkWindowAttr* window_attributes,
     gint* mask,
     GError** error) {
   EGLint visual_id;
-  if (!eglGetConfigAttrib(egl_display, egl_config, EGL_NATIVE_VISUAL_ID,
-                          &visual_id)) {
+  if (!eglGetConfigAttrib(display, config, EGL_NATIVE_VISUAL_ID, &visual_id)) {
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
                 "Failed to determine EGL configuration visual");
     return FALSE;
   }
 
-  GtkWidget* view_widget = GTK_WIDGET(fl_renderer_get_view(renderer));
-  GdkX11Screen* screen = GDK_X11_SCREEN(gtk_widget_get_screen(view_widget));
+  GdkX11Screen* screen = GDK_X11_SCREEN(gtk_widget_get_screen(widget));
   if (!screen) {
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
                 "View widget is not on an X11 screen");
@@ -58,13 +57,13 @@ static EGLDisplay fl_renderer_x11_create_display(FlRenderer* renderer) {
 
 // Implements FlRenderer::create_surfaces.
 static gboolean fl_renderer_x11_create_surfaces(FlRenderer* renderer,
+                                                GtkWidget* widget,
                                                 EGLDisplay display,
                                                 EGLConfig config,
                                                 EGLSurface* visible,
                                                 EGLSurface* resource,
                                                 GError** error) {
-  GdkWindow* window =
-      gtk_widget_get_window(GTK_WIDGET(fl_renderer_get_view(renderer)));
+  GdkWindow* window = gtk_widget_get_window(widget);
   if (!GDK_IS_X11_WINDOW(window)) {
     g_set_error(
         error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,

--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -7,24 +7,13 @@
 
 struct _FlRendererX11 {
   FlRenderer parent_instance;
-
-  GdkX11Window* window;
 };
 
 G_DEFINE_TYPE(FlRendererX11, fl_renderer_x11, fl_renderer_get_type())
 
-static void fl_renderer_x11_dispose(GObject* object) {
-  FlRendererX11* self = FL_RENDERER_X11(object);
-
-  g_clear_object(&self->window);
-
-  G_OBJECT_CLASS(fl_renderer_x11_parent_class)->dispose(object);
-}
-
 // Implements FlRenderer::setup_window_attr.
 static gboolean fl_renderer_x11_setup_window_attr(
     FlRenderer* renderer,
-    GtkWidget* widget,
     EGLDisplay egl_display,
     EGLConfig egl_config,
     GdkWindowAttr* window_attributes,
@@ -38,10 +27,11 @@ static gboolean fl_renderer_x11_setup_window_attr(
     return FALSE;
   }
 
-  GdkX11Screen* screen = GDK_X11_SCREEN(gtk_widget_get_screen(widget));
+  GtkWidget* view_widget = GTK_WIDGET(fl_renderer_get_view(renderer));
+  GdkX11Screen* screen = GDK_X11_SCREEN(gtk_widget_get_screen(view_widget));
   if (!screen) {
     g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
-                "Widget is not on an X11 screen");
+                "View widget is not on an X11 screen");
     return FALSE;
   }
 
@@ -55,15 +45,6 @@ static gboolean fl_renderer_x11_setup_window_attr(
   *mask |= GDK_WA_VISUAL;
 
   return TRUE;
-}
-
-// Implements FlRenderer::set_window.
-static void fl_renderer_x11_set_window(FlRenderer* renderer,
-                                       GdkWindow* window) {
-  FlRendererX11* self = FL_RENDERER_X11(renderer);
-  g_return_if_fail(GDK_IS_X11_WINDOW(window));
-  g_assert_null(self->window);
-  self->window = GDK_X11_WINDOW(g_object_ref(window));
 }
 
 // Implements FlRenderer::create_display.
@@ -82,16 +63,17 @@ static gboolean fl_renderer_x11_create_surfaces(FlRenderer* renderer,
                                                 EGLSurface* visible,
                                                 EGLSurface* resource,
                                                 GError** error) {
-  FlRendererX11* self = FL_RENDERER_X11(renderer);
-
-  if (!self->window) {
-    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
-                "Can not create EGL surface: FlRendererX11::window not set");
+  GdkWindow* window =
+      gtk_widget_get_window(GTK_WIDGET(fl_renderer_get_view(renderer)));
+  if (!GDK_IS_X11_WINDOW(window)) {
+    g_set_error(
+        error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+        "Can not create EGL surface: view doesn't have an X11 GDK window");
     return FALSE;
   }
 
-  *visible = eglCreateWindowSurface(
-      display, config, gdk_x11_window_get_xid(self->window), nullptr);
+  *visible = eglCreateWindowSurface(display, config,
+                                    gdk_x11_window_get_xid(window), nullptr);
   if (*visible == EGL_NO_SURFACE) {
     EGLint egl_error = eglGetError();  // Must be before egl_config_to_string().
     g_autofree gchar* config_string = egl_config_to_string(display, config);
@@ -116,10 +98,8 @@ static gboolean fl_renderer_x11_create_surfaces(FlRenderer* renderer,
 }
 
 static void fl_renderer_x11_class_init(FlRendererX11Class* klass) {
-  G_OBJECT_CLASS(klass)->dispose = fl_renderer_x11_dispose;
   FL_RENDERER_CLASS(klass)->setup_window_attr =
       fl_renderer_x11_setup_window_attr;
-  FL_RENDERER_CLASS(klass)->set_window = fl_renderer_x11_set_window;
   FL_RENDERER_CLASS(klass)->create_display = fl_renderer_x11_create_display;
   FL_RENDERER_CLASS(klass)->create_surfaces = fl_renderer_x11_create_surfaces;
 }

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -209,7 +209,7 @@ static void fl_view_realize(GtkWidget* widget) {
 
   gtk_widget_set_realized(widget, TRUE);
 
-  if (!fl_renderer_start(self->renderer, widget, &error)) {
+  if (!fl_renderer_start(self->renderer, self, &error)) {
     g_warning("Failed to start Flutter renderer: %s", error->message);
     return;
   }

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -4,8 +4,8 @@
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_view.h"
 
-#include <gdk/gdkx.h>
 #include <gdk/gdkwayland.h>
+#include <gdk/gdkx.h>
 #include <cstring>
 
 #include "flutter/shell/platform/linux/fl_engine_private.h"

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -218,7 +218,7 @@ static void fl_view_realize(GtkWidget* widget) {
 
   gtk_widget_set_realized(widget, TRUE);
 
-  if (!fl_renderer_start(self->renderer, self, &error)) {
+  if (!fl_renderer_start(self->renderer, widget, &error)) {
     g_warning("Failed to start Flutter renderer: %s", error->message);
     return;
   }

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_view.h"
 
 #include <gdk/gdkx.h>
+#include <gdk/gdkwayland.h>
 #include <cstring>
 
 #include "flutter/shell/platform/linux/fl_engine_private.h"
@@ -12,6 +13,7 @@
 #include "flutter/shell/platform/linux/fl_mouse_cursor_plugin.h"
 #include "flutter/shell/platform/linux/fl_platform_plugin.h"
 #include "flutter/shell/platform/linux/fl_plugin_registrar_private.h"
+#include "flutter/shell/platform/linux/fl_renderer_wayland.h"
 #include "flutter/shell/platform/linux/fl_renderer_x11.h"
 #include "flutter/shell/platform/linux/fl_text_input_plugin.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
@@ -132,7 +134,14 @@ static void fl_view_plugin_registry_iface_init(
 static void fl_view_constructed(GObject* object) {
   FlView* self = FL_VIEW(object);
 
-  self->renderer = FL_RENDERER(fl_renderer_x11_new());
+  GdkDisplay* display = gtk_widget_get_display(GTK_WIDGET(self));
+  if (GDK_IS_X11_DISPLAY(display)) {
+    self->renderer = FL_RENDERER(fl_renderer_x11_new());
+  } else if (GDK_IS_WAYLAND_DISPLAY(display)) {
+    self->renderer = FL_RENDERER(fl_renderer_wayland_new());
+  } else {
+    g_error("Unsupported GDK backend");
+  }
   self->engine = fl_engine_new(self->project, self->renderer);
 
   // Create system channel handlers.

--- a/shell/platform/linux/testing/mock_renderer.cc
+++ b/shell/platform/linux/testing/mock_renderer.cc
@@ -17,6 +17,7 @@ static EGLDisplay fl_mock_renderer_create_display(FlRenderer* renderer) {
 
 // Implements FlRenderer::create_surfaces.
 static gboolean fl_mock_renderer_create_surfaces(FlRenderer* renderer,
+                                                 GtkWidget* widget,
                                                  EGLDisplay display,
                                                  EGLConfig config,
                                                  EGLSurface* visible,


### PR DESCRIPTION
## Description
WIP based on top of https://github.com/flutter/engine/pull/20336

Adds Wayland support to the Linux/GTK platform. Most of what's required come from GTK's Wayland support, but we need to do some things in the renderer to make it work with Flutter. Specifically we need to control an EGL surface, and to do that we make a Wayland subsurface off of the main surface GTK creates.

## Related Issues
https://github.com/flutter/flutter/issues/57932

## Tests
None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
