### PR TITLE
fuchsia: Disable flaky test

### DIFF
--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -142,10 +142,13 @@ echo "$(date) START:ui_tests ----------------------------------------"
    --packages-directory packages
 echo "$(date) DONE:ui_tests -----------------------------------------"
 
+# TODO(https://github.com/flutter/flutter/issues/64343): Re-enable this when it
+# stops flaking.
 echo "$(date) START:shell_tests -------------------------------------"
 ./fuchsia_ctl -d $device_name test \
     -f shell_tests-0.far  \
     -t shell_tests \
+    -a "--gtest_filter=-ShellTest.InitializeWithDifferentThreads" \
     --identity-file $pkey \
     --timeout-seconds $test_timeout_seconds \
     --packages-directory packages


### PR DESCRIPTION
## Description

This test only flakes on FEMU, but disable it for now until we can figure out how to only disable it in the emulator.

## Related Issues

https://github.com/flutter/flutter/issues/64343
