### PR TITLE
fuchsia: Convert legacy permutations to build flag

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -19,18 +19,12 @@ config("config") {
       cflags = [ "/WX" ]  # Treat warnings as errors.
     }
   }
-}
 
-# This "fuchsia_legacy" configuration includes old, non-embedder API sources and
-# defines the LEGACY_FUCHSIA_EMBEDDER symbol.  This config and its associated
-# template are both transitional and will be removed after the embedder API
-# transition is complete.
-#
-# See `source_set_maybe_fuchsia_legacy` in //flutter/common/config.gni
-#
-# TODO(fxb/54041): Remove when no longer neccesary.
-config("fuchsia_legacy") {
-  if (is_fuchsia) {
+  # This define is transitional and will be removed after the embedder API
+  # transition is complete.
+  #
+  # TODO(bugs.fuchsia.dev/54041): Remove when no longer neccesary.
+  if (is_fuchsia && flutter_enable_legacy_fuchsia_embedder) {
     defines = [ "LEGACY_FUCHSIA_EMBEDDER" ]
   }
 }

--- a/common/config.gni
+++ b/common/config.gni
@@ -16,6 +16,9 @@ declare_args() {
 
   # Whether to use the Skia text shaper module
   flutter_enable_skshaper = false
+
+  # Whether to use the legacy embedder when building for Fuchsia.
+  flutter_enable_legacy_fuchsia_embedder = true
 }
 
 # feature_defines_list ---------------------------------------------------------
@@ -55,120 +58,4 @@ if (is_ios || is_mac) {
     "-Werror=undeclared-selector",
   ]
   flutter_cflags_objcc = flutter_cflags_objc
-}
-
-# This template creates a `source_set` in both standard and "fuchsia_legacy"
-# configurations.
-#
-# The "fuchsia_legacy" configuration includes old, non-embedder API sources and
-# defines the LEGACY_FUCHSIA_EMBEDDER symbol.  This template and the config
-# are both transitional and will be removed after the embedder API transition
-# is complete.
-# TODO(fxb/54041): Remove when no longer neccesary.
-#
-# `sources`, `defines`, `public_configs`, `configs`, `public_deps`, `deps` work
-# as they do in a normal `source_set`.
-#
-# `legacy_deps` is the list of dependencies which should be mutated by
-# appending '_fuchsia_legacy' when creating the 2 `source_set`'s.  The template adds
-# `legacy_deps` to `public_deps`, whether it mutates them or not.
-template("source_set_maybe_fuchsia_legacy") {
-  public_deps_non_legacy = []
-  deps_non_legacy = []
-  if (defined(invoker.public_deps)) {
-    public_deps_non_legacy += invoker.public_deps
-  }
-  if (defined(invoker.deps)) {
-    deps_non_legacy += invoker.deps
-  }
-  if (defined(invoker.public_deps_legacy_and_next)) {
-    foreach(legacy_dep, invoker.public_deps_legacy_and_next) {
-      public_deps_non_legacy += [ legacy_dep ]
-    }
-  }
-  if (defined(invoker.deps_legacy_and_next)) {
-    foreach(legacy_dep, invoker.deps_legacy_and_next) {
-      deps_non_legacy += [ legacy_dep ]
-    }
-  }
-
-  source_set(target_name) {
-    forward_variables_from(invoker,
-                           [
-                             "testonly",
-                             "sources",
-                             "defines",
-                             "public_configs",
-                             "configs",
-                           ])
-    public_deps = public_deps_non_legacy
-    deps = deps_non_legacy
-  }
-
-  if (is_fuchsia) {
-    legagcy_suffix = "_fuchsia_legacy"
-
-    sources_legacy = []
-    if (defined(invoker.sources_legacy)) {
-      sources_legacy += invoker.sources_legacy
-    }
-    if (defined(invoker.sources)) {
-      sources_legacy += invoker.sources
-    }
-
-    public_configs_legacy = [ "//flutter:fuchsia_legacy" ]
-    if (defined(invoker.public_configs)) {
-      public_configs_legacy += invoker.public_configs
-    }
-
-    public_deps_legacy = []
-    deps_legacy = []
-    if (defined(invoker.public_deps)) {
-      public_deps_legacy += invoker.public_deps
-    }
-    if (defined(invoker.deps)) {
-      deps_legacy += invoker.deps
-    }
-    if (defined(invoker.public_deps_legacy)) {
-      public_deps_legacy += invoker.public_deps_legacy
-    }
-    if (defined(invoker.deps_legacy)) {
-      deps_legacy += invoker.deps_legacy
-    }
-    if (defined(invoker.public_deps_legacy_and_next)) {
-      foreach(legacy_dep, invoker.public_deps_legacy_and_next) {
-        public_deps_legacy += [ legacy_dep + legagcy_suffix ]
-      }
-    }
-    if (defined(invoker.deps_legacy_and_next)) {
-      foreach(legacy_dep, invoker.deps_legacy_and_next) {
-        deps_legacy += [ legacy_dep + legagcy_suffix ]
-      }
-    }
-
-    source_set(target_name + legagcy_suffix) {
-      forward_variables_from(invoker,
-                             [
-                               "testonly",
-                               "defines",
-                               "configs",
-                             ])
-      sources = sources_legacy
-
-      public_configs = public_configs_legacy
-
-      public_deps = public_deps_legacy
-      deps = deps_legacy
-    }
-  } else {
-    if (defined(invoker.sources_legacy)) {
-      not_needed(invoker, [ "sources_legacy" ])
-    }
-    if (defined(invoker.public_deps_legacy)) {
-      not_needed(invoker, [ "public_deps_legacy" ])
-    }
-    if (defined(invoker.deps_legacy)) {
-      not_needed(invoker, [ "deps_legacy" ])
-    }
-  }
 }

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -6,7 +6,7 @@ import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
 
