### PR TITLE
Fix for issue flutter/#66502.

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/path.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/path.dart
@@ -257,6 +257,7 @@ class CkPath implements ui.Path {
 
   @override
   void reset() {
+    _fillType = ui.PathFillType.nonZero;
     _skPath.reset();
   }
 


### PR DESCRIPTION
## Description

Fixes issue #66502 where the fillType is cached on the CkPath and doesn't get synced when the SkPath is reset.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.