### PR TITLE
restore FML_DCHECK removed due to a code reviewing error

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -404,9 +404,7 @@ RasterStatus Rasterizer::DoDraw(
 
 RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
   TRACE_EVENT0("flutter", "Rasterizer::DrawToSurface");
-  if (!surface_) {
-    return RasterStatus::kFailed;
-  }
+  FML_DCHECK(surface_);
 
   // There is no way for the compositor to know how long the layer tree
   // construction took. Fortunately, the layer tree does. Grab that time


### PR DESCRIPTION
This FML_DCHECK was removed based on (my own) misreading of an earlier PR. The surface_ pointer should have already been checked for nullptr by the time it reaches this method.