### PR TITLE
Smooth window resizing on macOS

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1047,6 +1047,10 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterExter
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterExternalTextureGL.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputModel.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputModel.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.h
@@ -1056,6 +1060,8 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterView.
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/MacOSSwitchableGLContext.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/MacOSSwitchableGLContext.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/module.modulemap
 FILE: ../../../flutter/shell/platform/embedder/assets/EmbedderInfo.plist

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -66,11 +66,14 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterView.mm",
     "framework/Source/FlutterViewController.mm",
     "framework/Source/FlutterViewController_Internal.h",
+    "framework/Source/MacOSSwitchableGLContext.h",
+    "framework/Source/MacOSSwitchableGLContext.mm",
   ]
 
   sources += _flutter_framework_headers
 
   deps = [
+    "//flutter/flow:flow",
     "//flutter/fml:fml",
     "//flutter/shell/platform/common/cpp:common_cpp_switches",
     "//flutter/shell/platform/darwin/common:framework_shared",

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -54,6 +54,10 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterExternalTextureGL.mm",
     "framework/Source/FlutterMouseCursorPlugin.h",
     "framework/Source/FlutterMouseCursorPlugin.mm",
+    "framework/Source/FlutterResizeSynchronizer.h",
+    "framework/Source/FlutterResizeSynchronizer.mm",
+    "framework/Source/FlutterSurfaceManager.h",
+    "framework/Source/FlutterSurfaceManager.mm",
     "framework/Source/FlutterTextInputModel.h",
     "framework/Source/FlutterTextInputModel.mm",
     "framework/Source/FlutterTextInputPlugin.h",
@@ -81,6 +85,8 @@ source_set("flutter_framework_source") {
   libs = [
     "Cocoa.framework",
     "CoreVideo.framework",
+    "IOSurface.framework",
+    "QuartzCore.framework",
   ]
 }
 

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -71,6 +71,7 @@ source_set("flutter_framework_source") {
   sources += _flutter_framework_headers
 
   deps = [
+    "//flutter/fml:fml",
     "//flutter/shell/platform/common/cpp:common_cpp_switches",
     "//flutter/shell/platform/darwin/common:framework_shared",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -297,7 +297,6 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   const FlutterCustomTaskRunners custom_task_runners = {
       .struct_size = sizeof(FlutterCustomTaskRunners),
       .platform_task_runner = &cocoa_task_runner_description,
-      .render_task_runner = &cocoa_task_runner_description,
   };
   flutterArguments.custom_task_runners = &custom_task_runners;
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -321,7 +321,7 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
 
   [self sendUserLocales];
   [self updateDisplayConfig];
-  [self.viewController.flutterView start];
+  self.viewController.flutterView.synchronousResizing = YES;
   return YES;
 }
 
@@ -363,7 +363,7 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
     _resourceContext = nil;
   }
   if (_engine) {
-    [self.viewController.flutterView start];
+    self.viewController.flutterView.synchronousResizing = YES;
   }
 }
 
@@ -415,7 +415,7 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   CVDisplayLinkRelease(displayLinkRef);
 }
 
-// Must be driven by FlutterView (i.e. [FlutterView start])
+// Called by [FlutterViewController viewDidReshape]
 - (void)updateWindowMetrics {
   if (!_engine) {
     return;

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -320,6 +320,7 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   }
 
   [self sendUserLocales];
+  [self updateWindowMetrics];
   [self updateDisplayConfig];
   self.viewController.flutterView.synchronousResizing = YES;
   return YES;
@@ -415,7 +416,6 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   CVDisplayLinkRelease(displayLinkRef);
 }
 
