### PR TITLE
Rename Registrar to PluginRegistrar in Win/GLFW C API

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h
@@ -91,8 +91,8 @@ class PluginRegistrarManager {
     auto insert_result =
         registrars_.emplace(registrar_ref, std::make_unique<T>(registrar_ref));
     auto& registrar_pair = *(insert_result.first);
-    FlutterDesktopRegistrarSetDestructionHandler(registrar_pair.first,
-                                                 OnRegistrarDestroyed);
+    FlutterDesktopPluginRegistrarSetDestructionHandler(registrar_pair.first,
+                                                       OnRegistrarDestroyed);
     return static_cast<T*>(registrar_pair.second.get());
   }
 

--- a/shell/platform/common/cpp/client_wrapper/plugin_registrar.cc
+++ b/shell/platform/common/cpp/client_wrapper/plugin_registrar.cc
@@ -17,7 +17,7 @@ namespace flutter {
 
 PluginRegistrar::PluginRegistrar(FlutterDesktopPluginRegistrarRef registrar)
     : registrar_(registrar) {
-  auto core_messenger = FlutterDesktopRegistrarGetMessenger(registrar_);
+  auto core_messenger = FlutterDesktopPluginRegistrarGetMessenger(registrar_);
   messenger_ = std::make_unique<BinaryMessengerImpl>(core_messenger);
 }
 

--- a/shell/platform/common/cpp/client_wrapper/plugin_registrar_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/plugin_registrar_unittests.cc
@@ -39,7 +39,7 @@ class TestApi : public testing::StubFlutterApi {
     last_message_callback_set_ = callback;
   }
 
-  void RegistrarSetDestructionHandler(
+  void PluginRegistrarSetDestructionHandler(
       FlutterDesktopOnRegistrarDestroyed callback) override {
     last_destruction_callback_set_ = callback;
   }

--- a/shell/platform/common/cpp/client_wrapper/plugin_registrar_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/plugin_registrar_unittests.cc
@@ -40,7 +40,7 @@ class TestApi : public testing::StubFlutterApi {
   }
 
   void PluginRegistrarSetDestructionHandler(
-      FlutterDesktopOnRegistrarDestroyed callback) override {
+      FlutterDesktopOnPluginRegistrarDestroyed callback) override {
     last_destruction_callback_set_ = callback;
   }
 
@@ -48,14 +48,15 @@ class TestApi : public testing::StubFlutterApi {
   FlutterDesktopMessageCallback last_message_callback_set() {
     return last_message_callback_set_;
   }
-  FlutterDesktopOnRegistrarDestroyed last_destruction_callback_set() {
+  FlutterDesktopOnPluginRegistrarDestroyed last_destruction_callback_set() {
     return last_destruction_callback_set_;
   }
 
  private:
   const uint8_t* last_data_sent_ = nullptr;
   FlutterDesktopMessageCallback last_message_callback_set_ = nullptr;
-  FlutterDesktopOnRegistrarDestroyed last_destruction_callback_set_ = nullptr;
+  FlutterDesktopOnPluginRegistrarDestroyed last_destruction_callback_set_ =
+      nullptr;
 };
 
 // A PluginRegistrar whose destruction can be watched for by tests.

--- a/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.cc
+++ b/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.cc
@@ -38,17 +38,17 @@ ScopedStubFlutterApi::~ScopedStubFlutterApi() {
 
 // Forwarding dummy implementations of the C API.
 
-FlutterDesktopMessengerRef FlutterDesktopRegistrarGetMessenger(
+FlutterDesktopMessengerRef FlutterDesktopPluginRegistrarGetMessenger(
     FlutterDesktopPluginRegistrarRef registrar) {
   // The stub ignores this, so just return an arbitrary non-zero value.
   return reinterpret_cast<FlutterDesktopMessengerRef>(1);
 }
 
-void FlutterDesktopRegistrarSetDestructionHandler(
+void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopOnRegistrarDestroyed callback) {
   if (s_stub_implementation) {
-    s_stub_implementation->RegistrarSetDestructionHandler(callback);
+    s_stub_implementation->PluginRegistrarSetDestructionHandler(callback);
   }
 }
 

--- a/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.cc
+++ b/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.cc
@@ -46,7 +46,7 @@ FlutterDesktopMessengerRef FlutterDesktopPluginRegistrarGetMessenger(
 
 void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
-    FlutterDesktopOnRegistrarDestroyed callback) {
+    FlutterDesktopOnPluginRegistrarDestroyed callback) {
   if (s_stub_implementation) {
     s_stub_implementation->PluginRegistrarSetDestructionHandler(callback);
   }

--- a/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.h
+++ b/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.h
@@ -34,8 +34,8 @@ class StubFlutterApi {
 
   virtual ~StubFlutterApi() {}
 
-  // Called for FlutterDesktopRegistrarSetDestructionHandler.
-  virtual void RegistrarSetDestructionHandler(
+  // Called for FlutterDesktopPluginRegistrarSetDestructionHandler.
+  virtual void PluginRegistrarSetDestructionHandler(
       FlutterDesktopOnRegistrarDestroyed callback) {}
 
   // Called for FlutterDesktopMessengerSend.

--- a/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.h
+++ b/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.h
@@ -36,7 +36,7 @@ class StubFlutterApi {
 
   // Called for FlutterDesktopPluginRegistrarSetDestructionHandler.
   virtual void PluginRegistrarSetDestructionHandler(
-      FlutterDesktopOnRegistrarDestroyed callback) {}
+      FlutterDesktopOnPluginRegistrarDestroyed callback) {}
 
   // Called for FlutterDesktopMessengerSend.
   virtual bool MessengerSend(const char* channel,

--- a/shell/platform/common/cpp/public/flutter_plugin_registrar.h
+++ b/shell/platform/common/cpp/public/flutter_plugin_registrar.h
@@ -24,10 +24,11 @@ typedef void (*FlutterDesktopOnRegistrarDestroyed)(
 
 // Returns the engine messenger associated with this registrar.
 FLUTTER_EXPORT FlutterDesktopMessengerRef
-FlutterDesktopRegistrarGetMessenger(FlutterDesktopPluginRegistrarRef registrar);
+FlutterDesktopPluginRegistrarGetMessenger(
+    FlutterDesktopPluginRegistrarRef registrar);
 
 // Registers a callback to be called when the plugin registrar is destroyed.
-FLUTTER_EXPORT void FlutterDesktopRegistrarSetDestructionHandler(
+FLUTTER_EXPORT void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopOnRegistrarDestroyed callback);
 

--- a/shell/platform/common/cpp/public/flutter_plugin_registrar.h
+++ b/shell/platform/common/cpp/public/flutter_plugin_registrar.h
@@ -19,7 +19,7 @@ extern "C" {
 typedef struct FlutterDesktopPluginRegistrar* FlutterDesktopPluginRegistrarRef;
 
 // Function pointer type for registrar destruction callback.
-typedef void (*FlutterDesktopOnRegistrarDestroyed)(
+typedef void (*FlutterDesktopOnPluginRegistrarDestroyed)(
     FlutterDesktopPluginRegistrarRef);
 
 // Returns the engine messenger associated with this registrar.
@@ -30,7 +30,7 @@ FlutterDesktopPluginRegistrarGetMessenger(
 // Registers a callback to be called when the plugin registrar is destroyed.
 FLUTTER_EXPORT void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
-    FlutterDesktopOnRegistrarDestroyed callback);
+    FlutterDesktopOnPluginRegistrarDestroyed callback);
 
 #if defined(__cplusplus)
 }  // extern "C"

--- a/shell/platform/glfw/client_wrapper/include/flutter/plugin_registrar_glfw.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/plugin_registrar_glfw.h
@@ -23,7 +23,7 @@ class PluginRegistrarGlfw : public PluginRegistrar {
   explicit PluginRegistrarGlfw(FlutterDesktopPluginRegistrarRef core_registrar)
       : PluginRegistrar(core_registrar) {
     window_ = std::make_unique<FlutterWindow>(
-        FlutterDesktopRegistrarGetWindow(core_registrar));
+        FlutterDesktopPluginRegistrarGetWindow(core_registrar));
   }
 
   virtual ~PluginRegistrarGlfw() = default;
@@ -39,7 +39,8 @@ class PluginRegistrarGlfw : public PluginRegistrar {
   // If set, then the parent window should disable input callbacks
   // while waiting for the handler for messages on that channel to run.
   void EnableInputBlockingForChannel(const std::string& channel) {
-    FlutterDesktopRegistrarEnableInputBlocking(registrar(), channel.c_str());
+    FlutterDesktopPluginRegistrarEnableInputBlocking(registrar(),
+                                                     channel.c_str());
   }
 
  private:

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -183,10 +183,10 @@ FlutterDesktopPluginRegistrarRef FlutterDesktopGetPluginRegistrar(
   return reinterpret_cast<FlutterDesktopPluginRegistrarRef>(2);
 }
 
-void FlutterDesktopRegistrarEnableInputBlocking(
+void FlutterDesktopPluginRegistrarEnableInputBlocking(
     FlutterDesktopPluginRegistrarRef registrar,
     const char* channel) {
   if (s_stub_implementation) {
-    s_stub_implementation->RegistrarEnableInputBlocking(channel);
+    s_stub_implementation->PluginRegistrarEnableInputBlocking(channel);
   }
 }

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
@@ -89,8 +89,8 @@ class StubFlutterGlfwApi {
   // Called for FlutterDesktopShutDownEngine.
   virtual bool ShutDownEngine() { return true; }
 
-  // Called for FlutterDesktopRegistrarEnableInputBlocking.
-  virtual void RegistrarEnableInputBlocking(const char* channel) {}
+  // Called for FlutterDesktopPluginRegistrarEnableInputBlocking.
+  virtual void PluginRegistrarEnableInputBlocking(const char* channel) {}
 };
 
 // A test helper that owns a stub implementation, making it the test stub for

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -138,7 +138,7 @@ struct FlutterDesktopPluginRegistrar {
   FlutterDesktopEngineState* engine;
 
   // Callback to be called on registrar destruction.
-  FlutterDesktopOnRegistrarDestroyed destruction_handler;
+  FlutterDesktopOnPluginRegistrarDestroyed destruction_handler;
 };
 
 // State associated with the messenger used to communicate with the engine.
@@ -976,7 +976,7 @@ FlutterDesktopMessengerRef FlutterDesktopPluginRegistrarGetMessenger(
 
 void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
-    FlutterDesktopOnRegistrarDestroyed callback) {
+    FlutterDesktopOnPluginRegistrarDestroyed callback) {
   registrar->destruction_handler = callback;
 }
 

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -963,24 +963,24 @@ bool FlutterDesktopShutDownEngine(FlutterDesktopEngineRef engine) {
   return (result == kSuccess);
 }
 
-void FlutterDesktopRegistrarEnableInputBlocking(
+void FlutterDesktopPluginRegistrarEnableInputBlocking(
     FlutterDesktopPluginRegistrarRef registrar,
     const char* channel) {
   registrar->engine->message_dispatcher->EnableInputBlockingForChannel(channel);
 }
 
-FlutterDesktopMessengerRef FlutterDesktopRegistrarGetMessenger(
+FlutterDesktopMessengerRef FlutterDesktopPluginRegistrarGetMessenger(
     FlutterDesktopPluginRegistrarRef registrar) {
   return registrar->engine->messenger.get();
 }
 
-void FlutterDesktopRegistrarSetDestructionHandler(
+void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopOnRegistrarDestroyed callback) {
   registrar->destruction_handler = callback;
 }
 
-FlutterDesktopWindowRef FlutterDesktopRegistrarGetWindow(
+FlutterDesktopWindowRef FlutterDesktopPluginRegistrarGetWindow(
     FlutterDesktopPluginRegistrarRef registrar) {
   FlutterDesktopWindowControllerState* controller =
       registrar->engine->window_controller;

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -221,8 +221,8 @@ FLUTTER_EXPORT bool FlutterDesktopShutDownEngine(
 // Returns the window associated with this registrar's engine instance.
 //
 // This is a GLFW shell-specific extension to flutter_plugin_registrar.h
-FLUTTER_EXPORT FlutterDesktopWindowRef
-FlutterDesktopRegistrarGetWindow(FlutterDesktopPluginRegistrarRef registrar);
+FLUTTER_EXPORT FlutterDesktopWindowRef FlutterDesktopPluginRegistrarGetWindow(
+    FlutterDesktopPluginRegistrarRef registrar);
 
 // Enables input blocking on the given channel.
 //
@@ -235,7 +235,7 @@ FlutterDesktopRegistrarGetWindow(FlutterDesktopPluginRegistrarRef registrar);
 // default of disabled.
 //
 // This is a GLFW shell-specific extension to flutter_plugin_registrar.h
-FLUTTER_EXPORT void FlutterDesktopRegistrarEnableInputBlocking(
+FLUTTER_EXPORT void FlutterDesktopPluginRegistrarEnableInputBlocking(
     FlutterDesktopPluginRegistrarRef registrar,
     const char* channel);
 

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -196,12 +196,12 @@ void FlutterDesktopResyncOutputStreams() {
 
 // Implementations of common/cpp/ API methods.
 
-FlutterDesktopMessengerRef FlutterDesktopRegistrarGetMessenger(
+FlutterDesktopMessengerRef FlutterDesktopPluginRegistrarGetMessenger(
     FlutterDesktopPluginRegistrarRef registrar) {
   return registrar->engine->messenger();
 }
 
-void FlutterDesktopRegistrarSetDestructionHandler(
+void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
     FlutterDesktopOnRegistrarDestroyed callback) {
   registrar->engine->SetPluginRegistrarDestructionCallback(callback);

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -203,7 +203,7 @@ FlutterDesktopMessengerRef FlutterDesktopPluginRegistrarGetMessenger(
 
 void FlutterDesktopPluginRegistrarSetDestructionHandler(
     FlutterDesktopPluginRegistrarRef registrar,
-    FlutterDesktopOnRegistrarDestroyed callback) {
+    FlutterDesktopOnPluginRegistrarDestroyed callback) {
   registrar->engine->SetPluginRegistrarDestructionCallback(callback);
 }
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -217,7 +217,7 @@ FlutterDesktopPluginRegistrarRef FlutterWindowsEngine::GetRegistrar() {
 }
 
 void FlutterWindowsEngine::SetPluginRegistrarDestructionCallback(
-    FlutterDesktopOnRegistrarDestroyed callback) {
+    FlutterDesktopOnPluginRegistrarDestroyed callback) {
   plugin_registrar_destruction_callback_ = callback;
 }
 

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -63,7 +63,7 @@ class FlutterWindowsEngine {
 
   // Sets |callback| to be called when the plugin registrar is destroyed.
   void SetPluginRegistrarDestructionCallback(
-      FlutterDesktopOnRegistrarDestroyed callback);
+      FlutterDesktopOnPluginRegistrarDestroyed callback);
 
   FLUTTER_API_SYMBOL(FlutterEngine) engine() { return engine_; }
 
@@ -115,7 +115,8 @@ class FlutterWindowsEngine {
 
   // A callback to be called when the engine (and thus the plugin registrar)
   // is being destroyed.
-  FlutterDesktopOnRegistrarDestroyed plugin_registrar_destruction_callback_;
+  FlutterDesktopOnPluginRegistrarDestroyed
+      plugin_registrar_destruction_callback_;
 
   // The manager for WindowProc delegate registration and callbacks.
   std::unique_ptr<Win32WindowProcDelegateManager> window_proc_delegate_manager_;


### PR DESCRIPTION
## Description

The C API for the C++ shared embedding code used by Windows and GLFW
initiall just referred to the PluginRegistrar as "Registrar". Since
there will be at least one more registrar (the TextureRegistrar), this
renames them to avoid ambiguity.

This alligns the rest of the C API with changes already made for the
Windows-specific additions.

## Related Issues

None

## Tests

I added the following tests: Existing tests have been updated to the new names

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
   - [x] Windows is not yet subject to the breaking change policy. Also, this will not break clients of the C++ wrapper, which should be pretty much everyone.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
