### PR TITLE
Remove ASCII art from mDNS error log

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -115,18 +115,16 @@
     FML_LOG(ERROR) << "Failed to register observatory port with mDNS with error " << err << ".";
     if (@available(iOS 14.0, *)) {
       FML_LOG(ERROR)
-          << "▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒\n"
           << "On iOS 14+, local network broadcast in apps need to be declared in "
           << "the app's Info.plist. Debug and profile Flutter apps and modules host "
           << "VM services on the local network to support debugging features such "
-          << "as hot reload and DevTools.\n\nTo make your Flutter app or module "
+          << "as hot reload and DevTools. To make your Flutter app or module "
           << "attachable and debuggable, add a '" << registrationType << "' value "
           << "to the 'NSBonjourServices' key in your Info.plist for the Debug/"
-          << "Profile configurations.\n\n"
+          << "Profile configurations. "
           << "For more information, see "
           // Update link to a specific header as needed.
-          << "https://flutter.dev/docs/development/add-to-app/ios/project-setup"
-          << "\n▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒";
+          << "https://flutter.dev/docs/development/add-to-app/ios/project-setup";
     }
   } else {
     DNSServiceSetDispatchQueue(_dnsServiceRef, dispatch_get_main_queue());

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -114,17 +114,16 @@
   if (err != 0) {
     FML_LOG(ERROR) << "Failed to register observatory port with mDNS with error " << err << ".";
     if (@available(iOS 14.0, *)) {
-      FML_LOG(ERROR)
-          << "On iOS 14+, local network broadcast in apps need to be declared in "
-          << "the app's Info.plist. Debug and profile Flutter apps and modules host "
-          << "VM services on the local network to support debugging features such "
-          << "as hot reload and DevTools. To make your Flutter app or module "
-          << "attachable and debuggable, add a '" << registrationType << "' value "
-          << "to the 'NSBonjourServices' key in your Info.plist for the Debug/"
-          << "Profile configurations. "
-          << "For more information, see "
-          // Update link to a specific header as needed.
-          << "https://flutter.dev/docs/development/add-to-app/ios/project-setup";
+      FML_LOG(ERROR) << "On iOS 14+, local network broadcast in apps need to be declared in "
+                     << "the app's Info.plist. Debug and profile Flutter apps and modules host "
+                     << "VM services on the local network to support debugging features such "
+                     << "as hot reload and DevTools. To make your Flutter app or module "
+                     << "attachable and debuggable, add a '" << registrationType << "' value "
+                     << "to the 'NSBonjourServices' key in your Info.plist for the Debug/"
+                     << "Profile configurations. "
+                     << "For more information, see "
+                     // Update link to a specific header as needed.
+                     << "https://flutter.dev/docs/development/add-to-app/ios/project-setup";
     }
   } else {
     DNSServiceSetDispatchQueue(_dnsServiceRef, dispatch_get_main_queue());


### PR DESCRIPTION
## Description

Remove ASCII art and whitespace from log.  It looks weird in `flutter` output.
![Screen Shot 2020-09-24 at 8 41 41 PM](https://user-images.githubusercontent.com/682784/94224299-d16f9b00-fea6-11ea-92ec-33b5f72b73fd.png)

## Related Issues

#20991

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*