### PR TITLE
Revert "Roll Fuchsia Linux SDK from LhYt1i9FP... to al88o71XB..."

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -536,7 +536,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': 'al88o71XBlAxa8OdaYRuq8GATocf63HHatBq11t5_eQC'
+        'version': 'LhYt1i9FPQeIhMU1ReI1t1fk4Zx0F3uQwhrr4NkLpuMC'
        }
      ],
      'condition': 'host_os == "linux"',

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: 067717eebfd50e31793e69dc8466fc50
+Signature: cca1700ca777f682864d7baed336e5bc
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Reverts flutter/engine#20756

Roll caused failure on Linux Fuchsia FEMU.

https://github.com/dart-lang/sdk/commit/0e1d32f10c had just rolled in from Dart.

```
[ RUN      ] FuchsiaShellTest.LocaltimesVaryOnTimezoneChanges
../../flutter/shell/common/shell_fuchsia_unittests.cc:188: Failure
Expected equality of these values:
  initial_dart_isolate_time_str
    Which is: "2020-08-26 02"
  final_dart_isolate_time_str
    Which is: "2020-08-25 20"
Local time in Europe/Amsterdam rounded down to nearest hour read twiceshould be the same but this test says they are not; time zone handling in the dart VM is likely broken.
[  FAILED  ] FuchsiaShellTest.LocaltimesVaryOnTimezoneChanges (352 **ms)**
```