### PR TITLE
Clean up C++ header includes

### DIFF
--- a/flow/gl_context_switch_unittests.cc
+++ b/flow/gl_context_switch_unittests.cc
@@ -3,11 +3,12 @@
 // found in the LICENSE file.
 #define FML_USED_ON_EMBEDDER
 
+#include "flutter/flow/gl_context_switch.h"
+
 #include <functional>
 #include <future>
 #include <memory>
 
-#include "flutter/flow/gl_context_switch.h"
 #include "flutter/flow/testing/gl_context_switch_test.h"
 #include "gtest/gtest.h"
 

--- a/flow/layers/backdrop_filter_layer.h
+++ b/flow/layers/backdrop_filter_layer.h
@@ -6,7 +6,6 @@
 #define FLUTTER_FLOW_LAYERS_BACKDROP_FILTER_LAYER_H_
 
 #include "flutter/flow/layers/container_layer.h"
-
 #include "third_party/skia/include/core/SkImageFilter.h"
 
 namespace flutter {

--- a/flow/layers/child_scene_layer.h
+++ b/flow/layers/child_scene_layer.h
@@ -5,12 +5,11 @@
 #ifndef FLUTTER_FLOW_LAYERS_CHILD_SCENE_LAYER_H_
 #define FLUTTER_FLOW_LAYERS_CHILD_SCENE_LAYER_H_
 
+#include "flutter/flow/layers/layer.h"
+#include "flutter/flow/scene_update_context.h"
 #include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/skia/include/core/SkPoint.h"
 #include "third_party/skia/include/core/SkSize.h"
-
-#include "flutter/flow/layers/layer.h"
-#include "flutter/flow/scene_update_context.h"
 
 namespace flutter {
 

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -5,9 +5,7 @@
 #include "flutter/flow/layers/clip_path_layer.h"
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-
 #include "lib/ui/scenic/cpp/commands.h"
-
 #endif
 
 namespace flutter {

--- a/flow/layers/color_filter_layer.h
+++ b/flow/layers/color_filter_layer.h
@@ -6,7 +6,6 @@
 #define FLUTTER_FLOW_LAYERS_COLOR_FILTER_LAYER_H_
 
 #include "flutter/flow/layers/container_layer.h"
-
 #include "third_party/skia/include/core/SkColorFilter.h"
 
 namespace flutter {

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -6,6 +6,7 @@
 #define FLUTTER_FLOW_LAYERS_CONTAINER_LAYER_H_
 
 #include <vector>
+
 #include "flutter/flow/layers/layer.h"
 
 namespace flutter {

--- a/flow/layers/fuchsia_layer_unittests.cc
+++ b/flow/layers/fuchsia_layer_unittests.cc
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <deque>
-
-#include "gtest/gtest.h"
-
 #include <fuchsia/ui/scenic/cpp/fidl.h>
 #include <fuchsia/ui/scenic/cpp/fidl_test_base.h>
 #include <lib/async-loop/cpp/loop.h>
@@ -16,6 +12,8 @@
 #include <lib/ui/scenic/cpp/id.h>
 #include <lib/ui/scenic/cpp/view_token_pair.h>
 
+#include <deque>
+
 #include "flutter/flow/layers/child_scene_layer.h"
 #include "flutter/flow/layers/container_layer.h"
 #include "flutter/flow/layers/opacity_layer.h"
@@ -24,6 +22,7 @@
 #include "flutter/flow/view_holder.h"
 #include "flutter/fml/platform/fuchsia/message_loop_fuchsia.h"
 #include "flutter/fml/task_runner.h"
+#include "gtest/gtest.h"
 
 namespace flutter {
 namespace testing {

--- a/flow/layers/image_filter_layer.h
+++ b/flow/layers/image_filter_layer.h
@@ -6,7 +6,6 @@
 #define FLUTTER_FLOW_LAYERS_IMAGE_FILTER_LAYER_H_
 
 #include "flutter/flow/layers/container_layer.h"
-
 #include "third_party/skia/include/core/SkImageFilter.h"
 
 namespace flutter {

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -28,11 +28,9 @@
 #include "third_party/skia/include/utils/SkNWayCanvas.h"
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-
 #include "flutter/flow/scene_update_context.h"  //nogncheck
 #include "lib/ui/scenic/cpp/resources.h"        //nogncheck
 #include "lib/ui/scenic/cpp/session.h"          //nogncheck
-
 #endif
 
 namespace flutter {

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/flow/layers/performance_overlay_layer.h"
+
 #include <iomanip>
 #include <iostream>
 #include <string>
 
-#include "flutter/flow/layers/performance_overlay_layer.h"
 #include "third_party/skia/include/core/SkFont.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
 

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -4,6 +4,9 @@
 
 #include "flutter/flow/layers/performance_overlay_layer.h"
 
+#include <cstdint>
+#include <sstream>
+
 #include "flutter/flow/flow_test_utils.h"
 #include "flutter/flow/raster_cache.h"
 #include "flutter/flow/testing/layer_test.h"
@@ -17,9 +20,6 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
 #include "third_party/skia/include/utils/SkBase64.h"
-
-#include <cstdint>
-#include <sstream>
 
 namespace flutter {
 namespace testing {

--- a/flow/layers/platform_view_layer_unittests.cc
+++ b/flow/layers/platform_view_layer_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/platform_view_layer.h"
+
 #include "flutter/flow/testing/layer_test.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/fml/macros.h"

--- a/flow/layers/shader_mask_layer.h
+++ b/flow/layers/shader_mask_layer.h
@@ -6,7 +6,6 @@
 #define FLUTTER_FLOW_LAYERS_SHADER_MASK_LAYER_H_
 
 #include "flutter/flow/layers/container_layer.h"
-
 #include "third_party/skia/include/core/SkShader.h"
 
 namespace flutter {

--- a/flow/matrix_decomposition_unittests.cc
+++ b/flow/matrix_decomposition_unittests.cc
@@ -4,9 +4,10 @@
 
 #define _USE_MATH_DEFINES
 
+#include "flutter/flow/matrix_decomposition.h"
+
 #include <cmath>
 
-#include "flutter/flow/matrix_decomposition.h"
 #include "gtest/gtest.h"
 
 namespace flutter {

--- a/flow/mutators_stack_unittests.cc
+++ b/flow/mutators_stack_unittests.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/embedded_views.h"
-
 #include "gtest/gtest.h"
 
 namespace flutter {

--- a/flow/raster_cache_key.h
+++ b/flow/raster_cache_key.h
@@ -6,6 +6,7 @@
 #define FLUTTER_FLOW_RASTER_CACHE_KEY_H_
 
 #include <unordered_map>
+
 #include "flutter/flow/matrix_decomposition.h"
 #include "flutter/fml/logging.h"
 

--- a/flow/skia_gpu_object_unittests.cc
+++ b/flow/skia_gpu_object_unittests.cc
@@ -4,14 +4,14 @@
 
 #include "flutter/flow/skia_gpu_object.h"
 
+#include <future>
+
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/testing/thread_test.h"
 #include "gtest/gtest.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
-
-#include <future>
 
 namespace flutter {
 namespace testing {

--- a/flow/testing/mock_texture.h
+++ b/flow/testing/mock_texture.h
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/flow/texture.h"
-#include "flutter/testing/assertions_skia.h"
-
 #include <ostream>
 #include <vector>
+
+#include "flutter/flow/texture.h"
+#include "flutter/testing/assertions_skia.h"
 
 namespace flutter {
 namespace testing {

--- a/flow/texture_unittests.cc
+++ b/flow/texture_unittests.cc
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/flow/testing/mock_texture.h"
 #include "flutter/flow/texture.h"
 
+#include "flutter/flow/testing/mock_texture.h"
 #include "gtest/gtest.h"
 
 namespace flutter {

--- a/fml/ascii_trie.cc
+++ b/fml/ascii_trie.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/ascii_trie.h"
+
 #include "flutter/fml/logging.h"
 
 namespace fml {

--- a/fml/ascii_trie_unittests.cc
+++ b/fml/ascii_trie_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/ascii_trie.h"
+
 #include "gtest/gtest.h"
 
 using fml::AsciiTrie;

--- a/fml/backtrace.cc
+++ b/fml/backtrace.cc
@@ -5,11 +5,11 @@
 #include "flutter/fml/backtrace.h"
 
 #include <cxxabi.h>
-#include <sstream>
-
 #include <dlfcn.h>
 #include <execinfo.h>
 #include <signal.h>
+
+#include <sstream>
 
 #include "flutter/fml/logging.h"
 

--- a/fml/backtrace_unittests.cc
+++ b/fml/backtrace_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "backtrace.h"
+
 #include "gtest/gtest.h"
 #include "logging.h"
 

--- a/fml/base32_unittest.cc
+++ b/fml/base32_unittest.cc
@@ -3,9 +3,10 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/base32.h"
-#include "gtest/gtest.h"
 
 #include <iostream>
+
+#include "gtest/gtest.h"
 
 TEST(Base32Test, CanEncode) {
   {

--- a/fml/delayed_task.h
+++ b/fml/delayed_task.h
@@ -5,10 +5,10 @@
 #ifndef FLUTTER_FML_DELAYED_TASK_H_
 #define FLUTTER_FML_DELAYED_TASK_H_
 
+#include <queue>
+
 #include "flutter/fml/closure.h"
 #include "flutter/fml/time/time_point.h"
-
-#include <queue>
 
 namespace fml {
 

--- a/fml/eintr_wrapper.h
+++ b/fml/eintr_wrapper.h
@@ -5,9 +5,9 @@
 #ifndef FLUTTER_FML_EINTR_WRAPPER_H_
 #define FLUTTER_FML_EINTR_WRAPPER_H_
 
-#include "flutter/fml/build_config.h"
-
 #include <errno.h>
+
+#include "flutter/fml/build_config.h"
 
 #if defined(OS_WIN)
 

--- a/fml/file_unittest.cc
+++ b/fml/file_unittest.cc
@@ -2,16 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <cstring>
 #include <memory>
 #include <vector>
-
-#include "gtest/gtest.h"
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/paths.h"
 #include "flutter/fml/unique_fd.h"
+#include "gtest/gtest.h"
 
 static bool WriteStringToFile(const fml::UniqueFD& fd,
                               const std::string& contents) {

--- a/fml/hash_combine_unittests.cc
+++ b/fml/hash_combine_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/hash_combine.h"
+
 #include "flutter/testing/testing.h"
 
 namespace fml {

--- a/fml/log_settings.h
+++ b/fml/log_settings.h
@@ -5,9 +5,9 @@
 #ifndef FLUTTER_FML_LOG_SETTINGS_H_
 #define FLUTTER_FML_LOG_SETTINGS_H_
 
-#include "flutter/fml/log_level.h"
-
 #include <string>
+
+#include "flutter/fml/log_level.h"
 
 namespace fml {
 

--- a/fml/memory/ref_ptr.h
+++ b/fml/memory/ref_ptr.h
@@ -8,7 +8,6 @@
 #define FLUTTER_FML_MEMORY_REF_PTR_H_
 
 #include <cstddef>
-
 #include <functional>
 #include <utility>
 

--- a/fml/memory/task_runner_checker_unittest.cc
+++ b/fml/memory/task_runner_checker_unittest.cc
@@ -4,15 +4,15 @@
 
 #define FML_USED_ON_EMBEDDER
 
-#include <gtest/gtest.h>
+#include "flutter/fml/memory/task_runner_checker.h"
 
 #include <thread>
-#include "flutter/fml/memory/task_runner_checker.h"
 
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/raster_thread_merger.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/synchronization/waitable_event.h"
+#include "gtest/gtest.h"
 
 namespace fml {
 namespace testing {

--- a/fml/memory/thread_checker.h
+++ b/fml/memory/thread_checker.h
@@ -9,15 +9,14 @@
 #define FLUTTER_FML_MEMORY_THREAD_CHECKER_H_
 
 #include "flutter/fml/build_config.h"
+#include "flutter/fml/logging.h"
+#include "flutter/fml/macros.h"
 
 #if defined(OS_WIN)
 #include <windows.h>
 #else
 #include <pthread.h>
 #endif
-
-#include "flutter/fml/logging.h"
-#include "flutter/fml/macros.h"
 
 namespace fml {
 

--- a/fml/message_loop_task_queues.cc
+++ b/fml/message_loop_task_queues.cc
@@ -5,10 +5,11 @@
 #define FML_USED_ON_EMBEDDER
 
 #include "flutter/fml/message_loop_task_queues.h"
-#include "flutter/fml/make_copyable.h"
-#include "flutter/fml/message_loop_impl.h"
 
 #include <iostream>
+
+#include "flutter/fml/make_copyable.h"
+#include "flutter/fml/message_loop_impl.h"
 
 namespace fml {
 

--- a/fml/message_loop_task_queues_benchmark.cc
+++ b/fml/message_loop_task_queues_benchmark.cc
@@ -2,12 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/fml/message_loop_task_queues.h"
+
 #include <cassert>
 #include <string>
 #include <thread>
 #include <vector>
+
 #include "flutter/benchmarking/benchmarking.h"
-#include "flutter/fml/message_loop_task_queues.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
 
 namespace fml {

--- a/fml/message_loop_task_queues_unittests.cc
+++ b/fml/message_loop_task_queues_unittests.cc
@@ -4,9 +4,10 @@
 
 #define FML_USED_ON_EMBEDDER
 
+#include "flutter/fml/message_loop_task_queues.h"
+
 #include <thread>
 
-#include "flutter/fml/message_loop_task_queues.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "gtest/gtest.h"

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -4,12 +4,13 @@
 
 #define FML_USED_ON_EMBEDDER
 
+#include "flutter/fml/message_loop.h"
+
 #include <iostream>
 #include <thread>
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/concurrent_message_loop.h"
-#include "flutter/fml/message_loop.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/task_runner.h"

--- a/fml/message_unittests.cc
+++ b/fml/message_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/message.h"
+
 #include "gtest/gtest.h"
 
 namespace fml {

--- a/fml/native_library.h
+++ b/fml/native_library.h
@@ -10,11 +10,9 @@
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/memory/ref_ptr.h"
 
-#if OS_WIN
-
+#if defined(OS_WIN)
 #include <windows.h>
-
-#endif  // OS_WIN
+#endif  // defined(OS_WIN)
 
 namespace fml {
 class NativeLibrary : public fml::RefCountedThreadSafe<NativeLibrary> {

--- a/fml/paths_unittests.cc
+++ b/fml/paths_unittests.cc
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "gtest/gtest.h"
-
 #include "flutter/fml/paths.h"
+
+#include "gtest/gtest.h"
 
 TEST(Paths, SanitizeURI) {
   ASSERT_EQ(fml::paths::SanitizeURIEscapedCharacters("hello"), "hello");

--- a/fml/platform/android/jni_util.cc
+++ b/fml/platform/android/jni_util.cc
@@ -5,6 +5,7 @@
 #include "flutter/fml/platform/android/jni_util.h"
 
 #include <sys/prctl.h>
+
 #include <codecvt>
 #include <string>
 

--- a/fml/platform/darwin/cf_utils_unittests.mm
+++ b/fml/platform/darwin/cf_utils_unittests.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/platform/darwin/cf_utils.h"
+
 #include "flutter/testing/testing.h"
 
 namespace fml {

--- a/fml/platform/darwin/platform_version.h
+++ b/fml/platform/darwin/platform_version.h
@@ -6,6 +6,7 @@
 #define FLUTTER_FML_PLATFORM_DARWIN_PLATFORM_VERSION_H_
 
 #include <sys/types.h>
+
 #include "flutter/fml/macros.h"
 
 namespace fml {

--- a/fml/platform/darwin/platform_version.mm
+++ b/fml/platform/darwin/platform_version.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/platform/darwin/platform_version.h"
+
 #include <Foundation/NSProcessInfo.h>
 
 namespace fml {

--- a/fml/platform/linux/paths_linux.cc
+++ b/fml/platform/linux/paths_linux.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/fml/paths.h"
-
 #include <unistd.h>
 
 #include "flutter/fml/paths.h"

--- a/fml/platform/posix/shared_mutex_posix.cc
+++ b/fml/platform/posix/shared_mutex_posix.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/fml/platform/posix/shared_mutex_posix.h"
+
 #include "flutter/fml/logging.h"
 
 namespace fml {

--- a/fml/platform/posix/shared_mutex_posix.h
+++ b/fml/platform/posix/shared_mutex_posix.h
@@ -6,6 +6,7 @@
 #define FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_POSIX_H_
 
 #include <shared_mutex>
+
 #include "flutter/fml/synchronization/shared_mutex.h"
 
 namespace fml {

--- a/fml/platform/win/message_loop_win.h
+++ b/fml/platform/win/message_loop_win.h
@@ -5,9 +5,9 @@
 #ifndef FLUTTER_FML_PLATFORM_WIN_MESSAGE_LOOP_WIN_H_
 #define FLUTTER_FML_PLATFORM_WIN_MESSAGE_LOOP_WIN_H_
 
-#include <atomic>
-
 #include <windows.h>
+
+#include <atomic>
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop_impl.h"

--- a/fml/platform/win/paths_win.cc
+++ b/fml/platform/win/paths_win.cc
@@ -5,6 +5,7 @@
 #include "flutter/fml/paths.h"
 
 #include <windows.h>
+
 #include <algorithm>
 
 #include "flutter/fml/paths.h"

--- a/fml/raster_thread_merger.cc
+++ b/fml/raster_thread_merger.cc
@@ -5,6 +5,7 @@
 #define FML_USED_ON_EMBEDDER
 
 #include "flutter/fml/raster_thread_merger.h"
+
 #include "flutter/fml/message_loop_impl.h"
 
 namespace fml {

--- a/fml/raster_thread_merger.h
+++ b/fml/raster_thread_merger.h
@@ -7,6 +7,7 @@
 
 #include <condition_variable>
 #include <mutex>
+
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/message_loop_task_queues.h"

--- a/fml/raster_thread_merger_unittests.cc
+++ b/fml/raster_thread_merger_unittests.cc
@@ -4,11 +4,12 @@
 
 #define FML_USED_ON_EMBEDDER
 
+#include "flutter/fml/raster_thread_merger.h"
+
 #include <atomic>
 #include <thread>
 
 #include "flutter/fml/message_loop.h"
-#include "flutter/fml/raster_thread_merger.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/task_runner.h"

--- a/fml/synchronization/count_down_latch_unittests.cc
+++ b/fml/synchronization/count_down_latch_unittests.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/fml/synchronization/count_down_latch.h"
+
 #include <chrono>
 #include <thread>
 
 #include "flutter/fml/build_config.h"
-#include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/thread.h"
 #include "flutter/testing/testing.h"
 

--- a/fml/synchronization/semaphore_unittest.cc
+++ b/fml/synchronization/semaphore_unittest.cc
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/fml/synchronization/semaphore.h"
+
 #include <thread>
 
-#include "flutter/fml/synchronization/semaphore.h"
 #include "gtest/gtest.h"
 
 TEST(SemaphoreTest, SimpleValidity) {

--- a/fml/synchronization/shared_mutex_std.h
+++ b/fml/synchronization/shared_mutex_std.h
@@ -5,8 +5,9 @@
 #ifndef FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_STD_H_
 #define FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_STD_H_
 
-#include <shared_mutex>
 #include "flutter/fml/synchronization/shared_mutex.h"
+
+#include <shared_mutex>
 
 namespace fml {
 

--- a/fml/thread.cc
+++ b/fml/thread.cc
@@ -6,7 +6,12 @@
 
 #include "flutter/fml/thread.h"
 
+#include <memory>
+#include <string>
+
 #include "flutter/fml/build_config.h"
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/synchronization/waitable_event.h"
 
 #if defined(OS_WIN)
 #include <windows.h>
@@ -15,12 +20,6 @@
 #else
 #include <pthread.h>
 #endif
-
-#include <memory>
-#include <string>
-
-#include "flutter/fml/message_loop.h"
-#include "flutter/fml/synchronization/waitable_event.h"
 
 namespace fml {
 

--- a/fml/thread_unittests.cc
+++ b/fml/thread_unittests.cc
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "gtest/gtest.h"
-
 #include "flutter/fml/thread.h"
+
+#include "gtest/gtest.h"
 
 TEST(Thread, CanStartAndEnd) {
   fml::Thread thread;

--- a/fml/unique_fd.h
+++ b/fml/unique_fd.h
@@ -9,14 +9,10 @@
 #include "flutter/fml/unique_object.h"
 
 #if OS_WIN
-
 #include <windows.h>
-
 #else  // OS_WIN
-
 #include <dirent.h>
 #include <unistd.h>
-
 #endif  // OS_WIN
 
 namespace fml {

--- a/lib/io/dart_io.cc
+++ b/lib/io/dart_io.cc
@@ -5,7 +5,6 @@
 #include "flutter/lib/io/dart_io.h"
 
 #include "flutter/fml/logging.h"
-
 #include "third_party/dart/runtime/include/bin/dart_io_api.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/converter/dart_converter.h"

--- a/lib/ui/compositing/scene_host.cc
+++ b/lib/ui/compositing/scene_host.cc
@@ -6,14 +6,14 @@
 
 #include <lib/ui/scenic/cpp/view_token_pair.h>
 #include <lib/zx/eventpair.h>
-#include "third_party/tonic/dart_args.h"
-#include "third_party/tonic/dart_binding_macros.h"
-#include "third_party/tonic/logging/dart_invoke.h"
 
 #include "flutter/flow/view_holder.h"
 #include "flutter/fml/thread_local.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/dart/runtime/include/dart_api.h"
+#include "third_party/tonic/dart_args.h"
+#include "third_party/tonic/dart_binding_macros.h"
+#include "third_party/tonic/logging/dart_invoke.h"
 
 namespace {
 

--- a/lib/ui/isolate_name_server/isolate_name_server_natives.cc
+++ b/lib/ui/isolate_name_server/isolate_name_server_natives.cc
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/lib/ui/isolate_name_server/isolate_name_server_natives.h"
+
 #include <string>
 
 #include "flutter/lib/ui/isolate_name_server/isolate_name_server.h"
-#include "flutter/lib/ui/isolate_name_server/isolate_name_server_natives.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"

--- a/lib/ui/isolate_name_server/isolate_name_server_natives.h
+++ b/lib/ui/isolate_name_server/isolate_name_server_natives.h
@@ -6,6 +6,7 @@
 #define FLUTTER_LIB_UI_ISOLATE_NAME_SERVER_NATIVES_H_
 
 #include <string>
+
 #include "third_party/dart/runtime/include/dart_api.h"
 
 namespace tonic {

--- a/lib/ui/painting/color_filter.cc
+++ b/lib/ui/painting/color_filter.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/lib/ui/painting/color_filter.h"
 
+#include <cstring>
+
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"

--- a/lib/ui/painting/engine_layer.h
+++ b/lib/ui/painting/engine_layer.h
@@ -5,9 +5,8 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_ENGINE_LAYER_H_
 #define FLUTTER_LIB_UI_PAINTING_ENGINE_LAYER_H_
 
-#include "flutter/lib/ui/dart_wrapper.h"
-
 #include "flutter/flow/layers/container_layer.h"
+#include "flutter/lib/ui/dart_wrapper.h"
 
 namespace tonic {
 class DartLibraryNatives;

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/lib/ui/painting/image_decoder.h"
+
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/synchronization/waitable_event.h"
-#include "flutter/lib/ui/painting/image_decoder.h"
 #include "flutter/lib/ui/painting/multi_frame_codec.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/runtime/dart_vm_lifecycle.h"

--- a/lib/ui/painting/image_encoding_unittests.cc
+++ b/lib/ui/painting/image_encoding_unittests.cc
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/lib/ui/painting/image_encoding.h"
+
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/synchronization/waitable_event.h"
-#include "flutter/lib/ui/painting/image_encoding.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/shell_test.h"
 #include "flutter/shell/common/thread_host.h"

--- a/lib/ui/painting/immutable_buffer.cc
+++ b/lib/ui/painting/immutable_buffer.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/lib/ui/painting/immutable_buffer.h"
 
+#include <cstring>
+
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"

--- a/lib/ui/painting/vertices.cc
+++ b/lib/ui/painting/vertices.cc
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 
 #include "flutter/lib/ui/painting/vertices.h"
-#include "flutter/lib/ui/ui_dart_state.h"
 
 #include <algorithm>
 
+#include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 

--- a/lib/ui/painting/vertices_unittests.cc
+++ b/lib/ui/painting/vertices_unittests.cc
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/lib/ui/painting/vertices.h"
+
 #include <memory>
+
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/synchronization/waitable_event.h"
-#include "flutter/lib/ui/painting/vertices.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/shell_test.h"
 #include "flutter/shell/common/thread_host.h"

--- a/lib/ui/plugins/callback_cache.cc
+++ b/lib/ui/plugins/callback_cache.cc
@@ -3,13 +3,14 @@
 // found in the LICENSE file.
 // FLUTTER_NOLINT
 
+#include "flutter/lib/ui/plugins/callback_cache.h"
+
 #include <fstream>
 #include <iterator>
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/paths.h"
-#include "flutter/lib/ui/plugins/callback_cache.h"
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/writer.h"

--- a/lib/ui/semantics/semantics_update.cc
+++ b/lib/ui/semantics/semantics_update.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/lib/ui/semantics/semantics_update_builder.h"
+#include "flutter/lib/ui/semantics/semantics_update.h"
 
 #include <memory>
 
 #include "flutter/lib/ui/painting/matrix.h"
+#include "flutter/lib/ui/semantics/semantics_update_builder.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"

--- a/lib/ui/semantics/semantics_update_builder.cc
+++ b/lib/ui/semantics/semantics_update_builder.cc
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 #include "flutter/lib/ui/semantics/semantics_update_builder.h"
-#include "flutter/lib/ui/ui_dart_state.h"
 
+#include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/skia/include/core/SkScalar.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/lib/ui/text/paragraph_builder.h"
 
+#include <cstring>
+
 #include "flutter/common/settings.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/logging.h"

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/lib/ui/window/platform_configuration.h"
 
+#include <cstring>
+
 #include "flutter/lib/ui/compositing/scene.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/platform_message_response_dart.h"

--- a/lib/ui/window/platform_configuration_unittests.cc
+++ b/lib/ui/window/platform_configuration_unittests.cc
@@ -4,9 +4,9 @@
 
 #define FML_USED_ON_EMBEDDER
 
-#include <memory>
-
 #include "flutter/lib/ui/window/platform_configuration.h"
+
+#include <memory>
 
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/synchronization/waitable_event.h"

--- a/lib/ui/window/pointer_data_packet_converter_unittests.cc
+++ b/lib/ui/window/pointer_data_packet_converter_unittests.cc
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 #include "flutter/lib/ui/window/pointer_data_packet_converter.h"
+
+#include <cstring>
+
 #include "gtest/gtest.h"
 
 namespace flutter {

--- a/runtime/dart_isolate_group_data.cc
+++ b/runtime/dart_isolate_group_data.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/runtime/dart_isolate_group_data.h"
+
 #include "flutter/runtime/dart_snapshot.h"
 
 namespace flutter {

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/runtime/dart_isolate.h"
+
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/thread.h"
-#include "flutter/runtime/dart_isolate.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/testing/dart_isolate_runner.h"

--- a/runtime/dart_service_isolate_unittests.cc
+++ b/runtime/dart_service_isolate_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/runtime/dart_service_isolate.h"
+
 #include "flutter/testing/testing.h"
 
 namespace flutter {

--- a/runtime/dart_vm_unittests.cc
+++ b/runtime/dart_vm_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/runtime/dart_vm.h"
+
 #include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/testing/fixture_test.h"
 #include "gtest/gtest.h"

--- a/runtime/platform_data.h
+++ b/runtime/platform_data.h
@@ -5,11 +5,11 @@
 #ifndef FLUTTER_RUNTIME_PLATFORM_DATA_H_
 #define FLUTTER_RUNTIME_PLATFORM_DATA_H_
 
-#include "flutter/lib/ui/window/viewport_metrics.h"
-
 #include <memory>
 #include <string>
 #include <vector>
+
+#include "flutter/lib/ui/window/viewport_metrics.h"
 
 namespace flutter {
 

--- a/shell/common/animator_unittests.cc
+++ b/shell/common/animator_unittests.cc
@@ -5,11 +5,12 @@
 
 #define FML_USED_ON_EMBEDDER
 
+#include "flutter/shell/common/animator.h"
+
 #include <functional>
 #include <future>
 #include <memory>
 
-#include "flutter/shell/common/animator.h"
 #include "flutter/shell/common/shell_test.h"
 #include "flutter/shell/common/shell_test_platform_view.h"
 #include "flutter/testing/testing.h"

--- a/shell/common/canvas_spy_unittests.cc
+++ b/shell/common/canvas_spy_unittests.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "canvas_spy.h"
+
 #include "gtest/gtest.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "third_party/skia/include/core/SkSurface.h"

--- a/shell/common/persistent_cache.cc
+++ b/shell/common/persistent_cache.cc
@@ -9,9 +9,6 @@
 #include <string>
 #include <string_view>
 
-#include "rapidjson/document.h"
-#include "third_party/skia/include/utils/SkBase64.h"
-
 #include "flutter/fml/base32.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/logging.h"
@@ -20,6 +17,8 @@
 #include "flutter/fml/paths.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/version/version.h"
+#include "rapidjson/document.h"
+#include "third_party/skia/include/utils/SkBase64.h"
 
 namespace flutter {
 

--- a/shell/common/persistent_cache_unittests.cc
+++ b/shell/common/persistent_cache_unittests.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/shell/common/persistent_cache.h"
+
 #include <memory>
 
 #include "flutter/assets/directory_asset_bundle.h"
@@ -13,7 +15,6 @@
 #include "flutter/fml/file.h"
 #include "flutter/fml/log_settings.h"
 #include "flutter/fml/unique_fd.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/shell_test.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/version/version.h"

--- a/shell/common/pipeline.h
+++ b/shell/common/pipeline.h
@@ -5,14 +5,14 @@
 #ifndef FLUTTER_SHELL_COMMON_PIPELINE_H_
 #define FLUTTER_SHELL_COMMON_PIPELINE_H_
 
+#include <deque>
+#include <memory>
+#include <mutex>
+
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/synchronization/semaphore.h"
 #include "flutter/fml/trace_event.h"
-
-#include <deque>
-#include <memory>
-#include <mutex>
 
 namespace flutter {
 

--- a/shell/common/pipeline_unittests.cc
+++ b/shell/common/pipeline_unittests.cc
@@ -4,11 +4,12 @@
 
 #define FML_USED_ON_EMBEDDER
 
+#include "flutter/shell/common/pipeline.h"
+
 #include <functional>
 #include <future>
 #include <memory>
 
-#include "flutter/shell/common/pipeline.h"
 #include "gtest/gtest.h"
 
 namespace flutter {

--- a/shell/common/shell_benchmarks.cc
+++ b/shell/common/shell_benchmarks.cc
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 // FLUTTER_NOLINT
 
+#include "flutter/shell/common/shell.h"
+
 #include "flutter/benchmarking/benchmarking.h"
 #include "flutter/fml/logging.h"
 #include "flutter/runtime/dart_vm.h"
-#include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/testing/elf_loader.h"
 #include "flutter/testing/testing.h"

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_SHELL_COMMON_SHELL_TEST_H_
 #define FLUTTER_SHELL_COMMON_SHELL_TEST_H_
 
+#include "flutter/shell/common/shell.h"
+
 #include <memory>
 
 #include "flutter/common/settings.h"
@@ -15,7 +17,6 @@
 #include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/run_configuration.h"
-#include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/shell_test_external_view_embedder.h"
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/common/vsync_waiters_test.h"

--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/common/shell_test_platform_view_gl.h"
+
 #include "flutter/shell/gpu/gpu_surface_gl.h"
 
 namespace flutter {

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/common/shell_test_platform_view_vulkan.h"
+
 #include "flutter/shell/common/persistent_cache.h"
 #include "flutter/vulkan/vulkan_utilities.h"
 

--- a/shell/common/skia_event_tracer_impl.cc
+++ b/shell/common/skia_event_tracer_impl.cc
@@ -52,7 +52,7 @@ inline T BitCast(const U& u) {
   memcpy(&t, &u, sizeof(t));
   return t;
 }
-#endif
+#endif  // defined(OS_FUCHSIA)
 
 }  // namespace
 

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 // FLUTTER_NOLINT
 
-#include "gpu_surface_gl.h"
+#include "flutter/shell/gpu/gpu_surface_gl.h"
 
 #include "flutter/fml/base32.h"
 #include "flutter/fml/logging.h"

--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
 
+#include <cstring>
+
 #include "third_party/skia/include/gpu/gl/GrGLAssembleInterface.h"
 
 namespace flutter {

--- a/shell/gpu/gpu_surface_software_delegate.cc
+++ b/shell/gpu/gpu_surface_software_delegate.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "gpu_surface_software_delegate.h"
+#include "shell/gpu/gpu_surface_software_delegate.h"
 
 namespace flutter {
 

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -4,6 +4,7 @@
 // FLUTTER_NOLINT
 
 #include "flutter/shell/gpu/gpu_surface_vulkan.h"
+
 #include "flutter/fml/logging.h"
 
 namespace flutter {

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_TEXTURE_GL_H_
 
 #include <GLES/gl.h>
+
 #include "flutter/flow/texture.h"
 #include "flutter/fml/platform/android/jni_weak_ref.h"
 #include "flutter/shell/platform/android/platform_view_android_jni_impl.h"

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_SURFACE_GL_H_
 
 #include <jni.h>
+
 #include <memory>
 
 #include "flutter/fml/macros.h"

--- a/shell/platform/android/android_surface_vulkan.h
+++ b/shell/platform/android/android_surface_vulkan.h
@@ -6,7 +6,9 @@
 #define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_SURFACE_VULKAN_H_
 
 #include <jni.h>
+
 #include <memory>
+
 #include "flutter/fml/macros.h"
 #include "flutter/shell/gpu/gpu_surface_vulkan_delegate.h"
 #include "flutter/shell/platform/android/external_view_embedder/external_view_embedder.h"

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -2,13 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/shell/platform/android/apk_asset_provider.h"
+
 #include <unistd.h>
 
 #include <algorithm>
 #include <sstream>
 
 #include "flutter/fml/logging.h"
-#include "flutter/shell/platform/android/apk_asset_provider.h"
 
 namespace flutter {
 

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -3,11 +3,12 @@
 // found in the LICENSE file.
 // FLUTTER_NOLINT
 
+#include "flutter/shell/platform/android/external_view_embedder/external_view_embedder.h"
+
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/raster_thread_merger.h"
 #include "flutter/fml/thread.h"
-#include "flutter/shell/platform/android/external_view_embedder/external_view_embedder.h"
 #include "flutter/shell/platform/android/jni/jni_mock.h"
 #include "flutter/shell/platform/android/surface/android_surface_mock.h"
 #include "gmock/gmock.h"

--- a/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
+++ b/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 // FLUTTER_NOLINT
 
-#include "flutter/fml/make_copyable.h"
 #include "flutter/shell/platform/android/external_view_embedder/surface_pool.h"
+
+#include "flutter/fml/make_copyable.h"
 #include "flutter/shell/platform/android/jni/jni_mock.h"
 #include "flutter/shell/platform/android/surface/android_surface_mock.h"
 #include "gmock/gmock.h"

--- a/shell/platform/android/jni/jni_mock_unittest.cc
+++ b/shell/platform/android/jni/jni_mock_unittest.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/android/jni/jni_mock.h"
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/shell/platform/android/jni/platform_view_android_jni.h
+++ b/shell/platform/android/jni/platform_view_android_jni.h
@@ -8,14 +8,14 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
 
-#if OS_ANDROID
-#include "flutter/fml/platform/android/jni_weak_ref.h"
-#endif
-
 #include "flutter/flow/embedded_views.h"
 #include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/shell/platform/android/surface/android_native_window.h"
 #include "third_party/skia/include/core/SkMatrix.h"
+
+#if OS_ANDROID
+#include "flutter/fml/platform/android/jni_weak_ref.h"
+#endif
 
 namespace flutter {
 

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate_unittests.cc
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/shell/platform/android/jni/jni_mock.h"
 #include "flutter/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h"
+
+#include "flutter/shell/platform/android/jni/jni_mock.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -6,6 +6,7 @@
 
 #include <android/native_window_jni.h>
 #include <jni.h>
+
 #include <utility>
 
 #include "unicode/uchar.h"

--- a/shell/platform/android/surface/android_native_window.h
+++ b/shell/platform/android/surface/android_native_window.h
@@ -7,13 +7,13 @@
 
 #include "flutter/fml/build_config.h"
 
-#if OS_ANDROID
-#include <android/native_window.h>
-#endif  // OS_ANDROID
-
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted.h"
 #include "third_party/skia/include/core/SkSize.h"
+
+#if OS_ANDROID
+#include <android/native_window.h>
+#endif  // OS_ANDROID
 
 namespace flutter {
 

--- a/shell/platform/common/cpp/client_wrapper/basic_message_channel_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/basic_message_channel_unittests.cc
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/basic_message_channel.h"
+
 #include <memory>
 #include <string>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/basic_message_channel.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_message_codec.h"
 #include "gtest/gtest.h"

--- a/shell/platform/common/cpp/client_wrapper/encodable_value_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/encodable_value_unittests.cc
@@ -3,9 +3,10 @@
 // found in the LICENSE file.
 // FLUTTER_NOLINT
 
+#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/encodable_value.h"
+
 #include <limits>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/encodable_value.h"
 #include "gtest/gtest.h"
 
 namespace flutter {

--- a/shell/platform/common/cpp/client_wrapper/event_channel_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/event_channel_unittests.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/event_channel.h"
+
 #include <memory>
 #include <string>
 
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/event_channel.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/event_stream_handler_functions.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_method_codec.h"
 #include "gtest/gtest.h"

--- a/shell/platform/common/cpp/client_wrapper/method_channel_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/method_channel_unittests.cc
@@ -2,11 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h"
+
 #include <memory>
 #include <string>
 
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h"
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_method_codec.h"
 #include "gtest/gtest.h"

--- a/shell/platform/common/cpp/client_wrapper/method_result_functions_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/method_result_functions_unittests.cc
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h"
+
 #include <functional>
 #include <string>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h"
 #include "gtest/gtest.h"
 
 namespace flutter {

--- a/shell/platform/common/cpp/client_wrapper/plugin_registrar_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/plugin_registrar_unittests.cc
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h"
+
 #include <memory>
 #include <vector>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/testing/stub_flutter_api.h"
 #include "gtest/gtest.h"
 

--- a/shell/platform/common/cpp/client_wrapper/standard_message_codec_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/standard_message_codec_unittests.cc
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_message_codec.h"
+
 #include <map>
 #include <vector>
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_message_codec.h"
 #include "gtest/gtest.h"
 
 #ifndef USE_LEGACY_ENCODABLE_VALUE

--- a/shell/platform/common/cpp/client_wrapper/standard_method_codec_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/standard_method_codec_unittests.cc
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_method_codec.h"
+
+#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h"
 #include "flutter/shell/platform/common/cpp/client_wrapper/testing/test_codec_extensions.h"
 #include "gtest/gtest.h"
 

--- a/shell/platform/common/cpp/public/flutter_messenger.h
+++ b/shell/platform/common/cpp/public/flutter_messenger.h
@@ -12,7 +12,7 @@
 
 #if defined(__cplusplus)
 extern "C" {
-#endif
+#endif  // defined(__cplusplus)
 
 // Opaque reference to a Flutter engine messenger.
 typedef struct FlutterDesktopMessenger* FlutterDesktopMessengerRef;

--- a/shell/platform/common/cpp/public/flutter_plugin_registrar.h
+++ b/shell/platform/common/cpp/public/flutter_plugin_registrar.h
@@ -13,7 +13,7 @@
 
 #if defined(__cplusplus)
 extern "C" {
-#endif
+#endif  // defined(__cplusplus)
 
 // Opaque reference to a plugin registrar.
 typedef struct FlutterDesktopPluginRegistrar* FlutterDesktopPluginRegistrarRef;

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -7,6 +7,7 @@
 #define FML_USED_ON_EMBEDDER
 #define RAPIDJSON_HAS_STDSTRING 1
 
+#include <cstring>
 #include <iostream>
 #include <memory>
 #include <string>

--- a/shell/platform/fuchsia/dart_runner/builtin_libraries.cc
+++ b/shell/platform/fuchsia/dart_runner/builtin_libraries.cc
@@ -6,6 +6,7 @@
 
 #include <lib/fdio/namespace.h>
 #include <lib/zx/channel.h>
+
 #include <optional>
 
 #include "dart-pkg/fuchsia/sdk_ext/fuchsia.h"

--- a/shell/platform/fuchsia/dart_runner/builtin_libraries.h
+++ b/shell/platform/fuchsia/dart_runner/builtin_libraries.h
@@ -5,12 +5,11 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_RUNNER_BUILTIN_LIBRARIES_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_RUNNER_BUILTIN_LIBRARIES_H_
 
-#include <memory>
-#include <string>
-
+#include <fuchsia/sys/cpp/fidl.h>
 #include <lib/fdio/namespace.h>
 
-#include <fuchsia/sys/cpp/fidl.h>
+#include <memory>
+#include <string>
 
 namespace dart_runner {
 

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <zircon/status.h>
+
 #include <regex>
 #include <utility>
 

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -20,6 +20,7 @@
 #include <zircon/dlfcn.h>
 #include <zircon/status.h>
 #include <zircon/types.h>
+
 #include <memory>
 #include <regex>
 #include <sstream>

--- a/shell/platform/fuchsia/flutter/fuchsia_intl_unittest.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_intl_unittest.cc
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 #include <fuchsia/intl/cpp/fidl.h>
-#include <gtest/gtest.h>
 
 #include "flutter/fml/icu_util.h"
+#include "gtest/gtest.h"
 
 #include "fuchsia_intl.h"
 

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -7,6 +7,8 @@
 #include "platform_view.h"
 
 #include <fuchsia/ui/gfx/cpp/fidl.h>
+
+#include <cstring>
 #include <sstream>
 
 #include "flutter/fml/logging.h"

--- a/shell/platform/fuchsia/flutter/thread.h
+++ b/shell/platform/fuchsia/flutter/thread.h
@@ -5,12 +5,11 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_THREAD_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_THREAD_H_
 
+#include <lib/async-loop/cpp/loop.h>
+#include <lib/async/default.h>
 #include <pthread.h>
 
 #include <functional>
-
-#include <lib/async-loop/cpp/loop.h>
-#include <lib/async/default.h>
 
 #include "flutter/fml/macros.h"
 

--- a/shell/platform/fuchsia/flutter/vsync_waiter_unittests.cc
+++ b/shell/platform/fuchsia/flutter/vsync_waiter_unittests.cc
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <array>
-
 #include <gtest/gtest.h>
 #include <lib/async-loop/default.h>
 #include <lib/zx/event.h>
 #include <zircon/syscalls.h>
+
+#include <array>
 
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/time/time_delta.h"

--- a/shell/platform/fuchsia/runtime/dart/utils/handle_exception.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/handle_exception.cc
@@ -10,9 +10,10 @@
 #include <lib/zx/vmo.h>
 #include <sys/types.h>
 #include <zircon/status.h>
-#include "third_party/tonic/converter/dart_converter.h"
 
 #include <string>
+
+#include "third_party/tonic/converter/dart_converter.h"
 
 #include "logging.h"
 

--- a/shell/platform/fuchsia/runtime/dart/utils/handle_exception.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/handle_exception.h
@@ -6,10 +6,11 @@
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_HANDLE_EXCEPTION_H_
 
 #include <lib/sys/cpp/service_directory.h>
-#include "third_party/dart/runtime/include/dart_api.h"
 
 #include <memory>
 #include <string>
+
+#include "third_party/dart/runtime/include/dart_api.h"
 
 namespace dart_utils {
 

--- a/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
@@ -18,9 +18,10 @@
 #include <zircon/dlfcn.h>
 #include <zircon/status.h>
 
+#include "third_party/dart/runtime/include/dart_api.h"
+
 #include "inlines.h"
 #include "logging.h"
-#include "third_party/dart/runtime/include/dart_api.h"
 #include "vmo.h"
 
 namespace dart_utils {

--- a/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.h
@@ -7,6 +7,7 @@
 
 #include <fuchsia/mem/cpp/fidl.h>
 #include <lib/fdio/namespace.h>
+
 #include "third_party/dart/runtime/bin/elf_loader.h"
 
 namespace dart_utils {

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
@@ -5,10 +5,10 @@
 #ifndef FLUTTER_SHELL_PLATFORM_GLFW_CLIENT_WRAPPER_INCLUDE_FLUTTER_FLUTTER_WINDOW_H_
 #define FLUTTER_SHELL_PLATFORM_GLFW_CLIENT_WRAPPER_INCLUDE_FLUTTER_FLUTTER_WINDOW_H_
 
+#include <flutter_glfw.h>
+
 #include <string>
 #include <vector>
-
-#include <flutter_glfw.h>
 
 #include "plugin_registrar.h"
 

--- a/shell/platform/linux/fl_binary_messenger_test.cc
+++ b/shell/platform/linux/fl_binary_messenger_test.cc
@@ -5,6 +5,8 @@
 // Included first as it collides with the X11 headers.
 #include "gtest/gtest.h"
 
+#include <cstring>
+
 #include "flutter/shell/platform/linux/fl_binary_messenger_private.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h"

--- a/shell/platform/linux/fl_json_message_codec.cc
+++ b/shell/platform/linux/fl_json_message_codec.cc
@@ -2,12 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(cbracken): lint disabled due to rapidjson null deref issue.
+// https://github.com/flutter/flutter/issues/65676
+// FLUTTER_NOLINT
+
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h"
+
+#include <gmodule.h>
+
+#include <cstring>
 
 #include "rapidjson/reader.h"
 #include "rapidjson/writer.h"
-
-#include <gmodule.h>
 
 G_DEFINE_QUARK(fl_json_message_codec_error_quark, fl_json_message_codec_error)
 
@@ -47,40 +53,46 @@ static gboolean write_value(rapidjson::Writer<rapidjson::StringBuffer>& writer,
     case FL_VALUE_TYPE_UINT8_LIST: {
       writer.StartArray();
       const uint8_t* data = fl_value_get_uint8_list(value);
-      for (size_t i = 0; i < fl_value_get_length(value); i++)
+      for (size_t i = 0; i < fl_value_get_length(value); i++) {
         writer.Int(data[i]);
+      }
       writer.EndArray();
       break;
     }
     case FL_VALUE_TYPE_INT32_LIST: {
       writer.StartArray();
       const int32_t* data = fl_value_get_int32_list(value);
-      for (size_t i = 0; i < fl_value_get_length(value); i++)
+      for (size_t i = 0; i < fl_value_get_length(value); i++) {
         writer.Int(data[i]);
+      }
       writer.EndArray();
       break;
     }
     case FL_VALUE_TYPE_INT64_LIST: {
       writer.StartArray();
       const int64_t* data = fl_value_get_int64_list(value);
-      for (size_t i = 0; i < fl_value_get_length(value); i++)
+      for (size_t i = 0; i < fl_value_get_length(value); i++) {
         writer.Int64(data[i]);
+      }
       writer.EndArray();
       break;
     }
     case FL_VALUE_TYPE_FLOAT_LIST: {
       writer.StartArray();
       const double* data = fl_value_get_float_list(value);
-      for (size_t i = 0; i < fl_value_get_length(value); i++)
+      for (size_t i = 0; i < fl_value_get_length(value); i++) {
         writer.Double(data[i]);
+      }
       writer.EndArray();
       break;
     }
     case FL_VALUE_TYPE_LIST: {
       writer.StartArray();
-      for (size_t i = 0; i < fl_value_get_length(value); i++)
-        if (!write_value(writer, fl_value_get_list_value(value, i), error))
+      for (size_t i = 0; i < fl_value_get_length(value); i++) {
+        if (!write_value(writer, fl_value_get_list_value(value, i), error)) {
           return FALSE;
+        }
+      }
       writer.EndArray();
       break;
     }
@@ -95,8 +107,9 @@ static gboolean write_value(rapidjson::Writer<rapidjson::StringBuffer>& writer,
           return FALSE;
         }
         writer.Key(fl_value_get_string(key));
-        if (!write_value(writer, fl_value_get_map_value(value, i), error))
+        if (!write_value(writer, fl_value_get_map_value(value, i), error)) {
           return FALSE;
+        }
       }
       writer.EndObject();
       break;
@@ -126,16 +139,19 @@ struct FlValueHandler {
 
   ~FlValueHandler() {
     g_ptr_array_unref(stack);
-    if (key != nullptr)
+    if (key != nullptr) {
       fl_value_unref(key);
-    if (error != nullptr)
+    }
+    if (error != nullptr) {
       g_error_free(error);
+    }
   }
 
   // Gets the current head of the stack.
   FlValue* get_head() {
-    if (stack->len == 0)
+    if (stack->len == 0) {
       return nullptr;
+    }
     return static_cast<FlValue*>(g_ptr_array_index(stack, stack->len - 1));
   }
 
@@ -163,8 +179,9 @@ struct FlValueHandler {
     }
 
     if (fl_value_get_type(owned_value) == FL_VALUE_TYPE_LIST ||
-        fl_value_get_type(owned_value) == FL_VALUE_TYPE_MAP)
+        fl_value_get_type(owned_value) == FL_VALUE_TYPE_MAP) {
       push(value);
+    }
 
     return true;
   }
@@ -183,10 +200,11 @@ struct FlValueHandler {
 
   bool Uint64(uint64_t i) {
     // For some reason (bug in rapidjson?) this is not returned in Int64.
-    if (i == G_MAXINT64)
+    if (i == G_MAXINT64) {
       return add(fl_value_new_int(i));
-    else
+    } else {
       return add(fl_value_new_float(i));
+    }
   }
 
   bool Double(double d) { return add(fl_value_new_float(d)); }
@@ -205,8 +223,9 @@ struct FlValueHandler {
   bool StartObject() { return add(fl_value_new_map()); }
 
   bool Key(const char* str, rapidjson::SizeType length, bool copy) {
-    if (key != nullptr)
+    if (key != nullptr) {
       fl_value_unref(key);
+    }
     key = fl_value_new_string_sized(str, length);
     return true;
   }
@@ -231,8 +250,9 @@ static GBytes* fl_json_message_codec_encode_message(FlMessageCodec* codec,
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-  if (!write_value(writer, message, error))
+  if (!write_value(writer, message, error)) {
     return nullptr;
+  }
 
   const gchar* text = buffer.GetString();
   return g_bytes_new(text, strlen(text));
@@ -300,8 +320,9 @@ G_MODULE_EXPORT gchar* fl_json_message_codec_encode(FlJsonMessageCodec* codec,
   rapidjson::StringBuffer buffer;
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
 
-  if (!write_value(writer, value, error))
+  if (!write_value(writer, value, error)) {
     return nullptr;
+  }
 
   return g_strdup(buffer.GetString());
 }
@@ -314,8 +335,9 @@ G_MODULE_EXPORT FlValue* fl_json_message_codec_decode(FlJsonMessageCodec* codec,
   g_autoptr(GBytes) data = g_bytes_new_static(text, strlen(text));
   g_autoptr(FlValue) value = fl_json_message_codec_decode_message(
       FL_MESSAGE_CODEC(codec), data, error);
-  if (value == nullptr)
+  if (value == nullptr) {
     return nullptr;
+  }
 
   return fl_value_ref(value);
 }

--- a/shell/platform/linux/fl_json_method_codec.cc
+++ b/shell/platform/linux/fl_json_method_codec.cc
@@ -4,9 +4,9 @@
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_json_method_codec.h"
 
-#include "flutter/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h"
-
 #include <gmodule.h>
+
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h"
 
 static constexpr char kMethodKey[] = "method";
 static constexpr char kArgsKey[] = "args";

--- a/shell/platform/linux/fl_json_method_codec_test.cc
+++ b/shell/platform/linux/fl_json_method_codec_test.cc
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_json_method_codec.h"
+
+#include <cstring>
+
 #include "flutter/shell/platform/linux/fl_method_codec_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_message_codec.h"

--- a/shell/platform/linux/fl_method_channel.cc
+++ b/shell/platform/linux/fl_method_channel.cc
@@ -4,11 +4,11 @@
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_method_channel.h"
 
+#include <gmodule.h>
+
 #include "flutter/shell/platform/linux/fl_method_call_private.h"
 #include "flutter/shell/platform/linux/fl_method_channel_private.h"
 #include "flutter/shell/platform/linux/fl_method_codec_private.h"
-
-#include <gmodule.h>
 
 struct _FlMethodChannel {
   GObject parent_instance;

--- a/shell/platform/linux/fl_method_codec_test.cc
+++ b/shell/platform/linux/fl_method_codec_test.cc
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_method_codec.h"
+
+#include <cstring>
+
 #include "flutter/shell/platform/linux/fl_method_codec_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_message_codec.h"
 #include "gtest/gtest.h"

--- a/shell/platform/linux/fl_mouse_cursor_plugin.cc
+++ b/shell/platform/linux/fl_mouse_cursor_plugin.cc
@@ -4,10 +4,10 @@
 
 #include "flutter/shell/platform/linux/fl_mouse_cursor_plugin.h"
 
+#include <gtk/gtk.h>
+
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_method_channel.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_method_codec.h"
-
-#include <gtk/gtk.h>
 
 static constexpr char kChannelName[] = "flutter/mousecursor";
 static constexpr char kBadArgumentsError[] = "Bad Arguments";
@@ -93,8 +93,9 @@ FlMethodResponse* activate_system_cursor(FlMouseCursorPlugin* self,
 
   FlValue* kind_value = fl_value_lookup_string(args, kKindKey);
   const gchar* kind = nullptr;
-  if (fl_value_get_type(kind_value) == FL_VALUE_TYPE_STRING)
+  if (fl_value_get_type(kind_value) == FL_VALUE_TYPE_STRING) {
     kind = fl_value_get_string(kind_value);
+  }
 
   if (self->system_cursor_table == nullptr) {
     self->system_cursor_table = g_hash_table_new(g_str_hash, g_str_equal);
@@ -103,8 +104,9 @@ FlMethodResponse* activate_system_cursor(FlMouseCursorPlugin* self,
 
   const gchar* cursor_name = reinterpret_cast<const gchar*>(
       g_hash_table_lookup(self->system_cursor_table, kind));
-  if (cursor_name == nullptr)
+  if (cursor_name == nullptr) {
     cursor_name = kFallbackCursor;
+  }
 
   GdkWindow* window =
       gtk_widget_get_window(gtk_widget_get_toplevel(GTK_WIDGET(self->view)));
@@ -125,14 +127,16 @@ static void method_call_cb(FlMethodChannel* channel,
   FlValue* args = fl_method_call_get_args(method_call);
 
   g_autoptr(FlMethodResponse) response = nullptr;
-  if (strcmp(method, kActivateSystemCursorMethod) == 0)
+  if (strcmp(method, kActivateSystemCursorMethod) == 0) {
     response = activate_system_cursor(self, args);
-  else
+  } else {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
 
   g_autoptr(GError) error = nullptr;
-  if (!fl_method_call_respond(method_call, response, &error))
+  if (!fl_method_call_respond(method_call, response, &error)) {
     g_warning("Failed to send method call response: %s", error->message);
+  }
 }
 
 static void view_weak_notify_cb(gpointer user_data, GObject* object) {

--- a/shell/platform/linux/fl_platform_plugin.cc
+++ b/shell/platform/linux/fl_platform_plugin.cc
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/linux/fl_platform_plugin.h"
-#include "flutter/shell/platform/linux/public/flutter_linux/fl_json_method_codec.h"
-#include "flutter/shell/platform/linux/public/flutter_linux/fl_method_channel.h"
 
 #include <gtk/gtk.h>
+
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_json_method_codec.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_method_channel.h"
 
 static constexpr char kChannelName[] = "flutter/platform";
 static constexpr char kBadArgumentsError[] = "Bad Arguments";
@@ -32,8 +33,9 @@ G_DEFINE_TYPE(FlPlatformPlugin, fl_platform_plugin, G_TYPE_OBJECT)
 static void send_response(FlMethodCall* method_call,
                           FlMethodResponse* response) {
   g_autoptr(GError) error = nullptr;
-  if (!fl_method_call_respond(method_call, response, &error))
+  if (!fl_method_call_respond(method_call, response, &error)) {
     g_warning("Failed to send method call response: %s", error->message);
+  }
 }
 
 // Called when clipboard text received.
@@ -124,17 +126,19 @@ static void method_call_cb(FlMethodChannel* channel,
   FlValue* args = fl_method_call_get_args(method_call);
 
   g_autoptr(FlMethodResponse) response = nullptr;
-  if (strcmp(method, kSetClipboardDataMethod) == 0)
+  if (strcmp(method, kSetClipboardDataMethod) == 0) {
     response = clipboard_set_data(self, args);
-  else if (strcmp(method, kGetClipboardDataMethod) == 0)
+  } else if (strcmp(method, kGetClipboardDataMethod) == 0) {
     response = clipboard_get_data_async(self, method_call);
-  else if (strcmp(method, kSystemNavigatorPopMethod) == 0)
+  } else if (strcmp(method, kSystemNavigatorPopMethod) == 0) {
     response = system_navigator_pop(self);
-  else
+  } else {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
 
-  if (response != nullptr)
+  if (response != nullptr) {
     send_response(method_call, response);
+  }
 }
 
 static void fl_platform_plugin_dispose(GObject* object) {

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -6,7 +6,6 @@
 #define FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_H_
 
 #include <EGL/egl.h>
-
 #include <gtk/gtk.h>
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h"

--- a/shell/platform/linux/fl_standard_message_codec.cc
+++ b/shell/platform/linux/fl_standard_message_codec.cc
@@ -6,6 +6,7 @@
 #include "flutter/shell/platform/linux/fl_standard_message_codec_private.h"
 
 #include <gmodule.h>
+
 #include <cstring>
 
 // See lib/src/services/message_codecs.dart in Flutter source for description of

--- a/shell/platform/linux/fl_standard_method_codec.cc
+++ b/shell/platform/linux/fl_standard_method_codec.cc
@@ -4,10 +4,10 @@
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_method_codec.h"
 
+#include <gmodule.h>
+
 #include "flutter/shell/platform/linux/fl_standard_message_codec_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_message_codec.h"
-
-#include <gmodule.h>
 
 // See lib/src/services/message_codecs.dart in Flutter source for description of
 // encoding.

--- a/shell/platform/linux/fl_string_codec.cc
+++ b/shell/platform/linux/fl_string_codec.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_string_codec.h"
 
 #include <gmodule.h>
+
 #include <cstring>
 
 G_DEFINE_QUARK(fl_string_codec_error_quark, fl_string_codec_error)

--- a/shell/platform/linux/fl_value.cc
+++ b/shell/platform/linux/fl_value.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_value.h"
 
 #include <gmodule.h>
+
 #include <cstring>
 
 struct _FlValue {

--- a/shell/platform/linux/fl_value_test.cc
+++ b/shell/platform/linux/fl_value_test.cc
@@ -3,9 +3,10 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_value.h"
-#include "gtest/gtest.h"
 
 #include <gmodule.h>
+
+#include "gtest/gtest.h"
 
 TEST(FlDartProjectTest, Null) {
   g_autoptr(FlValue) value = fl_value_new_null();

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_view.h"
 
+#include <gdk/gdkx.h>
+
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/fl_key_event_plugin.h"
 #include "flutter/shell/platform/linux/fl_mouse_cursor_plugin.h"
@@ -13,8 +15,6 @@
 #include "flutter/shell/platform/linux/fl_text_input_plugin.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_plugin_registry.h"
-
-#include <gdk/gdkx.h>
 
 static constexpr int kMicrosecondsPerMillisecond = 1000;
 

--- a/shell/platform/linux/public/flutter_linux/fl_plugin_registrar.h
+++ b/shell/platform/linux/public/flutter_linux/fl_plugin_registrar.h
@@ -10,6 +10,7 @@
 #endif
 
 #include <glib-object.h>
+
 #include "fl_binary_messenger.h"
 #include "fl_view.h"
 

--- a/shell/platform/linux/public/flutter_linux/fl_plugin_registry.h
+++ b/shell/platform/linux/public/flutter_linux/fl_plugin_registry.h
@@ -10,6 +10,7 @@
 #endif
 
 #include <glib-object.h>
+
 #include "fl_plugin_registrar.h"
 
 G_BEGIN_DECLS

--- a/shell/platform/windows/win32_platform_handler.cc
+++ b/shell/platform/windows/win32_platform_handler.cc
@@ -6,6 +6,7 @@
 
 #include <windows.h>
 
+#include <cstring>
 #include <iostream>
 #include <optional>
 

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/windows/win32_window.h"
 
+#include <cstring>
+
 #include "win32_dpi_utils.h"
 
 namespace flutter {

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -6,9 +6,11 @@
 #define FML_USED_ON_EMBEDDER
 
 #include <cstdlib>
+#include <cstring>
 
 #include "flutter/assets/asset_manager.h"
 #include "flutter/assets/directory_asset_bundle.h"
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/message_loop.h"

--- a/testing/debugger_detection.cc
+++ b/testing/debugger_detection.cc
@@ -8,19 +8,15 @@
 #include "flutter/fml/logging.h"
 
 #if OS_MACOSX
-
 #include <assert.h>
 #include <stdbool.h>
 #include <sys/sysctl.h>
 #include <sys/types.h>
 #include <unistd.h>
-
 #endif  // OS_MACOSX
 
 #if OS_WIN
-
 #include <windows.h>
-
 #endif  // OS_WIN
 
 namespace flutter {

--- a/testing/scenario_app/ios/Scenarios/Scenarios/main.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/main.m
@@ -1,5 +1,6 @@
 #import <Flutter/Flutter.h>
 #import <UIKit/UIKit.h>
+
 #import "AppDelegate.h"
 
 int main(int argc, char* argv[]) {

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
@@ -4,6 +4,7 @@
 
 #import <Flutter/Flutter.h>
 #import <XCTest/XCTest.h>
+
 #import "ScreenBeforeFlutter.h"
 
 FLUTTER_ASSERT_ARC

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
@@ -4,6 +4,7 @@
 
 #import <Flutter/Flutter.h>
 #import <XCTest/XCTest.h>
+
 #import "AppDelegate.h"
 
 @interface FlutterEngineTest : XCTestCase

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerInitialRouteTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerInitialRouteTest.m
@@ -4,6 +4,7 @@
 
 #import <Flutter/Flutter.h>
 #import <XCTest/XCTest.h>
+
 #import "AppDelegate.h"
 
 FLUTTER_ASSERT_ARC

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerTest.m
@@ -4,6 +4,7 @@
 
 #import <Flutter/Flutter.h>
 #import <XCTest/XCTest.h>
+
 #import "AppDelegate.h"
 
 FLUTTER_ASSERT_ARC

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenImage.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenImage.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "GoldenImage.h"
+
 #import <XCTest/XCTest.h>
 #include <sys/sysctl.h>
 

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 #import "GoldenPlatformViewTests.h"
+
 #include <sys/sysctl.h>
+
 #import "PlatformViewGoldenTestManager.h"
 
 static const NSInteger kSecondsToWaitForPlatformView = 30;

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewGoldenTestManager.h
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewGoldenTestManager.h
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import <Foundation/Foundation.h>
+
 #import "GoldenImage.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewGoldenTestManager.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewGoldenTestManager.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "PlatformViewGoldenTestManager.h"
+
 #import <XCTest/XCTest.h>
 
 @interface PlatformViewGoldenTestManager ()

--- a/third_party/tonic/dart_microtask_queue.cc
+++ b/third_party/tonic/dart_microtask_queue.cc
@@ -10,7 +10,7 @@
 
 #ifdef OS_IOS
 #include <pthread.h>
-#endif
+#endif  // OS_IOS
 
 namespace tonic {
 namespace {

--- a/third_party/tonic/logging/dart_error.cc
+++ b/third_party/tonic/logging/dart_error.cc
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 #include "tonic/logging/dart_error.h"
-#include "tonic/converter/dart_converter.h"
 
 #include "tonic/common/macros.h"
+#include "tonic/converter/dart_converter.h"
 
 namespace tonic {
 namespace DartError {

--- a/third_party/tonic/typed_data/dart_byte_data.cc
+++ b/third_party/tonic/typed_data/dart_byte_data.cc
@@ -4,6 +4,8 @@
 
 #include "tonic/typed_data/dart_byte_data.h"
 
+#include <cstring>
+
 #include "tonic/logging/dart_error.h"
 
 namespace tonic {

--- a/third_party/txt/benchmarks/paragraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/paragraph_benchmarks.cc
@@ -16,6 +16,8 @@
 
 #include <minikin/Layout.h>
 
+#include <cstring>
+
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"

--- a/third_party/txt/benchmarks/skparagraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/skparagraph_benchmarks.cc
@@ -15,6 +15,7 @@
  */
 
 #include <sstream>
+
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"

--- a/third_party/txt/src/txt/asset_font_manager.h
+++ b/third_party/txt/src/txt/asset_font_manager.h
@@ -18,6 +18,7 @@
 #define TXT_ASSET_FONT_MANAGER_H_
 
 #include <memory>
+
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkFontMgr.h"
 #include "third_party/skia/include/core/SkStream.h"

--- a/third_party/txt/src/txt/font_asset_provider.h
+++ b/third_party/txt/src/txt/font_asset_provider.h
@@ -18,6 +18,7 @@
 #define TXT_FONT_ASSET_PROVIDER_H_
 
 #include <string>
+
 #include "third_party/skia/include/core/SkFontMgr.h"
 
 namespace txt {

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -21,6 +21,7 @@
 #include <set>
 #include <string>
 #include <unordered_map>
+
 #include "flutter/fml/macros.h"
 #include "minikin/FontCollection.h"
 #include "minikin/FontFamily.h"

--- a/third_party/txt/src/txt/font_skia.cc
+++ b/third_party/txt/src/txt/font_skia.cc
@@ -15,9 +15,10 @@
  */
 
 #include "font_skia.h"
-#include "third_party/skia/include/core/SkFont.h"
 
 #include <minikin/MinikinFont.h>
+
+#include "third_party/skia/include/core/SkFont.h"
 
 namespace txt {
 namespace {

--- a/third_party/txt/src/txt/font_skia.h
+++ b/third_party/txt/src/txt/font_skia.h
@@ -15,6 +15,7 @@
  */
 
 #include <minikin/MinikinFont.h>
+
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/skia/include/core/SkTypeface.h"

--- a/third_party/txt/src/txt/paragraph_builder.cc
+++ b/third_party/txt/src/txt/paragraph_builder.cc
@@ -15,6 +15,7 @@
  */
 
 #include "paragraph_builder.h"
+
 #include "paragraph_builder_txt.h"
 #include "paragraph_style.h"
 #include "third_party/icu/source/common/unicode/unistr.h"

--- a/third_party/txt/src/txt/paragraph_builder_txt.cc
+++ b/third_party/txt/src/txt/paragraph_builder_txt.cc
@@ -15,6 +15,7 @@
  */
 
 #include "paragraph_builder_txt.h"
+
 #include "paragraph_txt.h"
 
 namespace txt {

--- a/third_party/txt/src/txt/paragraph_builder_txt.h
+++ b/third_party/txt/src/txt/paragraph_builder_txt.h
@@ -18,6 +18,7 @@
 #define LIB_TXT_SRC_PARAGRAPH_BUILDER_TXT_H_
 
 #include "paragraph_builder.h"
+
 #include "styled_runs.h"
 
 namespace txt {

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -20,6 +20,7 @@
 #include <minikin/Layout.h>
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 #include <map>
 #include <numeric>

--- a/third_party/txt/src/txt/platform.h
+++ b/third_party/txt/src/txt/platform.h
@@ -9,7 +9,6 @@
 #include <vector>
 
 #include "flutter/fml/macros.h"
-
 #include "third_party/skia/include/core/SkFontMgr.h"
 
 namespace txt {

--- a/third_party/txt/src/txt/platform_mac.mm
+++ b/third_party/txt/src/txt/platform_mac.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <TargetConditionals.h>
+
 #include "flutter/fml/platform/darwin/platform_version.h"
 #include "txt/platform.h"
 

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cstring>
 #include <iostream>
 
 #include "flutter/fml/logging.h"

--- a/third_party/txt/tests/render_test.h
+++ b/third_party/txt/tests/render_test.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+
 #include "flutter/fml/macros.h"
 #include "gtest/gtest.h"
 #include "third_party/skia/include/core/SkBitmap.h"

--- a/third_party/txt/tests/txt_run_all_unittests.cc
+++ b/third_party/txt/tests/txt_run_all_unittests.cc
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+#include <cassert>
+
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/icu_util.h"
 #include "flutter/fml/logging.h"
 #include "flutter/testing/testing.h"
 #include "third_party/skia/include/core/SkGraphics.h"
 #include "txt_test_utils.h"
-
-#include <cassert>
 
 int main(int argc, char** argv) {
   fml::CommandLine cmd = fml::CommandLineFromArgcArgv(argc, argv);

--- a/tools/font-subset/hb_wrappers.h
+++ b/tools/font-subset/hb_wrappers.h
@@ -6,6 +6,7 @@
 #define HB_WRAPPERS_H_
 
 #include <hb-subset.h>
+
 #include <memory>
 
 namespace HarfbuzzWrappers {

--- a/vulkan/vulkan_application.h
+++ b/vulkan/vulkan_application.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+
 #include "flutter/fml/macros.h"
 #include "vulkan_debug_report.h"
 #include "vulkan_handle.h"

--- a/vulkan/vulkan_utilities.cc
+++ b/vulkan/vulkan_utilities.cc
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 #include "vulkan_utilities.h"
-#include "flutter/fml/build_config.h"
 
 #include <algorithm>
 #include <unordered_set>
+
+#include "flutter/fml/build_config.h"
 
 namespace vulkan {
 


### PR DESCRIPTION
Cleans up header order/grouping for consistency: associated header, C/C++ system/standard library headers, library headers, platform-specific #includes.

Adds <cstring> where strlen, memcpy are being used: there are a bunch of places we use them transitively.

This patch does not cover flutter/shell/platform/darwin. There's a separate, slightly more intensive cleanup for those in progress.
