### PR TITLE
enable Web Framework tests on try builds

### DIFF
--- a/ci/dev/try_builders.json
+++ b/ci/dev/try_builders.json
@@ -31,6 +31,11 @@
          "enabled": true
       },
       {
+        "name":"Linux Web Framework tests",
+        "repo":"engine",
+        "enabled": true
+      },
+      {
          "name":"Mac Android AOT Engine",
          "repo":"engine",
          "enabled": true

--- a/ci/dev/try_builders.json
+++ b/ci/dev/try_builders.json
@@ -33,7 +33,8 @@
       {
         "name":"Linux Web Framework tests",
         "repo":"engine",
-        "enabled": true
+        "enabled": true,
+        "run_if": ["DEPS", "lib/web_ui/**", "web_sdk/**"]
       },
       {
          "name":"Mac Android AOT Engine",


### PR DESCRIPTION
Enable Web Framework tests on try builds.

These tests run successfully on post commit: https://ci.chromium.org/p/flutter/builders/prod/Linux%20Web%20Framework%20tests/1

related: https://github.com/flutter/flutter/issues/65052