### PR TITLE
Fixed ios layout change to not refocus semantics object if the focus …

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -453,7 +453,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 - (void)accessibilityElementDidBecomeFocused {
   if (![self isAccessibilityBridgeAlive])
     return;
-  [self bridge]->AccessibilityFocusDidChange([self uid]);
+  [self bridge]->AccessibilityObjectDidBecomeFocused([self uid]);
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden) ||
       [self node].HasFlag(flutter::SemanticsFlags::kIsHeader)) {
     [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
@@ -467,6 +467,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 - (void)accessibilityElementDidLoseFocus {
   if (![self isAccessibilityBridgeAlive])
     return;
+  [self bridge]->AccessibilityObjectDidLoseFocus([self uid]);
   if ([self node].HasAction(flutter::SemanticsAction::kDidLoseAccessibilityFocus)) {
     [self bridge]->DispatchSemanticsAction([self uid],
                                            flutter::SemanticsAction::kDidLoseAccessibilityFocus);

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -33,7 +33,8 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
     SemanticsActionObservation observation(id, action);
     observations.push_back(observation);
   }
-  void AccessibilityFocusDidChange(int32_t id) override {}
+  void AccessibilityObjectDidBecomeFocused(int32_t id) override {}
+  void AccessibilityObjectDidLoseFocus(int32_t id) override {}
   FlutterPlatformViewsController* GetPlatformViewsController() const override { return nil; }
   std::vector<SemanticsActionObservation> observations;
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -86,9 +86,9 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   FlutterViewController* view_controller_;
   PlatformViewIOS* platform_view_;
   FlutterPlatformViewsController* platform_views_controller_;
-  // If the this id is -1, it means either nothing has been focused or the
-  // focus is currently outside of the flutter application (i.e. the status bar
-  // or keyboard)
+  // If the this id is kSemanticObjectIdInvalid, it means either nothing has
+  // been focused or the focus is currently outside of the flutter application
+  // (i.e. the status bar or keyboard)
   int32_t last_focused_semantics_object_id_;
   fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -87,8 +87,8 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   PlatformViewIOS* platform_view_;
   FlutterPlatformViewsController* platform_views_controller_;
   // If the this id is -1, it means either nothing has been focused or the
-  // focus is currently outside of the flutter application (status bar or
-  // the keyboard)
+  // focus is currently outside of the flutter application (i.e. the status bar
+  // or keyboard)
   int32_t last_focused_semantics_object_id_;
   fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -61,7 +61,8 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   void DispatchSemanticsAction(int32_t id,
                                flutter::SemanticsAction action,
                                std::vector<uint8_t> args) override;
-  void AccessibilityFocusDidChange(int32_t id) override;
+  void AccessibilityObjectDidBecomeFocused(int32_t id) override;
+  void AccessibilityObjectDidLoseFocus(int32_t id) override;
 
   UIView<UITextInput>* textInputView() override;
 
@@ -85,6 +86,9 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   FlutterViewController* view_controller_;
   PlatformViewIOS* platform_view_;
   FlutterPlatformViewsController* platform_views_controller_;
+  // If the this id is -1, it means either nothing has been focused or the
+  // focus is currently outside of the flutter application (status bar or
+  // the keyboard)
   int32_t last_focused_semantics_object_id_;
   fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -174,7 +174,6 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
       int index = [newRoutes count] - 1;
       lastAdded = [newRoutes objectAtIndex:index];
     }
-
     if (lastAdded != nil && [lastAdded uid] != previous_route_id_) {
       previous_route_id_ = [lastAdded uid];
       routeChanged = true;
@@ -206,7 +205,7 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
   } else if (layoutChanged) {
     SemanticsObject* nextToFocus = nil;
     // This property will be -1 if the focus is outside of the flutter
-    // application. In this case, we should not try to refocus anything.
+    // application. In this case, we should not refocus anything.
     if (last_focused_semantics_object_id_ != -1) {
       // Tries to refocus the previous focused semantics object to avoid random jumps.
       nextToFocus = [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -16,6 +16,8 @@ FLUTTER_ASSERT_NOT_ARC
 namespace flutter {
 namespace {
 
+constexpr int32_t kSemanticObjectIdInvalid = -1;
+
 class DefaultIosDelegate : public AccessibilityBridge::IosDelegate {
  public:
   bool IsFlutterViewControllerPresentingModalViewController(
@@ -41,7 +43,7 @@ AccessibilityBridge::AccessibilityBridge(FlutterViewController* view_controller,
     : view_controller_(view_controller),
       platform_view_(platform_view),
       platform_views_controller_(platform_views_controller),
-      last_focused_semantics_object_id_(-1),
+      last_focused_semantics_object_id_(kSemanticObjectIdInvalid),
       objects_([[NSMutableDictionary alloc] init]),
       weak_factory_(this),
       previous_route_id_(0),
@@ -72,8 +74,9 @@ void AccessibilityBridge::AccessibilityObjectDidBecomeFocused(int32_t id) {
 }
 
 void AccessibilityBridge::AccessibilityObjectDidLoseFocus(int32_t id) {
-  if (last_focused_semantics_object_id_ == id)
-    last_focused_semantics_object_id_ = -1;
+  if (last_focused_semantics_object_id_ == id) {
+    last_focused_semantics_object_id_ = kSemanticObjectIdInvalid;
+  }
 }
 
 void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
@@ -206,7 +209,7 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     SemanticsObject* nextToFocus = nil;
     // This property will be -1 if the focus is outside of the flutter
     // application. In this case, we should not refocus anything.
-    if (last_focused_semantics_object_id_ != -1) {
+    if (last_focused_semantics_object_id_ != kSemanticObjectIdInvalid) {
       // Tries to refocus the previous focused semantics object to avoid random jumps.
       nextToFocus = [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];
       if (!nextToFocus && root) {
@@ -220,7 +223,7 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     // point, it is guarantee the previous focused object is still in the tree
     // so that we don't need to worry about focus lost. (e.g. "Screen 0 of 3")
     SemanticsObject* nextToFocus = nil;
-    if (last_focused_semantics_object_id_ != -1) {
+    if (last_focused_semantics_object_id_ != kSemanticObjectIdInvalid) {
       nextToFocus = [objects_.get() objectForKey:@(last_focused_semantics_object_id_)];
       if (!nextToFocus && root) {
         nextToFocus = FindFirstFocusable(root);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
@@ -25,12 +25,17 @@ class AccessibilityBridgeIos {
                                        flutter::SemanticsAction action,
                                        std::vector<uint8_t> args) = 0;
   /**
-   * A callback that is called after the accessibility focus has moved to a new
-   * SemanticObject.
+   * A callback that is called when a SemanticObject receives focus.
    *
    * The input id is the uid of the newly focused SemanticObject.
    */
-  virtual void AccessibilityFocusDidChange(int32_t id) = 0;
+  virtual void AccessibilityObjectDidBecomeFocused(int32_t id) = 0;
+  /**
+   * A callback that is called when a SemanticObject loses focus
+   *
+   * The input id is the uid of the newly focused SemanticObject.
+   */
+  virtual void AccessibilityObjectDidLoseFocus(int32_t id) = 0;
   virtual FlutterPlatformViewsController* GetPlatformViewsController() const = 0;
 };
 


### PR DESCRIPTION
…is outside of flutter

## Description

We try to refocus the last focused semantics object when layout changes, but that does not take into account when the focus went outside of the flutter application (for example soft keyboard). This will interrupt the user focus and make the focus jump back to flutter.

This PR fixes it by making the semantics objects to notify the bridge when it lose focus, so that the bridge can accurately keep track of whether the focus has gone to outside of the app.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/65423

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
