### PR TITLE
Writing the commit no to a text file

### DIFF
--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-set -x
 
 if [[ -z $ENGINE_PATH ]]
 then
@@ -14,7 +13,6 @@ cd $ENGINE_PATH/src/flutter
 # Get latest commit's time for the engine repo.
 # Use date based on local time otherwise timezones might get mixed.
 LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
-echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
 
 if [[ -z $FLUTTER_CLONE_REPO_PATH ]]
 then
@@ -28,11 +26,7 @@ fi
 # Git log uses commit date not the author date.
 # Before makes the comparison considering the timezone as well.
 COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
-echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO
 
 # Set commit no to an env variable.
 echo "$COMMIT_NO"
-
-# Print out the flutter version for troubleshooting
-$FLUTTER_CLONE_REPO_PATH/bin/flutter --version

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -31,5 +31,8 @@ COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cu
 echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO
 
+# Set commit no to an env variable.
+export REF_SHA=$COMMIT_NO
+
 # Print out the flutter version for troubleshooting
 $FLUTTER_CLONE_REPO_PATH/bin/flutter --version

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -32,7 +32,7 @@ echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO
 
 # Set commit no to an env variable.
-export REF_SHA=$COMMIT_NO
+export FLUTTER_REF=$COMMIT_NO
 
 # Print out the flutter version for troubleshooting
 $FLUTTER_CLONE_REPO_PATH/bin/flutter --version

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -34,5 +34,8 @@ git reset --hard $COMMIT_NO
 # Write the commit number to a file. This file will be read by the LUCI recipe.
 echo "$COMMIT_NO" >> flutter_ref.txt
 
+pwd
+ls -a
+
 # Print out the flutter version for troubleshooting
 $FLUTTER_CLONE_REPO_PATH/bin/flutter --version

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -29,4 +29,4 @@ COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cu
 git reset --hard $COMMIT_NO
 
 # Set commit no to an env variable.
-echo "$COMMIT_NO"
+echo '{ "FLUTTER_REF" : ' $COMMIT_NO '} '

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -x
 
 if [[ -z $ENGINE_PATH ]]
 then
@@ -13,6 +14,7 @@ cd $ENGINE_PATH/src/flutter
 # Get latest commit's time for the engine repo.
 # Use date based on local time otherwise timezones might get mixed.
 LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
+echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
 
 if [[ -z $FLUTTER_CLONE_REPO_PATH ]]
 then
@@ -26,7 +28,11 @@ fi
 # Git log uses commit date not the author date.
 # Before makes the comparison considering the timezone as well.
 COMMIT_NO=`git log --before="$LATEST_COMMIT_TIME_ENGINE" -n 1 | grep commit | cut -d ' ' -f2`
+echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO
 
-# Set commit no to an env variable.
-echo '{ "FLUTTER_REF" : ' $COMMIT_NO '} '
+# Write the commit number to a file. This file will be read by the LUCI recipe.
+echo "$COMMIT_NO" >> flutter_ref.txt
+
+# Print out the flutter version for troubleshooting
+$FLUTTER_CLONE_REPO_PATH/bin/flutter --version

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -32,7 +32,7 @@ echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO
 
 # Set commit no to an env variable.
-export FLUTTER_REF="$COMMIT_NO"
+echo "$COMMIT_NO"
 
 # Print out the flutter version for troubleshooting
 $FLUTTER_CLONE_REPO_PATH/bin/flutter --version

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -34,8 +34,5 @@ git reset --hard $COMMIT_NO
 # Write the commit number to a file. This file will be read by the LUCI recipe.
 echo "$COMMIT_NO" >> flutter_ref.txt
 
-pwd
-ls -a
-
 # Print out the flutter version for troubleshooting
-$FLUTTER_CLONE_REPO_PATH/bin/flutter --version
+$FLUTTER_CLONE_REPO_PATH/bin/flutter --version -v

--- a/tools/configure_framework_commit.sh
+++ b/tools/configure_framework_commit.sh
@@ -32,7 +32,7 @@ echo "Using the flutter/flutter commit $COMMIT_NO";
 git reset --hard $COMMIT_NO
 
 # Set commit no to an env variable.
-export FLUTTER_REF=$COMMIT_NO
+export FLUTTER_REF="$COMMIT_NO"
 
 # Print out the flutter version for troubleshooting
 $FLUTTER_CLONE_REPO_PATH/bin/flutter --version


### PR DESCRIPTION
Writing the commit no to a text file. This will be used for ref number to send the drones in the web tests: https://devops-console-oss.corp.google.com/flutter/recipes/+/master:recipes/engine/web_engine_framework.py;l=137

I initially thought I can use one of the library calls to get the commit no we synced using the [API](https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/master/recipes/README.recipes.md#class-gitapi_recipeapi). However I couldn't find a method for it.

other tried methods:

- Using the stepData (or using the stdout directly) both methods failed since we are also printing other important information to the logs during the script. StepData converts the out value to a json. Our other logs (such as flutter version) corrupts the json format.
- Using an env variable. We weren't able to read this variable back in the recipe using env['name']

Usage inside the recipe:

```
ref = api.file.read_text('read commit no', commit_no_file, 'b6efc758213fdfffee1234465')
```