### PR TITLE
Do not pass invalid platform view rendering surfaces to the rasterizer

### DIFF
--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -72,9 +72,16 @@ void PlatformView::NotifyCreated() {
   fml::TaskRunner::RunNowOrPostTask(
       task_runners_.GetRasterTaskRunner(), [platform_view, &surface, &latch]() {
         surface = platform_view->CreateRenderingSurface();
+        if (surface && !surface->IsValid()) {
+          surface.reset();
+        }
         latch.Signal();
       });
   latch.Wait();
+  if (!surface) {
+    FML_LOG(ERROR) << "Failed to create platform view rendering surface";
+    return;
+  }
   delegate_.OnPlatformViewCreated(std::move(surface));
 }
 


### PR DESCRIPTION
If PlatformView::CreateRenderingSurface produces a surface that is not
fully initialized, then the invalid surface will cause crashes when it
is eventually used by the rasterizer.

See https://github.com/flutter/flutter/issues/63663
