### PR TITLE
re-enable CanvasKit path ops test

### DIFF
--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -215,6 +215,28 @@ void _pathOpTests() {
       expect(toSkPathOp(op).value, op.index);
     }
   });
+
+  test('Path.combine test', () {
+    final ui.Path path1 = ui.Path();
+    expect(path1, isA<CkPath>());
+    path1.addRect(ui.Rect.fromLTRB(0, 0, 10, 10));
+    path1.addOval(ui.Rect.fromLTRB(10, 10, 100, 100));
+
+    final ui.Path path2 = ui.Path();
+    expect(path2, isA<CkPath>());
+    path2.addRect(ui.Rect.fromLTRB(5, 5, 15, 15));
+    path2.addOval(ui.Rect.fromLTRB(15, 15, 105, 105));
+
+    final ui.Path union = ui.Path.combine(ui.PathOperation.union, path1, path2);
+    expect(union, isA<CkPath>());
+    expect(union.getBounds(), const ui.Rect.fromLTRB(0, 0, 105, 105));
+
+    // Smoke-test other operations.
+    for (final ui.PathOperation operation in ui.PathOperation.values) {
+      final ui.Path combined = ui.Path.combine(operation, path1, path2);
+      expect(combined, isA<CkPath>());
+    }
+  });
 }
 
 void _clipOpTests() {

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -202,20 +202,19 @@ void _fillTypeTests() {
 }
 
 void _pathOpTests() {
-  // TODO(yjbanov): https://github.com/flutter/flutter/issues/61403
-  // test('path op mapping is correct', () {
-  //   expect(canvasKit.PathOp.Difference.value, ui.PathOperation.difference.index);
-  //   expect(canvasKit.PathOp.Intersect.value, ui.PathOperation.intersect.index);
-  //   expect(canvasKit.PathOp.Union.value, ui.PathOperation.union.index);
-  //   expect(canvasKit.PathOp.XOR.value, ui.PathOperation.xor.index);
-  //   expect(canvasKit.PathOp.ReverseDifference, ui.PathOperation.reverseDifference.index);
-  // });
+  test('path op mapping is correct', () {
+    expect(canvasKit.PathOp.Difference.value, ui.PathOperation.difference.index);
+    expect(canvasKit.PathOp.Intersect.value, ui.PathOperation.intersect.index);
+    expect(canvasKit.PathOp.Union.value, ui.PathOperation.union.index);
+    expect(canvasKit.PathOp.XOR.value, ui.PathOperation.xor.index);
+    expect(canvasKit.PathOp.ReverseDifference.value, ui.PathOperation.reverseDifference.index);
+  });
 
-  // test('ui.PathOperation converts to SkPathOp', () {
-  //   for (ui.PathOperation op in ui.PathOperation.values) {
-  //     expect(toSkPathOp(op).value, op.index);
-  //   }
-  // });
+  test('ui.PathOperation converts to SkPathOp', () {
+    for (ui.PathOperation op in ui.PathOperation.values) {
+      expect(toSkPathOp(op).value, op.index);
+    }
+  });
 }
 
 void _clipOpTests() {


### PR DESCRIPTION
## Description

Path ops are back in CanvasKit now (i.e. `Path.combine`)

## Related Issues

Fixes https://github.com/flutter/flutter/issues/61403

## Tests

Test is the only thing this is adding.

/cc @kjlubick