### PR TITLE
Open a fresh dir during LoadSkSLs

### DIFF
--- a/shell/common/persistent_cache.cc
+++ b/shell/common/persistent_cache.cc
@@ -192,7 +192,8 @@ std::vector<PersistentCache::SkSLCache> PersistentCache::LoadSkSLs() {
   if (IsValid()) {
     // In case `rewinddir` doesn't work reliably, load SkSLs from a freshly
     // opened directory (https://github.com/flutter/flutter/issues/65258).
-    fml::UniqueFD fresh_dir = fml::OpenDirectoryReadOnly(*cache_directory_, kSkSLSubdirName);
+    fml::UniqueFD fresh_dir =
+        fml::OpenDirectoryReadOnly(*cache_directory_, kSkSLSubdirName);
     fml::VisitFiles(fresh_dir, visitor);
   }
 

--- a/shell/common/persistent_cache.cc
+++ b/shell/common/persistent_cache.cc
@@ -190,7 +190,10 @@ std::vector<PersistentCache::SkSLCache> PersistentCache::LoadSkSLs() {
   // However, we'd like to continue visit the asset dir even if this persistent
   // cache is invalid.
   if (IsValid()) {
-    fml::VisitFiles(*sksl_cache_directory_, visitor);
+    // In case `rewinddir` doesn't work reliably, load SkSLs from a freshly
+    // opened directory (https://github.com/flutter/flutter/issues/65258).
+    fml::UniqueFD fresh_dir = fml::OpenDirectoryReadOnly(*cache_directory_, kSkSLSubdirName);
+    fml::VisitFiles(fresh_dir, visitor);
   }
 
   std::unique_ptr<fml::Mapping> mapping = nullptr;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/65258

The following devicelab tests should pass after this patch:

- flutter_gallery_sksl_warmup__transition_perf_e2e_ios32
- flutter_gallery_sksl_warmup_ios32__transition_perf
