### PR TITLE
Verify Flutter clang module, add hook for verifying consumer warnings

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -305,9 +305,14 @@ copy("copy_license") {
   outputs = [ "$root_out_dir/LICENSE" ]
 }
 
-shared_library("copy_and_verify_framework_headers") {
+shared_library("copy_and_verify_framework_module") {
+  framework_search_path = rebase_path("$root_out_dir")
   visibility = [ ":*" ]
-  include_dirs = [ "$_flutter_framework_headers_copy_dir" ]
+  cflags_objc = [
+    "-F$framework_search_path",
+    "-fmodules",
+    "-Wnon-modular-include-in-framework-module",
+  ]
 
   sources = [ "framework/Source/FlutterUmbrellaImport.m" ]
   deps = [ ":copy_framework_headers" ]
@@ -315,11 +320,11 @@ shared_library("copy_and_verify_framework_headers") {
 
 group("flutter_framework") {
   deps = [
-    ":copy_and_verify_framework_headers",
+    ":copy_framework_module_map",
+    ":copy_framework_info_plist",
+    ":copy_and_verify_framework_module",
     ":copy_dylib",
     ":copy_framework_icu",
-    ":copy_framework_info_plist",
-    ":copy_framework_module_map",
     ":copy_framework_podspec",
     ":copy_license",
   ]

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -315,16 +315,20 @@ shared_library("copy_and_verify_framework_module") {
   ]
 
   sources = [ "framework/Source/FlutterUmbrellaImport.m" ]
-  deps = [ ":copy_framework_headers" ]
+  deps = [
+    ":copy_framework_headers",
+    ":copy_framework_info_plist",
+    ":copy_framework_module_map",
+  ]
 }
 
 group("flutter_framework") {
   deps = [
-    ":copy_framework_module_map",
-    ":copy_framework_info_plist",
     ":copy_and_verify_framework_module",
     ":copy_dylib",
     ":copy_framework_icu",
+    ":copy_framework_info_plist",
+    ":copy_framework_module_map",
     ":copy_framework_podspec",
     ":copy_license",
   ]

--- a/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m
@@ -4,6 +4,6 @@
 
 // The only point of this file is to ensure that the Flutter framework umbrella header can be
 // cleanly imported from an Objective-C translation unit. The target that uses this file copies the
-// headers to a path that simulats how users would actually consume the framework outside of the
+// headers to a path that simulates how users would actually import the framework outside of the
 // engine source root.
-#import "Flutter.h"
+#import <Flutter/Flutter.h>


### PR DESCRIPTION
## Description

Validate importing the iOS framework as a module instead of directly importing the umbrella header.  Add clang warning "non-modular-include-in-framework-module" which is an example of a warning that can manifest in a consumer rather than during framework source compilation.

## Related Issues

Once flutter/flutter#60025 is fixed, we can add `"-Wquoted-include-in-framework-header"` to `copy_and_verify_framework_module`.

## Checklist
- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*