### PR TITLE
[web] Add canUpdateAsMatch to PersistedPlatformView.

### DIFF
--- a/lib/web_ui/dev/driver_manager.dart
+++ b/lib/web_ui/dev/driver_manager.dart
@@ -5,7 +5,6 @@
 // @dart = 2.6
 import 'dart:io' as io;
 
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as pathlib;
 import 'package:web_driver_installer/chrome_driver_installer.dart';
 import 'package:web_driver_installer/firefox_driver_installer.dart';

--- a/lib/web_ui/dev/driver_manager.dart
+++ b/lib/web_ui/dev/driver_manager.dart
@@ -184,14 +184,12 @@ class SafariDriverManager extends DriverManager {
 /// tests.
 abstract class DriverManager {
   /// Installation directory for browser's driver.
-  @protected
   final io.Directory _browserDriverDir;
 
   /// This is the parent directory for all drivers.
   ///
   /// This directory is saved to [temporaryDirectories] and deleted before
   /// tests shutdown.
-  @protected
   final io.Directory _drivers;
 
   DriverManager(String browser)
@@ -223,7 +221,6 @@ abstract class DriverManager {
 
   Future<void> _verifyDriverForLUCI();
 
-  @protected
   Future<void> _startDriver();
 
   static DriverManager chooseDriver(String browser) {

--- a/lib/web_ui/lib/src/engine/history.dart
+++ b/lib/web_ui/lib/src/engine/history.dart
@@ -88,16 +88,13 @@ abstract class BrowserHistory {
   ///
   /// Subclasses should send appropriate system messages to update the flutter
   /// applications accordingly.
-  @protected
   void onPopState(covariant html.PopStateEvent event);
 
   /// Sets up any prerequisites to use this browser history class.
-  @protected
   Future<void> setup() => Future<void>.value();
 
   /// Restore any modifications to the html browser history during the lifetime
   /// of this class.
-  @protected
   Future<void> tearDown() => Future<void>.value();
 }
 

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -79,9 +79,8 @@ class PersistedPlatformView extends PersistedLeafSurface {
   @override
   bool canUpdateAsMatch(PersistedSurface oldSurface) {
     if (super.canUpdateAsMatch(oldSurface)) {
-      if (oldSurface is PersistedPlatformView) {
-        return viewId == oldSurface.viewId;
-      }
+      // super checks the runtimeType of the surface, so we can just cast...
+      return viewId == ((oldSurface as PersistedPlatformView).viewId);
     }
     return false;
   }

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -75,6 +75,17 @@ class PersistedPlatformView extends PersistedLeafSurface {
     }
   }
 
+  // Platform Views can only be updated if their viewId matches.
+  @override
+  bool canUpdateAsMatch(PersistedSurface oldSurface) {
+    if (super.canUpdateAsMatch(oldSurface)) {
+      if (oldSurface is PersistedPlatformView) {
+        return viewId == oldSurface.viewId;
+      }
+    }
+    return false;
+  }
+
   @override
   double matchForUpdate(PersistedPlatformView existingSurface) {
     return existingSurface.viewId == viewId ? 0.0 : 1.0;
@@ -82,11 +93,10 @@ class PersistedPlatformView extends PersistedLeafSurface {
 
   @override
   void update(PersistedPlatformView oldSurface) {
+    assert(viewId == oldSurface.viewId, 'PersistedPlatformView with different viewId should never be updated. Check the canUpdateAsMatch method.',);
     super.update(oldSurface);
-    if (viewId != oldSurface.viewId) {
-      // The content of the surface has to be rebuild if the viewId is changed.
-      build();
-    } else if (dx != oldSurface.dx ||
+    // Only update if the view has been resized
+    if (dx != oldSurface.dx ||
         dy != oldSurface.dy ||
         width != oldSurface.width ||
         height != oldSurface.height) {

--- a/lib/web_ui/lib/src/engine/html/surface.dart
+++ b/lib/web_ui/lib/src/engine/html/surface.dart
@@ -275,7 +275,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
   /// retain came in.
   @mustCallSuper
   @visibleForTesting
-  @protected
   void revive() {
     assert(debugAssertSurfaceState(this, PersistedSurfaceState.released));
     state = PersistedSurfaceState.created;
@@ -342,7 +341,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
   ///
   /// This is called when we failed to locate an existing DOM element to reuse,
   /// such as on the very first frame.
-  @protected
   @mustCallSuper
   void build() {
     if (rootElement != null) {
@@ -371,7 +369,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
   /// frame, we reuse old ones as much as possible. This method should only be
   /// called when [isTotalMatchFor] returns true for the [oldSurface]. Otherwise
   /// adopting the [oldSurface]'s elements could lead to correctness issues.
-  @protected
   @mustCallSuper
   void adoptElements(covariant PersistedSurface oldSurface) {
     assert(oldSurface.rootElement != null);
@@ -399,7 +396,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
   ///
   /// Attempts to reuse [oldSurface]'s DOM element, if possible. Otherwise,
   /// creates a new element by calling [build].
-  @protected
   @mustCallSuper
   void update(covariant PersistedSurface oldSurface) {
     assert(oldSurface != null); // ignore: unnecessary_null_comparison
@@ -424,7 +420,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
   ///
   /// This is also different from [build], which constructs a brand new surface
   /// sub-tree.
-  @protected
   @mustCallSuper
   void retain() {
     assert(rootElement != null);
@@ -448,7 +443,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
   ///
   /// This method may be overridden by concrete implementations, for example, to
   /// recycle the resources owned by this surface.
-  @protected
   @mustCallSuper
   void discard() {
     assert(debugAssertSurfaceState(this, PersistedSurfaceState.active));
@@ -471,7 +465,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
     state = PersistedSurfaceState.released;
   }
 
-  @protected
   @mustCallSuper
   void debugValidate(List<String> validationErrors) {
     if (rootElement == null) {
@@ -541,7 +534,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
   /// clip behaviors.
   ///
   /// This method is called by the [preroll] method.
-  @protected
   void recomputeTransformAndClip() {
     _transform = parent!._transform;
     _localClipBounds = null;
@@ -578,7 +570,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
     }
   }
 
-  @protected
   @mustCallSuper
   void debugPrintAttributes(StringBuffer buffer) {
     if (rootElement != null) {
@@ -586,7 +577,6 @@ abstract class PersistedSurface implements ui.EngineLayer {
     }
   }
 
-  @protected
   @mustCallSuper
   void debugPrintChildren(StringBuffer buffer, int indent) {}
 
@@ -1155,7 +1145,6 @@ abstract class PersistedContainerSurface extends PersistedSurface {
   }
 
   @override
-  @protected
   @mustCallSuper
   void debugValidate(List<String> validationErrors) {
     super.debugValidate(validationErrors);

--- a/lib/web_ui/lib/src/engine/html/surface.dart
+++ b/lib/web_ui/lib/src/engine/html/surface.dart
@@ -303,6 +303,7 @@ abstract class PersistedSurface implements ui.EngineLayer {
   html.Element? rootElement;
 
   /// Whether this surface can update an existing [oldSurface].
+  @mustCallSuper
   bool canUpdateAsMatch(PersistedSurface oldSurface) {
     return oldSurface.isActive && runtimeType == oldSurface.runtimeType;
   }

--- a/lib/web_ui/test/engine/surface/platform_view_test.dart
+++ b/lib/web_ui/test/engine/surface/platform_view_test.dart
@@ -26,9 +26,14 @@ void testMain() {
 
   group('PersistedPlatformView', () {
     setUp(() async {
-      SurfaceSceneBuilder.debugForgetFrameScene();
-      platformViewRegistry.registerViewFactory('test-0', (viewId) => html.DivElement());
-      platformViewRegistry.registerViewFactory('test-1', (viewId) => html.DivElement());
+      platformViewRegistry.registerViewFactory(
+        'test-0',
+        (viewId) => html.DivElement(),
+      );
+      platformViewRegistry.registerViewFactory(
+        'test-1',
+        (viewId) => html.DivElement(),
+      );
       // Ensure the views are created...
       await Future.wait([
         _createPlatformView(0, 'test-0'),
@@ -40,7 +45,9 @@ void testMain() {
     group('update', () {
       test('throws assertion error if called with different viewIds', () {
         final differentView = PersistedPlatformView(1, 1, 1, 100, 100)..build();
-        expect(() { view.update(differentView); }, throwsAssertionError);
+        expect(() {
+          view.update(differentView);
+        }, throwsAssertionError);
       });
     });
 
@@ -70,7 +77,10 @@ Future<void> _createPlatformView(int id, String viewType) {
     'flutter/platform_views',
     codec.encodeMethodCall(MethodCall(
       'create',
-      <String, dynamic>{'id': id, 'viewType': viewType,},
+      <String, dynamic>{
+        'id': id,
+        'viewType': viewType,
+      },
     )),
     (dynamic _) => completer.complete(),
   );

--- a/lib/web_ui/test/engine/surface/platform_view_test.dart
+++ b/lib/web_ui/test/engine/surface/platform_view_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.6
+import 'dart:async';
+import 'dart:html' as html;
+
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+import '../../matchers.dart';
+
+const MethodCodec codec = StandardMethodCodec();
+final EngineWindow window = EngineWindow();
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  PersistedPlatformView view;
+
+  group('PersistedPlatformView', () {
+    setUp(() async {
+      SurfaceSceneBuilder.debugForgetFrameScene();
+      platformViewRegistry.registerViewFactory('test-0', (viewId) => html.DivElement());
+      platformViewRegistry.registerViewFactory('test-1', (viewId) => html.DivElement());
+      // Ensure the views are created...
+      await Future.wait([
+        _createPlatformView(0, 'test-0'),
+        _createPlatformView(1, 'test-1'),
+      ]);
+      view = PersistedPlatformView(0, 0, 0, 100, 100)..build();
+    });
+
+    group('update', () {
+      test('throws assertion error if called with different viewIds', () {
+        final differentView = PersistedPlatformView(1, 1, 1, 100, 100)..build();
+        expect(() { view.update(differentView); }, throwsAssertionError);
+      });
+    });
+
+    group('canUpdateAsMatch', () {
+      test('returns true when viewId is the same', () {
+        final sameView = PersistedPlatformView(0, 1, 1, 100, 100)..build();
+        expect(view.canUpdateAsMatch(sameView), isTrue);
+      });
+
+      test('returns false when viewId is different', () {
+        final differentView = PersistedPlatformView(1, 1, 1, 100, 100)..build();
+        expect(view.canUpdateAsMatch(differentView), isFalse);
+      });
+
+      test('returns false when other view is not a PlatformView', () {
+        final anyView = PersistedOpacity(null, 1, Offset(0, 0))..build();
+        expect(view.canUpdateAsMatch(anyView), isFalse);
+      });
+    });
+  });
+}
+
+// Sends a platform message to create a Platform View with the given id and viewType.
+Future<void> _createPlatformView(int id, String viewType) {
+  final completer = Completer<void>();
+  window.sendPlatformMessage(
+    'flutter/platform_views',
+    codec.encodeMethodCall(MethodCall(
+      'create',
+      <String, dynamic>{'id': id, 'viewType': viewType,},
+    )),
+    (dynamic _) => completer.complete(),
+  );
+  return completer.future;
+}


### PR DESCRIPTION
## Description

Override `canUpdateAsMatch` on the PersistedPlatformView class. This allows the framework to discard potential match candidates when their viewId's differ. (The current implementation would allow for partial matches and was causing trouble (see linked bug below)).

Slightly simplify the `update` method of the Platform View, since we don't have to worry about the case where viewIds are equal.

Remove leftover `@protected` annotations from the engine.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/65529

## Tests

I added the following tests:

* web_ui/test/engine/surface/platform_view_test.dart (new file)

Ran `felt test` and all unit tests seem to pass. Didn't wait for chromedriver tests.

(However I'm not sure if the tests I wrote are OK wrt initializing the PersistedPlatformViews by hand)


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
