### PR TITLE
Support Wayland only (without X11 support in gdk)

### DIFF
--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 #include "fl_renderer_x11.h"
+#ifdef GDK_WINDOWING_X11
+
 #include "flutter/shell/platform/linux/egl_utils.h"
 
 struct _FlRendererX11 {
@@ -108,3 +110,5 @@ static void fl_renderer_x11_init(FlRendererX11* self) {}
 FlRendererX11* fl_renderer_x11_new() {
   return FL_RENDERER_X11(g_object_new(fl_renderer_x11_get_type(), nullptr));
 }
+
+#endif  // GDK_WINDOWING_X11

--- a/shell/platform/linux/fl_renderer_x11.h
+++ b/shell/platform/linux/fl_renderer_x11.h
@@ -5,6 +5,9 @@
 #ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_X11_H_
 #define FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_X11_H_
 
+#include <gdk/gdk.h>
+
+#ifdef GDK_WINDOWING_X11
 #include <gdk/gdkx.h>
 
 #include "flutter/shell/platform/linux/fl_renderer.h"
@@ -34,5 +37,7 @@ G_DECLARE_FINAL_TYPE(FlRendererX11,
 FlRendererX11* fl_renderer_x11_new();
 
 G_END_DECLS
+
+#endif  // GDK_WINDOWING_X11
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_X11_H_


### PR DESCRIPTION
Adds a support for compiling flutter engine when
gdk does not have X11 backend. In such a configuration
the generated gdkconfig.h header file looks like the following:

```c
 /* gdkconfig.h
  *
  * This is a generated file.  Please modify `configure.ac'
  */

 #ifndef __GDKCONFIG_H__
 #define __GDKCONFIG_H__

 #if !defined (__GDK_H_INSIDE__) && !defined (GDK_COMPILATION)
 #error "Only <gdk/gdk.h> can be included directly."
 #endif

 #include <glib.h>

 G_BEGIN_DECLS

 #define GDK_WINDOWING_WAYLAND

 G_END_DECLS

 #endif  /* __GDKCONFIG_H__ */
```

Additionally headers like `<gdk/gdkx.h>` are not available at all.

Above configuration can be found on the most of the embedded systems.

This patch enables compilation of X11 specific code only when gdk
defines GDK_WINDOWING_X11.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
