### PR TITLE
fuchsia: Rollback broken SDK and re-enable test

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -536,7 +536,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': 'veVL2IxV1cbdZ-eFqRw4GCYPwqY9m2Bg9ls9VV4SMckC'
+        'version': 'LhYt1i9FPQeIhMU1ReI1t1fk4Zx0F3uQwhrr4NkLpuMC'
        }
      ],
      'condition': 'host_os == "linux"',

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: f4ec4327569d162b6bcad5d3e97572af
+Signature: cca1700ca777f682864d7baed336e5bc
 
 UNUSED LICENSES:
 

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -142,13 +142,10 @@ echo "$(date) START:ui_tests ----------------------------------------"
    --packages-directory packages
 echo "$(date) DONE:ui_tests -----------------------------------------"
 
-# TODO(https://github.com/flutter/flutter/issues/64343): Re-enable this when it
-# stops flaking.
 echo "$(date) START:shell_tests -------------------------------------"
 ./fuchsia_ctl -d $device_name test \
     -f shell_tests-0.far  \
     -t shell_tests \
-    -a "--gtest_filter=-ShellTest.InitializeWithDifferentThreads" \
     --identity-file $pkey \
     --timeout-seconds $test_timeout_seconds \
     --packages-directory packages


### PR DESCRIPTION
## Description

This should get the tree green again from a Fuchsia standpoint.

## Related Issues

https://github.com/flutter/flutter/issues/64343

## Tests

https://chromium-swarm.appspot.com/task?id=4e2bba8cd38d2510
https://chromium-swarm.appspot.com/task?id=4e2bc2259376a910
