### PR TITLE
[Fix] Replaces call to deprecated method Name.name.

### DIFF
--- a/flutter_frontend_server/lib/server.dart
+++ b/flutter_frontend_server/lib/server.dart
@@ -224,7 +224,7 @@ class ToStringVisitor extends RecursiveVisitor<void> {
   @override
   void visitProcedure(Procedure node) {
     if (
-      node.name.name        == 'toString' &&
+      node.name.text        == 'toString' &&
       node.enclosingClass   != null       &&
       node.enclosingLibrary != null       &&
       !node.isStatic                      &&

--- a/flutter_frontend_server/test/to_string_test.dart
+++ b/flutter_frontend_server/test/to_string_test.dart
@@ -194,7 +194,7 @@ void main(List<String> args) async {
     final ReturnStatement replacement = verify(body.replaceWith(captureAny)).captured.single as ReturnStatement;
     expect(replacement.expression, isA<SuperMethodInvocation>());
     final SuperMethodInvocation superMethodInvocation = replacement.expression as SuperMethodInvocation;
-    expect(superMethodInvocation.name.name, 'toString');
+    expect(superMethodInvocation.name.text, 'toString');
   }
 
   test('ToStringVisitor replaces toString in specified libraries (dart:ui)', () {


### PR DESCRIPTION
This is a quick fix, replacing two calls to a now deprecated method, Name.name.
Name.name was deprecated in favour of Name.text in https://dart-review.googlesource.com/c/sdk/+/163062