### PR TITLE
Revert "Enable lazy-async-stacks by-default in all modes (Take 3)"

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -59,8 +59,7 @@ static const char* kDartLanguageArgs[] = {
     // clang-format off
     "--enable_mirrors=false",
     "--background_compilation",
-    "--no-causal_async_stacks",
-    "--lazy_async_stacks",
+    "--causal_async_stacks",
     // clang-format on
 };
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -312,7 +312,6 @@ TEST_F(ShellTest, AllowedDartVMFlag) {
   const std::vector<fml::CommandLine::Option> options = {
 #if !FLUTTER_RELEASE
     fml::CommandLine::Option("dart-flags",
-                             "--lazy_async_stacks,--no-causal_async_stacks,"
                              "--max_profile_depth 1,--random_seed 42")
 #endif
   };
@@ -320,11 +319,9 @@ TEST_F(ShellTest, AllowedDartVMFlag) {
   flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
 
 #if !FLUTTER_RELEASE
-  EXPECT_EQ(settings.dart_flags.size(), 4u);
-  EXPECT_EQ(settings.dart_flags[0], "--lazy_async_stacks");
-  EXPECT_EQ(settings.dart_flags[1], "--no-causal_async_stacks");
-  EXPECT_EQ(settings.dart_flags[2], "--max_profile_depth 1");
-  EXPECT_EQ(settings.dart_flags[3], "--random_seed 42");
+  EXPECT_EQ(settings.dart_flags.size(), 2u);
+  EXPECT_EQ(settings.dart_flags[0], "--max_profile_depth 1");
+  EXPECT_EQ(settings.dart_flags[1], "--random_seed 42");
 #else
   EXPECT_EQ(settings.dart_flags.size(), 0u);
 #endif

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -35,8 +35,9 @@ namespace {
 
 const char* kDartVMArgs[] = {
     // clang-format off
+    // TODO(FL-117): Re-enable causal async stack traces when this issue is
+    // addressed.
     "--no_causal_async_stacks",
-    "--lazy_async_stacks",
 
     "--systrace_timeline",
     "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM",

--- a/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
@@ -47,7 +47,6 @@ template("create_aot_snapshot") {
 
     args = [
       "--no_causal_async_stacks",
-      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=vm-aot-assembly",
       "--assembly=" + rebase_path(snapshot_assembly),

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -72,8 +72,9 @@ template("create_kernel_core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
+      # TODO(FL-117): Re-enable causal async stack traces when this issue is
+      # addressed.
       "--no_causal_async_stacks",
-      "--lazy_async_stacks",
       "--use_bytecode_compiler",
       "--enable_mirrors=false",
       "--deterministic",

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -58,7 +58,6 @@ template("aot_snapshot") {
 
     args = [
       "--no_causal_async_stacks",
-      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(snapshot_path),

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -401,6 +401,10 @@ Application::Application(
   settings_.task_observer_remove = std::bind(
       &CurrentMessageLoopRemoveAfterTaskObserver, std::placeholders::_1);
 
+  // TODO(FL-117): Re-enable causal async stack traces when this issue is
+  // addressed.
+  settings_.dart_flags = {"--no_causal_async_stacks"};
+
   // Disable code collection as it interferes with JIT code warmup
   // by decreasing usage counters and flushing code which is still useful.
   settings_.dart_flags.push_back("--no-collect_code");

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -76,8 +76,9 @@ template("core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
+      # TODO(FL-117): Re-enable causal async stack traces when this issue is
+      # addressed.
       "--no_causal_async_stacks",
-      "--lazy_async_stacks",
       "--use_bytecode_compiler",
       "--enable_mirrors=false",
       "--deterministic",

--- a/testing/scenario_app/compile_ios_jit.sh
+++ b/testing/scenario_app/compile_ios_jit.sh
@@ -74,8 +74,7 @@ echo "Compiling JIT Snapshot..."
 
 "$DEVICE_TOOLS/gen_snapshot" --deterministic \
   --enable-asserts \
-  --no-causal_async_stacks \
-  --lazy_async_stacks \
+  --causal_async_stacks \
   --isolate_snapshot_instructions="$OUTDIR/isolate_snapshot_instr" \
   --snapshot_kind=app-jit \
   --load_vm_snapshot_data="$DEVICE_TOOLS/../gen/flutter/lib/snapshot/vm_isolate_snapshot.bin" \

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -128,8 +128,7 @@ template("dart_snapshot_aot") {
     outputs = [ elf_object ]
 
     args = [
-      "--no-causal_async_stacks",
-      "--lazy_async_stacks",
+      "--causal_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(elf_object),


### PR DESCRIPTION
Reverts flutter/engine#20895

Still some test failures on Windows:

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8869626383922720992/+/steps/run_test.dart_for_tool_tests_shard_and_subshard_integration/0/stdout?format=raw