### PR TITLE
fuchsia: Compile disabled RasterThreadMerger code

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -77,9 +77,6 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
                              user_override_resource_cache_bytes_);
   }
   compositor_context_->OnGrContextCreated();
-#if !defined(OS_FUCHSIA)
-  // TODO(sanjayc77): https://github.com/flutter/flutter/issues/53179. Add
-  // support for raster thread merger for Fuchsia.
   if (surface_->GetExternalViewEmbedder() &&
       surface_->GetExternalViewEmbedder()->SupportsDynamicThreadMerging() &&
       !raster_thread_merger_) {
@@ -98,7 +95,6 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
       }
     });
   }
-#endif
 }
 
 void Rasterizer::Teardown() {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -497,9 +497,6 @@ TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
   DestroyShell(std::move(shell));
 }
 
-#if !defined(OS_FUCHSIA)
-// TODO(sanjayc77): https://github.com/flutter/flutter/issues/53179. Add
-// support for raster thread merger for Fuchsia.
 TEST_F(ShellTest, ExternalEmbedderNoThreadMerger) {
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
@@ -548,8 +545,14 @@ TEST_F(ShellTest, ExternalEmbedderNoThreadMerger) {
   DestroyShell(std::move(shell));
 }
 
+// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
 TEST_F(ShellTest,
-       ExternalEmbedderEndFrameIsCalledWhenPostPrerollResultIsResubmit) {
+#if defined(OS_FUCHSIA)
+       DISABLED_ExternalEmbedderEndFrameIsCalledWhenPostPrerollResultIsResubmit
+#else
+       ExternalEmbedderEndFrameIsCalledWhenPostPrerollResultIsResubmit
+#endif
+) {
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
   bool end_frame_called = false;
@@ -597,7 +600,14 @@ TEST_F(ShellTest,
   DestroyShell(std::move(shell));
 }
 
-TEST_F(ShellTest, OnPlatformViewDestroyDisablesThreadMerger) {
+// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
+TEST_F(ShellTest,
+#if defined(OS_FUCHSIA)
+       DISABLED_OnPlatformViewDestroyDisablesThreadMerger
+#else
+       OnPlatformViewDestroyDisablesThreadMerger
+#endif
+) {
   auto settings = CreateSettingsForFixture();
   fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger;
   auto end_frame_callback =
@@ -653,7 +663,14 @@ TEST_F(ShellTest, OnPlatformViewDestroyDisablesThreadMerger) {
   DestroyShell(std::move(shell));
 }
 
-TEST_F(ShellTest, OnPlatformViewDestroyAfterMergingThreads) {
+// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
+TEST_F(ShellTest,
+#if defined(OS_FUCHSIA)
+       DISABLED_OnPlatformViewDestroyAfterMergingThreads
+#else
+       OnPlatformViewDestroyAfterMergingThreads
+#endif
+) {
   const size_t ThreadMergingLease = 10;
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
@@ -719,7 +736,14 @@ TEST_F(ShellTest, OnPlatformViewDestroyAfterMergingThreads) {
   DestroyShell(std::move(shell));
 }
 
-TEST_F(ShellTest, OnPlatformViewDestroyWhenThreadsAreMerging) {
+// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
+TEST_F(ShellTest,
+#if defined(OS_FUCHSIA)
+       DISABLED_OnPlatformViewDestroyWhenThreadsAreMerging
+#else
+       OnPlatformViewDestroyWhenThreadsAreMerging
+#endif
+) {
   const size_t kThreadMergingLease = 10;
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
@@ -792,8 +816,14 @@ TEST_F(ShellTest, OnPlatformViewDestroyWhenThreadsAreMerging) {
   DestroyShell(std::move(shell));
 }
 
+// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
 TEST_F(ShellTest,
-       OnPlatformViewDestroyWithThreadMergerWhileThreadsAreUnmerged) {
+#if defined(OS_FUCHSIA)
+       DISABLED_OnPlatformViewDestroyWithThreadMergerWhileThreadsAreUnmerged
+#else
+       OnPlatformViewDestroyWithThreadMergerWhileThreadsAreUnmerged
+#endif
+) {
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
   auto end_frame_callback =
@@ -894,9 +924,15 @@ TEST_F(ShellTest, OnPlatformViewDestroyWithoutRasterThreadMerger) {
 
   DestroyShell(std::move(shell));
 }
-#endif
 
-TEST_F(ShellTest, OnPlatformViewDestroyWithStaticThreadMerging) {
+// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
+TEST_F(ShellTest,
+#if defined(OS_FUCHSIA)
+       DISABLED_OnPlatformViewDestroyWithStaticThreadMerging
+#else
+       OnPlatformViewDestroyWithStaticThreadMerging
+#endif
+) {
   auto settings = CreateSettingsForFixture();
   fml::AutoResetWaitableEvent end_frame_latch;
   auto end_frame_callback =


### PR DESCRIPTION
## Description

This code was completely ifdef'ed out on Fuchsia, when it doesn't need to be.  Compile and disable the tests instead.

## Related Issues

https://github.com/flutter/flutter/issues/59816

## Tests

Re-ran existing tests.