### PR TITLE
Make scoped_nsprotocol::release() private.

### DIFF
--- a/fml/platform/darwin/scoped_nsobject.h
+++ b/fml/platform/darwin/scoped_nsobject.h
@@ -76,6 +76,12 @@ class scoped_nsprotocol {
     object_ = temp;
   }
 
+  // Shift reference to the autorelease pool to be released later.
+  NST autorelease() { return [release() autorelease]; }
+
+ private:
+  NST object_;
+
   // scoped_nsprotocol<>::release() is like scoped_ptr<>::release.  It is NOT a
   // wrapper for [object_ release].  To force a scoped_nsprotocol<> to call
   // [object_ release], use scoped_nsprotocol<>::reset().
@@ -84,12 +90,6 @@ class scoped_nsprotocol {
     object_ = nil;
     return temp;
   }
-
-  // Shift reference to the autorelease pool to be released later.
-  NST autorelease() { return [release() autorelease]; }
-
- private:
-  NST object_;
 };
 
 // Free functions


### PR DESCRIPTION
This is not used anywhere in the engine. However, this API is easy to misuse as
one might incorrectly assume that it releases the reference on the underlying
object. Callers must use `reset` for this purpose.