### PR TITLE
Revert "Make drain() consistently asynchronous."

### DIFF
--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -181,11 +181,7 @@ class ChannelBuffers {
   ///
   /// This should be called once a channel is prepared to handle messages
   /// (i.e. when a message handler is setup in the framework).
-  ///
-  /// The messages are processed by calling the given `callback`. Each message
-  /// is processed in its own microtask.
   Future<void> drain(String channel, DrainChannelCallback callback) async {
-    await null; // Ensures that the rest of this method is scheduled in a microtask.
     while (!_isEmpty(channel)) {
       final _StoredMessage message = _pop(channel)!;
       await callback(message.data, message.callback);

--- a/lib/web_ui/lib/src/ui/channel_buffers.dart
+++ b/lib/web_ui/lib/src/ui/channel_buffers.dart
@@ -119,7 +119,6 @@ class ChannelBuffers {
   }
 
   Future<void> drain(String channel, DrainChannelCallback callback) async {
-    await null; // Ensures that the rest of this method is scheduled in a microtask.
     while (!_isEmpty(channel)) {
       final _StoredMessage message = _pop(channel)!;
       await callback(message.data, message.callback);

--- a/testing/dart/channel_buffers_test.dart
+++ b/testing/dart/channel_buffers_test.dart
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
-
-import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
@@ -34,32 +32,6 @@ void main() {
       expect(drainedCallback, equals(callback));
       return;
     });
-  });
-
-  test('drain is async', () async {
-    const String channel = 'foo';
-    final ByteData data = _makeByteData('message');
-    final ui.ChannelBuffers buffers = ui.ChannelBuffers();
-    final ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
-    buffers.push(channel, data, callback);
-    final List<String> log = <String>[];
-    final Completer<void> completer = Completer<void>();
-    scheduleMicrotask(() { log.add('before drain, microtask'); });
-    log.add('before drain');
-    buffers.drain(channel, (ByteData drainedData, ui.PlatformMessageResponseCallback drainedCallback) async {
-      log.add('callback');
-      completer.complete();
-    });
-    log.add('after drain, before await');
-    await completer.future;
-    log.add('after await');
-    expect(log, <String>[
-      'before drain',
-      'after drain, before await',
-      'before drain, microtask',
-      'callback',
-      'after await'
-    ]);
   });
 
   test('push drain zero', () async {


### PR DESCRIPTION
Reverts flutter/engine#21062, which caused a hang in a google3 test.