### PR TITLE
Always set the callback during Rasterizer setup

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -89,6 +89,8 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
         delegate_.GetTaskRunners().GetRasterTaskRunner()->GetTaskQueueId();
     raster_thread_merger_ =
         fml::MakeRefCounted<fml::RasterThreadMerger>(platform_id, gpu_id);
+  }
+  if (raster_thread_merger_) {
     raster_thread_merger_->SetMergeUnmergeCallback([=]() {
       // Clear the GL context after the thread configuration has changed.
       if (surface_) {


### PR DESCRIPTION
When I added ` raster_thread_merger_->SetMergeUnmergeCallback(nullptr);`, the callback must be reset in every `Setup` invocation if the embedder supports thread merging.