### PR TITLE
[embedder] Add gl present callback that takes present info

### DIFF
--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -55,13 +55,13 @@ bool ShellTestPlatformViewGL::GLContextClearCurrent() {
 }
 
 // |GPUSurfaceGLDelegate|
-bool ShellTestPlatformViewGL::GLContextPresent() {
+bool ShellTestPlatformViewGL::GLContextPresent(uint32_t fbo_id) {
   return gl_surface_.Present();
 }
 
 // |GPUSurfaceGLDelegate|
 intptr_t ShellTestPlatformViewGL::GLContextFBO(GLFrameInfo frame_info) const {
-  return gl_surface_.GetFramebuffer();
+  return gl_surface_.GetFramebuffer(frame_info.width, frame_info.height);
 }
 
 // |GPUSurfaceGLDelegate|

--- a/shell/common/shell_test_platform_view_gl.h
+++ b/shell/common/shell_test_platform_view_gl.h
@@ -53,7 +53,7 @@ class ShellTestPlatformViewGL : public ShellTestPlatformView,
   bool GLContextClearCurrent() override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent() override;
+  bool GLContextPresent(uint32_t fbo_id) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -52,6 +52,8 @@ class GPUSurfaceGL : public Surface {
   GPUSurfaceGLDelegate* delegate_;
   sk_sp<GrDirectContext> context_;
   sk_sp<SkSurface> onscreen_surface_;
+  /// FBO backing the current `onscreen_surface_`.
+  uint32_t fbo_id_;
   bool context_owner_;
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an
   // external view embedder may want to render to the root surface. This is a

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -37,7 +37,7 @@ class GPUSurfaceGLDelegate : public GPUSurfaceDelegate {
 
   // Called to present the main GL surface. This is only called for the main GL
   // context and not any of the contexts dedicated for IO.
-  virtual bool GLContextPresent() = 0;
+  virtual bool GLContextPresent(uint32_t fbo_id) = 0;
 
   // The ID of the main window bound framebuffer. Typically FBO0.
   virtual intptr_t GLContextFBO(GLFrameInfo frame_info) const = 0;

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -113,7 +113,7 @@ bool AndroidSurfaceGL::GLContextClearCurrent() {
   return android_context_->ClearCurrent();
 }
 
-bool AndroidSurfaceGL::GLContextPresent() {
+bool AndroidSurfaceGL::GLContextPresent(uint32_t fbo_id) {
   FML_DCHECK(IsValid());
   FML_DCHECK(onscreen_surface_);
   return onscreen_surface_->SwapBuffers();

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -56,7 +56,7 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   bool GLContextClearCurrent() override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent() override;
+  bool GLContextPresent(uint32_t fbo_id) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/platform/android/surface/android_surface_mock.cc
+++ b/shell/platform/android/surface/android_surface_mock.cc
@@ -14,7 +14,7 @@ bool AndroidSurfaceMock::GLContextClearCurrent() {
   return true;
 }
 
-bool AndroidSurfaceMock::GLContextPresent() {
+bool AndroidSurfaceMock::GLContextPresent(uint32_t fbo_id) {
   return true;
 }
 

--- a/shell/platform/android/surface/android_surface_mock.h
+++ b/shell/platform/android/surface/android_surface_mock.h
@@ -45,7 +45,7 @@ class AndroidSurfaceMock final : public GPUSurfaceGLDelegate,
   bool GLContextClearCurrent() override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent() override;
+  bool GLContextPresent(uint32_t fbo_id) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -40,7 +40,7 @@ class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
   bool GLContextClearCurrent() override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent() override;
+  bool GLContextPresent(uint32_t fbo_id) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -77,7 +77,7 @@ bool IOSSurfaceGL::GLContextClearCurrent() {
 }
 
 // |GPUSurfaceGLDelegate|
-bool IOSSurfaceGL::GLContextPresent() {
+bool IOSSurfaceGL::GLContextPresent(uint32_t fbo_id) {
   TRACE_EVENT0("flutter", "IOSSurfaceGL::GLContextPresent");
   return IsValid() && render_target_->PresentRenderBuffer();
 }

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -346,7 +346,7 @@ typedef struct {
 /// This information is passed to the embedder when requesting a frame buffer
 /// object.
 ///
-/// See: \ref FlutterSoftwareRendererConfig.fbo_with_frame_info_callback.
+/// See: \ref FlutterOpenGLRendererConfig.fbo_with_frame_info_callback.
 typedef struct {
   /// The size of this struct. Must be sizeof(FlutterFrameInfo).
   size_t struct_size;
@@ -354,15 +354,34 @@ typedef struct {
   FlutterUIntSize size;
 } FlutterFrameInfo;
 
+/// Callback for when a frame buffer object is requested.
 typedef uint32_t (*UIntFrameInfoCallback)(
     void* /* user data */,
     const FlutterFrameInfo* /* frame info */);
+
+/// This information is passed to the embedder when a surface is presented.
+///
+/// See: \ref FlutterOpenGLRendererConfig.present_with_info.
+typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterFrameInfo).
+  size_t struct_size;
+  /// Id of the fbo backing the surface that was presented.
+  uint32_t fbo_id;
+} FlutterPresentInfo;
+
+/// Callback for when a surface is presented.
+typedef bool (*BoolPresentInfoCallback)(
+    void* /* user data */,
+    const FlutterPresentInfo* /* present info */);
 
 typedef struct {
   /// The size of this struct. Must be sizeof(FlutterOpenGLRendererConfig).
   size_t struct_size;
   BoolCallback make_current;
   BoolCallback clear_current;
+  /// Specifying one (and only one) of `present` or `present_with_info` is
+  /// required. Specifying both is an error and engine initialization will be
+  /// terminated. The return value indicates success of the present call.
   BoolCallback present;
   /// Specifying one (and only one) of the `fbo_callback` or
   /// `fbo_with_frame_info_callback` is required. Specifying both is an error
@@ -407,6 +426,12 @@ typedef struct {
   /// `FlutterFrameInfo` struct that indicates the properties of the surface
   /// that flutter will acquire from the returned fbo.
   UIntFrameInfoCallback fbo_with_frame_info_callback;
+  /// Specifying one (and only one) of `present` or `present_with_info` is
+  /// required. Specifying both is an error and engine initialization will be
+  /// terminated. When using this variant, the embedder is passed a
+  /// `FlutterPresentInfo` struct that the embedder can use to release any
+  /// resources. The return value indicates success of the present call.
+  BoolPresentInfoCallback present_with_info;
 } FlutterOpenGLRendererConfig;
 
 typedef struct {

--- a/shell/platform/embedder/embedder_safe_access.h
+++ b/shell/platform/embedder/embedder_safe_access.h
@@ -17,4 +17,12 @@
     return static_cast<decltype(pointer->member)>((default_value));      \
   })()
 
+/// Checks if the member exists.
+#define SAFE_EXISTS(pointer, member) \
+  (SAFE_ACCESS(pointer, member, nullptr) != nullptr)
+
+/// Checks if exactly one of member1 or member2 exists.
+#define SAFE_EXISTS_ONE_OF(pointer, member1, member2) \
+  (SAFE_EXISTS(pointer, member1) != SAFE_EXISTS(pointer, member2))
+
 #endif  // FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_SAFE_ACCESS_H_

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -45,8 +45,8 @@ bool EmbedderSurfaceGL::GLContextClearCurrent() {
 }
 
 // |GPUSurfaceGLDelegate|
-bool EmbedderSurfaceGL::GLContextPresent() {
-  return gl_dispatch_table_.gl_present_callback();
+bool EmbedderSurfaceGL::GLContextPresent(uint32_t fbo_id) {
+  return gl_dispatch_table_.gl_present_callback(fbo_id);
 }
 
 // |GPUSurfaceGLDelegate|

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -18,7 +18,7 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   struct GLDispatchTable {
     std::function<bool(void)> gl_make_current_callback;           // required
     std::function<bool(void)> gl_clear_current_callback;          // required
-    std::function<bool(void)> gl_present_callback;                // required
+    std::function<bool(uint32_t)> gl_present_callback;            // required
     std::function<intptr_t(GLFrameInfo)> gl_fbo_callback;         // required
     std::function<bool(void)> gl_make_resource_current_callback;  // optional
     std::function<SkMatrix(void)>
@@ -56,7 +56,7 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   bool GLContextClearCurrent() override;
 
   // |GPUSurfaceGLDelegate|
-  bool GLContextPresent() override;
+  bool GLContextPresent(uint32_t fbo_id) override;
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -32,8 +32,10 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
   opengl_renderer_config_.clear_current = [](void* context) -> bool {
     return reinterpret_cast<EmbedderTestContext*>(context)->GLClearCurrent();
   };
-  opengl_renderer_config_.present = [](void* context) -> bool {
-    return reinterpret_cast<EmbedderTestContext*>(context)->GLPresent();
+  opengl_renderer_config_.present_with_info =
+      [](void* context, const FlutterPresentInfo* present_info) -> bool {
+    return reinterpret_cast<EmbedderTestContext*>(context)->GLPresent(
+        present_info->fbo_id);
   };
   opengl_renderer_config_.fbo_with_frame_info_callback =
       [](void* context, const FlutterFrameInfo* frame_info) -> uint32_t {
@@ -124,6 +126,15 @@ void EmbedderConfigBuilder::SetOpenGLFBOCallBack() {
     frame_info.size.height = 0;
     return reinterpret_cast<EmbedderTestContext*>(context)->GLGetFramebuffer(
         frame_info);
+  };
+}
+
+void EmbedderConfigBuilder::SetOpenGLPresentCallBack() {
+  // SetOpenGLRendererConfig must be called before this.
+  FML_CHECK(renderer_config_.type == FlutterRendererType::kOpenGL);
+  renderer_config_.open_gl.present = [](void* context) -> bool {
+    // passing a placeholder fbo_id.
+    return reinterpret_cast<EmbedderTestContext*>(context)->GLPresent(0);
   };
 }
 

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -55,6 +55,12 @@ class EmbedderConfigBuilder {
   // explicitly test this behavior.
   void SetOpenGLFBOCallBack();
 
+  // Used to explicitly set an `open_gl.present`. Using this method will cause
+  // your test to fail since the ctor for this class sets
+  // `open_gl.present_with_info`. This method exists as a utility to explicitly
+  // test this behavior.
+  void SetOpenGLPresentCallBack();
+
   void SetAssetsPath();
 
   void SetSnapshots();

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -191,7 +191,7 @@ bool EmbedderTestContext::GLPresent(uint32_t fbo_id) {
 
   GLPresentCallback callback;
   {
-    std::scoped_lock lock(gl_present_callback_mutex_);
+    std::scoped_lock lock(gl_callback_mutex_);
     callback = gl_present_callback_;
   }
 
@@ -210,12 +210,12 @@ bool EmbedderTestContext::GLPresent(uint32_t fbo_id) {
 }
 
 void EmbedderTestContext::SetGLGetFBOCallback(GLGetFBOCallback callback) {
-  std::scoped_lock lock(gl_get_fbo_callback_mutex_);
+  std::scoped_lock lock(gl_callback_mutex_);
   gl_get_fbo_callback_ = callback;
 }
 
 void EmbedderTestContext::SetGLPresentCallback(GLPresentCallback callback) {
-  std::scoped_lock lock(gl_present_callback_mutex_);
+  std::scoped_lock lock(gl_callback_mutex_);
   gl_present_callback_ = callback;
 }
 
@@ -224,7 +224,7 @@ uint32_t EmbedderTestContext::GLGetFramebuffer(FlutterFrameInfo frame_info) {
 
   GLGetFBOCallback callback;
   {
-    std::scoped_lock lock(gl_get_fbo_callback_mutex_);
+    std::scoped_lock lock(gl_callback_mutex_);
     callback = gl_get_fbo_callback_;
   }
 

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -185,9 +185,10 @@ bool EmbedderTestContext::GLClearCurrent() {
   return gl_surface_->ClearCurrent();
 }
 
-bool EmbedderTestContext::GLPresent() {
+bool EmbedderTestContext::GLPresent(uint32_t fbo_id) {
   FML_CHECK(gl_surface_) << "GL surface must be initialized.";
   gl_surface_present_count_++;
+  presented_fbos_.push_back(fbo_id);
 
   FireRootSurfacePresentCallbackIfPresent(
       [&]() { return gl_surface_->GetRasterSurfaceSnapshot(); });
@@ -217,7 +218,8 @@ uint32_t EmbedderTestContext::GLGetFramebuffer(FlutterFrameInfo frame_info) {
     callback(frame_info);
   }
 
-  return gl_surface_->GetFramebuffer();
+  const auto size = frame_info.size;
+  return gl_surface_->GetFramebuffer(size.width, size.height);
 }
 
 bool EmbedderTestContext::GLMakeResourceCurrent() {

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -311,5 +311,10 @@ void EmbedderTestContext::FireRootSurfacePresentCallbackIfPresent(
   callback(image_callback());
 }
 
+uint32_t EmbedderTestContext::GetWindowFBOId() const {
+  FML_CHECK(gl_surface_);
+  return gl_surface_->GetWindowFBOId();
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -95,6 +95,8 @@ class EmbedderTestContext {
   ///
   void SetGLGetFBOCallback(GLGetFBOCallback callback);
 
+  uint32_t GetWindowFBOId() const;
+
   using GLPresentCallback = std::function<void(uint32_t fbo_id)>;
 
   //----------------------------------------------------------------------------

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -136,9 +136,8 @@ class EmbedderTestContext {
   SkMatrix root_surface_transformation_;
   size_t gl_surface_present_count_ = 0;
   size_t software_surface_present_count_ = 0;
-  std::mutex gl_get_fbo_callback_mutex_;
+  std::mutex gl_callback_mutex_;
   GLGetFBOCallback gl_get_fbo_callback_;
-  std::mutex gl_present_callback_mutex_;
   GLPresentCallback gl_present_callback_;
 
   static VoidCallback GetIsolateCreateCallbackHook();

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -95,8 +95,20 @@ class EmbedderTestContext {
   ///
   void SetGLGetFBOCallback(GLGetFBOCallback callback);
 
-  // Returns the fbo ids inorder of their presentation.
-  std::vector<uint32_t> GetPresentedFBOs();
+  using GLPresentCallback = std::function<void(uint32_t fbo_id)>;
+
+  //----------------------------------------------------------------------------
+  /// @brief      Sets a callback that will be invoked (on the raster task
+  ///             runner) when the engine presents an fbo that was given by the
+  ///             embedder.
+  ///
+  /// @attention  The callback will be invoked on the raster task runner. The
+  ///             callback can be set on the tests host thread.
+  ///
+  /// @param[in]  callback  The callback to set. The previous callback will be
+  ///                       un-registered.
+  ///
+  void SetGLPresentCallback(GLPresentCallback callback);
 
  private:
   // This allows the builder to access the hooks.
@@ -124,7 +136,8 @@ class EmbedderTestContext {
   size_t software_surface_present_count_ = 0;
   std::mutex gl_get_fbo_callback_mutex_;
   GLGetFBOCallback gl_get_fbo_callback_;
-  std::vector<uint32_t> presented_fbos_;
+  std::mutex gl_present_callback_mutex_;
+  GLPresentCallback gl_present_callback_;
 
   static VoidCallback GetIsolateCreateCallbackHook();
 

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -95,6 +95,9 @@ class EmbedderTestContext {
   ///
   void SetGLGetFBOCallback(GLGetFBOCallback callback);
 
+  // Returns the fbo ids inorder of their presentation.
+  std::vector<uint32_t> GetPresentedFBOs();
+
  private:
   // This allows the builder to access the hooks.
   friend class EmbedderConfigBuilder;
@@ -121,6 +124,7 @@ class EmbedderTestContext {
   size_t software_surface_present_count_ = 0;
   std::mutex gl_get_fbo_callback_mutex_;
   GLGetFBOCallback gl_get_fbo_callback_;
+  std::vector<uint32_t> presented_fbos_;
 
   static VoidCallback GetIsolateCreateCallbackHook();
 
@@ -149,7 +153,7 @@ class EmbedderTestContext {
 
   bool GLClearCurrent();
 
-  bool GLPresent();
+  bool GLPresent(uint32_t fbo_id);
 
   uint32_t GLGetFramebuffer(FlutterFrameInfo frame_info);
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4448,12 +4448,13 @@ TEST_F(EmbedderTest, PresentInfoContainsValidFBOId) {
                               /* Nothing to do. */
                             }));
 
-  context.SetGLPresentCallback([&frame_latch](uint32_t fbo_id) {
-    // this must be the window FBO id.
-    ASSERT_EQ(fbo_id, 0u);
+  const uint32_t window_fbo_id = context.GetWindowFBOId();
+  context.SetGLPresentCallback(
+      [window_fbo_id = window_fbo_id, &frame_latch](uint32_t fbo_id) {
+        ASSERT_EQ(fbo_id, window_fbo_id);
 
-    frame_latch.CountDown();
-  });
+        frame_latch.CountDown();
+      });
 
   frame_latch.Wait();
 }

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4406,5 +4406,16 @@ TEST_F(EmbedderTest, MustNotRunWithBothFBOCallbacksSet) {
   ASSERT_FALSE(engine.is_valid());
 }
 
+TEST_F(EmbedderTest, MustNotRunWithBothPresentCallbacksSet) {
+  auto& context = GetEmbedderContext();
+
+  EmbedderConfigBuilder builder(context);
+  builder.SetOpenGLRendererConfig(SkISize::Make(600, 1024));
+  builder.SetOpenGLPresentCallBack();
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_FALSE(engine.is_valid());
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/testing/test_gl_surface.cc
+++ b/testing/test_gl_surface.cc
@@ -220,7 +220,7 @@ bool TestGLSurface::Present() {
   return result == EGL_TRUE;
 }
 
-uint32_t TestGLSurface::GetFramebuffer() const {
+uint32_t TestGLSurface::GetFramebuffer(uint32_t width, uint32_t height) const {
   // Return FBO0
   return 0;
 }
@@ -296,7 +296,9 @@ sk_sp<SkSurface> TestGLSurface::GetOnscreenSurface() {
   FML_CHECK(::eglGetCurrentContext() != EGL_NO_CONTEXT);
 
   GrGLFramebufferInfo framebuffer_info = {};
-  framebuffer_info.fFBOID = GetFramebuffer();
+  const uint32_t width = surface_size_.width();
+  const uint32_t height = surface_size_.height();
+  framebuffer_info.fFBOID = GetFramebuffer(width, height);
 #if OS_MACOSX
   framebuffer_info.fFormat = GR_GL_RGBA8;
 #else
@@ -304,11 +306,11 @@ sk_sp<SkSurface> TestGLSurface::GetOnscreenSurface() {
 #endif
 
   GrBackendRenderTarget backend_render_target(
-      surface_size_.width(),   // width
-      surface_size_.height(),  // height
-      1,                       // sample count
-      8,                       // stencil bits
-      framebuffer_info         // framebuffer info
+      width,            // width
+      height,           // height
+      1,                // sample count
+      8,                // stencil bits
+      framebuffer_info  // framebuffer info
   );
 
   SkSurfaceProps surface_properties(

--- a/testing/test_gl_surface.cc
+++ b/testing/test_gl_surface.cc
@@ -221,8 +221,7 @@ bool TestGLSurface::Present() {
 }
 
 uint32_t TestGLSurface::GetFramebuffer(uint32_t width, uint32_t height) const {
-  // Return FBO0
-  return 0;
+  return GetWindowFBOId();
 }
 
 bool TestGLSurface::MakeResourceCurrent() {
@@ -362,6 +361,10 @@ sk_sp<SkImage> TestGLSurface::GetRasterSurfaceSnapshot() {
   }
 
   return host_snapshot;
+}
+
+uint32_t TestGLSurface::GetWindowFBOId() const {
+  return 0u;
 }
 
 }  // namespace testing

--- a/testing/test_gl_surface.h
+++ b/testing/test_gl_surface.h
@@ -27,7 +27,7 @@ class TestGLSurface {
 
   bool Present();
 
-  uint32_t GetFramebuffer() const;
+  uint32_t GetFramebuffer(uint32_t width, uint32_t height) const;
 
   bool MakeResourceCurrent();
 

--- a/testing/test_gl_surface.h
+++ b/testing/test_gl_surface.h
@@ -41,6 +41,8 @@ class TestGLSurface {
 
   sk_sp<SkImage> GetRasterSurfaceSnapshot();
 
+  uint32_t GetWindowFBOId() const;
+
  private:
   // Importing the EGL.h pulls in platform headers which are problematic
   // (especially X11 which #defineds types like Bool). Any TUs importing


### PR DESCRIPTION
When we present a frame we now pass back the fbo information to the embedder. While this is usually the window fbo, this could be different and now the embedder will have a chance to release the fbo or do any additional book-keeping that it wishes to do.

To this effect, we have added a `present_with_info` callback, which is a variant of the `present` callback that has `FlutterPresentInfo` passed to it.

See EC-2 in [flutter.dev/go/double-buffered-window-resize](http://flutter.dev/go/double-buffered-window-resize) and https://github.com/flutter/flutter/issues/44136