### PR TITLE
Fix getNextFrame

### DIFF
--- a/testing/dart/image_dispose_test.dart
+++ b/testing/dart/image_dispose_test.dart
@@ -114,6 +114,18 @@ void main() {
 
     expect(frame2.image.isCloneOf(frame.image), false);
   });
+
+  test('getNextFrame does not return a disposed image', () async {
+    final Uint8List bytes = await readFile('2x2.png');
+    final Codec codec = await instantiateImageCodec(bytes);
+    final FrameInfo frame = await codec.getNextFrame();
+
+    frame.image.dispose();
+
+    final FrameInfo frame2 = await codec.getNextFrame();
+    expect(frame2.image.clone()..dispose(), isNotNull);
+    frame2.image.dispose();
+  });
 }
 
 Future<Uint8List> readFile(String fileName) async {


### PR DESCRIPTION
We can't cache this information, because we expect the recipient to dispose of it. If that happens and someone uses the same codec to get the next frame, they can't anymore because the image handle has been disposed already. We also don't want this object to just secretly hold the image data which can then never be disposed.