### PR TITLE
Disable flaky iOS Scenario app tests

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
@@ -227,9 +227,7 @@ FLUTTER_ASSERT_ARC
   [engine setViewController:nil];
 }
 
-// TODO(cbracken): re-enable this test by removing the skip_ prefix once the source of its flakiness
-// has been identified. https://github.com/flutter/flutter/issues/61620
-- (void)skip_testFlutterViewControllerDetachingSendsApplicationLifecycle {
+- (void)testFlutterViewControllerDetachingSendsApplicationLifecycle {
   XCTestExpectation* engineStartedExpectation = [self expectationWithDescription:@"Engine started"];
 
   // Let the engine finish booting (at the end of which the channels are properly set-up) before

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -33,9 +33,14 @@ if [[ $# -eq 1 ]]; then
   FLUTTER_ENGINE="$1"
 fi
 
-cd ios/Scenarios
-set -o pipefail && xcodebuild -sdk iphonesimulator \
-  -scheme Scenarios \
-  -destination 'platform=iOS Simulator,name=iPhone 8' \
-  test \
-  FLUTTER_ENGINE="$FLUTTER_ENGINE"
+echo "iOS Scenarios tests currently disabled due to flakiness"
+echo "See: https://github.com/flutter/flutter/issues/61620"
+
+# TODO(cbracken): re-enable when
+# https://github.com/flutter/flutter/issues/61620 is fixed.
+# cd ios/Scenarios
+# set -o pipefail && xcodebuild -sdk iphonesimulator \
+#   -scheme Scenarios \
+#   -destination 'platform=iOS Simulator,name=iPhone 8' \
+#   test \
+#   FLUTTER_ENGINE="$FLUTTER_ENGINE"


### PR DESCRIPTION
This disables the macOS Scenarios app tests until a fix for the flakiness is found.

This reverts commit 55d447a1c3e124e4b1ae6c8a1230808412657a85 (flutter/engine#21075) which disabled one of the tests. After landing, the Scenarios app tests started failing on a different test.

Related issue: https://github.com/flutter/flutter/issues/61620