### PR TITLE
Revert "Paragraph.longest_line_ to account for trailing inline placeholders"

### DIFF
--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -1045,16 +1045,16 @@ void ParagraphTxt::Layout(double width) {
                     return a.code_units.start < b.code_units.start;
                   });
 
-        double blob_x_pos_start = glyph_positions.front().x_pos.start;
-        double blob_x_pos_end = run.is_placeholder_run()
-                                    ? glyph_positions.back().x_pos.start +
-                                          run.placeholder_run()->width
-                                    : glyph_positions.back().x_pos.end;
         line_code_unit_runs.emplace_back(
             std::move(code_unit_positions),
             Range<size_t>(run.start(), run.end()),
-            Range<double>(blob_x_pos_start, blob_x_pos_end), line_number,
-            *metrics, run.style(), run.direction(), run.placeholder_run());
+            Range<double>(glyph_positions.front().x_pos.start,
+                          run.is_placeholder_run()
+                              ? glyph_positions.back().x_pos.start +
+                                    run.placeholder_run()->width
+                              : glyph_positions.back().x_pos.end),
+            line_number, *metrics, run.style(), run.direction(),
+            run.placeholder_run());
 
         if (run.is_placeholder_run()) {
           line_inline_placeholder_code_unit_runs.push_back(
@@ -1062,8 +1062,8 @@ void ParagraphTxt::Layout(double width) {
         }
 
         if (!run.is_ghost()) {
-          min_left_ = std::min(min_left_, blob_x_pos_start);
-          max_right_ = std::max(max_right_, blob_x_pos_end);
+          min_left_ = std::min(min_left_, glyph_positions.front().x_pos.start);
+          max_right_ = std::max(max_right_, glyph_positions.back().x_pos.end);
         }
       }  // for each in glyph_blobs
 

--- a/third_party/txt/src/txt/paragraph_txt.h
+++ b/third_party/txt/src/txt/paragraph_txt.h
@@ -139,7 +139,6 @@ class ParagraphTxt : public Paragraph {
   FRIEND_TEST_WINDOWS_DISABLED(ParagraphTest, CenterAlignParagraph);
   FRIEND_TEST_WINDOWS_DISABLED(ParagraphTest, JustifyAlignParagraph);
   FRIEND_TEST_WINDOWS_DISABLED(ParagraphTest, JustifyRTL);
-  FRIEND_TEST_WINDOWS_DISABLED(ParagraphTest, InlinePlaceholderLongestLine);
   FRIEND_TEST_LINUX_ONLY(ParagraphTest, JustifyRTLNewLine);
   FRIEND_TEST(ParagraphTest, DecorationsParagraph);
   FRIEND_TEST(ParagraphTest, ItalicsParagraph);

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -1454,35 +1454,6 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderGetRectsParagraph)) {
   ASSERT_TRUE(Snapshot());
 }
 
-TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderLongestLine)) {
-  txt::ParagraphStyle paragraph_style;
-  paragraph_style.max_lines = 1;
-  txt::ParagraphBuilderTxt builder(paragraph_style, GetTestFontCollection());
-
-  txt::TextStyle text_style;
-  text_style.font_families = std::vector<std::string>(1, "Roboto");
-  text_style.font_size = 26;
-  text_style.letter_spacing = 1;
-  text_style.word_spacing = 5;
-  text_style.color = SK_ColorBLACK;
-  text_style.height = 1;
-  text_style.decoration = TextDecoration::kUnderline;
-  text_style.decoration_color = SK_ColorBLACK;
-  builder.PushStyle(text_style);
-
-  txt::PlaceholderRun placeholder_run(50, 50, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kAlphabetic, 0);
-  builder.AddPlaceholder(placeholder_run);
-  builder.Pop();
-
-  auto paragraph = BuildParagraph(builder);
-  paragraph->Layout(GetTestCanvasWidth());
-
-  ASSERT_DOUBLE_EQ(paragraph->width_, GetTestCanvasWidth());
-  ASSERT_TRUE(paragraph->longest_line_ < GetTestCanvasWidth());
-  ASSERT_TRUE(paragraph->longest_line_ >= 50);
-}
-
 #if OS_LINUX
 // Tests if manually inserted 0xFFFC characters are replaced to 0xFFFD in order
 // to not interfere with the placeholder box layout.


### PR DESCRIPTION
Reverts flutter/engine#20370

Test if flaking on CI.