### PR TITLE
[Android R] Integrate DisplayCutouts into viewportMetrics

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -510,6 +510,14 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   public final WindowInsets onApplyWindowInsets(@NonNull WindowInsets insets) {
     WindowInsets newInsets = super.onApplyWindowInsets(insets);
 
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      Insets systemGestureInsets = insets.getSystemGestureInsets();
+      viewportMetrics.systemGestureInsetTop = systemGestureInsets.top;
+      viewportMetrics.systemGestureInsetRight = systemGestureInsets.right;
+      viewportMetrics.systemGestureInsetBottom = systemGestureInsets.bottom;
+      viewportMetrics.systemGestureInsetLeft = systemGestureInsets.left;
+    }
+
     boolean statusBarVisible = (SYSTEM_UI_FLAG_FULLSCREEN & getWindowSystemUiVisibility()) == 0;
     boolean navigationBarVisible =
         (SYSTEM_UI_FLAG_HIDE_NAVIGATION & getWindowSystemUiVisibility()) == 0;
@@ -537,16 +545,15 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
       // TODO(garyq): Expose the full rects of the display cutout.
 
       // Take the max of the display cutout insets and ui element insets to merge them
-      DisplayCutout cutout = insets.getDisplayCutout();
+      DisplayCutout cutout = getDisplay().getCutout();
       if (cutout != null) {
         Insets waterfallInsets = cutout.getWaterfallInsets();
-
-        viewportMetrics.paddingTop = Math.max(Math.max(viewportMetrics.paddingTop, waterfallInsets.top), cutout.getSafeInsetTop());
-        viewportMetrics.paddingRight = Math.max(Math.max(viewportMetrics.paddingRight, waterfallInsets.right), cutout.getSafeInsetRight());
-        viewportMetrics.paddingBottom = Math.max(waterfallInsets.bottom, cutout.getSafeInsetBottom());
-        viewportMetrics.paddingLeft = Math.max(Math.max(viewportMetrics.paddingLeft, waterfallInsets.left), cutout.getSafeInsetLeft());
-
+        viewportMetrics.systemGestureInsetTop = Math.max(Math.max(viewportMetrics.systemGestureInsetTop, waterfallInsets.top), cutout.getSafeInsetTop());
+        viewportMetrics.systemGestureInsetRight = Math.max(Math.max(viewportMetrics.systemGestureInsetRight, waterfallInsets.right), cutout.getSafeInsetRight());
+        viewportMetrics.systemGestureInsetBottom = Math.max(Math.max(viewportMetrics.systemGestureInsetBottom, waterfallInsets.bottom), cutout.getSafeInsetBottom());
+        viewportMetrics.systemGestureInsetLeft = Math.max(Math.max(viewportMetrics.systemGestureInsetLeft, waterfallInsets.left), cutout.getSafeInsetLeft());
       }
