### PR TITLE
Enable embedder_unittests on Fuchsia

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -95,6 +95,7 @@ group("flutter") {
       "//flutter/lib/ui:ui_unittests",
       "//flutter/runtime:runtime_unittests",
       "//flutter/shell/common:shell_unittests",
+      "//flutter/shell/platform/embedder:embedder_unittests",
       "//flutter/testing:testing_unittests",
       "//flutter/third_party/txt:txt_unittests",
     ]
@@ -114,11 +115,6 @@ group("flutter") {
         "//flutter/shell/platform/android/jni:jni_unittests",
         "//flutter/shell/platform/android/platform_view_android_delegate:platform_view_android_delegate_unittests",
       ]
-    }
-
-    # TODO(): Enable embedder_unittests on fucsia.
-    if (!is_fuchsia) {
-      public_deps += [ "//flutter/shell/platform/embedder:embedder_unittests" ]
     }
 
     # Unit tests for desktop embeddings should only be built if the desktop

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -144,13 +144,6 @@ template("shell_host_executable") {
 }
 
 if (enable_unittests) {
-  declare_args() {
-    test_enable_vulkan = is_fuchsia
-    test_enable_gl = !is_fuchsia
-    test_enable_software = true
-    test_enable_metal = false
-  }
-
   config("test_enable_gl_config") {
     defines = [ "SHELL_ENABLE_GL" ]
   }

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -5,6 +5,17 @@
 declare_args() {
   shell_enable_gl = !is_fuchsia
   shell_enable_metal = false
+
+  # TODO(gw280): Enable once Fuchsia supports Vulkan through the embedder
   shell_enable_vulkan = false
+  shell_enable_software = true
+
   stripped_symbols = true
+}
+
+declare_args() {
+  test_enable_gl = shell_enable_gl
+  test_enable_metal = shell_enable_metal
+  test_enable_vulkan = is_fuchsia
+  test_enable_software = shell_enable_software
 }

--- a/shell/gpu/gpu.gni
+++ b/shell/gpu/gpu.gni
@@ -33,4 +33,21 @@ template("shell_gpu_configuration") {
       public_deps += [ "//flutter/shell/gpu:gpu_surface_metal" ]
     }
   }
+
+  config("${target_name}_config") {
+    defines = []
+
+    if (invoker.enable_software) {
+      defines += [ "SHELL_ENABLE_SOFTWARE" ]
+    }
+    if (invoker.enable_gl) {
+      defines += [ "SHELL_ENABLE_GL" ]
+    }
+    if (invoker.enable_vulkan) {
+      defines += [ "SHELL_ENABLE_VULKAN" ]
+    }
+    if (invoker.enable_metal) {
+      defines += [ "SHELL_ENABLE_METAL" ]
+    }
+  }
 }

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -8,11 +8,18 @@ import("//flutter/shell/gpu/gpu.gni")
 import("//flutter/shell/platform/embedder/embedder.gni")
 import("//flutter/testing/testing.gni")
 
+declare_args() {
+  embedder_enable_software = shell_enable_software
+  embedder_enable_vulkan = shell_enable_vulkan
+  embedder_enable_gl = shell_enable_gl
+  embedder_enable_metal = shell_enable_metal
+}
+
 shell_gpu_configuration("embedder_gpu_configuration") {
-  enable_software = true
-  enable_vulkan = false
-  enable_gl = true
-  enable_metal = false
+  enable_software = embedder_enable_software
+  enable_vulkan = embedder_enable_vulkan
+  enable_gl = embedder_enable_gl
+  enable_metal = embedder_enable_metal
 }
 
 _framework_binary_subpath = "Versions/A/FlutterEmbedder"
