### PR TITLE
embedder: Exclude GL code

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -59,6 +59,10 @@ extern const intptr_t kPlatformStrongDillSize;
 #include "rapidjson/rapidjson.h"
 #include "rapidjson/writer.h"
 
+#ifdef SHELL_ENABLE_GL
+#include "flutter/shell/platform/embedder/embedder_external_texture_gl.h"
+#endif
+
 const int32_t kFlutterSemanticsNodeIdBatchEnd = -1;
 const int32_t kFlutterSemanticsCustomActionIdBatchEnd = -1;
 
@@ -1034,11 +1038,11 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         return std::make_unique<flutter::Rasterizer>(shell);
       };
 
+#ifdef SHELL_ENABLE_GL
   // TODO(chinmaygarde): This is the wrong spot for this. It belongs in the
   // platform view jump table.
   flutter::EmbedderExternalTextureGL::ExternalTextureCallback
       external_texture_callback;
-#ifdef SHELL_ENABLE_GL
   if (config->type == kOpenGL) {
     const FlutterOpenGLRendererConfig* open_gl_config = &config->open_gl;
     if (SAFE_ACCESS(open_gl_config, gl_external_texture_frame_callback,
@@ -1135,8 +1139,11 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
       std::move(settings),           //
       std::move(run_configuration),  //
       on_create_platform_view,       //
-      on_create_rasterizer,          //
-      external_texture_callback      //
+      on_create_rasterizer           //
+#ifdef SHELL_ENABLE_GL
+      ,
+      external_texture_callback  //
+#endif
   );
 
   // Release the ownership of the embedder engine to the caller.

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -27,16 +27,24 @@ EmbedderEngine::EmbedderEngine(
     flutter::Settings settings,
     RunConfiguration run_configuration,
     Shell::CreateCallback<PlatformView> on_create_platform_view,
-    Shell::CreateCallback<Rasterizer> on_create_rasterizer,
-    EmbedderExternalTextureGL::ExternalTextureCallback
-        external_texture_callback)
+    Shell::CreateCallback<Rasterizer> on_create_rasterizer
+#ifdef SHELL_ENABLE_GL
+    ,
+    EmbedderExternalTextureGL::ExternalTextureCallback external_texture_callback
+#endif
+    )
     : thread_host_(std::move(thread_host)),
       task_runners_(task_runners),
       run_configuration_(std::move(run_configuration)),
       shell_args_(std::make_unique<ShellArgs>(std::move(settings),
                                               on_create_platform_view,
-                                              on_create_rasterizer)),
-      external_texture_callback_(external_texture_callback) {}
+                                              on_create_rasterizer))
+#ifdef SHELL_ENABLE_GL
+      ,
+      external_texture_callback_(external_texture_callback)
+#endif
+{
+}
 
 EmbedderEngine::~EmbedderEngine() = default;
 
@@ -144,28 +152,37 @@ bool EmbedderEngine::SendPlatformMessage(
 }
 
 bool EmbedderEngine::RegisterTexture(int64_t texture) {
+#ifdef SHELL_ENABLE_GL
   if (!IsValid() || !external_texture_callback_) {
     return false;
   }
   shell_->GetPlatformView()->RegisterTexture(
       std::make_unique<EmbedderExternalTextureGL>(texture,
                                                   external_texture_callback_));
+#endif
+
   return true;
 }
 
 bool EmbedderEngine::UnregisterTexture(int64_t texture) {
+#ifdef SHELL_ENABLE_GL
   if (!IsValid() || !external_texture_callback_) {
     return false;
   }
   shell_->GetPlatformView()->UnregisterTexture(texture);
+#endif
+
   return true;
 }
 
 bool EmbedderEngine::MarkTextureFrameAvailable(int64_t texture) {
+#ifdef SHELL_ENABLE_GL
   if (!IsValid() || !external_texture_callback_) {
     return false;
   }
   shell_->GetPlatformView()->MarkTextureFrameAvailable(texture);
+#endif
+
   return true;
 }
 

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -12,8 +12,11 @@
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/platform/embedder/embedder.h"
-#include "flutter/shell/platform/embedder/embedder_external_texture_gl.h"
 #include "flutter/shell/platform/embedder/embedder_thread_host.h"
+
+#ifdef SHELL_ENABLE_GL
+#include "flutter/shell/platform/embedder/embedder_external_texture_gl.h"
+#endif
 
 namespace flutter {
 
@@ -28,9 +31,13 @@ class EmbedderEngine {
                  Settings settings,
                  RunConfiguration run_configuration,
                  Shell::CreateCallback<PlatformView> on_create_platform_view,
-                 Shell::CreateCallback<Rasterizer> on_create_rasterizer,
+                 Shell::CreateCallback<Rasterizer> on_create_rasterizer
+#ifdef SHELL_ENABLE_GL
+                 ,
                  EmbedderExternalTextureGL::ExternalTextureCallback
-                     external_texture_callback);
+                     external_texture_callback
+#endif
+  );
 
   ~EmbedderEngine();
 
