### PR TITLE
Fix x-axis direction in Offset.direction doc

### DIFF
--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -155,7 +155,7 @@ class Offset extends OffsetBase {
 
   /// The angle of this offset as radians clockwise from the positive x-axis, in
   /// the range -[pi] to [pi], assuming positive values of the x-axis go to the
-  /// left and positive values of the y-axis go down.
+  /// right and positive values of the y-axis go down.
   ///
   /// Zero means that [dy] is zero and [dx] is zero or positive.
   ///


### PR DESCRIPTION
## Description

<!-- *Replace this paragraph with a description of what this PR is doing. If you're
modifying existing behavior, describe the existing behavior, how this PR is
changing it, and what motivated the change.* -->

This PR fixes the doc comment for `Offset.direction` to correctly say that the x-axis goes to the right (rather than to the left).

## Related Issues

<!-- *Replace this paragraph with a list of issues related to this PR from our [issue
database]. Indicate, which of these issues are resolved or fixed by this PR.
There should be at least one issue listed here.* -->

None that I am aware of. Rather than opening an issue for something this small, I'm sending a PR right away.

## Tests

I added the following tests:

<!-- *Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*
-->

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

ad style guide: I haven't read it yet, but didn't change any code
ad tests: I didn't run them since I didn't change any code

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

I didn't run the tests, but I'd assume "No".

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
