### PR TITLE
fuchsia: Remove display device availability check from Flutter

### DIFF
--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -24,7 +24,7 @@ Surface::~Surface() = default;
 
 // |flutter::Surface|
 bool Surface::IsValid() {
-  return valid_;
+  return true;
 }
 
 // |flutter::Surface|
@@ -40,30 +40,6 @@ std::unique_ptr<flutter::SurfaceFrame> Surface::AcquireFrame(
 // |flutter::Surface|
 GrDirectContext* Surface::GetContext() {
   return gr_context_;
-}
-
-static zx_status_t DriverWatcher(int dirfd,
-                                 int event,
-                                 const char* fn,
-                                 void* cookie) {
-  if (event == WATCH_EVENT_ADD_FILE && !strcmp(fn, "000")) {
-    return ZX_ERR_STOP;
-  }
-  return ZX_OK;
-}
-
-bool Surface::CanConnectToDisplay() {
-  constexpr char kGpuDriverClass[] = "/dev/class/gpu";
-  fml::UniqueFD fd(open(kGpuDriverClass, O_DIRECTORY | O_RDONLY));
-  if (fd.get() < 0) {
-    FML_DLOG(ERROR) << "Failed to open " << kGpuDriverClass;
-    return false;
-  }
-
-  zx_status_t status = fdio_watch_directory(
-      fd.get(), DriverWatcher,
-      zx::deadline_after(zx::duration(ZX_SEC(5))).get(), nullptr);
-  return status == ZX_ERR_STOP;
 }
 
 // |flutter::Surface|

--- a/shell/platform/fuchsia/flutter/surface.h
+++ b/shell/platform/fuchsia/flutter/surface.h
@@ -22,7 +22,6 @@ class Surface final : public flutter::Surface {
   ~Surface() override;
 
  private:
-  const bool valid_ = CanConnectToDisplay();
   const std::string debug_label_;
   flutter::ExternalViewEmbedder* view_embedder_;
   GrDirectContext* gr_context_;
@@ -42,8 +41,6 @@ class Surface final : public flutter::Surface {
 
   // |flutter::Surface|
   flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
-
-  static bool CanConnectToDisplay();
 
   FML_DISALLOW_COPY_AND_ASSIGN(Surface);
 };


### PR DESCRIPTION
## Description

When Flutter engine connects to Scenic, Scenic has already checked the display and graphics device availability before Scenic starts; so it is guaranteed that display devices are available and surface is valid when it is created.

Thus this change removes the device watching details from flutter surface on Fuchsia so that it doesn't need to do duplicated checks and hides the device-specific details.

## Related Issues

b/169632318
http://fxbug.dev/23795

## Tests

TEST= PlatformViewTests.CreateSurfaceTest passed on Fuchsia.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
