### PR TITLE
Reset Shell::weak_factory_gpu_ on the raster thread

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -400,13 +400,12 @@ Shell::~Shell() {
 
   fml::TaskRunner::RunNowOrPostTask(
       task_runners_.GetRasterTaskRunner(),
-      fml::MakeCopyable([rasterizer = std::move(rasterizer_),
-                         weak_factory_gpu = std::move(weak_factory_gpu_),
-                         &gpu_latch]() mutable {
-        rasterizer.reset();
-        weak_factory_gpu.reset();
-        gpu_latch.Signal();
-      }));
+      fml::MakeCopyable(
+          [this, rasterizer = std::move(rasterizer_), &gpu_latch]() mutable {
+            rasterizer.reset();
+            this->weak_factory_gpu_.reset();
+            gpu_latch.Signal();
+          }));
   gpu_latch.Wait();
 
   fml::TaskRunner::RunNowOrPostTask(


### PR DESCRIPTION
weak_factory_gpu_ should only be accessed on the raster thread.  If the Shell
destructor running on the platform thread does a std::move of
weak_factory_gpu_, then pending raster thread tasks may read it as null.

Fixes internal bug b/166295661