### PR TITLE
Remove support for option 'dart_custom_version_for_pub'

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -189,8 +189,6 @@ def to_gn_args(args):
         gn_args['dart_use_fallback_root_certificates'] = True
 
 
-    gn_args['dart_custom_version_for_pub'] = 'flutter'
-
     # Make sure host_cpu matches the bit width of target_cpu on x86.
     if gn_args['target_cpu'] == 'x86':
       gn_args['host_cpu'] = 'x86'


### PR DESCRIPTION
Remove support for option 'dart_custom_version_for_pub' that generates a custom version string of Dart for Flutter.

Dart is going to be removing support for this ability to generate
a custom version string (only dev branch hashes are being rolled into
flutter).
