### PR TITLE
WIP: API to track damage rectangles

### DIFF
--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -10,6 +10,8 @@ source_set("flow") {
   sources = [
     "compositor_context.cc",
     "compositor_context.h",
+    "damage_context.cc",
+    "damage_context.h",
     "embedded_views.cc",
     "embedded_views.h",
     "gl_context_switch.cc",

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -39,8 +39,9 @@ std::unique_ptr<CompositorContext::ScopedFrame> CompositorContext::AcquireFrame(
     bool surface_supports_readback,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
   return std::make_unique<ScopedFrame>(
-      *this, gr_context, canvas, view_embedder, root_surface_transformation,
-      instrumentation_enabled, surface_supports_readback, raster_thread_merger);
+      *this, gr_context, canvas, view_embedder, &damage_context_,
+      root_surface_transformation, instrumentation_enabled,
+      surface_supports_readback, raster_thread_merger);
 }
 
 CompositorContext::ScopedFrame::ScopedFrame(
@@ -48,6 +49,7 @@ CompositorContext::ScopedFrame::ScopedFrame(
     GrDirectContext* gr_context,
     SkCanvas* canvas,
     ExternalViewEmbedder* view_embedder,
+    DamageContext* damage_context,
     const SkMatrix& root_surface_transformation,
     bool instrumentation_enabled,
     bool surface_supports_readback,
@@ -56,6 +58,7 @@ CompositorContext::ScopedFrame::ScopedFrame(
       gr_context_(gr_context),
       canvas_(canvas),
       view_embedder_(view_embedder),
+      damage_context_(damage_context),
       root_surface_transformation_(root_surface_transformation),
       instrumentation_enabled_(instrumentation_enabled),
       surface_supports_readback_(surface_supports_readback),
@@ -69,9 +72,31 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
 
 RasterStatus CompositorContext::ScopedFrame::Raster(
     flutter::LayerTree& layer_tree,
-    bool ignore_raster_cache) {
+    bool ignore_raster_cache,
+    FrameDamage* frame_damage) {
   TRACE_EVENT0("flutter", "CompositorContext::ScopedFrame::Raster");
-  bool root_needs_readback = layer_tree.Preroll(*this, ignore_raster_cache);
+
+  std::optional<DamageArea> damage_area;
+
+  if (frame_damage) {
+    damage_context()->InitFrame(layer_tree.frame_size(),
+                                frame_damage->previous_frame_description);
+    layer_tree.Preroll(*this, true);
+    auto damage_res = damage_context()->FinishFrame();
+    frame_damage->frame_description = std::move(damage_res.frame_description);
+
+    // only bother clipping when less than 80% of screen
+    if (damage_res.area.bounds().width() * damage_res.area.bounds().height() <
+        0.8 * layer_tree.frame_size().width() *
+            layer_tree.frame_size().height()) {
+      damage_area = std::move(damage_res.area);
+    }
+  }
+
+  auto cull_rect =
+      damage_area ? SkRect::Make(damage_area->bounds()) : kGiantRect;
+  bool root_needs_readback =
+      layer_tree.Preroll(*this, ignore_raster_cache, cull_rect);
   bool needs_save_layer = root_needs_readback && !surface_supports_readback();
   PostPrerollResult post_preroll_result = PostPrerollResult::kSuccess;
   if (view_embedder_ && raster_thread_merger_) {
@@ -82,6 +107,12 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
   if (post_preroll_result == PostPrerollResult::kResubmitFrame) {
     return RasterStatus::kResubmit;
   }
+
+  if (canvas() && damage_area) {
+    canvas()->save();
+    canvas()->clipRect(SkRect::Make(damage_area->bounds()));
+  }
+
   // Clearing canvas after preroll reduces one render target switch when preroll
   // paints some raster cache.
   if (canvas()) {
@@ -98,6 +129,14 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
   if (canvas() && needs_save_layer) {
     canvas()->restore();
   }
+  if (canvas() && damage_area) {
+    canvas()->restore();
+  }
+
+  if (frame_damage) {
+    frame_damage->damage_area = std::move(damage_area);
+  }
+
   return RasterStatus::kSuccess;
 }
 

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "flutter/flow/damage_context.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/instrumentation.h"
 #include "flutter/flow/raster_cache.h"
@@ -35,6 +36,18 @@ enum class RasterStatus {
   kFailed
 };
 
+struct FrameDamage {
+  // in: description for frame previously rasterized in target framebuffer
+  const DamageContext::FrameDescription* previous_frame_description;
+
+  // out: description for frame being rasterized
+  std::unique_ptr<DamageContext::FrameDescription> frame_description;
+
+  // out: area in framebuffer that has changed between frames;
+  // if optional is empty, whole frame was repainted
+  std::optional<DamageArea> damage_area;
+};
+
 class CompositorContext {
  public:
   class ScopedFrame {
@@ -43,6 +56,7 @@ class CompositorContext {
                 GrDirectContext* gr_context,
                 SkCanvas* canvas,
                 ExternalViewEmbedder* view_embedder,
+                DamageContext* damage_context,
                 const SkMatrix& root_surface_transformation,
                 bool instrumentation_enabled,
                 bool surface_supports_readback,
@@ -53,6 +67,8 @@ class CompositorContext {
     SkCanvas* canvas() { return canvas_; }
 
     ExternalViewEmbedder* view_embedder() { return view_embedder_; }
+
+    DamageContext* damage_context() { return damage_context_; }
 
     CompositorContext& context() const { return context_; }
 
@@ -65,13 +81,15 @@ class CompositorContext {
     GrDirectContext* gr_context() const { return gr_context_; }
 
     virtual RasterStatus Raster(LayerTree& layer_tree,
-                                bool ignore_raster_cache);
+                                bool ignore_raster_cache,
+                                FrameDamage* frame_damage);
 
    private:
     CompositorContext& context_;
     GrDirectContext* gr_context_;
     SkCanvas* canvas_;
     ExternalViewEmbedder* view_embedder_;
+    DamageContext* damage_context_;
     const SkMatrix& root_surface_transformation_;
     const bool instrumentation_enabled_;
     const bool surface_supports_readback_;
@@ -110,6 +128,7 @@ class CompositorContext {
  private:
   RasterCache raster_cache_;
   TextureRegistry texture_registry_;
+  DamageContext damage_context_;
   Counter frame_count_;
   Stopwatch raster_time_;
   Stopwatch ui_time_;

--- a/flow/damage_context.cc
+++ b/flow/damage_context.cc
@@ -1,0 +1,200 @@
+#include "flutter/flow/damage_context.h"
+#include "flutter/flow/layers/layer.h"
+#include "third_party/skia/include/core/SkImageFilter.h"
+
+namespace flutter {
+
+std::size_t DamageContext::LayerContribution::Hash::operator()(
+    const LayerContribution& e) const noexcept {
+  size_t res = e.paint_bounds.left();
+  res = 37 * res + e.paint_bounds.top();
+  res = 37 * res + e.paint_bounds.width();
+  res = 37 * res + e.paint_bounds.height();
+  res = 37 * res + size_t(reinterpret_cast<std::uintptr_t>(e.comparator));
+  return res;
+}
+
+bool DamageContext::LayerContribution::operator==(
+    const LayerContribution& e) const {
+  return comparator == e.comparator && paint_bounds == e.paint_bounds &&
+         std::equal(
+             mutators.begin(), mutators.end(), e.mutators.begin(),
+             e.mutators.end(),
+             [](const std::shared_ptr<Mutator>& m1,
+                const std::shared_ptr<Mutator>& m2) { return *m1 == *m2; }) &&
+         (layer.get() == e.layer.get() ||
+          comparator(layer.get(), e.layer.get()));
+}
+
+void DamageContext::InitFrame(const SkISize& tree_size,
+                              const FrameDescription* previous_frame) {
+  current_layer_tree_size_ = tree_size;
+  previous_frame_ = previous_frame;
+}
+
+void DamageContext::PushLayerContribution(const Layer* layer,
+                                          LayerComparator comparator,
+                                          const SkMatrix& matrix,
+                                          const PrerollContext& preroll_context,
+                                          size_t index) {
+  if (current_layer_tree_size_.isEmpty() || layer->paint_bounds().isEmpty()) {
+    return;
+  }
+
+  LayerContribution e;
+  e.layer = layer->shared_from_this();
+  e.comparator = comparator;
+
+  SkRect bounds = layer->paint_bounds();
+  bounds.intersect(preroll_context.cull_rect);
+  e.paint_bounds = matrix.mapRect(bounds);
+
+  for (auto i = preroll_context.mutators_stack.Begin();
+       i != preroll_context.mutators_stack.End(); ++i) {
+    auto type = (*i)->GetType();
+    // transforms are irrelevant because we compare paint_bounds in
+    // screen coordinates
+    if (type != MutatorType::transform) {
+      e.mutators.push_back(*i);
+    }
+  }
+  if (index == size_t(-1)) {
+    layer_entries_.push_back(std::move(e));
+  } else {
+    layer_entries_.insert(layer_entries_.begin() + index, std::move(e));
+  }
+}
+
+bool DamageContext::ApplyImageFilter(size_t from,
+                                     size_t count,
+                                     const SkImageFilter* filter,
+                                     const SkMatrix& matrix,
+                                     const SkRect& bounds) {
+  SkMatrix inverted;
+  if (!matrix.invert(&inverted)) {
+    return false;
+  }
+
+  for (size_t i = from; i < count; ++i) {
+    auto& entry = layer_entries_[i];
+    SkRect layer_bounds(entry.paint_bounds);
+    inverted.mapRect(&layer_bounds);
+    if (layer_bounds.intersects(bounds)) {
+      // layer paint bounds after filter can not get bigger than union of
+      // original paint bounds and filter bounds
+      SkRect max(layer_bounds);
+      max.join(bounds);
+
+      layer_bounds = filter->computeFastBounds(layer_bounds);
+      layer_bounds.intersect(max);
+
+      matrix.mapRect(&layer_bounds);
+      entry.paint_bounds = layer_bounds;
+    }
+  }
+
+  return true;
+}
+
+void DamageArea::AddRect(const SkRect& rect) {
+  SkIRect irect;
+  rect.roundOut(&irect);
+  bounds_.join(irect);
+}
+
+void DamageArea::AddRect(const SkIRect& rect) {
+  bounds_.join(rect);
+}
+
+std::vector<SkIRect> DamageArea::GetRects() const {
+  std::vector<SkIRect> res;
+  res.push_back(bounds_);
+  return res;
+}
+
+DamageContext::DamageResult DamageContext::FinishFrame() {
+  DamageResult res;
+  res.frame_description.reset(new FrameDescription());
+  res.frame_description->layer_tree_size = current_layer_tree_size_;
+  auto& entries = res.frame_description->entries;
+
+  for (size_t i = 0; i < layer_entries_.size(); ++i) {
+    auto& entry = layer_entries_[i];
+    entry.paint_order = i;
+    entries.insert(std::move(entry));
+  }
+
+  if (!previous_frame_ ||
+      previous_frame_->layer_tree_size != current_layer_tree_size_) {
+    res.area.AddRect(SkRect::MakeIWH(current_layer_tree_size_.width(),
+                                     current_layer_tree_size_.height()));
+  } else {
+    // layer entries that are only found in one set (only this frame or only
+    // previous frame) are for layers that were either added, removed, or
+    // modified in any way (fail the equality check in LayerContribution) and
+    // thus contribute to damage area
+
+    // matching layer entries from previous frame and this frame; we still need
+    // to check for paint order to detect reordered layers
+    std::vector<const LayerContribution*> matching_previous;
+    std::vector<const LayerContribution*> matching_current;
+
+    for (const auto& l : entries) {
+      auto prev = previous_frame_->entries.find(l);
+      if (prev == previous_frame_->entries.end()) {
+        res.area.AddRect(l.paint_bounds);
+      } else {
+        matching_current.push_back(&l);
+        matching_previous.push_back(&*prev);
+      }
+    }
+    for (const auto& l : previous_frame_->entries) {
+      if (entries.find(l) == entries.end()) {
+        res.area.AddRect(l.paint_bounds);
+      }
+    }
+
+    // determine which layers are reordered
+    auto comparator = [](const LayerContribution* l1,
+                         const LayerContribution* l2) {
+      return l1->paint_order < l2->paint_order;
+    };
+    std::sort(matching_previous.begin(), matching_previous.end(), comparator);
+    std::sort(matching_current.begin(), matching_current.end(), comparator);
+
+    // We have two sets of matching layer entries that possibly differ in paint
+    // order and we sorted them by paint order, i.e.
+    // B C D E
+    // ^-- prev
+    // C D B E
+    // ^-- cur
+    // 1. move cur until match with prev is found (B)
+    // all layers before cur that intersect with prev are reordered and will
+    // contribute to damage, as does prev
+    // 2. remove prev and cur (now both pointing at B)
+    // 3. repeat until empty
+    // (except we actually do it in reverse to not erase from beginning)
+    while (!matching_previous.empty()) {
+      auto prev = matching_previous.end() - 1;
+      auto cur = matching_current.end() - 1;
+
+      while (*(*prev) != *(*cur)) {
+        if ((*prev)->paint_bounds.intersects((*cur)->paint_bounds)) {
+          res.area.AddRect((*prev)->paint_bounds);
+          res.area.AddRect((*cur)->paint_bounds);
+        }
+        --cur;
+      }
+      matching_previous.erase(prev);
+      matching_current.erase(cur);
+    }
+  }
+
+  previous_frame_ = nullptr;
+  layer_entries_.clear();
+  current_layer_tree_size_ = SkISize::MakeEmpty();
+
+  return res;
+}
+
+}  // namespace flutter

--- a/flow/damage_context.h
+++ b/flow/damage_context.h
@@ -1,0 +1,106 @@
+#ifndef FLUTTER_FLOW_CONTEXT_H_
+#define FLUTTER_FLOW_CONTEXT_H_
+
+#include <unordered_set>
+#include "flutter/flow/embedded_views.h"
+#include "third_party/skia/include/core/SkRect.h"
+
+class SkImageFilter;
+
+namespace flutter {
+
+struct PrerollContext;
+class Layer;
+
+class DamageArea {
+ public:
+  FML_DISALLOW_COPY_AND_ASSIGN(DamageArea);
+
+  DamageArea() = default;
+  DamageArea(DamageArea&&) = default;
+  DamageArea& operator=(DamageArea&&) = default;
+
+  const SkIRect& bounds() const { return bounds_; }
+
+  std::vector<SkIRect> GetRects() const;
+
+  void AddRect(const SkRect& rect);
+  void AddRect(const SkIRect& rect);
+
+ private:
+  SkIRect bounds_ = SkIRect::MakeEmpty();
+};
+
+class DamageContext {
+ public:
+  typedef bool (*LayerComparator)(const Layer* l1, const Layer* l2);
+
+  // Opaque representation of a frame contents
+  class FrameDescription;
+
+  void InitFrame(const SkISize& frame_size,
+                 const FrameDescription* previous_frame_description);
+
+  void PushLayerContribution(const Layer* layer,
+                             LayerComparator comparator,
+                             const SkMatrix& matrix,
+                             const PrerollContext& preroll_context,
+                             size_t index = size_t(-1));
+
+  size_t layer_entries_count() const { return layer_entries_.size(); }
+
+  // Adjusts the paint bounds of layer entries within given range according to
+  // filter bounds
+  bool ApplyImageFilter(size_t from,
+                        size_t count,
+                        const SkImageFilter* filter,
+                        const SkMatrix& matrix,
+                        const SkRect& bounds);
+
+  struct DamageResult {
+    DamageArea area;
+    std::unique_ptr<FrameDescription> frame_description;
+  };
+
+  DamageResult FinishFrame();
+
+ private:
+  // Represents a layer contribution to screen contents
+  // LayerContribution can compare itself with a LayerContribution from past
+  // frame to determine if the content they'd produce is identical
+  // Diffing set of LayerContributions will give us damage area
+  struct LayerContribution {
+    SkRect paint_bounds;  // in screen coordinates
+    std::shared_ptr<const Layer> layer;
+    LayerComparator comparator;
+
+    std::vector<std::shared_ptr<Mutator>> mutators;
+    int paint_order;
+
+    bool operator==(const LayerContribution& e) const;
+    bool operator!=(const LayerContribution& e) const { return !(*this == e); }
+
+    struct Hash {
+      std::size_t operator()(const LayerContribution& e) const noexcept;
+    };
+  };
+
+  using LayerContributionSet =
+      std::unordered_set<LayerContribution, LayerContribution::Hash>;
+  using LayerContributionList = std::vector<LayerContribution>;
+
+  const FrameDescription* previous_frame_ = nullptr;
+  SkISize current_layer_tree_size_ = SkISize::MakeEmpty();
+  LayerContributionList layer_entries_;
+
+ public:
+  class FrameDescription {
+    SkISize layer_tree_size;
+    DamageContext::LayerContributionSet entries;
+    friend class DamageContext;
+  };
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_FLOW_CONTEXT_H_

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -11,9 +11,21 @@ BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
 
 void BackdropFilterLayer::Preroll(PrerollContext* context,
                                   const SkMatrix& matrix) {
+  size_t count = 0;
+  if (context->damage_context) {
+    count = context->damage_context->layer_entries_count();
+  }
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context, true, bool(filter_));
   ContainerLayer::Preroll(context, matrix);
+  if (context->damage_context) {
+    // Adjust display bounds to layers below this layer
+    context->damage_context->ApplyImageFilter(0, count, filter_.get(), matrix,
+                                              paint_bounds());
+    // Push entry before children
+    context->damage_context->PushLayerContribution(this, compare, matrix, *context,
+                                            count);
+  }
 }
 
 void BackdropFilterLayer::Paint(PaintContext& context) const {
@@ -24,6 +36,14 @@ void BackdropFilterLayer::Paint(PaintContext& context) const {
       context,
       SkCanvas::SaveLayerRec{&paint_bounds(), nullptr, filter_.get(), 0});
   PaintChildren(context);
+}
+
+bool BackdropFilterLayer::compare(const Layer* l1, const Layer* l2) {
+  const auto* bf1 = reinterpret_cast<const BackdropFilterLayer*>(l1);
+  const auto* bf2 = reinterpret_cast<const BackdropFilterLayer*>(l2);
+  auto d1 = bf1->filter_->serialize();
+  auto d2 = bf2->filter_->serialize();
+  return d1 && d1->equals(d2.get());
 }
 
 }  // namespace flutter

--- a/flow/layers/backdrop_filter_layer.h
+++ b/flow/layers/backdrop_filter_layer.h
@@ -22,6 +22,8 @@ class BackdropFilterLayer : public ContainerLayer {
  private:
   sk_sp<SkImageFilter> filter_;
 
+  static bool compare(const Layer* l1, const Layer* l2);
+
   FML_DISALLOW_COPY_AND_ASSIGN(BackdropFilterLayer);
 };
 

--- a/flow/layers/image_filter_layer.h
+++ b/flow/layers/image_filter_layer.h
@@ -20,6 +20,8 @@ class ImageFilterLayer : public MergedContainerLayer {
   void Paint(PaintContext& context) const override;
 
  private:
+  static bool compare(const Layer* l1, const Layer* l2);
+
   // The ImageFilterLayer might cache the filtered output of this layer
   // if the layer remains stable (if it is not animating for instance).
   // If the ImageFilterLayer is not the same between rendered frames,

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#include "flutter/flow/damage_context.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/instrumentation.h"
 #include "flutter/flow/raster_cache.h"
@@ -47,6 +48,7 @@ struct PrerollContext {
   GrDirectContext* gr_context;
   ExternalViewEmbedder* view_embedder;
   MutatorsStack& mutators_stack;
+  DamageContext* damage_context;
   SkColorSpace* dst_color_space;
   SkRect cull_rect;
   bool surface_needs_readback;
@@ -71,7 +73,7 @@ struct PrerollContext {
 
 // Represents a single composited layer. Created on the UI thread but then
 // subquently used on the Rasterizer thread.
-class Layer {
+class Layer : public std::enable_shared_from_this<Layer> {
  public:
   Layer();
   virtual ~Layer();

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -146,6 +146,7 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
       nullptr,                  // gr_context  (used for the raster cache)
       nullptr,                  // external view embedder
       unused_stack,             // mutator stack
+      nullptr,                  // damage context
       nullptr,                  // SkColorSpace* dst_color_space
       kGiantRect,               // SkRect cull_rect
       false,                    // layer reads from surface

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -30,7 +30,8 @@ void LayerTree::RecordBuildTime(fml::TimePoint vsync_start,
 }
 
 bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
-                        bool ignore_raster_cache) {
+                        bool ignore_raster_cache,
+                        const SkRect& cull_rect) {
   TRACE_EVENT0("flutter", "LayerTree::Preroll");
 
   if (!root_layer_) {
@@ -48,8 +49,9 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       frame.gr_context(),
       frame.view_embedder(),
       stack,
+      frame.damage_context(),
       color_space,
-      kGiantRect,
+      cull_rect,
       false,
       frame.context().raster_time(),
       frame.context().ui_time(),

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -30,7 +30,8 @@ class LayerTree {
   //   layer tree performs any operations that require readback
   //   from the root surface.
   bool Preroll(CompositorContext::ScopedFrame& frame,
-               bool ignore_raster_cache = false);
+               bool ignore_raster_cache = false,
+               const SkRect& cull_rect = kGiantRect);
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   void UpdateScene(SceneUpdateContext& context);

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -20,7 +20,7 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   const bool parent_is_opaque = context->is_opaque;
   SkMatrix child_matrix = matrix;
-  child_matrix.postTranslate(offset_.fX, offset_.fY);
+  child_matrix.preTranslate(offset_.fX, offset_.fY);
 
   // Similar to what's done in TransformLayer::Preroll, we have to apply the
   // reverse transformation to the cull rect to properly cull child layers.

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -41,6 +41,10 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
     set_paint_bounds(ComputeShadowBounds(path_.getBounds(), elevation_,
                                          context->frame_device_pixel_ratio));
   }
+
+  if (!context->cull_rect.intersects(paint_bounds())) {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 void PhysicalShapeLayer::Paint(PaintContext& context) const {

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -29,9 +29,6 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
 
-  SkRect child_paint_bounds;
-  PrerollChildren(context, matrix, &child_paint_bounds);
-
   if (elevation_ == 0) {
     set_paint_bounds(path_.getBounds());
   } else {
@@ -45,6 +42,13 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
   if (!context->cull_rect.intersects(paint_bounds())) {
     set_paint_bounds(SkRect::MakeEmpty());
   }
+
+  if (context->damage_context) {
+    context->damage_context->PushLayerContribution(this, compare, matrix, *context);
+  }
+
+  SkRect child_paint_bounds;
+  PrerollChildren(context, matrix, &child_paint_bounds);
 }
 
 void PhysicalShapeLayer::Paint(PaintContext& context) const {
@@ -161,6 +165,14 @@ void PhysicalShapeLayer::DrawShadow(SkCanvas* canvas,
       canvas, path, SkPoint3::Make(0, 0, dpr * elevation),
       SkPoint3::Make(shadow_x, shadow_y, dpr * kLightHeight),
       dpr * kLightRadius, ambientColor, spotColor, flags);
+}
+
+bool PhysicalShapeLayer::compare(const Layer* l1, const Layer* l2) {
+  const auto* p1 = reinterpret_cast<const PhysicalShapeLayer*>(l1);
+  const auto* p2 = reinterpret_cast<const PhysicalShapeLayer*>(l2);
+  return p1->color_ == p2->color_ && p1->shadow_color_ == p2->shadow_color_ &&
+         p1->elevation_ == p2->elevation_ && p1->path_ == p2->path_ &&
+         p1->clip_behavior_ == p2->clip_behavior_;
 }
 
 }  // namespace flutter

--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -38,6 +38,8 @@ class PhysicalShapeLayer : public ContainerLayer {
   float elevation() const { return elevation_; }
 
  private:
+  static bool compare(const Layer* l1, const Layer* l2);
+
   SkColor color_;
   SkColor shadow_color_;
   float elevation_ = 0.0f;

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -30,7 +30,7 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
     TRACE_EVENT0("flutter", "PictureLayer::RasterCache (Preroll)");
 
     SkMatrix ctm = matrix;
-    ctm.postTranslate(offset_.x(), offset_.y());
+    ctm.preTranslate(offset_.x(), offset_.y());
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
     ctm = RasterCache::GetIntegralTransCTM(ctm);
 #endif

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -39,7 +39,12 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   }
 
   SkRect bounds = sk_picture->cullRect().makeOffset(offset_.x(), offset_.y());
-  set_paint_bounds(bounds);
+
+  if (context->cull_rect.intersects(bounds)) {
+    set_paint_bounds(bounds);
+  } else {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 void PictureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -5,6 +5,7 @@
 #include "flutter/flow/layers/picture_layer.h"
 
 #include "flutter/fml/logging.h"
+#include "third_party/skia/include/core/SkSerialProcs.h"
 
 namespace flutter {
 
@@ -45,6 +46,10 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   } else {
     set_paint_bounds(SkRect::MakeEmpty());
   }
+
+  if (context->damage_context) {
+    context->damage_context->PushLayerContribution(this, compare, matrix, *context);
+  }
 }
 
 void PictureLayer::Paint(PaintContext& context) const {
@@ -65,6 +70,64 @@ void PictureLayer::Paint(PaintContext& context) const {
     return;
   }
   picture()->playback(context.leaf_nodes_canvas);
+}
+
+sk_sp<SkData> PictureLayer::SerializedPicture() const {
+  SkSerialProcs procs = {
+      nullptr,
+      nullptr,
+      [](SkImage* i, void* ctx) {
+        auto id = i->uniqueID();
+        return SkData::MakeWithCopy(&id, sizeof(id));
+      },
+      nullptr,
+      [](SkTypeface* tf, void* ctx) {
+        auto id = tf->uniqueID();
+        return SkData::MakeWithCopy(&id, sizeof(id));
+      },
+      nullptr,
+  };
+
+  if (!cached_serialized_picture_) {
+    cached_serialized_picture_ = picture_.get()->serialize(&procs);
+  } else {
+  }
+  return cached_serialized_picture_;
+}
+
+#define USE_THOROUGH_COMPARE
+
+bool PictureLayer::compare(const Layer* l1, const Layer* l2) {
+  // Pictures are cached in flutter layers until repaint so
+  // identity comparison often works
+  const auto* pic_layer_1 = reinterpret_cast<const PictureLayer*>(l1);
+  const auto* pic_layer_2 = reinterpret_cast<const PictureLayer*>(l2);
+  const auto& pic1 = pic_layer_1->picture_.get();
+  const auto& pic2 = pic_layer_2->picture_.get();
+  if (pic1.get() == pic2.get()) {
+    return true;
+  }
+#ifdef USE_THOROUGH_COMPARE
+  auto op_cnt_1 = pic1->approximateOpCount();
+  auto op_cnt_2 = pic2->approximateOpCount();
+  if (op_cnt_1 != op_cnt_2 || pic1->cullRect() != pic2->cullRect()) {
+    return false;
+  }
+
+  if (op_cnt_1 > 10) {
+    return false;
+  }
+
+  // TODO(knopp) we don't actually need the data; this could be done without
+  // allocations by implementing stream that calculates SHA hash and
+  // comparing those hashes
+  auto d1 = pic_layer_1->SerializedPicture();
+  auto d2 = pic_layer_2->SerializedPicture();
+  auto res = d1->equals(d2.get());
+  return res;
+#else
+  return false;
+#endif
 }
 
 }  // namespace flutter

--- a/flow/layers/picture_layer.h
+++ b/flow/layers/picture_layer.h
@@ -27,12 +27,18 @@ class PictureLayer : public Layer {
   void Paint(PaintContext& context) const override;
 
  private:
+  static bool compare(const Layer* l1, const Layer* l2);
+
   SkPoint offset_;
   // Even though pictures themselves are not GPU resources, they may reference
   // images that have a reference to a GPU resource.
   SkiaGPUObject<SkPicture> picture_;
   bool is_complex_ = false;
   bool will_change_ = false;
+
+  sk_sp<SkData> SerializedPicture() const;
+
+  mutable sk_sp<SkData> cached_serialized_picture_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PictureLayer);
 };

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -32,6 +32,10 @@ void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   if (!context->cull_rect.intersects(paint_bounds())) {
     set_paint_bounds(SkRect::MakeEmpty());
   }
+
+  if (context->damage_context) {
+    context->damage_context->PushLayerContribution(this, compare, matrix, *context);
+  }
 }
 
 void TextureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -28,6 +28,10 @@ void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));
+
+  if (!context->cull_rect.intersects(paint_bounds())) {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 void TextureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -24,6 +24,10 @@ class TextureLayer : public Layer {
   void Paint(PaintContext& context) const override;
 
  private:
+  // TODO(knopp) It would be great if there was way to determine if texture
+  // has changed and whether it needs to contribute to damage rectangle
+  static bool compare(const Layer* l1, const Layer* l2) { return false; }
+
   SkPoint offset_;
   SkSize size_;
   int64_t texture_id_;

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -40,10 +40,11 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
  public:
   LayerTestBase()
       : preroll_context_({
-            nullptr, /* raster_cache */
-            nullptr, /* gr_context */
-            nullptr, /* external_view_embedder */
-            mutators_stack_, TestT::mock_canvas().imageInfo().colorSpace(),
+            nullptr,                  /* raster_cache */
+            nullptr,                  /* gr_context */
+            nullptr,                  /* external_view_embedder */
+            mutators_stack_, nullptr, /* damage_context */
+            TestT::mock_canvas().imageInfo().colorSpace(),
             kGiantRect, /* cull_rect */
             false,      /* layer reads from surface */
             raster_time_, ui_time_, texture_registry_,

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -462,7 +462,8 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
   );
 
   if (compositor_frame) {
-    RasterStatus raster_status = compositor_frame->Raster(layer_tree, false);
+    RasterStatus raster_status =
+        compositor_frame->Raster(layer_tree, false, nullptr);
     if (raster_status == RasterStatus::kFailed) {
       return raster_status;
     }
@@ -503,7 +504,7 @@ static sk_sp<SkData> ScreenshotLayerTreeAsPicture(
   auto frame = compositor_context.ACQUIRE_FRAME(
       nullptr, recorder.getRecordingCanvas(), nullptr,
       root_surface_transformation, false, true, nullptr);
-  frame->Raster(*tree, true);
+  frame->Raster(*tree, true, nullptr);
 
 #if defined(OS_FUCHSIA)
   SkSerialProcs procs = {0};
@@ -570,7 +571,7 @@ sk_sp<SkData> Rasterizer::ScreenshotLayerTreeAsImage(
       surface_context, canvas, nullptr, root_surface_transformation, false,
       true, nullptr);
   canvas->clear(SK_ColorTRANSPARENT);
-  frame->Raster(*tree, true);
+  frame->Raster(*tree, true, nullptr);
   canvas->flush();
 
   // Prepare an image from the surface, this image may potentially be on th GPU.

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1849,7 +1849,8 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
             nullptr,                 /* raster_cache */
             nullptr,                 /* gr_context */
             nullptr,                 /* external_view_embedder */
-            mutators_stack, nullptr, /* color_space */
+            mutators_stack, nullptr, /* damage_context */
+            nullptr,                 /* color_space */
             kGiantRect,              /* cull_rect */
             false,                   /* layer reads from surface */
             raster_time,    ui_time, texture_registry,

--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -42,7 +42,8 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
   flutter::SceneUpdateContext& scene_update_context_;
 
   flutter::RasterStatus Raster(flutter::LayerTree& layer_tree,
-                               bool ignore_raster_cache) override {
+                               bool ignore_raster_cache,
+                               flutter::FrameDamage* frame_damage) override {
     std::vector<flutter::SceneUpdateContext::PaintTask> frame_paint_tasks;
     std::vector<std::unique_ptr<SurfaceProducerSurface>> frame_surfaces;
 


### PR DESCRIPTION
## Description

This PR replaces https://github.com/flutter/engine/pull/21009

This PR adds api to track damage rectangles during rendering. Usage is relatively simple, it introduces the following structure in `compositor_context.h`
```cpp
struct FrameDamage {
  // in: description for frame previously rasterized in target framebuffer
  const DamageContext::FrameDescription* previous_frame_description;

  // out: description for frame being rasterized
  std::unique_ptr<DamageContext::FrameDescription> frame_description;

  // out: area in framebuffer that has changed between frames;
  // if optional is empty, whole frame was repainted
  std::optional<DamageArea> damage_area;
};
```

This can be provided as argument to `CompositorContext::ScopedFrame::Raster`. The caller is responsible for providing `previous_frame_description`, which was obtained during previous rasterization to current framebuffer, as well as storing incoming `frame_description`.

## Related Issues

https://github.com/flutter/flutter/issues/33939

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

This shouldn't be breaking change, if `frame_damage` is not provided (default). 
However it does prevent rendering of picture, physical shape and texture layers that are outside of cull rect. 

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
