### PR TITLE
Remove suppression of null-related warnings

### DIFF
--- a/lib/web_ui/analysis_options.yaml
+++ b/lib/web_ui/analysis_options.yaml
@@ -12,8 +12,6 @@ analyzer:
     missing_required_param: warning
     missing_return: warning
     native_function_body_in_non_sdk_code: ignore
-    unnecessary_non_null_assertion: ignore
-    unnecessary_null_comparison: ignore
     todo: ignore
 
 linter:

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -31,7 +31,6 @@ class CkParagraphStyle implements ui.ParagraphStyle {
           fontStyle,
           ellipsis,
         ) {
-    assert(skParagraphStyle != null);
     _textDirection = textDirection ?? ui.TextDirection.ltr;
     _fontFamily = fontFamily;
   }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -656,7 +656,7 @@ class EngineWindow extends ui.Window {
             assert(_browserHistory is MultiEntriesBrowserHistory);
             _browserHistory.setRouteName(
               message!['location'],
-              state: message!['state'],
+              state: message['state'],
             );
             _replyToPlatformMessage(
               callback, codec.encodeSuccessEnvelope(true));

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -528,12 +528,9 @@ class Shadow {
     this.color = const Color(_kColorDefault),
     this.offset = Offset.zero,
     this.blurRadius = 0.0,
-  })  : assert(color != null,
-            'Text shadow color was null.'), // ignore: unnecessary_null_comparison
-        assert(offset != null,
-            'Text shadow offset was null.'), // ignore: unnecessary_null_comparison
-        assert(blurRadius >= 0.0,
-            'Text shadow blur radius should be non-negative.');
+  })  : assert(color != null, 'Text shadow color was null.'), // ignore: unnecessary_null_comparison
+        assert(offset != null, 'Text shadow offset was null.'), // ignore: unnecessary_null_comparison
+        assert(blurRadius >= 0.0, 'Text shadow blur radius should be non-negative.');
 
   static const int _kColorDefault = 0xFF000000;
   final Color color;


### PR DESCRIPTION
Since dart-lang/sdk#41905 has closed, this CL removes the suppression of
unnecessary_non_null_assertion and unnecessary_null_comparison.

Related issues: dart-lang/sdk#41905 (resolved)