### PR TITLE
Check for dart2js on felt startup

### DIFF
--- a/lib/web_ui/dev/felt
+++ b/lib/web_ui/dev/felt
@@ -34,12 +34,13 @@ DART_SDK_DIR="${ENGINE_SRC_DIR}/out/host_debug_unopt/dart-sdk"
 GN="${FLUTTER_DIR}/tools/gn"
 DART_TOOL_DIR="${WEB_UI_DIR}/.dart_tool"
 PUB_PATH="$DART_SDK_DIR/bin/pub"
+DART2JS_PATH="$DART_SDK_DIR/bin/dart2js"
 SNAPSHOT_PATH="${DART_TOOL_DIR}/felt.snapshot"
 STAMP_PATH="${DART_TOOL_DIR}/felt.snapshot.stamp"
 SCRIPT_PATH="${DEV_DIR}/felt.dart"
 REVISION="$(cd "$FLUTTER_DIR"; git rev-parse HEAD)"
 
-if [ ! -f "${PUB_PATH}" ]
+if [ ! -f "${PUB_PATH}" -o ! -f "${DART2JS_PATH}" ]
 then
   echo "Compiling the Dart SDK."
   gclient sync


### PR DESCRIPTION
This adds a check for the presence of dart2js in the engine build.

Felt relies on an engine build with `--full-dart-sdk` set. Previously,
we checked for the presence of pub, but not for the presence of
web-specific tooling such as dart2js that felt relies on. Pub is built
as part of the default Dart SDK build when `--full-dart-sdk` is not set,
so its presence is insufficient to prove that other required tooling is
present.

Without this check, we get the following error on run:

    Unhandled exception:
    ProcessException: No such file or directory
      Command: /Users/cbracken/src/flutter/engine/src/out/host_debug_unopt/dart-sdk/bin/dart2js --no-minify --disable-inlining --enable-asserts --enable-experiment=non-nullable --no-sound-null-safety -O2 -o test/paragraph_builder_test.dart.browser_test.dart.js test/paragraph_builder_test.dart

Fixes flutter/flutter#65500