### PR TITLE
Do not create a TestGLSurface for software-only rendering in EmbedderTest

### DIFF
--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -107,11 +107,7 @@ FlutterProjectArgs& EmbedderConfigBuilder::GetProjectArgs() {
 void EmbedderConfigBuilder::SetSoftwareRendererConfig(SkISize surface_size) {
   renderer_config_.type = FlutterRendererType::kSoftware;
   renderer_config_.software = software_renderer_config_;
-
-  // TODO(chinmaygarde): The compositor still uses a GL surface for operation.
-  // Once this is no longer the case, don't setup the GL surface when using the
-  // software renderer config.
-  context_.SetupOpenGLSurface(surface_size);
+  context_.SetupSurface(surface_size);
 }
 
 void EmbedderConfigBuilder::SetOpenGLFBOCallBack() {
@@ -141,7 +137,7 @@ void EmbedderConfigBuilder::SetOpenGLPresentCallBack() {
 void EmbedderConfigBuilder::SetOpenGLRendererConfig(SkISize surface_size) {
   renderer_config_.type = FlutterRendererType::kOpenGL;
   renderer_config_.open_gl = opengl_renderer_config_;
-  context_.SetupOpenGLSurface(surface_size);
+  context_.SetupSurface(surface_size);
 }
 
 void EmbedderConfigBuilder::SetAssetsPath() {

--- a/shell/platform/embedder/tests/embedder_test_compositor.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor.cc
@@ -15,7 +15,6 @@ EmbedderTestCompositor::EmbedderTestCompositor(SkISize surface_size,
                                                sk_sp<GrDirectContext> context)
     : surface_size_(surface_size), context_(context) {
   FML_CHECK(!surface_size_.isEmpty()) << "Surface size must not be empty";
-  FML_CHECK(context_);
 }
 
 EmbedderTestCompositor::~EmbedderTestCompositor() = default;

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.cc
@@ -12,9 +12,8 @@ namespace flutter {
 namespace testing {
 
 EmbedderTestCompositorSoftware::EmbedderTestCompositorSoftware(
-    SkISize surface_size,
-    sk_sp<GrDirectContext> context)
-    : EmbedderTestCompositor(surface_size, context) {}
+    SkISize surface_size)
+    : EmbedderTestCompositor(surface_size, nullptr) {}
 
 EmbedderTestCompositorSoftware::~EmbedderTestCompositorSoftware() = default;
 
@@ -54,10 +53,9 @@ bool EmbedderTestCompositorSoftware::UpdateOffscrenComposition(
 
         break;
       case kFlutterLayerContentTypePlatformView:
-        layer_image =
-            platform_view_renderer_callback_
-                ? platform_view_renderer_callback_(*layer, context_.get())
-                : nullptr;
+        layer_image = platform_view_renderer_callback_
+                          ? platform_view_renderer_callback_(*layer, nullptr)
+                          : nullptr;
         canvas_offset = SkIPoint::Make(layer->offset.x, layer->offset.y);
         break;
     };

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.h
@@ -12,8 +12,7 @@ namespace testing {
 
 class EmbedderTestCompositorSoftware : public EmbedderTestCompositor {
  public:
-  EmbedderTestCompositorSoftware(SkISize surface_size,
-                                 sk_sp<GrDirectContext> context);
+  EmbedderTestCompositorSoftware(SkISize surface_size);
 
   ~EmbedderTestCompositorSoftware() override;
 

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -131,7 +131,7 @@ class EmbedderTestContext {
 
   void SetNextSceneCallback(const NextSceneCallback& next_scene_callback);
 
-  virtual void SetupOpenGLSurface(SkISize surface_size) = 0;
+  virtual void SetupSurface(SkISize surface_size) = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderTestContext);
 };

--- a/shell/platform/embedder/tests/embedder_test_context_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_context_gl.cc
@@ -23,7 +23,7 @@ EmbedderTestContextGL::~EmbedderTestContextGL() {
   SetGLGetFBOCallback(nullptr);
 }
 
-void EmbedderTestContextGL::SetupOpenGLSurface(SkISize surface_size) {
+void EmbedderTestContextGL::SetupSurface(SkISize surface_size) {
   FML_CHECK(!gl_surface_);
   gl_surface_ = std::make_unique<TestGLSurface>(surface_size);
 }

--- a/shell/platform/embedder/tests/embedder_test_context_gl.h
+++ b/shell/platform/embedder/tests/embedder_test_context_gl.h
@@ -62,7 +62,7 @@ class EmbedderTestContextGL : public EmbedderTestContext {
   GLGetFBOCallback gl_get_fbo_callback_;
   GLPresentCallback gl_present_callback_;
 
-  void SetupOpenGLSurface(SkISize surface_size) override;
+  void SetupSurface(SkISize surface_size) override;
 
   bool GLMakeCurrent();
 

--- a/shell/platform/embedder/tests/embedder_test_context_software.cc
+++ b/shell/platform/embedder/tests/embedder_test_context_software.cc
@@ -34,17 +34,13 @@ size_t EmbedderTestContextSoftware::GetSurfacePresentCount() const {
   return software_surface_present_count_;
 }
 
-void EmbedderTestContextSoftware::SetupOpenGLSurface(SkISize surface_size) {
-  FML_CHECK(!gl_surface_);
-  gl_surface_ = std::make_unique<TestGLSurface>(surface_size);
+void EmbedderTestContextSoftware::SetupSurface(SkISize surface_size) {
+  surface_size_ = surface_size;
 }
 
 void EmbedderTestContextSoftware::SetupCompositor() {
-  FML_CHECK(!compositor_) << "Already ssetup a compositor in this context.";
-  FML_CHECK(gl_surface_)
-      << "Setup the GL surface before setting up a compositor.";
-  compositor_ = std::make_unique<EmbedderTestCompositorSoftware>(
-      gl_surface_->GetSurfaceSize(), gl_surface_->GetGrContext());
+  FML_CHECK(!compositor_) << "Already setup a compositor in this context.";
+  compositor_ = std::make_unique<EmbedderTestCompositorSoftware>(surface_size_);
 }
 
 }  // namespace testing

--- a/shell/platform/embedder/tests/embedder_test_context_software.h
+++ b/shell/platform/embedder/tests/embedder_test_context_software.h
@@ -24,9 +24,10 @@ class EmbedderTestContextSoftware : public EmbedderTestContext {
   virtual void SetupCompositor() override;
 
  private:
-  std::unique_ptr<TestGLSurface> gl_surface_;
+  sk_sp<SkSurface> surface_;
+  SkISize surface_size_;
   size_t software_surface_present_count_ = 0;
-  void SetupOpenGLSurface(SkISize surface_size) override;
+  void SetupSurface(SkISize surface_size) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderTestContextSoftware);
 };


### PR DESCRIPTION
We don't seem to need to actually create any sort of surface for the software-only case.