### PR TITLE
add checker board when call savelayer operation

### DIFF
--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/clip_path_layer.h"
+#include <flutter/flow/paint_utils.h>
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
 
@@ -72,6 +73,9 @@ void ClipPathLayer::Paint(PaintContext& context) const {
   PaintChildren(context);
   if (UsesSaveLayer()) {
     context.internal_nodes_canvas->restore();
+    if (context.checkerboard_offscreen_layers) {
+      DrawCheckerboard(context.internal_nodes_canvas, paint_bounds());
+    }
   }
 }
 

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/clip_rect_layer.h"
+#include "flutter/flow/paint_utils.h"
 
 namespace flutter {
 
@@ -65,6 +66,9 @@ void ClipRectLayer::Paint(PaintContext& context) const {
   PaintChildren(context);
   if (UsesSaveLayer()) {
     context.internal_nodes_canvas->restore();
+    if (context.checkerboard_offscreen_layers) {
+      DrawCheckerboard(context.internal_nodes_canvas, clip_rect_);
+    }
   }
 }
 

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/clip_rrect_layer.h"
+#include "flutter/flow/paint_utils.h"
 
 namespace flutter {
 
@@ -66,6 +67,9 @@ void ClipRRectLayer::Paint(PaintContext& context) const {
   PaintChildren(context);
   if (UsesSaveLayer()) {
     context.internal_nodes_canvas->restore();
+    if (context.checkerboard_offscreen_layers) {
+      DrawCheckerboard(context.internal_nodes_canvas, paint_bounds());
+    }
   }
 }
 

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -87,6 +87,12 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
   PaintChildren(context);
 
   context.internal_nodes_canvas->restoreToCount(saveCount);
+
+  if (UsesSaveLayer()){
+    if (context.checkerboard_offscreen_layers) {
+      DrawCheckerboard(context.internal_nodes_canvas, paint_bounds());
+    }
+  }
 }
 
 SkRect PhysicalShapeLayer::ComputeShadowBounds(const SkRect& bounds,


### PR DESCRIPTION
## Description

Some layer not support checkerboardOffscreenLayers diagnostic flag even set checkerboardOffscreenLayers to true.
So I just add some checkerboard to the layers.

## Related Issues

flutter/flutter#11332

## Tests

I added the following tests:

checked: ClipRRect, ClipRect. ClipPathLayer, physical shape layer using demo to check if it's available

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ x] I signed the [CLA].
- [x ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ x] I updated/added relevant documentation.
- [x ] All existing and new tests are passing.
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
