### PR TITLE
adjust blur radius for HTML to match CanvasKit

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 57327a39aba333794a092d4e72777bb37102f8ba
+revision: f1e5b87249f54998e23a34788e19ec864358e50b

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -563,9 +563,9 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   }
 }
 
-// TODO(yjbanov): in HTML the blur looks too aggressive. The current
-//                implementation was copied from the existing backdrop-filter
-//                but probably needs a revision.
+// HTML only supports a single radius, but Flutter ImageFilter supports separate
+// horizontal and vertical radii. The best approximation we can provide is to
+// average the two radii together for a single compromise value.
 String _imageFilterToCss(EngineImageFilter filter) {
-  return 'blur(${math.max(filter.sigmaX, filter.sigmaY) * 2}px)';
+  return 'blur(${(filter.sigmaX + filter.sigmaY) / 2}px)';
 }


### PR DESCRIPTION
The blur radius was too aggressive for HTML. The results for CanvasKit matched what we say on mobile hardware pretty well, but the HTML blurs were always too blurry. I don't know why the `* 2` factor was chosen, but both the Flutter parameters and the HTML parameters are radii so they should be compatible.

I also adjusted it to be an average of the X & Y values rather than a max. I don't have a strong opinion on that, but I think it chooses a middle ground for when the dimensional radii are different.

Here are the before/after images (snapshots from Chrome, but results on Safari were pretty much the same, and Firefox doesn't seem to implement blur). Ignore the shade of the square in the middle - it was animating and the shade just depends on when I clicked "snapshot":

| build | backend | resulting screenshot |
| :----: | :------: | -------------------- |
| before fix | HTML | <img width="245" alt="before_html" src="https://user-images.githubusercontent.com/50503328/91509501-455e5980-e88f-11ea-8ca8-92f3dd2c5017.png"> |
| before fix | CanvasKit | <img width="245" alt="before_canvaskit" src="https://user-images.githubusercontent.com/50503328/91509505-498a7700-e88f-11ea-897f-8663d129b922.png"> |
| after fix | HTML | <img width="245" alt="after_html" src="https://user-images.githubusercontent.com/50503328/91509512-4c856780-e88f-11ea-9aee-5f39975922c5.png"> |
| after fix | CanvasKit | <img width="245" alt="after_canvaskit" src="https://user-images.githubusercontent.com/50503328/91509516-4f805800-e88f-11ea-9684-b40088485471.png"> |
| (reference) | (Android Skia on Moto G4) | <img width="360" alt="flutter_01" src="https://user-images.githubusercontent.com/50503328/91509590-92dac680-e88f-11ea-9db8-9c7ac935b74c.png"> |
