### PR TITLE
[ios] Remove unused is_valid_ from IOS Metal Context

### DIFF
--- a/shell/platform/darwin/ios/ios_context_metal.h
+++ b/shell/platform/darwin/ios/ios_context_metal.h
@@ -37,7 +37,6 @@ class IOSContextMetal final : public IOSContext {
   sk_sp<GrDirectContext> main_context_;
   sk_sp<GrDirectContext> resource_context_;
   fml::CFRef<CVMetalTextureCacheRef> texture_cache_;
-  bool is_valid_ = false;
 
   // |IOSContext|
   sk_sp<GrDirectContext> CreateResourceContext() override;

--- a/shell/platform/darwin/ios/ios_context_metal.mm
+++ b/shell/platform/darwin/ios/ios_context_metal.mm
@@ -65,8 +65,6 @@ IOSContextMetal::IOSContextMetal() {
     return;
   }
   texture_cache_.Reset(texture_cache_raw);
-
-  is_valid_ = false;
 }
 
 IOSContextMetal::~IOSContextMetal() = default;


### PR DESCRIPTION
Removes an unused (incorrectly set) field. This was presumably replaced by `ios_surface_metal`'s `is_valid_`