### PR TITLE
Flutter should not stop registering unregistered plugins in case of an error registering a plugin

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
@@ -130,7 +130,20 @@ class FlutterEnginePluginRegistry
     // Add the plugin to our generic set of plugins and notify the plugin
     // that is has been attached to an engine.
     plugins.put(plugin.getClass(), plugin);
-    plugin.onAttachedToEngine(pluginBinding);
+
+    try {
+      plugin.onAttachedToEngine(pluginBinding);
+    }catch(Exception e){
+      Log.w(
+        TAG, 
+        "Attempted to attach plugin ("
+              + plugin
+              + ") but there's a problem with this FlutterEngine ("
+              + flutterEngine
+              + ").");
+      return;
+    }
+    
 
     // For ActivityAware plugins, add the plugin to our set of ActivityAware
     // plugins, and if this engine is currently attached to an Activity,

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
@@ -126,14 +126,62 @@ class FlutterEnginePluginRegistry
       return;
     }
 
-    Log.v(TAG, "Adding plugin: " + plugin);
-    // Add the plugin to our generic set of plugins and notify the plugin
-    // that is has been attached to an engine.
-    plugins.put(plugin.getClass(), plugin);
-
     try {
+      Log.v(TAG, "Adding plugin: " + plugin);
+      // Add the plugin to our generic set of plugins and notify the plugin
+      // that is has been attached to an engine.
+      plugins.put(plugin.getClass(), plugin);
       plugin.onAttachedToEngine(pluginBinding);
-    }catch(Exception e){
+    
+      // For ActivityAware plugins, add the plugin to our set of ActivityAware
+      // plugins, and if this engine is currently attached to an Activity,
+      // notify the ActivityAware plugin that it is now attached to an Activity.
+      if (plugin instanceof ActivityAware) {
+        ActivityAware activityAware = (ActivityAware) plugin;
+        activityAwarePlugins.put(plugin.getClass(), activityAware);
+
+        if (isAttachedToActivity()) {
+          activityAware.onAttachedToActivity(activityPluginBinding);
+        }
+      }
+
+      // For ServiceAware plugins, add the plugin to our set of ServiceAware
+      // plugins, and if this engine is currently attached to a Service,
+      // notify the ServiceAware plugin that it is now attached to a Service.
+      if (plugin instanceof ServiceAware) {
+        ServiceAware serviceAware = (ServiceAware) plugin;
+        serviceAwarePlugins.put(plugin.getClass(), serviceAware);
+
+        if (isAttachedToService()) {
+          serviceAware.onAttachedToService(servicePluginBinding);
+        }
+      }
+
+      // For BroadcastReceiverAware plugins, add the plugin to our set of BroadcastReceiverAware
+      // plugins, and if this engine is currently attached to a BroadcastReceiver,
+      // notify the BroadcastReceiverAware plugin that it is now attached to a BroadcastReceiver.
+      if (plugin instanceof BroadcastReceiverAware) {
+        BroadcastReceiverAware broadcastReceiverAware = (BroadcastReceiverAware) plugin;
+        broadcastReceiverAwarePlugins.put(plugin.getClass(), broadcastReceiverAware);
+
+        if (isAttachedToBroadcastReceiver()) {
+          broadcastReceiverAware.onAttachedToBroadcastReceiver(broadcastReceiverPluginBinding);
+        }
+      }
+
+      // For ContentProviderAware plugins, add the plugin to our set of ContentProviderAware
+      // plugins, and if this engine is currently attached to a ContentProvider,
+      // notify the ContentProviderAware plugin that it is now attached to a ContentProvider.
+      if (plugin instanceof ContentProviderAware) {
+        ContentProviderAware contentProviderAware = (ContentProviderAware) plugin;
+        contentProviderAwarePlugins.put(plugin.getClass(), contentProviderAware);
+
+        if (isAttachedToContentProvider()) {
+          contentProviderAware.onAttachedToContentProvider(contentProviderPluginBinding);
+        }
+      }
+
+    } catch(Exception e) {
       Log.w(
         TAG, 
         "Attempted to attach plugin ("
@@ -142,55 +190,6 @@ class FlutterEnginePluginRegistry
               + flutterEngine
               + ").");
       return;
-    }
-    
-
-    // For ActivityAware plugins, add the plugin to our set of ActivityAware
-    // plugins, and if this engine is currently attached to an Activity,
-    // notify the ActivityAware plugin that it is now attached to an Activity.
-    if (plugin instanceof ActivityAware) {
-      ActivityAware activityAware = (ActivityAware) plugin;
-      activityAwarePlugins.put(plugin.getClass(), activityAware);
-
-      if (isAttachedToActivity()) {
-        activityAware.onAttachedToActivity(activityPluginBinding);
-      }
-    }
-
-    // For ServiceAware plugins, add the plugin to our set of ServiceAware
-    // plugins, and if this engine is currently attached to a Service,
-    // notify the ServiceAware plugin that it is now attached to a Service.
-    if (plugin instanceof ServiceAware) {
-      ServiceAware serviceAware = (ServiceAware) plugin;
-      serviceAwarePlugins.put(plugin.getClass(), serviceAware);
-
-      if (isAttachedToService()) {
-        serviceAware.onAttachedToService(servicePluginBinding);
-      }
-    }
-
-    // For BroadcastReceiverAware plugins, add the plugin to our set of BroadcastReceiverAware
-    // plugins, and if this engine is currently attached to a BroadcastReceiver,
-    // notify the BroadcastReceiverAware plugin that it is now attached to a BroadcastReceiver.
-    if (plugin instanceof BroadcastReceiverAware) {
-      BroadcastReceiverAware broadcastReceiverAware = (BroadcastReceiverAware) plugin;
-      broadcastReceiverAwarePlugins.put(plugin.getClass(), broadcastReceiverAware);
-
-      if (isAttachedToBroadcastReceiver()) {
-        broadcastReceiverAware.onAttachedToBroadcastReceiver(broadcastReceiverPluginBinding);
-      }
-    }
-
-    // For ContentProviderAware plugins, add the plugin to our set of ContentProviderAware
-    // plugins, and if this engine is currently attached to a ContentProvider,
-    // notify the ContentProviderAware plugin that it is now attached to a ContentProvider.
-    if (plugin instanceof ContentProviderAware) {
-      ContentProviderAware contentProviderAware = (ContentProviderAware) plugin;
-      contentProviderAwarePlugins.put(plugin.getClass(), contentProviderAware);
-
-      if (isAttachedToContentProvider()) {
-        contentProviderAware.onAttachedToContentProvider(contentProviderPluginBinding);
-      }
     }
   }
 


### PR DESCRIPTION
## Description

When a plugin fails to register with a FlutterEngine it will cause unregistered plugins not to be registered because GeneratedPluginRegistrant.registerWith throws an error and stops the plugin registration process.

## Related Issues

https://github.com/flutter/flutter/issues/65525

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
