### PR TITLE
fuchsia: Call out legacy rasterizer code

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -19,6 +19,18 @@
 #include "third_party/skia/include/core/SkSurfaceCharacterization.h"
 #include "third_party/skia/include/utils/SkBase64.h"
 
+// When screenshotting we want to ensure we call the base method for
+// CompositorContext::AcquireFrame instead of the platform-specific method.
+// Specifically, Fuchsia's CompositorContext handles the rendering surface
+// itself which means that we will still continue to render to the onscreen
+// surface if we don't call the base method.
+// TODO(arbreng: fxb/55805)
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
+#define ACQUIRE_FRAME flutter::CompositorContext::AcquireFrame
+#else
+#define ACQUIRE_FRAME AcquireFrame
+#endif
+
 namespace flutter {
 
 // The rasterizer will tell Skia to purge cached resources that have not been
@@ -26,10 +38,16 @@ namespace flutter {
 static constexpr std::chrono::milliseconds kSkiaCleanupExpiration(15000);
 
 Rasterizer::Rasterizer(Delegate& delegate)
-    : Rasterizer(delegate,
-                 std::make_unique<flutter::CompositorContext>(
-                     delegate.GetFrameBudget())) {}
+    : delegate_(delegate),
+      compositor_context_(std::make_unique<flutter::CompositorContext>(
+          delegate.GetFrameBudget())),
+      user_override_resource_cache_bytes_(false),
+      weak_factory_(this) {
+  FML_DCHECK(compositor_context_);
+}
 
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
+// TODO(arbreng: fxb/55805)
 Rasterizer::Rasterizer(
     Delegate& delegate,
     std::unique_ptr<flutter::CompositorContext> compositor_context)
@@ -39,6 +57,7 @@ Rasterizer::Rasterizer(
       weak_factory_(this) {
   FML_DCHECK(compositor_context_);
 }
+#endif
 
 Rasterizer::~Rasterizer() = default;
 
@@ -453,21 +472,11 @@ static sk_sp<SkData> ScreenshotLayerTreeAsPicture(
   SkMatrix root_surface_transformation;
   root_surface_transformation.reset();
 
-#if defined(LEGACY_FUCHSIA_EMBEDDER)
-  // TODO(arbreng: fxb/55805) Our ScopedFrame implementation doesnt do the
-  // right thing here so initialize the base class directly. This wont be
-  // needed after we move to using the embedder API on Fuchsia.
-  auto frame = std::make_unique<flutter::CompositorContext::ScopedFrame>(
-      compositor_context, nullptr, recorder.getRecordingCanvas(), nullptr,
-      root_surface_transformation, false, true, nullptr);
-#else
   // TODO(amirh): figure out how to take a screenshot with embedded UIView.
   // https://github.com/flutter/flutter/issues/23435
-  auto frame = compositor_context.AcquireFrame(
+  auto frame = compositor_context.ACQUIRE_FRAME(
       nullptr, recorder.getRecordingCanvas(), nullptr,
       root_surface_transformation, false, true, nullptr);
-#endif  // defined(LEGACY_FUCHSIA_EMBEDDER)
-
   frame->Raster(*tree, true);
 
 #if defined(OS_FUCHSIA)
@@ -521,12 +530,7 @@ sk_sp<SkData> Rasterizer::ScreenshotLayerTreeAsImage(
   SkMatrix root_surface_transformation;
   root_surface_transformation.reset();
 
-  // We want to ensure we call the base method for
-  // CompositorContext::AcquireFrame instead of the platform-specific method.
-  // Specifically, Fuchsia's CompositorContext handles the rendering surface
-  // itself which means that we will still continue to render to the onscreen
-  // surface if we don't call the base method.
-  auto frame = compositor_context.flutter::CompositorContext::AcquireFrame(
+  auto frame = compositor_context.ACQUIRE_FRAME(
       surface_context, canvas, nullptr, root_surface_transformation, false,
       true, nullptr);
   canvas->clear(SK_ColorTRANSPARENT);

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -97,6 +97,7 @@ class Rasterizer final : public SnapshotDelegate {
   ///
   Rasterizer(Delegate& delegate);
 
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
   //----------------------------------------------------------------------------
   /// @brief      Creates a new instance of a rasterizer. Rasterizers may only
   ///             be created on the GPU task runner. Rasterizers are currently
@@ -109,6 +110,7 @@ class Rasterizer final : public SnapshotDelegate {
   ///
   Rasterizer(Delegate& delegate,
              std::unique_ptr<flutter::CompositorContext> compositor_context);
+#endif
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys the rasterizer. This must happen on the GPU task


### PR DESCRIPTION
## Description

This code can be removed when Fuchsia stops using a custom CompositorContext, so call it out for later removal

## Related Issues

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=55805

## Tests

N/A