+
     } else {
       // We zero the left and/or right sides to prevent the padding the
       // navigation bar would have caused.
@@ -578,13 +585,6 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
       viewportMetrics.viewInsetLeft = 0;
     }
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      Insets systemGestureInsets = insets.getSystemGestureInsets();
-      viewportMetrics.systemGestureInsetTop = systemGestureInsets.top;
-      viewportMetrics.systemGestureInsetRight = systemGestureInsets.right;
-      viewportMetrics.systemGestureInsetBottom = systemGestureInsets.bottom;
-      viewportMetrics.systemGestureInsetLeft = systemGestureInsets.left;
-    }
 
     Log.v(
         TAG,

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -44,7 +44,6 @@ import io.flutter.plugin.localization.LocalizationPlugin;
 import io.flutter.plugin.mouse.MouseCursorPlugin;
 import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.view.AccessibilityBridge;
-import java.lang.Math;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -544,7 +543,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
 
       // TODO(garyq): Expose the full rects of the display cutout.
 
-      // Take the max of the display cutout insets and ui element insets to merge them
+      // Take the max of the display cutout insets and existing insets to merge them
       DisplayCutout cutout = getDisplay().getCutout();
       if (cutout != null) {
         Insets waterfallInsets = cutout.getWaterfallInsets();

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -544,7 +544,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
       // TODO(garyq): Expose the full rects of the display cutout.
 
       // Take the max of the display cutout insets and existing insets to merge them
-      DisplayCutout cutout = getDisplay().getCutout();
+      DisplayCutout cutout = insets.getCutout();
       if (cutout != null) {
         Insets waterfallInsets = cutout.getWaterfallInsets();
         viewportMetrics.systemGestureInsetTop = Math.max(Math.max(viewportMetrics.systemGestureInsetTop, waterfallInsets.top), cutout.getSafeInsetTop());

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -542,7 +542,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
       viewportMetrics.viewInsetBottom = imeInsets.bottom; // Typically, only bottom is non-zero
       viewportMetrics.viewInsetLeft = imeInsets.left;
 
-      Insets systemGestureInsets = insets.getInsets(android.view.WindowInsets.Type.systemGestures());
+      Insets systemGestureInsets =
+          insets.getInsets(android.view.WindowInsets.Type.systemGestures());
       viewportMetrics.systemGestureInsetTop = systemGestureInsets.top;
       viewportMetrics.systemGestureInsetRight = systemGestureInsets.right;
       viewportMetrics.systemGestureInsetBottom = systemGestureInsets.bottom;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -543,9 +543,9 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
 
         viewportMetrics.paddingTop = Math.max(Math.max(viewportMetrics.paddingTop, waterfallInsets.top), cutout.getSafeInsetTop());
         viewportMetrics.paddingRight = Math.max(Math.max(viewportMetrics.paddingRight, waterfallInsets.right), cutout.getSafeInsetRight());
+        viewportMetrics.paddingBottom = Math.max(waterfallInsets.bottom, cutout.getSafeInsetBottom());
         viewportMetrics.paddingLeft = Math.max(Math.max(viewportMetrics.paddingLeft, waterfallInsets.left), cutout.getSafeInsetLeft());
 
-        viewportMetrics.viewInsetBottom = Math.max(Math.max(viewportMetrics.viewInsetBottom, waterfallInsets.bottom), cutout.getSafeInsetBottom());
       }
     } else {
       // We zero the left and/or right sides to prevent the padding the

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -622,7 +622,8 @@ public class FlutterView extends SurfaceView
       mMetrics.physicalViewInsetBottom = imeInsets.bottom; // Typically, only bottom is non-zero
       mMetrics.physicalViewInsetLeft = imeInsets.left;
 
-      Insets systemGestureInsets = insets.getInsets(android.view.WindowInsets.Type.systemGestures());
+      Insets systemGestureInsets =
+          insets.getInsets(android.view.WindowInsets.Type.systemGestures());
       mMetrics.systemGestureInsetTop = systemGestureInsets.top;
       mMetrics.systemGestureInsetRight = systemGestureInsets.right;
       mMetrics.systemGestureInsetBottom = systemGestureInsets.bottom;

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -625,7 +625,7 @@ public class FlutterView extends SurfaceView
       // TODO(garyq): Expose the full rects of the display cutout.
 
       // Take the max of the display cutout insets and existing insets to merge them
-      DisplayCutout cutout = getDisplay().getCutout();
+      DisplayCutout cutout = insets.getCutout();
       if (cutout != null) {
         Insets waterfallInsets = cutout.getWaterfallInsets();
         mMetrics.systemGestureInsetTop = Math.max(Math.max(mMetrics.systemGestureInsetTop, waterfallInsets.top), cutout.getSafeInsetTop());

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -21,6 +21,7 @@ import android.text.format.DateFormat;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.SparseArray;
+import android.view.DisplayCutout;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.PointerIcon;
@@ -588,40 +589,6 @@ public class FlutterView extends SurfaceView
   @RequiresApi(20)
   @SuppressLint({"InlinedApi", "NewApi"})
   public final WindowInsets onApplyWindowInsets(WindowInsets insets) {
-    boolean statusBarHidden = (SYSTEM_UI_FLAG_FULLSCREEN & getWindowSystemUiVisibility()) != 0;
-    boolean navigationBarHidden =
-        (SYSTEM_UI_FLAG_HIDE_NAVIGATION & getWindowSystemUiVisibility()) != 0;
-
-    // We zero the left and/or right sides to prevent the padding the
-    // navigation bar would have caused.
-    ZeroSides zeroSides = ZeroSides.NONE;
-    if (navigationBarHidden) {
-      zeroSides = calculateShouldZeroSides();
-    }
-
-    // The padding on top should be removed when the statusbar is hidden.
-    mMetrics.physicalPaddingTop = statusBarHidden ? 0 : insets.getSystemWindowInsetTop();
-    mMetrics.physicalPaddingRight =
-        zeroSides == ZeroSides.RIGHT || zeroSides == ZeroSides.BOTH
-            ? 0
-            : insets.getSystemWindowInsetRight();
-    mMetrics.physicalPaddingBottom = 0;
-    mMetrics.physicalPaddingLeft =
-        zeroSides == ZeroSides.LEFT || zeroSides == ZeroSides.BOTH
-            ? 0
-            : insets.getSystemWindowInsetLeft();
-
-    // Bottom system inset (keyboard) should adjust scrollable bottom edge (inset).
-    mMetrics.physicalViewInsetTop = 0;
-    mMetrics.physicalViewInsetRight = 0;
-    // We perform hidden navbar and keyboard handling if the navbar is set to hidden. Otherwise,
-    // the navbar padding should always be provided.
-    mMetrics.physicalViewInsetBottom =
-        navigationBarHidden
-            ? guessBottomKeyboardInset(insets)
-            : insets.getSystemWindowInsetBottom();
-    mMetrics.physicalViewInsetLeft = 0;
-
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       Insets systemGestureInsets = insets.getSystemGestureInsets();
       mMetrics.systemGestureInsetTop = systemGestureInsets.top;
@@ -629,6 +596,75 @@ public class FlutterView extends SurfaceView
       mMetrics.systemGestureInsetBottom = systemGestureInsets.bottom;
       mMetrics.systemGestureInsetLeft = systemGestureInsets.left;
     }
+
+    boolean statusBarVisible = (SYSTEM_UI_FLAG_FULLSCREEN & getWindowSystemUiVisibility()) == 0;
+    boolean navigationBarVisible =
+        (SYSTEM_UI_FLAG_HIDE_NAVIGATION & getWindowSystemUiVisibility()) == 0;
+
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      int mask = android.view.WindowInsets.Type.ime();
+      if (navigationBarVisible) {
+        mask = mask | android.view.WindowInsets.Type.navigationBars();
+      }
+      if (statusBarVisible) {
+        mask = mask | android.view.WindowInsets.Type.statusBars();
+      }
+      Insets uiInsets = insets.getInsets(mask);
+
+      mMetrics.physicalPaddingTop = uiInsets.top;
+      mMetrics.physicalPaddingRight = uiInsets.right;
+      mMetrics.physicalPaddingBottom = 0;
+      mMetrics.physicalPaddingLeft = uiInsets.left;
+
+      mMetrics.physicalViewInsetTop = 0;
+      mMetrics.physicalViewInsetRight = 0;
+      mMetrics.physicalViewInsetBottom = uiInsets.bottom;
+      mMetrics.physicalViewInsetLeft = 0;
+
+      // TODO(garyq): Expose the full rects of the display cutout.
+
+      // Take the max of the display cutout insets and existing insets to merge them
+      DisplayCutout cutout = getDisplay().getCutout();
+      if (cutout != null) {
+        Insets waterfallInsets = cutout.getWaterfallInsets();
+        mMetrics.systemGestureInsetTop = Math.max(Math.max(mMetrics.systemGestureInsetTop, waterfallInsets.top), cutout.getSafeInsetTop());
+        mMetrics.systemGestureInsetRight = Math.max(Math.max(mMetrics.systemGestureInsetRight, waterfallInsets.right), cutout.getSafeInsetRight());
+        mMetrics.systemGestureInsetBottom = Math.max(Math.max(mMetrics.systemGestureInsetBottom, waterfallInsets.bottom), cutout.getSafeInsetBottom());
+        mMetrics.systemGestureInsetLeft = Math.max(Math.max(mMetrics.systemGestureInsetLeft, waterfallInsets.left), cutout.getSafeInsetLeft());
+      }
+
+    } else {
+      // We zero the left and/or right sides to prevent the padding the
+      // navigation bar would have caused.
+      ZeroSides zeroSides = ZeroSides.NONE;
+      if (!navigationBarVisible) {
+        zeroSides = calculateShouldZeroSides();
+      }
+
+      // Status bar (top) and left/right system insets should partially obscure the content
+      // (padding).
+      mMetrics.physicalPaddingTop = statusBarVisible ? insets.getSystemWindowInsetTop() : 0;
+      mMetrics.physicalPaddingRight =
+          zeroSides == ZeroSides.RIGHT || zeroSides == ZeroSides.BOTH
+              ? 0
+              : insets.getSystemWindowInsetRight();
+      mMetrics.physicalPaddingBottom = 0;
+      mMetrics.physicalPaddingLeft =
+          zeroSides == ZeroSides.LEFT || zeroSides == ZeroSides.BOTH
+              ? 0
+              : insets.getSystemWindowInsetLeft();
+
+      // Bottom system inset (keyboard) should adjust scrollable bottom edge (inset).
+      mMetrics.physicalViewInsetTop = 0;
+      mMetrics.physicalViewInsetRight = 0;
+      mMetrics.physicalViewInsetBottom =
+          navigationBarVisible
+              ? insets.getSystemWindowInsetBottom()
+              : guessBottomKeyboardInset(insets);
+      mMetrics.physicalViewInsetLeft = 0;
+    }
+
     updateViewportMetrics();
     return super.onApplyWindowInsets(insets);
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -22,6 +22,7 @@ import android.graphics.Insets;
 import android.media.Image;
 import android.media.Image.Plane;
 import android.media.ImageReader;
+import android.view.DisplayCutout;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowInsets;
@@ -523,8 +524,8 @@ public class FlutterViewTest {
     when(windowInsets.getSystemWindowInsetLeft()).thenReturn(-1);
     when(windowInsets.getSystemWindowInsetRight()).thenReturn(-1);
     when(windowInsets.getInsets(anyInt())).thenReturn(insets);
-    when(windowInsets.getSystemGestureInsets(anyInt())).thenReturn(systemGestureInsets);
-    when(windowInsets.getCutout()).thenReturn(displayCutout);
+    when(windowInsets.getSystemGestureInsets()).thenReturn(systemGestureInsets);
+    when(windowInsets.getDisplayCutout()).thenReturn(displayCutout);
 
     Insets waterfallInsets = Insets.of(200, 0, 200, 0);
     when(displayCutout.getWaterfallInsets()).thenReturn(waterfallInsets);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -496,7 +496,6 @@ public class FlutterViewTest {
             ((WindowManager)
                     RuntimeEnvironment.systemContext.getSystemService(Context.WINDOW_SERVICE))
                 .getDefaultDisplay());
-    // display.setRotation(0);
     assertEquals(0, flutterView.getSystemUiVisibility());
     when(flutterView.getWindowSystemUiVisibility()).thenReturn(0);
     when(flutterView.getContext()).thenReturn(RuntimeEnvironment.systemContext);
@@ -529,20 +528,20 @@ public class FlutterViewTest {
 
     Insets waterfallInsets = Insets.of(200, 0, 200, 0);
     when(displayCutout.getWaterfallInsets()).thenReturn(waterfallInsets);
-    when(displatCutout.getSafeInsetTop()).thenReturn(150);
-    when(displatCutout.getSafeInsetBottom()).thenReturn(150);
-    when(displatCutout.getSafeInsetLeft()).thenReturn(150);
-    when(displatCutout.getSafeInsetRight()).thenReturn(150);
+    when(displayCutout.getSafeInsetTop()).thenReturn(150);
+    when(displayCutout.getSafeInsetBottom()).thenReturn(150);
+    when(displayCutout.getSafeInsetLeft()).thenReturn(150);
+    when(displayCutout.getSafeInsetRight()).thenReturn(150);
 
     flutterView.onApplyWindowInsets(windowInsets);
 
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(150, viewportMetricsCaptor.getValue().systemGestureInsetTop);
-    assertEquals(150, viewportMetricsCaptor.getValue().systemGestureInsetBottom);
-    assertEquals(200, viewportMetricsCaptor.getValue().systemGestureInsetLeft);
-    assertEquals(200, viewportMetricsCaptor.getValue().systemGestureInsetRight);
+    assertEquals(150, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(150, viewportMetricsCaptor.getValue().paddingBottom);
+    assertEquals(200, viewportMetricsCaptor.getValue().paddingLeft);
+    assertEquals(200, viewportMetricsCaptor.getValue().paddingRight);
 
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewInsetTop);
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/56599

Integrates the display cutout data into the existing padding and view insets API

This does not make use of the detailed cutout rects, which may be added in a future PR as new API.

https://github.com/flutter/flutter/issues/65088 tracks additional work to expose the full rects.