### PR TITLE
Replace kLegacyFontHost_InitType with kUnknown_SkPixelGeometry.

### DIFF
--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -170,9 +170,7 @@ static sk_sp<SkSurface> WrapOnscreenSurface(GrDirectContext* context,
   );
 
   sk_sp<SkColorSpace> colorspace = SkColorSpace::MakeSRGB();
-
-  SkSurfaceProps surface_props(
-      SkSurfaceProps::InitType::kLegacyFontHost_InitType);
+  SkSurfaceProps surface_props(0, kUnknown_SkPixelGeometry);
 
   return SkSurface::MakeFromBackendRenderTarget(
       context,                                       // gr context

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -353,8 +353,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
                                    texture_info         //
   );
 
-  SkSurfaceProps surface_properties(
-      SkSurfaceProps::InitType::kLegacyFontHost_InitType);
+  SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 
   auto surface = SkSurface::MakeFromBackendTexture(
       context,                      // context
@@ -398,8 +397,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
       framebuffer_info     // framebuffer info
   );
 
-  SkSurfaceProps surface_properties(
-      SkSurfaceProps::InitType::kLegacyFontHost_InitType);
+  SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 
   auto surface = SkSurface::MakeFromBackendRenderTarget(
       context,                      //  context

--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -349,8 +349,7 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrDirectContext> context,
   GrBackendRenderTarget sk_render_target(size.width(), size.height(), 0,
                                          image_info);
 
-  SkSurfaceProps sk_surface_props(
-      SkSurfaceProps::InitType::kLegacyFontHost_InitType);
+  SkSurfaceProps sk_surface_props(0, kUnknown_SkPixelGeometry);
 
   auto sk_surface =
       SkSurface::MakeFromBackendRenderTarget(context.get(),             //

--- a/testing/test_gl_surface.cc
+++ b/testing/test_gl_surface.cc
@@ -312,8 +312,7 @@ sk_sp<SkSurface> TestGLSurface::GetOnscreenSurface() {
       framebuffer_info  // framebuffer info
   );
 
-  SkSurfaceProps surface_properties(
-      SkSurfaceProps::InitType::kLegacyFontHost_InitType);
+  SkSurfaceProps surface_properties(0, kUnknown_SkPixelGeometry);
 
   auto surface = SkSurface::MakeFromBackendRenderTarget(
       GetGrContext().get(),         // context

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -232,7 +232,7 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(
   // TODO(chinmaygarde): Setup the stencil buffer and the sampleCnt.
   GrBackendRenderTarget backend_render_target(size.fWidth, size.fHeight, 0,
                                               image_info);
-  SkSurfaceProps props(SkSurfaceProps::InitType::kLegacyFontHost_InitType);
+  SkSurfaceProps props(0, kUnknown_SkPixelGeometry);
 
   return SkSurface::MakeFromBackendRenderTarget(
       gr_context,                // context


### PR DESCRIPTION
Skia is removing the deprecated legacy display setting globals and
associated kLegacyFontHost_InitType. This change replaces all such uses
with default surface properties with no special flags and an unknown
pixel geometry. Flutter never set the associated globals, leaving them
with their initial default values, which were no special flags and
horizontal RGB pixel geometry. The values used here are different but
this change should make no difference as Flutter never mentions
SkFont::kSubpixelAntiAlias to take advantage of the pixel geometry