### PR TITLE
Implement toString for Images on web

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -95,6 +95,9 @@ class CkAnimatedImage implements ui.Image {
     final ByteData data = bytes.buffer.asByteData(0, bytes.length);
     return Future<ByteData>.value(data);
   }
+
+  @override
+  String toString() => '[$width\u00D7$height]';
 }
 
 /// A [ui.Image] backed by an `SkImage` from Skia.
@@ -143,6 +146,9 @@ class CkImage implements ui.Image {
     final ByteData data = bytes.buffer.asByteData(0, bytes.length);
     return Future<ByteData>.value(data);
   }
+
+  @override
+  String toString() => '[$width\u00D7$height]';
 }
 
 /// A [Codec] that wraps an `SkAnimatedImage`.

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -149,4 +149,7 @@ class HtmlImage implements ui.Image {
       return imgElement;
     }
   }
+
+  @override
+  String toString() => '[$width\u00D7$height]';
 }

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -21,6 +21,13 @@ void testMain() {
       await ui.webOnlyInitializePlatform();
     });
 
+    test('CkAnimatedImage toString', () {
+      final SkAnimatedImage skAnimatedImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
+      final CkAnimatedImage image = CkAnimatedImage(skAnimatedImage);
+      expect(image.toString(), '[1×1]');
+      image.dispose();
+    });
+
     test('CkAnimatedImage can be explicitly disposed of', () {
       final SkAnimatedImage skAnimatedImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
       final CkAnimatedImage image = CkAnimatedImage(skAnimatedImage);
@@ -29,6 +36,13 @@ void testMain() {
       expect(image.box.isDeleted, true);
       image.dispose();
       expect(image.box.isDeleted, true);
+    });
+
+    test('CkImage toString', () {
+      final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage).getCurrentFrame();
+      final CkImage image = CkImage(skImage);
+      expect(image.toString(), '[1×1]');
+      image.dispose();
     });
 
     test('CkImage can be explicitly disposed of', () {

--- a/lib/web_ui/test/engine/image/html_image_codec_test.dart
+++ b/lib/web_ui/test/engine/image/html_image_codec_test.dart
@@ -20,6 +20,7 @@ void testMain() async {
       final ui.FrameInfo frameInfo = await codec.getNextFrame();
       expect(frameInfo.image, isNotNull);
       expect(frameInfo.image.width, 100);
+      expect(frameInfo.image.toString(), '[100×100]');
     });
     test('provides image loading progress', () async {
       StringBuffer buffer = new StringBuffer();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/66289

As it stands right now, there are tests in the framework being disabled because of this, since this string is used in `toStringDeep` for diagnostics, and we expect not to see `instance of` in those strings.