### PR TITLE
[web] Fix leaking canvas in text placeholder tests

### DIFF
--- a/lib/web_ui/dev/browser_lock.yaml
+++ b/lib/web_ui/dev/browser_lock.yaml
@@ -34,7 +34,7 @@ ios-safari:
   # `heightOfHeader` is the number of pixels taken by the phone's header menu
   # and the browsers address bar.
   # TODO: https://github.com/flutter/flutter/issues/65672
-  heightOfHeader: 282
+  heightOfHeader: 283
   # `heightOfFooter` is the number of pixels taken by the phone's navigation
   # menu.
   heightOfFooter: 250

--- a/lib/web_ui/dev/safari_installation.dart
+++ b/lib/web_ui/dev/safari_installation.dart
@@ -104,7 +104,7 @@ class IosSafariArgParser extends BrowserArgParser {
       );
     } catch (e) {
       throw Exception('Error getting requested simulator. Try running '
-          '`felt create` command first before running the tests. Exception: '
+          '`felt create_simulator` command first before running the tests. Exception: '
           '$e');
     }
 

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -397,7 +397,8 @@ class TestCommand extends Command<bool> with ArgUtils {
     // after solving the git issue faced on macOS and Windows bots:
     // TODO: https://github.com/flutter/flutter/issues/63710
     if ((isChrome && isLuci && io.Platform.isLinux) ||
-        ((isChrome || isSafariIOS) && !isLuci)) {
+        (isChrome && !isLuci) || (isSafariIOS && isLuci)) {
+      print('INFO: Also running the screenshot tests.');
       // Separate screenshot tests from unit-tests. Screenshot tests must run
       // one at a time. Otherwise, they will end up screenshotting each other.
       // This is not an issue for unit-tests.

--- a/lib/web_ui/test/golden_tests/engine/text_placeholders_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/text_placeholders_test.dart
@@ -27,6 +27,7 @@ void testMain() async {
     final Rect screenRect = const Rect.fromLTWH(0, 0, 600, 600);
     final RecordingCanvas recordingCanvas = RecordingCanvas(screenRect);
 
+    recordingCanvas.save();
     Offset offset = Offset.zero;
     for (PlaceholderAlignment placeholderAlignment
         in PlaceholderAlignment.values) {
@@ -39,6 +40,7 @@ void testMain() async {
       );
       offset = offset.translate(0.0, 80.0);
     }
+    recordingCanvas.restore();
     recordingCanvas.endRecording();
     recordingCanvas.apply(canvas, screenRect);
     return scuba.diffCanvasScreenshot(canvas, 'text_with_placeholders');
@@ -48,6 +50,7 @@ void testMain() async {
     final Rect screenRect = const Rect.fromLTWH(0, 0, 600, 600);
     final RecordingCanvas recordingCanvas = RecordingCanvas(screenRect);
 
+    recordingCanvas.save();
     Offset offset = Offset.zero;
     _paintTextWithPlaceholder(
       recordingCanvas,
@@ -72,6 +75,7 @@ void testMain() async {
       after: 'ipsum.',
       textAlignment: TextAlign.end,
     );
+    recordingCanvas.restore();
     recordingCanvas.endRecording();
     recordingCanvas.apply(canvas, screenRect);
     return scuba.diffCanvasScreenshot(canvas, 'text_align_with_placeholders');


### PR DESCRIPTION
## Description

The text placeholder test used to leak canvases which led to errors in iOS Safari because it stops creating canvases after some time. This PR fixes the leakage.

cc @ferhatb to confirm this is the right way to fix the leakage.