### PR TITLE
Remove the type parameter from `SkObjectFinalizationRegistry`.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1640,7 +1640,7 @@ class TypefaceFontProviderNamespace {
 Timer? _skObjectCollector;
 List<SkDeletable> _skObjectDeleteQueue = <SkDeletable>[];
 
-final SkObjectFinalizationRegistry<SkDeletable> skObjectFinalizationRegistry = SkObjectFinalizationRegistry<SkDeletable>(js.allowInterop((SkDeletable deletable) {
+final SkObjectFinalizationRegistry skObjectFinalizationRegistry = SkObjectFinalizationRegistry(js.allowInterop((SkDeletable deletable) {
   _skObjectDeleteQueue.add(deletable);
   _skObjectCollector ??= _scheduleSkObjectCollection();
 }));
@@ -1673,8 +1673,6 @@ Timer _scheduleSkObjectCollection() => Timer(Duration.zero, () {
   html.window.performance.measure('SkObject collection', 'SkObject collection-start', 'SkObject collection-end');
 });
 
-typedef SkObjectFinalizer<T> = void Function(T key);
-
 /// Any Skia object that has a `delete` method.
 @JS()
 @anonymous
@@ -1698,8 +1696,10 @@ class SkDeletable {
 /// 5. The finalizer function is called with the SkPaint as the sole argument.
 /// 6. We call `delete` on SkPaint.
 @JS('window.FinalizationRegistry')
-class SkObjectFinalizationRegistry<T> {
-  external SkObjectFinalizationRegistry(SkObjectFinalizer<T> finalizer);
+class SkObjectFinalizationRegistry {
+  // TODO(hterkelsen): Add a type for the `cleanup` function when
+  // native constructors support type parameters.
+  external SkObjectFinalizationRegistry(Function cleanup);
   external void register(Object ckObject, Object skObject);
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -264,9 +264,8 @@ class SkiaObjectBox {
   bool _isDeleted = false;
 
   /// Deletes Skia objects when their wrappers are garbage collected.
-  static final SkObjectFinalizationRegistry<SkiaObjectBox> boxRegistry =
-      SkObjectFinalizationRegistry<SkiaObjectBox>(
-          js.allowInterop((SkiaObjectBox box) {
+  static final SkObjectFinalizationRegistry boxRegistry =
+      SkObjectFinalizationRegistry(js.allowInterop((SkiaObjectBox box) {
     box.delete();
   }));
 


### PR DESCRIPTION
Dart2js will pass the type parameter to the native object, which
causes an error in Chrome Canary.

## Description

Dart2js will pass the type parameter to the native object, which
causes an error in Chrome Canary.

## Related Issues

Fixes https://github.com/flutter/devtools/issues/2290

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
