### PR TITLE
Avoid passing nil to IOS accessibility announcement 

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -77,15 +77,14 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
 
  private:
   SemanticsObject* GetOrCreateObject(int32_t id, flutter::SemanticsNodeUpdates& updates);
-  void UpdateFirstFocusable(SemanticsObject* object);
-  void WalkAndProccessTree(SemanticsObject* object);
+  SemanticsObject* FindFirstFocusable(SemanticsObject* object);
+  void VisitObjectsRecursivelyAndRemove(SemanticsObject* object,
+                                        NSMutableArray<NSNumber*>* doomed_uids);
   void HandleEvent(NSDictionary<NSString*, id>* annotatedEvent);
 
   FlutterViewController* view_controller_;
   PlatformViewIOS* platform_view_;
   FlutterPlatformViewsController* platform_views_controller_;
-  SemanticsObject* first_focusable_;
-  NSMutableArray<NSNumber*>* doomed_uids_;
   int32_t last_focused_semantics_object_id_;
   fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -77,13 +77,15 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
 
  private:
   SemanticsObject* GetOrCreateObject(int32_t id, flutter::SemanticsNodeUpdates& updates);
-  void VisitObjectsRecursivelyAndRemove(SemanticsObject* object,
-                                        NSMutableArray<NSNumber*>* doomed_uids);
+  void UpdateFirstFocusable(SemanticsObject* object);
+  void WalkAndProccessTree(SemanticsObject* object);
   void HandleEvent(NSDictionary<NSString*, id>* annotatedEvent);
 
   FlutterViewController* view_controller_;
   PlatformViewIOS* platform_view_;
   FlutterPlatformViewsController* platform_views_controller_;
+  SemanticsObject* first_focusable_;
+  NSMutableArray<NSNumber*>* doomed_uids_;
   int32_t last_focused_semantics_object_id_;
   fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -199,22 +199,22 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     }
   } else if (layoutChanged) {
     // Tries to refocus the previous focused semantics object to avoid random jumps.
-    SemanticsObject* nextToFocus = [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];
+    SemanticsObject* nextToFocus =
+        [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];
     if (!nextToFocus)
       nextToFocus = first_focusable_;
-    ios_delegate_->PostAccessibilityNotification(
-        UIAccessibilityLayoutChangedNotification,
-        nextToFocus);
+    ios_delegate_->PostAccessibilityNotification(UIAccessibilityLayoutChangedNotification,
+                                                 nextToFocus);
   } else if (scrollOccured) {
     // TODO(chunhtai): figure out what string to use for notification. At this
     // point, it is guarantee the previous focused object is still in the tree
     // so that we don't need to worry about focus lost. (e.g. "Screen 0 of 3")
-    SemanticsObject* nextToFocus = [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];
+    SemanticsObject* nextToFocus =
+        [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];
     if (!nextToFocus)
       nextToFocus = first_focusable_;
-    ios_delegate_->PostAccessibilityNotification(
-        UIAccessibilityPageScrolledNotification,
-        nextToFocus);
+    ios_delegate_->PostAccessibilityNotification(UIAccessibilityPageScrolledNotification,
+                                                 nextToFocus);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -202,8 +202,8 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     SemanticsObject* nextToFocus =
         [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];
     if (!nextToFocus && root) {
-        nextToFocus = FindFirstFocusable(root);
-      }
+      nextToFocus = FindFirstFocusable(root);
+    }
     ios_delegate_->PostAccessibilityNotification(UIAccessibilityLayoutChangedNotification,
                                                  nextToFocus);
   } else if (scrollOccured) {
@@ -213,8 +213,8 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     SemanticsObject* nextToFocus =
         [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];
     if (!nextToFocus && root) {
-        nextToFocus = FindFirstFocusable(root);
-      }
+      nextToFocus = FindFirstFocusable(root);
+    }
     ios_delegate_->PostAccessibilityNotification(UIAccessibilityPageScrolledNotification,
                                                  nextToFocus);
   }


### PR DESCRIPTION
## Description

We passed nil to layoutchange announcement when the previous focused node changes, which is correct that the ios should focus the first element on the screen. However, it seems like ios accessiblity api sometimes may take up to 10s+ to figure out what to focus next when there are frequent screen changes such as scrolling + semantics tree changes.

This PR finds the first element on the screen to focus instead of passing nil to reduce the lag.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64339

## Tests

I added the following tests:

See files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
