### PR TITLE
Fix iOS platform view's mask view blocking touch events.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -90,10 +90,12 @@ void ResetAnchor(CALayer* layer) {
   return self;
 }
 
-// In some scenarios, when we add this view as a maskView of the ChildClippingView, iOS added this view as a
-// subview of the ChildClippingView. This results this view blocking touch events on the ChildClippingView.
-// So we should always ignore any touch events sent to this view.
-// See https://github.com/flutter/flutter/issues/66044
+// // In some scenarios, when we add this view as a maskView of the ChildClippingView, iOS added
+// this view as a
+// // subview of the ChildClippingView. This results this view blocking touch events on the
+// ChildClippingView.
+// // So we should always ignore any touch events sent to this view.
+// // See https://github.com/flutter/flutter/issues/66044
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent*)event {
   return NO;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -90,6 +90,14 @@ void ResetAnchor(CALayer* layer) {
   return self;
 }
 
+// In some scenarios, when we add this view as a maskView of the ChildClippingView, iOS added this view as a
+// subview of the ChildClippingView. This results this view blocking touch events on the ChildClippingView.
+// So we should always ignore any touch events sent to this view.
+// See https://github.com/flutter/flutter/issues/66044
+- (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent*)event {
+  return NO;
+}
+
 - (void)drawRect:(CGRect)rect {
   CGContextRef context = UIGraphicsGetCurrentContext();
   CGContextSaveGState(context);

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -91,9 +91,8 @@ void ResetAnchor(CALayer* layer) {
 }
 
 // In some scenarios, when we add this view as a maskView of the ChildClippingView, iOS added
-// this view as a
-// subview of the ChildClippingView. This results this view blocking touch events on the
-// ChildClippingView.
+// this view as a subview of the ChildClippingView.
+// This results this view blocking touch events on the ChildClippingView.
 // So we should always ignore any touch events sent to this view.
 // See https://github.com/flutter/flutter/issues/66044
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent*)event {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -90,12 +90,12 @@ void ResetAnchor(CALayer* layer) {
   return self;
 }
 
-// // In some scenarios, when we add this view as a maskView of the ChildClippingView, iOS added
+// In some scenarios, when we add this view as a maskView of the ChildClippingView, iOS added
 // this view as a
-// // subview of the ChildClippingView. This results this view blocking touch events on the
+// subview of the ChildClippingView. This results this view blocking touch events on the
 // ChildClippingView.
-// // So we should always ignore any touch events sent to this view.
-// // See https://github.com/flutter/flutter/issues/66044
+// So we should always ignore any touch events sent to this view.
+// See https://github.com/flutter/flutter/issues/66044
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent*)event {
   return NO;
 }

--- a/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m
@@ -23,7 +23,9 @@
 - (BOOL)application:(UIApplication*)application
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
   self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
-
+  if ([[[NSProcessInfo processInfo] arguments] containsObject:@"--maskview-blocking"]) {
+    self.window.tintColor = UIColor.systemPinkColor;
+  }
   NSDictionary<NSString*, NSString*>* launchArgsMap = @{
     // The Platform view golden test args should match `PlatformViewGoldenTestManager`.
     @"--locale-initialization" : @"locale_initialization",
@@ -58,7 +60,6 @@
           *stop = YES;
         }
       }];
-
   if (flutterViewControllerTestName) {
     [self setupFlutterViewControllerTest:flutterViewControllerTestName];
   } else if ([[[NSProcessInfo processInfo] arguments] containsObject:@"--screen-before-flutter"]) {

--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -336,9 +336,9 @@ class MultiPlatformViewBackgroundForegroundScenario extends Scenario with _BaseP
   MultiPlatformViewBackgroundForegroundScenario(Window window, {this.firstId, this.secondId})
       : assert(window != null),
         super(window) {
+    _nextFrame = _firstFrame;
     createPlatformView(window, 'platform view 1', firstId);
     createPlatformView(window, 'platform view 2', secondId);
-    _nextFrame = _firstFrame;
   }
 
   /// The platform view identifier to use for the first platform view.
@@ -532,6 +532,8 @@ class PlatformViewForTouchIOSScenario extends Scenario
 
   int _viewId;
   bool _accept;
+
+  VoidCallback _nextFrame;
   /// Creates the PlatformView scenario.
   ///
   /// The [window] parameter must not be null.
@@ -545,14 +547,24 @@ class PlatformViewForTouchIOSScenario extends Scenario
     } else {
       createPlatformView(window, text, id);
     }
+    _nextFrame = _firstFrame;
   }
 
   @override
   void onBeginFrame(Duration duration) {
-    final SceneBuilder builder = SceneBuilder();
+    _nextFrame();
+  }
 
-    builder.pushOffset(0, 0);
-    finishBuilderByAddingPlatformViewAndPicture(builder, _viewId);
+  @override
+  void onDrawFrame() {
+    // Some iOS gesture recognizers bugs are introduced in the second frame (with a different platform view rect) after laying out the platform view.
+    // So in this test, we pop 2 frames to ensure that we cover those cases.
+    // See https://github.com/flutter/flutter/issues/66044
+    if (_nextFrame == _firstFrame) {
+      _nextFrame = _secondFrame;
+      window.scheduleFrame();
+    }
+    super.onDrawFrame();
   }
 
   @override
@@ -584,6 +596,20 @@ class PlatformViewForTouchIOSScenario extends Scenario
     );
     }
 
+  }
+
+  void _firstFrame() {
+    final SceneBuilder builder = SceneBuilder();
+
+    builder.pushOffset(0, 0);
+    finishBuilderByAddingPlatformViewAndPicture(builder, _viewId);
+  }
+
+  void _secondFrame() {
+    final SceneBuilder builder = SceneBuilder();
+
+    builder.pushOffset(5, 5);
+    finishBuilderByAddingPlatformViewAndPicture(builder, _viewId);
   }
 }
 


### PR DESCRIPTION
## Description

The iOS platform view's mask view are sometimes physically added to the view hierarchy which resulting blocking the touch events. It is not documented and I'm not sure what is iOS's intention of doing that. (Could be an iOS bug) The mask view is only for determining the alpha channel for the platform view (for clipping), and we can always ignore the touch events. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66044

## Tests

I added the following tests:

- testGestureWithMaskViewBlockingPlatformView
Also updated the PlatformViewForTouchIOSScenario to produce a second frame which reproduces this issue.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
