### PR TITLE
Adopt NWListener in observatory publisher

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -152,9 +152,13 @@ source_set("flutter_framework_source") {
     "UIKit.framework",
   ]
   if (flutter_runtime_mode == "profile" || flutter_runtime_mode == "debug") {
-    # This is required by the profiler_metrics_ios.mm to get GPU statistics.
-    # Usage in release builds will cause rejection from the App Store.
-    libs += [ "IOKit.framework" ]
+    libs += [
+      # This is required by the profiler_metrics_ios.mm to get GPU statistics.
+      # Usage in release builds will cause rejection from the App Store.
+      "IOKit.framework",
+      # Used by the observatory publisher.
+      "Network.framework",
+    ]
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -33,6 +33,10 @@
 // 3) The Dart multicast_dns package, which is what Flutter uses to find the
 //    port and auth code. If the advertizement shows up in dns-sd and Python
 //    zeroconf but not multicast_dns, then it is a bug in multicast_dns.
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_13_0
+#include <Network/Network.h>
+#endif
+
 #include <dns_sd.h>
 #include <net/if.h>
 
@@ -58,6 +62,10 @@
 @property(readonly) NSString* serviceName;
 @property(readonly) fml::scoped_nsobject<NSObject<FlutterObservatoryPublisherDelegate>> delegate;
 
+@end
+
+API_AVAILABLE(ios(13.0))
+@interface ObservatoryNWListenerDelegate : NSObject <FlutterObservatoryPublisherDelegate>
 @end
 
 @interface ObservatoryNSNetServiceDelegate
@@ -109,7 +117,7 @@
   int err =
       DNSServiceRegister(&_dnsServiceRef, flags, interfaceIndex,
                          [_owner.get().serviceName UTF8String], registrationType, domain, NULL,
-                         htons(port), txtData.length, txtData.bytes, registrationCallback, NULL);
+                         htons(port), txtData.length, txtData.bytes, dnsRegistrationCallback, NULL);
 
   if (err != 0) {
     FML_LOG(ERROR) << "Failed to register observatory port with mDNS.";
@@ -118,19 +126,127 @@
   }
 }
 
