### PR TITLE
Reland "Pass platform configuration to Dart VM for insecure socket policy"

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -216,10 +216,9 @@ public class FlutterLoader {
       }
 
       shellArgs.add("--cache-dir-path=" + result.engineCachesPath);
-      // TODO(mehmetf): Announce this since it is a breaking change then enable it.
-      // if (!flutterApplicationInfo.clearTextPermitted) {
-      //   shellArgs.add("--disallow-insecure-connections");
-      // }
+      if (!flutterApplicationInfo.clearTextPermitted) {
+        shellArgs.add("--disallow-insecure-connections");
+      }
       if (flutterApplicationInfo.domainNetworkPolicy != null) {
         shellArgs.add("--domain-network-policy=" + flutterApplicationInfo.domainNetworkPolicy);
       }

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -140,12 +140,6 @@ static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
   settings.domain_network_policy =
       [FlutterDartProject domainNetworkPolicy:appTransportSecurity].UTF8String;
 
-  // TODO(mehmetf): We need to announce this change since it is breaking.
-  // Remove these two lines after we announce and we know which release this is
-  // going to be part of.
-  settings.may_insecurely_connect_to_all_domains = true;
-  settings.domain_network_policy = "";
-
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   // There are no ownership concerns here as all mappings are owned by the
   // embedder and not the engine.


### PR DESCRIPTION
Reverts flutter/engine#20812

This is now able to reland because we fixed a `package:grpc` issue where `SecureSocket.secure()` method was being unnecessarily used instead of `SecureSocket.connect()`. Also see https://github.com/dart-lang/sdk/issues/43223.