### PR TITLE
WIP: API to diff layer tree to track damage

### DIFF
--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -10,6 +10,8 @@ source_set("flow") {
   sources = [
     "compositor_context.cc",
     "compositor_context.h",
+    "diff_context.cc",
+    "diff_context.h",
     "embedded_views.cc",
     "embedded_views.h",
     "gl_context_switch.cc",

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/flow/compositor_context.h"
 
+#include "flutter/flow/diff_context.h"
 #include "flutter/flow/layers/layer_tree.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 
@@ -69,9 +70,37 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
 
 RasterStatus CompositorContext::ScopedFrame::Raster(
     flutter::LayerTree& layer_tree,
-    bool ignore_raster_cache) {
+    bool ignore_raster_cache,
+    FrameDamage* frame_damage) {
   TRACE_EVENT0("flutter", "CompositorContext::ScopedFrame::Raster");
-  bool root_needs_readback = layer_tree.Preroll(*this, ignore_raster_cache);
+
+  SkRect clip_rect = kGiantRect;
+
+  if (frame_damage) {
+    DiffContext context(layer_tree.device_pixel_ratio());
+    context.PushCullRect(SkRect::MakeIWH(layer_tree.frame_size().width(),
+                                         layer_tree.frame_size().height()));
+
+    {
+      DiffContext::AutoSubtreeRestore subtree(&context);
+      const Layer* prev_root_layer = nullptr;
+      if (!frame_damage->prev_layer_tree ||
+          frame_damage->prev_layer_tree->frame_size() !=
+              layer_tree.frame_size()) {
+        context.MarkSubtreeDirty();
+      } else {
+        prev_root_layer = frame_damage->prev_layer_tree->root_layer();
+      }
+      layer_tree.root_layer()->Diff(&context, prev_root_layer);
+    }
+
+    frame_damage->damage_out =
+        context.GetDamage(frame_damage->additional_damage);
+    clip_rect = SkRect::Make(frame_damage->damage_out.framebuffer_damage);
+  }
+
+  bool root_needs_readback =
+      layer_tree.Preroll(*this, ignore_raster_cache, clip_rect);
   bool needs_save_layer = root_needs_readback && !surface_supports_readback();
   PostPrerollResult post_preroll_result = PostPrerollResult::kSuccess;
   if (view_embedder_ && raster_thread_merger_) {
@@ -85,6 +114,12 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
   if (post_preroll_result == PostPrerollResult::kSkipAndRetryFrame) {
     return RasterStatus::kSkipAndRetry;
   }
+
+  SkAutoCanvasRestore restore(canvas(), clip_rect != kGiantRect);
+  if (clip_rect != kGiantRect) {
+    canvas()->clipRect(clip_rect);
+  }
+
   // Clearing canvas after preroll reduces one render target switch when preroll
   // paints some raster cache.
   if (canvas()) {
@@ -101,6 +136,7 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
   if (canvas() && needs_save_layer) {
     canvas()->restore();
   }
+
   return RasterStatus::kSuccess;
 }
 

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "flutter/flow/diff_context.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/instrumentation.h"
 #include "flutter/flow/raster_cache.h"
@@ -48,6 +49,17 @@ enum class RasterStatus {
   kFailed
 };
 
+struct FrameDamage {
+  // IN: Previous layer tree
+  const LayerTree* prev_layer_tree = nullptr;
+
+  // IN: Additional damage (accumulated for double / triple buffering)
+  SkIRect additional_damage = SkIRect::MakeEmpty();
+
+  // OUT: Damage
+  Damage damage_out;
+};
+
 class CompositorContext {
  public:
   class ScopedFrame {
@@ -78,7 +90,8 @@ class CompositorContext {
     GrDirectContext* gr_context() const { return gr_context_; }
 
     virtual RasterStatus Raster(LayerTree& layer_tree,
-                                bool ignore_raster_cache);
+                                bool ignore_raster_cache,
+                                FrameDamage* frame_damage);
 
    private:
     CompositorContext& context_;

--- a/flow/diff_context.cc
+++ b/flow/diff_context.cc
@@ -1,0 +1,122 @@
+#include "diff_context.h"
+#include "flutter/flow/layers/layer.h"
+
+namespace flutter {
+
+SkRect PaintRegion::GetBounds() const {
+  SkRect res = SkRect::MakeEmpty();
+  for (const auto& r : *this) {
+    res.join(r);
+  }
+  return res;
+}
+
+DiffContext::DiffContext(double frame_device_pixel_ratio)
+    : rects_(std::make_shared<std::vector<SkRect>>()),
+      frame_device_pixel_ratio_(frame_device_pixel_ratio) {}
+
+void DiffContext::BeginSubtree() {
+  state_stack_.push_back(state_);
+  state_.rect_index_ = rects_->size();
+}
+
+void DiffContext::EndSubtree() {
+  assert(!state_stack_.empty());
+  state_ = std::move(state_stack_.back());
+  state_stack_.pop_back();
+}
+
+DiffContext::State::State()
+    : dirty(false), cull_rect(kGiantRect), rect_index_(0) {}
+
+void DiffContext::PushTransform(const SkMatrix& transform) {
+  state_.transform.preConcat(transform);
+  SkMatrix inverse_transform;
+  // Perspective projections don't produce rectangles that are useful for
+  // culling for some reason.
+  if (!transform.hasPerspective() && transform.invert(&inverse_transform)) {
+    inverse_transform.mapRect(&state_.cull_rect);
+  } else {
+    state_.cull_rect = kGiantRect;
+  }
+}
+
+Damage DiffContext::GetDamage(
+    const SkIRect& accumulated_framebuffer_damage) const {
+  SkRect framebuffer = SkRect::Make(accumulated_framebuffer_damage);
+  framebuffer.join(damage_);
+  SkRect net(damage_);
+
+  for (const auto& r : readbacks_) {
+    if (r.rect.intersects(net)) {
+      net.join(r.rect);
+    }
+    if (r.rect.intersects(framebuffer)) {
+      framebuffer.join(r.rect);
+    }
+  }
+
+  Damage res;
+  framebuffer.roundOut(&res.framebuffer_damage);
+  net.roundOut(&res.net_damage);
+  return res;
+}
+
+bool DiffContext::PushCullRect(const SkRect& clip) {
+  return state_.cull_rect.intersect(clip);
+}
+
+void DiffContext::MarkSubtreeDirty(const PaintRegion& previous_paint_region) {
+  assert(!IsSubtreeDirty());
+  if (previous_paint_region.is_valid()) {
+    AddDamage(previous_paint_region);
+  }
+  state_.dirty = true;
+}
+
+void DiffContext::AddPaintRegion(const SkRect& rect) {
+  SkRect r(rect);
+  if (r.intersect(state_.cull_rect)) {
+    state_.transform.mapRect(&r);
+    if (!r.isEmpty()) {
+      rects_->push_back(r);
+      if (IsSubtreeDirty()) {
+        AddDamage(r);
+      }
+    }
+  }
+}
+
+void DiffContext::AddPaintRegion(const PaintRegion& region) {
+  rects_->insert(rects_->end(), region.begin(), region.end());
+}
+
+void DiffContext::AddReadbackRegion(const SkRect& rect) {
+  SkRect r(rect);
+  state_.transform.mapRect(&r);
+  Readback readback;
+  readback.rect = r;
+  readback.position = rects_->size();
+  // Push empty rect as a placeholder for position in current subtree
+  rects_->push_back(SkRect::MakeEmpty());
+  readbacks_.push_back(std::move(readback));
+}
+
+PaintRegion DiffContext::CurrentSubtreeRegion() const {
+  bool has_readback = std::any_of(
+      readbacks_.begin(), readbacks_.end(),
+      [&](const Readback& r) { return r.position >= state_.rect_index_; });
+  return PaintRegion(rects_, state_.rect_index_, rects_->size(), has_readback);
+}
+
+void DiffContext::AddDamage(const PaintRegion& damage) {
+  for (const auto& r : damage) {
+    damage_.join(r);
+  }
+}
+
+void DiffContext::AddDamage(const SkRect& rect) {
+  damage_.join(rect);
+}
+
+}  // namespace flutter

--- a/flow/diff_context.h
+++ b/flow/diff_context.h
@@ -1,0 +1,172 @@
+#ifndef FLUTTER_FLOW_DIFF_CONTEXT_H_
+#define FLUTTER_FLOW_DIFF_CONTEXT_H_
+
+#include <vector>
+#include "flutter/fml/macros.h"
+#include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkRect.h"
+
+namespace flutter {
+
+struct Damage {
+  // This is the damage between current and previous frame;
+  // When using double or triple buffering, this damage must be acumulated
+  // for each "inactive" framebuffer and then be provided as additional_damage.
+  SkIRect net_damage;
+
+  // Reflects actual change to target framebuffer; This is net_damage + damage
+  // previously acumulated for the framebuffer. If embedder supports partial
+  // update, this is the region that needs to be updated.
+  SkIRect framebuffer_damage;
+};
+
+// Every layer has a PaintRegion that covers screen area where the layer subtree
+// painted anything.
+//
+// The area is used when adding damage of removed or dirty later.
+//
+// Because there is PaintRegion for each layer, it must be able to represent
+// the area with minimal overhead. This is accomplished by having one
+// vector of SkRect shared between all paint regions, and each paint region
+// keeping begin and end index of rects relevant to particular subtree.
+//
+// All rects are in screen coordinates.
+class PaintRegion {
+ public:
+  PaintRegion() {}
+  PaintRegion(std::shared_ptr<std::vector<SkRect>> rects,
+              size_t from,
+              size_t to,
+              bool has_readback)
+      : rects_(rects), from_(from), to_(to), has_readback_(has_readback) {}
+
+  std::vector<SkRect>::const_iterator begin() const {
+    assert(is_valid());
+    return rects_->begin() + from_;
+  }
+
+  std::vector<SkRect>::const_iterator end() const {
+    assert(is_valid());
+    return rects_->begin() + to_;
+  }
+
+  // Compute bounds for this region
+  SkRect GetBounds() const;
+
+  bool is_valid() const { return rects_ != nullptr; }
+
+  // Returns true if there is a layer in subtree represented by this region
+  // that performs readback
+  bool has_readback() const { return has_readback_; }
+
+ private:
+  std::shared_ptr<std::vector<SkRect>> rects_;
+  size_t from_ = 0;
+  size_t to_ = 0;
+  bool has_readback_ = false;
+};
+
+// Tracks state during tree diffing process and computes resulting damage
+class DiffContext {
+ public:
+  explicit DiffContext(double device_pixel_aspect_ratio);
+
+  // Starts a new subtree.
+  void BeginSubtree();
+
+  // Ends current subtree; All modifications to state (transform, cullrect,
+  // dirty) will be restored
+  void EndSubtree();
+
+  // Creates subtree in current scope and closes it on scope exit
+  class AutoSubtreeRestore {
+    FML_DISALLOW_COPY_ASSIGN_AND_MOVE(AutoSubtreeRestore);
+
+   public:
+    explicit AutoSubtreeRestore(DiffContext* context) : context_(context) {
+      context->BeginSubtree();
+    }
+    ~AutoSubtreeRestore() { context_->EndSubtree(); }
+
+   private:
+    DiffContext* context_;
+  };
+
+  // Pushes additional transform for current subtree
+  void PushTransform(const SkMatrix& transform);
+
+  // Pushes cull rect for current subtree
+  bool PushCullRect(const SkRect& clip);
+
+  // Returns transform matrix for current subtree
+  SkMatrix GetTransform() const { return state_.transform; }
+
+  // Return cull rect for current subtree (in local coordinates)
+  SkRect GetCullRect() const { return state_.cull_rect; }
+
+  // Sets the dirty flag on current subtree;
+  //
+  // previous_paint_region, which should represent region of previous subtree
+  // at this level will be added to damage area
+  //
+  // Each paint region added to dirty subtree (through AddPaintRegion) is also
+  // added to damage
+  void MarkSubtreeDirty(
+      const PaintRegion& previous_paint_region = PaintRegion());
+
+  bool IsSubtreeDirty() const { return state_.dirty; }
+
+  // Add paint region for layer; rect is in "local" (layer) coordinates
+  void AddPaintRegion(const SkRect& rect);
+
+  // Add entire paint region for current subtree
+  void AddPaintRegion(const PaintRegion& region);
+
+  // The idea of readback region is that if any part of the readback region
+  // needs to be repainted, then the whole readback region must be repainted;
+  void AddReadbackRegion(const SkRect& rect);
+
+  // Returns the paint region for current subtree; Each rect in paint region is
+  // in screen coordinates; The result should be set to layer's paint_region
+  // before closing the subtree
+  PaintRegion CurrentSubtreeRegion() const;
+
+  // Computes final damage
+  //
+  // additional_damage is the previously accumulated net_damage for
+  // current framebuffer
+  Damage GetDamage(const SkIRect& additional_damage) const;
+
+  double frame_device_pixel_ratio() const { return frame_device_pixel_ratio_; };
+
+ private:
+  struct State {
+    State();
+
+    bool dirty;
+    SkRect cull_rect;
+    SkMatrix transform;
+    size_t rect_index_;
+  };
+
+  std::shared_ptr<std::vector<SkRect>> rects_;
+  State state_;
+  double frame_device_pixel_ratio_;
+  std::vector<State> state_stack_;
+
+  SkRect damage_ = SkRect::MakeEmpty();
+
+  void AddDamage(const SkRect& rect);
+  void AddDamage(const PaintRegion& damage);
+
+  struct Readback {
+    size_t position;
+    SkRect rect;
+  };
+
+  std::vector<Readback> readbacks_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_FLOW_DIFF_CONTEXT_H_

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -11,8 +11,10 @@ BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
 
 void BackdropFilterLayer::Preroll(PrerollContext* context,
                                   const SkMatrix& matrix) {
+  bool active = !context->cull_rect.isEmpty();
+
   Layer::AutoPrerollSaveLayerState save =
-      Layer::AutoPrerollSaveLayerState::Create(context, true, bool(filter_));
+      Layer::AutoPrerollSaveLayerState::Create(context, active, bool(filter_));
   ContainerLayer::Preroll(context, matrix);
 
   // paint bounds is determined by clip, not children

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -14,6 +14,9 @@ void BackdropFilterLayer::Preroll(PrerollContext* context,
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context, true, bool(filter_));
   ContainerLayer::Preroll(context, matrix);
+
+  // paint bounds is determined by clip, not children
+  set_paint_bounds(context->cull_rect);
 }
 
 void BackdropFilterLayer::Paint(PaintContext& context) const {

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -9,6 +9,26 @@ namespace flutter {
 BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
     : filter_(std::move(filter)) {}
 
+void BackdropFilterLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  auto* prev = reinterpret_cast<const BackdropFilterLayer*>(old_layer);
+  if (!context->IsSubtreeDirty()) {
+    assert(prev);
+    if (filter_ != prev->filter_) {
+      context->MarkSubtreeDirty(old_layer->paint_region());
+    }
+  }
+
+  // Backdrop filter paints everywhere in cull rect
+  auto paint_bounds = filter_->computeFastBounds(context->GetCullRect());
+  context->AddPaintRegion(paint_bounds);
+  context->AddReadbackRegion(paint_bounds);
+
+  DiffChildren(context, prev);
+
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void BackdropFilterLayer::Preroll(PrerollContext* context,
                                   const SkMatrix& matrix) {
   bool active = !context->cull_rect.isEmpty();

--- a/flow/layers/backdrop_filter_layer.h
+++ b/flow/layers/backdrop_filter_layer.h
@@ -14,6 +14,8 @@ class BackdropFilterLayer : public ContainerLayer {
  public:
   BackdropFilterLayer(sk_sp<SkImageFilter> filter);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -15,6 +15,22 @@ ClipPathLayer::ClipPathLayer(const SkPath& clip_path, Clip clip_behavior)
   FML_DCHECK(clip_behavior != Clip::none);
 }
 
+void ClipPathLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  auto* prev = reinterpret_cast<const ClipPathLayer*>(old_layer);
+  if (!context->IsSubtreeDirty()) {
+    assert(prev);
+    if (clip_behavior_ != prev->clip_behavior_ ||
+        clip_path_ != prev->clip_path_) {
+      context->MarkSubtreeDirty(old_layer->paint_region());
+    }
+  }
+  if (context->PushCullRect(clip_path_.getBounds())) {
+    DiffChildren(context, prev);
+  }
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "ClipPathLayer::Preroll");
 

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -13,6 +13,8 @@ class ClipPathLayer : public ContainerLayer {
  public:
   ClipPathLayer(const SkPath& clip_path, Clip clip_behavior = Clip::antiAlias);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -11,6 +11,22 @@ ClipRectLayer::ClipRectLayer(const SkRect& clip_rect, Clip clip_behavior)
   FML_DCHECK(clip_behavior != Clip::none);
 }
 
+void ClipRectLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  auto* prev = reinterpret_cast<const ClipRectLayer*>(old_layer);
+  if (!context->IsSubtreeDirty()) {
+    assert(prev);
+    if (clip_behavior_ != prev->clip_behavior_ ||
+        clip_rect_ != prev->clip_rect_) {
+      context->MarkSubtreeDirty(old_layer->paint_region());
+    }
+  }
+  if (context->PushCullRect(clip_rect_)) {
+    DiffChildren(context, prev);
+  }
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "ClipRectLayer::Preroll");
 

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -13,6 +13,7 @@ class ClipRectLayer : public ContainerLayer {
  public:
   ClipRectLayer(const SkRect& clip_rect, Clip clip_behavior);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -11,6 +11,22 @@ ClipRRectLayer::ClipRRectLayer(const SkRRect& clip_rrect, Clip clip_behavior)
   FML_DCHECK(clip_behavior != Clip::none);
 }
 
+void ClipRRectLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  auto* prev = reinterpret_cast<const ClipRRectLayer*>(old_layer);
+  if (!context->IsSubtreeDirty()) {
+    assert(prev);
+    if (clip_behavior_ != prev->clip_behavior_ ||
+        clip_rrect_ != prev->clip_rrect_) {
+      context->MarkSubtreeDirty(old_layer->paint_region());
+    }
+  }
+  if (context->PushCullRect(clip_rrect_.getBounds())) {
+    DiffChildren(context, prev);
+  }
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "ClipRRectLayer::Preroll");
 

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -13,6 +13,8 @@ class ClipRRectLayer : public ContainerLayer {
  public:
   ClipRRectLayer(const SkRRect& clip_rrect, Clip clip_behavior);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -9,6 +9,21 @@ namespace flutter {
 ColorFilterLayer::ColorFilterLayer(sk_sp<SkColorFilter> filter)
     : filter_(std::move(filter)) {}
 
+void ColorFilterLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  auto* prev = reinterpret_cast<const ColorFilterLayer*>(old_layer);
+  if (!context->IsSubtreeDirty()) {
+    assert(prev);
+    if (filter_ != prev->filter_) {
+      context->MarkSubtreeDirty(old_layer->paint_region());
+    }
+  }
+
+  DiffChildren(context, prev);
+
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void ColorFilterLayer::Preroll(PrerollContext* context,
                                const SkMatrix& matrix) {
   Layer::AutoPrerollSaveLayerState save =

--- a/flow/layers/color_filter_layer.h
+++ b/flow/layers/color_filter_layer.h
@@ -14,6 +14,8 @@ class ColorFilterLayer : public ContainerLayer {
  public:
   ColorFilterLayer(sk_sp<SkColorFilter> filter);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -10,10 +10,6 @@ namespace flutter {
 
 ContainerLayer::ContainerLayer() {}
 
-void ContainerLayer::AssignOldLayer(std::shared_ptr<ContainerLayer> old_layer) {
-  old_layer_ = old_layer;
-}
-
 void ContainerLayer::Diff(DiffContext* context, const Layer* old_layer) {
   auto old_container = reinterpret_cast<const ContainerLayer*>(old_layer);
   DiffContext::AutoSubtreeRestore subtree(context);

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -11,7 +11,6 @@ namespace flutter {
 ContainerLayer::ContainerLayer() {}
 
 void ContainerLayer::AssignOldLayer(std::shared_ptr<ContainerLayer> old_layer) {
-  old_layer->old_layer_ = nullptr;
   old_layer_ = old_layer;
 }
 

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -10,6 +10,91 @@ namespace flutter {
 
 ContainerLayer::ContainerLayer() {}
 
+void ContainerLayer::AssignOldLayer(std::shared_ptr<ContainerLayer> old_layer) {
+  old_layer->old_layer_ = nullptr;
+  old_layer_ = old_layer;
+}
+
+void ContainerLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  auto old_container = reinterpret_cast<const ContainerLayer*>(old_layer);
+  DiffContext::AutoSubtreeRestore subtree(context);
+  DiffChildren(context, old_container);
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
+void ContainerLayer::DiffChildren(DiffContext* context,
+                                  const ContainerLayer* old_layer) {
+  if (context->IsSubtreeDirty()) {
+    for (auto& layer : layers_) {
+      layer->Diff(context, nullptr);
+    }
+    return;
+  }
+  assert(old_layer);
+
+  const auto& prev_layers = old_layer->layers_;
+
+  // first mismatched element
+  int new_children_top = 0;
+  int old_children_top = 0;
+
+  // last mismatched element
+  int new_children_bottom = layers_.size() - 1;
+  int old_children_bottom = prev_layers.size() - 1;
+
+  while ((old_children_top <= old_children_bottom) &&
+         (new_children_top <= new_children_bottom)) {
+    if (!layers_[new_children_top]->CanDiff(
+            prev_layers[old_children_top].get())) {
+      break;
+    }
+    ++new_children_top;
+    ++old_children_top;
+  }
+
+  while ((old_children_top <= old_children_bottom) &&
+         (new_children_top <= new_children_bottom)) {
+    if (!layers_[new_children_top]->CanDiff(
+            prev_layers[old_children_top].get())) {
+      break;
+    }
+    --new_children_bottom;
+    --old_children_bottom;
+  }
+
+  // old layers that don't match
+  for (int i = old_children_top; i <= old_children_bottom; ++i) {
+    auto layer = prev_layers[i];
+    DiffContext::AutoSubtreeRestore subtree(context);
+    context->MarkSubtreeDirty(layer->paint_region());
+  }
+
+  for (int i = 0; i < static_cast<int>(layers_.size()); ++i) {
+    if (i < new_children_top || i > new_children_bottom) {
+      int i_prev =
+          i < new_children_top ? i : prev_layers.size() - (layers_.size() - i);
+      auto layer = layers_[i];
+      auto prev_layer = prev_layers[i_prev];
+      if (layer == prev_layer && !layer->paint_region().has_readback()) {
+        // for retained layers, stop processing the subtree and add existing
+        // region; We know current subtree is not dirty (every ancestor up to
+        // here matches) so the retained subtree will render identically to
+        // previous frame; We can only do this if there is no readback in the
+        // subtree. Layers that do readback must be able to register readback
+        // inside Diff
+        context->AddPaintRegion(layer->paint_region());
+      } else {
+        layer->Diff(context, prev_layer.get());
+      }
+    } else {
+      DiffContext::AutoSubtreeRestore subtree(context);
+      context->MarkSubtreeDirty();
+      auto layer = layers_[i];
+      layer->Diff(context, nullptr);
+    }
+  }
+}
+
 void ContainerLayer::Add(std::shared_ptr<Layer> layer) {
   layers_.emplace_back(std::move(layer));
 }

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -15,6 +15,14 @@ class ContainerLayer : public Layer {
  public:
   ContainerLayer();
 
+  void AssignOldLayer(std::shared_ptr<ContainerLayer> old_layer);
+
+  bool CanDiff(const Layer* layer) const override {
+    return layer == this || layer == this->old_layer_.get();
+  }
+
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   virtual void Add(std::shared_ptr<Layer> layer);
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
@@ -27,6 +35,8 @@ class ContainerLayer : public Layer {
   const std::vector<std::shared_ptr<Layer>>& layers() const { return layers_; }
 
  protected:
+  void DiffChildren(DiffContext* context, const ContainerLayer* old_layer);
+
   void PrerollChildren(PrerollContext* context,
                        const SkMatrix& child_matrix,
                        SkRect* child_paint_bounds);
@@ -52,6 +62,8 @@ class ContainerLayer : public Layer {
 
  private:
   std::vector<std::shared_ptr<Layer>> layers_;
+
+  std::shared_ptr<const ContainerLayer> old_layer_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContainerLayer);
 };

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -15,12 +15,6 @@ class ContainerLayer : public Layer {
  public:
   ContainerLayer();
 
-  void AssignOldLayer(std::shared_ptr<ContainerLayer> old_layer);
-
-  bool CanDiff(const Layer* layer) const override {
-    return layer == this || layer == this->old_layer_.lock().get();
-  }
-
   void Diff(DiffContext* context, const Layer* old_layer) override;
 
   virtual void Add(std::shared_ptr<Layer> layer);
@@ -62,8 +56,6 @@ class ContainerLayer : public Layer {
 
  private:
   std::vector<std::shared_ptr<Layer>> layers_;
-
-  std::weak_ptr<const ContainerLayer> old_layer_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContainerLayer);
 };

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -18,7 +18,7 @@ class ContainerLayer : public Layer {
   void AssignOldLayer(std::shared_ptr<ContainerLayer> old_layer);
 
   bool CanDiff(const Layer* layer) const override {
-    return layer == this || layer == this->old_layer_.get();
+    return layer == this || layer == this->old_layer_.lock().get();
   }
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
@@ -63,7 +63,7 @@ class ContainerLayer : public Layer {
  private:
   std::vector<std::shared_ptr<Layer>> layers_;
 
-  std::shared_ptr<const ContainerLayer> old_layer_;
+  std::weak_ptr<const ContainerLayer> old_layer_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContainerLayer);
 };

--- a/flow/layers/image_filter_layer.h
+++ b/flow/layers/image_filter_layer.h
@@ -14,6 +14,8 @@ class ImageFilterLayer : public MergedContainerLayer {
  public:
   ImageFilterLayer(sk_sp<SkImageFilter> filter);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -12,6 +12,7 @@ namespace flutter {
 Layer::Layer()
     : paint_bounds_(SkRect::MakeEmpty()),
       unique_id_(NextUniqueID()),
+      diff_id_(unique_id_),
       needs_system_composite_(false) {}
 
 Layer::~Layer() = default;

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -79,7 +79,13 @@ class Layer {
   Layer();
   virtual ~Layer();
 
-  virtual bool CanDiff(const Layer* layer) const { return layer == this; }
+  void AssignOldLayer(std::shared_ptr<Layer> old_layer) {
+    diff_id_ = old_layer->diff_id_;
+  }
+
+  virtual bool CanDiff(const Layer* layer) const {
+    return diff_id_ == layer->diff_id_;
+  }
 
   virtual void Diff(DiffContext* context, const Layer* old_layer) {}
 
@@ -205,6 +211,7 @@ class Layer {
  private:
   SkRect paint_bounds_;
   uint64_t unique_id_;
+  uint64_t diff_id_;
   bool needs_system_composite_;
 
   PaintRegion paint_region_;

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -30,7 +30,8 @@ void LayerTree::RecordBuildTime(fml::TimePoint vsync_start,
 }
 
 bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
-                        bool ignore_raster_cache) {
+                        bool ignore_raster_cache,
+                        const SkRect& cull_rect) {
   TRACE_EVENT0("flutter", "LayerTree::Preroll");
 
   if (!root_layer_) {
@@ -49,7 +50,7 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       frame.view_embedder(),
       stack,
       color_space,
-      kGiantRect,
+      cull_rect,
       false,
       frame.context().raster_time(),
       frame.context().ui_time(),

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -29,7 +29,8 @@ class LayerTree {
   //   layer tree performs any operations that require readback
   //   from the root surface.
   bool Preroll(CompositorContext::ScopedFrame& frame,
-               bool ignore_raster_cache = false);
+               bool ignore_raster_cache = false,
+               const SkRect& cull_rect = kGiantRect);
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   void UpdateScene(SceneUpdateContext& context);

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -12,6 +12,20 @@ namespace flutter {
 OpacityLayer::OpacityLayer(SkAlpha alpha, const SkPoint& offset)
     : alpha_(alpha), offset_(offset) {}
 
+void OpacityLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  auto* prev = reinterpret_cast<const OpacityLayer*>(old_layer);
+  if (!context->IsSubtreeDirty()) {
+    assert(prev);
+    if (alpha_ != prev->alpha_ || offset_ != prev->offset_) {
+      context->MarkSubtreeDirty(old_layer->paint_region());
+    }
+  }
+  context->PushTransform(SkMatrix::Translate(offset_.fX, offset_.fY));
+  DiffChildren(context, prev);
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "OpacityLayer::Preroll");
 

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -20,7 +20,7 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   const bool parent_is_opaque = context->is_opaque;
   SkMatrix child_matrix = matrix;
-  child_matrix.postTranslate(offset_.fX, offset_.fY);
+  child_matrix.preTranslate(offset_.fX, offset_.fY);
 
   // Similar to what's done in TransformLayer::Preroll, we have to apply the
   // reverse transformation to the cull rect to properly cull child layers.

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -27,6 +27,8 @@ class OpacityLayer : public MergedContainerLayer {
   // the propagation as repainting the OpacityLayer is expensive.
   OpacityLayer(SkAlpha alpha, const SkPoint& offset);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -74,6 +74,18 @@ PerformanceOverlayLayer::PerformanceOverlayLayer(uint64_t options,
   }
 }
 
+void PerformanceOverlayLayer::Diff(DiffContext* context,
+                                   const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  if (!context->IsSubtreeDirty()) {
+    assert(old_layer);
+    auto prev = old_layer->as_performance_overlay_layer();
+    context->MarkSubtreeDirty(prev->paint_region());
+  }
+  context->AddPaintRegion(paint_bounds());
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void PerformanceOverlayLayer::Paint(PaintContext& context) const {
   const int padding = 8;
 

--- a/flow/layers/performance_overlay_layer.h
+++ b/flow/layers/performance_overlay_layer.h
@@ -26,10 +26,20 @@ class PerformanceOverlayLayer : public Layer {
                                               const std::string& label_prefix,
                                               const std::string& font_path);
 
+  bool CanDiff(const Layer* layer) const override {
+    return layer->as_performance_overlay_layer() != nullptr;
+  }
+
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   explicit PerformanceOverlayLayer(uint64_t options,
                                    const char* font_path = nullptr);
 
   void Paint(PaintContext& context) const override;
+
+  const PerformanceOverlayLayer* as_performance_overlay_layer() const override {
+    return this;
+  }
 
  private:
   int options_;

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -41,6 +41,10 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
     set_paint_bounds(ComputeShadowBounds(path_.getBounds(), elevation_,
                                          context->frame_device_pixel_ratio));
   }
+
+  if (!context->cull_rect.intersects(paint_bounds())) {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 void PhysicalShapeLayer::Paint(PaintContext& context) const {

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -23,6 +23,34 @@ PhysicalShapeLayer::PhysicalShapeLayer(SkColor color,
       path_(path),
       clip_behavior_(clip_behavior) {}
 
+void PhysicalShapeLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  auto* prev = reinterpret_cast<const PhysicalShapeLayer*>(old_layer);
+  if (!context->IsSubtreeDirty()) {
+    assert(prev);
+    if (color_ != prev->color_ || shadow_color_ != prev->shadow_color_ ||
+        elevation_ != prev->elevation() || path_ != prev->path_ ||
+        clip_behavior_ != prev->clip_behavior_) {
+      context->MarkSubtreeDirty(old_layer->paint_region());
+    }
+  }
+
+  SkRect bounds;
+  if (elevation_ == 0) {
+    bounds = path_.getBounds();
+  } else {
+    bounds = ComputeShadowBounds(path_.getBounds(), elevation_,
+                                 context->frame_device_pixel_ratio());
+  }
+
+  context->AddPaintRegion(bounds);
+
+  if (context->PushCullRect(bounds)) {
+    DiffChildren(context, prev);
+  }
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void PhysicalShapeLayer::Preroll(PrerollContext* context,
                                  const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "PhysicalShapeLayer::Preroll");

--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -27,6 +27,8 @@ class PhysicalShapeLayer : public ContainerLayer {
                          bool transparentOccluder,
                          SkScalar dpr);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -30,7 +30,7 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
     TRACE_EVENT0("flutter", "PictureLayer::RasterCache (Preroll)");
 
     SkMatrix ctm = matrix;
-    ctm.postTranslate(offset_.x(), offset_.y());
+    ctm.preTranslate(offset_.x(), offset_.y());
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
     ctm = RasterCache::GetIntegralTransCTM(ctm);
 #endif

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -39,7 +39,12 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   }
 
   SkRect bounds = sk_picture->cullRect().makeOffset(offset_.x(), offset_.y());
-  set_paint_bounds(bounds);
+
+  if (context->cull_rect.intersects(bounds)) {
+    set_paint_bounds(bounds);
+  } else {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 void PictureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -5,6 +5,7 @@
 #include "flutter/flow/layers/picture_layer.h"
 
 #include "flutter/fml/logging.h"
+#include "third_party/skia/include/core/SkSerialProcs.h"
 
 namespace flutter {
 
@@ -16,6 +17,68 @@ PictureLayer::PictureLayer(const SkPoint& offset,
       picture_(std::move(picture)),
       is_complex_(is_complex),
       will_change_(will_change) {}
+
+void PictureLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  if (!context->IsSubtreeDirty()) {
+    assert(old_layer);
+    auto prev = old_layer->as_picture_layer();
+    if (!Compare(this, prev)) {
+      context->MarkSubtreeDirty(prev->paint_region());
+    }
+  }
+  context->PushTransform(SkMatrix::Translate(offset_.x(), offset_.y()));
+  context->AddPaintRegion(picture()->cullRect());
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
+bool PictureLayer::Compare(const PictureLayer* l1, const PictureLayer* l2) {
+  const auto& pic1 = l1->picture_.get();
+  const auto& pic2 = l2->picture_.get();
+  if (pic1.get() == pic2.get()) {
+    return true;
+  }
+  auto op_cnt_1 = pic1->approximateOpCount();
+  auto op_cnt_2 = pic2->approximateOpCount();
+  if (op_cnt_1 != op_cnt_2 || pic1->cullRect() != pic2->cullRect()) {
+    return false;
+  }
+
+  if (op_cnt_1 > 10) {
+    return false;
+  }
+
+  // TODO(knopp) we don't actually need the data; this could be done without
+  // allocations by implementing stream that calculates SHA hash and
+  // comparing those hashes
+  auto d1 = l1->SerializedPicture();
+  auto d2 = l2->SerializedPicture();
+  auto res = d1->equals(d2.get());
+  return res;
+}
+
+sk_sp<SkData> PictureLayer::SerializedPicture() const {
+  SkSerialProcs procs = {
+      nullptr,
+      nullptr,
+      [](SkImage* i, void* ctx) {
+        auto id = i->uniqueID();
+        return SkData::MakeWithCopy(&id, sizeof(id));
+      },
+      nullptr,
+      [](SkTypeface* tf, void* ctx) {
+        auto id = tf->uniqueID();
+        return SkData::MakeWithCopy(&id, sizeof(id));
+      },
+      nullptr,
+  };
+
+  if (!cached_serialized_picture_) {
+    cached_serialized_picture_ = picture_.get()->serialize(&procs);
+  } else {
+  }
+  return cached_serialized_picture_;
+}
 
 void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "PictureLayer::Preroll");

--- a/flow/layers/picture_layer.h
+++ b/flow/layers/picture_layer.h
@@ -22,9 +22,17 @@ class PictureLayer : public Layer {
 
   SkPicture* picture() const { return picture_.get().get(); }
 
+  bool CanDiff(const Layer* layer) const override {
+    return layer->as_picture_layer() != nullptr;
+  }
+
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* frame, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;
+
+  const PictureLayer* as_picture_layer() const override { return this; }
 
  private:
   SkPoint offset_;
@@ -33,6 +41,10 @@ class PictureLayer : public Layer {
   SkiaGPUObject<SkPicture> picture_;
   bool is_complex_ = false;
   bool will_change_ = false;
+
+  sk_sp<SkData> SerializedPicture() const;
+  mutable sk_sp<SkData> cached_serialized_picture_;
+  static bool Compare(const PictureLayer* l1, const PictureLayer* l2);
 
   FML_DISALLOW_COPY_AND_ASSIGN(PictureLayer);
 };

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -11,6 +11,22 @@ ShaderMaskLayer::ShaderMaskLayer(sk_sp<SkShader> shader,
                                  SkBlendMode blend_mode)
     : shader_(shader), mask_rect_(mask_rect), blend_mode_(blend_mode) {}
 
+void ShaderMaskLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  auto* prev = reinterpret_cast<const ShaderMaskLayer*>(old_layer);
+  if (!context->IsSubtreeDirty()) {
+    assert(prev);
+    if (shader_ != prev->shader_ || mask_rect_ != prev->mask_rect_ ||
+        blend_mode_ != prev->blend_mode_) {
+      context->MarkSubtreeDirty(old_layer->paint_region());
+    }
+  }
+
+  DiffChildren(context, prev);
+
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void ShaderMaskLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   CheckForChildLayerBelow(context);

--- a/flow/layers/shader_mask_layer.h
+++ b/flow/layers/shader_mask_layer.h
@@ -16,6 +16,8 @@ class ShaderMaskLayer : public ContainerLayer {
                   const SkRect& mask_rect,
                   SkBlendMode blend_mode);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -19,6 +19,20 @@ TextureLayer::TextureLayer(const SkPoint& offset,
       freeze_(freeze),
       filter_quality_(filter_quality) {}
 
+void TextureLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  if (!context->IsSubtreeDirty()) {
+    assert(old_layer);
+    auto prev = old_layer->as_texture_layer();
+    // TODO(knopp) It would be nice to be able to determine that a texture is
+    // dirty
+    context->MarkSubtreeDirty(prev->paint_region());
+  }
+  context->AddPaintRegion(SkRect::MakeXYWH(offset_.x(), offset_.y(),
+                                           size_.width(), size_.height()));
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "TextureLayer::Preroll");
 

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -28,6 +28,10 @@ void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));
+
+  if (!context->cull_rect.intersects(paint_bounds())) {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 void TextureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -20,8 +20,16 @@ class TextureLayer : public Layer {
                bool freeze,
                SkFilterQuality filter_quality);
 
+  bool CanDiff(const Layer* layer) const override {
+    return layer->as_texture_layer() != nullptr;
+  }
+
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
+
+  const TextureLayer* as_texture_layer() const override { return this; }
 
  private:
   SkPoint offset_;

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -26,6 +26,20 @@ TransformLayer::TransformLayer(const SkMatrix& transform)
   }
 }
 
+void TransformLayer::Diff(DiffContext* context, const Layer* old_layer) {
+  DiffContext::AutoSubtreeRestore subtree(context);
+  auto* prev = reinterpret_cast<const TransformLayer*>(old_layer);
+  if (!context->IsSubtreeDirty()) {
+    assert(prev);
+    if (transform_ != prev->transform_) {
+      context->MarkSubtreeDirty(old_layer->paint_region());
+    }
+  }
+  context->PushTransform(transform_);
+  DiffChildren(context, prev);
+  set_paint_region(context->CurrentSubtreeRegion());
+}
+
 void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "TransformLayer::Preroll");
 

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -15,6 +15,8 @@ class TransformLayer : public ContainerLayer {
  public:
   TransformLayer(const SkMatrix& transform);
 
+  void Diff(DiffContext* context, const Layer* old_layer) override;
+
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -279,13 +279,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     assert(_matrix4IsValid(matrix4));
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushTransform'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushTransform(engineLayer, matrix4);
+    _pushTransform(engineLayer, matrix4, oldLayer?._nativeLayer);
     final TransformEngineLayer layer = TransformEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushTransform(EngineLayer layer, Float64List matrix4) native 'SceneBuilder_pushTransform';
+  void _pushTransform(EngineLayer layer, Float64List matrix4, EngineLayer? oldLayer)
+      native 'SceneBuilder_pushTransform';
 
   /// Pushes an offset operation onto the operation stack.
   ///
@@ -303,13 +304,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushOffset'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushOffset(engineLayer, dx, dy);
+    _pushOffset(engineLayer, dx, dy, oldLayer?._nativeLayer);
     final OffsetEngineLayer layer = OffsetEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushOffset(EngineLayer layer, double dx, double dy) native 'SceneBuilder_pushOffset';
+  void _pushOffset(EngineLayer layer, double dx, double dy, EngineLayer? oldLayer)
+      native 'SceneBuilder_pushOffset';
 
   /// Pushes a rectangular clip operation onto the operation stack.
   ///
@@ -330,14 +332,15 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipRect'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushClipRect(engineLayer, rect.left, rect.right, rect.top, rect.bottom, clipBehavior.index);
+    _pushClipRect(engineLayer, rect.left, rect.right, rect.top, rect.bottom, clipBehavior.index,
+        oldLayer?._nativeLayer);
     final ClipRectEngineLayer layer = ClipRectEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushClipRect(EngineLayer outEngineLayer, double left, double right, double top, double bottom, int clipBehavior)
-      native 'SceneBuilder_pushClipRect';
+  void _pushClipRect(EngineLayer outEngineLayer, double left, double right, double top,
+      double bottom, int clipBehavior, EngineLayer? oldLayer) native 'SceneBuilder_pushClipRect';
 
   /// Pushes a rounded-rectangular clip operation onto the operation stack.
   ///
@@ -358,13 +361,13 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipRRect'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushClipRRect(engineLayer, rrect._value32, clipBehavior.index);
+    _pushClipRRect(engineLayer, rrect._value32, clipBehavior.index, oldLayer?._nativeLayer);
     final ClipRRectEngineLayer layer = ClipRRectEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushClipRRect(EngineLayer layer, Float32List rrect, int clipBehavior)
+  void _pushClipRRect(EngineLayer layer, Float32List rrect, int clipBehavior, EngineLayer? oldLayer)
       native 'SceneBuilder_pushClipRRect';
 
   /// Pushes a path clip operation onto the operation stack.
@@ -386,13 +389,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipPath'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushClipPath(engineLayer, path, clipBehavior.index);
+    _pushClipPath(engineLayer, path, clipBehavior.index, oldLayer?._nativeLayer);
     final ClipPathEngineLayer layer = ClipPathEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushClipPath(EngineLayer layer, Path path, int clipBehavior) native 'SceneBuilder_pushClipPath';
+  void _pushClipPath(EngineLayer layer, Path path, int clipBehavior, EngineLayer? oldLayer)
+      native 'SceneBuilder_pushClipPath';
 
   /// Pushes an opacity operation onto the operation stack.
   ///
@@ -413,13 +417,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushOpacity'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushOpacity(engineLayer, alpha, offset!.dx, offset.dy);
+    _pushOpacity(engineLayer, alpha, offset!.dx, offset.dy, oldLayer?._nativeLayer);
     final OpacityEngineLayer layer = OpacityEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushOpacity(EngineLayer layer, int alpha, double dx, double dy) native 'SceneBuilder_pushOpacity';
+  void _pushOpacity(EngineLayer layer, int alpha, double dx, double dy, EngineLayer? oldLayer)
+      native 'SceneBuilder_pushOpacity';
 
   /// Pushes a color filter operation onto the operation stack.
   ///
@@ -440,13 +445,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     final _ColorFilter nativeFilter = filter._toNativeColorFilter()!;
     assert(nativeFilter != null); // ignore: unnecessary_null_comparison
     final EngineLayer engineLayer = EngineLayer._();
-    _pushColorFilter(engineLayer, nativeFilter);
+    _pushColorFilter(engineLayer, nativeFilter, oldLayer?._nativeLayer);
     final ColorFilterEngineLayer layer = ColorFilterEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushColorFilter(EngineLayer layer, _ColorFilter filter) native 'SceneBuilder_pushColorFilter';
+  void _pushColorFilter(EngineLayer layer, _ColorFilter filter, EngineLayer? oldLayer)
+      native 'SceneBuilder_pushColorFilter';
 
   /// Pushes an image filter operation onto the operation stack.
   ///
@@ -467,13 +473,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     final _ImageFilter nativeFilter = filter._toNativeImageFilter();
     assert(nativeFilter != null); // ignore: unnecessary_null_comparison
     final EngineLayer engineLayer = EngineLayer._();
-    _pushImageFilter(engineLayer, nativeFilter);
+    _pushImageFilter(engineLayer, nativeFilter, oldLayer?._nativeLayer);
     final ImageFilterEngineLayer layer = ImageFilterEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushImageFilter(EngineLayer outEngineLayer, _ImageFilter filter) native 'SceneBuilder_pushImageFilter';
+  void _pushImageFilter(EngineLayer outEngineLayer, _ImageFilter filter, EngineLayer? oldLayer)
+      native 'SceneBuilder_pushImageFilter';
 
   /// Pushes a backdrop filter operation onto the operation stack.
   ///
@@ -491,13 +498,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushBackdropFilter'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushBackdropFilter(engineLayer, filter._toNativeImageFilter());
+    _pushBackdropFilter(engineLayer, filter._toNativeImageFilter(), oldLayer?._nativeLayer);
     final BackdropFilterEngineLayer layer = BackdropFilterEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushBackdropFilter(EngineLayer outEngineLayer, _ImageFilter filter) native 'SceneBuilder_pushBackdropFilter';
+  void _pushBackdropFilter(EngineLayer outEngineLayer, _ImageFilter filter, EngineLayer? oldLayer)
+      native 'SceneBuilder_pushBackdropFilter';
 
   /// Pushes a shader mask operation onto the operation stack.
   ///
@@ -525,6 +533,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
       maskRect.top,
       maskRect.bottom,
       blendMode.index,
+      oldLayer?._nativeLayer,
     );
     final ShaderMaskEngineLayer layer = ShaderMaskEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
@@ -538,7 +547,8 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
       double maskRectRight,
       double maskRectTop,
       double maskRectBottom,
-      int blendMode) native 'SceneBuilder_pushShaderMask';
+      int blendMode,
+      EngineLayer? oldLayer) native 'SceneBuilder_pushShaderMask';
 
   /// Pushes a physical layer operation for an arbitrary shape onto the
   /// operation stack.
@@ -567,21 +577,21 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushPhysicalShape'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushPhysicalShape(
-      engineLayer,
-      path,
-      elevation,
-      color.value,
-      shadowColor?.value ?? 0xFF000000,
-      clipBehavior.index,
-    );
+    _pushPhysicalShape(engineLayer, path, elevation, color.value, shadowColor?.value ?? 0xFF000000,
+        clipBehavior.index, oldLayer?._nativeLayer);
     final PhysicalShapeEngineLayer layer = PhysicalShapeEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  EngineLayer _pushPhysicalShape(EngineLayer outEngineLayer, Path path, double elevation, int color, int shadowColor,
-      int clipBehavior) native 'SceneBuilder_pushPhysicalShape';
+  EngineLayer _pushPhysicalShape(
+      EngineLayer outEngineLayer,
+      Path path,
+      double elevation,
+      int color,
+      int shadowColor,
+      int clipBehavior,
+      EngineLayer? oldLayer) native 'SceneBuilder_pushPhysicalShape';
 
   /// Ends the effect of the most recently pushed operation.
   ///

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -90,20 +90,32 @@ SceneBuilder::SceneBuilder() {
 SceneBuilder::~SceneBuilder() = default;
 
 void SceneBuilder::pushTransform(Dart_Handle layer_handle,
-                                 tonic::Float64List& matrix4) {
+                                 tonic::Float64List& matrix4,
+                                 fml::RefPtr<EngineLayer> oldLayer) {
   SkMatrix sk_matrix = ToSkMatrix(matrix4);
   auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix);
   PushLayer(layer);
   // matrix4 has to be released before we can return another Dart object
   matrix4.Release();
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
-void SceneBuilder::pushOffset(Dart_Handle layer_handle, double dx, double dy) {
+void SceneBuilder::pushOffset(Dart_Handle layer_handle,
+                              double dx,
+                              double dy,
+                              fml::RefPtr<EngineLayer> oldLayer) {
   SkMatrix sk_matrix = SkMatrix::Translate(dx, dy);
   auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix);
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::pushClipRect(Dart_Handle layer_handle,
@@ -111,67 +123,102 @@ void SceneBuilder::pushClipRect(Dart_Handle layer_handle,
                                 double right,
                                 double top,
                                 double bottom,
-                                int clipBehavior) {
+                                int clipBehavior,
+                                fml::RefPtr<EngineLayer> oldLayer) {
   SkRect clipRect = SkRect::MakeLTRB(left, top, right, bottom);
   flutter::Clip clip_behavior = static_cast<flutter::Clip>(clipBehavior);
   auto layer =
       std::make_shared<flutter::ClipRectLayer>(clipRect, clip_behavior);
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::pushClipRRect(Dart_Handle layer_handle,
                                  const RRect& rrect,
-                                 int clipBehavior) {
+                                 int clipBehavior,
+                                 fml::RefPtr<EngineLayer> oldLayer) {
   flutter::Clip clip_behavior = static_cast<flutter::Clip>(clipBehavior);
   auto layer =
       std::make_shared<flutter::ClipRRectLayer>(rrect.sk_rrect, clip_behavior);
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::pushClipPath(Dart_Handle layer_handle,
                                 const CanvasPath* path,
-                                int clipBehavior) {
+                                int clipBehavior,
+                                fml::RefPtr<EngineLayer> oldLayer) {
   flutter::Clip clip_behavior = static_cast<flutter::Clip>(clipBehavior);
   FML_DCHECK(clip_behavior != flutter::Clip::none);
   auto layer =
       std::make_shared<flutter::ClipPathLayer>(path->path(), clip_behavior);
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::pushOpacity(Dart_Handle layer_handle,
                                int alpha,
                                double dx,
-                               double dy) {
+                               double dy,
+                               fml::RefPtr<EngineLayer> oldLayer) {
   auto layer =
       std::make_shared<flutter::OpacityLayer>(alpha, SkPoint::Make(dx, dy));
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::pushColorFilter(Dart_Handle layer_handle,
-                                   const ColorFilter* color_filter) {
+                                   const ColorFilter* color_filter,
+                                   fml::RefPtr<EngineLayer> oldLayer) {
   auto layer =
       std::make_shared<flutter::ColorFilterLayer>(color_filter->filter());
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::pushImageFilter(Dart_Handle layer_handle,
-                                   const ImageFilter* image_filter) {
+                                   const ImageFilter* image_filter,
+                                   fml::RefPtr<EngineLayer> oldLayer) {
   auto layer =
       std::make_shared<flutter::ImageFilterLayer>(image_filter->filter());
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::pushBackdropFilter(Dart_Handle layer_handle,
-                                      ImageFilter* filter) {
+                                      ImageFilter* filter,
+                                      fml::RefPtr<EngineLayer> oldLayer) {
   auto layer = std::make_shared<flutter::BackdropFilterLayer>(filter->filter());
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::pushShaderMask(Dart_Handle layer_handle,
@@ -180,13 +227,18 @@ void SceneBuilder::pushShaderMask(Dart_Handle layer_handle,
                                   double maskRectRight,
                                   double maskRectTop,
                                   double maskRectBottom,
-                                  int blendMode) {
+                                  int blendMode,
+                                  fml::RefPtr<EngineLayer> oldLayer) {
   SkRect rect = SkRect::MakeLTRB(maskRectLeft, maskRectTop, maskRectRight,
                                  maskRectBottom);
   auto layer = std::make_shared<flutter::ShaderMaskLayer>(
       shader->shader(), rect, static_cast<SkBlendMode>(blendMode));
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::pushPhysicalShape(Dart_Handle layer_handle,
@@ -194,13 +246,18 @@ void SceneBuilder::pushPhysicalShape(Dart_Handle layer_handle,
                                      double elevation,
                                      int color,
                                      int shadow_color,
-                                     int clipBehavior) {
+                                     int clipBehavior,
+                                     fml::RefPtr<EngineLayer> oldLayer) {
   auto layer = std::make_shared<flutter::PhysicalShapeLayer>(
       static_cast<SkColor>(color), static_cast<SkColor>(shadow_color),
       static_cast<float>(elevation), path->path(),
       static_cast<flutter::Clip>(clipBehavior));
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
+
+  if (oldLayer && oldLayer->Layer()) {
+    layer->AssignOldLayer(oldLayer->Layer());
+  }
 }
 
 void SceneBuilder::addRetained(fml::RefPtr<EngineLayer> retainedLayer) {

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -37,42 +37,57 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   }
   ~SceneBuilder() override;
 
-  void pushTransform(Dart_Handle layer_handle, tonic::Float64List& matrix4);
-  void pushOffset(Dart_Handle layer_handle, double dx, double dy);
+  void pushTransform(Dart_Handle layer_handle,
+                     tonic::Float64List& matrix4,
+                     fml::RefPtr<EngineLayer> oldLayer);
+  void pushOffset(Dart_Handle layer_handle,
+                  double dx,
+                  double dy,
+                  fml::RefPtr<EngineLayer> oldLayer);
   void pushClipRect(Dart_Handle layer_handle,
                     double left,
                     double right,
                     double top,
                     double bottom,
-                    int clipBehavior);
+                    int clipBehavior,
+                    fml::RefPtr<EngineLayer> oldLayer);
   void pushClipRRect(Dart_Handle layer_handle,
                      const RRect& rrect,
-                     int clipBehavior);
+                     int clipBehavior,
+                     fml::RefPtr<EngineLayer> oldLayer);
   void pushClipPath(Dart_Handle layer_handle,
                     const CanvasPath* path,
-                    int clipBehavior);
+                    int clipBehavior,
+                    fml::RefPtr<EngineLayer> oldLayer);
   void pushOpacity(Dart_Handle layer_handle,
                    int alpha,
-                   double dx = 0,
-                   double dy = 0);
+                   double dx,
+                   double dy,
+                   fml::RefPtr<EngineLayer> oldLayer);
   void pushColorFilter(Dart_Handle layer_handle,
-                       const ColorFilter* color_filter);
+                       const ColorFilter* color_filter,
+                       fml::RefPtr<EngineLayer> oldLayer);
   void pushImageFilter(Dart_Handle layer_handle,
-                       const ImageFilter* image_filter);
-  void pushBackdropFilter(Dart_Handle layer_handle, ImageFilter* filter);
+                       const ImageFilter* image_filter,
+                       fml::RefPtr<EngineLayer> oldLayer);
+  void pushBackdropFilter(Dart_Handle layer_handle,
+                          ImageFilter* filter,
+                          fml::RefPtr<EngineLayer> oldLayer);
   void pushShaderMask(Dart_Handle layer_handle,
                       Shader* shader,
                       double maskRectLeft,
                       double maskRectRight,
                       double maskRectTop,
                       double maskRectBottom,
-                      int blendMode);
+                      int blendMode,
+                      fml::RefPtr<EngineLayer> oldLayer);
   void pushPhysicalShape(Dart_Handle layer_handle,
                          const CanvasPath* path,
                          double elevation,
                          int color,
                          int shadowColor,
-                         int clipBehavior);
+                         int clipBehavior,
+                         fml::RefPtr<EngineLayer> oldLayer);
 
   void addRetained(fml::RefPtr<EngineLayer> retainedLayer);
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -459,7 +459,8 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
   );
 
   if (compositor_frame) {
-    RasterStatus raster_status = compositor_frame->Raster(layer_tree, false);
+    RasterStatus raster_status =
+        compositor_frame->Raster(layer_tree, false, nullptr);
     if (raster_status == RasterStatus::kFailed ||
         raster_status == RasterStatus::kSkipAndRetry) {
       return raster_status;
@@ -501,7 +502,7 @@ static sk_sp<SkData> ScreenshotLayerTreeAsPicture(
   auto frame = compositor_context.ACQUIRE_FRAME(
       nullptr, recorder.getRecordingCanvas(), nullptr,
       root_surface_transformation, false, true, nullptr);
-  frame->Raster(*tree, true);
+  frame->Raster(*tree, true, nullptr);
 
 #if defined(OS_FUCHSIA)
   SkSerialProcs procs = {0};
@@ -568,7 +569,7 @@ sk_sp<SkData> Rasterizer::ScreenshotLayerTreeAsImage(
       surface_context, canvas, nullptr, root_surface_transformation, false,
       true, nullptr);
   canvas->clear(SK_ColorTRANSPARENT);
-  frame->Raster(*tree, true);
+  frame->Raster(*tree, true, nullptr);
   canvas->flush();
 
   // Prepare an image from the surface, this image may potentially be on th GPU.


### PR DESCRIPTION
## Description

Replaces https://github.com/flutter/engine/pull/21299

This PR adds api to track damage rectangles during rendering. Usage is relatively simple, it introduces the following structure in `compositor_context.h`
```cpp
struct FrameDamage {
  // IN: Previous layer tree
  const LayerTree* prev_layer_tree = nullptr;

  // IN: Additional damage (accumulated for double / triple buffering)
  SkIRect additional_damage = SkIRect::MakeEmpty();

  // OUT: Damage
  Damage damage_out;
};

struct Damage {
  // This is the damage between current and previous frame;
  // When using double or triple buffering, this damage must be acumulated
  // for each "inactive" framebuffer and then be provided as additional_damage.
  SkIRect net_damage;

  // Reflects actual change to target framebuffer; This is net_damage + damage
  // previously acumulated for the framebuffer. If embedder supports partial
  // update, this is the region that needs to be updated.
  SkIRect framebuffer_damage;
};
```

This is a completely new implementation that does tree diffing instead of determining the damage outside of tree. It does require some changes to framework to diff correctly, but those should be relatively minor.

## Related Issues

https://github.com/flutter/flutter/issues/33939

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

This shouldn't be breaking change, if `frame_damage` is not provided (default). 
However it does prevent rendering of picture, physical shape and texture layers that are outside of cull rect. 

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
