### PR TITLE
Prefer C++ standard headers to their C counterpart

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -6,9 +6,9 @@
 #define FLUTTER_COMMON_SETTINGS_H_
 
 #include <fcntl.h>
-#include <stdint.h>
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>

--- a/examples/glfw/FlutterEmbedderGLFW.cc
+++ b/examples/glfw/FlutterEmbedderGLFW.cc
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <assert.h>
 #include <embedder.h>
 #include <glfw3.h>
 
+#include <cassert>
 #include <chrono>
 #include <iostream>
 

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -5,8 +5,7 @@
 #ifndef FLUTTER_FLOW_LAYERS_LAYER_TREE_H_
 #define FLUTTER_FLOW_LAYERS_LAYER_TREE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <memory>
 
 #include "flutter/flow/compositor_context.h"

--- a/flow/matrix_decomposition_unittests.cc
+++ b/flow/matrix_decomposition_unittests.cc
@@ -2,11 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/fml/build_config.h"
-
-#if defined(OS_WIN)
 #define _USE_MATH_DEFINES
-#endif
+
 #include <cmath>
 
 #include "flutter/flow/matrix_decomposition.h"

--- a/fml/command_line.h
+++ b/fml/command_line.h
@@ -36,8 +36,7 @@
 #ifndef LIB_FML_COMMAND_LINE_H_
 #define LIB_FML_COMMAND_LINE_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <initializer_list>
 #include <string>
 #include <string_view>

--- a/fml/log_settings.cc
+++ b/fml/log_settings.cc
@@ -5,9 +5,9 @@
 #include "flutter/fml/log_settings.h"
 
 #include <fcntl.h>
-#include <string.h>
 
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 
 #include "flutter/fml/logging.h"

--- a/fml/platform/android/scoped_java_ref.h
+++ b/fml/platform/android/scoped_java_ref.h
@@ -6,7 +6,8 @@
 #define FLUTTER_FML_PLATFORM_ANDROID_SCOPED_JAVA_REF_H_
 
 #include <jni.h>
-#include <stddef.h>
+
+#include <cstddef>
 
 #include "flutter/fml/macros.h"
 

--- a/fml/platform/posix/paths_posix.cc
+++ b/fml/platform/posix/paths_posix.cc
@@ -4,8 +4,9 @@
 
 #include "flutter/fml/paths.h"
 
-#include <limits.h>
 #include <unistd.h>
+
+#include <climits>
 
 #include "flutter/fml/logging.h"
 

