### PR TITLE
Add missing returns in system channels handlers

### DIFF
--- a/shell/platform/glfw/text_input_plugin.cc
+++ b/shell/platform/glfw/text_input_plugin.cc
@@ -139,6 +139,7 @@ void TextInputPlugin::HandleMethodCall(
     if (client_config.IsNull()) {
       result->Error(kBadArgumentError,
                     "Could not set client, missing arguments.");
+      return;
     }
     client_id_ = client_id_json.GetInt();
     input_action_ = "";

--- a/shell/platform/windows/cursor_handler.cc
+++ b/shell/platform/windows/cursor_handler.cc
@@ -40,6 +40,7 @@ void CursorHandler::HandleMethodCall(
     if (kind_iter == arguments.end()) {
       result->Error("Argument error",
                     "Missing argument while trying to activate system cursor");
+      return;
     }
     const auto& kind = std::get<std::string>(kind_iter->second);
     delegate_->UpdateFlutterCursor(kind);


### PR DESCRIPTION
## Description

The Windows and GLFW embeddings both had cases of missing returns after
calling `Error` on a method channel result object, leading to incorrect
double-calls on the result if the error paths were ever hit.

## Related Issues

None

## Tests

I added the following tests: Needs the engine interposing layer to test, which hasn't been written yet.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
