### PR TITLE
Pass text input key events to the EventResponder if they do not yield characters

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -402,15 +402,16 @@ class InputConnectionAdaptor extends BaseInputConnection {
       } else {
         // Enter a character.
         int character = event.getUnicodeChar();
-        if (character != 0) {
-          int selStart = Math.max(0, Selection.getSelectionStart(mEditable));
-          int selEnd = Math.max(0, Selection.getSelectionEnd(mEditable));
-          int selMin = Math.min(selStart, selEnd);
-          int selMax = Math.max(selStart, selEnd);
-          if (selMin != selMax) mEditable.delete(selMin, selMax);
-          mEditable.insert(selMin, String.valueOf((char) character));
-          setSelection(selMin + 1, selMin + 1);
+        if (character == 0) {
+          return false;
         }
+        int selStart = Math.max(0, Selection.getSelectionStart(mEditable));
+        int selEnd = Math.max(0, Selection.getSelectionEnd(mEditable));
+        int selMin = Math.min(selStart, selEnd);
+        int selMax = Math.max(selStart, selEnd);
+        if (selMin != selMax) mEditable.delete(selMin, selMax);
+        mEditable.insert(selMin, String.valueOf((char) character));
+        setSelection(selMin + 1, selMin + 1);
         return true;
       }
     }

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -1106,6 +1106,17 @@ public class InputConnectionAdaptorTest {
     assertEquals(Selection.getSelectionStart(editable), 0);
   }
 
+  @Test
+  public void testDoesNotConsumeBackButton() {
+    Editable editable = sampleEditable(0, 0);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    FakeKeyEvent keyEvent = new FakeKeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK);
+    boolean didConsume = adaptor.sendKeyEvent(keyEvent);
+
+    assertFalse(didConsume);
+  }
+
   private static final String SAMPLE_TEXT =
       "Lorem ipsum dolor sit amet," + "\nconsectetur adipiscing elit.";
 

--- a/shell/platform/android/test/io/flutter/util/FakeKeyEvent.java
+++ b/shell/platform/android/test/io/flutter/util/FakeKeyEvent.java
@@ -10,6 +10,9 @@ public class FakeKeyEvent extends KeyEvent {
   }
 
   public final int getUnicodeChar() {
+    if (getKeyCode() == KeyEvent.KEYCODE_BACK) {
+      return 0;
+    }
     return 1;
   }
 }


### PR DESCRIPTION
If the InputConnectionAdaptor receives a key event that does not move
the caret or produce a text character (such as the back button), then
the event should be given to the EventResponder which will forward it
to the view.

Fixes https://github.com/flutter/flutter/issues/64864
