### PR TITLE
Remove deprecated methods from FlutterViewController

### DIFF
--- a/shell/platform/windows/client_wrapper/flutter_view_controller.cc
+++ b/shell/platform/windows/client_wrapper/flutter_view_controller.cc
@@ -40,13 +40,4 @@ std::optional<LRESULT> FlutterViewController::HandleTopLevelWindowProc(
   return handled ? result : std::optional<LRESULT>(std::nullopt);
 }
 
-std::chrono::nanoseconds FlutterViewController::ProcessMessages() {
-  return engine_->ProcessMessages();
-}
-
-FlutterDesktopPluginRegistrarRef FlutterViewController::GetRegistrarForPlugin(
-    const std::string& plugin_name) {
-  return engine_->GetRegistrarForPlugin(plugin_name);
-}
-
 }  // namespace flutter

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
@@ -24,7 +24,7 @@ namespace flutter {
 // This is the primary wrapper class for the desktop C API.
 // If you use this class, you should not call any of the setup or teardown
 // methods in the C API directly, as this class will do that internally.
-class FlutterViewController : public PluginRegistry {
+class FlutterViewController {
  public:
   // Creates a FlutterView that can be parented into a Windows View hierarchy
   // either using HWNDs or in the future into a CoreWindow, or using compositor.
@@ -55,13 +55,6 @@ class FlutterViewController : public PluginRegistry {
                                                   UINT message,
                                                   WPARAM wparam,
                                                   LPARAM lparam);
-
-  // DEPRECATED. Call engine()->ProcessMessages() instead.
-  std::chrono::nanoseconds ProcessMessages();
-
-  // DEPRECATED. Call engine()->GetRegistrarForPlugin() instead.
-  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
-      const std::string& plugin_name) override;
 
  private:
   // Handle for interacting with the C API's view controller, if any.


### PR DESCRIPTION
## Description

The template now uses the FlutterEngine versions.

## Related Issues

Part of https://github.com/flutter/flutter/issues/52748

## Tests

I added the following tests: N/A, just removes deprecated code.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
   - [x] Windows is not yet subject to the breaking change policy. The template has already been updated with a template version rev, so in practice this shouldn't break anyone.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
