### PR TITLE
Deprecate Android v1 embedding classes

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -18,9 +18,8 @@ import io.flutter.view.FlutterView;
 /**
  * Deprecated base class for activities that use Flutter.
  *
- * @deprecated {@link io.flutter.embedding.android.FlutterActivity} is the new API that now
- * replaces this class. See https://flutter.dev/go/android-project-migration for more migration
- * details.
+ * @deprecated {@link io.flutter.embedding.android.FlutterActivity} is the new API that now replaces
+ *     this class. See https://flutter.dev/go/android-project-migration for more migration details.
  */
 @Deprecated
 public class FlutterActivity extends Activity

--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -18,10 +18,11 @@ import io.flutter.view.FlutterView;
 /**
  * Deprecated base class for activities that use Flutter.
  *
- * <p>Deprecation: {@link io.flutter.embedding.android.FlutterActivity} is the new API that now
+ * @deprecated {@link io.flutter.embedding.android.FlutterActivity} is the new API that now
  * replaces this class. See https://flutter.dev/go/android-project-migration for more migration
  * details.
  */
+@Deprecated
 public class FlutterActivity extends Activity
     implements FlutterView.Provider, PluginRegistry, ViewFactory {
   private static final String TAG = "FlutterActivity";

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -50,9 +50,9 @@ import java.util.ArrayList;
  * your activity implement {@link PluginRegistry} and/or {@link
  * io.flutter.view.FlutterView.Provider} and forward those methods to this class as well.
  *
- * @deprecated {@link io.flutter.embedding.android.FlutterActivity} is the new API that now
- * replaces this class and {@link io.flutter.app.FlutterActivity}. See
- * https://flutter.dev/go/android-project-migration for more migration details.
+ * @deprecated {@link io.flutter.embedding.android.FlutterActivity} is the new API that now replaces
+ *     this class and {@link io.flutter.app.FlutterActivity}. See
+ *     https://flutter.dev/go/android-project-migration for more migration details.
  */
 @Deprecated
 public final class FlutterActivityDelegate

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -50,10 +50,11 @@ import java.util.ArrayList;
  * your activity implement {@link PluginRegistry} and/or {@link
  * io.flutter.view.FlutterView.Provider} and forward those methods to this class as well.
  *
- * <p>Deprecation: {@link io.flutter.embedding.android.FlutterActivity} is the new API that now
+ * @deprecated {@link io.flutter.embedding.android.FlutterActivity} is the new API that now
  * replaces this class and {@link io.flutter.app.FlutterActivity}. See
  * https://flutter.dev/go/android-project-migration for more migration details.
  */
+@Deprecated
 public final class FlutterActivityDelegate
     implements FlutterActivityEvents, FlutterView.Provider, PluginRegistry {
   private static final String SPLASH_SCREEN_META_DATA_KEY =

--- a/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
@@ -18,9 +18,6 @@ import io.flutter.view.FlutterView;
  * Deprecated class for activities that use Flutter who also require the use of the Android v4
  * Support library's {@link FragmentActivity}.
  *
- * <p>Deprecation: this class is replaced by {@link
- * io.flutter.embedding.android.FlutterFragmentActivity}.
- *
  * <p>Applications that don't have this need will likely want to use {@link FlutterActivity}
  * instead.
  *
@@ -31,7 +28,11 @@ import io.flutter.view.FlutterView;
  *
  * @see <a target="_new"
  *     href="https://developer.android.com/training/testing/set-up-project">https://developer.android.com/training/testing/set-up-project</a>
+ *
+ * @deprecated this class is replaced by {@link
+ * io.flutter.embedding.android.FlutterFragmentActivity}.
  */
+@Deprecated
 public class FlutterFragmentActivity extends FragmentActivity
     implements FlutterView.Provider, PluginRegistry, ViewFactory {
   private final FlutterActivityDelegate delegate = new FlutterActivityDelegate(this, this);

--- a/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
@@ -28,9 +28,8 @@ import io.flutter.view.FlutterView;
  *
  * @see <a target="_new"
  *     href="https://developer.android.com/training/testing/set-up-project">https://developer.android.com/training/testing/set-up-project</a>
- *
  * @deprecated this class is replaced by {@link
- * io.flutter.embedding.android.FlutterFragmentActivity}.
+ *     io.flutter.embedding.android.FlutterFragmentActivity}.
  */
 @Deprecated
 public class FlutterFragmentActivity extends FragmentActivity

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -21,8 +21,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/// This class is now deprecated. See https://flutter.dev/go/android-project-migration for
-/// migration instructions.
+/**
+ * @deprecated See https://flutter.dev/go/android-project-migration for
+ * migration instructions.
+ */
+@Deprecated
 public class FlutterPluginRegistry
     implements PluginRegistry,
         PluginRegistry.RequestPermissionsResultListener,

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -21,10 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @deprecated See https://flutter.dev/go/android-project-migration for
- * migration instructions.
- */
+/** @deprecated See https://flutter.dev/go/android-project-migration for migration instructions. */
 @Deprecated
 public class FlutterPluginRegistry
     implements PluginRegistry,

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -25,8 +25,7 @@ import io.flutter.view.TextureRegistry;
  * defaults to an instance of {@link io.flutter.app.FlutterActivity}, itself a {@link
  * PluginRegistry}.
  *
- * @deprecated See https://flutter.dev/go/android-project-migration for
- * migration details.
+ * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
  */
 @Deprecated
 public interface PluginRegistry {

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -25,9 +25,10 @@ import io.flutter.view.TextureRegistry;
  * defaults to an instance of {@link io.flutter.app.FlutterActivity}, itself a {@link
  * PluginRegistry}.
  *
- * <p>This class is now deprecated. See https://flutter.dev/go/android-project-migration for
+ * @deprecated See https://flutter.dev/go/android-project-migration for
  * migration details.
  */
+@Deprecated
 public interface PluginRegistry {
   /**
    * Returns a {@link Registrar} for receiving the registrations pertaining to the specified plugin.

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -14,8 +14,9 @@ import io.flutter.embedding.engine.loader.FlutterLoader;
 /**
  * A legacy class to initialize the Flutter engine.
  *
- * <p>Replaced by {@link io.flutter.embedding.engine.loader.FlutterLoader}.
+ * @deprecated Replaced by {@link io.flutter.embedding.engine.loader.FlutterLoader}.
  */
+@Deprecated
 public class FlutterMain {
 
   public static class Settings {

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -17,6 +17,11 @@ import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 import io.flutter.plugin.common.*;
 import java.nio.ByteBuffer;
 
+/**
+ * @deprecated {@link io.flutter.embedding.android.FlutterView} is the new API that now replaces
+ * this class. See https://flutter.dev/go/android-project-migration for more migration details.
+ */
+@Deprecated
 public class FlutterNativeView implements BinaryMessenger {
   private static final String TAG = "FlutterNativeView";
 

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -19,7 +19,7 @@ import java.nio.ByteBuffer;
 
 /**
  * @deprecated {@link io.flutter.embedding.android.FlutterView} is the new API that now replaces
- * this class. See https://flutter.dev/go/android-project-migration for more migration details.
+ *     this class. See https://flutter.dev/go/android-project-migration for more migration details.
  */
 @Deprecated
 public class FlutterNativeView implements BinaryMessenger {

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -63,7 +63,6 @@ import io.flutter.plugin.localization.LocalizationPlugin;
 import io.flutter.plugin.mouse.MouseCursorPlugin;
 import io.flutter.plugin.platform.PlatformPlugin;
 import io.flutter.plugin.platform.PlatformViewsController;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -73,7 +72,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * Deprecated Android view containing a Flutter app.
  *
  * @deprecated {@link io.flutter.embedding.android.FlutterView} is the new API that now replaces
- * this class. See https://flutter.dev/go/android-project-migration for more migration details.
+ *     this class. See https://flutter.dev/go/android-project-migration for more migration details.
  */
 @Deprecated
 public class FlutterView extends SurfaceView

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -63,6 +63,7 @@ import io.flutter.plugin.localization.LocalizationPlugin;
 import io.flutter.plugin.mouse.MouseCursorPlugin;
 import io.flutter.plugin.platform.PlatformPlugin;
 import io.flutter.plugin.platform.PlatformViewsController;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,9 +72,10 @@ import java.util.concurrent.atomic.AtomicLong;
 /**
  * Deprecated Android view containing a Flutter app.
  *
- * <p>Deprecation: {@link io.flutter.embedding.android.FlutterView} is the new API that now replaces
+ * @deprecated {@link io.flutter.embedding.android.FlutterView} is the new API that now replaces
  * this class. See https://flutter.dev/go/android-project-migration for more migration details.
  */
+@Deprecated
 public class FlutterView extends SurfaceView
     implements BinaryMessenger, TextureRegistry, MouseCursorPlugin.MouseCursorViewDelegate {
   /**


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/43298.

To submit after 1.22 cut. 