### PR TITLE
Extract Dart test utilities library

### DIFF
--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -12,6 +12,8 @@ import 'package:image/image.dart' as dart_image;
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
+import 'test_util.dart';
+
 typedef CanvasCallback = void Function(Canvas canvas);
 
 Future<Image> createImage(int width, int height) {
@@ -36,35 +38,6 @@ void testCanvas(CanvasCallback callback) {
   try {
     callback(Canvas(PictureRecorder(), const Rect.fromLTRB(0.0, 0.0, 0.0, 0.0)));
   } catch (error) { } // ignore: empty_catches
-}
-
-void expectAssertion(Function callback) {
-  bool assertsEnabled = false;
-  assert(() {
-    assertsEnabled = true;
-    return true;
-  }());
-  if (assertsEnabled) {
-    bool threw = false;
-    try {
-      callback();
-    } catch (e) {
-      expect(e is AssertionError, true);
-      threw = true;
-    }
-    expect(threw, true);
-  }
-}
-
-void expectArgumentError(Function callback) {
-  bool threw = false;
-  try {
-    callback();
-  } catch (e) {
-    expect(e is ArgumentError, true);
-    threw = true;
-  }
-  expect(threw, true);
 }
 
 void testNoCrashes() {

--- a/testing/dart/test_util.dart
+++ b/testing/dart/test_util.dart
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.6
+
+import 'package:test/test.dart';
+
+/// Asserts that `callback` throws an [AssertionError].
+///
+/// When running in a VM in which assertions are enabled, asserts that the
+/// specified callback throws an [AssertionError]. When asserts are not
+/// enabled, such as when running using a release-mode VM with default
+/// settings, this acts as a no-op.
+void expectAssertion(Function callback) {
+  bool assertsEnabled = false;
+  assert(() {
+    assertsEnabled = true;
+    return true;
+  }());
+  if (assertsEnabled) {
+    bool threw = false;
+    try {
+      callback();
+    } catch (e) {
+      expect(e is AssertionError, true);
+      threw = true;
+    }
+    expect(threw, true);
+  }
+}
+
+/// Asserts that `callback` throws an [ArgumentError].
+void expectArgumentError(Function callback) {
+  bool threw = false;
+  try {
+    callback();
+  } catch (e) {
+    expect(e is ArgumentError, true);
+    threw = true;
+  }
+  expect(threw, true);
+}
+

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -395,7 +395,7 @@ def RunDartTests(build_dir, filter, verbose_dart_snapshot):
   # Now that we have the Sky packages at the hardcoded location, run `pub get`.
   RunEngineExecutable(build_dir, os.path.join('dart-sdk', 'bin', 'pub'), None, flags=['get'], cwd=dart_tests_dir)
 
-  dart_tests = glob.glob('%s/*.dart' % dart_tests_dir)
+  dart_tests = glob.glob('%s/*_test.dart' % dart_tests_dir)
 
   for dart_test_file in dart_tests:
     if filter is not None and os.path.basename(dart_test_file) not in filter:


### PR DESCRIPTION
## Description

This extracts a Dart test utilities library, containing `expectAssertion` and `expectArgumentError` functions that simplify running tests that test assertions across debug, profile, and release configurations.

This change also restricts Dart unit tests to testing files whose filename matches `*_test.dart` under `flutter/testing/dart`; previously any file in that directory was run, but all files matched the above pattern.