### PR TITLE
[web] Fix setPreferredOrientations failure on iOS due to NNBD change.

### DIFF
--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -536,18 +536,18 @@ flt-glass-pane * {
   Future<bool> setPreferredOrientation(List<dynamic>? orientations) {
     final html.Screen screen = html.window.screen!;
     if (!_unsafeIsNull(screen)) {
-      final html.ScreenOrientation screenOrientation =
-          screen.orientation!;
+      final html.ScreenOrientation? screenOrientation =
+          screen.orientation;
       if (!_unsafeIsNull(screenOrientation)) {
         if (orientations!.isEmpty) {
-          screenOrientation.unlock();
+          screenOrientation!.unlock();
           return Future.value(true);
         } else {
           String? lockType = _deviceOrientationToLockType(orientations.first);
           if (lockType != null) {
             final Completer<bool> completer = Completer<bool>();
             try {
-              screenOrientation.lock(lockType).then((dynamic _) {
+              screenOrientation!.lock(lockType).then((dynamic _) {
                 completer.complete(true);
               }).catchError((dynamic error) {
                 // On Chrome desktop an error with 'not supported on this device

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -248,6 +248,7 @@ void testMain() {
     expect(responded, isTrue);
   });
 
+  /// Regression test for https://github.com/flutter/flutter/issues/66128.
   test('setPreferredOrientation responds even if browser doesn\'t support api', () async {
     final html.Screen screen = html.window.screen;
     js_util.setProperty(screen, 'orientation', null);

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -4,6 +4,7 @@
 
 // @dart = 2.6
 import 'dart:async';
+import 'dart:js_util' as js_util;
 import 'dart:html' as html;
 import 'dart:typed_data';
 
@@ -245,6 +246,28 @@ void testMain() {
 
     await Future<void>.delayed(const Duration(milliseconds: 1));
     expect(responded, isTrue);
+  });
+
+  test('setPreferredOrientation responds even if browser doesn\'t support api', () async {
+    final html.Screen screen = html.window.screen;
+    js_util.setProperty(screen, 'orientation', null);
+    bool responded = false;
+
+    final Completer<void> completer = Completer<void>();
+    final ByteData inputData = JSONMethodCodec().encodeMethodCall(MethodCall(
+        'SystemChrome.setPreferredOrientations',
+        <dynamic>[]));
+
+    window.sendPlatformMessage(
+      'flutter/platform',
+          inputData,
+          (outputData) {
+        responded = true;
+        completer.complete();
+      },
+    );
+    await completer.future;
+    expect(responded, true);
   });
 
   test('Window implements locale, locales, and locale change notifications', () async {


### PR DESCRIPTION
## Description

Fixes feature detection failure when using SystemChrome.setPreferredOrientations.
Instead of returning false on a browser that doesn't support feature, it was crashing on iOS.

## Related Issues

https://github.com/flutter/flutter/issues/66128

## Tests

Updated window_test.dart with case that will fail when run with --browser=ios-safari

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
