### PR TITLE
Update view attributes after creation

### DIFF
--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -248,6 +248,13 @@ void SceneUpdateContext::CreateView(int64_t view_id,
                               nullptr);
   auto* view_holder = ViewHolder::FromId(view_id);
   FML_DCHECK(view_holder);
+}
+
+void SceneUpdateContext::UpdateView(int64_t view_id,
+                                    bool hit_testable,
+                                    bool focusable) {
+  auto* view_holder = ViewHolder::FromId(view_id);
+  FML_DCHECK(view_holder);
 
   view_holder->set_hit_testable(hit_testable);
   view_holder->set_focusable(focusable);

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -235,6 +235,8 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
 
   void CreateView(int64_t view_id, bool hit_testable, bool focusable);
 
+  void UpdateView(int64_t view_id, bool hit_testable, bool focusable);
+
   void DestroyView(int64_t view_id);
 
   void UpdateScene(int64_t view_id, const SkPoint& offset, const SkSize& size);

--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -103,6 +103,13 @@ void CompositorContext::OnCreateView(int64_t view_id,
                                                         focusable);
 }
 
+void CompositorContext::OnUpdateView(int64_t view_id,
+                                     bool hit_testable,
+                                     bool focusable) {
+  session_connection_.scene_update_context().UpdateView(view_id, hit_testable,
+                                                        focusable);
+}
+
 void CompositorContext::OnDestroyView(int64_t view_id) {
   session_connection_.scene_update_context().DestroyView(view_id);
 }

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -36,6 +36,7 @@ class CompositorContext final : public flutter::CompositorContext {
 
   void OnWireframeEnabled(bool enabled);
   void OnCreateView(int64_t view_id, bool hit_testable, bool focusable);
+  void OnUpdateView(int64_t view_id, bool hit_testable, bool focusable);
   void OnDestroyView(int64_t view_id);
 
   flutter::ExternalViewEmbedder* GetViewEmbedder() {

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -110,6 +110,10 @@ Engine::Engine(Delegate& delegate,
       std::bind(&Engine::OnCreateView, this, std::placeholders::_1,
                 std::placeholders::_2, std::placeholders::_3);
 
+  flutter_runner::OnUpdateView on_update_view_callback =
+      std::bind(&Engine::OnUpdateView, this, std::placeholders::_1,
+                std::placeholders::_2, std::placeholders::_3);
+
   flutter_runner::OnDestroyView on_destroy_view_callback =
       std::bind(&Engine::OnDestroyView, this, std::placeholders::_1);
 
@@ -154,6 +158,7 @@ Engine::Engine(Delegate& delegate,
            on_enable_wireframe_callback =
                std::move(on_enable_wireframe_callback),
            on_create_view_callback = std::move(on_create_view_callback),
+           on_update_view_callback = std::move(on_update_view_callback),
            on_destroy_view_callback = std::move(on_destroy_view_callback),
            on_get_view_embedder_callback =
                std::move(on_get_view_embedder_callback),
@@ -174,6 +179,7 @@ Engine::Engine(Delegate& delegate,
                 std::move(on_session_size_change_hint_callback),
                 std::move(on_enable_wireframe_callback),
                 std::move(on_create_view_callback),
+                std::move(on_update_view_callback),
                 std::move(on_destroy_view_callback),
                 std::move(on_get_view_embedder_callback),
                 std::move(on_get_gr_context_callback),
@@ -540,6 +546,23 @@ void Engine::OnCreateView(int64_t view_id, bool hit_testable, bool focusable) {
               reinterpret_cast<flutter_runner::CompositorContext*>(
                   rasterizer->compositor_context());
           compositor_context->OnCreateView(view_id, hit_testable, focusable);
+        }
+      });
+}
+
+void Engine::OnUpdateView(int64_t view_id, bool hit_testable, bool focusable) {
+  if (!shell_) {
+    return;
+  }
+
+  shell_->GetTaskRunners().GetRasterTaskRunner()->PostTask(
+      [rasterizer = shell_->GetRasterizer(), view_id, hit_testable,
+       focusable]() {
+        if (rasterizer) {
+          auto compositor_context =
+              reinterpret_cast<flutter_runner::CompositorContext*>(
+                  rasterizer->compositor_context());
+          compositor_context->OnUpdateView(view_id, hit_testable, focusable);
         }
       });
 }

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -79,6 +79,8 @@ class Engine final {
 
   void OnCreateView(int64_t view_id, bool hit_testable, bool focusable);
 
+  void OnUpdateView(int64_t view_id, bool hit_testable, bool focusable);
+
   void OnDestroyView(int64_t view_id);
 
   flutter::ExternalViewEmbedder* GetViewEmbedder();

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -94,6 +94,7 @@ PlatformView::PlatformView(
     OnSizeChangeHint session_size_change_hint_callback,
     OnEnableWireframe wireframe_enabled_callback,
     OnCreateView on_create_view_callback,
+    OnUpdateView on_update_view_callback,
     OnDestroyView on_destroy_view_callback,
     OnGetViewEmbedder on_get_view_embedder_callback,
     OnGetGrContext on_get_gr_context_callback,
@@ -110,6 +111,7 @@ PlatformView::PlatformView(
       size_change_hint_callback_(std::move(session_size_change_hint_callback)),
       wireframe_enabled_callback_(std::move(wireframe_enabled_callback)),
       on_create_view_callback_(std::move(on_create_view_callback)),
+      on_update_view_callback_(std::move(on_update_view_callback)),
       on_destroy_view_callback_(std::move(on_destroy_view_callback)),
       on_get_view_embedder_callback_(std::move(on_get_view_embedder_callback)),
       on_get_gr_context_callback_(std::move(on_get_gr_context_callback)),
@@ -824,6 +826,35 @@ void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
       message->response()->Complete(
           std::make_unique<fml::NonOwnedMapping>((const uint8_t*)"[0]", 3u));
     }
+  } else if (method->value == "View.update") {
+    auto args_it = root.FindMember("args");
+    if (args_it == root.MemberEnd() || !args_it->value.IsObject()) {
+      FML_LOG(ERROR) << "No arguments found.";
+      return;
+    }
+    const auto& args = args_it->value;
+
+    auto view_id = args.FindMember("viewId");
+    if (!view_id->value.IsUint64()) {
+      FML_LOG(ERROR) << "Argument 'viewId' is not a int64";
+      return;
+    }
+
+    auto hit_testable = args.FindMember("hitTestable");
+    if (!hit_testable->value.IsBool()) {
+      FML_LOG(ERROR) << "Argument 'hitTestable' is not a bool";
+      return;
+    }
+
+    auto focusable = args.FindMember("focusable");
+    if (!focusable->value.IsBool()) {
+      FML_LOG(ERROR) << "Argument 'focusable' is not a bool";
+      return;
+    }
+
+    on_update_view_callback_(view_id->value.GetUint64(),
+                             hit_testable->value.GetBool(),
+                             focusable->value.GetBool());
   } else if (method->value == "View.dispose") {
     auto args_it = root.FindMember("args");
     if (args_it == root.MemberEnd() || !args_it->value.IsObject()) {

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -29,6 +29,7 @@ using OnSizeChangeHint =
     fit::function<void(float width_change_factor, float height_change_factor)>;
 using OnEnableWireframe = fit::function<void(bool)>;
 using OnCreateView = fit::function<void(int64_t, bool, bool)>;
+using OnUpdateView = fit::function<void(int64_t, bool, bool)>;
 using OnDestroyView = fit::function<void(int64_t)>;
 using OnGetViewEmbedder = fit::function<flutter::ExternalViewEmbedder*()>;
 using OnGetGrContext = fit::function<GrDirectContext*()>;
@@ -59,6 +60,7 @@ class PlatformView final : public flutter::PlatformView,
                OnSizeChangeHint session_size_change_hint_callback,
                OnEnableWireframe wireframe_enabled_callback,
                OnCreateView on_create_view_callback,
+               OnUpdateView on_update_view_callback,
                OnDestroyView on_destroy_view_callback,
                OnGetViewEmbedder on_get_view_embedder_callback,
                OnGetGrContext on_get_gr_context_callback,
@@ -100,6 +102,7 @@ class PlatformView final : public flutter::PlatformView,
   OnSizeChangeHint size_change_hint_callback_;
   OnEnableWireframe wireframe_enabled_callback_;
   OnCreateView on_create_view_callback_;
+  OnUpdateView on_update_view_callback_;
   OnDestroyView on_destroy_view_callback_;
   OnGetViewEmbedder on_get_view_embedder_callback_;
   OnGetGrContext on_get_gr_context_callback_;

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -167,6 +167,7 @@ TEST_F(PlatformViewTests, ChangesAccessibilitySettings) {
       nullptr,  // session_size_change_hint_callback
       nullptr,  // on_enable_wireframe_callback,
       nullptr,  // on_create_view_callback,
+      nullptr,  // on_update_view_callback,
       nullptr,  // on_destroy_view_callback,
       nullptr,  // on_get_view_embedder_callback,
       nullptr,  // on_get_gr_context_callback,
@@ -225,6 +226,7 @@ TEST_F(PlatformViewTests, EnableWireframeTest) {
       nullptr,                  // session_size_change_hint_callback
       EnableWireframeCallback,  // on_enable_wireframe_callback,
       nullptr,                  // on_create_view_callback,
+      nullptr,                  // on_update_view_callback,
       nullptr,                  // on_destroy_view_callback,
       nullptr,                  // on_get_view_embedder_callback,
       nullptr,                  // on_get_gr_context_callback,
@@ -294,6 +296,7 @@ TEST_F(PlatformViewTests, CreateViewTest) {
       nullptr,             // session_size_change_hint_callback
       nullptr,             // on_enable_wireframe_callback,
       CreateViewCallback,  // on_create_view_callback,
+      nullptr,             // on_update_view_callback,
       nullptr,             // on_destroy_view_callback,
       nullptr,             // on_get_view_embedder_callback,
       nullptr,             // on_get_gr_context_callback,
@@ -327,6 +330,78 @@ TEST_F(PlatformViewTests, CreateViewTest) {
   RunLoopUntilIdle();
 
   EXPECT_TRUE(create_view_called);
+}
+
+// Test to make sure that PlatformView correctly registers messages sent on
+// the "flutter/platform_views" channel, correctly parses the JSON it receives
+// and calls the UdpateViewCallback with the appropriate args.
+TEST_F(PlatformViewTests, UpdateViewTest) {
+  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
+  MockPlatformViewDelegate delegate;
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
+  flutter::TaskRunners task_runners =
+      flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
+
+  // Test wireframe callback function. If the message sent to the platform
+  // view was properly handled and parsed, this function should be called,
+  // setting |wireframe_enabled| to true.
+  int64_t update_view_called = false;
+  auto UpdateViewCallback = [&update_view_called](
+                                int64_t view_id, bool hit_testable,
+                                bool focusable) { update_view_called = true; };
+
+  auto platform_view = flutter_runner::PlatformView(
+      delegate,                               // delegate
+      "test_platform_view",                   // label
+      std::move(view_ref),                    // view_refs
+      std::move(task_runners),                // task_runners
+      services_provider.service_directory(),  // runner_services
+      nullptr,             // parent_environment_service_provider_handle
+      nullptr,             // session_listener_request
+      nullptr,             // focuser,
+      nullptr,             // on_session_listener_error_callback
+      nullptr,             // session_metrics_did_change_callback
+      nullptr,             // session_size_change_hint_callback
+      nullptr,             // on_enable_wireframe_callback,
+      nullptr,             // on_create_view_callback,
+      UpdateViewCallback,  // on_update_view_callback,
+      nullptr,             // on_destroy_view_callback,
+      nullptr,             // on_get_view_embedder_callback,
+      nullptr,             // on_get_gr_context_callback,
+      0u,                  // vsync_event_handle
+      {}                   // product_config
+  );
+
+  // Cast platform_view to its base view so we can have access to the public
+  // "HandlePlatformMessage" function.
+  auto base_view = dynamic_cast<flutter::PlatformView*>(&platform_view);
+  EXPECT_TRUE(base_view);
+
+  // JSON for the message to be passed into the PlatformView.
+  const uint8_t txt[] =
+      "{"
+      "    \"method\":\"View.update\","
+      "    \"args\": {"
+      "       \"viewId\":42,"
+      "       \"hitTestable\":true,"
+      "       \"focusable\":true"
+      "    }"
+      "}";
+
+  fml::RefPtr<flutter::PlatformMessage> message =
+      fml::MakeRefCounted<flutter::PlatformMessage>(
+          "flutter/platform_views",
+          std::vector<uint8_t>(txt, txt + sizeof(txt)),
+          fml::RefPtr<flutter::PlatformMessageResponse>());
+  base_view->HandlePlatformMessage(message);
+
+  RunLoopUntilIdle();
+
+  EXPECT_TRUE(update_view_called);
 }
 
 // Test to make sure that PlatformView correctly registers messages sent on
@@ -365,6 +440,7 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
       nullptr,              // session_size_change_hint_callback
       nullptr,              // on_enable_wireframe_callback,
       nullptr,              // on_create_view_callback,
+      nullptr,              // on_update_view_callback,
       DestroyViewCallback,  // on_destroy_view_callback,
       nullptr,              // on_get_view_embedder_callback,
       nullptr,              // on_get_gr_context_callback,
@@ -430,6 +506,7 @@ TEST_F(PlatformViewTests, RequestFocusTest) {
       nullptr,                    // session_size_change_hint_callback
       nullptr,                    // on_enable_wireframe_callback,
       nullptr,                    // on_create_view_callback,
+      nullptr,                    // on_update_view_callback,
       nullptr,                    // on_destroy_view_callback,
       nullptr,                    // on_get_gr_context_callback,
       nullptr,                    // on_get_view_embedder_callback,
@@ -505,6 +582,7 @@ TEST_F(PlatformViewTests, GetViewEmbedderTest) {
       nullptr,                  // session_size_change_hint_callback
       nullptr,                  // on_enable_wireframe_callback,
       nullptr,                  // on_create_view_callback,
+      nullptr,                  // on_update_view_callback,
       nullptr,                  // on_destroy_view_callback,
       GetViewEmbedderCallback,  // on_get_view_embedder_callback,
       nullptr,                  // on_get_gr_context_callback,
@@ -561,6 +639,7 @@ TEST_F(PlatformViewTests, GetGrContextTest) {
       nullptr,               // session_size_change_hint_callback
       nullptr,               // on_enable_wireframe_callback,
       nullptr,               // on_create_view_callback,
+      nullptr,               // on_update_view_callback,
       nullptr,               // on_destroy_view_callback,
       nullptr,               // on_get_view_embedder_callback,
       GetGrContextCallback,  // on_get_gr_context_callback,


### PR DESCRIPTION

# Update view attributes after creation

## Description

This change allows changing the 'hitTestable' and 'focusable'
attributes of the scenic view after it is created. A flutter
app may want to change these flags to allow gestures on top of
child views.

## Tests

Adds unittest for update view functionality
