### PR TITLE
Dark mode friendly iOS debugging message

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -338,6 +338,7 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
     messageLabel.textAlignment = NSTextAlignmentCenter;
     messageLabel.autoresizingMask =
         UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    messageLabel.textColor = UIColor.blackColor;
     messageLabel.text =
         @"In iOS 14+, Flutter application in debug mode can only be launched from Flutter tooling, "
         @"IDEs with Flutter plugins or from Xcode.\n\nAlternatively, build in profile or release "

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -326,7 +326,11 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
   auto placeholder = [[[UIView alloc] init] autorelease];
 
   placeholder.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  placeholder.backgroundColor = UIColor.whiteColor;
+  if (@available(iOS 13.0, *)) {
+    placeholder.backgroundColor = UIColor.systemBackgroundColor;
+  } else {
+    placeholder.backgroundColor = UIColor.whiteColor;
+  }
   placeholder.autoresizesSubviews = YES;
 
   // Only add the label when we know we have failed to enable tracing (and it was necessary).
@@ -338,7 +342,6 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
     messageLabel.textAlignment = NSTextAlignmentCenter;
     messageLabel.autoresizingMask =
         UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-    messageLabel.textColor = UIColor.blackColor;
     messageLabel.text =
         @"In iOS 14+, Flutter application in debug mode can only be launched from Flutter tooling, "
         @"IDEs with Flutter plugins or from Xcode.\n\nAlternatively, build in profile or release "


### PR DESCRIPTION
## Description

With dark mode on, the "Flutter application in debug mode can only be launched from Flutter tooling" was a white label on a white background, and wasn't visible.  Make the container dark-mode-friendly.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66161

## Tests

My eyeballs.
![flutter_01](https://user-images.githubusercontent.com/682784/93809018-9a2c9000-fc01-11ea-9ac4-3f1e102e6d8d.png)

