### PR TITLE
[web] dispatch browser event on flutter/service_worker channel

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -565,6 +565,11 @@ class EngineWindow extends ui.Window {
         }
         break;
 
+      // Dispatched by the bindings to delay service worker initialization.
+      case 'flutter/service_worker':
+        html.window.dispatchEvent(html.Event('flutter-first-frame'));
+        return;
+
       case 'flutter/textinput':
         textEditing.channel.handleTextInput(data, callback);
         return;

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -255,4 +255,20 @@ void testMain() {
     expect(window.locales, isNotEmpty);
     expect(localeChangedCount, 1);
   });
+
+  test('dispatches browser event on flutter/service_worker channel', () async {
+    final Completer<void> completer = Completer<void>();
+    html.window.addEventListener('flutter-first-frame', completer.complete);
+    final Zone innerZone = Zone.current.fork();
+
+    innerZone.runGuarded(() {
+      window.sendPlatformMessage(
+        'flutter/service_worker',
+        ByteData(0),
+        (outputData) { },
+      );
+    });
+
+    await expectLater(completer.future, completes);
+  });
 }


### PR DESCRIPTION
## Description

Registering the service worker immediately after the documented has loaded may cause SW initialization to compete with framework initialization. It was recommended to us that we defer the service worker setup until after the framework is done with setup, which should be sometime after the first frame.

To implement this, the binding will dispatch a platform message on startup. This can be listened for in the html document
 #66066