### PR TITLE
Adds increment/decrement actions to fuchsia accessibility bridge.

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -356,6 +356,10 @@ AccessibilityBridge::GetFlutterSemanticsAction(
     // Scroll node to make it visible.
     case fuchsia::accessibility::semantics::Action::SHOW_ON_SCREEN:
       return flutter::SemanticsAction::kShowOnScreen;
+    case fuchsia::accessibility::semantics::Action::INCREMENT:
+      return flutter::SemanticsAction::kIncrease;
+    case fuchsia::accessibility::semantics::Action::DECREMENT:
+      return flutter::SemanticsAction::kDecrease;
     default:
       FML_DLOG(WARNING) << "Unexpected action "
                         << static_cast<int32_t>(fuchsia_action)

--- a/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
@@ -633,5 +633,19 @@ TEST_F(AccessibilityBridgeTest, Actions) {
       2u, fuchsia::accessibility::semantics::Action::DEFAULT,
       unhandled_callback);
   EXPECT_EQ(accessibility_delegate_.actions.size(), 3u);
+
+  accessibility_bridge_->OnAccessibilityActionRequested(
+      0u, fuchsia::accessibility::semantics::Action::INCREMENT,
+      handled_callback);
+  EXPECT_EQ(accessibility_delegate_.actions.size(), 4u);
+  EXPECT_EQ(accessibility_delegate_.actions.back(),
+            std::make_pair(0, flutter::SemanticsAction::kIncrease));
+
+  accessibility_bridge_->OnAccessibilityActionRequested(
+      0u, fuchsia::accessibility::semantics::Action::DECREMENT,
+      handled_callback);
+  EXPECT_EQ(accessibility_delegate_.actions.size(), 5u);
+  EXPECT_EQ(accessibility_delegate_.actions.back(),
+            std::make_pair(0, flutter::SemanticsAction::kDecrease));
 }
 }  // namespace flutter_runner_test


### PR DESCRIPTION
## Description

This change adds support for increment/decrement node actions to the fuchsia accessibility bridge.

## Related Issues

N/A

## Tests

I added the following tests:

Added coverage for the additional cases in AccessibilityBridge::GetFlutterSemanticsAction().

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
