### PR TITLE
[web] Make word boundary consistent with native flutter

### DIFF
--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -589,13 +589,13 @@ class EngineParagraph implements ui.Paragraph {
   @override
   ui.TextRange getWordBoundary(ui.TextPosition position) {
     ui.TextPosition textPosition = position;
-    if (_plainText == null) {
+    final String? text = _plainText;
+    if (text == null) {
       return ui.TextRange(start: textPosition.offset, end: textPosition.offset);
     }
 
-    final int start =
-        WordBreaker.prevBreakIndex(_plainText!, textPosition.offset + 1);
-    final int end = WordBreaker.nextBreakIndex(_plainText!, textPosition.offset);
+    final int start = WordBreaker.prevBreakIndex(text, textPosition.offset + 1);
+    final int end = WordBreaker.nextBreakIndex(text, textPosition.offset);
     return ui.TextRange(start: start, end: end);
   }
 

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -594,8 +594,8 @@ class EngineParagraph implements ui.Paragraph {
     }
 
     final int start =
-        WordBreaker.prevBreakIndex(_plainText, textPosition.offset);
-    final int end = WordBreaker.nextBreakIndex(_plainText, textPosition.offset);
+        WordBreaker.prevBreakIndex(_plainText!, textPosition.offset + 1);
+    final int end = WordBreaker.nextBreakIndex(_plainText!, textPosition.offset);
     return ui.TextRange(start: start, end: end);
   }
 

--- a/lib/web_ui/lib/src/engine/text/word_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/word_breaker.dart
@@ -5,12 +5,13 @@
 // @dart = 2.10
 part of engine;
 
-enum _FindBreakDirection {
-  /// Indicates to find the word break by looking forward.
-  forward,
+class _FindBreakDirection {
+  static const _FindBreakDirection forward = _FindBreakDirection(step: 1);
+  static const _FindBreakDirection backward = _FindBreakDirection(step: -1);
 
-  /// Indicates to find the word break by looking backward.
-  backward,
+  const _FindBreakDirection({required this.step});
+
+  final int step;
 }
 
 /// [WordBreaker] exposes static methods to identify word boundaries.
@@ -29,15 +30,14 @@ abstract class WordBreaker {
     String text,
     int index,
   ) {
-    final int step = direction == _FindBreakDirection.forward ? 1 : -1;
     int i = index;
     while (i >= 0 && i <= text.length) {
-      i += step;
+      i += direction.step;
       if (_isBreak(text, i)) {
         break;
       }
     }
-    return i.clamp(0, text.length) as int;
+    return clampInt(i, 0, text.length);
   }
 
   /// Find out if there's a word break between [index - 1] and [index].

--- a/lib/web_ui/lib/src/engine/text/word_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/word_breaker.dart
@@ -16,38 +16,28 @@ enum _FindBreakDirection {
 /// [WordBreaker] exposes static methods to identify word boundaries.
 abstract class WordBreaker {
   /// It starts from [index] and tries to find the next word boundary in [text].
-  static int nextBreakIndex(String? text, int index) =>
+  static int nextBreakIndex(String text, int index) =>
       _findBreakIndex(_FindBreakDirection.forward, text, index);
 
   /// It starts from [index] and tries to find the previous word boundary in
   /// [text].
-  static int prevBreakIndex(String? text, int index) =>
+  static int prevBreakIndex(String text, int index) =>
       _findBreakIndex(_FindBreakDirection.backward, text, index);
 
   static int _findBreakIndex(
     _FindBreakDirection direction,
-    String? text,
+    String text,
     int index,
   ) {
-    int step, min, max;
-    if (direction == _FindBreakDirection.forward) {
-      step = 1;
-      min = 0;
-      max = text!.length - 1;
-    } else {
-      step = -1;
-      min = 1;
-      max = text!.length;
-    }
-
+    final int step = direction == _FindBreakDirection.forward ? 1 : -1;
     int i = index;
-    while (i >= min && i <= max) {
+    while (i >= 0 && i <= text.length) {
       i += step;
       if (_isBreak(text, i)) {
         break;
       }
     }
-    return i;
+    return i.clamp(0, text.length) as int;
   }
 
   /// Find out if there's a word break between [index - 1] and [index].

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -552,3 +552,14 @@ void _validateColorStops(List<ui.Color> colors, List<double>? colorStops) {
           '"colors" and "colorStops" arguments must have equal length.');
   }
 }
+
+int clampInt(int value, int min, int max) {
+  assert(min <= max);
+  if (value < min) {
+    return min;
+  } else if (value > max) {
+    return max;
+  } else {
+    return value;
+  }
+}

--- a/lib/web_ui/lib/src/ui/lerp.dart
+++ b/lib/web_ui/lib/src/ui/lerp.dart
@@ -21,14 +21,3 @@ double _lerpDouble(double a, double b, double t) {
 double _lerpInt(int a, int b, double t) {
   return a + (b - a) * t;
 }
-
-int _clampInt(int value, int min, int max) {
-  assert(min <= max);
-  if (value < min) {
-    return min;
-  } else if (value > max) {
-    return max;
-  } else {
-    return value;
-  }
-}

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -30,7 +30,7 @@ void _validateColorStops(List<Color> colors, List<double>? colorStops) {
 }
 
 Color _scaleAlpha(Color a, double factor) {
-  return a.withAlpha(_clampInt((a.alpha * factor).round(), 0, 255));
+  return a.withAlpha(engine.clampInt((a.alpha * factor).round(), 0, 255));
 }
 
 class Color {
@@ -103,10 +103,10 @@ class Color {
         return _scaleAlpha(b, t);
       } else {
         return Color.fromARGB(
-          _clampInt(_lerpInt(a.alpha, b.alpha, t).toInt(), 0, 255),
-          _clampInt(_lerpInt(a.red, b.red, t).toInt(), 0, 255),
-          _clampInt(_lerpInt(a.green, b.green, t).toInt(), 0, 255),
-          _clampInt(_lerpInt(a.blue, b.blue, t).toInt(), 0, 255),
+          engine.clampInt(_lerpInt(a.alpha, b.alpha, t).toInt(), 0, 255),
+          engine.clampInt(_lerpInt(a.red, b.red, t).toInt(), 0, 255),
+          engine.clampInt(_lerpInt(a.green, b.green, t).toInt(), 0, 255),
+          engine.clampInt(_lerpInt(a.blue, b.blue, t).toInt(), 0, 255),
         );
       }
     }

--- a/lib/web_ui/lib/src/ui/text.dart
+++ b/lib/web_ui/lib/src/ui/text.dart
@@ -49,7 +49,7 @@ class FontWeight {
     assert(t != null); // ignore: unnecessary_null_comparison
     if (a == null && b == null)
       return null;
-    return values[_clampInt(lerpDouble(a?.index ?? normal.index, b?.index ?? normal.index, t)!.round(), 0, 8)];
+    return values[engine.clampInt(lerpDouble(a?.index ?? normal.index, b?.index ?? normal.index, t)!.round(), 0, 8)];
   }
 
   @override

--- a/lib/web_ui/test/paragraph_test.dart
+++ b/lib/web_ui/test/paragraph_test.dart
@@ -397,6 +397,42 @@ void testMain() async {
     WebExperiments.instance.useCanvasText = null;
   });
 
+  test('getWordBoundary', () {
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle())
+      ..addText('Lorem ipsum dolor');
+    final Paragraph paragraph = builder.build();
+
+    const TextRange loremRange = TextRange(start: 0, end: 5);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 0)), loremRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 1)), loremRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 2)), loremRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 3)), loremRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 4)), loremRange);
+
+    const TextRange firstSpace = TextRange(start: 5, end: 6);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 5)), firstSpace);
+
+    const TextRange ipsumRange = TextRange(start: 6, end: 11);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 6)), ipsumRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 7)), ipsumRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 8)), ipsumRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 9)), ipsumRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 10)), ipsumRange);
+
+    const TextRange secondSpace = TextRange(start: 11, end: 12);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 11)), secondSpace);
+
+    const TextRange dolorRange = TextRange(start: 12, end: 17);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 12)), dolorRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 13)), dolorRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 14)), dolorRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 15)), dolorRange);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 16)), dolorRange);
+
+    const TextRange endRange = TextRange(start: 17, end: 17);
+    expect(paragraph.getWordBoundary(TextPosition(offset: 17)), endRange);
+  });
+
   testEachMeasurement('getBoxesForRange returns a box', () {
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
       fontFamily: 'Ahem',

--- a/lib/web_ui/test/text/word_breaker_test.dart
+++ b/lib/web_ui/test/text/word_breaker_test.dart
@@ -15,8 +15,13 @@ void main() {
 void testMain() {
   group('$WordBreaker', () {
     test('Does not go beyond the ends of a string', () {
+      expect(WordBreaker.prevBreakIndex('foo', -1), 0);
       expect(WordBreaker.prevBreakIndex('foo', 0), 0);
+      expect(WordBreaker.prevBreakIndex('foo', 'foo'.length + 1), 'foo'.length);
+
+      expect(WordBreaker.nextBreakIndex('foo', -1), 0);
       expect(WordBreaker.nextBreakIndex('foo', 'foo'.length), 'foo'.length);
+      expect(WordBreaker.nextBreakIndex('foo', 'foo'.length + 1), 'foo'.length);
     });
 
     test('Words and spaces', () {
@@ -138,7 +143,10 @@ void expectWords(String text, List<String> expectedWords) {
   // Forward word break lookup.
   for (String word in expectedWords) {
     final int nextBreak = WordBreaker.nextBreakIndex(text, strIndex);
-    expect(nextBreak, strIndex + word.length);
+    expect(
+      nextBreak, strIndex + word.length,
+      reason: 'Forward word break lookup: expecting to move to the end of "$word" in "$text".'
+    );
     strIndex += word.length;
   }
 
@@ -146,7 +154,10 @@ void expectWords(String text, List<String> expectedWords) {
   strIndex = text.length;
   for (String word in expectedWords.reversed) {
     final int prevBreak = WordBreaker.prevBreakIndex(text, strIndex);
-    expect(prevBreak, strIndex - word.length);
+    expect(
+      prevBreak, strIndex - word.length,
+      reason: 'Backward word break lookup: expecting to move to the start of "$word" in "$text".'
+    );
     strIndex -= word.length;
   }
 }


### PR DESCRIPTION
## Description

Around the edges of words, we used to return slightly different results from what Flutter expects. This PR follows what Flutter's [native engine does](https://github.com/flutter/engine/blob/d6a0b965b0e08fabb435112e9e165bc11aea4f54/third_party/txt/src/txt/paragraph_txt.cc#L1989-L1990).

## Related Issues

https://github.com/flutter/flutter/issues/64507

## Tests

I added tests in:

- `lib/web_ui/test/paragraph_test.dart`
- `lib/web_ui/test/text/word_breaker_test.dart`