@@ -90,8 +97,10 @@ class EmbedderEngine {
   RunConfiguration run_configuration_;
   std::unique_ptr<ShellArgs> shell_args_;
   std::unique_ptr<Shell> shell_;
+#ifdef SHELL_ENABLE_GL
   const EmbedderExternalTextureGL::ExternalTextureCallback
       external_texture_callback_;
+#endif
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderEngine);
 };

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -9,6 +9,19 @@ namespace flutter {
 PlatformViewEmbedder::PlatformViewEmbedder(
     PlatformView::Delegate& delegate,
     flutter::TaskRunners task_runners,
+    EmbedderSurfaceSoftware::SoftwareDispatchTable software_dispatch_table,
+    PlatformDispatchTable platform_dispatch_table,
+    std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
+    : PlatformView(delegate, std::move(task_runners)),
+      embedder_surface_(std::make_unique<EmbedderSurfaceSoftware>(
+          software_dispatch_table,
+          std::move(external_view_embedder))),
+      platform_dispatch_table_(platform_dispatch_table) {}
+
+#ifdef SHELL_ENABLE_GL
+PlatformViewEmbedder::PlatformViewEmbedder(
+    PlatformView::Delegate& delegate,
+    flutter::TaskRunners task_runners,
     EmbedderSurfaceGL::GLDispatchTable gl_dispatch_table,
     bool fbo_reset_after_present,
     PlatformDispatchTable platform_dispatch_table,
@@ -19,18 +32,7 @@ PlatformViewEmbedder::PlatformViewEmbedder(
           fbo_reset_after_present,
           std::move(external_view_embedder))),
       platform_dispatch_table_(platform_dispatch_table) {}
-
-PlatformViewEmbedder::PlatformViewEmbedder(
-    PlatformView::Delegate& delegate,
-    flutter::TaskRunners task_runners,
-    EmbedderSurfaceSoftware::SoftwareDispatchTable software_dispatch_table,
-    PlatformDispatchTable platform_dispatch_table,
-    std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
-    : PlatformView(delegate, std::move(task_runners)),
-      embedder_surface_(std::make_unique<EmbedderSurfaceSoftware>(
-          software_dispatch_table,
-          std::move(external_view_embedder))),
-      platform_dispatch_table_(platform_dispatch_table) {}
+#endif
 
 PlatformViewEmbedder::~PlatformViewEmbedder() = default;
 

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -11,9 +11,12 @@
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/embedder_surface.h"
-#include "flutter/shell/platform/embedder/embedder_surface_gl.h"
 #include "flutter/shell/platform/embedder/embedder_surface_software.h"
 #include "flutter/shell/platform/embedder/vsync_waiter_embedder.h"
+
+#ifdef SHELL_ENABLE_GL
+#include "flutter/shell/platform/embedder/embedder_surface_gl.h"
+#endif
 
 namespace flutter {
 
@@ -40,6 +43,15 @@ class PlatformViewEmbedder final : public PlatformView {
         compute_platform_resolved_locale_callback;
   };
 
+  // Create a platform view that sets up a software rasterizer.
+  PlatformViewEmbedder(
+      PlatformView::Delegate& delegate,
+      flutter::TaskRunners task_runners,
+      EmbedderSurfaceSoftware::SoftwareDispatchTable software_dispatch_table,
+      PlatformDispatchTable platform_dispatch_table,
+      std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
+
+#ifdef SHELL_ENABLE_GL
   // Creates a platform view that sets up an OpenGL rasterizer.
   PlatformViewEmbedder(
       PlatformView::Delegate& delegate,
@@ -48,14 +60,7 @@ class PlatformViewEmbedder final : public PlatformView {
       bool fbo_reset_after_present,
       PlatformDispatchTable platform_dispatch_table,
       std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
-
-  // Create a platform view that sets up a software rasterizer.
-  PlatformViewEmbedder(
-      PlatformView::Delegate& delegate,
-      flutter::TaskRunners task_runners,
-      EmbedderSurfaceSoftware::SoftwareDispatchTable software_dispatch_table,
-      PlatformDispatchTable platform_dispatch_table,
-      std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
+#endif
 
   ~PlatformViewEmbedder() override;
 


### PR DESCRIPTION
## Description

Fuchisa embedder_unittests fail to compile in unopt mode because of still including these GL-related files.  I'm not sure why it works in release mode.

## Related Issues

https://github.com/flutter/engine/pull/21462

## Tests

N/A
