### PR TITLE
Enable delayed event delivery for macOS

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1073,6 +1073,8 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterGLCom
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterGLCompositorUnittests.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -60,6 +60,8 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterGLCompositor.mm",
     "framework/Source/FlutterIOSurfaceHolder.h",
     "framework/Source/FlutterIOSurfaceHolder.mm",
+    "framework/Source/FlutterIntermediateKeyResponder.h",
+    "framework/Source/FlutterIntermediateKeyResponder.mm",
     "framework/Source/FlutterMouseCursorPlugin.h",
     "framework/Source/FlutterMouseCursorPlugin.mm",
     "framework/Source/FlutterResizeSynchronizer.h",

--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -40,19 +40,6 @@ FLUTTER_EXPORT
 @property(nonatomic) FlutterMouseTrackingMode mouseTrackingMode;
 
 /**
- * Initializes this FlutterViewController with the specified `FlutterEngine`.
- *
- * The initialized viewcontroller will attach itself to the engine as part of this process.
- *
- * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
- * @param nibName The NIB name to initialize this controller with.
- * @param nibBundle The NIB bundle.
- */
-- (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
-                               nibName:(nullable NSString*)nibName
-                                bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
-
-/**
  * Initializes a controller that will run the given project.
  *
  * @param project The project to run in this view controller. If nil, a default `FlutterDartProject`
@@ -64,7 +51,6 @@ FLUTTER_EXPORT
 - (nonnull instancetype)initWithNibName:(nullable NSString*)nibNameOrNil
                                  bundle:(nullable NSBundle*)nibBundleOrNil
     NS_DESIGNATED_INITIALIZER;
-
-- (nonnull instancetype)initWithCoder:(nonnull NSCoder*)coder NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithCoder:(nonnull NSCoder*)nibNameOrNil NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h
@@ -40,6 +40,19 @@ FLUTTER_EXPORT
 @property(nonatomic) FlutterMouseTrackingMode mouseTrackingMode;
 
 /**
+ * Initializes this FlutterViewController with the specified `FlutterEngine`.
+ *
+ * The initialized viewcontroller will attach itself to the engine as part of this process.
+ *
+ * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
+ * @param nibName The NIB name to initialize this controller with.
+ * @param nibBundle The NIB bundle.
+ */
+- (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
+                               nibName:(nullable NSString*)nibName
+                                bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
+
+/**
  * Initializes a controller that will run the given project.
  *
  * @param project The project to run in this view controller. If nil, a default `FlutterDartProject`
@@ -51,6 +64,7 @@ FLUTTER_EXPORT
 - (nonnull instancetype)initWithNibName:(nullable NSString*)nibNameOrNil
                                  bundle:(nullable NSBundle*)nibBundleOrNil
     NS_DESIGNATED_INITIALIZER;
-- (nonnull instancetype)initWithCoder:(nonnull NSCoder*)nibNameOrNil NS_DESIGNATED_INITIALIZER;
+
+- (nonnull instancetype)initWithCoder:(nonnull NSCoder*)coder NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+
+/*
+ * An interface for adding key responders that are processed after the framework
+ * has had a chance to handle the key, but before the next responder is given
+ * the key.
+ *
+ * It differs from an NSResponder in that it returns a boolean from the keyUp
+ * and keyDown calls, allowing the callee to indicate whether or not it handled
+ * the given event. If handled, then the event is not passed to the next
+ * responder.
+ */
+@interface FlutterIntermediateKeyResponder : NSObject
+/*
+ * Informs the receiver that the user has released a key.
+ */
+- (BOOL)handleKeyUp:(NSEvent*)event;
+/*
+ * Informs the receiver that the user has pressed a key.
+ */
+- (BOOL)handleKeyDown:(NSEvent*)event;
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h
@@ -5,20 +5,24 @@
 #import <Cocoa/Cocoa.h>
 
 /*
- * An interface for adding key responders that can declare itself as the final
+ * An interface for a key responder that can declare itself as the final
  * responder of the event, terminating the event propagation.
  *
  * It differs from an NSResponder in that it returns a boolean from the
  * handleKeyUp and handleKeyDown calls, where true means it has handled the
- * given event. A handled event is not passed to the next responder.
+ * given event.
  */
 @interface FlutterIntermediateKeyResponder : NSObject
 /*
  * Informs the receiver that the user has released a key.
+ *
+ * Default implementation returns NO.
  */
-- (BOOL)handleKeyUp:(NSEvent*)event;
+- (BOOL)handleKeyUp:(nonnull NSEvent*)event;
 /*
  * Informs the receiver that the user has pressed a key.
+ *
+ * Default implementation returns NO.
  */
-- (BOOL)handleKeyDown:(NSEvent*)event;
+- (BOOL)handleKeyDown:(nonnull NSEvent*)event;
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h
@@ -5,14 +5,12 @@
 #import <Cocoa/Cocoa.h>
 
 /*
- * An interface for adding key responders that are processed after the framework
- * has had a chance to handle the key, but before the next responder is given
- * the key.
+ * An interface for adding key responders that can declare itself as the final
+ * responder of the event, terminating the event propagation.
  *
- * It differs from an NSResponder in that it returns a boolean from the keyUp
- * and keyDown calls, allowing the callee to indicate whether or not it handled
- * the given event. If handled, then the event is not passed to the next
- * responder.
+ * It differs from an NSResponder in that it returns a boolean from the
+ * handleKeyUp and handleKeyDown calls, where true means it has handled the
+ * given event. A handled event is not passed to the next responder.
  */
 @interface FlutterIntermediateKeyResponder : NSObject
 /*

--- a/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.mm
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h"
+
+@implementation FlutterIntermediateKeyResponder {
+}
+
+#pragma mark - Default key handling methods
+
+- (BOOL)handleKeyUp:(NSEvent*)event {
+  return NO;
+}
+
+- (BOOL)handleKeyDown:(NSEvent*)event {
+  return NO;
+}
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -6,6 +6,7 @@
 
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h"
 
 /**
  * A plugin to handle text input.
@@ -16,7 +17,7 @@
  * This is not an FlutterPlugin since it needs access to FlutterViewController internals, so needs
  * to be managed differently.
  */
-@interface FlutterTextInputPlugin : NSResponder
+@interface FlutterTextInputPlugin : FlutterIntermediateKeyResponder
 
 /**
  * Initializes a text input plugin that coordinates key event handling with |viewController|.

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -129,17 +129,20 @@ static NSString* const kMultilineInputType = @"TextInputType.multiline";
 }
 
 #pragma mark -
-#pragma mark NSResponder
+#pragma mark FlutterIntermediateKeyResponder
 
 /**
+ * Handles key down events received from the view controller, responding TRUE if
+ * the event was handled.
+ *
  * Note, the Apple docs suggest that clients should override essentially all the
  * mouse and keyboard event-handling methods of NSResponder. However, experimentation
  * indicates that only key events are processed by the native layer; Flutter processes
  * mouse events. Additionally, processing both keyUp and keyDown results in duplicate
- * processing of the same keys. So for now, limit processing to just keyDown.
+ * processing of the same keys. So for now, limit processing to just handleKeyDown.
  */
-- (void)keyDown:(NSEvent*)event {
-  [_textInputContext handleEvent:event];
+- (BOOL)handleKeyDown:(NSEvent*)event {
+  return [_textInputContext handleEvent:event];
 }
 
 #pragma mark -

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -219,7 +219,7 @@ struct KeyboardState {
  * Performs initialization that's common between the different init paths.
  */
 static void CommonInit(FlutterViewController* controller) {
-  if (controller->_engine == nullptr) {
+  if (!controller->_engine) {
     controller->_engine = [[FlutterEngine alloc] initWithName:@"io.flutter"
                                                       project:controller->_project
                                        allowHeadlessExecution:NO];
@@ -260,11 +260,11 @@ static void CommonInit(FlutterViewController* controller) {
   self = [super initWithNibName:nibName bundle:nibBundle];
   if (self) {
     if (engine.viewController) {
-      NSLog(@"The supplied FlutterEngine %s is already used with FlutterViewController "
-             "instance %s. One instance of the FlutterEngine can only be attached to one "
+      NSLog(@"The supplied FlutterEngine %@ is already used with FlutterViewController "
+             "instance %@. One instance of the FlutterEngine can only be attached to one "
              "FlutterViewController at a time. Set FlutterEngine.viewController "
              "to nil before attaching it to another FlutterViewController.",
-            [[engine description] UTF8String], [[engine.viewController description] UTF8String]);
+            [engine description], [engine.viewController description]);
     }
     _engine = engine;
     CommonInit(self);

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -84,7 +84,7 @@ struct KeyboardState {
 /**
  * A list of additional responders to keyboard events. Keybord events are forwarded to all of them.
  */
-@property(nonatomic) NSMutableOrderedSet<NSResponder*>* additionalKeyResponders;
+@property(nonatomic) NSMutableOrderedSet<FlutterIntermediateKeyResponder*>* additionalKeyResponders;
 
 /**
  * The tracking area used to generate hover events, if enabled.
@@ -318,11 +318,11 @@ static void CommonInit(FlutterViewController* controller) {
   return static_cast<FlutterView*>(self.view);
 }
 
-- (void)addKeyResponder:(NSResponder*)responder {
+- (void)addKeyResponder:(FlutterIntermediateKeyResponder*)responder {
   [self.additionalKeyResponders addObject:responder];
 }
 
-- (void)removeKeyResponder:(NSResponder*)responder {
+- (void)removeKeyResponder:(FlutterIntermediateKeyResponder*)responder {
   [self.additionalKeyResponders removeObject:responder];
 }
 
@@ -493,18 +493,22 @@ static void CommonInit(FlutterViewController* controller) {
 
 - (void)propagateKeyEvent:(NSEvent*)event ofType:(NSString*)type {
   if ([type isEqual:@"keydown"]) {
-    for (NSResponder* responder in self.additionalKeyResponders) {
-      if ([responder respondsToSelector:@selector(keyDown:)]) {
-        [responder keyDown:event];
+    for (FlutterIntermediateKeyResponder* responder in self.additionalKeyResponders) {
+      if ([responder respondsToSelector:@selector(handleKeyDown:)]) {
+        if ([responder handleKeyDown:event]) {
+          return;
+        }
       }
     }
     if ([self.nextResponder respondsToSelector:@selector(keyDown:)]) {
       [self.nextResponder keyDown:event];
     }
   } else if ([type isEqual:@"keyup"]) {
-    for (NSResponder* responder in self.additionalKeyResponders) {
-      if ([responder respondsToSelector:@selector(keyUp:)]) {
-        [responder keyUp:event];
+    for (FlutterIntermediateKeyResponder* responder in self.additionalKeyResponders) {
+      if ([responder respondsToSelector:@selector(handleKeyUp:)]) {
+        if ([responder handleKeyUp:event]) {
+          return;
+        }
       }
     }
     if ([self.nextResponder respondsToSelector:@selector(keyUp:)]) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 
 #import <OCMock/OCMock.h>
@@ -12,7 +13,38 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.h"
 #include "flutter/testing/testing.h"
 
+@interface FlutterViewControllerTestObjC : NSObject
+- (bool)testKeyEventsAreSentToFramework;
+- (bool)testKeyEventsArePropagatedIfNotHandled;
+- (bool)testKeyEventsAreNotPropagatedIfHandled;
+@end
+
 namespace flutter::testing {
+
+// Returns a mock FlutterViewController that is able to work in environments
+// without a real pasteboard.
+id mockViewController(NSString* pasteboardString) {
+  NSString* fixtures = @(testing::GetFixturesPath());
+  FlutterDartProject* project = [[FlutterDartProject alloc]
+      initWithAssetsPath:fixtures
+             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+
+  // Mock pasteboard so that this test will work in environments without a
+  // real pasteboard.
+  id pasteboardMock = OCMClassMock([NSPasteboard class]);
+  OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
+      [pasteboardMock stringForType:[OCMArg any]])
+      .andDo(^(NSInvocation* invocation) {
+        NSString* returnValue = pasteboardString.length > 0 ? pasteboardString : nil;
+        [invocation setReturnValue:&returnValue];
+      });
+  id viewControllerMock = OCMPartialMock(viewController);
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [viewControllerMock pasteboard])
+      .andReturn(pasteboardMock);
+  return viewControllerMock;
+}
 
 TEST(FlutterViewController, HasStringsWhenPasteboardEmpty) {
   // Mock FlutterViewController so that it behaves like the pasteboard is empty.
@@ -53,4 +85,153 @@ TEST(FlutterViewController, HasStringsWhenPasteboardFull) {
   EXPECT_TRUE(value);
 }
 
-}  // flutter::testing
+TEST(FlutterViewControllerTest, TestKeyEventsAreSentToFramework) {
+  ASSERT_TRUE([[FlutterViewControllerTestObjC alloc] testKeyEventsAreSentToFramework]);
+}
+
+TEST(FlutterViewControllerTest, TestKeyEventsArePropagatedIfNotHandled) {
+  ASSERT_TRUE([[FlutterViewControllerTestObjC alloc] testKeyEventsArePropagatedIfNotHandled]);
+}
+
+TEST(FlutterViewControllerTest, TestKeyEventsAreNotPropagatedIfHandled) {
+  ASSERT_TRUE([[FlutterViewControllerTestObjC alloc] testKeyEventsAreNotPropagatedIfHandled]);
+}
+
+}  // namespace flutter::testing
+
+@implementation FlutterViewControllerTestObjC
+
+- (bool)testKeyEventsAreSentToFramework {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+  NSDictionary* expectedEvent = @{
+    @"keymap" : @"macos",
+    @"type" : @"keydown",
+    @"keyCode" : @(65),
+    @"modifiers" : @(538968064),
+    @"characters" : @".",
+    @"charactersIgnoringModifiers" : @".",
+  };
+  NSData* encodedKeyEvent = [[FlutterJSONMessageCodec sharedInstance] encode:expectedEvent];
+  CGEventRef cgEvent = CGEventCreateKeyboardEvent(NULL, 65, TRUE);
+  NSEvent* event = [NSEvent eventWithCGEvent:cgEvent];
+  [viewController viewWillAppear];  // Initializes the event channel.
+  [viewController keyDown:event];
+  @try {
+    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
+        [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
+                                   message:encodedKeyEvent
+                               binaryReply:[OCMArg any]]);
+  } @catch (...) {
+    return false;
+  }
+  return true;
+}
+
+- (bool)testKeyEventsArePropagatedIfNotHandled {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+  id responderMock = OCMClassMock([NSResponder class]);
+  [viewController addKeyResponder:responderMock];
+  NSDictionary* expectedEvent = @{
+    @"keymap" : @"macos",
+    @"type" : @"keydown",
+    @"keyCode" : @(65),
+    @"modifiers" : @(538968064),
+    @"characters" : @".",
+    @"charactersIgnoringModifiers" : @".",
+  };
+  NSData* encodedKeyEvent = [[FlutterJSONMessageCodec sharedInstance] encode:expectedEvent];
+  CGEventRef cgEvent = CGEventCreateKeyboardEvent(NULL, 65, TRUE);
+  NSEvent* event = [NSEvent eventWithCGEvent:cgEvent];
+  OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
+      [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
+                                 message:encodedKeyEvent
+                             binaryReply:[OCMArg any]])
+      .andDo((^(NSInvocation* invocation) {
+        FlutterBinaryReply handler;
+        [invocation getArgument:&handler atIndex:4];
+        NSDictionary* reply = @{
+          @"handled" : @(false),
+        };
+        NSData* encodedReply = [[FlutterJSONMessageCodec sharedInstance] encode:reply];
+        handler(encodedReply);
+      }));
+  [viewController viewWillAppear];  // Initializes the event channel.
+  [viewController keyDown:event];
+  @try {
+    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
+        [responderMock keyDown:[OCMArg any]]);
+    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
+        [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
+                                   message:encodedKeyEvent
+                               binaryReply:[OCMArg any]]);
+  } @catch (...) {
+    return false;
+  }
+  return true;
+}
+
+- (bool)testKeyEventsAreNotPropagatedIfHandled {
+  id engineMock = OCMClassMock([FlutterEngine class]);
+  id binaryMessengerMock = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub(  // NOLINT(google-objc-avoid-throwing-exception)
+      [engineMock binaryMessenger])
+      .andReturn(binaryMessengerMock);
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
+                                                                                nibName:@""
+                                                                                 bundle:nil];
+  id responderMock = OCMClassMock([NSResponder class]);
+  [viewController addKeyResponder:responderMock];
+  NSDictionary* expectedEvent = @{
+    @"keymap" : @"macos",
+    @"type" : @"keydown",
+    @"keyCode" : @(65),
+    @"modifiers" : @(538968064),
+    @"characters" : @".",
+    @"charactersIgnoringModifiers" : @".",
+  };
+  NSData* encodedKeyEvent = [[FlutterJSONMessageCodec sharedInstance] encode:expectedEvent];
+  CGEventRef cgEvent = CGEventCreateKeyboardEvent(NULL, 65, TRUE);
+  NSEvent* event = [NSEvent eventWithCGEvent:cgEvent];
+  OCMExpect(  // NOLINT(google-objc-avoid-throwing-exception)
+      [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
+                                 message:encodedKeyEvent
+                             binaryReply:[OCMArg any]])
+      .andDo((^(NSInvocation* invocation) {
+        FlutterBinaryReply handler;
+        [invocation getArgument:&handler atIndex:4];
+        NSDictionary* reply = @{
+          @"handled" : @(true),
+        };
+        NSData* encodedReply = [[FlutterJSONMessageCodec sharedInstance] encode:reply];
+        handler(encodedReply);
+      }));
+  [viewController viewWillAppear];  // Initializes the event channel.
+  [viewController keyDown:event];
+  @try {
+    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
+        never(), [responderMock keyDown:[OCMArg any]]);
+    OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
+        [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
+                                   message:encodedKeyEvent
+                               binaryReply:[OCMArg any]]);
+  } @catch (...) {
+    return false;
+  }
+  return true;
+}
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -2,16 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "FlutterBinaryMessenger.h"
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 
 #import <OCMock/OCMock.h>
 
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.h"
-#include "flutter/testing/testing.h"
+#import "flutter/testing/testing.h"
 
 @interface FlutterViewControllerTestObjC : NSObject
 - (bool)testKeyEventsAreSentToFramework;

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -143,7 +143,7 @@ TEST(FlutterViewControllerTest, TestKeyEventsAreNotPropagatedIfHandled) {
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  id responderMock = OCMClassMock([NSResponder class]);
+  id responderMock = OCMClassMock([FlutterIntermediateKeyResponder class]);
   [viewController addKeyResponder:responderMock];
   NSDictionary* expectedEvent = @{
     @"keymap" : @"macos",
@@ -173,7 +173,7 @@ TEST(FlutterViewControllerTest, TestKeyEventsAreNotPropagatedIfHandled) {
   [viewController keyDown:event];
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        [responderMock keyDown:[OCMArg any]]);
+        [responderMock handleKeyDown:[OCMArg any]]);
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
         [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
                                    message:encodedKeyEvent
@@ -193,7 +193,7 @@ TEST(FlutterViewControllerTest, TestKeyEventsAreNotPropagatedIfHandled) {
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:engineMock
                                                                                 nibName:@""
                                                                                  bundle:nil];
-  id responderMock = OCMClassMock([NSResponder class]);
+  id responderMock = OCMClassMock([FlutterIntermediateKeyResponder class]);
   [viewController addKeyResponder:responderMock];
   NSDictionary* expectedEvent = @{
     @"keymap" : @"macos",
@@ -223,7 +223,7 @@ TEST(FlutterViewControllerTest, TestKeyEventsAreNotPropagatedIfHandled) {
   [viewController keyDown:event];
   @try {
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
-        never(), [responderMock keyDown:[OCMArg any]]);
+        never(), [responderMock handleKeyDown:[OCMArg any]]);
     OCMVerify(  // NOLINT(google-objc-avoid-throwing-exception)
         [binaryMessengerMock sendOnChannel:@"flutter/keyevent"
                                    message:encodedKeyEvent

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -28,4 +28,16 @@
  */
 - (void)removeKeyResponder:(nonnull FlutterIntermediateKeyResponder*)responder;
 
+/**
+ * Initializes this FlutterViewController with the specified `FlutterEngine`.
+ *
+ * The initialized viewcontroller will attach itself to the engine as part of this process.
+ *
+ * @param engine The `FlutterEngine` instance to attach to. Cannot be nil.
+ * @param nibName The NIB name to initialize this controller with.
+ * @param nibBundle The NIB bundle.
+ */
+- (nonnull instancetype)initWithEngine:(nonnull FlutterEngine*)engine
+                               nibName:(nullable NSString*)nibName
+                                bundle:(nullable NSBundle*)nibBundle NS_DESIGNATED_INITIALIZER;
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
 
 @interface FlutterViewController ()
@@ -17,14 +18,14 @@
 @property(nonatomic, readonly, nonnull) NSPasteboard* pasteboard;
 
 /**
- * Adds a responder for keyboard events. Key up and key down events are forwarded to all added
- * responders.
+ * Adds an intermediate responder for keyboard events. Key up and key down events are forwarded to
+ * all added responders, and they either handle the keys or not.
  */
-- (void)addKeyResponder:(nonnull NSResponder*)responder;
+- (void)addKeyResponder:(nonnull FlutterIntermediateKeyResponder*)responder;
 
 /**
- * Removes a responder for keyboard events.
+ * Removes an intermediate responder for keyboard events.
  */
-- (void)removeKeyResponder:(nonnull NSResponder*)responder;
+- (void)removeKeyResponder:(nonnull FlutterIntermediateKeyResponder*)responder;
 
 @end

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -399,7 +399,7 @@ def RunDartTests(build_dir, filter, verbose_dart_snapshot):
   # This one is a bit messy. The pubspec.yaml at flutter/testing/dart/pubspec.yaml
   # has dependencies that are hardcoded to point to the sky packages at host_debug_unopt/
   # Before running Dart tests, make sure to run just that target (NOT the whole engine)
-  EnsureDebugUnoptSkyPackagesAreBuilt();
+  EnsureDebugUnoptSkyPackagesAreBuilt()
 
   # Now that we have the Sky packages at the hardcoded location, run `pub get`.
   RunEngineExecutable(build_dir, os.path.join('dart-sdk', 'bin', 'pub'), None, flags=['get'], cwd=dart_tests_dir)
@@ -443,7 +443,7 @@ def main():
   parser = argparse.ArgumentParser()
 
   parser.add_argument('--variant', dest='variant', action='store',
-      default='host_debug_unopt', help='The engine build variant to run the tests for.');
+      default='host_debug_unopt', help='The engine build variant to run the tests for.')
   parser.add_argument('--type', type=str, default='all')
   parser.add_argument('--engine-filter', type=str, default='',
       help='A list of engine test executables to run.')


### PR DESCRIPTION
## Description

This enables delayed event delivery for macOS, so that shortcuts can handle keys that are headed for a text field and intercept them. This fixes the problem where pressing TAB (or other shortcuts) in a text field also inserts a tab character into the text field.

## Related Issues

 - https://github.com/flutter/flutter/issues/47156

## Tests

I added tests to make sure that the events were sent to the framework, that they were propagated if the framework didn't handle them, and that they weren't propagated if the framework did handle them.

Writing the tests was a little weird, since I needed to use `OCMock` to mock things, but calling `OCMVerify` required that it be run inside of an `NSObject` method (it wanted `self` to be available). To do that, I created Flutter `TEST()` methods that verify that the NSObject method succeeded.

One note: The linter doesn't like that the OCM methods throw exceptions, so I had to mark each call to the OCM macros with `// NOLINT(google-objc-avoid-throwing-exceptions)`.

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.
