### PR TITLE
Only clear GL context after changing the thread configuration

### DIFF
--- a/fml/raster_thread_merger.cc
+++ b/fml/raster_thread_merger.cc
@@ -21,6 +21,10 @@ RasterThreadMerger::RasterThreadMerger(fml::TaskQueueId platform_queue_id,
   FML_CHECK(!task_queues_->Owns(platform_queue_id_, gpu_queue_id_));
 }
 
+void RasterThreadMerger::SetMergeUnmergeCallback(const fml::closure& callback) {
+  merge_unmerge_callback_ = callback;
+}
+
 void RasterThreadMerger::MergeWithLease(size_t lease_term) {
   std::scoped_lock lock(lease_term_mutex_);
   if (TaskQueuesAreSame()) {
@@ -30,11 +34,19 @@ void RasterThreadMerger::MergeWithLease(size_t lease_term) {
     return;
   }
   FML_DCHECK(lease_term > 0) << "lease_term should be positive.";
-  if (!IsMergedUnSafe()) {
-    bool success = task_queues_->Merge(platform_queue_id_, gpu_queue_id_);
-    FML_CHECK(success) << "Unable to merge the raster and platform threads.";
-    lease_term_ = lease_term;
+
+  if (IsMergedUnSafe()) {
+    merged_condition_.notify_one();
+    return;
   }
+
+  bool success = task_queues_->Merge(platform_queue_id_, gpu_queue_id_);
+  if (success && merge_unmerge_callback_ != nullptr) {
+    merge_unmerge_callback_();
+  }
+  FML_CHECK(success) << "Unable to merge the raster and platform threads.";
+  lease_term_ = lease_term;
+
   merged_condition_.notify_one();
 }
 
@@ -48,6 +60,9 @@ void RasterThreadMerger::UnMergeNow() {
   }
   lease_term_ = 0;
   bool success = task_queues_->Unmerge(platform_queue_id_);
+  if (success && merge_unmerge_callback_ != nullptr) {
+    merge_unmerge_callback_();
+  }
   FML_CHECK(success) << "Unable to un-merge the raster and platform threads.";
 }
 

--- a/fml/raster_thread_merger.h
+++ b/fml/raster_thread_merger.h
@@ -85,6 +85,13 @@ class RasterThreadMerger
   // noop.
   bool IsEnabled();
 
+  // Registers a callback that can be used to clean up global state right after
+  // the thread configuration has changed.
+  //
+  // For example, it can be used to clear the GL context so it can be used in
+  // the next task from a different thread.
+  void SetMergeUnmergeCallback(const fml::closure& callback);
+
  private:
   static const int kLeaseNotSet;
   fml::TaskQueueId platform_queue_id_;
@@ -93,6 +100,7 @@ class RasterThreadMerger
   std::atomic_int lease_term_;
   std::condition_variable merged_condition_;
   std::mutex lease_term_mutex_;
+  fml::closure merge_unmerge_callback_;
   bool enabled_;
 
   bool IsMergedUnSafe() const;

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -108,6 +108,7 @@ void Rasterizer::Teardown() {
       raster_thread_merger_.get()->IsMerged()) {
     FML_DCHECK(raster_thread_merger_->IsEnabled());
     raster_thread_merger_->UnMergeNow();
+    raster_thread_merger_->SetMergeUnmergeCallback(nullptr);
   }
 }
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -89,14 +89,12 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
         delegate_.GetTaskRunners().GetRasterTaskRunner()->GetTaskQueueId();
     raster_thread_merger_ =
         fml::MakeRefCounted<fml::RasterThreadMerger>(platform_id, gpu_id);
-
-    raster_thread_merger_->SetMergeUnmergeCallback(
-        [weak_this = weak_factory_.GetWeakPtr()]() {
-          // Clear the GL context after the thread configuration has changed.
-          if (weak_this && weak_this->surface_) {
-            weak_this->surface_->ClearRenderContext();
-          }
-        });
+    raster_thread_merger_->SetMergeUnmergeCallback([=]() {
+      // Clear the GL context after the thread configuration has changed.
+      if (surface_) {
+        surface_->ClearRenderContext();
+      }
+    });
   }
 #endif
 }


### PR DESCRIPTION
## Description

The GL context must be clear in the current thread prior to making it current in a different thread. In this PR, the thread merger callback can be used to perform such clean ups.  This is a more conservative approach than always clearing the context.


## Tests

I added the following tests: Unit tests

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
