### PR TITLE
[web] Change code locations for engine unit tests

### DIFF
--- a/lib/web_ui/dev/environment.dart
+++ b/lib/web_ui/dev/environment.dart
@@ -156,6 +156,12 @@ class Environment {
         'test',
       ));
 
+  /// Path to the "lib" directory containing web engine code.
+  io.Directory get webUiLibDir => io.Directory(pathlib.join(
+        webUiRootDir.path,
+        'lib',
+      ));
+
   /// Path to the clone of the flutter/goldens repository.
   io.Directory get webUiGoldensRepositoryDirectory => io.Directory(pathlib.join(
         webUiDartToolDir.path,


### PR DESCRIPTION
When felt debug feature is used:
```
felt test test/engine/surface/path/path_winding_test.dart --debug
```
Browser cannot find the content, which breaks debug:
```
Could not load content for http://localhost:59072/test/engine/surface/path/path_winding_test.dart (HTTP error: status code 404, net::ERR_HTTP_RESPONSE_CODE_FAILURE)
```

This happened we changed `build_runner` with `dart2js`. Apparently `build_runner` was copying all these files under the /build directory, making sure that everything pointed in the *.js.map file was in place. We forgot to do that for the new code. Before this PR, maps were showing file locations as:
```
"../../../../../test/engine/surface/path/path_winding_test.dart"
"../../../../../lib/src/engine/html/path/path_windings.dart"
```
Two things are wrong with this mapping:

1. contents of /lib were never carried under /build directory (we are using /build directory as `precompiled` input while running tests) 
2. test.dart was already in the same folder with *.js.map file.

This PR is fixing the following:
- target and source are on the same folder when running `dart2js`. Hence, *.js.map file points to the same directory.
- contents of /lib is copied under /build.

**Alternatives considered:** I also considered removing /build directory altogether. However when we start using isolates in LUCI, we can create an artifact from the contents of build file on a Linux machine and download this isolate from the relatively slower Mac/Windows machines, speeding up the running time for engine unit tests (This optimization is originally @yjbanov idea).   

Fixes: https://github.com/flutter/flutter/issues/64738