### PR TITLE
WIP: Smooth window resizing on macOS

### DIFF
--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -67,6 +67,7 @@ source_set("flutter_framework_source") {
   sources += _flutter_framework_headers
 
   deps = [
+    "//flutter/fml:fml",
     "//flutter/shell/platform/darwin/common:framework_shared",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
   ]
@@ -80,6 +81,8 @@ source_set("flutter_framework_source") {
   libs = [
     "Cocoa.framework",
     "CoreVideo.framework",
+    "IOSurface.framework",
+    "QuartzCore.framework",
   ]
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -262,7 +262,6 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   const FlutterCustomTaskRunners custom_task_runners = {
       .struct_size = sizeof(FlutterCustomTaskRunners),
       .platform_task_runner = &cocoa_task_runner_description,
-      .render_task_runner = &cocoa_task_runner_description,
   };
   flutterArguments.custom_task_runners = &custom_task_runners;
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -27,6 +27,11 @@
 - (void)updateWindowMetrics;
 
 /**
+ * Schedules the block on raster thread.
+ */
+- (void)scheduleOnRasterTread:(nonnull dispatch_block_t)block;
+
+/**
  * Dispatches the given pointer event data to engine.
  */
 - (void)sendPointerEvent:(const FlutterPointerEvent&)event;

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -4,35 +4,40 @@
 
 #import <Cocoa/Cocoa.h>
 
-/**
- * Listener for view resizing.
- */
-@protocol FlutterViewReshapeListener <NSObject>
+@protocol FlutterViewDelegate <NSObject>
 /**
  * Called when the view's backing store changes size.
  */
 - (void)viewDidReshape:(nonnull NSView*)view;
+
+- (void)scheduleOnRasterTread:(nonnull dispatch_block_t)block;
+
 @end
 
 /**
  * View capable of acting as a rendering target and input source for the Flutter
  * engine.
  */
-@interface FlutterView : NSOpenGLView
+@interface FlutterView : NSView
+
+@property(readwrite, nonatomic, nonnull) NSOpenGLContext* openGLContext;
 
 - (nullable instancetype)initWithFrame:(NSRect)frame
                           shareContext:(nonnull NSOpenGLContext*)shareContext
-                       reshapeListener:(nonnull id<FlutterViewReshapeListener>)reshapeListener
+                              delegate:(nonnull id<FlutterViewDelegate>)delegate
     NS_DESIGNATED_INITIALIZER;
 
 - (nullable instancetype)initWithShareContext:(nonnull NSOpenGLContext*)shareContext
-                              reshapeListener:
-                                  (nonnull id<FlutterViewReshapeListener>)reshapeListener;
+                                     delegate:(nonnull id<FlutterViewDelegate>)delegate;
 
 - (nullable instancetype)initWithFrame:(NSRect)frameRect
                            pixelFormat:(nullable NSOpenGLPixelFormat*)format NS_UNAVAILABLE;
 - (nonnull instancetype)initWithFrame:(NSRect)frameRect NS_UNAVAILABLE;
 - (nullable instancetype)initWithCoder:(nonnull NSCoder*)coder NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;
+
+- (void)start;
+- (void)present;
+- (int)getFrameBufferIdForWidth:(int)width height:(int)height;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -3,30 +3,281 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
+#include <OpenGL/gl.h>
+#include <OpenGL/glext.h>
+#import <QuartzCore/QuartzCore.h>
 
-@implementation FlutterView {
-  __weak id<FlutterViewReshapeListener> _reshapeListener;
+#import <functional>
+#import <thread>
+#include "flutter/fml/memory/ref_counted.h"
+
+@protocol SynchronizerDelegate
+
+// Invoked on raster thread; Delegate should recreate IOSurface with given size
+- (void)recreateSurfaceWithScaledSize:(CGSize)scaledSize;
+
+// Invoked on platform thread; Delegate should flush the OpenGL context and
+// update the surface
+- (void)commit;
+
+- (void)scheduleOnRasterThread:(dispatch_block_t)block;
+
+@end
+
+namespace {
+class ResizeSynchronizer;
 }
 
+enum {
+  kFront = 0,
+  kBack = 1,
+  kBufferCount,
+};
+
+@interface FlutterView () <SynchronizerDelegate> {
+  __weak id<FlutterViewDelegate> _delegate;
+  uint32_t _frameBufferId[kBufferCount];
+  uint32_t _backingTexture[kBufferCount];
+  IOSurfaceRef _ioSurface[kBufferCount];
+  fml::RefPtr<ResizeSynchronizer> synchronizer;
+  BOOL active;
+  CALayer* contentLayer;
+}
+
+@end
+
+@implementation FlutterView
+
+namespace {
+
+class ResizeSynchronizer : public fml::RefCountedThreadSafe<ResizeSynchronizer> {
+ public:
+  explicit ResizeSynchronizer(id<SynchronizerDelegate> delegate) : delegate_(delegate) {}
+
+  // Begins resize event; Will hold the thread until Commit is called;
+  // While holding the thread event loop is being processed
+  void BeginResize(CGSize scaledSize, dispatch_block_t notify) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!delegate_) {
+      return;
+    }
+
+    ++cookie_;
+
+    // from now on, ignore all incoming commits until the block below gets
+    // scheduled on raster thread
+    accepting_ = false;
+
+    // let pending commits finish to unblock the raster thread
+    cond_run_.notify_all();
+
+    // let the engine send resize notification
+    notify();
+
+    auto self = fml::Ref(this);
+
+    width_ = int(scaledSize.width);
+    height_ = int(scaledSize.height);
+
+    waiting_ = true;
+
+    cond_block_.wait(lock);
+
+    if (pending_commit_) {
+      [delegate_ commit];
+      pending_commit_ = false;
+      cond_run_.notify_all();
+    }
+
+    waiting_ = false;
+  }
+
+  // Must be invoked on raster thread
+  void RequestFrameBuffer(int width, int height) {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!accepting_) {
+      if (width_ == width && height == height_) {
+        accepting_ = true;
+        [delegate_ recreateSurfaceWithScaledSize:CGSizeMake(width, height)];
+      }
+    }
+  }
+
+  // Must be invoked on raster thread; Will synchronously invoke
+  // [delegate commit] on platform thread;
+  void Commit() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!accepting_) {
+      return;
+    }
+
+    if (waiting_) {  // BeginResize is in progress, interrupt it and schedule commit call
+      pending_commit_ = true;
+      cond_block_.notify_all();
+      cond_run_.wait(lock);
+    } else {
+      // No resize, schedule commit on platform thread and wait until either done
+      // or interrupted by incoming BeginResize
+      dispatch_async(dispatch_get_main_queue(), [this, cookie = cookie_] {
+        std::unique_lock<std::mutex> lock(mutex_);
+        if (cookie_ == cookie) {
+          id<SynchronizerDelegate> delegate = delegate_;
+          if (delegate) {
+            [delegate commit];
+          }
+          cond_run_.notify_all();
+        }
+      });
+      cond_run_.wait(lock);
+    }
+  }
+
+ private:
+  uint32_t cookie_ = 0;  // counter to detect stale callbacks
+  std::mutex mutex_;
+  std::condition_variable cond_run_;
+  std::condition_variable cond_block_;
+  bool accepting_ = true;
+
+  bool waiting_ = false;
+  bool pending_commit_ = false;
+
+  int width_;
+  int height_;
+
+  __weak id<SynchronizerDelegate> delegate_;
+};
+}  // namespace
+
 - (instancetype)initWithShareContext:(NSOpenGLContext*)shareContext
