### PR TITLE
[embedder] Project Arg to specify the display refresh rate

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1442,7 +1442,7 @@ bool Shell::OnServiceProtocolGetDisplayRefreshRate(
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
   response->SetObject();
   response->AddMember("type", "DisplayRefreshRate", response->GetAllocator());
-  response->AddMember("fps", engine_->GetDisplayRefreshRate(),
+  response->AddMember("fps", display_refresh_rate_.load(),
                       response->GetAllocator());
   return true;
 }

--- a/shell/common/vsync_waiter_fallback.cc
+++ b/shell/common/vsync_waiter_fallback.cc
@@ -21,8 +21,15 @@ static fml::TimePoint SnapToNextTick(fml::TimePoint value,
 
 }  // namespace
 
+VsyncWaiterFallback::VsyncWaiterFallback(TaskRunners task_runners,
+                                         float display_refresh_rate)
+    : VsyncWaiter(std::move(task_runners)),
+      phase_(fml::TimePoint::Now()),
+      display_refresh_rate_(display_refresh_rate) {}
+
 VsyncWaiterFallback::VsyncWaiterFallback(TaskRunners task_runners)
-    : VsyncWaiter(std::move(task_runners)), phase_(fml::TimePoint::Now()) {}
+    : VsyncWaiterFallback(std::move(task_runners),
+                          VsyncWaiter::kUnknownRefreshRateFPS) {}
 
 VsyncWaiterFallback::~VsyncWaiterFallback() = default;
 
@@ -35,6 +42,10 @@ void VsyncWaiterFallback::AwaitVSync() {
       SnapToNextTick(fml::TimePoint::Now(), phase_, kSingleFrameInterval);
 
   FireCallback(next, next + kSingleFrameInterval);
+}
+
+float VsyncWaiterFallback::GetDisplayRefreshRate() const {
+  return display_refresh_rate_;
 }
 
 }  // namespace flutter

--- a/shell/common/vsync_waiter_fallback.h
+++ b/shell/common/vsync_waiter_fallback.h
@@ -12,15 +12,22 @@
 
 namespace flutter {
 
-/// A |VsyncWaiter| that will fire at 60 fps irrespective of the vsync.
+/// A |VsyncWaiter| that will fire at 60 fps irrespective of the vsync. The
+/// refresh rate can also optionally be set, this is currently only used to
+/// indicate to devtools, this will still fire at 60fps.
 class VsyncWaiterFallback final : public VsyncWaiter {
  public:
   VsyncWaiterFallback(TaskRunners task_runners);
 
+  VsyncWaiterFallback(TaskRunners task_runners, float display_refresh_rate);
+
   ~VsyncWaiterFallback() override;
 
+  float GetDisplayRefreshRate() const override;
+
  private:
-  fml::TimePoint phase_;
+  const fml::TimePoint phase_;
+  const float display_refresh_rate_;
 
   // |VsyncWaiter|
   void AwaitVSync() override;

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1012,24 +1012,22 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
                                 "embedder, got 0 active displays.");
     }
 
-    display_settings.displays =
-        new FlutterDisplay[display_settings.display_count];
+    std::vector<FlutterDisplay> displays(display_settings.display_count);
+    display_settings.displays = displays.data();
     display_settings_callback(user_data, &display_settings);
 
     // TODO(iskakaushik): Add support for multiple displays.
     main_display_refresh_rate = display_settings.displays[0].refresh_rate;
