### PR TITLE
iOS: only add explicit transactions when there are platform views (only on main threads)

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -291,7 +291,8 @@ PostPrerollResult FlutterPlatformViewsController::PostPrerollAction(
 void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(
     int view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
-  // No CATransactions should be added in the begining of the frame.
+  // All the CATransactions should be committed by the end of the last frame,
+  // so catransaction_added_ must be false. 
   FML_DCHECK(!catransaction_added_);
   picture_recorders_[view_id] = std::make_unique<SkPictureRecorder>();
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -279,6 +279,10 @@ PostPrerollResult FlutterPlatformViewsController::PostPrerollAction(
     CancelFrame();
     return PostPrerollResult::kSkipAndRetryFrame;
   }
+  // If the post preroll action is successful, we will display platform views in the current frame.
+  // In order to sync the rendering of the platform views (quartz) with skia's rendering,
+  // We need to begin an explicit CATransaction. This transaction needs to be submitted
+  // after the current frame is submitted.
   [CATransaction begin];
   raster_thread_merger->ExtendLeaseTo(kDefaultMergedLeaseDuration);
   return PostPrerollResult::kSuccess;
@@ -548,6 +552,10 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
   composition_order_.clear();
 
   did_submit &= frame->Submit();
+
+  // The frame is submitted with embedded platform views.
+  // There should be a |[CATransaction begin]| call in this frame prior to all the drawing.
+  // Now we need to commit the transaction.
   [CATransaction commit];
   return did_submit;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -292,7 +292,7 @@ void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(
     int view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
   // All the CATransactions should be committed by the end of the last frame,
-  // so catransaction_added_ must be false. 
+  // so catransaction_added_ must be false.
   FML_DCHECK(!catransaction_added_);
   picture_recorders_[view_id] = std::make_unique<SkPictureRecorder>();
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -279,6 +279,7 @@ PostPrerollResult FlutterPlatformViewsController::PostPrerollAction(
     CancelFrame();
     return PostPrerollResult::kSkipAndRetryFrame;
   }
+  [CATransaction begin];
   raster_thread_merger->ExtendLeaseTo(kDefaultMergedLeaseDuration);
   return PostPrerollResult::kSuccess;
 }
@@ -547,7 +548,7 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
   composition_order_.clear();
 
   did_submit &= frame->Submit();
-
+  [CATransaction commit];
   return did_submit;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -676,6 +676,7 @@ void FlutterPlatformViewsController::DisposeViews() {
 
 void FlutterPlatformViewsController::BeginCATransaction() {
   FML_DCHECK([[NSThread currentThread] isMainThread]);
+  FML_DCHECK(!catransaction_added_);
   [CATransaction begin];
   catransaction_added_ = true;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -245,6 +245,8 @@ class FlutterPlatformViewsController {
 
   std::unique_ptr<fml::WeakPtrFactory<FlutterPlatformViewsController>> weak_factory_;
 
+  bool catransaction_added_ = false;
+
   void OnCreate(FlutterMethodCall* call, FlutterResult& result);
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);
   void OnAcceptGesture(FlutterMethodCall* call, FlutterResult& result);

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -296,6 +296,13 @@ class FlutterPlatformViewsController {
   // order.
   void BringLayersIntoView(LayersMap layer_map);
 
+  // Begin a CATransaction.
+  // This transaction needs to be balanced with |CommitCATransactionIfNeeded|.
+  void BeginCATransaction();
+
+  // Commit a CATransaction if |BeginCATransaction| has been called during the frame.
+  void CommitCATransactionIfNeeded();
+
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterPlatformViewsController);
 };
 


### PR DESCRIPTION
## Description

We only need to add explicit CATransactions on the main thread since platform views are only going to be on the main thread.
Also, adding explicit transactions seem to crash in certain image picker scenarios on iOS 14, so remove these transactions on the main thread will fix those crashes (on metal only) 

## Related Issues

https://github.com/flutter/flutter/issues/66647

## Tests

Not sure what we can do to test the rendering synchronization. I added a bunch of FML_DCHECKs so at least, the [scenario app tests](https://github.com/flutter/engine/tree/master/testing/scenario_app) in the engine should catch un-balanced CATransactions or CATransactions on the background thread. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