@@ -27,8 +34,6 @@ template("embedder_source_set") {
       "embedder.cc",
       "embedder_engine.cc",
       "embedder_engine.h",
-      "embedder_external_texture_gl.cc",
-      "embedder_external_texture_gl.h",
       "embedder_external_view.cc",
       "embedder_external_view.h",
       "embedder_external_view_embedder.cc",
@@ -46,8 +51,6 @@ template("embedder_source_set") {
       "embedder_safe_access.h",
       "embedder_surface.cc",
       "embedder_surface.h",
-      "embedder_surface_gl.cc",
-      "embedder_surface_gl.h",
       "embedder_surface_software.cc",
       "embedder_surface_software.h",
       "embedder_task_runner.cc",
@@ -59,6 +62,15 @@ template("embedder_source_set") {
       "vsync_waiter_embedder.cc",
       "vsync_waiter_embedder.h",
     ]
+
+    if (embedder_enable_gl) {
+      sources += [
+        "embedder_external_texture_gl.cc",
+        "embedder_external_texture_gl.h",
+        "embedder_surface_gl.cc",
+        "embedder_surface_gl.h",
+      ]
+    }
 
     deps = [
       ":embedder_gpu_configuration",
@@ -77,7 +89,10 @@ template("embedder_source_set") {
 
     public_deps = [ ":embedder_headers" ]
 
-    public_configs += [ "//flutter:config" ]
+    public_configs += [
+      ":embedder_gpu_configuration_config",
+      "//flutter:config",
+    ]
   }
 }
 
@@ -127,11 +142,14 @@ test_fixtures("fixtures") {
   ]
 }
 
-if (current_toolchain == host_toolchain) {
+if (enable_unittests) {
   executable("embedder_unittests") {
     testonly = true
 
-    configs += [ "//flutter:export_dynamic_symbols" ]
+    configs += [
+      ":embedder_gpu_configuration_config",
+      "//flutter:export_dynamic_symbols",
+    ]
 
     include_dirs = [ "." ]
 
@@ -145,35 +163,42 @@ if (current_toolchain == host_toolchain) {
       "tests/embedder_test_backingstore_producer.h",
       "tests/embedder_test_compositor.cc",
       "tests/embedder_test_compositor.h",
-      "tests/embedder_test_compositor_gl.cc",
-      "tests/embedder_test_compositor_gl.h",
       "tests/embedder_test_compositor_software.cc",
       "tests/embedder_test_compositor_software.h",
       "tests/embedder_test_context.cc",
       "tests/embedder_test_context.h",
-      "tests/embedder_test_context_gl.cc",
-      "tests/embedder_test_context_gl.h",
       "tests/embedder_test_context_software.cc",
       "tests/embedder_test_context_software.h",
       "tests/embedder_unittests.cc",
-      "tests/embedder_unittests_gl.cc",
       "tests/embedder_unittests_util.cc",
     ]
 
     deps = [
       ":embedder",
+      ":embedder_gpu_configuration",
       ":fixtures",
       "//flutter/flow",
       "//flutter/lib/ui",
       "//flutter/runtime",
       "//flutter/testing",
       "//flutter/testing:dart",
-      "//flutter/testing:opengl",
       "//flutter/testing:skia",
       "//flutter/third_party/tonic",
       "//third_party/dart/runtime/bin:elf_loader",
       "//third_party/skia",
     ]
+
+    if (test_enable_gl) {
+      sources += [
+        "tests/embedder_test_compositor_gl.cc",
+        "tests/embedder_test_compositor_gl.h",
+        "tests/embedder_test_context_gl.cc",
+        "tests/embedder_test_context_gl.h",
+        "tests/embedder_unittests_gl.cc",
+      ]
+
+      deps += [ "//flutter/testing:opengl" ]
+    }
   }
 }
 

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -8,6 +8,11 @@
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 
+#ifdef SHELL_ENABLE_GL
+#include "flutter/shell/platform/embedder/tests/embedder_test_compositor_gl.h"
+#include "flutter/shell/platform/embedder/tests/embedder_test_context_gl.h"
+#endif
+
 namespace flutter {
 namespace testing {
 
@@ -25,6 +30,7 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
 
   custom_task_runners_.struct_size = sizeof(FlutterCustomTaskRunners);
 
+#ifdef SHELL_ENABLE_GL
   opengl_renderer_config_.struct_size = sizeof(FlutterOpenGLRendererConfig);
   opengl_renderer_config_.make_current = [](void* context) -> bool {
     return reinterpret_cast<EmbedderTestContextGL*>(context)->GLMakeCurrent();
@@ -57,6 +63,7 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
     return reinterpret_cast<EmbedderTestContext*>(context)
         ->GetRootSurfaceTransformation();
   };
+#endif
 
   software_renderer_config_.struct_size = sizeof(FlutterSoftwareRendererConfig);
   software_renderer_config_.surface_present_callback =
@@ -111,6 +118,7 @@ void EmbedderConfigBuilder::SetSoftwareRendererConfig(SkISize surface_size) {
 }
 
 void EmbedderConfigBuilder::SetOpenGLFBOCallBack() {
+#ifdef SHELL_ENABLE_GL
   // SetOpenGLRendererConfig must be called before this.
   FML_CHECK(renderer_config_.type == FlutterRendererType::kOpenGL);
   renderer_config_.open_gl.fbo_callback = [](void* context) -> uint32_t {
@@ -123,21 +131,26 @@ void EmbedderConfigBuilder::SetOpenGLFBOCallBack() {
     return reinterpret_cast<EmbedderTestContextGL*>(context)->GLGetFramebuffer(
         frame_info);
   };
+#endif
 }
 
 void EmbedderConfigBuilder::SetOpenGLPresentCallBack() {
+#ifdef SHELL_ENABLE_GL
   // SetOpenGLRendererConfig must be called before this.
   FML_CHECK(renderer_config_.type == FlutterRendererType::kOpenGL);
   renderer_config_.open_gl.present = [](void* context) -> bool {
     // passing a placeholder fbo_id.
     return reinterpret_cast<EmbedderTestContextGL*>(context)->GLPresent(0);
   };
+#endif
 }
 
 void EmbedderConfigBuilder::SetOpenGLRendererConfig(SkISize surface_size) {
+#ifdef SHELL_ENABLE_GL
   renderer_config_.type = FlutterRendererType::kOpenGL;
   renderer_config_.open_gl = opengl_renderer_config_;
   context_.SetupSurface(surface_size);
+#endif
 }
 
 void EmbedderConfigBuilder::SetAssetsPath() {

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -9,8 +9,6 @@
 #include "flutter/fml/unique_object.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test.h"
-#include "flutter/shell/platform/embedder/tests/embedder_test_compositor_gl.h"
-#include "flutter/shell/platform/embedder/tests/embedder_test_context_gl.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test_context_software.h"
 
 namespace flutter {
@@ -101,7 +99,9 @@ class EmbedderConfigBuilder {
   FlutterProjectArgs project_args_ = {};
   FlutterRendererConfig renderer_config_ = {};
   FlutterSoftwareRendererConfig software_renderer_config_ = {};
+#ifdef SHELL_ENABLE_GL
   FlutterOpenGLRendererConfig opengl_renderer_config_ = {};
+#endif
   std::string dart_entrypoint_;
   FlutterCustomTaskRunners custom_task_runners_ = {};
   FlutterCompositor compositor_ = {};

--- a/shell/platform/embedder/tests/embedder_test.cc
+++ b/shell/platform/embedder/tests/embedder_test.cc
@@ -3,6 +3,11 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/embedder/tests/embedder_test.h"
+#include "flutter/shell/platform/embedder/tests/embedder_test_context_software.h"
+
+#ifdef SHELL_ENABLE_GL
+#include "flutter/shell/platform/embedder/tests/embedder_test_context_gl.h"
+#endif
 
 namespace flutter {
 namespace testing {
@@ -23,10 +28,12 @@ EmbedderTestContext& EmbedderTest::GetEmbedderContext(ContextType type) {
             std::make_unique<EmbedderTestContextSoftware>(
                 GetFixturesDirectory());
         break;
+#ifdef SHELL_ENABLE_GL
       case ContextType::kOpenGLContext:
         embedder_contexts_[type] =
             std::make_unique<EmbedderTestContextGL>(GetFixturesDirectory());
         break;
+#endif
       default:
         FML_DCHECK(false) << "Invalid context type specified.";
         break;

--- a/shell/platform/embedder/tests/embedder_test.h
+++ b/shell/platform/embedder/tests/embedder_test.h
@@ -9,8 +9,7 @@
 #include <memory>
 
 #include "flutter/fml/macros.h"
-#include "flutter/shell/platform/embedder/tests/embedder_test_context_gl.h"
-#include "flutter/shell/platform/embedder/tests/embedder_test_context_software.h"
+#include "flutter/shell/platform/embedder/tests/embedder_test_context.h"
 #include "flutter/testing/testing.h"
 #include "flutter/testing/thread_test.h"
 

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -23,10 +23,12 @@ bool EmbedderTestBackingStoreProducer::Create(
   switch (type_) {
     case RenderTargetType::kSoftwareBuffer:
       return CreateSoftware(config, renderer_out);
+#ifdef SHELL_ENABLE_GL
     case RenderTargetType::kOpenGLTexture:
       return CreateTexture(config, renderer_out);
     case RenderTargetType::kOpenGLFramebuffer:
       return CreateFramebuffer(config, renderer_out);
+#endif
     default:
       return false;
   }
@@ -35,6 +37,7 @@ bool EmbedderTestBackingStoreProducer::Create(
 bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
     const FlutterBackingStoreConfig* config,
     FlutterBackingStore* backing_store_out) {
+#ifdef SHELL_ENABLE_GL
   const auto image_info =
       SkImageInfo::MakeN32Premul(config->size.width, config->size.height);
 
@@ -79,11 +82,15 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
       [](void* user_data) { reinterpret_cast<SkSurface*>(user_data)->unref(); };
 
   return true;
+#else
+  return false;
+#endif
 }
 
 bool EmbedderTestBackingStoreProducer::CreateTexture(
     const FlutterBackingStoreConfig* config,
     FlutterBackingStore* backing_store_out) {
+#ifdef SHELL_ENABLE_GL
   const auto image_info =
       SkImageInfo::MakeN32Premul(config->size.width, config->size.height);
 
@@ -129,6 +136,9 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(
       [](void* user_data) { reinterpret_cast<SkSurface*>(user_data)->unref(); };
 
   return true;
+#else
+  return false;
+#endif
 }
 
 bool EmbedderTestBackingStoreProducer::CreateSoftware(

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -19,7 +19,6 @@
 #include "flutter/shell/platform/embedder/tests/embedder_test_compositor.h"
 #include "flutter/testing/elf_loader.h"
 #include "flutter/testing/test_dart_native_resolver.h"
-#include "flutter/testing/test_gl_surface.h"
 #include "third_party/skia/include/core/SkImage.h"
 
 namespace flutter {

--- a/shell/platform/embedder/tests/embedder_test_context_gl.h
+++ b/shell/platform/embedder/tests/embedder_test_context_gl.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_CONTEXT_GL_H_
 
 #include "flutter/shell/platform/embedder/tests/embedder_test_context.h"
+#include "flutter/testing/test_gl_surface.h"
 
 namespace flutter {
 namespace testing {

--- a/shell/platform/embedder/tests/embedder_unittests_gl.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_gl.cc
@@ -23,6 +23,7 @@
 #include "flutter/shell/platform/embedder/tests/embedder_assertions.h"
 #include "flutter/shell/platform/embedder/tests/embedder_config_builder.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test.h"
+#include "flutter/shell/platform/embedder/tests/embedder_test_context_gl.h"
 #include "flutter/shell/platform/embedder/tests/embedder_unittests_util.h"
 #include "flutter/testing/assertions_skia.h"
 #include "flutter/testing/testing.h"

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -758,12 +758,92 @@ fuchsia_test_archive("ui_tests") {
   resources += vulkan_icds
 }
 
+fuchsia_test_archive("embedder_tests") {
+  deps = [
+    "//flutter/shell/platform/embedder:embedder_unittests",
+    "//flutter/shell/platform/embedder:fixtures",
+  ]
+
+  binary = "embedder_unittests"
+
+  # TODO(gw280): https://github.com/flutter/flutter/issues/50294
+  # Right now we need to manually specify all the fixtures that are
+  # declared in the test_fixtures() call above.
+  resources = [
+    {
+      path =
+          "$root_gen_dir/flutter/shell/platform/embedder/assets/kernel_blob.bin"
+      dest = "assets/kernel_blob.bin"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/arc_end_caps.png"
+      dest = "assets/arc_end_caps.png"
+    },
+    {
+      path =
+          "$root_gen_dir/flutter/shell/platform/embedder/assets/compositor.png"
+      dest = "assets/compositor.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/compositor_root_surface_xformation.png"
+      dest = "assets/compositor_root_surface_xformation.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/compositor_software.png"
+      dest = "assets/compositor_software.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/compositor_with_platform_layer_on_bottom.png"
+      dest = "assets/compositor_with_platform_layer_on_bottom.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/compositor_with_root_layer_only.png"
+      dest = "assets/compositor_with_root_layer_only.png"
+    },
+    {
+      path =
+          "$root_gen_dir/flutter/shell/platform/embedder/assets/dpr_noxform.png"
+      dest = "assets/dpr_noxform.png"
+    },
+    {
+      path =
+          "$root_gen_dir/flutter/shell/platform/embedder/assets/dpr_xform.png"
+      dest = "assets/dpr_xform.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/gradient.png"
+      dest = "assets/gradient.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/gradient_xform.png"
+      dest = "assets/gradient_xform.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/scene_without_custom_compositor.png"
+      dest = "assets/scene_without_custom_compositor.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/scene_without_custom_compositor_with_xform.png"
+      dest = "assets/scene_without_custom_compositor_with_xform.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/verifyb143464703.png"
+      dest = "assets/verifyb143464703.png"
+    },
+    {
+      path = "$root_gen_dir/flutter/shell/platform/embedder/assets/verifyb143464703_soft_noxform.png"
+      dest = "assets/verifyb143464703_soft_noxform.png"
+    },
+  ]
+}
+
 # When adding a new dep here, please also ensure the dep is added to
 # testing/fuchsia/run_tests.sh and testing/fuchsia/test_fars
 group("tests") {
   testonly = true
 
   deps = [
+    ":embedder_tests",
     ":flow_tests",
     ":flutter_runner_scenic_tests",
     ":flutter_runner_tests",


### PR DESCRIPTION
This adds the build rules to build for Fuchsia without OpenGL support in the Embedder, and facilitates this by adding a few #ifdefs to conditionally compile the GL specific stuff in the Embedder.