### PR TITLE
Make SkCanvas types @anonymous; reduce logging noise

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1306,6 +1306,7 @@ class SkPictureRecorder {
 /// "borrowed", i.e. their memory is managed by other objects. In the case of
 /// [SkCanvas] it is managed by [SkPictureRecorder].
 @JS()
+@anonymous
 class SkCanvas {
   external void clear(Float32List color);
   external void clipPath(
@@ -1444,11 +1445,13 @@ class SkCanvas {
 }
 
 @JS()
+@anonymous
 class SkCanvasSaveLayerWithoutBoundsOverload {
   external void saveLayer(SkPaint paint);
 }
 
 @JS()
+@anonymous
 class SkCanvasSaveLayerWithFilterOverload {
   external void saveLayer(
     SkPaint? paint,

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1494,6 +1494,7 @@ class SkParagraphBuilder {
 }
 
 @JS()
+@anonymous
 class SkParagraphStyle {}
 
 @JS()

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1468,6 +1468,7 @@ class SkPicture {
 }
 
 @JS()
+@anonymous
 class SkParagraphBuilderNamespace {
   external SkParagraphBuilder Make(
     SkParagraphStyle paragraphStyle,

--- a/lib/web_ui/lib/src/ui/channel_buffers.dart
+++ b/lib/web_ui/lib/src/ui/channel_buffers.dart
@@ -86,7 +86,7 @@ class ChannelBuffers {
       // TODO(aaclarke): Update this message to include instructions on how to resize
       // the buffer once that is available to users and print in all engine builds
       // after we verify that dropping messages isn't part of normal execution.
-      _printDebug('Overflow on channel: $channel.  '
+      _debugPrintWarning('Overflow on channel: $channel.  '
                   'Messages on this channel are being discarded in FIFO fashion.  '
                   'The engine may not be running or you need to adjust '
                   'the buffer size if of the channel.');
@@ -113,7 +113,7 @@ class ChannelBuffers {
     } else {
       final int numberOfDroppedMessages = queue.resize(newSize);
       if (numberOfDroppedMessages > 0) {
-        _Logger._printString('Dropping messages on channel "$channel" as a result of shrinking the buffer size.');
+        _debugPrintWarning('Dropping messages on channel "$channel" as a result of shrinking the buffer size.');
       }
     }
   }

--- a/lib/web_ui/lib/src/ui/natives.dart
+++ b/lib/web_ui/lib/src/ui/natives.dart
@@ -5,26 +5,19 @@
 // @dart = 2.10
 part of ui;
 
-// Corelib 'print' implementation.
-// ignore: unused_element
-void _print(dynamic arg) {
-  _Logger._printString(arg.toString());
-}
-
-void _printDebug(dynamic arg) {
-  _Logger._printDebugString(arg.toString());
-}
-
-class _Logger {
-  static void _printString(String? s) {
-    print(s);
-  }
-
-  static void _printDebugString(String? s) {
-    html.window.console.error(s!);
-  }
+/// Prints a warning to the browser's debug console.
+void _debugPrintWarning(String warning) {
+    if (engine.assertionsEnabled) {
+      // Use a lower log level message to reduce noise in release mode.
+      html.window.console.debug(warning);
+      return;
+    }
+    html.window.console.warn(warning);
 }
 
 List<int> saveCompilationTrace() {
+  if (engine.assertionsEnabled) {
+    throw UnimplementedError('saveCompilationTrace is not implemented on the web.');
+  }
   throw UnimplementedError();
 }


### PR DESCRIPTION
## Description

- Make `SkCanvas` types `@anonymous` so DDC can cast between these types freely.
- Reduce the verbosity of channel overflow messages in release mode.

## Related Issues

This fixes the "Cannot find native JavaScript type" warnings in DDC mode in https://github.com/flutter/flutter/issues/66236.

## Tests

This is already covered by `canvaskit_api_test.dart`. This just fixes the console warnings.