### PR TITLE
Workaround for an Android emulator EGL bug that can cause inaccurate GL version strings

### DIFF
--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -57,7 +57,7 @@ class GPUSurfaceGLDelegate : public GPUSurfaceDelegate {
   // flushed.
   virtual SkMatrix GLContextSurfaceTransformation() const;
 
-  sk_sp<const GrGLInterface> GetGLInterface() const;
+  virtual sk_sp<const GrGLInterface> GetGLInterface() const;
 
   // TODO(chinmaygarde): The presence of this method is to work around the fact
   // that not all platforms can accept a custom GL proc table. Migrate all

--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -248,4 +248,12 @@ bool AndroidContextGL::ClearCurrent() {
   return true;
 }
 
+EGLContext AndroidContextGL::CreateNewContext() const {
+  bool success;
+  EGLContext context;
+  std::tie(success, context) =
+      CreateContext(environment_->Display(), config_, EGL_NO_CONTEXT);
+  return success ? context : EGL_NO_CONTEXT;
+}
+
 }  // namespace flutter

--- a/shell/platform/android/android_context_gl.h
+++ b/shell/platform/android/android_context_gl.h
@@ -110,6 +110,13 @@ class AndroidContextGL : public AndroidContext {
   ///
   bool ClearCurrent();
 
+  //----------------------------------------------------------------------------
+  /// @brief      Create a new EGLContext using the same EGLConfig.
+  ///
+  /// @return     The EGLContext.
+  ///
+  EGLContext CreateNewContext() const;
+
  private:
   fml::RefPtr<AndroidEnvironmentGL> environment_;
   EGLConfig config_;

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/android/android_surface_gl.h"
 
+#include <GLES/gl.h>
 #include <utility>
 
 #include "flutter/fml/logging.h"
@@ -11,6 +12,12 @@
 #include "flutter/shell/platform/android/android_shell_holder.h"
 
 namespace flutter {
+
+namespace {
+// GL renderer string prefix used by the Android emulator GLES implementation.
+constexpr char kEmulatorRendererPrefix[] =
+    "Android Emulator OpenGL ES Translator";
+}  // anonymous namespace
 
 AndroidSurfaceGL::AndroidSurfaceGL(
     std::shared_ptr<AndroidContext> android_context,
@@ -131,6 +138,39 @@ intptr_t AndroidSurfaceGL::GLContextFBO(GLFrameInfo frame_info) const {
 // |GPUSurfaceGLDelegate|
 ExternalViewEmbedder* AndroidSurfaceGL::GetExternalViewEmbedder() {
   return external_view_embedder_.get();
+}
+
+// |GPUSurfaceGLDelegate|
+sk_sp<const GrGLInterface> AndroidSurfaceGL::GetGLInterface() const {
+  // This is a workaround for a bug in the Android emulator EGL/GLES
+  // implementation.  Some versions of the emulator will not update the
+  // GL version string when the process switches to a new EGL context
+  // unless the EGL context is being made current for the first time.
+  // The inaccurate version string will be rejected by Skia when it
+  // tries to build the GrGLInterface.  Flutter can work around this
+  // by creating a new context, making it current to force an update
+  // of the version, and then reverting to the previous context.
+  const char* gl_renderer =
+      reinterpret_cast<const char*>(glGetString(GL_RENDERER));
+  if (gl_renderer && strncmp(gl_renderer, kEmulatorRendererPrefix,
+                             strlen(kEmulatorRendererPrefix)) == 0) {
+    EGLContext new_context = android_context_->CreateNewContext();
+    if (new_context != EGL_NO_CONTEXT) {
+      EGLContext old_context = eglGetCurrentContext();
+      EGLDisplay display = eglGetCurrentDisplay();
+      EGLSurface draw_surface = eglGetCurrentSurface(EGL_DRAW);
+      EGLSurface read_surface = eglGetCurrentSurface(EGL_READ);
+      EGLBoolean result =
+          eglMakeCurrent(display, draw_surface, read_surface, new_context);
+      FML_DCHECK(result == EGL_TRUE);
+      result = eglMakeCurrent(display, draw_surface, read_surface, old_context);
+      FML_DCHECK(result == EGL_TRUE);
+      result = eglDestroyContext(display, new_context);
+      FML_DCHECK(result == EGL_TRUE);
+    }
+  }
+
+  return GPUSurfaceGLDelegate::GetGLInterface();
 }
 
 }  // namespace flutter

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -65,6 +65,9 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   // |GPUSurfaceGLDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
+  // |GPUSurfaceGLDelegate|
+  sk_sp<const GrGLInterface> GetGLInterface() const override;
+
  private:
   const std::unique_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
   const std::shared_ptr<AndroidContextGL> android_context_;


### PR DESCRIPTION
Some versions of the Android emulator EGL implementation will only
update the GL_VERSION string when the process calls eglMakeCurrent
on an EGLContext for the first time.  If you select a GLES2 context,
then a GLES1 context, and then the original GLES2 context, the version
string will not be updated by the second eglMakeCurrent(GLES2) call.

So if a GLES1 context was previously current, then when the engine makes
its GLES2 context current Skia will continue to see the GLES1 version
string and will fail to build a GrGLInterface.

This workaround checks for the emulator GL renderer and creates a new
context to force a version string update before making the
GrGLInterface.

See internal bug b/168748787

Fixes https://github.com/flutter/flutter/issues/63663
