### PR TITLE
Add missing <cstring> header for (strcmp, strrchr)

### DIFF
--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -12,6 +12,7 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_plugin_registry.h"
 
 #include <gmodule.h>
+#include <cstring>
 
 static constexpr int kMicrosecondsPerNanosecond = 1000;
 

--- a/shell/platform/linux/fl_mouse_cursor_plugin.cc
+++ b/shell/platform/linux/fl_mouse_cursor_plugin.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/linux/fl_mouse_cursor_plugin.h"
 
 #include <gtk/gtk.h>
+#include <cstring>
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_method_channel.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_method_codec.h"

--- a/shell/platform/linux/fl_platform_plugin.cc
+++ b/shell/platform/linux/fl_platform_plugin.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/linux/fl_platform_plugin.h"
 
 #include <gtk/gtk.h>
+#include <cstring>
 
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_json_method_codec.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_method_channel.h"

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_view.h"
 
 #include <gdk/gdkx.h>
+#include <cstring>
 
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/fl_key_event_plugin.h"


### PR DESCRIPTION
Fixes the following compilation errors:
../../flutter/shell/platform/linux/fl_platform_plugin.cc:89:7: error: use of undeclared identifier 'strcmp'
  if (strcmp(format, kTextPlainFormat) != 0) {
      ^
../../flutter/shell/platform/linux/fl_platform_plugin.cc:127:7: error: use of undeclared identifier 'strcmp'
  if (strcmp(method, kSetClipboardDataMethod) == 0)
      ^
../../flutter/shell/platform/linux/fl_platform_plugin.cc:129:12: error: use of undeclared identifier 'strcmp'
  else if (strcmp(method, kGetClipboardDataMethod) == 0)
           ^
../../flutter/shell/platform/linux/fl_platform_plugin.cc:131:12: error: use of undeclared identifier 'strcmp'
  else if (strcmp(method, kSystemNavigatorPopMethod) == 0)
           ^
../../flutter/shell/platform/linux/fl_view.cc:194:7: error: use of undeclared identifier 'strcmp'
  if (strcmp(pspec->name, "scale-factor") == 0) {
      ^
../../flutter/shell/platform/linux/fl_engine.cc:67:18: error: use of undeclared identifier 'strrchr'
  gchar* match = strrchr(l, '@');
                 ^
../../flutter/shell/platform/linux/fl_engine.cc:75:11: error: use of undeclared identifier 'strrchr'
  match = strrchr(l, '.');
          ^
../../flutter/shell/platform/linux/fl_engine.cc:83:11: error: use of undeclared identifier 'strrchr'
  match = strrchr(l, '_');
          ^

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
