### PR TITLE
Discard wrong size layer tree instead of rendering it

### DIFF
--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -45,7 +45,9 @@ enum class RasterStatus {
   // only used when thread configuration change occurs.
   kEnqueuePipeline,
   // Failed to rasterize the frame.
-  kFailed
+  kFailed,
+  // Layer tree was discarded due to LayerTreeDiscardCallback
+  kDiscarded
 };
 
 class CompositorContext {

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -181,6 +181,13 @@ if (enable_unittests) {
     ]
   }
 
+  config("shell_test_fixture_sources_config") {
+    defines = [
+      # Required for MSVC STL
+      "_ENABLE_ATOMIC_ALIGNMENT_FIX",
+    ]
+  }
+
   source_set("shell_test_fixture_sources") {
     testonly = true
 
@@ -214,7 +221,7 @@ if (enable_unittests) {
       "//third_party/skia",
     ]
 
-    public_configs = []
+    public_configs = [ ":shell_test_fixture_sources_config" ]
 
     # SwiftShader only supports x86/x64_64
     if (target_cpu == "x86" || target_cpu == "x64") {

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -204,6 +204,8 @@ class Rasterizer final : public SnapshotDelegate {
   ///
   flutter::TextureRegistry* GetTextureRegistry();
 
+  using LayerTreeDiscardCallback = std::function<bool(flutter::LayerTree&)>;
+
   //----------------------------------------------------------------------------
   /// @brief      Takes the next item from the layer tree pipeline and executes
   ///             the raster thread frame workload for that pipeline item to
@@ -232,8 +234,11 @@ class Rasterizer final : public SnapshotDelegate {
   ///
   /// @param[in]  pipeline  The layer tree pipeline to take the next layer tree
   ///                       to render from.
+  /// @param[in]  discardCallback if specified and returns true, the layer tree
+  ///                             is discarded instead of being rendered
   ///
-  void Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline);
+  void Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline,
+            LayerTreeDiscardCallback discardCallback = NoDiscard);
 
   //----------------------------------------------------------------------------
   /// @brief      The type of the screenshot to obtain of the previously
@@ -453,6 +458,8 @@ class Rasterizer final : public SnapshotDelegate {
   RasterStatus DrawToSurface(flutter::LayerTree& layer_tree);
 
   void FireNextFrameCallbackIfPresent();
+
+  static bool NoDiscard(const flutter::LayerTree& layer_tree) { return false; }
 
   FML_DISALLOW_COPY_AND_ASSIGN(Rasterizer);
 };

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -425,6 +425,13 @@ class Shell final : public PlatformView::Delegate,
   // and read from the raster thread.
   std::atomic<float> display_refresh_rate_ = 0.0f;
 
+  // protects expected_frame_size_ which is set on platform thread and read on
+  // raster thread
+  std::mutex resize_mutex_;
+
+  // used to discard wrong size layer tree produced during interactive resizing
+  SkISize expected_frame_size_ = SkISize::MakeEmpty();
+
   // How many frames have been timed since last report.
   size_t UnreportedFramesCount() const;
 

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -24,6 +24,10 @@ int ShellTestExternalViewEmbedder::GetSubmittedFrameCount() {
   return submitted_frame_count_;
 }
 
+SkISize ShellTestExternalViewEmbedder::GetLastSubmittedFrameSize() {
+  return last_submitted_frame_size_;
+}
+
 // |ExternalViewEmbedder|
 void ShellTestExternalViewEmbedder::CancelFrame() {}
 
@@ -61,6 +65,12 @@ void ShellTestExternalViewEmbedder::SubmitFrame(
     GrDirectContext* context,
     std::unique_ptr<SurfaceFrame> frame) {
   frame->Submit();
+  if (frame && frame->SkiaSurface()) {
+    last_submitted_frame_size_ = SkISize::Make(frame->SkiaSurface()->width(),
+                                               frame->SkiaSurface()->height());
+  } else {
+    last_submitted_frame_size_ = SkISize::MakeEmpty();
+  }
   submitted_frame_count_++;
 }
 

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -32,6 +32,9 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
   // the external view embedder.
   int GetSubmittedFrameCount();
 
+  // Returns the size of last submitted frame surface
+  SkISize GetLastSubmittedFrameSize();
+
  private:
   // |ExternalViewEmbedder|
   void CancelFrame() override;
@@ -80,6 +83,7 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
   bool support_thread_merging_;
 
   std::atomic<int> submitted_frame_count_;
+  std::atomic<SkISize> last_submitted_frame_size_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTestExternalViewEmbedder);
 };

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2014,5 +2014,60 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
   DestroyShell(std::move(shell));
 }
 
+TEST_F(ShellTest, DiscardLayerTreeOnResize) {
+  auto settings = CreateSettingsForFixture();
+
+  SkISize wrong_size = SkISize::Make(400, 100);
+  SkISize expected_size = SkISize::Make(400, 200);
+
+  fml::AutoResetWaitableEvent end_frame_latch;
+
+  auto end_frame_callback = [&](bool, fml::RefPtr<fml::RasterThreadMerger>) {
+    end_frame_latch.Signal();
+  };
+
+  std::shared_ptr<ShellTestExternalViewEmbedder> external_view_embedder =
+      std::make_shared<ShellTestExternalViewEmbedder>(
+          std::move(end_frame_callback), PostPrerollResult::kSuccess, true);
+
+  std::unique_ptr<Shell> shell = CreateShell(
+      settings, GetTaskRunnersForFixture(), false, external_view_embedder);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  fml::TaskRunner::RunNowOrPostTask(
+      shell->GetTaskRunners().GetPlatformTaskRunner(),
+      [&shell, &expected_size]() {
+        shell->GetPlatformView()->SetViewportMetrics(
+            {1.0, static_cast<double>(expected_size.width()),
+             static_cast<double>(expected_size.height())});
+      });
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+
+  RunEngine(shell.get(), std::move(configuration));
+
+  fml::WeakPtr<RuntimeDelegate> runtime_delegate = shell->GetEngine();
+
+  PumpOneFrame(shell.get(), static_cast<double>(wrong_size.width()),
+               static_cast<double>(wrong_size.height()));
+
+  end_frame_latch.Wait();
+
+  ASSERT_EQ(0, external_view_embedder->GetSubmittedFrameCount());
+
+  PumpOneFrame(shell.get(), static_cast<double>(expected_size.width()),
+               static_cast<double>(expected_size.height()));
+
+  end_frame_latch.Wait();
+
+  ASSERT_EQ(1, external_view_embedder->GetSubmittedFrameCount());
+  ASSERT_EQ(expected_size, external_view_embedder->GetLastSubmittedFrameSize());
+
+  DestroyShell(std::move(shell));
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
## Description

This PR supersedes https://github.com/flutter/engine/pull/21108.

This PR will ensure that after viewport change metrics event is received, layer tree with previous (wrong size) are discarded and not rasterized. This is required for smooth resizing on both Mac and Windows.

**Important:** This will potentially affect iOS and Android embedders. We need to make sure this doesn't cause any issues.

## Related Issues

https://github.com/flutter/flutter/issues/44136

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
