### PR TITLE
[iOS TextInput] Avoid Unnecessary UndateEditingClient Calls

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -538,6 +538,8 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 }
 
 // Return true if the new input state needs to be synced back to the framework.
+// TODO(LongCatIsLooong): setTextInputState should never call updateEditingState. Sending the
+// editing value back may overwrite the framework's updated editing value.
 - (BOOL)setTextInputState:(NSDictionary*)state {
   NSString* newText = state[@"text"];
   BOOL textChanged = ![self.text isEqualToString:newText];
@@ -545,19 +547,14 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
     [self.inputDelegate textWillChange:self];
     [self.text setString:newText];
   }
-  BOOL needsEditingStateUpdate = textChanged;
   NSInteger composingBase = [state[@"composingBase"] intValue];
   NSInteger composingExtent = [state[@"composingExtent"] intValue];
   NSRange composingRange = [self clampSelection:NSMakeRange(MIN(composingBase, composingExtent),
                                                             ABS(composingBase - composingExtent))
                                         forText:self.text];
-  FlutterTextRange* newMarkedRange =
+
+  self.markedTextRange =
       composingRange.length > 0 ? [FlutterTextRange rangeWithNSRange:composingRange] : nil;
-  needsEditingStateUpdate =
-      needsEditingStateUpdate ||
-      (!newMarkedRange ? self.markedTextRange != nil
-                       : ![newMarkedRange isEqualTo:(FlutterTextRange*)self.markedTextRange]);
-  self.markedTextRange = newMarkedRange;
 
   NSRange selectedRange = [self clampSelectionFromBase:[state[@"selectionBase"] intValue]
                                                 extent:[state[@"selectionExtent"] intValue]
@@ -565,7 +562,6 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 
   NSRange oldSelectedRange = [(FlutterTextRange*)self.selectedTextRange range];
   if (!NSEqualRanges(selectedRange, oldSelectedRange)) {
-    needsEditingStateUpdate = YES;
     [self.inputDelegate selectionWillChange:self];
 
     [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:selectedRange]];
@@ -580,8 +576,8 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
     [self.inputDelegate textDidChange:self];
   }
 
-  // For consistency with Android behavior, send an update to the framework if anything changed.
-  return needsEditingStateUpdate;
+  // For consistency with Android behavior, send an update to the framework if the text changed.
+  return textChanged;
 }
 
 // Extracts the selection information from the editing state dictionary.
@@ -788,6 +784,8 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 }
 
 - (void)unmarkText {
+  if (!self.markedTextRange)
+    return;
   self.markedTextRange = nil;
   [self updateEditingState];
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -226,7 +226,7 @@ FLUTTER_ASSERT_ARC
   XCTAssertFalse([inputView setTextInputState:@{@"text" : @"AFTER"}]);
 }
 
-- (void)testSelectionChangeTriggersUpdateEditingClient {
+- (void)testSelectionChangeDoesNotTriggerUpdateEditingClient {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
   inputView.textInputDelegate = engine;
 
@@ -236,15 +236,15 @@ FLUTTER_ASSERT_ARC
 
   BOOL shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"SELECTION", @"selectionBase" : @0, @"selectionExtent" : @3}];
-  XCTAssertTrue(shouldUpdate);
+  XCTAssertFalse(shouldUpdate);
 
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"SELECTION", @"selectionBase" : @1, @"selectionExtent" : @3}];
-  XCTAssertTrue(shouldUpdate);
+  XCTAssertFalse(shouldUpdate);
 
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"SELECTION", @"selectionBase" : @1, @"selectionExtent" : @2}];
-  XCTAssertTrue(shouldUpdate);
+  XCTAssertFalse(shouldUpdate);
 
   // Don't send anything if there's nothing new.
   shouldUpdate = [inputView
@@ -252,7 +252,7 @@ FLUTTER_ASSERT_ARC
   XCTAssertFalse(shouldUpdate);
 }
 
-- (void)testComposingChangeTriggersUpdateEditingClient {
+- (void)testComposingChangeDoesNotTriggerUpdateEditingClient {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
   inputView.textInputDelegate = engine;
 
@@ -263,17 +263,16 @@ FLUTTER_ASSERT_ARC
 
   BOOL shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"COMPOSING", @"composingBase" : @0, @"composingExtent" : @3}];
-  XCTAssertTrue(shouldUpdate);
+  XCTAssertFalse(shouldUpdate);
 
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"COMPOSING", @"composingBase" : @1, @"composingExtent" : @3}];
-  XCTAssertTrue(shouldUpdate);
+  XCTAssertFalse(shouldUpdate);
 
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"COMPOSING", @"composingBase" : @1, @"composingExtent" : @2}];
-  XCTAssertTrue(shouldUpdate);
+  XCTAssertFalse(shouldUpdate);
 
-  // Don't send anything if there's nothing new.
   shouldUpdate = [inputView
       setTextInputState:@{@"text" : @"COMPOSING", @"composingBase" : @1, @"composingExtent" : @2}];
   XCTAssertFalse(shouldUpdate);

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -278,6 +278,29 @@ FLUTTER_ASSERT_ARC
   XCTAssertFalse(shouldUpdate);
 }
 
+- (void)testUITextInputAvoidUnnecessaryUndateEditingClientCalls {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
+  inputView.textInputDelegate = engine;
+
+  __block int updateCount = 0;
+  OCMStub([engine updateEditingClient:0 withState:[OCMArg isNotNil]])
+      .andDo(^(NSInvocation* invocation) {
+        updateCount++;
+      });
+
+  [inputView unmarkText];
+  // updateEditingClient shouldn't fire as the text is already unmarked.
+  XCTAssertEqual(updateCount, 0);
+
+  [inputView setMarkedText:@"marked text" selectedRange:NSMakeRange(0, 1)];
+  // updateEditingClient fires in response to setMarkedText.
+  XCTAssertEqual(updateCount, 1);
+
+  [inputView unmarkText];
+  // updateEditingClient fires in response to unmarkText.
+  XCTAssertEqual(updateCount, 2);
+}
+
 - (void)testUpdateEditingClientNegativeSelection {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
   inputView.textInputDelegate = engine;


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/issues/66144#issuecomment-696385582. I'm working on removing the "updateEditingState" call triggered by `textDidChange`.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66144

## Tests

I added the following tests:

- testUITextInputAvoidUnnecessaryUndateEditingClientCalls

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
