### PR TITLE
Define _USE_MATH_DEFINES on Windows where needed

### DIFF
--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -174,6 +174,14 @@ if (enable_unittests) {
       "//third_party/skia",
     ]
 
+    if (!defined(defines)) {
+      defines = []
+    }
+    if (is_win) {
+      # Required for M_PI and others.
+      defines += [ "_USE_MATH_DEFINES" ]
+    }
+
     if (is_fuchsia && flutter_enable_legacy_fuchsia_embedder) {
       sources += [ "layers/fuchsia_layer_unittests.cc" ]
 

--- a/flow/matrix_decomposition_unittests.cc
+++ b/flow/matrix_decomposition_unittests.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define _USE_MATH_DEFINES
-
 #include "flutter/flow/matrix_decomposition.h"
 
 #include <cmath>

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -129,8 +129,15 @@ source_set("ui") {
     "//third_party/skia",
   ]
 
+  if (!defined(defines)) {
+    defines = []
+  }
   if (flutter_enable_skshaper) {
-    defines = [ "FLUTTER_ENABLE_SKSHAPER" ]
+    defines += [ "FLUTTER_ENABLE_SKSHAPER" ]
+  }
+  if (is_win) {
+    # Required for M_PI and others.
+    defines += [ "_USE_MATH_DEFINES" ]
   }
 
   if (is_fuchsia && flutter_enable_legacy_fuchsia_embedder) {

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define _USE_MATH_DEFINES
-
 #include "flutter/lib/ui/painting/canvas.h"
 
 #include <cmath>

--- a/lib/ui/painting/gradient.cc
+++ b/lib/ui/painting/gradient.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define _USE_MATH_DEFINES
-
 #include "flutter/lib/ui/painting/gradient.h"
 
 #include "third_party/tonic/converter/dart_converter.h"

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define _USE_MATH_DEFINES
-
 #include "flutter/lib/ui/painting/path.h"
 
 #include <cmath>

--- a/lib/ui/painting/path_measure.cc
+++ b/lib/ui/painting/path_measure.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define _USE_MATH_DEFINES
-
 #include "flutter/lib/ui/painting/path_measure.h"
 
 #include <cmath>


### PR DESCRIPTION
On Windows, to enable constants like M_PI in cmath/math.h the symbol
_USE_MATH_DEFINES must be defined. It's easy to forget, and needs to be
defined before the first (transitive) import of cmath, so instead we
define in the build targets in which it's used.