### PR TITLE
The `ForwardingGestureRecognizers` to have back reference to the `PlatformViewsController` so it can access `FlutterViewController` when its available 

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -419,6 +419,9 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 }
 
 - (void)maybeSetupPlatformViewChannels {
+  if ([self platformViewsController] != nullptr) {
+    [self platformViewsController]->SetFlutterViewController([self viewController]);
+  }
   if (_shell && self.shell.IsSetup()) {
     FlutterPlatformPlugin* platformPlugin = _platformPlugin.get();
     [_platformChannel.get() setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -419,9 +419,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 }
 
 - (void)maybeSetupPlatformViewChannels {
-  if ([self platformViewsController] != nullptr) {
-    [self platformViewsController]->SetFlutterViewController([self viewController]);
-  }
   if (_shell && self.shell.IsSetup()) {
     FlutterPlatformPlugin* platformPlugin = _platformPlugin.get();
     [_platformChannel.get() setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -7,7 +7,9 @@
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 #import "third_party/ocmock/Source/OCMock/OCMock.h"
 
@@ -506,6 +508,18 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     }
   }
   flutterPlatformViewsController->Reset();
+}
+
+- (void)testViewFlutterViewControllerIsSetForPlatformView {
+  id engine = OCMClassMock([FlutterEngine class]);
+  id lifecycleChannel = OCMClassMock([FlutterBasicMessageChannel class]);
+  OCMStub([engine lifecycleChannel]).andReturn(lifecycleChannel);
+  auto flutterPlatformViewsController = std::make_shared<flutter::FlutterPlatformViewsController>();
+  OCMStub([engine platformViewsController]).andReturn(flutterPlatformViewsController.get());
+
+  FlutterViewController* viewController =
+      [[[FlutterViewController alloc] initWithEngine:engine nibName:nil bundle:nil] autorelease];
+  OCMVerify(flutterPlatformViewsController->SetFlutterViewController(viewController));
 }
 
 - (int)alphaOfPoint:(CGPoint)point onView:(UIView*)view {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -54,6 +54,10 @@
     gestureRecognizersBlockingPolicy:
         (FlutterPlatformViewGestureRecognizersBlockingPolicy)blockingPolicy;
 
+// Can be used to set the |FlutterViewController| if it wasn't available when
+// initlizing this object.
+- (void)setFlutterViewController:(UIViewController*)controllerOrNil;
+
 // Stop delaying any active touch sequence (and let it arrive the embedded view).
 - (void)releaseGesture;
 
@@ -250,6 +254,12 @@ class FlutterPlatformViewsController {
 
   // Only compoiste platform views in this set.
   std::unordered_set<int64_t> views_to_recomposite_;
+
+  // Sometimes, the `flutter_view_controller_` is not available yet when creating the
+  // |FlutterInterceptingView|. This is a record of those |FlutterInterceptingView|s and we will set
+  // the `flutter_view_controller_` later in a |SetViewController| call when the
+  // `flutter_view_controller_` is available.
+  std::unordered_set<int64_t> intercepting_views_to_update_vc_;
 
   // The FlutterPlatformViewGestureRecognizersBlockingPolicy for each type of platform view.
   std::map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -16,6 +16,8 @@
 #include "flutter/shell/platform/darwin/ios/ios_context.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 
+@class FlutterTouchInterceptingView;
+
 // A UIView that acts as a clipping mask for the |ChildClippingView|.
 //
 // On the [UIView drawRect:] method, this view performs a series of clipping operations and sets the
@@ -41,28 +43,6 @@
 // The `path` is transformed with the `matrix` before adding to the queue.
 - (void)clipPath:(const SkPath&)path matrix:(const CATransform3D&)matrix;
 
-@end
-
-// A UIView that is used as the parent for embedded UIViews.
-//
-// This view has 2 roles:
-// 1. Delay or prevent touch events from arriving the embedded view.
-// 2. Dispatching all events that are hittested to the embedded view to the FlutterView.
-@interface FlutterTouchInterceptingView : UIView
-- (instancetype)initWithEmbeddedView:(UIView*)embeddedView
-               flutterViewController:(UIViewController*)flutterViewController
-    gestureRecognizersBlockingPolicy:
-        (FlutterPlatformViewGestureRecognizersBlockingPolicy)blockingPolicy;
-
-// Can be used to set the |FlutterViewController| if it wasn't available when
-// initlizing this object.
-- (void)setFlutterViewController:(UIViewController*)controllerOrNil;
-
-// Stop delaying any active touch sequence (and let it arrive the embedded view).
-- (void)releaseGesture;
-
-// Prevent the touch sequence from ever arriving to the embedded view.
-- (void)blockGesture;
 @end
 
 // The parent view handles clipping to its subviews.
@@ -147,9 +127,13 @@ class FlutterPlatformViewsController {
 
   ~FlutterPlatformViewsController();
 
+  fml::WeakPtr<flutter::FlutterPlatformViewsController> GetWeakPtr();
+
   void SetFlutterView(UIView* flutter_view);
 
   void SetFlutterViewController(UIViewController* flutter_view_controller);
+
+  UIViewController* getFlutterViewController();
 
   void RegisterViewFactory(
       NSObject<FlutterPlatformViewFactory>* factory,
@@ -255,15 +239,11 @@ class FlutterPlatformViewsController {
   // Only compoiste platform views in this set.
   std::unordered_set<int64_t> views_to_recomposite_;
 
-  // Sometimes, the `flutter_view_controller_` is not available yet when creating the
-  // |FlutterInterceptingView|. This is a record of those |FlutterInterceptingView|s and we will set
-  // the `flutter_view_controller_` later in a |SetViewController| call when the
-  // `flutter_view_controller_` is available.
-  std::unordered_set<int64_t> intercepting_views_to_update_vc_;
-
   // The FlutterPlatformViewGestureRecognizersBlockingPolicy for each type of platform view.
   std::map<std::string, FlutterPlatformViewGestureRecognizersBlockingPolicy>
       gesture_recognizers_blocking_policies;
+
+  std::unique_ptr<fml::WeakPtrFactory<FlutterPlatformViewsController>> weak_factory_;
 
   void OnCreate(FlutterMethodCall* call, FlutterResult& result);
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);
@@ -322,5 +302,24 @@ class FlutterPlatformViewsController {
 };
 
 }  // namespace flutter
+
+// A UIView that is used as the parent for embedded UIViews.
+//
+// This view has 2 roles:
+// 1. Delay or prevent touch events from arriving the embedded view.
+// 2. Dispatching all events that are hittested to the embedded view to the FlutterView.
+@interface FlutterTouchInterceptingView : UIView
+- (instancetype)initWithEmbeddedView:(UIView*)embeddedView
+             platformViewsController:
+                 (fml::WeakPtr<flutter::FlutterPlatformViewsController>)platformViewsController
+    gestureRecognizersBlockingPolicy:
+        (FlutterPlatformViewGestureRecognizersBlockingPolicy)blockingPolicy;
+
+// Stop delaying any active touch sequence (and let it arrive the embedded view).
+- (void)releaseGesture;
+
+// Prevent the touch sequence from ever arriving to the embedded view.
+- (void)blockGesture;
+@end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -24,9 +24,14 @@ FlutterPlatformViewLayer::FlutterPlatformViewLayer(
 FlutterPlatformViewLayer::~FlutterPlatformViewLayer() = default;
 
 FlutterPlatformViewsController::FlutterPlatformViewsController()
-    : layer_pool_(std::make_unique<FlutterPlatformViewLayerPool>()){};
+    : layer_pool_(std::make_unique<FlutterPlatformViewLayerPool>()),
+      weak_factory_(std::make_unique<fml::WeakPtrFactory<FlutterPlatformViewsController>>(this)){};
 
 FlutterPlatformViewsController::~FlutterPlatformViewsController() = default;
+
+fml::WeakPtr<flutter::FlutterPlatformViewsController> FlutterPlatformViewsController::GetWeakPtr() {
+  return weak_factory_->GetWeakPtr();
+}
 
 CATransform3D GetCATransform3DFromSkMatrix(const SkMatrix& matrix) {
   // Skia only supports 2D transform so we don't map z.


### PR DESCRIPTION
## Description

This PR makes `PlatformViewsController` get `FlutterViewController` as early as possible when first launch.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64228

## Tests

I added the following tests:

testViewFlutterViewControllerIsSetForPlatformView

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
