### PR TITLE
Clean up extraneous window inset call

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -199,7 +199,16 @@ public class TextInputPlugin {
 
     private View view;
     private WindowInsets lastWindowInsets;
+    // True when an animation that matches deferredInsetTypes is active.
+    //
+    // While this is active, this class will capture the initial window inset
+    // sent into lastWindowInsets by flagging needsSave to true, and will hold
+    // onto the intitial inset until the animation is completed, when it will
+    // re-dispatch the inset change.
     private boolean animating = false;
+    // When an animation begins, android sends a WindowInset with the final
+    // state of the animation. When needsSave is true, we know to capture this
+    // initial WindowInset.
     private boolean needsSave = false;
 
     ImeSyncDeferringInsetsCallback(
@@ -214,7 +223,10 @@ public class TextInputPlugin {
     public WindowInsets onApplyWindowInsets(View view, WindowInsets windowInsets) {
       this.view = view;
       if (needsSave) {
-        // Store the view and insets for us in onEnd() below
+        // Store the view and insets for us in onEnd() below. This captured inset
+        // is not part of the animation and instead, represents the final state
+        // of the inset after the animation is completed. Thus, we defer the processing
+        // of this WindowInset until the animation completes.
         lastWindowInsets = windowInsets;
         needsSave = false;
       }

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -298,6 +298,10 @@ public class TextInputPlugin {
         }
       }
     }
+
+    public boolean isAnimating() {
+      return animating;
+    }
   }
 
   @NonNull

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -296,10 +296,6 @@ public class TextInputPlugin {
         }
       }
     }
-
-    public boolean isAnimating() {
-      return animating;
-    }
   }
 
   @NonNull

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -32,7 +32,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
-import io.flutter.Log;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
 import io.flutter.plugin.platform.PlatformViewsController;
 import java.util.HashMap;
@@ -232,8 +231,7 @@ public class TextInputPlugin {
     }
 
     @Override
-    public void onPrepare(
-        WindowInsetsAnimation animation) {
+    public void onPrepare(WindowInsetsAnimation animation) {
       if ((animation.getTypeMask() & deferredInsetTypes) != 0) {
         animating = true;
         needsSave = true;

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -669,6 +669,8 @@ public class TextInputPluginTest {
     WindowInsets.Builder builder = new WindowInsets.Builder();
     WindowInsets noneInsets = builder.build();
 
+    // imeInsets0, 1, and 2 contain unique IME bottom insets, and are used
+    // to distinguish which insets were sent at each stage.
     builder.setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 100));
     builder.setInsets(WindowInsets.Type.navigationBars(), Insets.of(10, 10, 10, 40));
     WindowInsets imeInsets0 = builder.build();

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -677,6 +677,10 @@ public class TextInputPluginTest {
     builder.setInsets(WindowInsets.Type.navigationBars(), Insets.of(10, 10, 10, 40));
     WindowInsets imeInsets1 = builder.build();
 
+    builder.setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 50));
+    builder.setInsets(WindowInsets.Type.navigationBars(), Insets.of(10, 10, 10, 40));
+    WindowInsets imeInsets2 = builder.build();
+
     builder.setInsets(WindowInsets.Type.ime(), Insets.of(0, 0, 0, 200));
     builder.setInsets(WindowInsets.Type.navigationBars(), Insets.of(10, 10, 10, 0));
     WindowInsets deferredInsets = builder.build();
@@ -696,6 +700,8 @@ public class TextInputPluginTest {
     imeSyncCallback.onPrepare(animation);
     imeSyncCallback.onApplyWindowInsets(testView, deferredInsets);
     imeSyncCallback.onStart(animation, null);
+    // Only the final state call is saved, extra calls are passed on.
+    imeSyncCallback.onApplyWindowInsets(testView, imeInsets2);
 
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
     // No change, as deferredInset is stored to be passed in onEnd()
@@ -723,7 +729,7 @@ public class TextInputPluginTest {
     imeSyncCallback.onEnd(animation);
 
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    // Values should be of deferredInsets
+    // Values should be of deferredInsets, not imeInsets2
     assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
     assertEquals(10, viewportMetricsCaptor.getValue().paddingTop);
     assertEquals(200, viewportMetricsCaptor.getValue().viewInsetBottom);


### PR DESCRIPTION
## Description

Fixes bug part of https://github.com/flutter/flutter/issues/65821

`onStart` is called too late, which resulted in one of the final IME position calls to slip through. This PR switches to the `onPrepare` instead and adds some additional safeguarding to prevent overwriting the saved inset. This is consistent with https://github.com/android/user-interface-samples/blob/master/WindowInsetsAnimation/app/src/main/java/com/google/android/samples/insetsanimation/RootViewDeferringInsetsCallback.kt which also uses `onPrepare` and is what this is roughly based on.
