### PR TITLE
Fix iOS text field input keyboard flickering & crash

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1282,7 +1282,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 // Removes every installed input field, unless it's in the current autofill
 // context. May remove the active view too if includeActiveView is YES.
 // When clearText is YES, the text on the input fields will be set to empty before
-// they are removed from the view hierarchy, to avoid autofill save .
+// they are removed from the view hierarchy, to avoid triggering autofill save.
 - (void)cleanUpViewHierarchy:(BOOL)includeActiveView clearText:(BOOL)clearText {
   for (UIView* view in self.textInputParentView.subviews) {
     if ([view isKindOfClass:[FlutterTextInputView class]] &&

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1290,7 +1290,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
       FlutterTextInputView* inputView = (FlutterTextInputView*)view;
       if (_autofillContext[inputView.autofillId] != view) {
         if (clearText) {
-          inputView.text.string = @"";
+          [inputView replaceRangeLocal:NSMakeRange(0, inputView.text.length) withText:@""];
         }
         [view removeFromSuperview];
       }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1147,6 +1147,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 }
 
 - (void)setTextInputClient:(int)client withConfiguration:(NSDictionary*)configuration {
+  [self resetAllClientIds];
   // Hide all input views from autofill, only make those in the new configuration visible
   // to autofill.
   [self changeInputViewsAutofillVisibility:NO];
@@ -1279,7 +1280,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 // When clearText is YES, the text on the input fields will be set to empty before
 // they are removed from the view hierarchy, to avoid autofill save .
 - (void)cleanUpViewHierarchy:(BOOL)includeActiveView clearText:(BOOL)clearText {
-  for (UIView* view in textInputParentView.subviews) {
+  for (UIView* view in self.textInputParentView.subviews) {
     if ([view isKindOfClass:[FlutterTextInputView class]] &&
         (includeActiveView || view != _activeView)) {
       FlutterTextInputView* inputView = (FlutterTextInputView*)view;
@@ -1293,23 +1294,31 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   }
 }
 
-// Change the visibility of every FlutterTextInputView currently in the
-// view hierarchy. If the new visiblity is NO, also sets the clientID
-// to 0.
+// Changes the visibility of every FlutterTextInputView currently in the
+// view hierarchy.
 - (void)changeInputViewsAutofillVisibility:(BOOL)newVisibility {
-  for (UIView* view in textInputParentView.subviews) {
+  for (UIView* view in self.textInputParentView.subviews) {
     if ([view isKindOfClass:[FlutterTextInputView class]]) {
       FlutterTextInputView* inputView = (FlutterTextInputView*)view;
       inputView.isVisibleToAutofill = newVisibility;
-      if (!newVisibility) {
-        [inputView setTextInputClient:0];
-      }
+    }
+  }
+}
+
+// Resets the client id of every FlutterTextInputView in the view hierarchy
+// to 0. Called when a new text input connection will be established.
+- (void)resetAllClientIds {
+  for (UIView* view in self.textInputParentView.subviews) {
+    if ([view isKindOfClass:[FlutterTextInputView class]]) {
+      FlutterTextInputView* inputView = (FlutterTextInputView*)view;
+      [inputView setTextInputClient:0];
     }
   }
 }
 
 - (void)addToInputParentViewIfNeeded:(FlutterTextInputView*)inputView {
-  UIView* parentView = textInputParentView if (inputView.parentView != parentView) {
+  UIView* parentView = self.textInputParentView;
+  if (inputView.superview != parentView) {
     [parentView addSubview:inputView];
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -639,4 +639,20 @@ FLUTTER_ASSERT_ARC
   XCTAssertNotEqual([inputView performSelector:@selector(font)], nil);
 }
 
+- (void)testGarbageInputViewsAreNotRemovedImmediately {
+  // Add a password field that should autofill.
+  [self setClientId:123 configuration:self.mutablePasswordTemplateCopy];
+  [self ensureOnlyActiveViewCanBecomeFirstResponder];
+
+  XCTAssertEqual(self.installedInputViews.count, 1);
+  // Add an input field that doesn't autofill. This should remove the password
+  // field, but not immediately.
+  [self setClientId:124 configuration:self.mutableTemplateCopy];
+  [self ensureOnlyActiveViewCanBecomeFirstResponder];
+
+  XCTAssertEqual(self.installedInputViews.count, 2);
+
+  [self commitAutofillContextAndVerify];
+}
+
 @end


### PR DESCRIPTION
## Description

Delay the removal of `FlutterTextInputView`s from their superview to prevent the keyboard from flickering.
Also ensures that the client id of an input view is reset to 0 when establishing a new connection.

| Before | After |
|---|---|
| ![before](https://user-images.githubusercontent.com/31859944/91381866-3919c400-e7dd-11ea-9356-8433bbd25c53.gif) | ![after](https://user-images.githubusercontent.com/31859944/91381822-23a49a00-e7dd-11ea-8760-67682f549f09.gif) |

## Related Issues

Fixes https://github.com/flutter/flutter/issues/64628

## Tests

I added the following tests:

- testGarbageInputViewsAreNotRemovedImmediately

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.


<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
