### PR TITLE
[web] Respond with null for unimplemented method channels

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -679,14 +679,10 @@ class EngineWindow extends ui.Window {
       return;
     }
 
-    // TODO(flutter_web): Some Flutter widgets send platform messages that we
-    // don't handle on web. So for now, let's just ignore them. In the future,
-    // we should consider uncommenting the following "callback(null)" line.
-
     // Passing [null] to [callback] indicates that the platform message isn't
     // implemented. Look at [MethodChannel.invokeMethod] to see how [null] is
     // handled.
-    // callback(null);
+    _replyToPlatformMessage(callback, null);
   }
 
   int _getHapticFeedbackDuration(String? type) {

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -229,6 +229,24 @@ void testMain() {
     await completer.future;
   });
 
+  test('sendPlatformMessage responds even when channel is unknown', () async {
+    bool responded = false;
+
+    final ByteData inputData = ByteData(4);
+    inputData.setUint32(0, 42);
+    window.sendPlatformMessage(
+      'flutter/__unknown__channel__',
+      null,
+      (outputData) {
+        responded = true;
+        expect(outputData, isNull);
+      },
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    expect(responded, isTrue);
+  });
+
   test('Window implements locale, locales, and locale change notifications', () async {
     // This will count how many times we notified about locale changes.
     int localeChangedCount = 0;


### PR DESCRIPTION
## Description

When we receive an unimplemented platform message, respond with null to indicate that it's unimplemented instead of doing nothing.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66380