### PR TITLE
[web] run safari desktop tests on luci

### DIFF
--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -133,11 +133,6 @@ class TestCommand extends Command<bool> with ArgUtils {
       /// Collect information on the bot.
       final MacOSInfo macOsInfo = new MacOSInfo();
       await macOsInfo.printInformation();
-
-      /// Tests may fail on the CI, therefore exit test_runner.
-      if (isLuci) {
-        return true;
-      }
     }
 
     switch (testTypesRequested) {

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -667,12 +667,6 @@ class SafariDesktopTextEditingStrategy extends DefaultTextEditingStrategy {
     _geometry?.applyToDomElement(domElement);
     if (hasAutofillGroup) {
       placeForm();
-      // Set the last editing state if it exists, this is critical for a
-      // users ongoing work to continue uninterrupted when there is an update to
-      // the transform.
-      if (_lastEditingState != null) {
-        _lastEditingState!.applyToDomElement(domElement);
-      }
       // On Safari Desktop, when a form is focused, it opens an autofill menu
       // immediately.
       // Flutter framework sends `setEditableSizeAndTransform` for informing
@@ -682,6 +676,15 @@ class SafariDesktopTextEditingStrategy extends DefaultTextEditingStrategy {
       // form only after placing it to the correct position and only once after
       // that. Calling focus multiple times causes flickering.
       focusedFormElement!.focus();
+
+      // Set the last editing state if it exists, this is critical for a
+      // users ongoing work to continue uninterrupted when there is an update to
+      // the transform.
+      // If domElement is not focused cursor location won't be correct.
+      domElement.focus();
+      if (_lastEditingState != null) {
+        _lastEditingState!.applyToDomElement(domElement);
+      }
     }
   }
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -680,7 +680,7 @@ class SafariDesktopTextEditingStrategy extends DefaultTextEditingStrategy {
       // Set the last editing state if it exists, this is critical for a
       // users ongoing work to continue uninterrupted when there is an update to
       // the transform.
-      // If domElement is not focused cursor location won't be correct.
+      // If domElement is not focused cursor location will not be correct.
       domElement.focus();
       if (_lastEditingState != null) {
         _lastEditingState!.applyToDomElement(domElement);

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -1016,7 +1016,7 @@ void testMain() {
 
     test(
         'singleTextField Autofill: setClient, setEditingState, show, '
-        'setEditingState, clearClient', () {
+        'setSizeAndTransform, setEditingState, clearClient', () {
       // Create a configuration with focused element has autofil hint.
       final Map<String, dynamic> flutterSingleAutofillElementConfig =
           createFlutterConfig('text', autofillHint: 'username');
@@ -1034,6 +1034,11 @@ void testMain() {
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
+
+      final MethodCall setSizeAndTransform =
+          configureSetSizeAndTransformMethodCall(150, 50,
+              Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // The second [setEditingState] should override the first one.
       checkInputEditingState(
@@ -1074,9 +1079,18 @@ void testMain() {
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
 
-      // The second [setEditingState] should override the first one.
-      checkInputEditingState(
-          textEditing.editingElement.domElement, 'abcd', 2, 3);
+      final InputElement inputElement =
+          textEditing.editingElement.domElement as InputElement;
+      expect(inputElement.value, 'abcd');
+      if (!(browserEngine == BrowserEngine.webkit &&
+          operatingSystem == OperatingSystem.macOs)) {
+        // In Safari Desktop Autofill menu appears as soon as an element is
+        // focused, therefore the input element is only focused after the
+        // location is received.
+        expect(document.activeElement, inputElement);
+        expect(inputElement.selectionStart, 2);
+        expect(inputElement.selectionEnd, 3);
+      }
 
       // The transform is changed. For example after a validation error, red
       // line appeared under the input field.
@@ -1104,7 +1118,7 @@ void testMain() {
 
     test(
         'multiTextField Autofill: setClient, setEditingState, show, '
-        'setEditingState, clearClient', () {
+        'setSizeAndTransform setEditingState, clearClient', () {
       // Create a configuration with an AutofillGroup of four text fields.
       final Map<String, dynamic> flutterMultiAutofillElementConfig =
           createFlutterConfig('text',
@@ -1129,6 +1143,11 @@ void testMain() {
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
+
+      final MethodCall setSizeAndTransform =
+          configureSetSizeAndTransformMethodCall(150, 50,
+              Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // The second [setEditingState] should override the first one.
       checkInputEditingState(
@@ -1501,6 +1520,11 @@ void testMain() {
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
+
+      final MethodCall setSizeAndTransform =
+          configureSetSizeAndTransformMethodCall(150, 50,
+              Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // The second [setEditingState] should override the first one.
       checkInputEditingState(


### PR DESCRIPTION
Re-enable Safari Desktop tests on LUCI. Will be merged after LUCI recipe change is in.

Example run with led: https://chromium-swarm.appspot.com/task?id=4eb5c0081b879e10

Fixes: https://github.com/flutter/flutter/issues/58012