### PR TITLE
[fuchsia] Send trace events to system tracing on all configurations

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -378,8 +378,7 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     args.push_back(old_gen_heap_size_args.c_str());
   }
 
-#if defined(OS_FUCHSIA) && \
-    (FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_PROFILE)
+#if defined(OS_FUCHSIA)
   PushBackAll(&args, kDartFuchsiaTraceArgs, fml::size(kDartFuchsiaTraceArgs));
   PushBackAll(&args, kDartTraceStreamsArgs, fml::size(kDartTraceStreamsArgs));
 #endif

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -39,9 +39,7 @@ const char* kDartVMArgs[] = {
     // addressed.
     "--no_causal_async_stacks",
 
-#if !defined(FLUTTER_PROFILE)
     "--systrace_timeline",
-#endif
     "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM",
 
 #if defined(AOT_RUNTIME)


### PR DESCRIPTION
This change reverts https://github.com/flutter/engine/pull/15900.  The
design of the expected consumer of the original PR changed, and the
feature ended up going unused.  Since the unexpected difference in trace
event routing behavior has mostly ended up as a source of confusion,
change things back to route trace events to Fuchsia system tracing on
all configurations.