### PR TITLE
remove web_tests from cirrus since they already run on LUCI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,28 +1,5 @@
 gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def3cf0d380830f06687a89ea69c87344c5ade369700fe]
 
-web_shard_template: &WEB_SHARD_TEMPLATE
-  only_if: "changesInclude('.cirrus.yml', 'DEPS', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
-  environment:
-    # As of March 2020, the Web shards needed 16G of RAM and 4 CPUs to run all framework tests with goldens without flaking.
-    # The tests are encountering a flake in Chrome. Increasing the number of shards to decrease race conditions.
-    # Shard number kept at 8 for the engine since 12 shards exhausted the Cirrus limits.
-    # https://github.com/flutter/flutter/issues/62510
-    WEB_SHARD_COUNT: 8
-    CPU: 4
-    MEMORY: 16G
-    CHROME_NO_SANDBOX: true
-  compile_host_script: |
-    cd $ENGINE_PATH/src
-    ./flutter/tools/gn --unoptimized --full-dart-sdk
-    ninja -C out/host_debug_unopt
-  fetch_framework_script: |
-    cd $ENGINE_PATH/src/flutter/tools
-    ./clone_flutter.sh
-    cd $FRAMEWORK_PATH/flutter
-    bin/flutter update-packages --local-engine=host_debug_unopt
-  script:
-    - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
-
 # LINUX
 task:
   gke_container:
@@ -101,31 +78,6 @@ task:
       test_framework_script: |
         cd $FRAMEWORK_PATH/flutter/packages/flutter
         ../../bin/flutter test --local-engine=host_debug_unopt
-
-    # PLEASE KEEP THESE WEB TEST SHARDS IN SYNC WITH THEIR COUNTERPARTS IN flutter/flutter's CIRRUS CONFIG.
-    - name: web_tests-0-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-1-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-2-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-3-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-4-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-5-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-6-linux
-      << : *WEB_SHARD_TEMPLATE
-
-    - name: web_tests-7_last-linux # last Web shard must end with _last
-      << : *WEB_SHARD_TEMPLATE
 
     - name: build_test
       build_script: |


### PR DESCRIPTION
remove web_tests from cirrus since they already run on LUCI:

prod: https://ci.chromium.org/p/flutter/builders/prod/Linux%20Web%20Framework%20tests
try: https://ci.chromium.org/p/flutter/builders/try/Linux%20Web%20Framework%20tests

related: https://github.com/flutter/flutter/issues/65052