### PR TITLE
Check for a valid SkSL cache directory before calling VisitFiles

### DIFF
--- a/shell/common/persistent_cache.cc
+++ b/shell/common/persistent_cache.cc
@@ -194,7 +194,9 @@ std::vector<PersistentCache::SkSLCache> PersistentCache::LoadSkSLs() {
     // opened directory (https://github.com/flutter/flutter/issues/65258).
     fml::UniqueFD fresh_dir =
         fml::OpenDirectoryReadOnly(*cache_directory_, kSkSLSubdirName);
-    fml::VisitFiles(fresh_dir, visitor);
+    if (fresh_dir.is_valid()) {
+      fml::VisitFiles(fresh_dir, visitor);
+    }
   }
 
   std::unique_ptr<fml::Mapping> mapping = nullptr;


### PR DESCRIPTION
The directory may be invalid when running shell_unittests because
some tests call SetCacheDirectoryPath and then delete the directory.
Later tests that try to use that cache base path will be unable to
open the directory.
