### PR TITLE
Disconnect the view's AndroidKeyProcessor when detaching from the engine

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/AndroidKeyProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidKeyProcessor.java
@@ -71,6 +71,15 @@ public class AndroidKeyProcessor {
   }
 
   /**
+   * Detaches the key processor from the Flutter engine.
+   *
+   * <p>The AndroidKeyProcessor instance should not be used after calling this.
+   */
+  public void destroy() {
+    keyEventChannel.setEventResponseHandler(null);
+  }
+
+  /**
    * Called when a key up event is received by the {@link FlutterView}.
    *
    * @param keyEvent the Android key event to respond to.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -992,6 +992,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     textInputPlugin.getInputMethodManager().restartInput(this);
     textInputPlugin.destroy();
 
+    androidKeyProcessor.destroy();
+
     if (mouseCursorPlugin != null) {
       mouseCursorPlugin.destroy();
     }

--- a/shell/platform/android/test/io/flutter/embedding/android/AndroidKeyProcessorTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/AndroidKeyProcessorTest.java
@@ -2,7 +2,9 @@ package io.flutter.embedding.android;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.notNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,6 +56,22 @@ public class AndroidKeyProcessorTest {
     verify(fakeKeyEventChannel, times(1)).keyDown(any(KeyEventChannel.FlutterKeyEvent.class));
     verify(fakeKeyEventChannel, times(0)).keyUp(any(KeyEventChannel.FlutterKeyEvent.class));
     verify(fakeView, times(0)).dispatchKeyEvent(any(KeyEvent.class));
+  }
+
+  @Test
+  public void destroyTest() {
+    FlutterEngine flutterEngine = mockFlutterEngine();
+    KeyEventChannel fakeKeyEventChannel = flutterEngine.getKeyEventChannel();
+    View fakeView = mock(View.class);
+
+    AndroidKeyProcessor processor =
+        new AndroidKeyProcessor(fakeView, fakeKeyEventChannel, mock(TextInputPlugin.class));
+
+    verify(fakeKeyEventChannel, times(1))
+        .setEventResponseHandler(notNull(KeyEventChannel.EventResponseHandler.class));
+    processor.destroy();
+    verify(fakeKeyEventChannel, times(1))
+        .setEventResponseHandler(isNull(KeyEventChannel.EventResponseHandler.class));
   }
 
   public void synthesizesEventsWhenKeyDownNotHandled() {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/65941
