### PR TITLE
creating test result directory before running tests

### DIFF
--- a/lib/web_ui/dev/environment.dart
+++ b/lib/web_ui/dev/environment.dart
@@ -168,6 +168,13 @@ class Environment {
         'goldens',
       ));
 
+  /// Directory to add test results which would later be uploaded to a gcs
+  /// bucket by LUCI.
+  io.Directory get webUiTestResultsDirectory => io.Directory(pathlib.join(
+        webUiDartToolDir.path,
+        'test_results',
+      ));
+
   /// Path to the screenshots taken by iOS simulator.
   io.Directory get webUiSimulatorScreenshotsDirectory =>
       io.Directory(pathlib.join(

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -248,17 +248,8 @@ To automatically create this file call matchGoldenFile('$filename', write: true)
     );
 
     if (diff.rate > 0) {
-      // Images are different, so produce some debug info
-      final String testResultsPath = isCirrus
-          ? p.join(
-              Platform.environment['CIRRUS_WORKING_DIR'],
-              'test_results',
-            )
-          : p.join(
-              env.environment.webUiDartToolDir.path,
-              'test_results',
-            );
-      Directory(testResultsPath).createSync(recursive: true);
+      final String testResultsPath =
+          env.environment.webUiTestResultsDirectory.path;
       final String basename = p.basenameWithoutExtension(file.path);
 
       final File actualFile =

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -184,9 +184,10 @@ class TestCommand extends Command<bool> with ArgUtils {
   /// Preparations before running the tests such as booting simulators or
   /// creating directories.
   Future<void> _prepare() async {
-    if(!environment.webUiTestResultsDirectory.existsSync()) {
-      environment.webUiTestResultsDirectory.createSync(recursive: true);
+    if (environment.webUiTestResultsDirectory.existsSync()) {
+      environment.webUiTestResultsDirectory.deleteSync(recursive: true);
     }
+    environment.webUiTestResultsDirectory.createSync(recursive: true);
 
     // In order to run iOS Safari unit tests we need to make sure iOS Simulator
     // is booted.

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -170,12 +170,7 @@ class TestCommand extends Command<bool> with ArgUtils {
       await _runPubGet();
     }
 
-    // In order to run iOS Safari unit tests we need to make sure iOS Simulator
-    // is booted.
-    if (isSafariIOS) {
-      await IosSafariArgParser.instance.initIosSimulator();
-    }
-
+    await _prepare();
     await _buildTargets();
 
     if (runAllTests) {
@@ -184,6 +179,20 @@ class TestCommand extends Command<bool> with ArgUtils {
       await _runSpecificTests(targetFiles);
     }
     return true;
+  }
+
+  /// Preparations before running the tests such as booting simulators or
+  /// creating directories.
+  Future<void> _prepare() async {
+    if(!environment.webUiTestResultsDirectory.existsSync()) {
+      environment.webUiTestResultsDirectory.createSync(recursive: true);
+    }
+
+    // In order to run iOS Safari unit tests we need to make sure iOS Simulator
+    // is booted.
+    if (isSafariIOS) {
+      await IosSafariArgParser.instance.initIosSimulator();
+    }
   }
 
   /// Builds all test targets that will be run.


### PR DESCRIPTION
Recipes are searching for this directory, so far it was created only during the screenshot tests which caused breakage in a few times on recipes:

- When we want to run only firefox tests on a recipe
- Where there is no failing screenshot (or no screenshot with a difference)
- On bots where do not run screenshot tests (such as windows bots)

The [file api](https://chromium.googlesource.com/infra/luci/recipes-py/+/84b31ee25882e7f1b190dbed036fa6c3da0b53fc/README.recipes.md#recipe_modules-file) used in recipes does not have a method to check the existence of the directory without throwing an error, therefore this change is best to be made on the repo side.