### PR TITLE
[macos] Allow engine flags via environment vars

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -877,6 +877,9 @@ FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/plugin_registrar
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/standard_codec.cc
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/standard_message_codec_unittests.cc
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/standard_method_codec_unittests.cc
+FILE: ../../../flutter/shell/platform/common/cpp/engine_switches.cc
+FILE: ../../../flutter/shell/platform/common/cpp/engine_switches.h
+FILE: ../../../flutter/shell/platform/common/cpp/engine_switches_unittests.cc
 FILE: ../../../flutter/shell/platform/common/cpp/incoming_message_dispatcher.cc
 FILE: ../../../flutter/shell/platform/common/cpp/incoming_message_dispatcher.h
 FILE: ../../../flutter/shell/platform/common/cpp/json_message_codec.cc

--- a/shell/platform/common/cpp/BUILD.gn
+++ b/shell/platform/common/cpp/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
 
 config("desktop_library_implementation") {
@@ -42,6 +43,8 @@ source_set("common_cpp_input") {
 
   configs += [ ":desktop_library_implementation" ]
 
+  public_configs = [ "//flutter:config" ]
+
   if (is_win) {
     # For wstring_conversion. See issue #50053.
     defines = [ "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING" ]
@@ -52,6 +55,11 @@ source_set("common_cpp_switches") {
   public = [ "engine_switches.h" ]
 
   sources = [ "engine_switches.cc" ]
+
+  public_configs = [
+    "//flutter:config",
+    "//flutter/common:flutter_config",
+  ]
 }
 
 source_set("common_cpp") {
@@ -70,6 +78,8 @@ source_set("common_cpp") {
   ]
 
   configs += [ ":desktop_library_implementation" ]
+
+  public_configs = [ "//flutter:config" ]
 
   deps = [
     ":common_cpp_library_headers",
@@ -91,6 +101,8 @@ source_set("common_cpp_core") {
   public = [ "path_utils.h" ]
 
   sources = [ "path_utils.cc" ]
+
+  public_configs = [ "//flutter:config" ]
 }
 
 if (enable_unittests) {

--- a/shell/platform/common/cpp/BUILD.gn
+++ b/shell/platform/common/cpp/BUILD.gn
@@ -48,6 +48,12 @@ source_set("common_cpp_input") {
   }
 }
 
+source_set("common_cpp_switches") {
+  public = [ "engine_switches.h" ]
+
+  sources = [ "engine_switches.cc" ]
+}
+
 source_set("common_cpp") {
   public = [
     "incoming_message_dispatcher.h",
@@ -115,6 +121,7 @@ if (enable_unittests) {
     testonly = true
 
     sources = [
+      "engine_switches_unittests.cc",
       "json_message_codec_unittests.cc",
       "json_method_codec_unittests.cc",
       "text_input_model_unittests.cc",
@@ -124,6 +131,7 @@ if (enable_unittests) {
       ":common_cpp",
       ":common_cpp_fixtures",
       ":common_cpp_input",
+      ":common_cpp_switches",
       "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
       "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper_library_stubs",
       "//flutter/testing",

--- a/shell/platform/common/cpp/engine_switches.cc
+++ b/shell/platform/common/cpp/engine_switches.cc
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/common/cpp/engine_switches.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+
+namespace flutter {
+
+std::vector<std::string> GetSwitchesFromEnvironment() {
+  std::vector<std::string> switches;
+  // Read engine switches from the environment in debug/profile. If release mode
+  // support is needed in the future, it should likely use a whitelist.
+#ifndef FLUTTER_RELEASE
+  const char* switch_count_key = "FLUTTER_ENGINE_SWITCHES";
+  const int kMaxSwitchCount = 50;
+  const char* switch_count_string = std::getenv(switch_count_key);
+  int switch_count = std::min(
+      kMaxSwitchCount, switch_count_string ? atoi(switch_count_string) : 0);
+  for (int i = 1; i <= switch_count; ++i) {
+    std::ostringstream switch_key;
+    switch_key << "FLUTTER_ENGINE_SWITCH_" << i;
+    const char* switch_value = std::getenv(switch_key.str().c_str());
+    if (switch_value) {
+      std::ostringstream switch_value_as_flag;
+      switch_value_as_flag << "--" << switch_value;
+      switches.push_back(switch_value_as_flag.str());
+    } else {
+      std::cerr << switch_count << " keys expected from " << switch_count_key
+                << ", but " << switch_key.str() << " is missing." << std::endl;
+    }
+  }
+#endif  // !FLUTTER_RELEASE
+  return switches;
+}
+
+}  // namespace flutter

--- a/shell/platform/common/cpp/engine_switches.cc
+++ b/shell/platform/common/cpp/engine_switches.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/common/cpp/engine_switches.h"
 
+#include <algorithm>
 #include <cstdlib>
 #include <iostream>
 #include <sstream>

--- a/shell/platform/common/cpp/engine_switches.h
+++ b/shell/platform/common/cpp/engine_switches.h
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_COMMON_CPP_ENGINE_SWITCHES_H_
+#define FLUTTER_SHELL_PLATFORM_COMMON_CPP_ENGINE_SWITCHES_H_
+
+#include <string>
+#include <vector>
+
+namespace flutter {
+
+// Returns an array of engine switches suitable to pass to the embedder API
+// in FlutterProjectArgs, based on parsing variables from the environment in
+// the form:
+//   FLUTTER_ENGINE_SWITCHES=<count>
+//   FLUTTER_ENGINE_SWITCH_1=...
+//   FLUTTER_ENGINE_SWITCH_2=...
+//   ...
+// Values should match those in shell/common/switches.h
+//
+// The returned array does not include the initial dummy argument expected by
+// the embedder API, so command_line_argv should not be set directly from it.
+//
+// In release mode, not all switches from the environment will necessarily be
+// returned. See the implementation for details.
+std::vector<std::string> GetSwitchesFromEnvironment();
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_COMMON_CPP_ENGINE_SWITCHES_H_

--- a/shell/platform/common/cpp/engine_switches_unittests.cc
+++ b/shell/platform/common/cpp/engine_switches_unittests.cc
@@ -35,6 +35,17 @@ TEST(FlutterProjectBundle, SwitchesEmpty) {
   EXPECT_EQ(GetSwitchesFromEnvironment().size(), 0U);
 }
 
+#ifdef FLUTTER_RELEASE
+TEST(FlutterProjectBundle, SwitchesIgnoredInRelease) {
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCHES", "2");
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCH_1", "abc");
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCH_2", "foo=\"bar, baz\"");
+
+  std::vector<std::string> switches = GetSwitchesFromEnvironment();
+  EXPECT_EQ(switches.size(), 0U);
+}
+#endif  // FLUTTER_RELEASE
+
 #ifndef FLUTTER_RELEASE
 TEST(FlutterProjectBundle, Switches) {
   SetEnvironmentVariable("FLUTTER_ENGINE_SWITCHES", "2");

--- a/shell/platform/common/cpp/engine_switches_unittests.cc
+++ b/shell/platform/common/cpp/engine_switches_unittests.cc
@@ -1,0 +1,77 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/common/cpp/engine_switches.h"
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+
+namespace {
+// Sets |key=value| in the environment of this process.
+void SetEnvironmentVariable(const char* key, const char* value) {
+#ifdef _WIN32
+  _putenv_s(key, value);
+#else
+  setenv(key, value, 1);
+#endif
+}
+
+// Removes |key| from the environment of this process, if present.
+void ClearEnvironmentVariable(const char* key) {
+#ifdef _WIN32
+  _putenv_s(key, "");
+#else
+  unsetenv(key);
+#endif
+}
+}  // namespace
+
+TEST(FlutterProjectBundle, SwitchesEmpty) {
+  // Clear the main environment variable, since test order is not guaranteed.
+  ClearEnvironmentVariable("FLUTTER_ENGINE_SWITCHES");
+
+  EXPECT_EQ(GetSwitchesFromEnvironment().size(), 0U);
+}
+
+#ifndef FLUTTER_RELEASE
+TEST(FlutterProjectBundle, Switches) {
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCHES", "2");
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCH_1", "abc");
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCH_2", "foo=\"bar, baz\"");
+
+  std::vector<std::string> switches = GetSwitchesFromEnvironment();
+  EXPECT_EQ(switches.size(), 2U);
+  EXPECT_EQ(switches[0], "--abc");
+  EXPECT_EQ(switches[1], "--foo=\"bar, baz\"");
+}
+
+TEST(FlutterProjectBundle, SwitchesExtraValues) {
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCHES", "1");
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCH_1", "abc");
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCH_2", "foo=\"bar, baz\"");
+
+  std::vector<std::string> switches = GetSwitchesFromEnvironment();
+  EXPECT_EQ(switches.size(), 1U);
+  EXPECT_EQ(switches[0], "--abc");
+}
+
+TEST(FlutterProjectBundle, SwitchesMissingValues) {
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCHES", "4");
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCH_1", "abc");
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCH_2", "foo=\"bar, baz\"");
+  ClearEnvironmentVariable("FLUTTER_ENGINE_SWITCH_3");
+  SetEnvironmentVariable("FLUTTER_ENGINE_SWITCH_4", "oops");
+
+  std::vector<std::string> switches = GetSwitchesFromEnvironment();
+  EXPECT_EQ(switches.size(), 3U);
+  EXPECT_EQ(switches[0], "--abc");
+  EXPECT_EQ(switches[1], "--foo=\"bar, baz\"");
+  // The missing switch should be skipped, leaving SWITCH_4 as the third
+  // switch in the array.
+  EXPECT_EQ(switches[2], "--oops");
+}
+#endif  // !FLUTTER_RELEASE
+
+}  // namespace flutter

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -67,6 +67,7 @@ source_set("flutter_framework_source") {
   sources += _flutter_framework_headers
 
   deps = [
+    "//flutter/shell/platform/common/cpp:common_cpp_switches",
     "//flutter/shell/platform/darwin/common:framework_shared",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
   ]

--- a/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
@@ -30,15 +30,11 @@ FLUTTER_EXPORT
     NS_DESIGNATED_INITIALIZER;
 
 /**
- * Switches to pass to the Flutter engine. See
- * https://github.com/flutter/engine/blob/master/shell/common/switches.h
- * for details. Not all switches will apply to embedding mode. Switches have not stability
- * guarantee, and are subject to change without notice.
+ * If set, allows the Flutter project to use the dart:mirrors library.
  *
- * Note: This property WILL BE REMOVED in the future. If you use this property, please see
- * https://github.com/flutter/flutter/issues/38569.
+ * Deprecated: This function is temporary and will be removed in a future release.
  */
-@property(nullable) NSArray<NSString*>* engineSwitches;
+@property(nonatomic) bool enableMirrors;
 
 @end
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -7,6 +7,8 @@
 
 #include <vector>
 
+#include "flutter/shell/platform/common/cpp/engine_switches.h"
+
 static NSString* const kICUBundlePath = @"icudtl.dat";
 static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
 
@@ -67,13 +69,10 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
   return path;
 }
 
-- (std::vector<const char*>)argv {
-  // FlutterProjectArgs expects a full argv, so when processing it for flags the first item is
-  // treated as the executable and ignored. Add a dummy value so that all provided arguments
-  // are used.
-  std::vector<const char*> arguments = {"placeholder"};
-  for (NSUInteger i = 0; i < _engineSwitches.count; ++i) {
-    arguments.push_back([_engineSwitches[i] UTF8String]);
+- (std::vector<std::string>)switches {
+  std::vector<std::string> arguments = flutter::GetSwitchesFromEnvironment();
+  if (self.enableMirrors) {
+    arguments.push_back("--dart-flags=--enable_mirrors=true");
   }
   return arguments;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h
@@ -7,6 +7,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h"
 
+#include <string>
 #include <vector>
 
 /**
@@ -26,12 +27,8 @@
 
 /**
  * The command line arguments array for the engine.
- *
- * WARNING: The pointers in this array are valid only until the next call to set `engineSwitches`.
- * The returned vector should be used immediately, then discarded. It is returned this way for
- * ease of use with FlutterProjectArgs.
  */
-@property(nonatomic, readonly) std::vector<const char*> argv;
+@property(nonatomic, readonly) std::vector<std::string> switches;
 
 /**
  * Instead of looking up the assets and ICU data path in the application bundle, this initializer

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -6,6 +6,7 @@
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 
+#include <algorithm>
 #include <vector>
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -236,13 +236,20 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
 
   // TODO(stuartmorgan): Move internal channel registration from FlutterViewController to here.
 
+  // FlutterProjectArgs is expecting a full argv, so when processing it for
+  // flags the first item is treated as the executable and ignored. Add a dummy
+  // value so that all provided arguments are used.
+  std::vector<std::string> switches = _project.switches;
+  std::vector<const char*> argv = {"placeholder"};
+  std::transform(switches.begin(), switches.end(), std::back_inserter(argv),
+                 [](const std::string& arg) -> const char* { return arg.c_str(); });
+
   FlutterProjectArgs flutterArguments = {};
   flutterArguments.struct_size = sizeof(FlutterProjectArgs);
   flutterArguments.assets_path = _project.assetsPath.UTF8String;
   flutterArguments.icu_data_path = _project.ICUDataPath.UTF8String;
-  std::vector<const char*> arguments = _project.argv;
-  flutterArguments.command_line_argc = static_cast<int>(arguments.size());
-  flutterArguments.command_line_argv = &arguments[0];
+  flutterArguments.command_line_argc = static_cast<int>(argv.size());
+  flutterArguments.command_line_argv = argv.size() > 0 ? argv.data() : nullptr;
   flutterArguments.platform_message_callback = (FlutterPlatformMessageCallback)OnPlatformMessage;
   flutterArguments.custom_dart_entrypoint = entrypoint.UTF8String;
   static size_t sTaskRunnerIdentifiers = 0;

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -86,6 +86,7 @@ source_set("flutter_windows_source") {
     ":flutter_windows_headers",
     "//flutter/shell/platform/common/cpp:common_cpp",
     "//flutter/shell/platform/common/cpp:common_cpp_input",
+    "//flutter/shell/platform/common/cpp:common_cpp_switches",
     "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/platform/windows/client_wrapper:client_wrapper_windows",

--- a/shell/platform/windows/flutter_project_bundle.cc
+++ b/shell/platform/windows/flutter_project_bundle.cc
@@ -4,11 +4,10 @@
 
 #include "flutter/shell/platform/windows/flutter_project_bundle.h"
 
-#include <cstdlib>
 #include <filesystem>
 #include <iostream>
-#include <sstream>
 
+#include "flutter/shell/platform/common/cpp/engine_switches.h"
 #include "flutter/shell/platform/common/cpp/path_utils.h"
 
 namespace flutter {
@@ -76,29 +75,7 @@ UniqueAotDataPtr FlutterProjectBundle::LoadAotData() {
 FlutterProjectBundle::~FlutterProjectBundle() {}
 
 const std::vector<std::string> FlutterProjectBundle::GetSwitches() {
-  std::vector<std::string> switches;
-  // Read engine switches from the environment in debug/profile.
-#ifndef FLUTTER_RELEASE
-  const char* switch_count_key = "FLUTTER_ENGINE_SWITCHES";
-  const int kMaxSwitchCount = 50;
-  const char* switch_count_string = std::getenv(switch_count_key);
-  int switch_count = std::min(
-      kMaxSwitchCount, switch_count_string ? atoi(switch_count_string) : 0);
-  for (int i = 1; i <= switch_count; ++i) {
-    std::ostringstream switch_key;
-    switch_key << "FLUTTER_ENGINE_SWITCH_" << i;
-    const char* switch_value = std::getenv(switch_key.str().c_str());
-    if (switch_value) {
-      std::ostringstream switch_value_as_flag;
-      switch_value_as_flag << "--" << switch_value;
-      switches.push_back(switch_value_as_flag.str());
-    } else {
-      std::cerr << switch_count << " keys expected from " << switch_count_key
-                << ", but " << switch_key.str() << " is missing." << std::endl;
-    }
-  }
-#endif  // !FLUTTER_RELEASE
-  return switches;
+  return GetSwitchesFromEnvironment();
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_project_bundle_unittests.cc
+++ b/shell/platform/windows/flutter_project_bundle_unittests.cc
@@ -64,43 +64,6 @@ TEST(FlutterProjectBundle, Switches) {
   EXPECT_EQ(switches[0], "--abc");
   EXPECT_EQ(switches[1], "--foo=\"bar, baz\"");
 }
-
-TEST(FlutterProjectBundle, SwitchesExtraValues) {
-  FlutterDesktopEngineProperties properties = {};
-  properties.assets_path = L"foo\\flutter_assets";
-  properties.icu_data_path = L"foo\\icudtl.dat";
-
-  _putenv_s("FLUTTER_ENGINE_SWITCHES", "1");
-  _putenv_s("FLUTTER_ENGINE_SWITCH_1", "abc");
-  _putenv_s("FLUTTER_ENGINE_SWITCH_2", "foo=\"bar, baz\"");
-
-  FlutterProjectBundle project(properties);
-
-  std::vector<std::string> switches = project.GetSwitches();
-  EXPECT_EQ(switches.size(), 1);
-  EXPECT_EQ(switches[0], "--abc");
-}
-
-TEST(FlutterProjectBundle, SwitchesMissingValues) {
-  FlutterDesktopEngineProperties properties = {};
-  properties.assets_path = L"foo\\flutter_assets";
-  properties.icu_data_path = L"foo\\icudtl.dat";
-
-  _putenv_s("FLUTTER_ENGINE_SWITCHES", "4");
-  _putenv_s("FLUTTER_ENGINE_SWITCH_1", "abc");
-  _putenv_s("FLUTTER_ENGINE_SWITCH_2", "foo=\"bar, baz\"");
-  _putenv_s("FLUTTER_ENGINE_SWITCH_4", "oops");
-
-  FlutterProjectBundle project(properties);
-
-  std::vector<std::string> switches = project.GetSwitches();
-  EXPECT_EQ(switches.size(), 3);
-  EXPECT_EQ(switches[0], "--abc");
-  EXPECT_EQ(switches[1], "--foo=\"bar, baz\"");
-  // The missing switch should be skipped, leaving SWITCH_4 as the third
-  // switch in the array.
-  EXPECT_EQ(switches[2], "--oops");
-}
 #endif  // !FLUTTER_RELEASE
 
 }  // namespace testing


### PR DESCRIPTION
## Description

Replaces the (temporary) compile-time option to pass engine switches
with the ability to pass them temporarily at runtime via environment
variables. This moves the recently-added code for doing this on Windows
to a shared location for use by all desktop embeddings.

This is enabled only for debug/profile to avoid potential issues with
tampering with released applications, but if there is a need for that in
the future it could be added (potentially with a whitelist, as is
currently used for Dart VM flags).

Temporarily adds a way to enable mirrors as a compile time option,
as is already provided in the Linux embedding, to provide a migration
path for the one remaining known need for compile-time options
that has been raised in https://github.com/flutter/flutter/issues/38569.

## Related Issues

flutter/flutter#38569
flutter/flutter#60393

## Tests

I added the following tests: Tests for the now-stand-alone utility for extracting switches from the environment.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [x] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
   - [x] Desktop is still in alpha, and this API has been marked as deprecated since before the alpha launch. Anyone using this API had already been instructed to follow https://github.com/flutter/flutter/issues/38569. A survey of GitHub found only a single current public use of this API, which is in flutter/devtools (where discussion of replacement has already been happening)

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
