### PR TITLE
clarify that offset is not used in addPlatformView for iOS/Android

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -715,8 +715,6 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
 
   /// Adds a platform view (e.g an iOS UIView) to the scene.
   ///
-  /// Only supported on iOS, this is currently a no-op on other platforms.
-  ///
   /// On iOS this layer splits the current output surface into two surfaces, one for the scene nodes
   /// preceding the platform view, and one for the scene nodes following the platform view.
   ///
@@ -729,6 +727,8 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// With a platform view in the scene, Quartz has to composite the two Flutter surfaces and the
   /// embedded UIView. In addition to that, on iOS versions greater than 9, the Flutter frames are
   /// synchronized with the UIView frames adding additional performance overhead.
+  ///
+  /// The `offset` argument is not used for iOS and Android.
   void addPlatformView(
     int viewId, {
     Offset offset = Offset.zero,

--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -707,21 +707,15 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
     SceneBuilder sceneBuilder,
     int viewId,
     double width,
-    double height, {
-    Offset overlayOffset,
-  }) {
-    overlayOffset ??= const Offset(50, 50);
+    double height,
+  ) {
     if (Platform.isIOS) {
-      sceneBuilder.addPlatformView(viewId, offset: overlayOffset, width: width, height: height);
+      sceneBuilder.addPlatformView(viewId, width: width, height: height);
     } else if (Platform.isAndroid) {
       if (usesAndroidHybridComposition) {
-        // Hybrid composition does not support `offset`.
-        // https://github.com/flutter/flutter/issues/60630
-        sceneBuilder.pushOffset(overlayOffset.dx, overlayOffset.dy);
         sceneBuilder.addPlatformView(viewId, width: width, height: height);
-        sceneBuilder.pop();
       } else if (_textureId != null) {
-        sceneBuilder.addTexture(_textureId, offset: overlayOffset, width: width, height: height);
+        sceneBuilder.addTexture(_textureId, width: width, height: height);
       }
     } else {
       throw UnsupportedError('Platform ${Platform.operatingSystem} is not supported');
@@ -740,7 +734,6 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
       viewId,
       500,
       500,
-      overlayOffset: overlayOffset,
     );
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);


### PR DESCRIPTION
Description
Currently addPlatformView's offset parameter is not used for iOS/Android. This PR clarifies that offset is not used for in addPlatformView for iOS and Android and removes offset from the scenario_app test for iOS/Android platform views.

Not yet removing offset completely since it may be used for Fuschia/Web. It may be desirable to remove offset completely for consistency between the platforms.

Also updated outdated comment stating addPlatformView is only supported for iOS.

## Related Issues
https://github.com/flutter/flutter/issues/37029

## Tests

I added the following tests:
N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
