### PR TITLE
Locale -> LanguageRange conversion to be more general in Android platformResolvedLocale

### DIFF
--- a/shell/platform/android/io/flutter/plugin/localization/LocalizationPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/localization/LocalizationPlugin.java
@@ -51,8 +51,15 @@ public class LocalizationPlugin {
       for (int index = 0; index < localeCount; ++index) {
         Locale locale = localeList.get(index);
         String localeString = locale.toString();
-        // This string replacement converts the locale string into the ranges format.
-        languageRanges.add(new Locale.LanguageRange(localeString.replace("_", "-")));
+        // Convert locale string into language range format.
+        String fullRange = locale.getLanguage();
+        if (!locale.getScript().isEmpty()) {
+          fullRange += "-" + locale.getScript();
+        }
+        if (!locale.getCountry().isEmpty()) {
+          fullRange += "-" + locale.getCountry();
+        }
+        languageRanges.add(new Locale.LanguageRange(fullRange));
         languageRanges.add(new Locale.LanguageRange(locale.getLanguage()));
         languageRanges.add(new Locale.LanguageRange(locale.getLanguage() + "-*"));
       }

--- a/shell/platform/android/io/flutter/plugin/localization/LocalizationPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/localization/LocalizationPlugin.java
@@ -50,7 +50,6 @@ public class LocalizationPlugin {
       int localeCount = localeList.size();
       for (int index = 0; index < localeCount; ++index) {
         Locale locale = localeList.get(index);
-        String localeString = locale.toString();
         // Convert locale string into language range format.
         String fullRange = locale.getLanguage();
         if (!locale.getScript().isEmpty()) {

--- a/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -215,6 +215,19 @@ public class LocalizationPluginTest {
     assertEquals(result[0], "it");
     assertEquals(result[1], "IT");
     assertEquals(result[2], "");
+
+    supportedLocales =
+        new String[] {
+          "zh", "CN", "Hant",
+          "zh", "CN", "Hans",
+        };
+    userLocale = new Locale("zh", "CN");
+    setLegacyLocale(config, userLocale);
+    result = flutterJNI.computePlatformResolvedLocale(supportedLocales);
+    assertEquals(result.length, 3);
+    assertEquals(result[0], "zh");
+    assertEquals(result[1], "CN");
+    assertEquals(result[2], "Hans");
   }
 
   // Tests the legacy pre API 24 algorithm.
@@ -306,19 +319,6 @@ public class LocalizationPluginTest {
     assertEquals(result[0], "fr");
     assertEquals(result[1], "");
     assertEquals(result[2], "");
-
-    supportedLocales =
-        new String[] {
-          "zh", "CN", "Hant",
-          "zh", "CN", "Hans",
-        };
-    userLocale = new Locale("zh", "CN");
-    setLegacyLocale(config, userLocale);
-    result = flutterJNI.computePlatformResolvedLocale(supportedLocales);
-    assertEquals(result.length, 3);
-    assertEquals(result[0], "zh");
-    assertEquals(result[1], "CN");
-    assertEquals(result[2], "Hans");
   }
 
   private static void setApiVersion(int apiVersion) {

--- a/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -306,6 +306,19 @@ public class LocalizationPluginTest {
     assertEquals(result[0], "fr");
     assertEquals(result[1], "");
     assertEquals(result[2], "");
+
+    supportedLocales =
+        new String[] {
+          "zh", "CN", "Hant",
+          "zh", "CN", "Hans",
+        };
+    userLocale = new Locale("zh", "CN");
+    setLegacyLocale(config, userLocale);
+    result = flutterJNI.computePlatformResolvedLocale(supportedLocales);
+    assertEquals(result.length, 3);
+    assertEquals(result[0], "zh");
+    assertEquals(result[1], "CN");
+    assertEquals(result[2], "Hans");
   }
 
   private static void setApiVersion(int apiVersion) {

--- a/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -123,11 +123,11 @@ public class LocalizationPluginTest {
 
     supportedLocales =
         new String[] {
-          "zh", "CN", "Hant",
           "zh", "CN", "Hans",
+          "zh", "HK", "Hant",
         };
-    Locale userLocale = new Locale("zh", "CN");
-    setLegacyLocale(config, userLocale);
+    localeList = new LocaleList(new Locale("zh", "CN"));
+    when(config.getLocales()).thenReturn(localeList);
     result = flutterJNI.computePlatformResolvedLocale(supportedLocales);
     assertEquals(result.length, 3);
     assertEquals(result[0], "zh");

--- a/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -120,6 +120,19 @@ public class LocalizationPluginTest {
     assertEquals(result[0], "it");
     assertEquals(result[1], "IT");
     assertEquals(result[2], "");
+
+    supportedLocales =
+        new String[] {
+          "zh", "CN", "Hant",
+          "zh", "CN", "Hans",
+        };
+    Locale userLocale = new Locale("zh", "CN");
+    setLegacyLocale(config, userLocale);
+    result = flutterJNI.computePlatformResolvedLocale(supportedLocales);
+    assertEquals(result.length, 3);
+    assertEquals(result[0], "zh");
+    assertEquals(result[1], "CN");
+    assertEquals(result[2], "Hans");
   }
 
   // This test should be synced with the version for API 26.
@@ -215,19 +228,6 @@ public class LocalizationPluginTest {
     assertEquals(result[0], "it");
     assertEquals(result[1], "IT");
     assertEquals(result[2], "");
-
-    supportedLocales =
-        new String[] {
-          "zh", "CN", "Hant",
-          "zh", "CN", "Hans",
-        };
-    userLocale = new Locale("zh", "CN");
-    setLegacyLocale(config, userLocale);
-    result = flutterJNI.computePlatformResolvedLocale(supportedLocales);
-    assertEquals(result.length, 3);
-    assertEquals(result[0], "zh");
-    assertEquals(result[1], "CN");
-    assertEquals(result[2], "Hans");
   }
 
   // Tests the legacy pre API 24 algorithm.


### PR DESCRIPTION
## Description

Some locales' toString may produce a format that does not simply convert to `LanguageRange` string with a replace. Use a more formal conversion instead.
