### PR TITLE
Add workaround for missing fl_method_xxx_response_get_type() symbols

### DIFF
--- a/shell/platform/linux/fl_method_response.cc
+++ b/shell/platform/linux/fl_method_response.cc
@@ -26,8 +26,11 @@ struct _FlMethodNotImplementedResponse {
   FlMethodResponse parent_instance;
 };
 
-// Added here to stop the compiler from optimising this function away.
+// Added here to stop the compiler from optimising these functions away.
 G_MODULE_EXPORT GType fl_method_response_get_type();
+G_MODULE_EXPORT GType fl_method_success_response_get_type();
+G_MODULE_EXPORT GType fl_method_error_response_get_type();
+G_MODULE_EXPORT GType fl_method_not_implemented_response_get_type();
 
 G_DEFINE_TYPE(FlMethodResponse, fl_method_response, G_TYPE_OBJECT)
 G_DEFINE_TYPE(FlMethodSuccessResponse,


### PR DESCRIPTION
## Description

Using the following macros:

- FL_METHOD_SUCCESS_RESPONSE()
- FL_METHOD_ERROR_RESPONSE()
- FL_METHOD_NOT_IMPLEMENTED_RESPONSE()

Would result to linking errors:

    /usr/bin/ld: foo_plugin.so: undefined reference to `fl_method_success_response_get_type'
    /usr/bin/ld: foo_plugin.so: undefined reference to `fl_method_error_response_get_type'
    /usr/bin/ld: foo_plugin.so: undefined reference to `fl_method_not_implemented_response_get_type'

## Related PR

https://github.com/flutter/engine/pull/18802

## Tests

N/A

## Checklist

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [-] I updated/added relevant documentation.
- [x ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
