### PR TITLE
Replace FlRenderer::get_visual() with FlRenderer::setup_window_attr()

### DIFF
--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -121,22 +121,13 @@ static gboolean setup_gdk_window(FlRenderer* self,
 
   gint window_attributes_mask = GDK_WA_X | GDK_WA_Y;
 
-  EGLint visual_id;
-  if (!eglGetConfigAttrib(priv->egl_display, priv->egl_config,
-                          EGL_NATIVE_VISUAL_ID, &visual_id)) {
-    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
-                "Failed to determine EGL configuration visual");
-    return FALSE;
+  if (FL_RENDERER_GET_CLASS(self)->setup_window_attr) {
+    if (!FL_RENDERER_GET_CLASS(self)->setup_window_attr(
+            self, widget, priv->egl_display, priv->egl_config,
+            &window_attributes, &window_attributes_mask, error)) {
+      return FALSE;
+    }
   }
-
-  window_attributes.visual = FL_RENDERER_GET_CLASS(self)->get_visual(
-      self, gtk_widget_get_screen(widget), visual_id);
-  if (window_attributes.visual == nullptr) {
-    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
-                "Failed to find visual 0x%x", visual_id);
-    return FALSE;
-  }
-  window_attributes_mask |= GDK_WA_VISUAL;
 
   GdkWindow* window =
       gdk_window_new(gtk_widget_get_parent_window(widget), &window_attributes,

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -35,10 +35,17 @@ G_DECLARE_DERIVABLE_TYPE(FlRenderer, fl_renderer, FL, RENDERER, GObject)
 struct _FlRendererClass {
   GObjectClass parent_class;
 
-  // Virtual method called to get the visual that matches the given ID.
-  GdkVisual* (*get_visual)(FlRenderer* renderer,
-                           GdkScreen* screen,
-                           EGLint visual_id);
+  /**
+   * Virtual method called before creating a GdkWindow for the widget.
+   * Does not need to be implemented.
+   */
+  gboolean (*setup_window_attr)(FlRenderer* renderer,
+                                GtkWidget* widget,
+                                EGLDisplay egl_display,
+                                EGLConfig egl_config,
+                                GdkWindowAttr* window_attributes,
+                                gint* mask,
+                                GError** error);
 
   /**
    * Virtual method called after a GDK window has been created.

--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -21,11 +21,40 @@ static void fl_renderer_x11_dispose(GObject* object) {
   G_OBJECT_CLASS(fl_renderer_x11_parent_class)->dispose(object);
 }
 
-// Implements FlRenderer::get_visual.
-static GdkVisual* fl_renderer_x11_get_visual(FlRenderer* renderer,
-                                             GdkScreen* screen,
-                                             EGLint visual_id) {
-  return gdk_x11_screen_lookup_visual(GDK_X11_SCREEN(screen), visual_id);
+// Implements FlRenderer::setup_window_attr.
+static gboolean fl_renderer_x11_setup_window_attr(
+    FlRenderer* renderer,
+    GtkWidget* widget,
+    EGLDisplay egl_display,
+    EGLConfig egl_config,
+    GdkWindowAttr* window_attributes,
+    gint* mask,
+    GError** error) {
+  EGLint visual_id;
+  if (!eglGetConfigAttrib(egl_display, egl_config, EGL_NATIVE_VISUAL_ID,
+                          &visual_id)) {
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "Failed to determine EGL configuration visual");
+    return FALSE;
+  }
+
+  GdkX11Screen* screen = GDK_X11_SCREEN(gtk_widget_get_screen(widget));
+  if (!screen) {
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "Widget is not on an X11 screen");
+    return FALSE;
+  }
+
+  window_attributes->visual = gdk_x11_screen_lookup_visual(screen, visual_id);
+  if (window_attributes->visual == nullptr) {
+    g_set_error(error, fl_renderer_error_quark(), FL_RENDERER_ERROR_FAILED,
+                "Failed to find visual 0x%x", visual_id);
+    return FALSE;
+  }
+
+  *mask |= GDK_WA_VISUAL;
+
+  return TRUE;
 }
 
 // Implements FlRenderer::set_window.
@@ -88,7 +117,8 @@ static gboolean fl_renderer_x11_create_surfaces(FlRenderer* renderer,
 
 static void fl_renderer_x11_class_init(FlRendererX11Class* klass) {
   G_OBJECT_CLASS(klass)->dispose = fl_renderer_x11_dispose;
-  FL_RENDERER_CLASS(klass)->get_visual = fl_renderer_x11_get_visual;
+  FL_RENDERER_CLASS(klass)->setup_window_attr =
+      fl_renderer_x11_setup_window_attr;
   FL_RENDERER_CLASS(klass)->set_window = fl_renderer_x11_set_window;
   FL_RENDERER_CLASS(klass)->create_display = fl_renderer_x11_create_display;
   FL_RENDERER_CLASS(klass)->create_surfaces = fl_renderer_x11_create_surfaces;

--- a/shell/platform/linux/testing/mock_renderer.cc
+++ b/shell/platform/linux/testing/mock_renderer.cc
@@ -10,13 +10,6 @@ struct _FlMockRenderer {
 
 G_DEFINE_TYPE(FlMockRenderer, fl_mock_renderer, fl_renderer_get_type())
 
-// Implements FlRenderer::get_visual.
-static GdkVisual* fl_mock_renderer_get_visual(FlRenderer* renderer,
-                                              GdkScreen* screen,
-                                              EGLint visual_id) {
-  return static_cast<GdkVisual*>(g_object_new(GDK_TYPE_VISUAL, nullptr));
-}
-
 // Implements FlRenderer::create_display.
 static EGLDisplay fl_mock_renderer_create_display(FlRenderer* renderer) {
   return eglGetDisplay(EGL_DEFAULT_DISPLAY);
@@ -36,7 +29,6 @@ static gboolean fl_mock_renderer_create_surfaces(FlRenderer* renderer,
 }
 
 static void fl_mock_renderer_class_init(FlMockRendererClass* klass) {
-  FL_RENDERER_CLASS(klass)->get_visual = fl_mock_renderer_get_visual;
   FL_RENDERER_CLASS(klass)->create_display = fl_mock_renderer_create_display;
   FL_RENDERER_CLASS(klass)->create_surfaces = fl_mock_renderer_create_surfaces;
 }


### PR DESCRIPTION
## Description
This simplifies the generic window setup, and moves all the X11-specific visual code into the X11 renderer. It could also provided a place to do Wayland-specific window setup, although that is not currently needed.

## Related Issues
https://github.com/flutter/flutter/issues/57932
Part of https://github.com/flutter/engine/pull/20629

## Tests
None

## Checklist
- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
