### PR TITLE
Fix the format script so that it works with deleted files.

### DIFF
--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -258,6 +258,7 @@ abstract class FormatChecker {
         'diff',
         '-U0',
         '--no-color',
+        '--diff-filter=d',
         '--name-only',
         baseGitRef,
         '--',


### PR DESCRIPTION
## Description

When I rewrote the format script, I forgot to filter out deleted files from the list of files that it looks at. This filters the file list to exclude deleted files.