### PR TITLE
Revert "[fuchsia][a11y] Don't populate hidden state. (#21484)"

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -104,8 +104,8 @@ fuchsia::accessibility::semantics::States AccessibilityBridge::GetNodeStates(
   // Set selected state.
   states.set_selected(node.HasFlag(flutter::SemanticsFlags::kIsSelected));
 
-  // Flutter's definition of a hidden node is different from Fuchsia, so it must
-  // not be set here.
+  // Set hidden state.
+  states.set_hidden(node.HasFlag(flutter::SemanticsFlags::kIsHidden));
 
   // Set value.
   if (node.value.size() > fuchsia::accessibility::semantics::MAX_VALUE_SIZE) {

--- a/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
@@ -286,6 +286,7 @@ TEST_F(AccessibilityBridgeTest, PopulatesCheckedState) {
   // HasCheckedState = true
   // IsChecked = true
   // IsSelected = false
+  // IsHidden = false
   node0.flags |= static_cast<int>(flutter::SemanticsFlags::kHasCheckedState);
   node0.flags |= static_cast<int>(flutter::SemanticsFlags::kIsChecked);
   node0.value = "value";
@@ -306,6 +307,8 @@ TEST_F(AccessibilityBridgeTest, PopulatesCheckedState) {
             fuchsia::accessibility::semantics::CheckedState::CHECKED);
   EXPECT_TRUE(states.has_selected());
   EXPECT_FALSE(states.selected());
+  EXPECT_TRUE(states.has_hidden());
+  EXPECT_FALSE(states.hidden());
   EXPECT_TRUE(states.has_value());
   EXPECT_EQ(states.value(), node0.value);
 
@@ -319,6 +322,7 @@ TEST_F(AccessibilityBridgeTest, PopulatesSelectedState) {
   // HasCheckedState = false
   // IsChecked = false
   // IsSelected = true
+  // IsHidden = false
   node0.flags = static_cast<int>(flutter::SemanticsFlags::kIsSelected);
 
   accessibility_bridge_->AddSemanticsNodeUpdate({{0, node0}}, 1.f);
@@ -337,6 +341,8 @@ TEST_F(AccessibilityBridgeTest, PopulatesSelectedState) {
             fuchsia::accessibility::semantics::CheckedState::NONE);
   EXPECT_TRUE(states.has_selected());
   EXPECT_TRUE(states.selected());
+  EXPECT_TRUE(states.has_hidden());
+  EXPECT_FALSE(states.hidden());
 
   EXPECT_FALSE(semantics_manager_.DeleteOverflowed());
   EXPECT_FALSE(semantics_manager_.UpdateOverflowed());
@@ -356,9 +362,7 @@ TEST_F(AccessibilityBridgeTest, ApplyViewPixelRatioToRoot) {
   EXPECT_EQ(fuchsia_node.transform().matrix[10], 1.f);
 }
 
-TEST_F(AccessibilityBridgeTest, DoesNotPopulatesHiddenState) {
-  // Flutter's notion of a hidden node is different from Fuchsia's hidden node.
-  // This test make sures that this state does not get sent.
+TEST_F(AccessibilityBridgeTest, PopulatesHiddenState) {
   flutter::SemanticsNode node0;
   node0.id = 0;
   // HasCheckedState = false
@@ -383,7 +387,8 @@ TEST_F(AccessibilityBridgeTest, DoesNotPopulatesHiddenState) {
             fuchsia::accessibility::semantics::CheckedState::NONE);
   EXPECT_TRUE(states.has_selected());
   EXPECT_FALSE(states.selected());
-  EXPECT_FALSE(states.has_hidden());
+  EXPECT_TRUE(states.has_hidden());
+  EXPECT_TRUE(states.hidden());
 
   EXPECT_FALSE(semantics_manager_.DeleteOverflowed());
   EXPECT_FALSE(semantics_manager_.UpdateOverflowed());


### PR DESCRIPTION
This reverts commit 20be7782500a270f27c1c0cd3a821108bbfea926.

See: https://github.com/flutter/flutter/issues/66922