-source_set_maybe_fuchsia_legacy("flow") {
+source_set("flow") {
   sources = [
     "compositor_context.cc",
     "compositor_context.h",
@@ -78,20 +78,23 @@ source_set_maybe_fuchsia_legacy("flow") {
     "//third_party/skia",
   ]
 
-  sources_legacy = [
-    "layers/child_scene_layer.cc",
-    "layers/child_scene_layer.h",
-    "scene_update_context.cc",
-    "scene_update_context.h",
-    "view_holder.cc",
-    "view_holder.h",
-  ]
+  if (is_fuchsia && flutter_enable_legacy_fuchsia_embedder) {
+    sources += [
+      "layers/child_scene_layer.cc",
+      "layers/child_scene_layer.h",
+      "scene_update_context.cc",
+      "scene_update_context.h",
+      "view_holder.cc",
+      "view_holder.h",
+    ]
 
-  public_deps_legacy = [
-    "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
-    "$fuchsia_sdk_root/fidl:fuchsia.ui.gfx",
-    "$fuchsia_sdk_root/pkg:scenic_cpp",
-  ]
+    public_deps = [
+      "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
+      "$fuchsia_sdk_root/fidl:fuchsia.ui.gfx",
+      "$fuchsia_sdk_root/fidl:fuchsia.ui.views",
+      "$fuchsia_sdk_root/pkg:scenic_cpp",
+    ]
+  }
 }
 
 if (enable_unittests) {
@@ -99,7 +102,7 @@ if (enable_unittests) {
     fixtures = []
   }
 
-  source_set_maybe_fuchsia_legacy("flow_testing") {
+  source_set("flow_testing") {
     testonly = true
 
     sources = [
@@ -121,10 +124,10 @@ if (enable_unittests) {
       "//third_party/googletest:gtest",
     ]
 
-    deps_legacy_and_next = [ ":flow" ]
+    deps = [ ":flow" ]
   }
 
-  source_set_maybe_fuchsia_legacy("flow_unittests_common") {
+  executable("flow_unittests") {
     testonly = true
 
     sources = [
@@ -160,7 +163,9 @@ if (enable_unittests) {
     ]
 
     deps = [
+      ":flow",
       ":flow_fixtures",
+      ":flow_testing",
       "//flutter/fml",
       "//flutter/testing:skia",
       "//flutter/testing:testing_lib",
@@ -169,32 +174,10 @@ if (enable_unittests) {
       "//third_party/skia",
     ]
 
-    sources_legacy = [ "layers/fuchsia_layer_unittests.cc" ]
+    if (is_fuchsia && flutter_enable_legacy_fuchsia_embedder) {
+      sources += [ "layers/fuchsia_layer_unittests.cc" ]
 
-    deps_legacy = [ "//build/fuchsia/pkg:sys_cpp_testing" ]
-
-    deps_legacy_and_next = [
-      ":flow",
-      ":flow_testing",
-    ]
-  }
-
-  if (is_fuchsia) {
-    executable("flow_unittests") {
-      testonly = true
-
-      deps = [ ":flow_unittests_common_fuchsia_legacy" ]
-    }
-    executable("flow_unittests_next") {
-      testonly = true
-
-      deps = [ ":flow_unittests_common" ]
-    }
-  } else {
-    executable("flow_unittests") {
-      testonly = true
-
-      deps = [ ":flow_unittests_common" ]
+      deps += [ "//build/fuchsia/pkg:sys_cpp_testing" ]
     }
   }
 }

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -6,7 +6,7 @@ import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
 
-source_set_maybe_fuchsia_legacy("ui") {
+source_set("ui") {
   sources = [
     "compositing/scene.cc",
     "compositing/scene.h",
@@ -120,6 +120,7 @@ source_set_maybe_fuchsia_legacy("ui") {
   deps = [
     "//flutter/assets",
     "//flutter/common",
+    "//flutter/flow",
     "//flutter/fml",
     "//flutter/runtime:test_font",
     "//flutter/third_party/tonic",
@@ -132,18 +133,18 @@ source_set_maybe_fuchsia_legacy("ui") {
     defines = [ "FLUTTER_ENABLE_SKSHAPER" ]
   }
 
-  sources_legacy = [
-    "compositing/scene_host.cc",
-    "compositing/scene_host.h",
-  ]
+  if (is_fuchsia && flutter_enable_legacy_fuchsia_embedder) {
+    sources += [
+      "compositing/scene_host.cc",
+      "compositing/scene_host.h",
+    ]
 
-  deps_legacy = [
-    "$fuchsia_sdk_root/pkg:async-cpp",
-    "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia",
-    "//flutter/shell/platform/fuchsia/dart-pkg/zircon",
-  ]
-
-  deps_legacy_and_next = [ "//flutter/flow:flow" ]
+    deps += [
+      "$fuchsia_sdk_root/pkg:async-cpp",
+      "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia",
+      "//flutter/shell/platform/fuchsia/dart-pkg/zircon",
+    ]
+  }
 }
 
 if (enable_unittests) {
@@ -174,7 +175,7 @@ if (enable_unittests) {
     ]
   }
 
-  source_set_maybe_fuchsia_legacy("ui_unittests_common") {
+  executable("ui_unittests") {
     testonly = true
 
     public_configs = [ "//flutter:export_dynamic_symbols" ]
@@ -187,44 +188,22 @@ if (enable_unittests) {
     ]
 
     deps = [
+      ":ui",
       ":ui_unittests_fixtures",
       "//flutter/common",
+      "//flutter/shell/common:shell_test_fixture_sources",
       "//flutter/testing",
+      "//flutter/testing:dart",
+      "//flutter/testing:fixture_test",
       "//flutter/third_party/tonic",
       "//third_party/dart/runtime/bin:elf_loader",
     ]
 
-    # TODO(): This test is hard-coded to use a TestGLSurface so it cannot run on fuchsia.
+    # TODO(https://github.com/flutter/flutter/issues/63837): This test is hard-coded to use a TestGLSurface so it cannot run on fuchsia.
     if (!is_fuchsia) {
       sources += [ "painting/image_decoder_unittests.cc" ]
 
       deps += [ "//flutter/testing:opengl" ]
-    }
-
-    deps_legacy_and_next = [
-      ":ui",
-      "//flutter/shell/common:shell_test_fixture_sources",
-      "//flutter/testing:dart",
-      "//flutter/testing:fixture_test",
-    ]
-  }
-
-  if (is_fuchsia) {
-    executable("ui_unittests") {
-      testonly = true
-
-      deps = [ ":ui_unittests_common_fuchsia_legacy" ]
-    }
-    executable("ui_unittests_next") {
-      testonly = true
-
-      deps = [ ":ui_unittests_common" ]
-    }
-  } else {
-    executable("ui_unittests") {
-      testonly = true
-
-      deps = [ ":ui_unittests_common" ]
     }
   }
 }

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -35,7 +35,7 @@ group("libdart") {
   }
 }
 
-source_set_maybe_fuchsia_legacy("runtime") {
+source_set("runtime") {
   sources = [
     "dart_isolate.cc",
     "dart_isolate.h",
@@ -75,8 +75,10 @@ source_set_maybe_fuchsia_legacy("runtime") {
     ":test_font",
     "//flutter/assets",
     "//flutter/common",
+    "//flutter/flow",
     "//flutter/fml",
     "//flutter/lib/io",
+    "//flutter/lib/ui",
     "//flutter/third_party/tonic",
     "//flutter/third_party/txt",
     "//third_party/dart/runtime:dart_api",
@@ -91,11 +93,6 @@ source_set_maybe_fuchsia_legacy("runtime") {
       "//third_party/dart/runtime/observatory:embedded_observatory_archive",
     ]
   }
-
-  deps_legacy_and_next = [
-    "//flutter/flow:flow",
-    "//flutter/lib/ui:ui",
-  ]
 }
 
 if (enable_unittests) {
@@ -103,7 +100,7 @@ if (enable_unittests) {
     dart_main = "fixtures/runtime_test.dart"
   }
 
-  source_set_maybe_fuchsia_legacy("runtime_unittests_common") {
+  executable("runtime_unittests") {
     testonly = true
 
     sources = [
@@ -117,40 +114,17 @@ if (enable_unittests) {
 
     public_deps = [
       ":libdart",
+      ":runtime",
       ":runtime_fixtures",
       "//flutter/common",
       "//flutter/fml",
       "//flutter/lib/snapshot",
       "//flutter/testing",
+      "//flutter/testing:dart",
+      "//flutter/testing:fixture_test",
       "//flutter/third_party/tonic",
       "//third_party/dart/runtime/bin:elf_loader",
       "//third_party/skia",
     ]
-
-    deps_legacy_and_next = [
-      ":runtime",
-      "//flutter/testing:dart",
-      "//flutter/testing:fixture_test",
-    ]
-  }
-
-  if (is_fuchsia) {
-    executable("runtime_unittests") {
-      testonly = true
-
-      deps = [ ":runtime_unittests_common_fuchsia_legacy" ]
-    }
-
-    executable("runtime_unittests_next") {
-      testonly = true
-
-      deps = [ ":runtime_unittests_common" ]
-    }
-  } else {
-    executable("runtime_unittests") {
-      testonly = true
-
-      deps = [ ":runtime_unittests_common" ]
-    }
   }
 }

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -58,7 +58,7 @@ template("dart_embedder_resources") {
   }
 }
 
-source_set_maybe_fuchsia_legacy("common") {
+source_set("common") {
   sources = [
     "animator.cc",
     "animator.h",
@@ -110,27 +110,17 @@ source_set_maybe_fuchsia_legacy("common") {
   deps = [
     "//flutter/assets",
     "//flutter/common",
+    "//flutter/flow",
     "//flutter/fml",
+    "//flutter/lib/ui",
+    "//flutter/runtime",
     "//flutter/shell/profiling",
     "//third_party/dart/runtime:dart_api",
     "//third_party/skia",
   ]
-
-  deps_legacy_and_next = [
-    "//flutter/flow:flow",
-    "//flutter/lib/ui:ui",
-    "//flutter/runtime:runtime",
-  ]
 }
 
 template("shell_host_executable") {
-  common_dep = ":common"
-  if (defined(invoker.fuchsia_legacy)) {
-    if (invoker.fuchsia_legacy) {
-      common_dep += "_fuchsia_legacy"
-    }
-  }
-
   executable(target_name) {
     testonly = true
 
@@ -141,9 +131,9 @@ template("shell_host_executable") {
     forward_variables_from(invoker, "*")
 
     deps += [
+      ":common",
       "//flutter/lib/snapshot",
       "//flutter/runtime:libdart",
-      common_dep,
     ]
 
     public_configs = [ "//flutter:export_dynamic_symbols" ]
@@ -185,12 +175,13 @@ if (enable_unittests) {
     deps = [
       ":shell_unittests_fixtures",
       "//flutter/benchmarking",
+      "//flutter/flow",
       "//flutter/testing:dart",
       "//flutter/testing:testing_lib",
     ]
   }
 
-  source_set_maybe_fuchsia_legacy("shell_test_fixture_sources") {
+  source_set("shell_test_fixture_sources") {
     testonly = true
 
     sources = [
@@ -205,13 +196,20 @@ if (enable_unittests) {
     ]
 
     public_deps = [
+      "//flutter/flow",
       "//flutter/fml/dart",
+      "//flutter/runtime",
+      "//flutter/shell/common",
       "//flutter/testing",
     ]
 
     deps = [
+      ":shell_unittests_gpu_configuration",
       "//flutter/assets",
       "//flutter/common",
+      "//flutter/lib/ui",
+      "//flutter/testing:dart",
+      "//flutter/testing:fixture_test",
       "//third_party/rapidjson",
       "//third_party/skia",
     ]
@@ -245,22 +243,9 @@ if (enable_unittests) {
         "//flutter/vulkan",
       ]
     }
-
-    public_deps_legacy_and_next = [
-      "//flutter/shell/common:common",
-      "//flutter/flow:flow",
-      "//flutter/runtime:runtime",
-    ]
-
-    deps_legacy_and_next = [
-      ":shell_unittests_gpu_configuration",
-      "//flutter/lib/ui:ui",
-      "//flutter/testing:dart",
-      "//flutter/testing:fixture_test",
-    ]
   }
 
-  source_set_maybe_fuchsia_legacy("shell_unittests_common") {
+  shell_host_executable("shell_unittests") {
     testonly = true
 
     sources = [
@@ -275,36 +260,11 @@ if (enable_unittests) {
     ]
 
     deps = [
+      ":shell_test_fixture_sources",
+      ":shell_unittests_fixtures",
       "//flutter/assets",
       "//flutter/shell/version",
       "//third_party/googletest:gmock",
     ]
-
-    public_deps_legacy_and_next = [ ":shell_test_fixture_sources" ]
-  }
-
-  if (is_fuchsia) {
-    shell_host_executable("shell_unittests") {
-      deps = [
-        ":shell_unittests_common_fuchsia_legacy",
-        ":shell_unittests_fixtures",
-      ]
-
-      fuchsia_legacy = true
-    }
-
-    shell_host_executable("shell_unittests_next") {
-      deps = [
-        ":shell_unittests_common",
-        ":shell_unittests_fixtures",
-      ]
-    }
-  } else {
-    shell_host_executable("shell_unittests") {
-      deps = [
-        ":shell_unittests_common",
-        ":shell_unittests_fixtures",
-      ]
-    }
   }
 }

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -5,69 +5,56 @@
 import("//flutter/common/config.gni")
 import("//flutter/shell/config.gni")
 
-gpu_dir = "//flutter/shell/gpu"
-
 gpu_common_deps = [
   "//flutter/common",
+  "//flutter/flow",
   "//flutter/fml",
+  "//flutter/shell/common",
   "//third_party/skia",
 ]
 
-gpu_common_deps_legacy_and_next = [
-  "//flutter/flow:flow",
-  "//flutter/shell/common:common",
-]
-
-source_set_maybe_fuchsia_legacy("gpu_surface_software") {
+source_set("gpu_surface_software") {
   sources = [
-    "$gpu_dir/gpu_surface_delegate.h",
-    "$gpu_dir/gpu_surface_software.cc",
-    "$gpu_dir/gpu_surface_software.h",
-    "$gpu_dir/gpu_surface_software_delegate.cc",
-    "$gpu_dir/gpu_surface_software_delegate.h",
+    "gpu_surface_delegate.h",
+    "gpu_surface_software.cc",
+    "gpu_surface_software.h",
+    "gpu_surface_software_delegate.cc",
+    "gpu_surface_software_delegate.h",
   ]
 
   deps = gpu_common_deps
-
-  deps_legacy_and_next = gpu_common_deps_legacy_and_next
 }
 
-source_set_maybe_fuchsia_legacy("gpu_surface_gl") {
+source_set("gpu_surface_gl") {
   sources = [
-    "$gpu_dir/gpu_surface_delegate.h",
-    "$gpu_dir/gpu_surface_gl.cc",
-    "$gpu_dir/gpu_surface_gl.h",
-    "$gpu_dir/gpu_surface_gl_delegate.cc",
-    "$gpu_dir/gpu_surface_gl_delegate.h",
+    "gpu_surface_delegate.h",
+    "gpu_surface_gl.cc",
+    "gpu_surface_gl.h",
+    "gpu_surface_gl_delegate.cc",
+    "gpu_surface_gl_delegate.h",
   ]
 
   deps = gpu_common_deps
-
-  deps_legacy_and_next = gpu_common_deps_legacy_and_next
 }
 
-source_set_maybe_fuchsia_legacy("gpu_surface_vulkan") {
+source_set("gpu_surface_vulkan") {
   sources = [
-    "$gpu_dir/gpu_surface_delegate.h",
-    "$gpu_dir/gpu_surface_vulkan.cc",
-    "$gpu_dir/gpu_surface_vulkan.h",
-    "$gpu_dir/gpu_surface_vulkan_delegate.cc",
-    "$gpu_dir/gpu_surface_vulkan_delegate.h",
+    "gpu_surface_delegate.h",
+    "gpu_surface_vulkan.cc",
+    "gpu_surface_vulkan.h",
+    "gpu_surface_vulkan_delegate.cc",
+    "gpu_surface_vulkan_delegate.h",
   ]
 
   deps = gpu_common_deps + [ "//flutter/vulkan" ]
-
-  deps_legacy_and_next = gpu_common_deps_legacy_and_next
 }
 
-source_set_maybe_fuchsia_legacy("gpu_surface_metal") {
+source_set("gpu_surface_metal") {
   sources = [
-    "$gpu_dir/gpu_surface_delegate.h",
-    "$gpu_dir/gpu_surface_metal.h",
-    "$gpu_dir/gpu_surface_metal.mm",
+    "gpu_surface_delegate.h",
+    "gpu_surface_metal.h",
+    "gpu_surface_metal.mm",
   ]
 
   deps = gpu_common_deps
-
-  deps_legacy_and_next = gpu_common_deps_legacy_and_next
 }

--- a/shell/gpu/gpu.gni
+++ b/shell/gpu/gpu.gni
@@ -33,30 +33,4 @@ template("shell_gpu_configuration") {
       public_deps += [ "//flutter/shell/gpu:gpu_surface_metal" ]
     }
   }
-
-  if (is_fuchsia) {
-    legagcy_suffix = "_fuchsia_legacy"
-    group(target_name + legagcy_suffix) {
-      public_deps = []
-
-      if (invoker.enable_software) {
-        public_deps +=
-            [ "//flutter/shell/gpu:gpu_surface_software" + legagcy_suffix ]
-      }
-
-      if (invoker.enable_gl) {
-        public_deps += [ "//flutter/shell/gpu:gpu_surface_gl" + legagcy_suffix ]
-      }
-
-      if (invoker.enable_vulkan) {
-        public_deps +=
-            [ "//flutter/shell/gpu:gpu_surface_vulkan" + legagcy_suffix ]
-      }
-
-      if (invoker.enable_metal) {
-        public_deps +=
-            [ "//flutter/shell/gpu:gpu_surface_metal" + legagcy_suffix ]
-      }
-    }
-  }
 }

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -14,7 +14,7 @@ import("//flutter/tools/fuchsia/fuchsia_libs.gni")
 import("//flutter/vulkan/config.gni")
 
 # Fuchsia uses its own custom Surface implementation.
-shell_gpu_configuration("fuchsia_legacy_gpu_configuration") {
+shell_gpu_configuration("fuchsia_gpu_configuration") {
   enable_software = false
   enable_gl = false
   enable_vulkan = false
@@ -98,13 +98,13 @@ template("runner_sources") {
     # The use of these dependencies is temporary and will be moved behind the
     # embedder API.
     flutter_public_deps = [
-      "//flutter/flow:flow_fuchsia_legacy",
-      "//flutter/lib/ui:ui_fuchsia_legacy",
-      "//flutter/runtime:runtime_fuchsia_legacy",
-      "//flutter/shell/common:common_fuchsia_legacy",
+      "//flutter/flow",
+      "//flutter/lib/ui",
+      "//flutter/runtime",
+      "//flutter/shell/common",
     ]
     flutter_deps = [
-      ":fuchsia_legacy_gpu_configuration",
+      ":fuchsia_gpu_configuration",
       "//flutter/assets",
       "//flutter/common",
       "//flutter/fml",
@@ -452,9 +452,9 @@ executable("flutter_runner_unittests") {
   # The use of these dependencies is temporary and will be moved behind the
   # embedder API.
   flutter_deps = [
-    "//flutter/flow:flow_fuchsia_legacy",
-    "//flutter/lib/ui:ui_fuchsia_legacy",
-    "//flutter/shell/common:common_fuchsia_legacy",
+    "//flutter/flow",
+    "//flutter/lib/ui",
+    "//flutter/shell/common",
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/dart/runtime/platform:libdart_platform_jit",
   ]
@@ -480,7 +480,7 @@ executable("flutter_runner_tzdata_unittests") {
   # The use of these dependencies is temporary and will be moved behind the
   # embedder API.
   flutter_deps = [
-    "//flutter/lib/ui:ui_fuchsia_legacy",
+    "//flutter/lib/ui",
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/dart/runtime/platform:libdart_platform_jit",
   ]
@@ -505,7 +505,7 @@ executable("flutter_runner_scenic_unittests") {
   # The use of these dependencies is temporary and will be moved behind the
   # embedder API.
   flutter_deps = [
-    "//flutter/lib/ui:ui_fuchsia_legacy",
+    "//flutter/lib/ui",
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/dart/runtime/platform:libdart_platform_jit",
   ]
@@ -641,30 +641,6 @@ fuchsia_test_archive("flow_tests") {
   ]
 }
 
-fuchsia_test_archive("flow_tests_next") {
-  deps = [ "//flutter/flow:flow_unittests_next" ]
-
-  binary = "flow_unittests_next"
-
-  resources = [
-    {
-      path = rebase_path(
-              "//flutter/testing/resources/performance_overlay_gold_60fps.png")
-      dest = "flutter/testing/resources/performance_overlay_gold_60fps.png"
-    },
-    {
-      path = rebase_path(
-              "//flutter/testing/resources/performance_overlay_gold_90fps.png")
-      dest = "flutter/testing/resources/performance_overlay_gold_90fps.png"
-    },
-    {
-      path = rebase_path(
-              "//flutter/testing/resources/performance_overlay_gold_120fps.png")
-      dest = "flutter/testing/resources/performance_overlay_gold_120fps.png"
-    },
-  ]
-}
-
 fuchsia_test_archive("runtime_tests") {
   deps = [
     "//flutter/runtime:runtime_fixtures",
@@ -684,25 +660,6 @@ fuchsia_test_archive("runtime_tests") {
   ]
 }
 
-fuchsia_test_archive("runtime_tests_next") {
-  deps = [
-    "//flutter/runtime:runtime_fixtures",
-    "//flutter/runtime:runtime_unittests_next",
-  ]
-
-  binary = "runtime_unittests_next"
-
-  # TODO(gw280): https://github.com/flutter/flutter/issues/50294
-  # Right now we need to manually specify all the fixtures that are
-  # declared in the test_fixtures() call above.
-  resources = [
-    {
-      path = "$root_gen_dir/flutter/runtime/assets/kernel_blob.bin"
-      dest = "assets/kernel_blob.bin"
-    },
-  ]
-}
-
 fuchsia_test_archive("shell_tests") {
   deps = [
     "//flutter/shell/common:shell_unittests",
@@ -710,33 +667,6 @@ fuchsia_test_archive("shell_tests") {
   ]
 
   binary = "shell_unittests"
-
-  # TODO(gw280): https://github.com/flutter/flutter/issues/50294
-  # Right now we need to manually specify all the fixtures that are
-  # declared in the test_fixtures() call above.
-  resources = [
-    {
-      path = "$root_gen_dir/flutter/shell/common/assets/kernel_blob.bin"
-      dest = "assets/kernel_blob.bin"
-    },
-    {
-      path =
-          "$root_gen_dir/flutter/shell/common/assets/shelltest_screenshot.png"
-      dest = "assets/shelltest_screenshot.png"
-    },
-  ]
-
-  libraries = vulkan_validation_libs
-  resources += vulkan_icds
-}
-
-fuchsia_test_archive("shell_tests_next") {
-  deps = [
-    "//flutter/shell/common:shell_unittests_fixtures",
-    "//flutter/shell/common:shell_unittests_next",
-  ]
-
-  binary = "shell_unittests_next"
 
   # TODO(gw280): https://github.com/flutter/flutter/issues/50294
   # Right now we need to manually specify all the fixtures that are
@@ -822,48 +752,6 @@ fuchsia_test_archive("ui_tests") {
   resources += vulkan_icds
 }
 
-fuchsia_test_archive("ui_tests_next") {
-  deps = [
-    "//flutter/lib/ui:ui_unittests_fixtures",
-    "//flutter/lib/ui:ui_unittests_next",
-  ]
-
-  binary = "ui_unittests_next"
-
-  # TODO(gw280): https://github.com/flutter/flutter/issues/50294
-  # Right now we need to manually specify all the fixtures that are
-  # declared in the test_fixtures() call above.
-  resources = [
-    {
-      path = "$root_gen_dir/flutter/lib/ui/assets/kernel_blob.bin"
-      dest = "assets/kernel_blob.bin"
-    },
-    {
-      path = "$root_gen_dir/flutter/lib/ui/assets/DashInNooglerHat.jpg"
-      dest = "assets/DashInNooglerHat.jpg"
-    },
-    {
-      path = "$root_gen_dir/flutter/lib/ui/assets/Horizontal.jpg"
-      dest = "assets/Horizontal.jpg"
-    },
-    {
-      path = "$root_gen_dir/flutter/lib/ui/assets/Horizontal.png"
-      dest = "assets/Horizontal.png"
-    },
-    {
-      path = "$root_gen_dir/flutter/lib/ui/assets/hello_loop_2.gif"
-      dest = "assets/hello_loop_2.gif"
-    },
-    {
-      path = "$root_gen_dir/flutter/lib/ui/assets/hello_loop_2.webp"
-      dest = "assets/hello_loop_2.webp"
-    },
-  ]
-
-  libraries = vulkan_validation_libs
-  resources += vulkan_icds
-}
-
 # When adding a new dep here, please also ensure the dep is added to
 # testing/fuchsia/run_tests.sh and testing/fuchsia/test_fars
 group("tests") {
@@ -871,18 +759,14 @@ group("tests") {
 
   deps = [
     ":flow_tests",
-    ":flow_tests_next",
     ":flutter_runner_scenic_tests",
     ":flutter_runner_tests",
     ":flutter_runner_tzdata_tests",
     ":fml_tests",
     ":runtime_tests",
-    ":runtime_tests_next",
     ":shell_tests",
-    ":shell_tests_next",
     ":testing_tests",
     ":txt_tests",
     ":ui_tests",
-    ":ui_tests_next",
   ]
 }

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -39,7 +39,7 @@ source_set("testing") {
   public_deps = [ ":testing_lib" ]
 }
 
-source_set_maybe_fuchsia_legacy("dart") {
+source_set("dart") {
   testonly = true
 
   sources = [
@@ -54,13 +54,12 @@ source_set_maybe_fuchsia_legacy("dart") {
   public_deps = [
     ":testing_lib",
     "//flutter/common",
+    "//flutter/runtime",
     "//flutter/runtime:libdart",
     "//flutter/third_party/tonic",
     "//third_party/dart/runtime/bin:elf_loader",
     "//third_party/skia",
   ]
-
-  public_deps_legacy_and_next = [ "//flutter/runtime:runtime" ]
 }
 
 source_set("skia") {
@@ -80,7 +79,7 @@ source_set("skia") {
   ]
 }
 
-source_set_maybe_fuchsia_legacy("fixture_test") {
+source_set("fixture_test") {
   testonly = true
 
   sources = [
@@ -88,11 +87,10 @@ source_set_maybe_fuchsia_legacy("fixture_test") {
     "fixture_test.h",
   ]
 
-  public_deps = [ "//flutter/common" ]
-
-  public_deps_legacy_and_next = [
+  public_deps = [
     ":dart",
-    "//flutter/runtime:runtime",
+    "//flutter/common",
+    "//flutter/runtime",
   ]
 }
 

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -121,13 +121,6 @@ echo "$(date) START:flow_tests --------------------------------------"
    --identity-file $pkey \
    --timeout-seconds $test_timeout_seconds \
    --packages-directory packages
-
-./fuchsia_ctl -d $device_name test \
-   -f flow_tests_next-0.far  \
-   -t flow_tests_next \
-   --identity-file $pkey \
-   --timeout-seconds $test_timeout_seconds \
-   --packages-directory packages
 echo "$(date) DONE:flow_tests ---------------------------------------"
 
 
@@ -135,13 +128,6 @@ echo "$(date) START:runtime_tests -----------------------------------"
 ./fuchsia_ctl -d $device_name test \
     -f runtime_tests-0.far  \
     -t runtime_tests \
-    --identity-file $pkey \
-    --timeout-seconds $test_timeout_seconds \
-    --packages-directory packages
-
-./fuchsia_ctl -d $device_name test \
-    -f runtime_tests_next-0.far  \
-    -t runtime_tests_next \
     --identity-file $pkey \
     --timeout-seconds $test_timeout_seconds \
     --packages-directory packages
@@ -154,26 +140,12 @@ echo "$(date) START:ui_tests ----------------------------------------"
    --identity-file $pkey \
    --timeout-seconds $test_timeout_seconds \
    --packages-directory packages
-
-./fuchsia_ctl -d $device_name test \
-   -f ui_tests_next-0.far  \
-   -t ui_tests_next \
-   --identity-file $pkey \
-   --timeout-seconds $test_timeout_seconds \
-   --packages-directory packages
 echo "$(date) DONE:ui_tests -----------------------------------------"
 
 echo "$(date) START:shell_tests -------------------------------------"
 ./fuchsia_ctl -d $device_name test \
     -f shell_tests-0.far  \
     -t shell_tests \
-    --identity-file $pkey \
-    --timeout-seconds $test_timeout_seconds \
-    --packages-directory packages
-
-./fuchsia_ctl -d $device_name test \
-    -f shell_tests_next-0.far  \
-    -t shell_tests_next \
     --identity-file $pkey \
     --timeout-seconds $test_timeout_seconds \
     --packages-directory packages

--- a/testing/fuchsia/test_fars
+++ b/testing/fuchsia/test_fars
@@ -8,7 +8,3 @@ shell_tests-0.far
 testing_tests-0.far
 txt_tests-0.far
 ui_tests-0.far
-flow_tests_next-0.far
-runtime_tests_next-0.far
-shell_tests_next-0.far
-ui_tests_next-0.far

--- a/tools/gn
+++ b/tools/gn
@@ -136,6 +136,9 @@ def to_gn_args(args):
     elif args.target_os == 'ios':
         gn_args['target_os'] = 'ios'
         gn_args['use_ios_simulator'] = args.simulator
+    elif args.target_os == 'fuchsia':
+        gn_args['target_os'] = 'fuchsia'
+        gn_args['flutter_enable_legacy_fuchsia_embedder'] = args.fuchsia_legacy
     elif args.target_os is not None:
         gn_args['target_os'] = args.target_os
 
@@ -309,6 +312,9 @@ def parse_args(args):
   parser.add_argument('--ios-cpu', type=str, choices=['arm', 'arm64'], default='arm64')
   parser.add_argument('--simulator', action='store_true', default=False)
   parser.add_argument('--fuchsia', dest='target_os', action='store_const', const='fuchsia')
+  parser.add_argument('--fuchsia-legacy', default=True, action='store_true')
+  parser.add_argument('--no-fuchsia-legacy', dest='fuchsia_legacy', action='store_false')
+
   parser.add_argument('--linux-cpu', type=str, choices=['x64', 'x86', 'arm64', 'arm'])
   parser.add_argument('--fuchsia-cpu', type=str, choices=['x64', 'arm64'], default = 'x64')
   parser.add_argument('--windows-cpu', type=str, choices=['x64', 'arm64'], default = 'x64')


### PR DESCRIPTION
## Description

These build permutations exist in order to create fuchsia artifacts that don't contain any legacy pre-embedder render code.  However we don't need both permutations within the same build, so a build flag is much simpler than the template.

## Related Issues

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=53847

## Tests

Tested both --legacy and --no-legacy built artifacts on workstation and internal builds.