-// Called by [FlutterViewController viewDidReshape]
 - (void)updateWindowMetrics {
   if (!_engine) {
     return;

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
@@ -12,7 +12,29 @@
 
 @end
 
-// Encapsulates the logic for blocking platform thread during window resize
+// Encapsulates the logic for blocking platform thread during window resize as
+// well as synchronizing the raster and platform thread during commit (presenting frame)
+//
+// Flow during window resize
+//
+// 1. Platform thread calls [synchronizer beginResize:notify:]
+//    This will hold the platform thread until we're ready to display contents.
+// 2. Raster thread calls [synchronizer shouldEnsureSurfaceForSize:] with target size
+//    This will return false for any size other than target size
+// 3. Raster thread calls [synchronizer requestCommit]
+//    Any commit calls before shouldEnsureSurfaceForSize: is called with the right
+//    size are simply ignored; There's no point rasterizing and displaying frames
+//    with wrong size.
+// Both delegate methods (flush/commit) will be invoked before beginResize returns
+//
+// Flow during regular operation (no resizing)
+//
+// 1. Raster thread calls [synchronizer requestCommit]
+//    This will invoke [delegate flush:] on raster thread and
+//    [delegate commit:] on platform thread. The requestCommit call will be blocked
+//    until this is done. This is necessary to ensure that rasterizer won't start
+//    rasterizing next frame before we flipped the surface, which must be performed
+//    on platform thread
 @interface FlutterResizeSynchronizer : NSObject
 
 - (instancetype)initWithDelegate:(id<FlutterResizeSynchronizerDelegate>)delegate;
@@ -22,6 +44,7 @@
 // - requestCommit is called
 // All requestCommit calls before `shouldEnsureSurfaceForSize` is called with
 // expected size are ignored;
+// The notify block is invoked immediately after syncrhonizer mutex is acquired
 - (void)beginResize:(CGSize)size notify:(dispatch_block_t)notify;
 
 // Returns whether the view should ensure surfaces with given size;

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
@@ -1,0 +1,34 @@
+#import <Cocoa/Cocoa.h>
+
+@class FlutterResizeSynchronizer;
+
+@protocol FlutterResizeSynchronizerDelegate
+
+// Invoked on platform thread; Delegate should flush OpenGL context and
+// flip the surfaces
+- (void)resizeSynchronizerCommit:(FlutterResizeSynchronizer*)synchronizer;
+
+@end
+
+// Encapsulates the logic for blocking platform thread during window resize
+@interface FlutterResizeSynchronizer : NSObject
+
+- (instancetype)initWithDelegate:(id<FlutterResizeSynchronizerDelegate>)delegate;
+
+// Blocks the platform thread until
+// - shouldEnsureSurfaceForSize is called with proper size and
+// - requestCommit is called
+// All requestCommit calls before `shouldEnsureSurfaceForSize` is called with
+// expected size are ignored;
+- (void)beginResize:(CGSize)size notify:(dispatch_block_t)notify;
+
+// Returns whether the view should ensure surfaces with given size;
+// This will be false during resizing for any size other than size specified
+// during beginResize
+- (bool)shouldEnsureSurfaceForSize:(CGSize)size;
+
+// Called from rasterizer thread, will block until delegate resizeSynchronizerCommit:
+// method is called (on platform thread)
+- (void)requestCommit;
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
@@ -4,8 +4,10 @@
 
 @protocol FlutterResizeSynchronizerDelegate
 
-// Invoked on platform thread; Delegate should flush OpenGL context and
-// flip the surfaces
+// Invoked on raster thread; Delegate should flush the OpenGL context
+- (void)resizeSynchronizerFlush:(FlutterResizeSynchronizer*)synchronizer;
+
+// Invoked on platform thread; Delegate should flip the surfaces
 - (void)resizeSynchronizerCommit:(FlutterResizeSynchronizer*)synchronizer;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
@@ -44,7 +44,7 @@
 // - requestCommit is called
 // All requestCommit calls before `shouldEnsureSurfaceForSize` is called with
 // expected size are ignored;
-// The notify block is invoked immediately after syncrhonizer mutex is acquired
+// The notify block is invoked immediately after synchronizer mutex is acquired
 - (void)beginResize:(CGSize)size notify:(dispatch_block_t)notify;
 
 // Returns whether the view should ensure surfaces with given size;

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.mm
@@ -74,15 +74,14 @@
     return;
   }
 
+  pendingCommit = true;
   if (waiting) {  // BeginResize is in progress, interrupt it and schedule commit call
-    pendingCommit = true;
     condPendingCommit.notify_all();
     condNoPendingCommit.wait(lock, [&]() { return !pendingCommit; });
   } else {
     // No resize, schedule commit on platform thread and wait until either done
     // or interrupted by incoming BeginResize
     [delegate resizeSynchronizerFlush:self];
-    pendingCommit = true;
     dispatch_async(dispatch_get_main_queue(), [self, cookie_ = cookie] {
       std::unique_lock<std::mutex> lock(mutex);
       if (cookie_ == cookie) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.mm
@@ -50,6 +50,7 @@
 
   condPendingCommit.wait(lock, [&] { return pendingCommit; });
 
+  [delegate resizeSynchronizerFlush:self];
   [delegate resizeSynchronizerCommit:self];
   pendingCommit = false;
   condNoPendingCommit.notify_all();
@@ -80,6 +81,7 @@
   } else {
     // No resize, schedule commit on platform thread and wait until either done
     // or interrupted by incoming BeginResize
+    [delegate resizeSynchronizerFlush:self];
     pendingCommit = true;
     dispatch_async(dispatch_get_main_queue(), [self, cookie_ = cookie] {
       std::unique_lock<std::mutex> lock(mutex);

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.mm
@@ -1,0 +1,97 @@
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h"
+
+#import <mutex>
+
+@interface FlutterResizeSynchronizer () {
+  uint32_t cookie;  // counter to detect stale callbacks
+  std::mutex mutex;
+  std::condition_variable condRun;
+  std::condition_variable condBlock;
+  bool accepting;
+  bool waiting;
+  bool pendingCommit;
+  CGSize newSize;
+  __weak id<FlutterResizeSynchronizerDelegate> delegate;
+}
+@end
+
+@implementation FlutterResizeSynchronizer
+
+- (instancetype)initWithDelegate:(id<FlutterResizeSynchronizerDelegate>)delegate_ {
+  if (self = [super init]) {
+    accepting = true;
+    delegate = delegate_;
+  }
+  return self;
+}
+
+- (void)beginResize:(CGSize)size notify:(dispatch_block_t)notify {
+  std::unique_lock<std::mutex> lock(mutex);
+  if (!delegate) {
+    return;
+  }
+
+  ++cookie;
+
+  // from now on, ignore all incoming commits until the block below gets
+  // scheduled on raster thread
+  accepting = false;
+
+  // let pending commits finish to unblock the raster thread
+  condRun.notify_all();
+
+  // let the engine send resize notification
+  notify();
+
+  newSize = size;
+
+  waiting = true;
+
+  condBlock.wait(lock);
+
+  if (pendingCommit) {
+    [delegate resizeSynchronizerCommit:self];
+    pendingCommit = false;
+    condRun.notify_all();
+  }
+
+  waiting = false;
+}
+
+- (bool)shouldEnsureSurfaceForSize:(CGSize)size {
+  std::unique_lock<std::mutex> lock(mutex);
+  if (!accepting) {
+    if (CGSizeEqualToSize(newSize, size)) {
+      accepting = true;
+    }
+  }
+  return accepting;
+}
+
+- (void)requestCommit {
+  std::unique_lock<std::mutex> lock(mutex);
+  if (!accepting) {
+    return;
+  }
+
+  if (waiting) {  // BeginResize is in progress, interrupt it and schedule commit call
+    pendingCommit = true;
+    condBlock.notify_all();
+    condRun.wait(lock);
+  } else {
+    // No resize, schedule commit on platform thread and wait until either done
+    // or interrupted by incoming BeginResize
+    dispatch_async(dispatch_get_main_queue(), [self, cookie_ = cookie] {
+      std::unique_lock<std::mutex> lock(mutex);
+      if (cookie_ == cookie) {
+        if (delegate) {
+          [delegate resizeSynchronizerCommit:self];
+        }
+        condRun.notify_all();
+      }
+    });
+    condRun.wait(lock);
+  }
+}
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h
@@ -1,0 +1,13 @@
+#import <Cocoa/Cocoa.h>
+
+// Manages the IOSurfaces for FlutterView
+@interface FlutterSurfaceManager : NSObject
+
+- (instancetype)initWithLayer:(CALayer*)layer openGLContext:(NSOpenGLContext*)opengLContext;
+
+- (void)ensureSurfaceSize:(CGSize)size;
+- (void)swapBuffers;
+
+- (uint32_t)glFrameBufferId;
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -30,17 +30,8 @@ enum {
     glGenFramebuffers(2, _frameBufferId);
     glGenTextures(2, _backingTexture);
 
-    glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId[0]);
-    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, _backingTexture[0]);
-    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
-
-    glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId[1]);
-    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, _backingTexture[1]);
-    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+    [self createFramebuffer:_frameBufferId[0] withBackingTexture:_backingTexture[0]];
+    [self createFramebuffer:_frameBufferId[1] withBackingTexture:_backingTexture[1]];
 
     if (prev) {
       [prev makeCurrentContext];
@@ -49,6 +40,16 @@ enum {
     }
   }
   return self;
+}
+
+- (void)createFramebuffer:(uint32_t)fbo withBackingTexture:(uint32_t)texture {
+  glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  glBindTexture(GL_TEXTURE_RECTANGLE_ARB, texture);
+  glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
 }
 
 - (void)ensureSurfaceSize:(CGSize)size {

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -1,0 +1,119 @@
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"
+
+#include <OpenGL/gl.h>
+
+enum {
+  kFront = 0,
+  kBack = 1,
+  kBufferCount,
+};
+
+@interface FlutterSurfaceManager () {
+  CGSize surfaceSize;
+  CALayer* layer;
+  NSOpenGLContext* openGLContext;
+  uint32_t _frameBufferId[kBufferCount];
+  uint32_t _backingTexture[kBufferCount];
+  IOSurfaceRef _ioSurface[kBufferCount];
+}
+@end
+
+@implementation FlutterSurfaceManager
+
+- (instancetype)initWithLayer:(CALayer*)layer_ openGLContext:(NSOpenGLContext*)opengLContext_ {
+  if (self = [super init]) {
+    layer = layer_;
+    openGLContext = opengLContext_;
+
+    NSOpenGLContext* prev = [NSOpenGLContext currentContext];
+    [openGLContext makeCurrentContext];
+    glGenFramebuffers(2, _frameBufferId);
+    glGenTextures(2, _backingTexture);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId[0]);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, _backingTexture[0]);
+    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId[1]);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, _backingTexture[1]);
+    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+
+    if (prev) {
+      [prev makeCurrentContext];
+    } else {
+      [NSOpenGLContext clearCurrentContext];
+    }
+  }
+  return self;
+}
+
+- (void)ensureSurfaceSize:(CGSize)size {
+  if (CGSizeEqualToSize(size, surfaceSize)) {
+    return;
+  }
+  surfaceSize = size;
+  NSOpenGLContext* prev = [NSOpenGLContext currentContext];
+  [openGLContext makeCurrentContext];
+
+  for (int i = 0; i < 2; ++i) {
+    if (_ioSurface[i]) {
+      CFRelease(_ioSurface[i]);
+    }
+    unsigned pixelFormat = 'BGRA';
+    unsigned bytesPerElement = 4;
+
+    size_t bytesPerRow =
+        IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, size.width * bytesPerElement);
+    size_t totalBytes = IOSurfaceAlignProperty(kIOSurfaceAllocSize, size.height * bytesPerRow);
+    NSDictionary* options = @{
+      (id)kIOSurfaceWidth : @(size.width),
+      (id)kIOSurfaceHeight : @(size.height),
+      (id)kIOSurfacePixelFormat : @(pixelFormat),
+      (id)kIOSurfaceBytesPerElement : @(bytesPerElement),
+      (id)kIOSurfaceBytesPerRow : @(bytesPerRow),
+      (id)kIOSurfaceAllocSize : @(totalBytes),
+    };
+    _ioSurface[i] = IOSurfaceCreate((CFDictionaryRef)options);
+
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, _backingTexture[i]);
+
+    CGLTexImageIOSurface2D(CGLGetCurrentContext(), GL_TEXTURE_RECTANGLE_ARB, GL_RGBA,
+                           int(size.width), int(size.height), GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV,
+                           _ioSurface[i], 0 /* plane */);
+    glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+
+    glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId[i]);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE_ARB,
+                           _backingTexture[i], 0);
+  }
+  if (prev) {
+    [prev makeCurrentContext];
+  } else {
+    [NSOpenGLContext clearCurrentContext];
+  }
+}
+
+- (void)swapBuffers {
+  [layer setContents:(__bridge id)_ioSurface[kBack]];
+  std::swap(_ioSurface[kBack], _ioSurface[kFront]);
+  std::swap(_frameBufferId[kBack], _frameBufferId[kFront]);
+  std::swap(_backingTexture[kBack], _backingTexture[kFront]);
+}
+
+- (uint32_t)glFrameBufferId {
+  return _frameBufferId[kBack];
+}
+
+- (void)dealloc {
+  for (int i = 0; i < kBufferCount; ++i) {
+    if (_ioSurface[i]) {
+      CFRelease(_ioSurface[i]);
+    }
+  }
+}
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -103,8 +103,8 @@ enum {
 - (void)swapBuffers {
   contentLayer.frame = layer.bounds;
   // OpengL texture is rendered upside down
-  contentLayer.transform =
-      CATransform3DTranslate(CATransform3DMakeScale(1, -1, 1), 0, -layer.frame.size.height, 0);
+  layer.sublayerTransform =
+      CATransform3DTranslate(CATransform3DMakeScale(1, -1, 1), 0, -layer.bounds.size.height, 0);
 
   [contentLayer setContents:(__bridge id)_ioSurface[kBack]];
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -102,10 +102,8 @@ enum {
 
 - (void)swapBuffers {
   contentLayer.frame = layer.bounds;
-  // OpengL texture is rendered upside down
-  layer.sublayerTransform =
-      CATransform3DTranslate(CATransform3DMakeScale(1, -1, 1), 0, -layer.bounds.size.height, 0);
 
+  contentLayer.transform = CATransform3DMakeScale(1, -1, 1);
   [contentLayer setContents:(__bridge id)_ioSurface[kBack]];
 
   std::swap(_ioSurface[kBack], _ioSurface[kFront]);

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -103,6 +103,8 @@ enum {
 - (void)swapBuffers {
   contentLayer.frame = layer.bounds;
 
+  // The surface is an OpenGL texture, which means it has origin in bottom left corner
+  // and needs to be flipped vertically
   contentLayer.transform = CATransform3DMakeScale(1, -1, 1);
   [contentLayer setContents:(__bridge id)_ioSurface[kBack]];
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -1,4 +1,5 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"
+#import "flutter/fml/logging.h"
 
 #include <OpenGL/gl.h>
 
@@ -90,6 +91,8 @@ enum {
     glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId[i]);
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE_ARB,
                            _backingTexture[i], 0);
+
+    FML_DCHECK(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE);
   }
   if (prev) {
     [prev makeCurrentContext];

--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -59,7 +59,7 @@ enum {
   NSOpenGLContext* prev = [NSOpenGLContext currentContext];
   [openGLContext makeCurrentContext];
 
-  for (int i = 0; i < 2; ++i) {
+  for (int i = 0; i < kBufferCount; ++i) {
     if (_ioSurface[i]) {
       CFRelease(_ioSurface[i]);
     }

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -21,6 +21,7 @@
 @interface FlutterView : NSView
 
 @property(readwrite, nonatomic, nonnull) NSOpenGLContext* openGLContext;
+@property(readwrite, nonatomic) BOOL synchronousResizing;
 
 - (nullable instancetype)initWithFrame:(NSRect)frame
                           shareContext:(nonnull NSOpenGLContext*)shareContext
@@ -37,7 +38,6 @@
 - (nullable instancetype)initWithCoder:(nonnull NSCoder*)coder NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
-- (void)start;
 - (void)present;
 - (int)getFrameBufferIdForSize:(CGSize)size;
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -18,7 +18,9 @@
  * View capable of acting as a rendering target and input source for the Flutter
  * engine.
  */
-@interface FlutterView : NSOpenGLView
+@interface FlutterView : NSView
+
+@property(readwrite, nonatomic, nonnull) NSOpenGLContext* openGLContext;
 
 - (nullable instancetype)initWithFrame:(NSRect)frame
                           shareContext:(nonnull NSOpenGLContext*)shareContext
@@ -34,5 +36,9 @@
 - (nonnull instancetype)initWithFrame:(NSRect)frameRect NS_UNAVAILABLE;
 - (nullable instancetype)initWithCoder:(nonnull NSCoder*)coder NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;
+
+- (void)start;
+- (void)present;
+- (int)getFrameBufferIdForSize:(CGSize)size;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -13,7 +13,6 @@
   __weak id<FlutterViewReshapeListener> _reshapeListener;
   FlutterResizeSynchronizer* resizeSynchronizer;
   FlutterSurfaceManager* surfaceManager;
-  CALayer* contentLayer;
 }
 
 @end
@@ -35,13 +34,8 @@
 
     [self setWantsLayer:YES];
 
-    // Layer for content (which will be set by surfaceManager). This is separate from
-    // self.layer because it needs to be flipped vertically (using layer.sublayerTransform)
-    contentLayer = [[CALayer alloc] init];
-    [self.layer addSublayer:contentLayer];
-
     resizeSynchronizer = [[FlutterResizeSynchronizer alloc] initWithDelegate:self];
-    surfaceManager = [[FlutterSurfaceManager alloc] initWithLayer:contentLayer
+    surfaceManager = [[FlutterSurfaceManager alloc] initWithLayer:self.layer
                                                     openGLContext:self.openGLContext];
 
     _reshapeListener = reshapeListener;
@@ -59,9 +53,6 @@
   [CATransaction begin];
   [CATransaction setDisableActions:YES];
   self.layer.frame = self.bounds;
-  self.layer.sublayerTransform = CATransform3DTranslate(CATransform3DMakeScale(1, -1, 1), 0,
-                                                        -self.layer.bounds.size.height, 0);
-  contentLayer.frame = self.layer.bounds;
 
   [surfaceManager swapBuffers];
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -3,10 +3,23 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"
 
-@implementation FlutterView {
+#import <OpenGL/gl.h>
+#import <QuartzCore/QuartzCore.h>
+
+@interface FlutterView () <FlutterResizeSynchronizerDelegate> {
   __weak id<FlutterViewReshapeListener> _reshapeListener;
+  FlutterResizeSynchronizer* resizeSynchronizer;
+  FlutterSurfaceManager* surfaceManager;
+  BOOL active;
+  CALayer* contentLayer;
 }
+
+@end
+
+@implementation FlutterView
 
 - (instancetype)initWithShareContext:(NSOpenGLContext*)shareContext
                      reshapeListener:(id<FlutterViewReshapeListener>)reshapeListener {
@@ -20,13 +33,72 @@
   if (self) {
     self.openGLContext = [[NSOpenGLContext alloc] initWithFormat:shareContext.pixelFormat
                                                     shareContext:shareContext];
+
+    [self setWantsLayer:YES];
+
+    // Layer for content (which will be set by surfaceManager). This is separate from
+    // self.layer because it needs to be flipped vertically (using layer.sublayerTransform)
+    contentLayer = [[CALayer alloc] init];
+    [self.layer addSublayer:contentLayer];
+
+    resizeSynchronizer = [[FlutterResizeSynchronizer alloc] initWithDelegate:self];
+    surfaceManager = [[FlutterSurfaceManager alloc] initWithLayer:contentLayer
+                                                    openGLContext:self.openGLContext];
+
     _reshapeListener = reshapeListener;
-    self.wantsBestResolutionOpenGLSurface = YES;
   }
   return self;
 }
 
+- (void)resizeSynchronizerCommit:(FlutterResizeSynchronizer*)synchronizer {
+  [self.openGLContext makeCurrentContext];
+  glFlush();
+  [NSOpenGLContext clearCurrentContext];
+
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+  self.layer.frame = self.bounds;
+  self.layer.sublayerTransform = CATransform3DTranslate(CATransform3DMakeScale(1, -1, 1), 0,
+                                                        -self.layer.bounds.size.height, 0);
+  contentLayer.frame = self.layer.bounds;
+
+  [surfaceManager swapBuffers];
+
+  [CATransaction commit];
+}
+
+- (int)getFrameBufferIdForSize:(CGSize)size {
+  if ([resizeSynchronizer shouldEnsureSurfaceForSize:size]) {
+    [surfaceManager ensureSurfaceSize:size];
+  }
+  return [surfaceManager glFrameBufferId];
+}
+
+- (void)present {
+  [resizeSynchronizer requestCommit];
+}
+
+- (void)start {
+  active = YES;
+  [self reshaped];
+}
+
+- (void)reshaped {
+  if (active) {
+    CGSize scaledSize = [self convertSizeToBacking:self.bounds.size];
+    [resizeSynchronizer beginResize:scaledSize
+                             notify:^{
+                               [_reshapeListener viewDidReshape:self];
+                             }];
+  }
+}
+
 #pragma mark - NSView overrides
+
+- (void)setFrameSize:(NSSize)newSize {
+  [super setFrameSize:newSize];
+  [self reshaped];
+}
 
 /**
  * Declares that the view uses a flipped coordinate system, consistent with Flutter conventions.
@@ -39,17 +111,13 @@
   return YES;
 }
 
-- (void)reshape {
-  [super reshape];
-  [_reshapeListener viewDidReshape:self];
-}
-
 - (BOOL)acceptsFirstResponder {
   return YES;
 }
 
 - (void)viewDidChangeBackingProperties {
   [super viewDidChangeBackingProperties];
+  // Force redraw
   [_reshapeListener viewDidReshape:self];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -53,7 +53,6 @@
 - (void)resizeSynchronizerCommit:(FlutterResizeSynchronizer*)synchronizer {
   [CATransaction begin];
   [CATransaction setDisableActions:YES];
-  self.layer.frame = self.bounds;
 
   [surfaceManager swapBuffers];
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -5,6 +5,7 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/MacOSSwitchableGLContext.h"
 
 #import <OpenGL/gl.h>
 #import <QuartzCore/QuartzCore.h>
@@ -44,9 +45,9 @@
 }
 
 - (void)resizeSynchronizerFlush:(FlutterResizeSynchronizer*)synchronizer {
-  [self.openGLContext makeCurrentContext];
+  flutter::GLContextSwitch context_switch(
+      std::make_unique<MacOSSwitchableGLContext>(self.openGLContext));
   glFlush();
-  [NSOpenGLContext clearCurrentContext];
 }
 
 - (void)resizeSynchronizerCommit:(FlutterResizeSynchronizer*)synchronizer {

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -13,7 +13,6 @@
   __weak id<FlutterViewReshapeListener> _reshapeListener;
   FlutterResizeSynchronizer* resizeSynchronizer;
   FlutterSurfaceManager* surfaceManager;
-  BOOL active;
   CALayer* contentLayer;
 }
 
@@ -80,18 +79,15 @@
   [resizeSynchronizer requestCommit];
 }
 
-- (void)start {
-  active = YES;
-  [self reshaped];
-}
-
 - (void)reshaped {
-  if (active) {
+  if (self.synchronousResizing) {
     CGSize scaledSize = [self convertSizeToBacking:self.bounds.size];
     [resizeSynchronizer beginResize:scaledSize
                              notify:^{
                                [_reshapeListener viewDidReshape:self];
                              }];
+  } else {
+    [_reshapeListener viewDidReshape:self];
   }
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -50,11 +50,13 @@
   return self;
 }
 
-- (void)resizeSynchronizerCommit:(FlutterResizeSynchronizer*)synchronizer {
+- (void)resizeSynchronizerFlush:(FlutterResizeSynchronizer*)synchronizer {
   [self.openGLContext makeCurrentContext];
   glFlush();
   [NSOpenGLContext clearCurrentContext];
+}
 
+- (void)resizeSynchronizerCommit:(FlutterResizeSynchronizer*)synchronizer {
   [CATransaction begin];
   [CATransaction setDisableActions:YES];
   self.layer.frame = self.bounds;

--- a/shell/platform/darwin/macos/framework/Source/MacOSSwitchableGLContext.h
+++ b/shell/platform/darwin/macos/framework/Source/MacOSSwitchableGLContext.h
@@ -1,0 +1,21 @@
+#include "flutter/flow/gl_context_switch.h"
+#include "flutter/fml/memory/thread_checker.h"
+
+#import <Cocoa/Cocoa.h>
+
+class MacOSSwitchableGLContext final : public flutter::SwitchableGLContext {
+ public:
+  explicit MacOSSwitchableGLContext(NSOpenGLContext* context);
+
+  bool SetCurrent() override;
+
+  bool RemoveCurrent() override;
+
+ private:
+  NSOpenGLContext* context_;
+  NSOpenGLContext* previous_context_;
+
+  FML_DECLARE_THREAD_CHECKER(checker);
+
+  FML_DISALLOW_COPY_AND_ASSIGN(MacOSSwitchableGLContext);
+};

--- a/shell/platform/darwin/macos/framework/Source/MacOSSwitchableGLContext.mm
+++ b/shell/platform/darwin/macos/framework/Source/MacOSSwitchableGLContext.mm
@@ -1,0 +1,19 @@
+#import "flutter/shell/platform/darwin/macos/framework/Source/MacOSSwitchableGLContext.h"
+
+MacOSSwitchableGLContext::MacOSSwitchableGLContext(NSOpenGLContext* context) : context_(context) {}
+
+bool MacOSSwitchableGLContext::SetCurrent() {
+  FML_DCHECK_CREATION_THREAD_IS_CURRENT(checker);
+  previous_context_ = [NSOpenGLContext currentContext];
+  [context_ makeCurrentContext];
+  return true;
+}
+
+bool MacOSSwitchableGLContext::RemoveCurrent() {
+  if (previous_context_) {
+    [previous_context_ makeCurrentContext];
+  } else {
+    [NSOpenGLContext clearCurrentContext];
+  }
+  return true;
+}


### PR DESCRIPTION
## Description

Replaces https://github.com/flutter/engine/pull/21252

Make window resizing on macOS smooth, responsive and synchronous with windows size.

Related design doc: https://flutter.dev/go/desktop-resize-macos

Notable change: It seems that double buffered IOSurface backed NSOpenGLContext is not all that double buffered after all and I was able to create a test case which resulted in partial drawn frame visible. This version uses single buffered NSOpenGLContext with two IOSurfaces (front and back) which eliminates the problem.

Depends on: https://github.com/flutter/engine/pull/21108

## Related Issues

https://github.com/flutter/flutter/issues/44136

## Tests

I added the following tests:


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
