### PR TITLE
[fuchsia][a11y] Don't populate hidden state.

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -104,8 +104,8 @@ fuchsia::accessibility::semantics::States AccessibilityBridge::GetNodeStates(
   // Set selected state.
   states.set_selected(node.HasFlag(flutter::SemanticsFlags::kIsSelected));
 
-  // Set hidden state.
-  states.set_hidden(node.HasFlag(flutter::SemanticsFlags::kIsHidden));
+  // Flutter's definition of a hidden node is different from Fuchsia, so it must
+  // not be set here.
 
   // Set value.
   if (node.value.size() > fuchsia::accessibility::semantics::MAX_VALUE_SIZE) {

--- a/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
@@ -286,7 +286,6 @@ TEST_F(AccessibilityBridgeTest, PopulatesCheckedState) {
   // HasCheckedState = true
   // IsChecked = true
   // IsSelected = false
-  // IsHidden = false
   node0.flags |= static_cast<int>(flutter::SemanticsFlags::kHasCheckedState);
   node0.flags |= static_cast<int>(flutter::SemanticsFlags::kIsChecked);
   node0.value = "value";
@@ -307,8 +306,6 @@ TEST_F(AccessibilityBridgeTest, PopulatesCheckedState) {
             fuchsia::accessibility::semantics::CheckedState::CHECKED);
   EXPECT_TRUE(states.has_selected());
   EXPECT_FALSE(states.selected());
-  EXPECT_TRUE(states.has_hidden());
-  EXPECT_FALSE(states.hidden());
   EXPECT_TRUE(states.has_value());
   EXPECT_EQ(states.value(), node0.value);
 
@@ -322,7 +319,6 @@ TEST_F(AccessibilityBridgeTest, PopulatesSelectedState) {
   // HasCheckedState = false
   // IsChecked = false
   // IsSelected = true
-  // IsHidden = false
   node0.flags = static_cast<int>(flutter::SemanticsFlags::kIsSelected);
 
   accessibility_bridge_->AddSemanticsNodeUpdate({{0, node0}}, 1.f);
@@ -341,8 +337,6 @@ TEST_F(AccessibilityBridgeTest, PopulatesSelectedState) {
             fuchsia::accessibility::semantics::CheckedState::NONE);
   EXPECT_TRUE(states.has_selected());
   EXPECT_TRUE(states.selected());
-  EXPECT_TRUE(states.has_hidden());
-  EXPECT_FALSE(states.hidden());
 
   EXPECT_FALSE(semantics_manager_.DeleteOverflowed());
   EXPECT_FALSE(semantics_manager_.UpdateOverflowed());
@@ -362,7 +356,9 @@ TEST_F(AccessibilityBridgeTest, ApplyViewPixelRatioToRoot) {
   EXPECT_EQ(fuchsia_node.transform().matrix[10], 1.f);
 }
 
-TEST_F(AccessibilityBridgeTest, PopulatesHiddenState) {
+TEST_F(AccessibilityBridgeTest, DoesNotPopulatesHiddenState) {
+  // Flutter's notion of a hidden node is different from Fuchsia's hidden node.
+  // This test make sures that this state does not get sent.
   flutter::SemanticsNode node0;
   node0.id = 0;
   // HasCheckedState = false
@@ -387,8 +383,7 @@ TEST_F(AccessibilityBridgeTest, PopulatesHiddenState) {
             fuchsia::accessibility::semantics::CheckedState::NONE);
   EXPECT_TRUE(states.has_selected());
   EXPECT_FALSE(states.selected());
-  EXPECT_TRUE(states.has_hidden());
-  EXPECT_TRUE(states.hidden());
+  EXPECT_FALSE(states.has_hidden());
 
   EXPECT_FALSE(semantics_manager_.DeleteOverflowed());
   EXPECT_FALSE(semantics_manager_.UpdateOverflowed());


### PR DESCRIPTION
## Description

Flutter's definition of a hidden node is different from the Fuchsia definition.

Flutter definition = a node that is not visible on the screen, but can be made visible by scrolling this node into the view port.

Fuchsia = a node that should be ignored by assistive technology, regardless of its position on the screen (similar to what aria hidden is for the web)



## Tests

I added the following tests:
-  DoesNotPopulatesHiddenState

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
