### PR TITLE
Increase thread priority before engine init

### DIFF
--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -135,6 +135,7 @@ AndroidShellHolder::AndroidShellHolder(
 
   platform_view_ = weak_platform_view;
   FML_DCHECK(platform_view_);
+  is_valid_ = shell_ != nullptr;
 }
 
 AndroidShellHolder::~AndroidShellHolder() {

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -107,6 +107,23 @@ AndroidShellHolder::AndroidShellHolder(
                                     ui_runner,        // ui
                                     io_runner         // io
   );
+  shell_->GetTaskRunners().GetRasterTaskRunner()->PostTask([]() {
+    // Android describes -8 as "most important display threads, for
+    // compositing the screen and retrieving input events". Conservatively
+    // set the raster thread to slightly lower priority than it.
+    if (::setpriority(PRIO_PROCESS, gettid(), -5) != 0) {
+      // Defensive fallback. Depending on the OEM, it may not be possible
+      // to set priority to -5.
+      if (::setpriority(PRIO_PROCESS, gettid(), -2) != 0) {
+        FML_LOG(ERROR) << "Failed to set GPU task runner priority";
+      }
+    }
+  });
+  shell_->GetTaskRunners().GetUITaskRunner()->PostTask([]() {
+    if (::setpriority(PRIO_PROCESS, gettid(), -1) != 0) {
+      FML_LOG(ERROR) << "Failed to set UI task runner priority";
+    }
+  });
 
   shell_ =
       Shell::Create(task_runners,              // task runners
@@ -118,28 +135,6 @@ AndroidShellHolder::AndroidShellHolder(
 
   platform_view_ = weak_platform_view;
   FML_DCHECK(platform_view_);
-
-  is_valid_ = shell_ != nullptr;
-
-  if (is_valid_) {
-    shell_->GetTaskRunners().GetRasterTaskRunner()->PostTask([]() {
-      // Android describes -8 as "most important display threads, for
-      // compositing the screen and retrieving input events". Conservatively
-      // set the raster thread to slightly lower priority than it.
-      if (::setpriority(PRIO_PROCESS, gettid(), -5) != 0) {
-        // Defensive fallback. Depending on the OEM, it may not be possible
-        // to set priority to -5.
-        if (::setpriority(PRIO_PROCESS, gettid(), -2) != 0) {
-          FML_LOG(ERROR) << "Failed to set GPU task runner priority";
-        }
-      }
-    });
-    shell_->GetTaskRunners().GetUITaskRunner()->PostTask([]() {
-      if (::setpriority(PRIO_PROCESS, gettid(), -1) != 0) {
-        FML_LOG(ERROR) << "Failed to set UI task runner priority";
-      }
-    });
-  }
 }
 
 AndroidShellHolder::~AndroidShellHolder() {

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -107,7 +107,7 @@ AndroidShellHolder::AndroidShellHolder(
                                     ui_runner,        // ui
                                     io_runner         // io
   );
-  shell_->GetTaskRunners().GetRasterTaskRunner()->PostTask([]() {
+  task_runners.GetRasterTaskRunner()->PostTask([]() {
     // Android describes -8 as "most important display threads, for
     // compositing the screen and retrieving input events". Conservatively
     // set the raster thread to slightly lower priority than it.
@@ -119,7 +119,7 @@ AndroidShellHolder::AndroidShellHolder(
       }
     }
   });
-  shell_->GetTaskRunners().GetUITaskRunner()->PostTask([]() {
+  task_runners.GetUITaskRunner()->PostTask([]() {
     if (::setpriority(PRIO_PROCESS, gettid(), -1) != 0) {
       FML_LOG(ERROR) << "Failed to set UI task runner priority";
     }


### PR DESCRIPTION
## Description

We get huge ANRs in not pure flutter app.
We found that 0.15% of the engine initialization took more than 10 seconds, every 10 million starts.

Fellow code show, engine init in ui thread. So Increase thread priority before engine init can reduce time cost

```
// shell/common/shell.cc
fml::TaskRunner::RunNowOrPostTask(
      shell->GetTaskRunners().GetUITaskRunner(),
      fml::MakeCopyable([&engine_promise,                                 //
                         shell = shell.get(),                             //
                         &dispatcher_maker,                               //
                         &platform_data,                                  //
                         isolate_snapshot = std::move(isolate_snapshot),  //
                         vsync_waiter = std::move(vsync_waiter),          //
                         &weak_io_manager_future,                         //
                         &snapshot_delegate_future,                       //
                         &unref_queue_future                              //
  ]() mutable {
        TRACE_EVENT0("flutter", "ShellSetupUISubsystem");
        const auto& task_runners = shell->GetTaskRunners();

        // The animator is owned by the UI thread but it gets its vsync pulses
        // from the platform.
        auto animator = std::make_unique<Animator>(*shell, task_runners,
                                                   std::move(vsync_waiter));

        engine_promise.set_value(std::make_unique<Engine>(
            *shell,                         //
            dispatcher_maker,               //
            *shell->GetDartVM(),            //
            std::move(isolate_snapshot),    //
            task_runners,                   //
            platform_data,                  //
            shell->GetSettings(),           //
            std::move(animator),            //
            weak_io_manager_future.get(),   //
            unref_queue_future.get(),       //
            snapshot_delegate_future.get()  //
            ));
      }));

```

## Tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
