### PR TITLE
updating the documentation after integration_test migration

### DIFF
--- a/e2etests/web/regular_integration_tests/README.md
+++ b/e2etests/web/regular_integration_tests/README.md
@@ -2,7 +2,7 @@
 
 This directory is for Flutter Web engine integration tests that does not need a specific configuration. If an integration test needs specialized app configuration (e.g. PWA vs non-PWA packaging), please create another directory under e2etests/web. Otherwise tests such as text_editing, history, scrolling, pointer events... should all go under this package.
 
-Tests can be run on both 'debug', 'release' and 'profile' modes. However 'profile' mode will shorten the error stack trace. 'release' mode is for testing release code, it does not run the `assert` checks. Use 'debug' mode for troubleshooting purposes and seeing full stack traces (if there is an error).
+Tests can be run on both 'debug', 'release' and 'profile' modes. However 'profile'/'release' modes will shorten the error stack trace. 'release' mode is for testing release code. Use 'debug' mode for troubleshooting purposes and seeing full stack traces (if there is an error). For more details on build [modes](https://flutter.dev/docs/testing/build-modes).
 
 ## To run the application under test for troubleshooting purposes
 

--- a/e2etests/web/regular_integration_tests/README.md
+++ b/e2etests/web/regular_integration_tests/README.md
@@ -1,22 +1,39 @@
+# Flutter for Web Engine Integration testing
+
+This directory is for Flutter Web engine integration tests that does not need a specific configuration. If an integration test needs specialized app configuration (e.g. PWA vs non-PWA packaging), please create another directory under e2etests/web. Otherwise tests such as text_editing, history, scrolling, pointer events... should all go under this package.
+
+Tests can be run on both 'debug', 'release' and 'profile' modes. However 'release' mode will shorten the error. Use 'debug' mode for trouble-shooting purposes where you can also see the full stack trace.
+
+## To run the application under test for trouble shooting purposes
+
 ```
-This directory is for Flutter Web engine integration tests that does not
-need a specific configuration. If an e2e test needs specialized app
-configuration (e.g. PWA vs non-PWA packaging), please create another
-directory under e2etests/web. Otherwise tests such as text_editing, history,
-scrolling, pointer events... should all go under this package.
-
-Tests can be run on both 'release' and 'profile' modes. However 'release' mode
-will shorten the error. Use 'profile' mode for trouble-shooting purposes where
-you can also see the full stack trace.
-
-# To run the application under test for trouble shooting purposes.
 flutter run -d web-server lib/text_editing_main.dart --local-engine=host_debug_unopt
-
-# To run the Text Editing test and use the developer tools in the browser.
-flutter run --target=test_driver/text_editing_e2e.dart -d web-server --web-port=8080 --profile --local-engine=host_debug_unopt
-
-# To test the Text Editing test with driver you either of the following:
-flutter drive -v --target=test_driver/text_editing_e2e.dart -d web-server --profile --browser-name=chrome --local-engine=host_debug_unopt
-
-flutter drive -v --target=test_driver/text_editing_e2e.dart -d web-server --release --browser-name=chrome --local-engine=host_debug_unopt
 ```
+
+## To run the Text Editing test and use the developer tools in the browser
+
+```
+flutter run --target=test_driver/text_editing_integration.dart -d web-server --web-port=8080 --profile --local-engine=host_debug_unopt
+```
+
+## To run the test for Text Editing with driver
+
+Either of the following options:
+
+```
+flutter drive -v --target=test_driver/text_editing_integration.dart -d web-server --profile --browser-name=chrome --local-engine=host_debug_unopt
+```
+
+```
+flutter drive -v --target=test_driver/text_editing_integration.dart -d web-server --release --browser-name=chrome --local-engine=host_debug_unopt
+```
+
+## Using different browsers
+
+The default browser is Chrome, you can also use `android-chrome`, `safari`,`ios-safari`, `firefox` or `edge` as your browser choice. Example:
+
+```
+flutter drive -v --target=test_driver/text_editing_integration.dart -d web-server --release --browser-name=firefox --local-engine=host_debug_unopt
+```
+
+More details for "Running Flutter Driver tests with Web" can be founf in [wiki](https://github.com/flutter/flutter/wiki/Running-Flutter-Driver-tests-with-Web).

--- a/e2etests/web/regular_integration_tests/README.md
+++ b/e2etests/web/regular_integration_tests/README.md
@@ -2,7 +2,7 @@
 
 This directory is for Flutter Web engine integration tests that does not need a specific configuration. If an integration test needs specialized app configuration (e.g. PWA vs non-PWA packaging), please create another directory under e2etests/web. Otherwise tests such as text_editing, history, scrolling, pointer events... should all go under this package.
 
-Tests can be run on both 'debug', 'release' and 'profile' modes. However 'release' mode will shorten the error. Use 'debug' mode for trouble-shooting purposes where you can also see the full stack trace.
+Tests can be run on both 'debug', 'release' and 'profile' modes. However 'profile' mode will shorten the error stack trace. 'release' mode is for testing release code, it does not run the `assert` checks. Use 'debug' mode for troubleshooting purposes and seeing full stack traces (if there is an error).
 
 ## To run the application under test for troubleshooting purposes
 
@@ -13,7 +13,7 @@ flutter run -d web-server lib/text_editing_main.dart --local-engine=host_debug_u
 ## To run the Text Editing test and use the developer tools in the browser
 
 ```
-flutter run --target=test_driver/text_editing_integration.dart -d web-server --web-port=8080 --profile --local-engine=host_debug_unopt
+flutter run test_driver/text_editing_integration.dart -d web-server --web-port=8080 --profile --local-engine=host_debug_unopt
 ```
 
 ## To run the test for Text Editing with driver
@@ -21,11 +21,11 @@ flutter run --target=test_driver/text_editing_integration.dart -d web-server --w
 Either of the following options:
 
 ```
-flutter drive -v --target=test_driver/text_editing_integration.dart -d web-server --profile --browser-name=chrome --local-engine=host_debug_unopt
+flutter drive -v --target=test_driver/text_editing_integration.dart -d web-server --profile --local-engine=host_debug_unopt
 ```
 
 ```
-flutter drive -v --target=test_driver/text_editing_integration.dart -d web-server --release --browser-name=chrome --local-engine=host_debug_unopt
+flutter drive -v --target=test_driver/text_editing_integration.dart -d web-server --release --local-engine=host_debug_unopt
 ```
 
 ## Using different browsers

--- a/e2etests/web/regular_integration_tests/README.md
+++ b/e2etests/web/regular_integration_tests/README.md
@@ -4,7 +4,7 @@ This directory is for Flutter Web engine integration tests that does not need a 
 
 Tests can be run on both 'debug', 'release' and 'profile' modes. However 'release' mode will shorten the error. Use 'debug' mode for trouble-shooting purposes where you can also see the full stack trace.
 
-## To run the application under test for trouble shooting purposes
+## To run the application under test for troubleshooting purposes
 
 ```
 flutter run -d web-server lib/text_editing_main.dart --local-engine=host_debug_unopt
@@ -36,4 +36,4 @@ The default browser is Chrome, you can also use `android-chrome`, `safari`,`ios-
 flutter drive -v --target=test_driver/text_editing_integration.dart -d web-server --release --browser-name=firefox --local-engine=host_debug_unopt
 ```
 
-More details for "Running Flutter Driver tests with Web" can be founf in [wiki](https://github.com/flutter/flutter/wiki/Running-Flutter-Driver-tests-with-Web).
+More details for "Running Flutter Driver tests with Web" can be found in [wiki](https://github.com/flutter/flutter/wiki/Running-Flutter-Driver-tests-with-Web).


### PR DESCRIPTION
updating the documentation for running integration tests 
- update after migration to integration_test
- adding more details on running with different browsers