-static void DNSSD_API registrationCallback(DNSServiceRef sdRef,
-                                           DNSServiceFlags flags,
-                                           DNSServiceErrorType errorCode,
-                                           const char* name,
-                                           const char* regType,
-                                           const char* domain,
-                                           void* context) {
+static void DNSSD_API dnsRegistrationCallback(DNSServiceRef sdRef,
+                                              DNSServiceFlags flags,
+                                              DNSServiceErrorType errorCode,
+                                              const char* name,
+                                              const char* regType,
+                                              const char* domain,
+                                              void* context) {
   if (errorCode == kDNSServiceErr_NoError) {
     FML_DLOG(INFO) << "FlutterObservatoryPublisher is ready!";
   } else {
     FML_LOG(ERROR) << "Could not register as server for FlutterObservatoryPublisher. Check your "
                       "network settings and relaunch the application.";
   }
+}
+
+@end
+
+@implementation ObservatoryNWListenerDelegate {
+  fml::scoped_nsobject<FlutterObservatoryPublisher> _owner;
+  nw_listener_t _listener;
+}
+
+@synthesize url;
+
+- (instancetype)initWithOwner:(FlutterObservatoryPublisher*)owner {
+  self = [super init];
+  NSAssert(self, @"Super must not return null on init.");
+  _owner.reset([owner retain]);
+  return self;
+}
+
+- (void)dealloc {
+  if (_listener != nil) {
+    nw_listener_cancel(_listener);
+    nw_release(_listener);
+  }
+  [super dealloc];
+}
+
+- (void)stopService {
+  if (_listener != nil) {
+    nw_listener_cancel(_listener);
+  }
+  _listener = nil;
+}
+
+- (void)publishServiceProtocolPort:(NSString*)uri {
+  url.reset([[NSURL alloc] initWithString:uri]);
+
+  // Make sure previous any previous listener is cancelled.
+  [self stopService];
+
+  nw_advertise_descriptor_t descriptor = nw_advertise_descriptor_create_bonjour_service(
+      NSBundle.mainBundle.bundleIdentifier.UTF8String, "_dartobservatory._tcp", NULL);
+  if (descriptor == nil) {
+    FML_LOG(ERROR) << "Failed to create Bonjour service _dartobservatory._tcp.";
+    return;
+  }
+
+  // uri comes in as something like 'http://127.0.0.1:XXXXX/YYYYY/' where XXXXX is the port and
+  // YYYYY is the auth code. number.
+  nw_txt_record_t txtRecord = nw_txt_record_create_dictionary();
+  NSString* path = [[url path] substringFromIndex:MIN(1, [url path].length)];
+  NSData* pathData = [path dataUsingEncoding:NSUTF8StringEncoding];
+
+  nw_txt_record_set_key(txtRecord, "authCode", (uint8_t*)pathData.bytes, pathData.length);
+
+  nw_advertise_descriptor_set_txt_record_object(descriptor, txtRecord);
+  nw_release(txtRecord);
+
+  nw_parameters_t parameters = nw_parameters_create_secure_tcp(NW_PARAMETERS_DISABLE_PROTOCOL,
+                                                               NW_PARAMETERS_DEFAULT_CONFIGURATION);
+
+  if (parameters == nil) {
+    FML_LOG(ERROR) << "Failed to create mDNS networking parameters.";
+    return;
+  }
+  nw_parameters_set_reuse_local_address(parameters, true);
+
+#if TARGET_IPHONE_SIMULATOR
+  // Simulator needs to use local loopback explicitly to work.
+  nw_parameters_set_required_interface_type(parameters, nw_interface_type_loopback);
+#else   // TARGET_IPHONE_SIMULATOR
+  // Physical devices need to request all interfaces.
+#endif  // TARGET_IPHONE_SIMULATOR
+
+  if ([url port] == nil) {
+    _listener = nw_listener_create(parameters);
+  } else {
+    _listener = nw_listener_create_with_port([url port].stringValue.UTF8String, parameters);
+  }
+  nw_release(parameters);
+
+  nw_listener_set_queue(_listener, dispatch_get_main_queue());
+  nw_listener_set_advertise_descriptor(_listener, descriptor);
+  nw_release(descriptor);
+
+  nw_listener_set_state_changed_handler(
+      _listener, ^(nw_listener_state_t state, _Nullable nw_error_t error) {
+        switch (state) {
+          case nw_listener_state_ready:
+            FML_DLOG(INFO) << "FlutterObservatoryPublisher is ready!";
+            break;
+          case nw_listener_state_failed:
+            FML_LOG(ERROR)
+                << "Could not register as server for FlutterObservatoryPublisher. Check your "
+                   "network settings and relaunch the application.";
+            break;
+          case nw_listener_state_cancelled:
+            FML_DLOG(INFO) << "Cancelled FlutterObservatoryPublisher port publication";
+            break;
+          default:
+            break;
+        }
+      });
+
+  nw_listener_set_new_connection_handler(_listener, ^(nw_connection_t connection) {
+    FML_DLOG(INFO) << "New connection detected";
+  });
+
+  nw_listener_start(_listener);
 }
 
 @end
@@ -193,7 +309,9 @@ static void DNSSD_API registrationCallback(DNSServiceRef sdRef,
   self = [super init];
   NSAssert(self, @"Super must not return null on init.");
 
-  if (@available(iOS 9.3, *)) {
+  if (@available(iOS 13.0, *)) {
+    _delegate.reset([[ObservatoryNWListenerDelegate alloc] initWithOwner:self]);
+  } else if (@available(iOS 9.3, *)) {
     _delegate.reset([[ObservatoryDNSServiceDelegate alloc] initWithOwner:self]);
   } else {
     _delegate.reset([[ObservatoryNSNetServiceDelegate alloc] initWithOwner:self]);


### PR DESCRIPTION
## Description

Adopt Network.framework APIs in observatory publisher.

In order to get this working, in the app's Info.plist add:
```
+       <key>NSBonjourServices</key>
+       <array>
+               <string>_dartobservatory._tcp</string>
+       </array>
```

## Related Issues

https://github.com/flutter/flutter/issues/63893