--- a/fml/platform/posix/posix_wrappers_posix.cc
+++ b/fml/platform/posix/posix_wrappers_posix.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/fml/posix_wrappers.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace fml {
 

--- a/fml/platform/win/file_win.cc
+++ b/fml/platform/win/file_win.cc
@@ -7,9 +7,10 @@
 #include <Fileapi.h>
 #include <Shlwapi.h>
 #include <fcntl.h>
-#include <limits.h>
 
 #include <algorithm>
+#include <climits>
+#include <cstring>
 #include <sstream>
 
 #include "flutter/fml/build_config.h"

--- a/fml/platform/win/posix_wrappers_win.cc
+++ b/fml/platform/win/posix_wrappers_win.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/fml/posix_wrappers.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace fml {
 

--- a/fml/synchronization/waitable_event.cc
+++ b/fml/synchronization/waitable_event.cc
@@ -4,12 +4,12 @@
 
 #include "flutter/fml/synchronization/waitable_event.h"
 
+#include <cerrno>
+#include <ctime>
+
 #include "flutter/fml/logging.h"
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"
-
-#include <errno.h>
-#include <time.h>
 
 namespace fml {
 

--- a/fml/synchronization/waitable_event_unittest.cc
+++ b/fml/synchronization/waitable_event_unittest.cc
@@ -4,11 +4,10 @@
 
 #include "flutter/fml/synchronization/waitable_event.h"
 
-#include <stddef.h>
-#include <stdint.h>
-#include <stdlib.h>
-
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
 #include <thread>
 #include <type_traits>
 #include <vector>

--- a/fml/time/time_delta.h
+++ b/fml/time/time_delta.h
@@ -5,10 +5,9 @@
 #ifndef FLUTTER_FML_TIME_TIME_DELTA_H_
 #define FLUTTER_FML_TIME_TIME_DELTA_H_
 
-#include <stdint.h>
-#include <time.h>
-
 #include <chrono>
+#include <cstdint>
+#include <ctime>
 #include <iosfwd>
 #include <limits>
 

--- a/fml/time/time_point.h
+++ b/fml/time/time_point.h
@@ -5,8 +5,7 @@
 #ifndef FLUTTER_FML_TIME_TIME_POINT_H_
 #define FLUTTER_FML_TIME_TIME_POINT_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <iosfwd>
 
 #include "flutter/fml/time/time_delta.h"

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_LIB_UI_COMPOSITING_SCENE_H_
 #define FLUTTER_LIB_UI_COMPOSITING_SCENE_H_
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 
 #include "flutter/flow/layers/layer_tree.h"

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -5,8 +5,7 @@
 #ifndef FLUTTER_LIB_UI_COMPOSITING_SCENE_BUILDER_H_
 #define FLUTTER_LIB_UI_COMPOSITING_SCENE_BUILDER_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/lib/ui/compositing/scene_host.h
+++ b/lib/ui/compositing/scene_host.h
@@ -6,15 +6,16 @@
 #define FLUTTER_LIB_UI_COMPOSITING_SCENE_HOST_H_
 
 #include <lib/ui/scenic/cpp/id.h>
-#include <stdint.h>
 #include <zircon/types.h>
-#include "third_party/tonic/dart_library_natives.h"
-#include "third_party/tonic/dart_persistent_value.h"
+
+#include <cstdint>
 
 #include "dart-pkg/zircon/sdk_ext/handle.h"
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/lib/ui/dart_wrapper.h"
+#include "third_party/tonic/dart_library_natives.h"
+#include "third_party/tonic/dart_persistent_value.h"
 
 namespace flutter {
 

--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -4,10 +4,9 @@
 
 #include "flutter/lib/ui/dart_runtime_hooks.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <sstream>
 

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#define _USE_MATH_DEFINES
+
 #include "flutter/lib/ui/painting/canvas.h"
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "flutter/flow/layers/physical_shape_layer.h"

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -5,7 +5,7 @@
 #include "flutter/lib/ui/painting/canvas.h"
 
 #define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 
 #include "flutter/flow/layers/physical_shape_layer.h"
 #include "flutter/lib/ui/painting/image.h"

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#define _USE_MATH_DEFINES
+
 #include "flutter/lib/ui/painting/path.h"
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "flutter/lib/ui/painting/matrix.h"

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -5,7 +5,7 @@
 #include "flutter/lib/ui/painting/path.h"
 
 #define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 
 #include "flutter/lib/ui/painting/matrix.h"
 #include "flutter/lib/ui/ui_dart_state.h"

--- a/lib/ui/painting/path_measure.cc
+++ b/lib/ui/painting/path_measure.cc
@@ -5,7 +5,7 @@
 #include "flutter/lib/ui/painting/path_measure.h"
 
 #define _USE_MATH_DEFINES
-#include <math.h>
+#include <cmath>
 
 #include "flutter/lib/ui/painting/matrix.h"
 #include "flutter/lib/ui/ui_dart_state.h"

--- a/lib/ui/painting/path_measure.cc
+++ b/lib/ui/painting/path_measure.cc
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#define _USE_MATH_DEFINES
+
 #include "flutter/lib/ui/painting/path_measure.h"
 
-#define _USE_MATH_DEFINES
 #include <cmath>
 
 #include "flutter/lib/ui/painting/matrix.h"

--- a/lib/ui/semantics/semantics_node.cc
+++ b/lib/ui/semantics/semantics_node.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/lib/ui/semantics/semantics_node.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace flutter {
 

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -5,8 +5,7 @@
 #ifndef FLUTTER_LIB_UI_SEMANTICS_SEMANTICS_NODE_H_
 #define FLUTTER_LIB_UI_SEMANTICS_SEMANTICS_NODE_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/lib/ui/window/pointer_data.cc
+++ b/lib/ui/window/pointer_data.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/lib/ui/window/pointer_data.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace flutter {
 

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_LIB_UI_WINDOW_POINTER_DATA_H_
 #define FLUTTER_LIB_UI_WINDOW_POINTER_DATA_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace flutter {
 

--- a/lib/ui/window/pointer_data_packet.cc
+++ b/lib/ui/window/pointer_data_packet.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 
-#include <string.h>
+#include <cstring>
 
 namespace flutter {
 

--- a/lib/ui/window/pointer_data_packet.h
+++ b/lib/ui/window/pointer_data_packet.h
@@ -5,8 +5,7 @@
 #ifndef FLUTTER_LIB_UI_WINDOW_POINTER_DATA_PACKET_H_
 #define FLUTTER_LIB_UI_WINDOW_POINTER_DATA_PACKET_H_
 
-#include <string.h>
-
+#include <cstring>
 #include <vector>
 
 #include "flutter/fml/macros.h"

--- a/lib/ui/window/pointer_data_packet_converter.cc
+++ b/lib/ui/window/pointer_data_packet_converter.cc
@@ -3,9 +3,10 @@
 // found in the LICENSE file.
 
 #include "flutter/lib/ui/window/pointer_data_packet_converter.h"
-#include "flutter/fml/logging.h"
 
-#include <string.h>
+#include <cstring>
+
+#include "flutter/fml/logging.h"
 
 namespace flutter {
 

--- a/lib/ui/window/pointer_data_packet_converter.h
+++ b/lib/ui/window/pointer_data_packet_converter.h
@@ -5,8 +5,7 @@
 #ifndef FLUTTER_LIB_UI_WINDOW_POINTER_DATA_PACKET_CONVERTER_H_
 #define FLUTTER_LIB_UI_WINDOW_POINTER_DATA_PACKET_CONVERTER_H_
 
-#include <string.h>
-
+#include <cstring>
 #include <map>
 #include <memory>
 #include <vector>

--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -4,8 +4,8 @@
 
 #include "flutter/runtime/dart_service_isolate.h"
 
-#include <string.h>
 #include <algorithm>
+#include <cstring>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/posix_wrappers.h"

--- a/runtime/embedder_resources.cc
+++ b/runtime/embedder_resources.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/runtime/embedder_resources.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "flutter/fml/logging.h"
 

--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -6,8 +6,7 @@
 
 #include "flutter/runtime/service_protocol.h"
 
-#include <string.h>
-
+#include <cstring>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -3,8 +3,11 @@
 // found in the LICENSE file.
 // FLUTTER_NOLINT
 
-#include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/shell/common/engine.h"
+
+#include <cstring>
+
+#include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/testing/testing.h"
 #include "gmock/gmock.h"

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -5,8 +5,8 @@
 
 #define FML_USED_ON_EMBEDDER
 
-#include <time.h>
 #include <algorithm>
+#include <ctime>
 #include <functional>
 #include <future>
 #include <memory>

--- a/shell/platform/common/cpp/client_wrapper/core_implementations.cc
+++ b/shell/platform/common/cpp/client_wrapper/core_implementations.cc
@@ -13,8 +13,7 @@
 // removed in favor of the normal structure since templates will no longer
 // manually include files.
 
-#include <assert.h>
-
+#include <cassert>
 #include <iostream>
 
 #include "binary_messenger_impl.h"

--- a/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.cc
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.cc
@@ -6,9 +6,8 @@
 
 #include <zircon/syscalls.h>
 
-#include <stdio.h>
-#include <string.h>
-
+#include <cstdio>
+#include <cstring>
 #include <memory>
 #include <vector>
 

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/natives.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/natives.cc
@@ -6,9 +6,7 @@
 
 #include <zircon/syscalls.h>
 
-#include <stdio.h>
-#include <string.h>
-
+#include <cstring>
 #include <memory>
 #include <vector>
 

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -4,13 +4,14 @@
 
 #include "dart_runner.h"
 
-#include <errno.h>
 #include <lib/async-loop/loop.h>
 #include <lib/async/default.h>
 #include <lib/syslog/global.h>
 #include <sys/stat.h>
 #include <zircon/status.h>
 #include <zircon/syscalls.h>
+
+#include <cerrno>
 #include <memory>
 #include <thread>
 #include <utility>

--- a/shell/platform/fuchsia/dart_runner/embedder/snapshot.h
+++ b/shell/platform/fuchsia/dart_runner/embedder/snapshot.h
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace dart_runner {
 

--- a/shell/platform/fuchsia/flutter/runner.cc
+++ b/shell/platform/fuchsia/flutter/runner.cc
@@ -4,14 +4,14 @@
 
 #include "runner.h"
 
+#include <fcntl.h>
 #include <fuchsia/mem/cpp/fidl.h>
 #include <lib/async/cpp/task.h>
 #include <lib/trace-engine/instrumentation.h>
 #include <zircon/status.h>
 #include <zircon/types.h>
 
-#include <fcntl.h>
-#include <stdint.h>
+#include <cstdint>
 #include <sstream>
 #include <utility>
 

--- a/shell/platform/fuchsia/flutter/thread.cc
+++ b/shell/platform/fuchsia/flutter/thread.cc
@@ -4,12 +4,11 @@
 
 #include "thread.h"
 
-#include <limits.h>
+#include <lib/async-loop/cpp/loop.h>
 #include <unistd.h>
 
 #include <algorithm>
-
-#include <lib/async-loop/cpp/loop.h>
+#include <climits>
 
 #include "flutter/fml/logging.h"
 #include "loop.h"

--- a/shell/platform/fuchsia/runtime/dart/utils/files.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/files.cc
@@ -5,7 +5,8 @@
 #include "files.h"
 
 #include <fcntl.h>
-#include <stdint.h>
+
+#include <cstdint>
 
 #include "inlines.h"
 #include "logging.h"

--- a/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.cc
@@ -5,12 +5,12 @@
 #include "vmservice_object.h"
 
 #include <dirent.h>
-#include <errno.h>
-#include <string>
-
 #include <fuchsia/io/cpp/fidl.h>
 #include <lib/syslog/global.h>
 #include <zircon/status.h>
+
+#include <cerrno>
+#include <string>
 
 #include "logging.h"
 

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -6,9 +6,9 @@
 #include "flutter/shell/platform/glfw/public/flutter_glfw.h"
 
 #include <GLFW/glfw3.h>
-#include <assert.h>
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>

--- a/shell/platform/linux/fl_json_message_codec_test.cc
+++ b/shell/platform/linux/fl_json_message_codec_test.cc
@@ -5,7 +5,7 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h"
 #include "gtest/gtest.h"
 
-#include <math.h>
+#include <cmath>
 
 // Encodes a message using FlJsonMessageCodec to a UTF-8 string.
 static gchar* encode_message(FlValue* value) {

--- a/shell/platform/linux/fl_json_message_codec_test.cc
+++ b/shell/platform/linux/fl_json_message_codec_test.cc
@@ -558,10 +558,11 @@ TEST(FlJsonMessageCodecTest, EncodeListNested) {
   g_autoptr(FlValue) even_numbers = fl_value_new_list();
   g_autoptr(FlValue) odd_numbers = fl_value_new_list();
   for (int i = 0; i < 10; i++) {
-    if (i % 2 == 0)
+    if (i % 2 == 0) {
       fl_value_append_take(even_numbers, fl_value_new_int(i));
-    else
+    } else {
       fl_value_append_take(odd_numbers, fl_value_new_int(i));
+    }
   }
   g_autoptr(FlValue) value = fl_value_new_list();
   fl_value_append(value, even_numbers);

--- a/shell/platform/linux/testing/mock_engine.cc
+++ b/shell/platform/linux/testing/mock_engine.cc
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <cstring>
+
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_method_codec_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_method_response.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_method_codec.h"
 #include "gtest/gtest.h"
-
-#include <string.h>
 
 struct _FlutterEngine {
   bool running;

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -4,10 +4,10 @@
 
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 
-#include <assert.h>
 #include <io.h>
 
 #include <algorithm>
+#include <cassert>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <wchar.h>
+#include <cwchar>
 
 #include "flutter/shell/platform/windows/system_utils.h"
 #include "gtest/gtest.h"

--- a/third_party/tonic/dart_list.h
+++ b/third_party/tonic/dart_list.h
@@ -5,7 +5,7 @@
 #ifndef LIB_TONIC_DART_LIST_H_
 #define LIB_TONIC_DART_LIST_H_
 
-#include <stddef.h>
+#include <cstddef>
 
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "tonic/converter/dart_converter.h"

--- a/third_party/tonic/file_loader/file_loader_fuchsia.cc
+++ b/third_party/tonic/file_loader/file_loader_fuchsia.cc
@@ -5,10 +5,10 @@
 #include "tonic/file_loader/file_loader.h"
 
 #include <dirent.h>
-#include <errno.h>
 #include <fcntl.h>
 #include <sys/types.h>
 
+#include <cerrno>
 #include <iostream>
 #include <memory>
 #include <utility>

--- a/third_party/tonic/filesystem/filesystem/eintr_wrapper.h
+++ b/third_party/tonic/filesystem/filesystem/eintr_wrapper.h
@@ -5,7 +5,7 @@
 #ifndef FILESYSTEM_EINTR_WRAPPER_H_
 #define FILESYSTEM_EINTR_WRAPPER_H_
 
-#include <errno.h>
+#include <cerrno>
 
 #include "tonic/common/build_config.h"
 

--- a/third_party/tonic/filesystem/filesystem/file.cc
+++ b/third_party/tonic/filesystem/filesystem/file.cc
@@ -5,9 +5,10 @@
 #include "filesystem/file.h"
 
 #include <fcntl.h>
-#include <limits.h>
-#include <stdint.h>
 #include <sys/stat.h>
+
+#include <climits>
+#include <cstdint>
 
 #include "tonic/common/build_config.h"
 

--- a/third_party/tonic/filesystem/filesystem/path_posix.cc
+++ b/third_party/tonic/filesystem/filesystem/path_posix.cc
@@ -5,14 +5,14 @@
 #include "filesystem/path.h"
 
 #include <dirent.h>
-#include <errno.h>
-#include <limits.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
+#include <cstring>
 #include <functional>
 #include <list>
 #include <memory>

--- a/third_party/tonic/filesystem/filesystem/path_win.cc
+++ b/third_party/tonic/filesystem/filesystem/path_win.cc
@@ -7,13 +7,13 @@
 #include <windows.h>
 
 #include <direct.h>
-#include <errno.h>
 #include <shellapi.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 #include <algorithm>
+#include <cerrno>
+#include <cstring>
 #include <functional>
 #include <list>
 #include <memory>

--- a/third_party/txt/src/utils/TypeHelpers.h
+++ b/third_party/txt/src/utils/TypeHelpers.h
@@ -17,12 +17,12 @@
 #ifndef ANDROID_TYPE_HELPERS_H
 #define ANDROID_TYPE_HELPERS_H
 
+#include <sys/types.h>
+
+#include <cstdint>
+#include <cstring>
 #include <new>
 #include <type_traits>
-
-#include <stdint.h>
-#include <string.h>
-#include <sys/types.h>
 
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
We currently use a mix of C standard includes (e.g. limits.h) and their
C++ variants (e.g. climits). This migrates to a consistent style for all
cases where the C++ variants are acceptable, but leaves the C
equivalents in place where they are required, such as in the embedder
API and other headers that may be used from C.