### PR TITLE
Start an engine in ShellTest.OnServiceProtocolGetSkSLsWorks

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1636,6 +1636,10 @@ TEST_F(ShellTest, OnServiceProtocolGetSkSLsWorks) {
 
   Settings settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+  RunEngine(shell.get(), std::move(configuration));
+
   ServiceProtocol::Handler::ServiceProtocolMap empty_params;
   rapidjson::Document document;
   OnServiceProtocol(shell.get(), ServiceProtocolEnum::kGetSkSLs,


### PR DESCRIPTION
This test invokes a service protocol handler, and related methods such
as Shell::GetServiceProtocolDescription make the assumption that an
engine is available.

See https://github.com/flutter/engine/pull/20142