### PR TITLE
Account for current open image in FlutterImageView

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -195,7 +195,11 @@ public class FlutterImageView extends View implements RenderSurface {
     // While the engine will also stop producing frames, there is a race condition.
     //
     // To avoid exceptions, check if a new image can be acquired.
-    if (imageQueue.size() < imageReader.getMaxImages()) {
+    int imageOpenedCount = imageQueue.size();
+    if (currentImage != null) {
+      imageOpenedCount++;
+    }
+    if (imageOpenedCount < imageReader.getMaxImages()) {
       final Image image = imageReader.acquireLatestImage();
       if (image != null) {
         imageQueue.add(image);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -592,9 +592,10 @@ public class FlutterViewTest {
   @Test
   public void flutterImageView_acquiresMaxImagesAtMost() {
     final ImageReader mockReader = mock(ImageReader.class);
-    when(mockReader.getMaxImages()).thenReturn(2);
+    when(mockReader.getMaxImages()).thenReturn(3);
 
     final Image mockImage = mock(Image.class);
+    when(mockImage.getPlanes()).thenReturn(new Plane[0]);
     when(mockReader.acquireLatestImage()).thenReturn(mockImage);
 
     final FlutterImageView imageView =
@@ -606,13 +607,31 @@ public class FlutterViewTest {
 
     final FlutterJNI jni = mock(FlutterJNI.class);
     imageView.attachToRenderer(new FlutterRenderer(jni));
-
     doNothing().when(imageView).invalidate();
-    assertTrue(imageView.acquireLatestImage());
-    assertTrue(imageView.acquireLatestImage());
-    assertTrue(imageView.acquireLatestImage());
 
-    verify(mockReader, times(2)).acquireLatestImage();
+    assertTrue(imageView.acquireLatestImage()); // 1 image
+    assertTrue(imageView.acquireLatestImage()); // 2 images
+    assertTrue(imageView.acquireLatestImage()); // 3 images
+    assertTrue(imageView.acquireLatestImage()); // 3 images
+    verify(mockReader, times(3)).acquireLatestImage();
+
+    imageView.onDraw(mock(Canvas.class)); // 3 images
+    assertTrue(imageView.acquireLatestImage()); // 3 images
+    verify(mockReader, times(3)).acquireLatestImage();
+
+    imageView.onDraw(mock(Canvas.class)); // 2 images
+    assertTrue(imageView.acquireLatestImage()); // 3 images
+    verify(mockReader, times(4)).acquireLatestImage();
+
+    imageView.onDraw(mock(Canvas.class)); // 2 images
+    imageView.onDraw(mock(Canvas.class)); // 1 image
+    imageView.onDraw(mock(Canvas.class)); // 1 image
+
+    assertTrue(imageView.acquireLatestImage()); // 2 images
+    assertTrue(imageView.acquireLatestImage()); // 3 images
+    assertTrue(imageView.acquireLatestImage()); // 3 images
+    assertTrue(imageView.acquireLatestImage()); // 3 images
+    verify(mockReader, times(6)).acquireLatestImage();
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -590,6 +590,7 @@ public class FlutterViewTest {
   }
 
   @Test
+  @SuppressLint("WrongCall") /*View#onDraw*/
   public void flutterImageView_acquiresMaxImagesAtMost() {
     final ImageReader mockReader = mock(ImageReader.class);
     when(mockReader.getMaxImages()).thenReturn(3);


### PR DESCRIPTION
## Description

My previous patch didn't account for the fact that the image remains open after it's dequeued, so there's a bug in the current implementation. I updated the test to account for this case.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/63897

## Tests

Unit test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
