### PR TITLE
Started printing out error messages when the observatory won't be reachable because of permissions problems.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -115,7 +115,7 @@
     FML_LOG(ERROR) << "Failed to register observatory port with mDNS.";
     if (@available(iOS 14.0, *)) {
       FML_LOG(ERROR) << "Make sure the 'NSBonjourServices' key is set in your Info.plist for '"
-                     << registrationType << "' for the Debug configuration."
+                     << registrationType << "' for the Debug/Profile configurations."
                      << "(See also: https://developer.apple.com/news/?id=0oi77447)";
     }
   } else {

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -113,6 +113,11 @@
 
   if (err != 0) {
     FML_LOG(ERROR) << "Failed to register observatory port with mDNS.";
+    if (@available(iOS 14.0, *)) {
+      FML_LOG(ERROR) << "Make sure the 'NSBonjourServices' key is set in your Info.plist for '"
+                     << registrationType << "'.  "
+                     << "(See also: https://developer.apple.com/news/?id=0oi77447)";
+    }
   } else {
     DNSServiceSetDispatchQueue(_dnsServiceRef, dispatch_get_main_queue());
   }
@@ -127,6 +132,11 @@ static void DNSSD_API registrationCallback(DNSServiceRef sdRef,
                                            void* context) {
   if (errorCode == kDNSServiceErr_NoError) {
     FML_DLOG(INFO) << "FlutterObservatoryPublisher is ready!";
+  } else if (errorCode == kDNSServiceErr_PolicyDenied) {
+    FML_LOG(ERROR)
+        << "Could not register as server for FlutterObservatoryPublisher, permission "
+        << "denied. Check your 'Local Network' permissions for this app in the Privacy section of "
+        << "the system Settings.";
   } else {
     FML_LOG(ERROR) << "Could not register as server for FlutterObservatoryPublisher. Check your "
                       "network settings and relaunch the application.";

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -115,13 +115,22 @@
     FML_LOG(ERROR) << "Failed to register observatory port with mDNS.";
     if (@available(iOS 14.0, *)) {
       FML_LOG(ERROR) << "Make sure the 'NSBonjourServices' key is set in your Info.plist for '"
-                     << registrationType << "'.  "
+                     << registrationType << "' for the Debug configuration."
                      << "(See also: https://developer.apple.com/news/?id=0oi77447)";
     }
   } else {
     DNSServiceSetDispatchQueue(_dnsServiceRef, dispatch_get_main_queue());
   }
 }
+
+/// TODO(aaclarke): Remove this preprocessor macro once infra is moved to Xcode 12.
+static const DNSServiceErrorType kFlutter_DNSServiceErr_PolicyDenied =
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 140000
+    kDNSServiceErr_PolicyDenied;
+#else
+    // Found in usr/include/dns_sd.h.
+    -65570;
+#endif  // __IPHONE_OS_VERSION_MAX_ALLOWED
 
 static void DNSSD_API registrationCallback(DNSServiceRef sdRef,
                                            DNSServiceFlags flags,
@@ -132,7 +141,7 @@ static void DNSSD_API registrationCallback(DNSServiceRef sdRef,
                                            void* context) {
   if (errorCode == kDNSServiceErr_NoError) {
     FML_DLOG(INFO) << "FlutterObservatoryPublisher is ready!";
-  } else if (errorCode == kDNSServiceErr_PolicyDenied) {
+  } else if (errorCode == kFlutter_DNSServiceErr_PolicyDenied) {
     FML_LOG(ERROR)
         << "Could not register as server for FlutterObservatoryPublisher, permission "
         << "denied. Check your 'Local Network' permissions for this app in the Privacy section of "


### PR DESCRIPTION
## Description

iOS 14 has changed their policy for mdns permissions.  This provides some guidance if users run afoul of them.

## Related Issues

https://github.com/flutter/flutter/issues/60634
https://github.com/flutter/flutter/issues/63893

## Tests

I added the following tests:

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
