### PR TITLE
Clear GL context before Gr context

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -467,15 +467,18 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
 
     FireNextFrameCallbackIfPresent();
 
+    // Clear the render context after submitting the frame.
+    // This ensures that the GL context is released after drawing to the
+    // surface.
+    //
+    // The GL context must be clear before performing Gr context deferred
+    // cleanup.
+    surface_->ClearRenderContext();
+
     if (surface_->GetContext()) {
       TRACE_EVENT0("flutter", "PerformDeferredSkiaCleanup");
       surface_->GetContext()->performDeferredCleanup(kSkiaCleanupExpiration);
     }
-
-    // Clear the render context after submitting the frame.
-    // This ensures that the GL context is released after drawing to the
-    // surface.
-    surface_->ClearRenderContext();
 
     return raster_status;
   }


### PR DESCRIPTION
I noted that in my previous patch I changed the order after triggering the Firebase test.

1. https://firebase.corp.google.com/u/0/project/flutter-infra/testlab/histories/bh.1b29258e8f97b976/matrices/7981524393941425454
2. https://firebase.corp.google.com/u/0/project/flutter-infra/testlab/histories/bh.1b29258e8f97b976/matrices/7467902746456543862