### PR TITLE
Workaround for iOS rewinddir issue

### DIFF
--- a/shell/common/persistent_cache.cc
+++ b/shell/common/persistent_cache.cc
@@ -184,13 +184,13 @@ static sk_sp<SkData> LoadFile(const fml::UniqueFD& dir,
   return SkData::MakeWithCopy(mapping->GetMapping(), mapping->GetSize());
 }
 
-static void PushSkSL(std::vector<PersistentCache::SkSLCache>& result,
+static void PushSkSL(std::vector<PersistentCache::SkSLCache>* result,
                      const fml::UniqueFD& directory,
                      const std::string& filename) {
   sk_sp<SkData> key = ParseBase32(filename);
   sk_sp<SkData> data = LoadFile(directory, filename);
   if (key != nullptr && data != nullptr) {
-    result.push_back({key, data});
+    result->push_back({key, data});
   } else {
     FML_LOG(ERROR) << "Failed to load: " << filename;
   }
@@ -206,7 +206,7 @@ std::vector<PersistentCache::SkSLCache> PersistentCache::LoadSkSLs() {
                                  const std::string& filename) {
     sksl_filenames_.insert(filename);
     visited_filenames.insert(filename);
-    PushSkSL(result, directory, filename);
+    PushSkSL(&result, directory, filename);
     return true;
   };
 
@@ -219,7 +219,7 @@ std::vector<PersistentCache::SkSLCache> PersistentCache::LoadSkSLs() {
     // sksl files manually (https://github.com/flutter/flutter/issues/65258).
     for (const std::string& filename : sksl_filenames_) {
       if (visited_filenames.count(filename) == 0) {
-        PushSkSL(result, *sksl_cache_directory_, filename);
+        PushSkSL(&result, *sksl_cache_directory_, filename);
       }
     }
   }

--- a/shell/common/persistent_cache.h
+++ b/shell/common/persistent_cache.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <unordered_set>
 
 #include "flutter/assets/asset_manager.h"
 #include "flutter/fml/macros.h"
@@ -105,11 +106,12 @@ class PersistentCache : public GrContextOptions::PersistentCache {
   mutable std::mutex worker_task_runners_mutex_;
   std::multiset<fml::RefPtr<fml::TaskRunner>> worker_task_runners_;
 
+  // Some iOS devices didn't `rewinddir` properly so we'll save the SkSL
+  // filenames visited to fix https://github.com/flutter/flutter/issues/65258.
+  std::unordered_set<std::string> sksl_filenames_;
+
   bool stored_new_shaders_ = false;
   bool is_dumping_skp_ = false;
-
-  static sk_sp<SkData> LoadFile(const fml::UniqueFD& dir,
-                                const std::string& filen_ame);
 
   bool IsValid() const;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/65258

The following devicelab tests should pass after this patch:
- flutter_gallery_sksl_warmup__transition_perf_e2e_ios32
- flutter_gallery_sksl_warmup_ios32__transition_perf
