### PR TITLE
[web] Fix monotonic quadratic winding

### DIFF
--- a/lib/web_ui/lib/src/engine/html/path/path_windings.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_windings.dart
@@ -146,7 +146,7 @@ class PathWinding {
 
     _QuadRoots quadRoots = _QuadRoots();
     final int n = quadRoots.findRoots(
-        startY - 2 * y1 + endY, 2 * (y1 - startY), endY - y);
+        startY - 2 * y1 + endY, 2 * (y1 - startY), startY - y);
     assert(n <= 1);
     double xt;
     if (0 == n) {

--- a/lib/web_ui/test/engine/surface/path/path_winding_test.dart
+++ b/lib/web_ui/test/engine/surface/path/path_winding_test.dart
@@ -298,6 +298,7 @@ void testMain() {
         }
       }
     });
+
     test('Concave lines path', () {
       final SurfacePath path = SurfacePath();
       path.moveTo(-0.284071773, -0.0622361786);
@@ -423,6 +424,20 @@ void testMain() {
         }
       }
       expect(strokedSin.convexityType, SPathConvexityType.kConcave);
+    });
+
+    /// Regression test for https://github.com/flutter/flutter/issues/66560.
+    test('Quadratic', () {
+      final SurfacePath path = SurfacePath();
+      path.moveTo(100.0, 0.0);
+      path.quadraticBezierTo(200.0, 0.0, 200.0, 100.0);
+      path.quadraticBezierTo(200.0, 200.0, 100.0, 200.0);
+      path.quadraticBezierTo(0.0, 200.0, 0.0, 100.0);
+      path.quadraticBezierTo(0.0, 0.0, 100.0, 0.0);
+      path.close();
+      expect(path.contains(Offset(100, 20)), true);
+      expect(path.contains(Offset(100, 120)), true);
+      expect(path.contains(Offset(100, -10)), false);
     });
   });
 }


### PR DESCRIPTION
## Description

Fixes root calculation for monotonic quads.
For reference see https://skia.googlesource.com/skia/+/master/src/core/SkPath.cpp#2732

## Related Issues

https://github.com/flutter/flutter/issues/66560

## Tests

Added regression test to path_winding_test.dart.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
