### PR TITLE
Remove use of ctors on Skia Vulkan struct

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -337,7 +337,7 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrDirectContext> context,
   alloc.fOffset = 0;
   alloc.fSize = memory_reqs.size;
   alloc.fFlags = 0;
-   
+
   GrVkImageInfo image_info;
   image_info.fImage = vulkan_image_.vk_image;
   image_info.fAlloc = alloc;

--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -332,14 +332,19 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrDirectContext> context,
     return false;
   }
 
-  const GrVkImageInfo image_info = {
-      vulkan_image_.vk_image,                // image
-      {vk_memory_, 0, memory_reqs.size, 0},  // alloc
-      image_create_info.tiling,              // tiling
-      image_create_info.initialLayout,       // layout
-      image_create_info.format,              // format
-      image_create_info.mipLevels,           // level count
-  };
+  GrVkAlloc alloc;
+  alloc.fMemory = vk_memory_;
+  alloc.fOffset = 0;
+  alloc.fSize = memory_reqs.size;
+  alloc.fFlags = 0;
+   
+  GrVkImageInfo image_info;
+  image_info.fImage = vulkan_image_.vk_image;
+  image_info.fAlloc = alloc;
+  image_info.fImageTiling = image_create_info.tiling;
+  image_info.fImageLayout = image_create_info.initialLayout;
+  image_info.fFormat = image_create_info.format;
+  image_info.fLevelCount = image_create_info.mipLevels;
 
   GrBackendRenderTarget sk_render_target(size.width(), size.height(), 0,
                                          image_info);

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -222,7 +222,7 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(
     return nullptr;
   }
 
-  const GrVkImageInfo image_info;
+  GrVkImageInfo image_info;
   image_info.fImage = image;
   image_info.fImageTiling = VK_IMAGE_TILING_OPTIMAL;
   image_info.fImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -222,14 +222,12 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(
     return nullptr;
   }
 
-  const GrVkImageInfo image_info = {
-      image,                      // image
-      GrVkAlloc(),                // alloc
-      VK_IMAGE_TILING_OPTIMAL,    // tiling
-      VK_IMAGE_LAYOUT_UNDEFINED,  // layout
-      surface_format_.format,     // format
-      1,                          // level count
-  };
+  const GrVkImageInfo image_info;
+  image_info.fImage = image;
+  image_info.fImageTiling = VK_IMAGE_TILING_OPTIMAL;
+  image_info.fImageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+  image_info.fFormat = surface_format_.format;
+  image_info.fLevelCount = 1;
 
   // TODO(chinmaygarde): Setup the stencil buffer and the sampleCnt.
   GrBackendRenderTarget backend_render_target(size.fWidth, size.fHeight, 0,


### PR DESCRIPTION
## Description

Skia is removing these ctors for vulkan structs so switch flutter over now.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
