### PR TITLE
Re-enable (most) iOS Scenarios tests

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
@@ -227,7 +227,9 @@ FLUTTER_ASSERT_ARC
   [engine setViewController:nil];
 }
 
-- (void)testFlutterViewControllerDetachingSendsApplicationLifecycle {
+// TODO(cbracken): re-enable this test by removing the skip_ prefix once the source of its flakiness
+// has been identified. https://github.com/flutter/flutter/issues/61620
+- (void)skip_testFlutterViewControllerDetachingSendsApplicationLifecycle {
   XCTestExpectation* engineStartedExpectation = [self expectationWithDescription:@"Engine started"];
 
   // Let the engine finish booting (at the end of which the channels are properly set-up) before

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerInitialRouteTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerInitialRouteTest.m
@@ -33,7 +33,9 @@ FLUTTER_ASSERT_ARC
   [super tearDown];
 }
 
-- (void)testSettingInitialRoute {
+// TODO(cbracken): re-enable this test by removing the skip_ prefix once the source of its flakiness
+// has been identified. https://github.com/flutter/flutter/issues/61620
+- (void)skip_testSettingInitialRoute {
   self.flutterViewController =
       [[FlutterViewController alloc] initWithProject:nil
                                         initialRoute:@"myCustomInitialRoute"

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -33,14 +33,9 @@ if [[ $# -eq 1 ]]; then
   FLUTTER_ENGINE="$1"
 fi
 
-echo "iOS Scenarios tests currently disabled due to flakiness"
-echo "See: https://github.com/flutter/flutter/issues/61620"
-
-# TODO(cbracken): re-enable when
-# https://github.com/flutter/flutter/issues/61620 is fixed.
-# cd ios/Scenarios
-# set -o pipefail && xcodebuild -sdk iphonesimulator \
-#   -scheme Scenarios \
-#   -destination 'platform=iOS Simulator,name=iPhone 8' \
-#   test \
-#   FLUTTER_ENGINE="$FLUTTER_ENGINE"
+cd ios/Scenarios
+set -o pipefail && xcodebuild -sdk iphonesimulator \
+  -scheme Scenarios \
+  -destination 'platform=iOS Simulator,name=iPhone 8' \
+  test \
+  FLUTTER_ENGINE="$FLUTTER_ENGINE"


### PR DESCRIPTION
This re-enables the iOS Scenarios tests which have been flaky in the
last couple days.

Disabling two tests where we've seen the flakes:
* AppLifecycleTests testFlutterViewControllerDetachingSendsApplicationLifecycle
* FlutterViewControllerInitialRouteTest testSettingInitialRoute

Related: https://github.com/flutter/flutter/issues/61620

This reverts commit 0c6c265a6f38bcacf551690a8fc8f78bb4f2c285.