### PR TITLE
Clean up scenario app scripts

### DIFF
--- a/testing/scenario_app/README.md
+++ b/testing/scenario_app/README.md
@@ -42,7 +42,7 @@ compared against golden reside.
 
 ## Running for Android
 
-The test is run on a x86 emulator. To run the test locally, you must create an emulator running API level 28, and set the following screen settings in the avd's `config.ini` file:
+The test is run on a x86 emulator. To run the test locally, you must create an emulator running API level 28, using an x86_64 ABI, and set the following screen settings in the avd's `config.ini` file:
 
 ```
 hw.lcd.density = 480

--- a/testing/scenario_app/assemble_apk.sh
+++ b/testing/scenario_app/assemble_apk.sh
@@ -2,15 +2,37 @@
 
 set -e
 
-pushd "${BASH_SOURCE%/*}/../../.."
-  ./flutter/tools/gn --unopt
-  ninja -C out/host_debug_unopt sky_engine sky_services
-popd
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
 
-pushd "${BASH_SOURCE%/*}"
-  ./compile_android_aot.sh "$1" "$2"
-popd
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -L "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
 
-pushd "${BASH_SOURCE%/*}/android"
-./gradlew assembleDebug --no-daemon
-popd
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+SRC_DIR="$(cd "$SCRIPT_DIR/../../.."; pwd -P)"
+export ANDROID_HOME="$SRC_DIR/third_party/android_tools/sdk"
+
+"$SRC_DIR/flutter/tools/gn" --unopt
+autoninja -C "$SRC_DIR/out/host_debug_unopt" sky_engine sky_services
+
+"$SCRIPT_DIR/compile_android_aot.sh" "$1" "$2"
+
+(
+  cd "$SCRIPT_DIR/android"
+  ./gradlew assembleDebug --no-daemon
+)

--- a/testing/scenario_app/build_and_run_android_tests.sh
+++ b/testing/scenario_app/build_and_run_android_tests.sh
@@ -5,29 +5,44 @@
 
 set -e
 
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
+
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -h "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
+
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+SRC_DIR="$(cd "$SCRIPT_DIR/../../.."; pwd -P)"
+GN="$SRC_DIR/flutter/tools/gn"
+
 FLUTTER_ENGINE=android_debug_unopt_x64
+export ANDROID_HOME="$SRC_DIR/third_party/android_tools/sdk"
 
-if [ $# -eq 1 ]; then
-  FLUTTER_ENGINE=$1
+if [[ $# -eq 1 ]]; then
+  FLUTTER_ENGINE="$1"
 fi
 
-cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd
-
-pushd ../../..
-
-if [ ! -d "out/$FLUTTER_ENGINE" ]; then
-  echo "You must GN to generate out/$FLUTTER_ENGINE and its host engine."
-  echo "Example: "
-  echo "  ./tools/gn --android --unoptimized --android-cpu x64 --runtime-mode debug"
-  echo "  ./tools/gn --unoptimized --runtime-mode debug"
-  echo "to create out/android_debug_unopt_x64 and out/host_debug_unopt."
-  exit 1
+if [[ ! -d "$SRC_DIR/out/$FLUTTER_ENGINE" ]]; then
+  "$GN" --android --unoptimized --android-cpu x64 --runtime-mode debug
+  "$GN" --unoptimized --runtime-mode debug
 fi
 
-autoninja -C out/$FLUTTER_ENGINE
+autoninja -C "$SRC_DIR/out/$FLUTTER_ENGINE"
 
-popd
-
-./compile_android_jit.sh ../../../out/host_debug_unopt ../../../out/$FLUTTER_ENGINE/clang_x64
-
-./run_android_tests.sh $FLUTTER_ENGINE
+"$SCRIPT_DIR/compile_android_jit.sh" "$SRC_DIR/out/host_debug_unopt" "$SRC_DIR/out/$FLUTTER_ENGINE/clang_x64"
+"$SCRIPT_DIR/run_android_tests.sh" "$FLUTTER_ENGINE"

--- a/testing/scenario_app/build_and_run_ios_tests.sh
+++ b/testing/scenario_app/build_and_run_ios_tests.sh
@@ -1,33 +1,47 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
 set -e
 
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
+
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -h "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
+
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+SRC_DIR="$(cd "$SCRIPT_DIR/../../.."; pwd -P)"
+GN="$SRC_DIR/flutter/tools/gn"
+
 FLUTTER_ENGINE=ios_debug_sim_unopt
 
-if [ $# -eq 1 ]; then
-  FLUTTER_ENGINE=$1
+if [[ $# -eq 1 ]]; then
+  FLUTTER_ENGINE="$1"
 fi
 
-cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd
-
-pushd ../../..
-
-if [ ! -d "out/$FLUTTER_ENGINE" ]; then
-  echo "You must GN to generate out/$FLUTTER_ENGINE"
-  echo "Example: "
-  echo "  ./flutter/tools/gn --ios --simulator --unoptimized"
-  echo "  ./flutter/tools/gn --unoptimized"
-  echo "to create out/ios_debug_sim_unopt and out/host_debug_unopt."
-  exit 1
+if [ ! -d "$SRC_DIR/out/$FLUTTER_ENGINE" ]; then
+  "$GN" --ios --simulator --unoptimized
+  "$GN" --unoptimized
 fi
 
-autoninja -C out/$FLUTTER_ENGINE
+autoninja -C "$SRC_DIR/out/$FLUTTER_ENGINE"
 
-popd
-
-./compile_ios_jit.sh ../../../out/host_debug_unopt ../../../out/$FLUTTER_ENGINE/clang_x64
-
-./run_ios_tests.sh $FLUTTER_ENGINE
+"$SCRIPT_DIR/compile_ios_jit.sh" "$SRC_DIR/out/host_debug_unopt" "$SRC_DIR/out/$FLUTTER_ENGINE/clang_x64"
+"$SCRIPT_DIR/run_ios_tests.sh" "$FLUTTER_ENGINE"

--- a/testing/scenario_app/compile_android_aot.sh
+++ b/testing/scenario_app/compile_android_aot.sh
@@ -7,31 +7,57 @@
 
 set -e
 
-HOST_TOOLS=$1
-DEVICE_TOOLS=$2
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
+
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -h "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
+
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+
+HOST_TOOLS="$1"
+DEVICE_TOOLS="$2"
 
 if [[ ! -d "$HOST_TOOLS" ]]; then
-  echo "Must specify the host out directory containing dart."
+  echo "Directory $HOST_TOOLS not found."
+  echo "First argument must specify the host out directory containing dart (e.g. out/host_debug_unopt)."
   exit 1
 fi
 
 if [[ ! -d "$DEVICE_TOOLS" ]]; then
-  echo "Must specify the device out directory containing gen_snapshot."
+  echo "Directory $DEVICE_TOOLS not found."
+  ehco "Second argument must specify the device out directory containing gen_snapshot (e.g. out/android_debug_unopt_x64/clang_x64)."
   exit 1
 fi
 
-PUB_VERSION=$($HOST_TOOLS/dart-sdk/bin/pub --version)
-echo "Using Pub ${PUB_VERSION} from $HOST_TOOLS/dart-sdk/bin/pub"
+PUB="$HOST_TOOLS/dart-sdk/bin/pub"
+PUB_VERSION="$("$PUB" --version)"
+echo "Using Pub ${PUB_VERSION} from $PUB"
 
-$HOST_TOOLS/dart-sdk/bin/pub get
+(cd "$SCRIPT_DIR"; "$PUB" get)
 
 echo "Using dart from $HOST_TOOLS, gen_snapshot from $DEVICE_TOOLS."
 
-OUTDIR="${BASH_SOURCE%/*}/build/android"
+OUTDIR="$SCRIPT_DIR/build/android"
 
 echo "Creating $OUTDIR..."
 
-mkdir -p $OUTDIR
+mkdir -p "$OUTDIR"
 
 echo "Compiling kernel..."
 
@@ -40,15 +66,15 @@ echo "Compiling kernel..."
   --sdk-root "$HOST_TOOLS/flutter_patched_sdk" \
   --aot --tfa --target=flutter \
   --output-dill "$OUTDIR/app.dill" \
-  "${BASH_SOURCE%/*}/lib/main.dart"
+  "$SCRIPT_DIR/lib/main.dart"
 
 echo "Compiling ELF Shared Library..."
 
-"$DEVICE_TOOLS/gen_snapshot" --deterministic --snapshot_kind=app-aot-elf --elf="$OUTDIR/libapp.so" --strip "$OUTDIR/app.dill"
+"$HOST_TOOLS/gen_snapshot" --deterministic --snapshot_kind=app-aot-elf --elf="$OUTDIR/libapp.so" --strip "$OUTDIR/app.dill"
 
-mkdir -p "${BASH_SOURCE%/*}/android/app/src/main/jniLibs/arm64-v8a"
-mkdir -p "${BASH_SOURCE%/*}/android/app/libs"
-cp "$OUTDIR/libapp.so" "${BASH_SOURCE%/*}/android/app/src/main/jniLibs/arm64-v8a/"
-cp "$DEVICE_TOOLS/../flutter.jar" "${BASH_SOURCE%/*}/android/app/libs/"
+mkdir -p "$SCRIPT_DIR/android/app/src/main/jniLibs/arm64-v8a"
+mkdir -p "$SCRIPT_DIR/android/app/libs"
+cp "$OUTDIR/libapp.so" "$SCRIPT_DIR/android/app/src/main/jniLibs/arm64-v8a/"
+cp "$DEVICE_TOOLS/../flutter.jar" "$SCRIPT_DIR/android/app/libs/"
 
 echo "Created $OUTDIR/libapp.so."

--- a/testing/scenario_app/compile_ios_aot.sh
+++ b/testing/scenario_app/compile_ios_aot.sh
@@ -7,31 +7,57 @@
 
 set -e
 
-HOST_TOOLS=$1
-DEVICE_TOOLS=$2
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
+
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -h "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
+
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+
+HOST_TOOLS="$1"
+DEVICE_TOOLS="$2"
 
 if [[ ! -d "$HOST_TOOLS" ]]; then
-  echo "Must specify the host out directory containing dart."
+  echo "Directory $HOST_TOOLS not found."
+  echo "First argument must specify the host out directory containing dart (e.g. host_debug_unopt)."
   exit 1
 fi
 
 if [[ ! -d "$DEVICE_TOOLS" ]]; then
-  echo "Must specify the device out directory containing gen_snapshot."
+  echo "Directory $DEVICE_TOOLS not found."
+  ehco "Second argument must specify the device out directory containing gen_snapshot (e.g. ios_debug_unopt)."
   exit 1
 fi
 
-PUB_VERSION=$($HOST_TOOLS/dart-sdk/bin/pub --version)
-echo "Using Pub ${PUB_VERSION} from $HOST_TOOLS/dart-sdk/bin/pub"
+PUB="$HOST_TOOLS/dart-sdk/bin/pub"
+PUB_VERSION=$("$PUB" --version)
+echo "Using Pub $PUB_VERSION from $PUB"
 
-$HOST_TOOLS/dart-sdk/bin/pub get
+"$PUB" get
 
 echo "Using dart from $HOST_TOOLS, gen_snapshot from $DEVICE_TOOLS."
 
-OUTDIR="${BASH_SOURCE%/*}/build/ios"
+OUTDIR="$SCRIPT_DIR/build/ios"
 
 echo "Creating $OUTDIR..."
 
-mkdir -p $OUTDIR
+mkdir -p "$OUTDIR"
 mkdir -p "$OUTDIR/App.framework"
 
 echo "Compiling kernel..."
@@ -41,13 +67,13 @@ echo "Compiling kernel..."
   --sdk-root "$HOST_TOOLS/flutter_patched_sdk" \
   --aot --tfa --target=flutter \
   --output-dill "$OUTDIR/app.dill" \
-  "${BASH_SOURCE%/*}/lib/main.dart"
+  "$SCRIPT_DIR/lib/main.dart"
 
 echo "Compiling AOT Assembly..."
 
-"$DEVICE_TOOLS/gen_snapshot" --deterministic --snapshot_kind=app-aot-assembly --assembly=$OUTDIR/snapshot_assembly.S $OUTDIR/app.dill
+"$DEVICE_TOOLS/gen_snapshot" --deterministic --snapshot_kind=app-aot-assembly --assembly="$OUTDIR/snapshot_assembly.S" "$OUTDIR/app.dill"
 
-SYSROOT=$(xcrun --sdk iphoneos --show-sdk-path)
+SYSROOT="$(xcrun --sdk iphoneos --show-sdk-path)"
 echo "Using $SYSROOT as sysroot."
 echo "Compiling Assembly..."
 
@@ -72,12 +98,12 @@ clang -arch arm64 \
 
 strip "$OUTDIR/App.framework/App"
 
-cp "${BASH_SOURCE%/*}/ios/AppFrameworkInfo.plist" "$OUTDIR/App.framework/Info.plist"
+cp "$SCRIPT_DIR/ios/AppFrameworkInfo.plist" "$OUTDIR/App.framework/Info.plist"
 
 echo "Created $OUTDIR/App.framework/App."
 
-rm -rf "${BASH_SOURCE%/*}/ios/Scenarios/App.framework"
-rm -rf "${BASH_SOURCE%/*}/ios/Scenarios/Flutter.framework"
-cp -R "$OUTDIR/App.framework" "${BASH_SOURCE%/*}/ios/Scenarios"
-cp -R "$DEVICE_TOOLS/../Flutter.framework" "${BASH_SOURCE%/*}/ios/Scenarios"
+rm -rf "$SCRIPT_DIR/ios/Scenarios/App.framework"
+rm -rf "$SCRIPT_DIR/ios/Scenarios/Flutter.framework"
+cp -R "$OUTDIR/App.framework" "$SCRIPT_DIR/ios/Scenarios"
+cp -R "$DEVICE_TOOLS/../Flutter.framework" "$SCRIPT_DIR/ios/Scenarios"
 

--- a/testing/scenario_app/firebase_xctest.sh
+++ b/testing/scenario_app/firebase_xctest.sh
@@ -2,26 +2,48 @@
 
 set -e
 
-"${BASH_SOURCE%/*}/compile_ios_aot.sh" $1 $2
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
 
-GIT_REVISION=${3:-$(git rev-parse HEAD)}
-BUILD_ID=${4:-$CIRRUS_BUILD_ID}
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -L "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
 
-pushd "${BASH_SOURCE%/*}/ios/Scenarios"
-xcodebuild -project Scenarios.xcodeproj -scheme Scenarios -configuration Debug \
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+
+"$SCRIPT_DIR/compile_ios_aot.sh" "$1" "$2"
+
+GIT_REVISION="${3:-$(git rev-parse HEAD)}"
+BUILD_ID="${4:-$CIRRUS_BUILD_ID}"
+
+(
+  cd "${BASH_SOURCE%/*}/ios/Scenarios"
+  xcodebuild -project Scenarios.xcodeproj -scheme Scenarios -configuration Debug \
     -sdk iphoneos \
     -derivedDataPath DerivedData/Scenarios \
     build-for-testing
+)
 
-pushd DerivedData/Scenarios/Build/Products
-
-zip -r scenarios.zip Debug-iphoneos Scenarios*.xctestrun
-
-gcloud firebase test ios run --test ./scenarios.zip \
+(
+  cd DerivedData/Scenarios/Build/Products
+  zip -r scenarios.zip Debug-iphoneos Scenarios*.xctestrun
+  gcloud firebase test ios run --test ./scenarios.zip \
     --device model=iphone8plus,version=12.0,locale=en_US,orientation=portrait \
     --xcode-version=10.2 \
     --results-bucket=gs://flutter_firebase_testlab \
-    --results-dir=engine_scenario_test/$GIT_REVISION/$BUILD_ID \
-
-popd
-popd
+    --results-dir="engine_scenario_test/$GIT_REVISION/$BUILD_ID"
+)

--- a/testing/scenario_app/run_android_tests.sh
+++ b/testing/scenario_app/run_android_tests.sh
@@ -7,12 +7,29 @@
 
 set -e
 
-cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
 
-GRADLE_USER_HOME=$(pwd)/android/gradle-home/.cache
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -L "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
 
-pushd android
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
 
+cd "$SCRIPT_DIR/android"
+GRADLE_USER_HOME="$PWD/android/gradle-home/.cache"
 set -o pipefail && ./gradlew app:verifyDebugAndroidTestScreenshotTest --gradle-user-home "$GRADLE_USER_HOME"
-
-popd

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -1,23 +1,44 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 
-FLUTTER_ENGINE=ios_debug_sim_unopt
 
-if [ $# -eq 1 ]; then
-  FLUTTER_ENGINE=$1
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
+
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -L "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
+
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+SRC_DIR="$(cd "$SCRIPT_DIR/../../.."; pwd -P)"
+
+FLUTTER_ENGINE="ios_debug_sim_unopt"
+
+if [[ $# -eq 1 ]]; then
+  FLUTTER_ENGINE="$1"
 fi
 
-cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd
-
 # Delete after LUCI push.
-./compile_ios_jit.sh ../../../out/host_debug_unopt ../../../out/$FLUTTER_ENGINE/clang_x64
+"$SCRIPT_DIR/compile_ios_jit.sh" "$SRC_DIR/out/host_debug_unopt" "$SRC_DIR/out/$FLUTTER_ENGINE/clang_x64"
 
-pushd ios/Scenarios
-
+cd ios/Scenarios
 set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme Scenarios \
   -destination 'platform=iOS Simulator,name=iPhone 8' \
   test \
-  FLUTTER_ENGINE=$FLUTTER_ENGINE
-popd
+  FLUTTER_ENGINE="$FLUTTER_ENGINE"


### PR DESCRIPTION
## Description

I just made a pass on the scenario scripts so that they can be more easily run from the scenario directory, set the `ANDROID_HOME` correctly, and generally fixed lint errors.

Also `compile_android_aot.sh` didn't appear to work, and I think I fixed it (it builds now), but that change might not be right (it wasn't pointing to `gen_snapshot` properly, or to `flutter.jar`).

I realize that these are mainly temporary scripts, but I needed to run them to test a change, and was having a hard time getting them to run.