### PR TITLE
[web] migrate from e2e to integration_test

### DIFF
--- a/e2etests/web/regular_integration_tests/pubspec.yaml
+++ b/e2etests/web/regular_integration_tests/pubspec.yaml
@@ -13,7 +13,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  e2e: 0.4.0
+  integration_test: 0.9.0
   http: 0.12.0+2
   test: any
 

--- a/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e.dart
@@ -6,10 +6,11 @@ import 'dart:html' as html;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/image_loading_main.dart' as app;
 
-import 'package:e2e/e2e.dart';
+import 'package:integration_test/integration_test.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('Image loads asset variant based on device pixel ratio',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e.dart
@@ -9,8 +9,7 @@ import 'package:regular_integration_tests/image_loading_main.dart' as app;
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
-      as IntegrationTestWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('Image loads asset variant based on device pixel ratio',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e_test.dart
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:e2e/e2e_driver.dart' as e2e;
+import 'package:integration_test/integration_test_driver.dart' as test;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => test.integrationDriver();

--- a/e2etests/web/regular_integration_tests/test_driver/platform_messages_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/platform_messages_e2e.dart
@@ -10,10 +10,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/platform_messages_main.dart' as app;
 
-import 'package:e2e/e2e.dart';
+import 'package:integration_test/integration_test.dart';
 
 void main() async {
-  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('platform message for Clipboard.setData reply with future',
       (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/platform_messages_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/platform_messages_e2e.dart
@@ -13,8 +13,7 @@ import 'package:regular_integration_tests/platform_messages_main.dart' as app;
 import 'package:integration_test/integration_test.dart';
 
 void main() async {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
-      as IntegrationTestWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('platform message for Clipboard.setData reply with future',
       (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/platform_messages_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/platform_messages_e2e_test.dart
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:e2e/e2e_driver.dart' as e2e;
+import 'package:integration_test/integration_test_driver.dart' as test;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => test.integrationDriver();

--- a/e2etests/web/regular_integration_tests/test_driver/profile_diagnostics_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/profile_diagnostics_e2e.dart
@@ -8,8 +8,7 @@ import 'package:regular_integration_tests/profile_diagnostics_main.dart' as app;
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
-      as IntegrationTestWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('App build method exception should form valid FlutterErrorDetails',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/profile_diagnostics_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/profile_diagnostics_e2e.dart
@@ -2,15 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html' as html;
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/profile_diagnostics_main.dart' as app;
 
-import 'package:e2e/e2e.dart';
+import 'package:integration_test/integration_test.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('App build method exception should form valid FlutterErrorDetails',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/profile_diagnostics_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/profile_diagnostics_e2e_test.dart
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:e2e/e2e_driver.dart' as e2e;
+import 'package:integration_test/integration_test_driver.dart' as test;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => test.integrationDriver();

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e.dart
@@ -6,10 +6,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/target_platform_main.dart' as app;
 import 'package:flutter/material.dart';
 
-import 'package:e2e/e2e.dart';
+import 'package:integration_test/integration_test.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('Should detect android platform when running on android device',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e.dart
@@ -9,8 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
-      as IntegrationTestWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('Should detect android platform when running on android device',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_android_e2e_test.dart
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:e2e/e2e_driver.dart' as e2e;
+import 'package:integration_test/integration_test_driver.dart' as test;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => test.integrationDriver();

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
@@ -6,10 +6,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/target_platform_main.dart' as app;
 import 'package:flutter/material.dart';
 
-import 'package:e2e/e2e.dart';
+import 'package:integration_test/integration_test.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('Should detect iOS platform when running on iOS device',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e.dart
@@ -9,8 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
-      as IntegrationTestWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('Should detect iOS platform when running on iOS device',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_ios_e2e_test.dart
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:e2e/e2e_driver.dart' as e2e;
+import 'package:integration_test/integration_test_driver.dart' as test;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => test.integrationDriver();

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
@@ -6,10 +6,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/target_platform_main.dart' as app;
 import 'package:flutter/material.dart';
 
-import 'package:e2e/e2e.dart';
+import 'package:integration_test/integration_test.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('Should detect MacOS platform when running on MacOS',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e.dart
@@ -9,8 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
-      as IntegrationTestWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('Should detect MacOS platform when running on MacOS',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/target_platform_macos_e2e_test.dart
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:e2e/e2e_driver.dart' as e2e;
+import 'package:integration_test/integration_test_driver.dart' as test;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => test.integrationDriver();

--- a/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e.dart
@@ -9,10 +9,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/text_editing_main.dart' as app;
 import 'package:flutter/material.dart';
 
-import 'package:e2e/e2e.dart';
+import 'package:integration_test/integration_test.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('Focused text field creates a native input element',
       (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e.dart
@@ -12,8 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
-      as IntegrationTestWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('Focused text field creates a native input element',
       (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e_test.dart
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:e2e/e2e_driver.dart' as e2e;
+import 'package:integration_test/integration_test_driver.dart' as test;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => test.integrationDriver();

--- a/e2etests/web/regular_integration_tests/test_driver/treeshaking_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/treeshaking_e2e.dart
@@ -10,8 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
-      as IntegrationTestWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('debug+Fill+Properties for widgets is tree shaken',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/treeshaking_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/treeshaking_e2e.dart
@@ -7,10 +7,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/treeshaking_main.dart' as app;
 import 'package:flutter/material.dart';
 
-import 'package:e2e/e2e.dart';
+import 'package:integration_test/integration_test.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized() as E2EWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+      as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('debug+Fill+Properties for widgets is tree shaken',
           (WidgetTester tester) async {

--- a/e2etests/web/regular_integration_tests/test_driver/treeshaking_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/treeshaking_e2e_test.dart
@@ -2,6 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:e2e/e2e_driver.dart' as e2e;
+import 'package:integration_test/integration_test_driver.dart' as test;
 
-Future<void> main() async => e2e.main();
+Future<void> main() async => test.integrationDriver();


### PR DESCRIPTION
Use integration_test package instead of e2e for web engine integration tests.