### PR TITLE
[fuchsia] add frames_in_flight info to trace events

### DIFF
--- a/shell/platform/fuchsia/flutter/session_connection.cc
+++ b/shell/platform/fuchsia/flutter/session_connection.cc
@@ -36,6 +36,9 @@ SessionConnection::SessionConnection(
         // A frame was presented: Update our |frames_in_flight| to match the
         // updated unfinalized present requests.
         frames_in_flight_ -= num_presents_handled;
+        TRACE_EVENT2("gfx", "OnFramePresentedFelipe", "frames_in_flight",
+                     frames_in_flight_, "max_frames_in_flight",
+                     kMaxFramesInFlight);
         FML_DCHECK(frames_in_flight_ >= 0);
 
         VsyncRecorder::GetInstance().UpdateFramePresentedInfo(
@@ -76,7 +79,8 @@ SessionConnection::SessionConnection(
 SessionConnection::~SessionConnection() = default;
 
 void SessionConnection::Present() {
-  TRACE_EVENT0("gfx", "SessionConnection::Present");
+  TRACE_EVENT2("gfx", "SessionConnection::Present", "frames_in_flight",
+               frames_in_flight_, "max_frames_in_flight", kMaxFramesInFlight);
 
   TRACE_FLOW_BEGIN("gfx", "SessionConnection::PresentSession",
                    next_present_session_trace_id_);


### PR DESCRIPTION
No change in functionality expected.