-
-    delete display_settings.displays;
   }
 
   flutter::PlatformViewEmbedder::PlatformDispatchTable platform_dispatch_table =
       {
-          update_semantics_nodes_callback,                //
-          update_semantics_custom_actions_callback,       //
-          platform_message_response_callback,             //
-          vsync_callback,                                 //
-          compute_platform_resolved_locale_callback,      //
-          static_cast<float>(main_display_refresh_rate),  //
+          update_semantics_nodes_callback,            //
+          update_semantics_custom_actions_callback,   //
+          platform_message_response_callback,         //
+          vsync_callback,                             //
+          compute_platform_resolved_locale_callback,  //
+          main_display_refresh_rate,                  //
       };
 
   auto on_create_platform_view = InferPlatformViewCreationCallback(

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -963,6 +963,43 @@ typedef const FlutterLocale* (*FlutterComputePlatformResolvedLocaleCallback)(
     const FlutterLocale** /* supported_locales*/,
     size_t /* Number of locales*/);
 
+/// Display refers to a graphics hardware system consisting of a framebuffer,
+/// typically a monitor or a screen. This ID is unique per display and is
+/// stable until the Flutter application restarts.
+typedef uint64_t FlutterDisplayId;
+
+typedef struct {
+  /// This size of this struct. Must be sizeof(FlutterDisplay).
+  size_t struct_size;
+
+  FlutterDisplayId display_id;
+
+  /// A double-precision floating-point value representing the actual refresh
+  /// period in seconds. This value may be zero if the device is not running or
+  /// unavaliable or unknown.
+  double refresh_rate;
+
+} FlutterDisplay;
+
+typedef struct {
+  /// This size of this struct. Must be sizeof(FlutterDisplaySettings).
+  size_t struct_size;
+
+  /// Contains the actual number of displays returned in the displays array.
+  size_t display_count;
+
+  /// A pointer to storage provided by the caller for an array of
+  /// FlutterDisplays. On return, the array contains a list of active displays.
+  /// If you pass NULL, on return the display_count contains the total number of
+  /// active displays.
+  FlutterDisplay* displays;
+
+} FlutterDisplaySettings;
+
+typedef void (*FlutterDisplaySettingsCallback)(
+    void* user_data,
+    FlutterDisplaySettings* display_settings);
+
 typedef int64_t FlutterEngineDartPort;
 
 typedef enum {
@@ -1318,6 +1355,15 @@ typedef struct {
   /// matches what the platform would natively resolve to as possible.
   FlutterComputePlatformResolvedLocaleCallback
       compute_platform_resolved_locale_callback;
+
+  /// A callback to provide the settings for all the displays that are active
+  /// i.e, not mirrored or sleeping.
+  ///
+  /// A display is considered active if:
+  ///    1. The frame buffer hardware is connected.
+  ///    2. The display is drawable, e.g. it isn't being mirrored from another
+  ///    connected display or sleeping.
+  FlutterDisplaySettingsCallback display_settings_callback;
 } FlutterProjectArgs;
 
 //------------------------------------------------------------------------------

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -85,12 +85,13 @@ sk_sp<GrDirectContext> PlatformViewEmbedder::CreateResourceContext() const {
 // |PlatformView|
 std::unique_ptr<VsyncWaiter> PlatformViewEmbedder::CreateVSyncWaiter() {
   if (!platform_dispatch_table_.vsync_callback) {
-    // Superclass implementation creates a timer based fallback.
-    return PlatformView::CreateVSyncWaiter();
+    return std::make_unique<VsyncWaiterFallback>(
+        task_runners_, platform_dispatch_table_.display_refresh_rate);
   }
 
   return std::make_unique<VsyncWaiterEmbedder>(
-      platform_dispatch_table_.vsync_callback, task_runners_);
+      platform_dispatch_table_.vsync_callback, task_runners_,
+      platform_dispatch_table_.display_refresh_rate);
 }
 
 // |PlatformView|

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -9,6 +9,7 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/common/platform_view.h"
+#include "flutter/shell/common/vsync_waiter_fallback.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/embedder_surface.h"
 #include "flutter/shell/platform/embedder/embedder_surface_gl.h"
@@ -38,6 +39,7 @@ class PlatformViewEmbedder final : public PlatformView {
     VsyncWaiterEmbedder::VsyncCallback vsync_callback;  // optional
     ComputePlatformResolvedLocaleCallback
         compute_platform_resolved_locale_callback;
+    float display_refresh_rate;
   };
 
   // Creates a platform view that sets up an OpenGL rasterizer.

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -39,7 +39,7 @@ class PlatformViewEmbedder final : public PlatformView {
     VsyncWaiterEmbedder::VsyncCallback vsync_callback;  // optional
     ComputePlatformResolvedLocaleCallback
         compute_platform_resolved_locale_callback;
-    float display_refresh_rate;
+    double display_refresh_rate;
   };
 
   // Creates a platform view that sets up an OpenGL rasterizer.

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -232,6 +232,22 @@ void EmbedderConfigBuilder::SetPlatformMessageCallback(
   context_.SetPlatformMessageCallback(callback);
 }
 
+void EmbedderConfigBuilder::SetDisplayRefreshRate(double refresh_rate) {
+  context_.SetDisplayRefreshRate(refresh_rate);
+  project_args_.display_settings_callback =
+      [](void* context, FlutterDisplaySettings* display_settings) {
+        if (!display_settings->displays) {
+          display_settings->display_count = 1;
+        } else {
+          auto& display = display_settings->displays[0];
+          display.struct_size = sizeof(FlutterDisplay);
+          display.display_id = 1;
+          display.refresh_rate = reinterpret_cast<EmbedderTestContext*>(context)
+                                     ->GetDisplayRefreshRate();
+        }
+      };
+}
+
 void EmbedderConfigBuilder::SetCompositor() {
   context_.SetupCompositor();
   auto& compositor = context_.GetCompositor();

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -87,6 +87,10 @@ class EmbedderConfigBuilder {
 
   void SetCompositor();
 
+  /// Sets the `FlutterProjectArgs`'s display refresh rate to
+  /// `display_refresh_rate`. This is in frames per second.
+  void SetDisplayRefreshRate(double display_refresh_rate);
+
   FlutterCompositor& GetCompositor();
 
   void SetRenderTargetType(

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -209,5 +209,13 @@ void EmbedderTestContext::FireRootSurfacePresentCallbackIfPresent(
   callback(image_callback());
 }
 
+void EmbedderTestContext::SetDisplayRefreshRate(double refresh_rate) {
+  display_refresh_rate_ = refresh_rate;
+}
+
+double EmbedderTestContext::GetDisplayRefreshRate() const {
+  return display_refresh_rate_;
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -78,6 +78,14 @@ class EmbedderTestContext {
 
   virtual size_t GetSurfacePresentCount() const = 0;
 
+  /// Sets the refresh rate of the display.
+  void SetDisplayRefreshRate(double refresh_rate);
+
+  /// Returns the last set refresh rate of the display. Returns zero otherwise.
+  ///
+  /// See: `SetDisplayRefreshRate`.
+  double GetDisplayRefreshRate() const;
+
   // TODO(gw280): encapsulate these properly for subclasses to use
  protected:
   // This allows the builder to access the hooks.
@@ -100,6 +108,7 @@ class EmbedderTestContext {
   std::unique_ptr<EmbedderTestCompositor> compositor_;
   NextSceneCallback next_scene_callback_;
   SkMatrix root_surface_transformation_;
+  double display_refresh_rate_ = 0;
 
   static VoidCallback GetIsolateCreateCallbackHook();
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4484,7 +4484,7 @@ TEST_F(EmbedderTest, PresentInfoContainsValidFBOId) {
 }
 
 TEST_F(EmbedderTest, DisplayRefreshRateIsSet) {
-  auto& context = GetEmbedderContext();
+  auto& context = GetEmbedderContext(ContextType::kOpenGLContext);
   fml::AutoResetWaitableEvent latch;
   context.AddIsolateCreateCallback([&latch]() { latch.Signal(); });
   EmbedderConfigBuilder builder(context);
@@ -4506,7 +4506,7 @@ TEST_F(EmbedderTest, DisplayRefreshRateIsSet) {
 }
 
 TEST_F(EmbedderTest, DefaultDisplayRefreshRateIsUnknown) {
-  auto& context = GetEmbedderContext();
+  auto& context = GetEmbedderContext(ContextType::kOpenGLContext);
   fml::AutoResetWaitableEvent latch;
   context.AddIsolateCreateCallback([&latch]() { latch.Signal(); });
   EmbedderConfigBuilder builder(context);

--- a/shell/platform/embedder/vsync_waiter_embedder.cc
+++ b/shell/platform/embedder/vsync_waiter_embedder.cc
@@ -7,8 +7,11 @@
 namespace flutter {
 
 VsyncWaiterEmbedder::VsyncWaiterEmbedder(const VsyncCallback& vsync_callback,
-                                         flutter::TaskRunners task_runners)
-    : VsyncWaiter(std::move(task_runners)), vsync_callback_(vsync_callback) {
+                                         flutter::TaskRunners task_runners,
+                                         float display_refresh_rate)
+    : VsyncWaiter(std::move(task_runners)),
+      vsync_callback_(vsync_callback),
+      display_refresh_rate_(display_refresh_rate) {
   FML_DCHECK(vsync_callback_);
 }
 
@@ -38,6 +41,10 @@ bool VsyncWaiterEmbedder::OnEmbedderVsync(intptr_t baton,
 
   strong_waiter->FireCallback(frame_start_time, frame_target_time);
   return true;
+}
+
+float VsyncWaiterEmbedder::GetDisplayRefreshRate() const {
+  return display_refresh_rate_;
 }
 
 }  // namespace flutter

--- a/shell/platform/embedder/vsync_waiter_embedder.h
+++ b/shell/platform/embedder/vsync_waiter_embedder.h
@@ -15,7 +15,8 @@ class VsyncWaiterEmbedder final : public VsyncWaiter {
   using VsyncCallback = std::function<void(intptr_t)>;
 
   VsyncWaiterEmbedder(const VsyncCallback& callback,
-                      flutter::TaskRunners task_runners);
+                      flutter::TaskRunners task_runners,
+                      float display_refresh_rate);
 
   ~VsyncWaiterEmbedder() override;
 
@@ -23,8 +24,11 @@ class VsyncWaiterEmbedder final : public VsyncWaiter {
                               fml::TimePoint frame_start_time,
                               fml::TimePoint frame_target_time);
 
+  float GetDisplayRefreshRate() const override;
+
  private:
   const VsyncCallback vsync_callback_;
+  const float display_refresh_rate_;
 
   // |VsyncWaiter|
   void AwaitVSync() override;


### PR DESCRIPTION
This is then wired to the vsync waiter to provide the advisory display refresh rate. `embedder_unittests` have been amended to test this value both when set and not set.