-                     reshapeListener:(id<FlutterViewReshapeListener>)reshapeListener {
-  return [self initWithFrame:NSZeroRect shareContext:shareContext reshapeListener:reshapeListener];
+                            delegate:(id<FlutterViewDelegate>)delegate {
+  return [self initWithFrame:NSZeroRect shareContext:shareContext delegate:delegate];
 }
 
 - (instancetype)initWithFrame:(NSRect)frame
                  shareContext:(NSOpenGLContext*)shareContext
-              reshapeListener:(id<FlutterViewReshapeListener>)reshapeListener {
+                     delegate:(id<FlutterViewDelegate>)delegate {
   self = [super initWithFrame:frame];
   if (self) {
     self.openGLContext = [[NSOpenGLContext alloc] initWithFormat:shareContext.pixelFormat
                                                     shareContext:shareContext];
-    _reshapeListener = reshapeListener;
-    self.wantsBestResolutionOpenGLSurface = YES;
+
+    [self setWantsLayer:YES];
+
+    // covers entire view
+    contentLayer = [[CALayer alloc] init];
+    [self.layer addSublayer:contentLayer];
+
+    synchronizer = fml::MakeRefCounted<ResizeSynchronizer>(self);
+
+    [self.openGLContext makeCurrentContext];
+
+    glGenFramebuffers(2, _frameBufferId);
+    glGenTextures(2, _backingTexture);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId[0]);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, _backingTexture[0]);
+    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId[1]);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, _backingTexture[1]);
+    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+
+    _delegate = delegate;
   }
   return self;
 }
 
+- (void)recreateSurfaceWithScaledSize:(CGSize)scaledSize {
+  for (int i = 0; i < 2; ++i) {
+    if (_ioSurface[i]) {
+      CFRelease(_ioSurface[i]);
+    }
+
+    [self.openGLContext makeCurrentContext];
+
+    unsigned pixelFormat = 'BGRA';
+    unsigned bytesPerElement = 4;
+
+    size_t bytesPerRow =
+        IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, scaledSize.width * bytesPerElement);
+    size_t totalBytes =
+        IOSurfaceAlignProperty(kIOSurfaceAllocSize, scaledSize.height * bytesPerRow);
+    NSDictionary* options = @{
+      (id)kIOSurfaceWidth : @(scaledSize.width),
+      (id)kIOSurfaceHeight : @(scaledSize.height),
+      (id)kIOSurfacePixelFormat : @(pixelFormat),
+      (id)kIOSurfaceBytesPerElement : @(bytesPerElement),
+      (id)kIOSurfaceBytesPerRow : @(bytesPerRow),
+      (id)kIOSurfaceAllocSize : @(totalBytes),
+    };
+    _ioSurface[i] = IOSurfaceCreate((CFDictionaryRef)options);
+
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, _backingTexture[i]);
+
+    CGLTexImageIOSurface2D(CGLGetCurrentContext(), GL_TEXTURE_RECTANGLE_ARB, GL_RGBA,
+                           int(scaledSize.width), int(scaledSize.height), GL_BGRA,
+                           GL_UNSIGNED_INT_8_8_8_8_REV, _ioSurface[i], 0 /* plane */);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId[i]);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE_ARB,
+                           _backingTexture[i], 0);
+  }
+}
+
+- (void)reshaped {
+  if (active) {
+    CGSize scaledSize = [self convertRectToBacking:self.bounds].size;
+    synchronizer->BeginResize(scaledSize, ^{
+      [_delegate viewDidReshape:self];
+    });
+  }
+}
+
 #pragma mark - NSView overrides
