### PR TITLE
Let FlutterActivity/Fragment/FragmentActivity have an app bundle path override instead of eager resolving during construction

### DIFF
--- a/shell/platform/android/io/flutter/FlutterInjector.java
+++ b/shell/platform/android/io/flutter/FlutterInjector.java
@@ -28,6 +28,7 @@ public final class FlutterInjector {
    * <p>This can only be called at the beginning of the program before the {@link #instance()} is
    * accessed.
    */
+  @VisibleForTesting
   public static void setInstance(@NonNull FlutterInjector injector) {
     if (accessed) {
       throw new IllegalStateException(

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -45,6 +45,7 @@ import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
 import io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister;
 import io.flutter.plugin.platform.PlatformPlugin;
 import io.flutter.view.FlutterMain;
+import java.lang.reflect.Method;
 
 /**
  * {@code Activity} which displays a fullscreen Flutter UI.
@@ -754,12 +755,14 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * The path to the bundle that contains this Flutter app's resources, e.g., Dart code snapshots.
+   * A custom path to the bundle that contains this Flutter app's resources, e.g., Dart code
+   * snapshots.
    *
    * <p>When this {@code FlutterActivity} is run by Flutter tooling and a data String is included in
    * the launching {@code Intent}, that data String is interpreted as an app bundle path.
    *
-   * <p>By default, the app bundle path is obtained from {@link FlutterMain#findAppBundlePath()}.
+   * <p>When otherwise unspecified, the value is null, which defaults to the app bundle path defined
+   * in {@link FlutterLoader#findAppBundlePath()}.
    *
    * <p>Subclasses may override this method to return a custom app bundle path.
    */
@@ -776,9 +779,7 @@ public class FlutterActivity extends Activity
       }
     }
 
-    // Return the default app bundle path.
-    // TODO(mattcarroll): move app bundle resolution into an appropriately named class.
-    return FlutterMain.findAppBundlePath();
+    return null;
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -44,8 +44,6 @@ import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
 import io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister;
 import io.flutter.plugin.platform.PlatformPlugin;
-import io.flutter.view.FlutterMain;
-import java.lang.reflect.Method;
 
 /**
  * {@code Activity} which displays a fullscreen Flutter UI.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -347,10 +347,6 @@ import java.util.Arrays;
       return;
     }
 
-    if (!FlutterInjector.instance().flutterLoader().initialized()) {
-      throw new AssertionError("Flutter UI can only be started once the Flutter engine's running.");
-    }
-
     if (flutterEngine.getDartExecutor().isExecutingDart()) {
       // No warning is logged because this situation will happen on every config
       // change if the developer does not choose to retain the Fragment instance.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -18,13 +18,13 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.Lifecycle;
+import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.app.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.dart.DartExecutor;
-import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 import io.flutter.plugin.platform.PlatformPlugin;
 import java.util.Arrays;
@@ -369,7 +369,7 @@ import java.util.Arrays;
 
     String appBundlePathOverride = host.getAppBundlePath();
     if (appBundlePathOverride == null || appBundlePathOverride.isEmpty()) {
-      appBundlePathOverride = FlutterLoader.getInstance().findAppBundlePath();
+      appBundlePathOverride = FlutterInjector.instance().flutterLoader().findAppBundlePath();
     }
 
     // Configure the Dart entrypoint and execute it.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -368,7 +368,7 @@ import java.util.Arrays;
     }
 
     String appBundlePathOverride = host.getAppBundlePath();
-    if (appBundlePathOverride == null || appBundlePathOverride.isBlank()) {
+    if (appBundlePathOverride == null || appBundlePathOverride.isEmpty()) {
       appBundlePathOverride = FlutterLoader.getInstance().findAppBundlePath();
     }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -24,6 +24,7 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 import io.flutter.plugin.platform.PlatformPlugin;
 import java.util.Arrays;
@@ -366,10 +367,15 @@ import java.util.Arrays;
       flutterEngine.getNavigationChannel().setInitialRoute(host.getInitialRoute());
     }
 
+    String appBundlePathOverride = host.getAppBundlePath();
+    if (appBundlePathOverride == null || appBundlePathOverride.isBlank()) {
+      appBundlePathOverride = FlutterLoader.getInstance().findAppBundlePath();
+    }
+
     // Configure the Dart entrypoint and execute it.
     DartExecutor.DartEntrypoint entrypoint =
         new DartExecutor.DartEntrypoint(
-            host.getAppBundlePath(), host.getDartEntrypointFunctionName());
+            appBundlePathOverride, host.getDartEntrypointFunctionName());
     flutterEngine.getDartExecutor().executeDartEntrypoint(entrypoint);
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -347,6 +347,10 @@ import java.util.Arrays;
       return;
     }
 
+    if (!FlutterInjector.instance().flutterLoader().initialized()) {
+      throw new AssertionError("Flutter UI can only be started once the Flutter engine's running.");
+    }
+
     if (flutterEngine.getDartExecutor().isExecutingDart()) {
       // No warning is logged because this situation will happen on every config
       // change if the developer does not choose to retain the Fragment instance.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -22,7 +22,6 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 import io.flutter.plugin.platform.PlatformPlugin;
-import io.flutter.view.FlutterMain;
 
 /**
  * {@code Fragment} which displays a Flutter UI that takes up all available {@code Fragment} space.
@@ -226,8 +225,8 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
     }
 
     /**
-     * The path to the app bundle which contains the Dart app to execute, defaults to {@link
-     * FlutterMain#findAppBundlePath()}
+     * The path to the app bundle which contains the Dart app to execute. Null when unspecified,
+     * which defaults to {@link FlutterLoader#findAppBundlePath()}
      */
     @NonNull
     public NewEngineFragmentBuilder appBundlePath(@NonNull String appBundlePath) {
@@ -800,16 +799,18 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
   }
 
   /**
-   * Returns the file path to the desired Flutter app's bundle of code.
+   * A custom path to the bundle that contains this Flutter app's resources, e.g., Dart code
+   * snapshots.
    *
-   * <p>Defaults to {@link FlutterMain#findAppBundlePath()}.
+   * <p>When unspecified, the value is null, which defaults to the app bundle path defined in {@link
+   * FlutterLoader#findAppBundlePath()}.
    *
    * <p>Used by this {@code FlutterFragment}'s {@link FlutterActivityAndFragmentDelegate.Host}
    */
   @Override
   @NonNull
   public String getAppBundlePath() {
-    return getArguments().getString(ARG_APP_BUNDLE_PATH, FlutterMain.findAppBundlePath());
+    return getArguments().getString(ARG_APP_BUNDLE_PATH);
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -41,7 +41,6 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.plugins.util.GeneratedPluginRegister;
 import io.flutter.plugin.platform.PlatformPlugin;
-import io.flutter.view.FlutterMain;
 
 /**
  * A Flutter {@code Activity} that is based upon {@link FragmentActivity}.
@@ -581,14 +580,15 @@ public class FlutterFragmentActivity extends FragmentActivity
   }
 
   /**
-   * The path to the bundle that contains this Flutter app's resources, e.g., Dart code snapshots.
+   * A custom path to the bundle that contains this Flutter app's resources, e.g., Dart code
+   * snapshots.
    *
    * <p>When this {@code FlutterFragmentActivity} is run by Flutter tooling and a data String is
    * included in the launching {@code Intent}, that data String is interpreted as an app bundle
    * path.
    *
-   * <p>By default, the app bundle path is obtained from {@link
-   * FlutterMain#findAppBundlePath(Context)}.
+   * <p>When otherwise unspecified, the value is null, which defaults to the app bundle path defined
+   * in {@link FlutterLoader#findAppBundlePath()}.
    *
    * <p>Subclasses may override this method to return a custom app bundle path.
    */
@@ -605,9 +605,7 @@ public class FlutterFragmentActivity extends FragmentActivity
       }
     }
 
-    // Return the default app bundle path.
-    // TODO(mattcarroll): move app bundle resolution into an appropriately named class.
-    return FlutterMain.findAppBundlePath();
+    return null;
   }
 
   /**

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -17,11 +17,13 @@ import android.content.Context;
 import android.content.Intent;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
+import io.flutter.FlutterInjector;
 import io.flutter.embedding.android.FlutterActivityAndFragmentDelegate.Host;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
@@ -51,6 +53,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
   @Before
   public void setup() {
+    FlutterInjector.reset();
     // Create a mocked FlutterEngine for the various interactions required by the delegate
     // being tested.
     mockFlutterEngine = mockFlutterEngine();
@@ -310,13 +313,18 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itUsesDefaultFlutterLoaderAppBundlePathWhenUnspecified() {
     // ---- Test setup ----
+    FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
+    when(mockFlutterLoader.findAppBundlePath()).thenReturn("default_flutter_assets/path");
+    FlutterInjector.setInstance(
+        new FlutterInjector.Builder().setFlutterLoader(mockFlutterLoader).build());
+
     // Set Dart entrypoint parameters on fake host.
     when(mockHost.getAppBundlePath()).thenReturn(null);
     when(mockHost.getDartEntrypointFunctionName()).thenReturn("myEntrypoint");
 
     // Create the DartEntrypoint that we expect to be executed.
     DartExecutor.DartEntrypoint dartEntrypoint =
-        new DartExecutor.DartEntrypoint("flutter_assets", "myEntrypoint");
+        new DartExecutor.DartEntrypoint("default_flutter_assets/path", "myEntrypoint");
 
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -307,6 +307,30 @@ public class FlutterActivityAndFragmentDelegateTest {
     verify(mockFlutterEngine.getDartExecutor(), times(1)).executeDartEntrypoint(eq(dartEntrypoint));
   }
 
+  @Test
+  public void itUsesDefaultFlutterLoaderAppBundlePathWhenUnspecified() {
+    // ---- Test setup ----
+    // Set Dart entrypoint parameters on fake host.
+    when(mockHost.getAppBundlePath()).thenReturn(null);
+    when(mockHost.getDartEntrypointFunctionName()).thenReturn("myEntrypoint");
+
+    // Create the DartEntrypoint that we expect to be executed.
+    DartExecutor.DartEntrypoint dartEntrypoint =
+        new DartExecutor.DartEntrypoint("flutter_assets", "myEntrypoint");
+
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // Dart is executed in onStart().
+    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onCreateView(null, null, null);
+    delegate.onStart();
+
+    // Verify that the host's Dart entrypoint was used.
+    verify(mockFlutterEngine.getDartExecutor(), times(1)).executeDartEntrypoint(eq(dartEntrypoint));
+  }
+
   // "Attaching" to the surrounding Activity refers to Flutter being able to control
   // system chrome and other Activity-level details. If Flutter is not attached to the
   // surrounding Activity, it cannot control those details. This includes plugins.


### PR DESCRIPTION
fixes flutter/flutter#64458

FlutterActivity and FlutterFragment are actually fine as is. Changing them too for consistency. 
FlutterActivity doesn't expose the bundle path via Intent. FlutterFragment has a builder for override only and that doesn't resolve until after the FlutterFragment is created. 

FlutterFragmentActivity tries to eager resolve to populate all the values of the FlutterFragment builder parameters.