### PR TITLE
Clear the GL context only after submitting the frame

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -404,7 +404,9 @@ RasterStatus Rasterizer::DoDraw(
 
 RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
   TRACE_EVENT0("flutter", "Rasterizer::DrawToSurface");
-  FML_DCHECK(surface_);
+  if (!surface_) {
+    return RasterStatus::kFailed;
+  }
 
   // There is no way for the compositor to know how long the layer tree
   // construction took. Fortunately, the layer tree does. Grab that time

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -550,13 +550,6 @@ sk_sp<SkData> Rasterizer::ScreenshotLayerTreeAsImage(
   SkMatrix root_surface_transformation;
   root_surface_transformation.reset();
 
-  auto frame = compositor_context.ACQUIRE_FRAME(
-      surface_context, canvas, nullptr, root_surface_transformation, false,
-      true, nullptr);
-  canvas->clear(SK_ColorTRANSPARENT);
-  frame->Raster(*tree, true);
-  canvas->flush();
-
   // snapshot_surface->makeImageSnapshot needs the GL context to be set if the
   // render context is GL. frame->Raster() pops the gl context in platforms that
   // gl context switching are used. (For example, older iOS that uses GL) We
@@ -566,6 +559,14 @@ sk_sp<SkData> Rasterizer::ScreenshotLayerTreeAsImage(
     FML_LOG(ERROR) << "Screenshot: unable to make image screenshot";
     return nullptr;
   }
+
+  auto frame = compositor_context.ACQUIRE_FRAME(
+      surface_context, canvas, nullptr, root_surface_transformation, false,
+      true, nullptr);
+  canvas->clear(SK_ColorTRANSPARENT);
+  frame->Raster(*tree, true);
+  canvas->flush();
+
   // Prepare an image from the surface, this image may potentially be on th GPU.
   auto potentially_gpu_snapshot = snapshot_surface->makeImageSnapshot();
   if (!potentially_gpu_snapshot) {

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -178,10 +178,6 @@ void Rasterizer::Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline) {
     consume_result = PipelineConsumeResult::MoreAvailable;
   }
 
-  if (surface_ != nullptr) {
-    surface_->ClearRenderContext();
-  }
-
   // Merging the thread as we know the next `Draw` should be run on the platform
   // thread.
   if (surface_ != nullptr && surface_->GetExternalViewEmbedder() != nullptr) {
@@ -473,6 +469,11 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
       TRACE_EVENT0("flutter", "PerformDeferredSkiaCleanup");
       surface_->GetContext()->performDeferredCleanup(kSkiaCleanupExpiration);
     }
+
+    // Clean the render context after submitting the frame.
+    // This ensures that the GL context is released after drawing to the
+    // surface.
+    surface_->ClearRenderContext();
 
     return raster_status;
   }

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -470,7 +470,7 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
       surface_->GetContext()->performDeferredCleanup(kSkiaCleanupExpiration);
     }
 
-    // Clean the render context after submitting the frame.
+    // Clear the render context after submitting the frame.
     // This ensures that the GL context is released after drawing to the
     // surface.
     surface_->ClearRenderContext();


### PR DESCRIPTION
Fixes Firebase Test Lab issues which is blocking the engine->flutter roll.

Last invocations:
1) https://firebase.corp.google.com/u/0/project/flutter-infra/testlab/histories/bh.1b29258e8f97b976/matrices/6468464381574999068

2) https://firebase.corp.google.com/u/0/project/flutter-infra/testlab/histories/bh.1b29258e8f97b976/matrices/8559470172519276437