### PR TITLE
[WIP] Exposing matrix convolution as image filter.

### DIFF
--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/lib/ui/painting/matrix.h"
 #include "third_party/skia/include/effects/SkBlurImageFilter.h"
+#include "third_party/skia/include/effects/SkImageFilters.h"
 #include "third_party/skia/include/effects/SkImageSource.h"
 #include "third_party/skia/include/effects/SkPictureImageFilter.h"
 #include "third_party/tonic/converter/dart_converter.h"
@@ -26,7 +27,8 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, ImageFilter);
   V(ImageFilter, initImage)   \
   V(ImageFilter, initPicture) \
   V(ImageFilter, initBlur)    \
-  V(ImageFilter, initMatrix)
+  V(ImageFilter, initMatrix)  \
+  V(ImageFilter, initMatrixConvolution)
 
 FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
 
@@ -62,6 +64,22 @@ void ImageFilter::initMatrix(const tonic::Float64List& matrix4,
   filter_ = SkImageFilter::MakeMatrixFilter(
       ToSkMatrix(matrix4), static_cast<SkFilterQuality>(filterQuality),
       nullptr);
+}
+
+void ImageFilter::initMatrixConvolution(uint32_t kernelWidth, uint32_t kernelHeight, const tonic::Float64List& kernelList) {
+  const SkISize kernelSize = SkISize::Make(kernelWidth, kernelHeight);
+  const SkIPoint canvasOffset = SkIPoint::Make(0, 0);
+  const SkScalar gain = 1;
+  const SkScalar bias = 0;
+
+  SkScalar kernel[9];
+  for (int i = 0; i < kernelList.num_elements(); i++) {
+    kernel[i] = SkIntToScalar(kernelList[i]);
+  }
+  filter_ = SkImageFilters::MatrixConvolution(
+      kernelSize, kernel, gain, bias, canvasOffset, SkTileMode::kRepeat,
+      /*convolveAlpha=*/false, /*input=*/nullptr,
+      /*cropRect=*/nullptr);
 }
 
 }  // namespace flutter

--- a/lib/ui/painting/image_filter.h
+++ b/lib/ui/painting/image_filter.h
@@ -25,6 +25,7 @@ class ImageFilter : public RefCountedDartWrappable<ImageFilter> {
   void initPicture(Picture*);
   void initBlur(double sigma_x, double sigma_y);
   void initMatrix(const tonic::Float64List& matrix4, int filter_quality);
+  void initMatrixConvolution(uint32_t kernelWidth, uint32_t kernelHeight, const tonic::Float64List& kernelList);
 
   const sk_sp<SkImageFilter>& filter() const { return filter_; }
 


### PR DESCRIPTION
There's still a few things missing, I'd love to get some input on
* What type of tests to create (and where)
* How to best passing down kernel width and height (just append to data? Or introduce new members to `_ImageFilter`?)
* Should the first version expose all parameters available in SkImageFilters::MatrixConvolution? If yes, how do I best wrap all of these types?

## Description

Exposing MatrixConvolution as Image filter, still a work in progress.

## Related Issues

https://github.com/flutter/flutter/issues/37919

## Tests

I added the following tests:

Unsure what tests would make sense here, 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*