### PR TITLE
Enable ios platform view by default

### DIFF
--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -34,8 +34,6 @@ class IOSSurface : public ExternalViewEmbedder {
 
   std::shared_ptr<IOSContext> GetContext() const;
 
-  ExternalViewEmbedder* GetExternalViewEmbedderIfEnabled();
-
   virtual bool IsValid() const = 0;
 
   virtual void UpdateStorageSizeIfNecessary() = 0;

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -66,10 +66,6 @@ SkCanvas* IOSSurface::GetRootCanvas() {
   return nullptr;
 }
 
-ExternalViewEmbedder* IOSSurface::GetExternalViewEmbedderIfEnabled() {
-  return this;
-}
-
 // |ExternalViewEmbedder|
 void IOSSurface::CancelFrame() {
   TRACE_EVENT0("flutter", "IOSSurface::CancelFrame");

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -13,15 +13,6 @@
 
 namespace flutter {
 
-// The name of the Info.plist flag to enable the embedded iOS views preview.
-constexpr const char* kEmbeddedViewsPreview = "io.flutter.embedded_views_preview";
-
-bool IsIosEmbeddedViewsPreviewEnabled() {
-  static bool preview_enabled =
-      [[[NSBundle mainBundle] objectForInfoDictionaryKey:@(kEmbeddedViewsPreview)] boolValue];
-  return preview_enabled;
-}
-
 std::unique_ptr<IOSSurface> IOSSurface::Create(
     std::shared_ptr<IOSContext> context,
     fml::scoped_nsobject<CALayer> layer,
@@ -76,11 +67,7 @@ SkCanvas* IOSSurface::GetRootCanvas() {
 }
 
 ExternalViewEmbedder* IOSSurface::GetExternalViewEmbedderIfEnabled() {
-  if (IsIosEmbeddedViewsPreviewEnabled()) {
-    return this;
-  } else {
-    return nullptr;
-  }
+  return this;
 }
 
 // |ExternalViewEmbedder|

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -84,7 +84,7 @@ bool IOSSurfaceGL::GLContextPresent() {
 
 // |GPUSurfaceGLDelegate|
 ExternalViewEmbedder* IOSSurfaceGL::GetExternalViewEmbedder() {
-  return GetExternalViewEmbedderIfEnabled();
+  return this;
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -55,7 +55,7 @@ std::unique_ptr<Surface> IOSSurfaceMetal::CreateGPUSurface(GrDirectContext* /* u
 
 // |GPUSurfaceDelegate|
 ExternalViewEmbedder* IOSSurfaceMetal::GetExternalViewEmbedder() {
-  return GetExternalViewEmbedderIfEnabled();
+  return this;
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -124,7 +124,7 @@ bool IOSSurfaceSoftware::PresentBackingStore(sk_sp<SkSurface> backing_store) {
 
 // |GPUSurfaceSoftwareDelegate|
 ExternalViewEmbedder* IOSSurfaceSoftware::GetExternalViewEmbedder() {
-  return GetExternalViewEmbedderIfEnabled();
+  return this;
 }
 
 }  // namespace flutter

--- a/testing/scenario_app/ios/Scenarios/Scenarios/Info.plist
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/Info.plist
@@ -41,7 +41,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>io.flutter.embedded_views_preview</key>
-	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

An app that uses platform view (webview, googlemap, etc) doesn't need to add the `io.flutter.embedded_views_preview` flag on their info.plist after this patch lands.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64270

## Tests

I added the following tests:

Updated the scenario app to not include the flag and the tests should still pass

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
