### PR TITLE
Revert "Adds fuchsia node roles to accessibility bridge updates."

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -300,12 +300,8 @@ class SemanticsFlag {
   static const int _kIsReadOnlyIndex = 1 << 20;
   static const int _kIsFocusableIndex = 1 << 21;
   static const int _kIsLinkIndex = 1 << 22;
-  static const int _kIsSliderIndex = 1 << 23;
   // READ THIS: if you add a flag here, you MUST update the numSemanticsFlags
-  // value in testing/dart/semantics_test.dart, or tests will fail. Also,
-  // please update the Flag enum in
-  // flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java,
-  // and the SemanticsFlag class in lib/web_ui/lib/src/ui/semantics.dart.
+  // value in testing/dart/semantics_test.dart, or tests will fail.
 
   const SemanticsFlag._(this.index) : assert(index != null); // ignore: unnecessary_null_comparison
 
@@ -358,9 +354,6 @@ class SemanticsFlag {
   /// Text fields are announced as such and allow text input via accessibility
   /// affordances.
   static const SemanticsFlag isTextField = SemanticsFlag._(_kIsTextFieldIndex);
-
-  /// Whether the semantic node represents a slider.
-  static const SemanticsFlag isSlider = SemanticsFlag._(_kIsSliderIndex);
 
   /// Whether the semantic node is read only.
   ///
@@ -558,8 +551,7 @@ class SemanticsFlag {
     _kIsReadOnlyIndex: isReadOnly,
     _kIsFocusableIndex: isFocusable,
     _kIsLinkIndex: isLink,
-    _kIsSliderIndex: isSlider,
-};
+  };
 
   @override
   String toString() {
@@ -610,8 +602,6 @@ class SemanticsFlag {
         return 'SemanticsFlag.isFocusable';
       case _kIsLinkIndex:
         return 'SemanticsFlag.isLink';
-      case _kIsSliderIndex:
-        return 'SemanticsFlag.isSlider';
     }
     assert(false, 'Unhandled index: $index');
     return '';

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -79,7 +79,6 @@ enum class SemanticsFlags : int32_t {
   kIsReadOnly = 1 << 20,
   kIsFocusable = 1 << 21,
   kIsLink = 1 << 22,
-  kIsSlider = 1 << 23,
 };
 
 const int kScrollableSemanticsFlags =

--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -156,7 +156,6 @@ class SemanticsFlag {
   static const int _kIsReadOnlyIndex = 1 << 20;
   static const int _kIsFocusableIndex = 1 << 21;
   static const int _kIsLinkIndex = 1 << 22;
-  static const int _kIsSliderIndex = 1 << 23;
 
   const SemanticsFlag._(this.index) : assert(index != null); // ignore: unnecessary_null_comparison
   final int index;
@@ -183,14 +182,12 @@ class SemanticsFlag {
   static const SemanticsFlag isToggled = SemanticsFlag._(_kIsToggledIndex);
   static const SemanticsFlag hasImplicitScrolling = SemanticsFlag._(_kHasImplicitScrollingIndex);
   static const SemanticsFlag isMultiline = SemanticsFlag._(_kIsMultilineIndex);
-  static const SemanticsFlag isSlider = SemanticsFlag._(_kIsSliderIndex);
   static const Map<int, SemanticsFlag> values = <int, SemanticsFlag>{
     _kHasCheckedStateIndex: hasCheckedState,
     _kIsCheckedIndex: isChecked,
     _kIsSelectedIndex: isSelected,
     _kIsButtonIndex: isButton,
     _kIsLinkIndex: isLink,
-    _kIsSliderIndex: isSlider,
     _kIsTextFieldIndex: isTextField,
     _kIsFocusableIndex: isFocusable,
     _kIsFocusedIndex: isFocused,

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -115,31 +115,6 @@ fuchsia::accessibility::semantics::States AccessibilityBridge::GetNodeStates(
   return states;
 }
 
-fuchsia::accessibility::semantics::Role AccessibilityBridge::GetNodeRole(
-    const flutter::SemanticsNode& node) const {
-  if (node.HasFlag(flutter::SemanticsFlags::kIsButton)) {
-    return fuchsia::accessibility::semantics::Role::BUTTON;
-  }
-
-  if (node.HasFlag(flutter::SemanticsFlags::kIsHeader)) {
-    return fuchsia::accessibility::semantics::Role::HEADER;
-  }
-
-  if (node.HasFlag(flutter::SemanticsFlags::kIsImage)) {
-    return fuchsia::accessibility::semantics::Role::IMAGE;
-  }
-
-  if (node.HasFlag(flutter::SemanticsFlags::kIsTextField)) {
-    return fuchsia::accessibility::semantics::Role::TEXT_FIELD;
-  }
-
-  if (node.HasFlag(flutter::SemanticsFlags::kIsSlider)) {
-    return fuchsia::accessibility::semantics::Role::SLIDER;
-  }
-
-  return fuchsia::accessibility::semantics::Role::UNKNOWN;
-}
-
 std::unordered_set<int32_t> AccessibilityBridge::GetDescendants(
     int32_t node_id) const {
   std::unordered_set<int32_t> descendents;
@@ -252,7 +227,6 @@ void AccessibilityBridge::AddSemanticsNodeUpdate(
         .set_transform(GetNodeTransform(flutter_node))
         .set_attributes(GetNodeAttributes(flutter_node, &this_node_size))
         .set_states(GetNodeStates(flutter_node, &this_node_size))
-        .set_role(GetNodeRole(flutter_node))
         .set_child_ids(child_ids);
     this_node_size +=
         kNodeIdSize * flutter_node.childrenInTraversalOrder.size();

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.h
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.h
@@ -145,11 +145,6 @@ class AccessibilityBridge
       const flutter::SemanticsNode& node,
       size_t* additional_size) const;
 
-  // Derives the role for a Fuchsia semantics node from a Flutter semantics
-  // node.
-  fuchsia::accessibility::semantics::Role GetNodeRole(
-      const flutter::SemanticsNode& node) const;
-
   // Gets the set of reachable descendants from the given node id.
   std::unordered_set<int32_t> GetDescendants(int32_t node_id) const;
 

--- a/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
@@ -19,20 +19,6 @@
 
 namespace flutter_runner_test {
 
-namespace {
-
-void ExpectNodeHasRole(
-    const fuchsia::accessibility::semantics::Node& node,
-    const std::unordered_map<uint32_t, fuchsia::accessibility::semantics::Role>
-        roles_by_node_id) {
-  ASSERT_TRUE(node.has_node_id());
-  ASSERT_NE(roles_by_node_id.find(node.node_id()), roles_by_node_id.end());
-  EXPECT_TRUE(node.has_role());
-  EXPECT_EQ(node.role(), roles_by_node_id.at(node.node_id()));
-}
-
-}  // namespace
-
 class AccessibilityBridgeTestDelegate
     : public flutter_runner::AccessibilityBridge::Delegate {
  public:
@@ -101,67 +87,6 @@ TEST_F(AccessibilityBridgeTest, EnableDisable) {
       accessibility_bridge_.release());
   listener->OnSemanticsModeChanged(true, nullptr);
   EXPECT_TRUE(accessibility_delegate_.enabled());
-}
-
-TEST_F(AccessibilityBridgeTest, UpdatesNodeRoles) {
-  flutter::SemanticsNodeUpdates updates;
-
-  flutter::SemanticsNode node0;
-  node0.id = 0;
-  node0.flags |= static_cast<int>(flutter::SemanticsFlags::kIsButton);
-  node0.childrenInTraversalOrder = {1, 2, 3, 4};
-  node0.childrenInHitTestOrder = {1, 2, 3, 4};
-  updates.emplace(0, node0);
-
-  flutter::SemanticsNode node1;
-  node1.id = 1;
-  node1.flags |= static_cast<int>(flutter::SemanticsFlags::kIsHeader);
-  node1.childrenInTraversalOrder = {};
-  node1.childrenInHitTestOrder = {};
-  updates.emplace(1, node1);
-
-  flutter::SemanticsNode node2;
-  node2.id = 2;
-  node2.flags |= static_cast<int>(flutter::SemanticsFlags::kIsImage);
-  node2.childrenInTraversalOrder = {};
-  node2.childrenInHitTestOrder = {};
-  updates.emplace(2, node2);
-
-  flutter::SemanticsNode node3;
-  node3.id = 3;
-  node3.flags |= static_cast<int>(flutter::SemanticsFlags::kIsTextField);
-  node3.childrenInTraversalOrder = {};
-  node3.childrenInHitTestOrder = {};
-  updates.emplace(3, node3);
-
-  flutter::SemanticsNode node4;
-  node4.childrenInTraversalOrder = {};
-  node4.childrenInHitTestOrder = {};
-  node4.id = 4;
-  node4.flags |= static_cast<int>(flutter::SemanticsFlags::kIsSlider);
-  updates.emplace(4, node4);
-
-  accessibility_bridge_->AddSemanticsNodeUpdate(std::move(updates));
-  RunLoopUntilIdle();
-
-  std::unordered_map<uint32_t, fuchsia::accessibility::semantics::Role>
-      roles_by_node_id = {
-          {0u, fuchsia::accessibility::semantics::Role::BUTTON},
-          {1u, fuchsia::accessibility::semantics::Role::HEADER},
-          {2u, fuchsia::accessibility::semantics::Role::IMAGE},
-          {3u, fuchsia::accessibility::semantics::Role::TEXT_FIELD},
-          {4u, fuchsia::accessibility::semantics::Role::SLIDER}};
-
-  EXPECT_EQ(0, semantics_manager_.DeleteCount());
-  EXPECT_EQ(1, semantics_manager_.UpdateCount());
-  EXPECT_EQ(1, semantics_manager_.CommitCount());
-  EXPECT_EQ(5U, semantics_manager_.LastUpdatedNodes().size());
-  for (const auto& node : semantics_manager_.LastUpdatedNodes()) {
-    ExpectNodeHasRole(node, roles_by_node_id);
-  }
-
-  EXPECT_FALSE(semantics_manager_.DeleteOverflowed());
-  EXPECT_FALSE(semantics_manager_.UpdateOverflowed());
 }
 
 TEST_F(AccessibilityBridgeTest, DeletesChildrenTransitively) {

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -9,7 +9,7 @@ import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
 /// Verifies Semantics flags and actions.
 void main() {
   // This must match the number of flags in lib/ui/semantics.dart
-  const int numSemanticsFlags = 24;
+  const int numSemanticsFlags = 23;
   test('SemanticsFlag.values refers to all flags.', () async {
     expect(SemanticsFlag.values.length, equals(numSemanticsFlags));
     for (int index = 0; index < numSemanticsFlags; ++index) {


### PR DESCRIPTION
Reverts flutter/engine#20385

This test was causing the following framework test failures for the engine roller:

```
00:18 +98 ~1: /tmp/flutter sdk/packages/flutter_test/test/matchers_test.dart: matchesSemanticsData Can match all semantics flags and actions                                                           
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure object was thrown running a test:
  Expected: has semantics with actions: [
            SemanticsAction:SemanticsAction.tap,
            SemanticsAction:SemanticsAction.longPress,
            SemanticsAction:SemanticsAction.scrollLeft,
            SemanticsAction:SemanticsAction.scrollRight,
            SemanticsAction:SemanticsAction.scrollUp,
            SemanticsAction:SemanticsAction.scrollDown,
            SemanticsAction:SemanticsAction.increase,
            SemanticsAction:SemanticsAction.decrease,
            SemanticsAction:SemanticsAction.showOnScreen,
            SemanticsAction:SemanticsAction.moveCursorForwardByCharacter,
            SemanticsAction:SemanticsAction.moveCursorBackwardByCharacter,
            SemanticsAction:SemanticsAction.setSelection,
            SemanticsAction:SemanticsAction.copy,
            SemanticsAction:SemanticsAction.cut,
            SemanticsAction:SemanticsAction.paste,
            SemanticsAction:SemanticsAction.didGainAccessibilityFocus,
            SemanticsAction:SemanticsAction.didLoseAccessibilityFocus,
            SemanticsAction:SemanticsAction.customAction,
            SemanticsAction:SemanticsAction.dismiss,
            SemanticsAction:SemanticsAction.moveCursorForwardByWord,
            SemanticsAction:SemanticsAction.moveCursorBackwardByWord
          ] with flags: [
            SemanticsFlag:SemanticsFlag.hasCheckedState,
            SemanticsFlag:SemanticsFlag.isChecked,
            SemanticsFlag:SemanticsFlag.isSelected,
            SemanticsFlag:SemanticsFlag.isButton,
            SemanticsFlag:SemanticsFlag.isLink,
            SemanticsFlag:SemanticsFlag.isTextField,
            SemanticsFlag:SemanticsFlag.isReadOnly,
            SemanticsFlag:SemanticsFlag.isFocused,
            SemanticsFlag:SemanticsFlag.isFocusable,
            SemanticsFlag:SemanticsFlag.hasEnabledState,
            SemanticsFlag:SemanticsFlag.isEnabled,
            SemanticsFlag:SemanticsFlag.isInMutuallyExclusiveGroup,
            SemanticsFlag:SemanticsFlag.isHeader,
            SemanticsFlag:SemanticsFlag.isObscured,
            SemanticsFlag:SemanticsFlag.namesRoute,
            SemanticsFlag:SemanticsFlag.scopesRoute,
            SemanticsFlag:SemanticsFlag.isHidden,
            SemanticsFlag:SemanticsFlag.isImage,
            SemanticsFlag:SemanticsFlag.isLiveRegion,
            SemanticsFlag:SemanticsFlag.hasToggledState,
            SemanticsFlag:SemanticsFlag.isToggled,
            SemanticsFlag:SemanticsFlag.hasImplicitScrolling
          ] with rect: Rect.fromLTRB(0.0, 0.0, 10.0, 10.0) with size: Size(10.0, 10.0) with
elevation: 3.0 with thickness: 4.0 with platformViewId: 105 with maxValueLength: 15 with
currentValueLength: 10 with custom actions: [CustomSemanticsAction(7, label:test, hint:null,
action:null)]
  Actual: _FakeSemanticsNode:<_FakeSemanticsNode#1(Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), invisible)>
   Which: flags were: [hasCheckedState, isChecked, isSelected, isButton, isTextField, isFocused,
hasEnabledState, isEnabled, isInMutuallyExclusiveGroup, isHeader, isObscured, scopesRoute,
namesRoute, isHidden, isImage, isLiveRegion, hasToggledState, isToggled, hasImplicitScrolling,
isReadOnly, isFocusable, isLink, isSlider]
When the exception was thrown, this was the stack:
#4      main.<anonymous closure>.<anonymous closure> (file:///tmp/flutter%20sdk/packages/flutter_test/test/matchers_test.dart:565:7)
#5      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:146:29)
<asynchronous suspension>
#6      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart)
#7      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:784:19)
<asynchronous suspension>
#10     TestWidgetsFlutterBinding._runTest (package:flutter_test/src/binding.dart:764:14)
#11     AutomatedTestWidgetsFlutterBinding.runTest.<anonymous closure> (package:flutter_test/src/binding.dart:1173:24)
#12     FakeAsync.run.<anonymous closure>.<anonymous closure> (package:fake_async/fake_async.dart:178:54)
#17     withClock (package:clock/src/default.dart:48:10)
#18     FakeAsync.run.<anonymous closure> (package:fake_async/fake_async.dart:178:22)
#23     FakeAsync.run (package:fake_async/fake_async.dart:178:7)
#24     AutomatedTestWidgetsFlutterBinding.runTest (package:flutter_test/src/binding.dart:1170:15)
#25     testWidgets.<anonymous closure> (package:flutter_test/src/widget_tester.dart:138:24)
#26     Declarer.test.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/declarer.dart:175:19)
<asynchronous suspension>
#27     Declarer.test.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/declarer.dart)
#32     Declarer.test.<anonymous closure> (package:test_api/src/backend/declarer.dart:173:13)
#33     Invoker.waitForOutstandingCallbacks.<anonymous closure> (package:test_api/src/backend/invoker.dart:231:15)
#38     Invoker.waitForOutstandingCallbacks (package:test_api/src/backend/invoker.dart:228:5)
#39     Invoker._onRun.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/invoker.dart:383:17)
<asynchronous suspension>
#40     Invoker._onRun.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/invoker.dart)
#45     Invoker._onRun.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/invoker.dart:370:9)
#46     Invoker._guardIfGuarded (package:test_api/src/backend/invoker.dart:415:15)
#47     Invoker._onRun.<anonymous closure> (package:test_api/src/backend/invoker.dart:369:7)
#54     Invoker._onRun (package:test_api/src/backend/invoker.dart:368:11)
#55     LiveTestController.run (package:test_api/src/backend/live_test_controller.dart:153:11)
#56     RemoteListener._runLiveTest.<anonymous closure> (package:test_api/src/remote_listener.dart:256:16)
#61     RemoteListener._runLiveTest (package:test_api/src/remote_listener.dart:255:5)
#62     RemoteListener._serializeTest.<anonymous closure> (package:test_api/src/remote_listener.dart:208:7)
#80     _GuaranteeSink.add (package:stream_channel/src/guarantee_channel.dart:125:12)
#81     new _MultiChannel.<anonymous closure> (package:stream_channel/src/multi_channel.dart:159:31)
#85     CastStreamSubscription._onData (dart:_internal/async_cast.dart:85:11)
#119    new _WebSocketImpl._fromSocket.<anonymous closure> (dart:_http/websocket_impl.dart:1145:21)
#127    _WebSocketProtocolTransformer._messageFrameEnd (dart:_http/websocket_impl.dart:338:23)
#128    _WebSocketProtocolTransformer.add (dart:_http/websocket_impl.dart:232:46)
#138    _Socket._onData (dart:io-patch/socket_patch.dart:2044:41)
#147    new _RawSocket.<anonymous closure> (dart:io-patch/socket_patch.dart:1580:33)
#148    _NativeSocket.issueReadEvent.issue (dart:io-patch/socket_patch.dart:1076:14)
(elided 111 frames from dart:async and package:stack_trace)
This was caught by the test expectation on the following line:
  file:///tmp/flutter%20sdk/packages/flutter_test/test/matchers_test.dart line 565
The test description was:
  Can match all semantics flags and actions
```