### PR TITLE
Respect the --debug option in Firefox

### DIFF
--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -70,7 +70,8 @@ user_pref("dom.max_script_run_time", 0);
         url.toString(),
         '--profile',
         '${temporaryProfileDirectory.path}',
-        '--headless',
+        if (!debug)
+          '--headless',
         '-width $kMaxScreenshotWidth',
         '-height $kMaxScreenshotHeight',
         isMac ? '--new-window' : '-new-window',


### PR DESCRIPTION
## Description

Make Firefox run _not_ in headless mode when running `felt --debug`. This allows debugging tests in Firefox.
