### PR TITLE
Workaround for apps crashing when FlutterActivity/Fragment

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterApplicationInfo.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterApplicationInfo.java
@@ -9,7 +9,7 @@ public final class FlutterApplicationInfo {
   private static final String DEFAULT_AOT_SHARED_LIBRARY_NAME = "libapp.so";
   private static final String DEFAULT_VM_SNAPSHOT_DATA = "vm_snapshot_data";
   private static final String DEFAULT_ISOLATE_SNAPSHOT_DATA = "isolate_snapshot_data";
-  private static final String DEFAULT_FLUTTER_ASSETS_DIR = "flutter_assets";
+  static final String DEFAULT_FLUTTER_ASSETS_DIR = "flutter_assets";
 
   final String aotSharedLibraryName;
   final String vmSnapshotData;

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -316,9 +316,18 @@ public class FlutterLoader {
     return resourceExtractor;
   }
 
+  private String flutterAssetsDir() {
+    // TODO(64458): Return default until we can fix initialization sequence.
+    // When fixed, flutterApplicationInfo should not be null.
+    if (flutterApplicationInfo == null) {
+      return FlutterApplicationInfo.DEFAULT_FLUTTER_ASSETS_DIR;
+    }
+    return flutterApplicationInfo.flutterAssetsDir;
+  }
+
   @NonNull
   public String findAppBundlePath() {
-    return flutterApplicationInfo.flutterAssetsDir;
+    return flutterAssetsDir();
   }
 
   /**
@@ -349,7 +358,7 @@ public class FlutterLoader {
 
   @NonNull
   private String fullAssetPathFrom(@NonNull String filePath) {
-    return flutterApplicationInfo.flutterAssetsDir + File.separator + filePath;
+    return flutterAssetsDir() + File.separator + filePath;
   }
 
   public static class Settings {


### PR DESCRIPTION
## Description

When FlutterActivity/Fragment access bundle inferred parameters without initializing `FlutterLoader`, they crash. Let's fix that temporarily until #64458 is fixed.

## Related Issues

https://github.com/flutter/flutter/issues/64458

## Tests

FlutterLoader does not have any tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
