### PR TITLE
Re-disable iOS Scenarios tests due to flakiness

### DIFF
--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -33,9 +33,14 @@ if [[ $# -eq 1 ]]; then
   FLUTTER_ENGINE="$1"
 fi
 
-cd ios/Scenarios
-set -o pipefail && xcodebuild -sdk iphonesimulator \
-  -scheme Scenarios \
-  -destination 'platform=iOS Simulator,name=iPhone 8' \
-  test \
-  FLUTTER_ENGINE="$FLUTTER_ENGINE"
+echo "iOS Scenarios tests currently disabled due to flakiness"
+echo "See: https://github.com/flutter/flutter/issues/61620"
+
+# TODO(cbracken): re-enable when
+# https://github.com/flutter/flutter/issues/61620 is fixed.
+# cd ios/Scenarios
+# set -o pipefail && xcodebuild -sdk iphonesimulator \
+#   -scheme Scenarios \
+#   -destination 'platform=iOS Simulator,name=iPhone 8' \
+#   test \
+#   FLUTTER_ENGINE="$FLUTTER_ENGINE"


### PR DESCRIPTION
This reverts #21087, which speculatively re-enabled the Scenarios iOS
tests once we'd got Dart/Skia/Fuchsia rolls in, which had been blocked
by flaky test runs. We'd hoped that that PR would be sufficient to
eliminate the tree closures but new tests within the suite started
failing instead. Reverting while the issue is root-caused and fixed.

Related P0 issue: https://github.com/flutter/flutter/issues/61620

This reverts commit bdaac368f85fb439055d20a9b93d604c2ea5ccf6.