### PR TITLE
Guard recording_canvas against restore calls without ending recording

### DIFF
--- a/lib/web_ui/lib/src/engine/html/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/recording_canvas.dart
@@ -227,7 +227,7 @@ class RecordingCanvas {
   }
 
   void restore() {
-    if (!_recordingEnded) {
+    if (!_recordingEnded && _saveCount > 1) {
       _paintBounds.restoreTransformsAndClip();
     }
     if (_commands.isNotEmpty && _commands.last is PaintSave) {

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -200,6 +200,13 @@ void testMain() {
     // Should not throw exception on restore.
     expect(() => rc.restore(), returnsNormally);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/61697.
+  test('Allows restore calls even if recording is not ended', () {
+    final RecordingCanvas rc = RecordingCanvas(Rect.fromLTRB(0, 0, 200, 400));
+    // Should not throw exception on restore.
+    expect(() => rc.restore(), returnsNormally);
+  });
 }
 
 // Expect a drawDRRect call to be registered in the mock call log, with the expectedArguments


### PR DESCRIPTION
## Description

Framework is now calling restore on incorrect canvas before calling endRecording on recording canvas. This change prevents crash. 

## Related Issues

https://github.com/flutter/flutter/issues/61697

## Tests

Updated recording_canvas_test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
