### PR TITLE
[web] Skip text placeholder tests in iOS Safari

### DIFF
--- a/lib/web_ui/test/golden_tests/engine/scuba.dart
+++ b/lib/web_ui/test/golden_tests/engine/scuba.dart
@@ -95,7 +95,7 @@ typedef CanvasTest = FutureOr<void> Function(EngineCanvas canvas);
 
 /// Runs the given test [body] with each type of canvas.
 void testEachCanvas(String description, CanvasTest body,
-    {double maxDiffRate}) {
+    {double maxDiffRate, bool skip = false}) {
   const ui.Rect bounds = ui.Rect.fromLTWH(0, 0, 600, 800);
   test('$description (bitmap)', () {
     try {
@@ -106,7 +106,7 @@ void testEachCanvas(String description, CanvasTest body,
       WebExperiments.instance.useCanvasText = null;
       TextMeasurementService.clearCache();
     }
-  });
+  }, skip: skip);
   test('$description (bitmap + canvas measurement)', () async {
     try {
       TextMeasurementService.initialize(rulerCacheCapacity: 2);
@@ -116,7 +116,7 @@ void testEachCanvas(String description, CanvasTest body,
       WebExperiments.instance.useCanvasText = null;
       TextMeasurementService.clearCache();
     }
-  });
+  }, skip: skip);
   test('$description (dom)', () {
     try {
       TextMeasurementService.initialize(rulerCacheCapacity: 2);
@@ -126,7 +126,7 @@ void testEachCanvas(String description, CanvasTest body,
       WebExperiments.instance.useCanvasText = null;
       TextMeasurementService.clearCache();
     }
-  });
+  }, skip: skip);
 }
 
 final ui.TextStyle _defaultTextStyle = ui.TextStyle(

--- a/lib/web_ui/test/golden_tests/engine/text_placeholders_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/text_placeholders_test.dart
@@ -42,7 +42,9 @@ void testMain() async {
     recordingCanvas.endRecording();
     recordingCanvas.apply(canvas, screenRect);
     return scuba.diffCanvasScreenshot(canvas, 'text_with_placeholders');
-  });
+  },  // https://github.com/flutter/flutter/issues/66129
+      skip: operatingSystem == OperatingSystem.iOs &&
+          browserEngine == BrowserEngine.webkit);
 
   testEachCanvas('text alignment and placeholders', (EngineCanvas canvas) {
     final Rect screenRect = const Rect.fromLTWH(0, 0, 600, 600);
@@ -75,7 +77,9 @@ void testMain() async {
     recordingCanvas.endRecording();
     recordingCanvas.apply(canvas, screenRect);
     return scuba.diffCanvasScreenshot(canvas, 'text_align_with_placeholders');
-  });
+  },  // https://github.com/flutter/flutter/issues/66129
+      skip: operatingSystem == OperatingSystem.iOs &&
+          browserEngine == BrowserEngine.webkit);
 }
 
 const Color black = Color(0xFF000000);


### PR DESCRIPTION
These tests are [failing](https://github.com/flutter/flutter/issues/66129) in iOS Safari.