### PR TITLE
Consolidate FlRenderer initialization into fl_renderer_start()

### DIFF
--- a/shell/platform/linux/fl_basic_message_channel_test.cc
+++ b/shell/platform/linux/fl_basic_message_channel_test.cc
@@ -15,9 +15,6 @@
 static FlEngine* make_mock_engine() {
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
-  g_autoptr(GError) renderer_error = nullptr;
-  EXPECT_TRUE(fl_renderer_setup(FL_RENDERER(renderer), &renderer_error));
-  EXPECT_EQ(renderer_error, nullptr);
   g_autoptr(FlEngine) engine = fl_engine_new(project, FL_RENDERER(renderer));
   g_autoptr(GError) engine_error = nullptr;
   EXPECT_TRUE(fl_engine_start(engine, &engine_error));

--- a/shell/platform/linux/fl_binary_messenger_test.cc
+++ b/shell/platform/linux/fl_binary_messenger_test.cc
@@ -14,9 +14,6 @@
 static FlEngine* make_mock_engine() {
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
-  g_autoptr(GError) renderer_error = nullptr;
-  EXPECT_TRUE(fl_renderer_setup(FL_RENDERER(renderer), &renderer_error));
-  EXPECT_EQ(renderer_error, nullptr);
   g_autoptr(FlEngine) engine = fl_engine_new(project, FL_RENDERER(renderer));
   g_autoptr(GError) engine_error = nullptr;
   EXPECT_TRUE(fl_engine_start(engine, &engine_error));

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -331,10 +331,6 @@ G_MODULE_EXPORT FlEngine* fl_engine_new_headless(FlDartProject* project) {
 gboolean fl_engine_start(FlEngine* self, GError** error) {
   g_return_val_if_fail(FL_IS_ENGINE(self), FALSE);
 
-  if (!fl_renderer_start(self->renderer, error)) {
-    return FALSE;
-  }
-
   FlutterRendererConfig config = {};
   config.type = kOpenGL;
   config.open_gl.struct_size = sizeof(FlutterOpenGLRendererConfig);

--- a/shell/platform/linux/fl_method_channel_test.cc
+++ b/shell/platform/linux/fl_method_channel_test.cc
@@ -17,9 +17,6 @@
 static FlEngine* make_mock_engine() {
   g_autoptr(FlDartProject) project = fl_dart_project_new();
   g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
-  g_autoptr(GError) renderer_error = nullptr;
-  EXPECT_TRUE(fl_renderer_setup(FL_RENDERER(renderer), &renderer_error));
-  EXPECT_EQ(renderer_error, nullptr);
   g_autoptr(FlEngine) engine = fl_engine_new(project, FL_RENDERER(renderer));
   g_autoptr(GError) engine_error = nullptr;
   EXPECT_TRUE(fl_engine_start(engine, &engine_error));

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -79,44 +79,9 @@ struct _FlRendererClass {
 };
 
 /**
- * fl_renderer_setup:
- * @renderer: an #FlRenderer.
- * @error: (allow-none): #GError location to store the error occurring, or %NULL
- * to ignore.
- *
- * Set up the renderer.
- *
- * Returns: %TRUE if successfully setup.
- */
-gboolean fl_renderer_setup(FlRenderer* renderer, GError** error);
-
-/**
- * fl_renderer_get_visual:
- * @renderer: an #FlRenderer.
- * @screen: the screen being rendered on.
- * @error: (allow-none): #GError location to store the error occurring, or %NULL
- * to ignore.
- *
- * Gets the visual required to render on.
- *
- * Returns: a #GdkVisual.
- */
-GdkVisual* fl_renderer_get_visual(FlRenderer* renderer,
-                                  GdkScreen* screen,
-                                  GError** error);
-
-/**
- * fl_renderer_set_window:
- * @renderer: an #FlRenderer.
- * @window: the GDK Window this renderer will render to.
- *
- * Set the window this renderer will use.
- */
-void fl_renderer_set_window(FlRenderer* renderer, GdkWindow* window);
-
-/**
  * fl_renderer_start:
  * @renderer: an #FlRenderer.
+ * @widget: the widget Flutter is renderering to.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  * to ignore.
  *
@@ -124,7 +89,9 @@ void fl_renderer_set_window(FlRenderer* renderer, GdkWindow* window);
  *
  * Returns: %TRUE if successfully started.
  */
-gboolean fl_renderer_start(FlRenderer* renderer, GError** error);
+gboolean fl_renderer_start(FlRenderer* renderer,
+                           GtkWidget* widget,
+                           GError** error);
 
 /**
  * fl_renderer_set_geometry:

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -204,44 +204,18 @@ static void fl_view_dispose(GObject* object) {
 // Implements GtkWidget::realize.
 static void fl_view_realize(GtkWidget* widget) {
   FlView* self = FL_VIEW(widget);
+  g_autoptr(GError) error = nullptr;
 
   gtk_widget_set_realized(widget, TRUE);
 
-  g_autoptr(GError) error = nullptr;
-  if (!fl_renderer_setup(self->renderer, &error)) {
-    g_warning("Failed to setup renderer: %s", error->message);
+  if (!fl_renderer_start(self->renderer, widget, &error)) {
+    g_warning("Failed to start Flutter renderer: %s", error->message);
+    return;
   }
-
-  GtkAllocation allocation;
-  gtk_widget_get_allocation(widget, &allocation);
-
-  GdkWindowAttr window_attributes;
-  window_attributes.window_type = GDK_WINDOW_CHILD;
-  window_attributes.x = allocation.x;
-  window_attributes.y = allocation.y;
-  window_attributes.width = allocation.width;
-  window_attributes.height = allocation.height;
-  window_attributes.wclass = GDK_INPUT_OUTPUT;
-  window_attributes.visual = fl_renderer_get_visual(
-      self->renderer, gtk_widget_get_screen(widget), nullptr);
-  window_attributes.event_mask =
-      gtk_widget_get_events(widget) | GDK_EXPOSURE_MASK |
-      GDK_POINTER_MOTION_MASK | GDK_BUTTON_PRESS_MASK |
-      GDK_BUTTON_RELEASE_MASK | GDK_SCROLL_MASK | GDK_SMOOTH_SCROLL_MASK |
-      GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK;
-
-  gint window_attributes_mask = GDK_WA_X | GDK_WA_Y | GDK_WA_VISUAL;
-
-  GdkWindow* window =
-      gdk_window_new(gtk_widget_get_parent_window(widget), &window_attributes,
-                     window_attributes_mask);
-  gtk_widget_register_window(widget, window);
-  gtk_widget_set_window(widget, window);
-
-  fl_renderer_set_window(self->renderer, window);
 
   if (!fl_engine_start(self->engine, &error)) {
     g_warning("Failed to start Flutter engine: %s", error->message);
+    return;
   }
 }
 


### PR DESCRIPTION
## Description
Refactor and simplify the `FlRenderer` setup process (`fl_renderer_start()` is now the only relevant publicly facing method)

One of the pieces of https://github.com/flutter/engine/pull/20336

## Related Issues
https://github.com/flutter/flutter/issues/57932

## Tests
None

## Checklist

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
