### PR TITLE
Fix linking issue (missing wayland-client library)

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -80,7 +80,10 @@ source_set("flutter_linux_sources") {
              "fl_standard_message_codec_private.h",
            ]
 
-  configs += [ "//flutter/shell/platform/linux/config:gtk" ]
+  configs += [
+    "//flutter/shell/platform/linux/config:gtk",
+    "//flutter/shell/platform/linux/config:wayland-client",
+  ]
 
   sources = [
     "egl_utils.cc",

--- a/shell/platform/linux/config/BUILD.gn
+++ b/shell/platform/linux/config/BUILD.gn
@@ -22,3 +22,7 @@ pkg_config("egl") {
 pkg_config("wayland-egl") {
   packages = [ "wayland-egl" ]
 }
+
+pkg_config("wayland-client") {
+  packages = [ "wayland-client" ]
+}


### PR DESCRIPTION
Linking libflutter_linux_gtk.so shared library fails on
embedded platform as follows:

 fl_renderer_wayland_dispose(_GObject*):
	error: undefined reference to 'wl_proxy_destroy'
 fl_renderer_wayland_dispose(_GObject*):
	error: undefined reference to 'wl_proxy_marshal'
 fl_renderer_wayland_dispose(_GObject*):
	error: undefined reference to 'wl_proxy_destroy'
 fl_renderer_wayland_dispose(_GObject*):
	error: undefined reference to 'wl_proxy_marshal'
 fl_renderer_wayland_dispose(_GObject*):
	error: undefined reference to 'wl_proxy_destroy'
 fl_renderer_wayland_dispose(_GObject*):
	error: undefined reference to 'wl_proxy_marshal'
 fl_renderer_wayland_dispose(_GObject*):
	error: undefined reference to 'wl_proxy_destroy'
 fl_renderer_wayland_dispose(_GObject*):
	error: undefined reference to 'wl_proxy_marshal'
 fl_renderer_wayland_create_surfaces(_FlRenderer*, _GtkWidget*, void*, void*, void**, void**, _GError**):
	error: undefined reference to 'wl_proxy_marshal_constructor'
 fl_renderer_wayland_create_surfaces(_FlRenderer*, _GtkWidget*, void*, void*, void**, void**, _GError**):
	error: undefined reference to 'wl_proxy_marshal_constructor'
 fl_renderer_wayland_create_surfaces(_FlRenderer*, _GtkWidget*, void*, void*, void**, void**, _GError**):
	error: undefined reference to 'wl_surface_interface'
 fl_renderer_wayland_on_window_map(_FlRendererWayland*, _GtkWidget*):
	error: undefined reference to 'wl_proxy_marshal_constructor'
 fl_renderer_wayland_on_window_map(_FlRendererWayland*, _GtkWidget*):
	error: undefined reference to 'wl_proxy_add_listener'
 fl_renderer_wayland_on_window_map(_FlRendererWayland*, _GtkWidget*):
	error: undefined reference to 'wl_display_roundtrip'
 fl_renderer_wayland_on_window_map(_FlRendererWayland*, _GtkWidget*):
	error: undefined reference to 'wl_proxy_marshal_constructor'
 fl_renderer_wayland_on_window_map(_FlRendererWayland*, _GtkWidget*):
	error: undefined reference to 'wl_registry_interface'
 fl_renderer_wayland_on_window_map(_FlRendererWayland*, _GtkWidget*):
	error: undefined reference to 'wl_subsurface_interface'
 fl_renderer_wayland_on_window_map(_FlRendererWayland*, _GtkWidget*):
	error: undefined reference to 'wl_region_interface'
 registry_handle_global(void*, wl_registry*, unsigned int, char const*, unsigned int):
	error: undefined reference to 'wl_proxy_marshal_constructor_versioned'
 registry_handle_global(void*, wl_registry*, unsigned int, char const*, unsigned int):
	error: undefined reference to 'wl_subcompositor_interface'

As fl_renderer_wayland.cc uses directly some of the wayland-client
related functions it should also add this library as a dependency.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
