### PR TITLE
fuchsia: Clean shell_unittests under FEMU

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -238,10 +238,7 @@ if (enable_unittests) {
 
       public_configs += [ ":test_enable_vulkan_config" ]
 
-      public_deps += [
-        "//flutter/testing:vulkan",
-        "//flutter/vulkan",
-      ]
+      public_deps += [ "//flutter/vulkan" ]
     }
   }
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -967,14 +967,7 @@ TEST_F(ShellTest, ReportTimingsIsCalledSoonerInNonReleaseMode) {
 #else
   // Our batch time is 100ms. Hopefully the 500ms limit is relaxed enough to
   // make it not too flaky.
-  //
-  // TODO(https://github.com/flutter/flutter/issues/64087): Fuchsia uses a
-  // 2000ms timeout to handle slowdowns in FEMU.
-#if OS_FUCHSIA
-  ASSERT_TRUE(elapsed <= fml::TimeDelta::FromMilliseconds(2000));
-#else
   ASSERT_TRUE(elapsed <= fml::TimeDelta::FromMilliseconds(500));
-#endif
 #endif
 }
 


### PR DESCRIPTION
## Description

Now that some underlying FEMU issues are fixed, remove some workarounds we had in place.

## Tests

https://ci.chromium.org/swarming/task/4e2c3fefba4a5e10?server=chromium-swarm.appspot.com
https://ci.chromium.org/swarming/task/4e2c401aedfee410?server=chromium-swarm.appspot.com