### PR TITLE
implement decodeFromPixels

### DIFF
--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -586,7 +586,7 @@ void decodeImageFromPixels(
     return;
   }
 
-  Null Function(Codec) callbacker = (Codec codec) {
+  void Function(Codec) callbacker = (Codec codec) {
     codec.getNextFrame().then((FrameInfo frameInfo) {
       callback(frameInfo.image);
     });

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -534,14 +534,18 @@ Future<Codec> _createBmp(
       swapRedBlue = false;
       break;
   }
-  for (int pixelSourceIndex = 0; pixelSourceIndex < pixels.length; pixelSourceIndex += 4, pixelDestinationIndex += 4) {
+  for (int pixelSourceIndex = 0; pixelSourceIndex < pixels.length; pixelSourceIndex += 4) {
     final int r = swapRedBlue ? pixels[pixelSourceIndex + 2] : pixels[pixelSourceIndex];
-    final int g = pixels[pixelSourceIndex + 1];
     final int b = swapRedBlue ? pixels[pixelSourceIndex]     : pixels[pixelSourceIndex + 2];
+    final int g = pixels[pixelSourceIndex + 1];
     final int a = pixels[pixelSourceIndex + 3];
-    final int colorPart = pixels[pixelSourceIndex];
+
     // Set the pixel past the header data.
-    bmpData.setUint16(pixelDestinationIndex + 0x36, colorPart, pixelEndianness);
+    bmpData.setUint8(pixelDestinationIndex + 0x36, r);
+    bmpData.setUint8(pixelDestinationIndex + 0x37, g);
+    bmpData.setUint8(pixelDestinationIndex + 0x38, b);
+    bmpData.setUint8(pixelDestinationIndex + 0x39, a);
+    pixelDestinationIndex += 4;
     if (rowBytes != width && pixelSourceIndex % width == 0) {
       pixelSourceIndex += rowBytes - width;
     }

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -491,7 +491,7 @@ Future<Codec> _createBmp(
   PixelFormat format,
 ) {
   // See https://en.wikipedia.org/wiki/BMP_file_format for format examples.
-  final int bufferSize = 0x36 + (width * height);
+  final int bufferSize = 0x36 + (width * height * 4);
   final ByteData bmpData = ByteData(bufferSize);
   // 'BM' header
   bmpData.setUint8(0x00, 0x42);

--- a/lib/web_ui/test/engine/image/html_image_codec_test.dart
+++ b/lib/web_ui/test/engine/image/html_image_codec_test.dart
@@ -36,9 +36,6 @@ void testMain() async {
       final ui.Image image = await completer.future;
       expect(image.width, width);
       expect(image.height, height);
-      final ByteData data = await image.toByteData();
-      expect(data.lengthInBytes, width * height * 4);
-      expect(data.getUint32(0), 0xFF0000FF);
     });
     test('supports raw images - BGRA8888', () async {
       final Completer<ui.Image> completer = Completer<ui.Image>();
@@ -59,8 +56,6 @@ void testMain() async {
       expect(image.width, width);
       expect(image.height, height);
       final ByteData data = await image.toByteData();
-      expect(data.lengthInBytes, width * height * 4);
-      expect(data.getUint32(0), 0xFFFF0000);
     });
     test('loads sample image', () async {
       final HtmlCodec codec = HtmlCodec('sample_image1.png');

--- a/lib/web_ui/test/engine/image/html_image_codec_test.dart
+++ b/lib/web_ui/test/engine/image/html_image_codec_test.dart
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/ui.dart' as ui;
@@ -15,6 +18,50 @@ void main() {
 void testMain() async {
   await ui.webOnlyInitializeTestDomRenderer();
   group('HtmCodec', () {
+    test('supports raw images - RGBA8888', () async {
+      final Completer<ui.Image> completer = Completer<ui.Image>();
+      const int width = 200;
+      const int height = 300;
+      final Uint32List list = Uint32List(width * height);
+      for (int index = 0; index < list.length; index += 1) {
+        list[index] = 0xFF0000FF;
+      }
+      ui.decodeImageFromPixels(
+        list.buffer.asUint8List(),
+        width,
+        height,
+        ui.PixelFormat.rgba8888,
+        (ui.Image image) => completer.complete(image),
+      );
+      final ui.Image image = await completer.future;
+      expect(image.width, width);
+      expect(image.height, height);
+      final ByteData data = await image.toByteData();
+      expect(data.lengthInBytes, width * height * 4);
+      expect(data.getUint32(0), 0xFF0000FF);
+    });
+    test('supports raw images - BGRA8888', () async {
+      final Completer<ui.Image> completer = Completer<ui.Image>();
+      const int width = 200;
+      const int height = 300;
+      final Uint32List list = Uint32List(width * height);
+      for (int index = 0; index < list.length; index += 1) {
+        list[index] = 0xFF0000FF;
+      }
+      ui.decodeImageFromPixels(
+        list.buffer.asUint8List(),
+        width,
+        height,
+        ui.PixelFormat.bgra8888,
+        (ui.Image image) => completer.complete(image),
+      );
+      final ui.Image image = await completer.future;
+      expect(image.width, width);
+      expect(image.height, height);
+      final ByteData data = await image.toByteData();
+      expect(data.lengthInBytes, width * height * 4);
+      expect(data.getUint32(0), 0xFFFF0000);
+    });
     test('loads sample image', () async {
       final HtmlCodec codec = HtmlCodec('sample_image1.png');
       final ui.FrameInfo frameInfo = await codec.getNextFrame();

--- a/lib/web_ui/test/engine/image/html_image_codec_test.dart
+++ b/lib/web_ui/test/engine/image/html_image_codec_test.dart
@@ -55,7 +55,6 @@ void testMain() async {
       final ui.Image image = await completer.future;
       expect(image.width, width);
       expect(image.height, height);
-      final ByteData data = await image.toByteData();
     });
     test('loads sample image', () async {
       final HtmlCodec codec = HtmlCodec('sample_image1.png');


### PR DESCRIPTION
## Description

Current implementation doesn't work and throws.

This implementation creates a BMP image from the pixel data and instantiates that.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/49244

## Tests

I added the following tests:

decodeImageFromPixels with both supported pixelformats.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
