### PR TITLE
WIP: Discard wrong size layer tree instead of rendering it

### DIFF
--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -204,6 +204,8 @@ class Rasterizer final : public SnapshotDelegate {
   ///
   flutter::TextureRegistry* GetTextureRegistry();
 
+  using DiscardCallback = std::function<bool(flutter::LayerTree&)>;
+
   //----------------------------------------------------------------------------
   /// @brief      Takes the next item from the layer tree pipeline and executes
   ///             the raster thread frame workload for that pipeline item to
@@ -232,8 +234,11 @@ class Rasterizer final : public SnapshotDelegate {
   ///
   /// @param[in]  pipeline  The layer tree pipeline to take the next layer tree
   ///                       to render from.
+  /// @param[in]  discardCallback if specified and returns true, the layer tree
+  //                              is discarded instead of being rendered
   ///
-  void Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline);
+  void Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline,
+             DiscardCallback discardCallback = nullptr);
 
   //----------------------------------------------------------------------------
   /// @brief      The type of the screenshot to obtain of the previously

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -425,6 +425,10 @@ class Shell final : public PlatformView::Delegate,
   // and read from the raster thread.
   std::atomic<float> display_refresh_rate_ = 0.0f;
 
+  std::mutex resize_mutex_;
+  SkISize expected_frame_size_ = SkISize::MakeEmpty();
+  size_t resource_cache_max_bytes_update_ = 0;
+
   // How many frames have been timed since last report.
   size_t UnreportedFramesCount() const;
 


### PR DESCRIPTION
## Description

This PR will ensure that after viewport change metrics event is received, layer tree with previous (wrong size) are discarded and not rasterized. This is required for smooth resizing on both Mac and Windows.

**Important:** This will potentially affect iOS and Android embedders. We need to make sure this doesn't cause any issues.

## Related Issues

https://github.com/flutter/flutter/issues/44136

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
