### PR TITLE
[fuchsia] Add fuchsia_ctl func to test script

### DIFF
--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -46,23 +46,24 @@ fuchsia_ctl() {
 
 reboot() {
   fuchsia_ctl ssh \
-       -c "log_listener --dump_logs yes --file /tmp/log.txt" \
        --timeout-seconds $ssh_timeout_seconds \
-       --identity-file $pkey
+       --identity-file $pkey \
+       -c "log_listener --dump_logs yes --file /tmp/log.txt"
   # As we are not using recipes we don't have a way to know the location
   # to upload the log to isolated. We are saving the log to a file to avoid dart
   # hanging when running the process and then just using printing the content to
   # the console.
   fuchsia_ctl ssh \
-       -c "cat /tmp/log.txt" \
        --timeout-seconds $ssh_timeout_seconds \
-       --identity-file $pkey
+       --identity-file $pkey \
+       -c "cat /tmp/log.txt"
+
 
   echo "$(date) START:REBOOT ----------------------------------------"
   # note: this will set an exit code of 255, which we can ignore.
   fuchsia_ctl ssh \
-      -c "dm reboot-recovery" \
-      --identity-file $pkey || true
+      --identity-file $pkey \
+      -c "dm reboot-recovery" || true
   echo "$(date) END:REBOOT ------------------------------------------"
 }
 

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -17,7 +17,7 @@
 # This script also expects a private key available at:
 # "/etc/botanist/keys/id_rsa_infra".
 
-set -Ee
+set -Eex
 
 test_timeout_seconds=300
 

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -39,8 +39,13 @@ else
   echo "Connecting to device $device_name"
 fi
 
+# Wrapper function to pass common args to fuchsia_ctl.
+fuchsia_ctl() {
+  ./fuchsia_ctl -d $device_name $@
+}
+
 reboot() {
-  ./fuchsia_ctl -d $device_name ssh \
+  fuchsia_ctl ssh \
        -c "log_listener --dump_logs yes --file /tmp/log.txt" \
        --timeout-seconds $ssh_timeout_seconds \
        --identity-file $pkey
@@ -48,14 +53,15 @@ reboot() {
   # to upload the log to isolated. We are saving the log to a file to avoid dart
   # hanging when running the process and then just using printing the content to
   # the console.
-  ./fuchsia_ctl -d $device_name ssh \
+  fuchsia_ctl ssh \
        -c "cat /tmp/log.txt" \
        --timeout-seconds $ssh_timeout_seconds \
        --identity-file $pkey
 
   echo "$(date) START:REBOOT ----------------------------------------"
   # note: this will set an exit code of 255, which we can ignore.
-  ./fuchsia_ctl -d $device_name ssh -c "dm reboot-recovery" \
+  fuchsia_ctl ssh \
+      -c "dm reboot-recovery" \
       --identity-file $pkey || true
   echo "$(date) END:REBOOT ------------------------------------------"
 }
@@ -64,13 +70,14 @@ trap reboot EXIT
 
 echo "$(date) START:PAVING ------------------------------------------"
 ssh-keygen -y -f $pkey > key.pub
-./fuchsia_ctl -d $device_name pave  -i $1 \
+fuchsia_ctl pave \
+      -i $1 \
       --public-key "key.pub"
 echo "$(date) END:PAVING --------------------------------------------"
 
 echo "$(date) START:WAIT_DEVICE_READY -------------------------------"
 for i in {1..10}; do
-  ./fuchsia_ctl -d $device_name ssh \
+  fuchsia_ctl ssh \
       --identity-file $pkey \
       -c "echo up" && break || sleep 15;
 done
@@ -82,7 +89,7 @@ tar -xvzf $2 -C packages 1> /dev/null
 echo "$(date) END:EXTRACT_PACKAGES  ---------------------------------"
 
 echo "$(date) START:testing_tests -----------------------------------"
-./fuchsia_ctl -d $device_name test \
+fuchsia_ctl test \
    -f testing_tests-0.far  \
    -t testing_tests \
    --identity-file $pkey \
@@ -93,7 +100,7 @@ echo "$(date) DONE:testing_tests ------------------------------------"
 # TODO(https://github.com/flutter/flutter/issues/61212): Re-enable ParagraphTest
 # once it passes on Fuchsia.
 echo "$(date) START:txt_tests ---------------------------------------"
-./fuchsia_ctl -d $device_name test \
+fuchsia_ctl test \
    -f txt_tests-0.far  \
    -t txt_tests \
    -a "--gtest_filter=-ParagraphTest.*" \
@@ -107,7 +114,7 @@ echo "$(date) DONE:txt_tests ----------------------------------------"
 # TODO(https://github.com/flutter/flutter/issues/58211): Re-enable MessageLoop
 # test once it passes on Fuchsia.
 echo "$(date) START:fml_tests ---------------------------------------"
-./fuchsia_ctl -d $device_name test \
+fuchsia_ctl test \
     -f fml_tests-0.far  \
     -t fml_tests \
     -a "--gtest_filter=-MessageLoop.TimeSensistiveTest_*:FileTest.CanTruncateAndWrite:FileTest.CreateDirectoryStructure" \
@@ -118,7 +125,7 @@ echo "$(date) DONE:fml_tests ----------------------------------------"
 
 
 echo "$(date) START:flow_tests --------------------------------------"
-./fuchsia_ctl -d $device_name test \
+fuchsia_ctl test \
    -f flow_tests-0.far  \
    -t flow_tests \
    --identity-file $pkey \
@@ -128,7 +135,7 @@ echo "$(date) DONE:flow_tests ---------------------------------------"
 
 
 echo "$(date) START:runtime_tests -----------------------------------"
-./fuchsia_ctl -d $device_name test \
+fuchsia_ctl test \
     -f runtime_tests-0.far  \
     -t runtime_tests \
     --identity-file $pkey \
@@ -137,7 +144,7 @@ echo "$(date) START:runtime_tests -----------------------------------"
 echo "$(date) DONE:runtime_tests ------------------------------------"
 
 echo "$(date) START:ui_tests ----------------------------------------"
-./fuchsia_ctl -d $device_name test \
+fuchsia_ctl test \
    -f ui_tests-0.far  \
    -t ui_tests \
    --identity-file $pkey \
@@ -146,7 +153,7 @@ echo "$(date) START:ui_tests ----------------------------------------"
 echo "$(date) DONE:ui_tests -----------------------------------------"
 
 echo "$(date) START:shell_tests -------------------------------------"
-./fuchsia_ctl -d $device_name test \
+fuchsia_ctl test \
     -f shell_tests-0.far  \
     -t shell_tests \
     --identity-file $pkey \
@@ -156,7 +163,7 @@ echo "$(date) DONE:shell_tests --------------------------------------"
 
 # TODO(gw280): Enable tests using JIT runner
 echo "$(date) START:flutter_runner_tests ----------------------------"
-./fuchsia_ctl -d $device_name test \
+fuchsia_ctl test \
     -f flutter_aot_runner-0.far    \
     -f flutter_runner_tests-0.far  \
     -t flutter_runner_tests        \
@@ -165,7 +172,7 @@ echo "$(date) START:flutter_runner_tests ----------------------------"
     --packages-directory packages
 
 # TODO(https://github.com/flutter/flutter/issues/61768): De-flake and re-enable
-# ./fuchsia_ctl -d $device_name test \
+# fuchsia_ctl test \
 #     -f flutter_aot_runner-0.far    \
 #     -f flutter_runner_scenic_tests-0.far  \
 #     -t flutter_runner_scenic_tests \
@@ -173,7 +180,7 @@ echo "$(date) START:flutter_runner_tests ----------------------------"
 #     --timeout-seconds $test_timeout_seconds \
 #     --packages-directory packages
 
-./fuchsia_ctl -d $device_name test \
+fuchsia_ctl test \
     -f flutter_aot_runner-0.far    \
     -f flutter_runner_tzdata_tests-0.far  \
     -t flutter_runner_tzdata_tests \

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -41,7 +41,7 @@ fi
 
 # Wrapper function to pass common args to fuchsia_ctl.
 fuchsia_ctl() {
-  ./fuchsia_ctl -d $device_name $@
+  ./fuchsia_ctl -d $device_name "$@"
 }
 
 reboot() {


### PR DESCRIPTION
## Description

Duplicate of https://github.com/flutter/flutter/pull/64736 to ensure always passing fuchsia_ctl variables.

This makes it easier to look at a diff between the two repos and to ensure files are in sync.

## Related Issues

#57044

## Tests

I added the following tests:

Ran script locally to verify function didn't break the current process.

This is a bash script to run tests from the SDK against Fuchsia.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*