+
+- (void)setFrameSize:(NSSize)newSize {
+  [super setFrameSize:newSize];
+  [self reshaped];
+}
+
+- (void)commit {
+  [self.openGLContext makeCurrentContext];
+  glFlush();
+  [NSOpenGLContext clearCurrentContext];
+
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+  self.layer.frame = self.bounds;
+  self.layer.sublayerTransform = CATransform3DTranslate(CATransform3DMakeScale(1, -1, 1), 0,
+                                                        -self.layer.bounds.size.height, 0);
+  contentLayer.frame = self.layer.bounds;
+
+  [contentLayer setContents:(__bridge id)_ioSurface[kBack]];
+  std::swap(_ioSurface[kBack], _ioSurface[kFront]);
+  std::swap(_frameBufferId[kBack], _frameBufferId[kFront]);
+  std::swap(_backingTexture[kBack], _backingTexture[kFront]);
+
+  [CATransaction commit];
+}
+
+- (int)getFrameBufferIdForWidth:(int)width height:(int)height {
+  synchronizer->RequestFrameBuffer(width, height);
+  return _frameBufferId[kBack];
+}
+
+- (void)scheduleOnRasterThread:(dispatch_block_t)block {
+  [_delegate scheduleOnRasterTread:block];
+}
+
+- (void)present {
+  synchronizer->Commit();
+}
 
 /**
  * Declares that the view uses a flipped coordinate system, consistent with Flutter conventions.
@@ -39,9 +290,10 @@
   return YES;
 }
 
-- (void)reshape {
-  [super reshape];
-  [_reshapeListener viewDidReshape:self];
+- (void)dealloc {
+  if (_ioSurface) {
+    CFRelease(_ioSurface);
+  }
 }
 
 - (BOOL)acceptsFirstResponder {
@@ -50,7 +302,13 @@
 
 - (void)viewDidChangeBackingProperties {
   [super viewDidChangeBackingProperties];
-  [_reshapeListener viewDidReshape:self];
+  // Force redraw
+  [_delegate viewDidReshape:self];
+}
+
+- (void)start {
+  active = YES;
+  [self reshaped];
 }
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -80,7 +80,7 @@ struct KeyboardState {
 /**
  * Private interface declaration for FlutterViewController.
  */
-@interface FlutterViewController () <FlutterViewReshapeListener>
+@interface FlutterViewController () <FlutterViewDelegate>
 
 /**
  * A list of additional responders to keyboard events. Keybord events are forwarded to all of them.
@@ -246,7 +246,7 @@ static void CommonInit(FlutterViewController* controller) {
     return;
   }
   FlutterView* flutterView = [[FlutterView alloc] initWithShareContext:resourceContext
-                                                       reshapeListener:self];
+                                                              delegate:self];
   self.view = flutterView;
 }
 
@@ -549,13 +549,17 @@ static void CommonInit(FlutterViewController* controller) {
   return [NSPasteboard generalPasteboard];
 }
 
-#pragma mark - FlutterViewReshapeListener
+#pragma mark - FlutterViewDelegate
 
 /**
  * Responds to view reshape by notifying the engine of the change in dimensions.
  */
 - (void)viewDidReshape:(NSView*)view {
   [_engine updateWindowMetrics];
+}
+
+- (void)scheduleOnRasterTread:(dispatch_block_t)block {
+  [_engine scheduleOnRasterTread:block];
 }
 
 #pragma mark - FlutterPluginRegistry


### PR DESCRIPTION
## Description

Superseds https://github.com/flutter/engine/pull/21110

Make window resizing on macOS smooth, responsive and synchronous with windows size.

Related design doc: https://flutter.dev/go/desktop-resize-macos

Notable change: It seems that double buffered IOSurface backed NSOpenGLContext is not all that double buffered after all and I was able to create a test case which resulted in partial drawn frame visible. This version uses single buffered NSOpenGLContext with two IOSurfaces (front and back) which eliminates the problem.

Depends on: https://github.com/flutter/engine/pull/21108

## Related Issues

https://github.com/flutter/flutter/issues/44136

## Tests

I added the following tests:


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
