### PR TITLE
Copyright header hygiene improvements

### DIFF
--- a/examples/glfw/FlutterEmbedderGLFW.cc
+++ b/examples/glfw/FlutterEmbedderGLFW.cc
@@ -1,7 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #include <assert.h>
 #include <embedder.h>
 #include <glfw3.h>
+
 #include <chrono>
 #include <iostream>
 

--- a/examples/glfw/main.dart
+++ b/examples/glfw/main.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart'
     show debugDefaultTargetPlatformOverride;

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -1,7 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-//
+
 #ifndef FLUTTER_FLOW_EMBEDDED_VIEWS_H_
 #define FLUTTER_FLOW_EMBEDDED_VIEWS_H_
 

--- a/flow/flow_run_all_unittests.cc
+++ b/flow/flow_run_all_unittests.cc
@@ -1,7 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-//
+
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"

--- a/flow/flow_test_utils.cc
+++ b/flow/flow_test_utils.cc
@@ -1,7 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-//
+
 #include <string>
 
 namespace flutter {

--- a/flow/flow_test_utils.h
+++ b/flow/flow_test_utils.h
@@ -1,7 +1,7 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-//
+
 #include <string>
 
 namespace flutter {

--- a/flutter_frontend_server/bin/starter.dart
+++ b/flutter_frontend_server/bin/starter.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 // @dart=2.8
 library frontend_server;
 

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "shell_test_external_view_embedder.h"
 
 namespace flutter {

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -1,4 +1,9 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include <unistd.h>
+
 #include <algorithm>
 #include <sstream>
 

--- a/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.cc
+++ b/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.cc
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Copyright 2013 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 #include "flutter/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.h"
 
 static flutter::testing::StubFlutterApi* s_stub_implementation;

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui';

--- a/shell/platform/windows/testing/mock_win32_window.cc
+++ b/shell/platform/windows/testing/mock_win32_window.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "flutter/shell/platform/windows/testing/mock_win32_window.h"
 
 namespace flutter {

--- a/shell/platform/windows/testing/win32_flutter_window_test.cc
+++ b/shell/platform/windows/testing/win32_flutter_window_test.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "flutter/shell/platform/windows/testing/win32_flutter_window_test.h"
 
 namespace flutter {

--- a/shell/platform/windows/win32_dpi_utils.cc
+++ b/shell/platform/windows/win32_dpi_utils.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "win32_dpi_utils.h"
 
 namespace flutter {

--- a/shell/platform/windows/win32_flutter_window.cc
+++ b/shell/platform/windows/win32_flutter_window.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "flutter/shell/platform/windows/win32_flutter_window.h"
 
 #include <chrono>

--- a/testing/dart/channel_buffers_test.dart
+++ b/testing/dart/channel_buffers_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 // @dart = 2.6
 import 'dart:convert';
 import 'dart:typed_data';

--- a/testing/dart/dart_test.dart
+++ b/testing/dart/dart_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/dart/image_filter_test.dart
+++ b/testing/dart/image_filter_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/dart/paragraph_test.dart
+++ b/testing/dart/paragraph_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/dart/task_order_test.dart
+++ b/testing/dart/task_order_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/dart/text_test.dart
+++ b/testing/dart/text_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/scenario_app/lib/src/channel_util.dart
+++ b/testing/scenario_app/lib/src/channel_util.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/scenario_app/lib/src/initial_route_reply.dart
+++ b/testing/scenario_app/lib/src/initial_route_reply.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/scenario_app/lib/src/locale_initialization.dart
+++ b/testing/scenario_app/lib/src/locale_initialization.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/scenario_app/lib/src/platform_echo_mixin.dart
+++ b/testing/scenario_app/lib/src/platform_echo_mixin.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/scenario_app/lib/src/poppable_screen.dart
+++ b/testing/scenario_app/lib/src/poppable_screen.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/scenario_app/lib/src/send_text_focus_semantics.dart
+++ b/testing/scenario_app/lib/src/send_text_focus_semantics.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/scenario_app/lib/src/touches_scenario.dart
+++ b/testing/scenario_app/lib/src/touches_scenario.dart
@@ -1,4 +1,4 @@
-// Copyright 2020 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 // @dart = 2.6
 import 'dart:convert';
 import 'dart:io';

--- a/third_party/txt/src/txt/styled_runs.cc
+++ b/third_party/txt/src/txt/styled_runs.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google, Inc.
+ * Copyright 2017 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -132,7 +132,7 @@ void _checkNonConsts() {
         },
         <String, dynamic>{
           'file': 'file://$fixtures/pkg/package.dart',
-          'line': 10,
+          'line': 14,
           'column': 25,
         }
       ]

--- a/tools/const_finder/test/fixtures/pkg/package.dart
+++ b/tools/const_finder/test/fixtures/pkg/package.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:const_finder_fixtures/target.dart';
 
 void createTargetInPackage() {

--- a/tools/generate_package_config/bin/generate_from_legacy.dart
+++ b/tools/generate_package_config/bin/generate_from_legacy.dart
@@ -1,6 +1,7 @@
-// Copyright (c) 2020, the Dart project authors.  Please see the AUTHORS file
-// for details. All rights reserved. Use of this source code is governed by a
-// BSD-style license that can be found in the LICENSE file.
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 // @dart=2.8
 import 'dart:convert';
 import 'dart:io';


### PR DESCRIPTION
Add copyright headers in a few files where they were missing.

Removes a duplicate copyright header.

Trims trailing blank comment line where present, for consistency with
other engine code.

Uses the standard libtxt copyright header in one file where it differed
(extra (C) and comma compared to other files in libtxt).

This also amends tools/const_finder/test/const_finder_test.dart to look
for a const an additional four lines down to account for the copyright
header added to the test fixture.