### PR TITLE
fl_method_response.cc: fix lint failures

### DIFF
--- a/shell/platform/linux/fl_method_response.cc
+++ b/shell/platform/linux/fl_method_response.cc
@@ -97,16 +97,19 @@ G_MODULE_EXPORT FlValue* fl_method_response_get_result(FlMethodResponse* self,
     FlValue* details =
         fl_method_error_response_get_details(FL_METHOD_ERROR_RESPONSE(self));
     g_autofree gchar* details_text = nullptr;
-    if (details != nullptr)
+    if (details != nullptr) {
       details_text = fl_value_to_string(details);
+    }
 
     g_autoptr(GString) error_message = g_string_new("");
     g_string_append_printf(error_message, "Remote code returned error %s",
                            code);
-    if (message != nullptr)
+    if (message != nullptr) {
       g_string_append_printf(error_message, ": %s", message);
-    if (details_text != nullptr)
+    }
+    if (details_text != nullptr) {
       g_string_append_printf(error_message, " %s", details_text);
+    }
     g_set_error_literal(error, FL_METHOD_RESPONSE_ERROR,
                         FL_METHOD_RESPONSE_ERROR_REMOTE_ERROR,
                         error_message->str);
@@ -128,8 +131,9 @@ G_MODULE_EXPORT FlMethodSuccessResponse* fl_method_success_response_new(
   FlMethodSuccessResponse* self = FL_METHOD_SUCCESS_RESPONSE(
       g_object_new(fl_method_success_response_get_type(), nullptr));
 
-  if (result != nullptr)
+  if (result != nullptr) {
     self->result = fl_value_ref(result);
+  }
 
   return self;
 }


### PR DESCRIPTION
## Description

```
The following errors have been reported by the Engine Clang Tidy Linter.  For
more information on addressing these issues please see:
https://github.com/flutter/flutter/wiki/Engine-Clang-Tidy-Linter

🔶 linting flutter/shell/platform/linux/fl_method_response.cc
Jobs: 100% done,   1/1   completed,  0 in progress,   0 pending,   0 failed.    
❌ Failures for clang-tidy on /b/s/w/ir/cache/builder/src/flutter/shell/platform/linux/fl_method_response.cc:
/b/s/w/ir/cache/builder/src/flutter/shell/platform/linux/fl_method_response.cc:103:28: warning: statement should be inside braces [google-readability-braces-around-statements]
    if (details != nullptr)
                           ^
                            {
/b/s/w/ir/cache/builder/src/flutter/shell/platform/linux/fl_method_response.cc:109:28: warning: statement should be inside braces [google-readability-braces-around-statements]
    if (message != nullptr)
                           ^
                            {
/b/s/w/ir/cache/builder/src/flutter/shell/platform/linux/fl_method_response.cc:111:33: warning: statement should be inside braces [google-readability-braces-around-statements]
    if (details_text != nullptr)
                                ^
                                 {
/b/s/w/ir/cache/builder/src/flutter/shell/platform/linux/fl_method_response.cc:134:25: warning: statement should be inside braces [google-readability-braces-around-statements]
  if (result != nullptr)
                        ^
                         {
```

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8868191791066544960/+/steps/lint_test/0/stdout

## Related PR

https://github.com/flutter/engine/pull/21405

## Tests

N/A

## Checklist

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
