### PR TITLE
Implement Image.clone for CanvasKit

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -683,6 +683,8 @@ class SkAnimatedImage {
   ///
   /// This object is no longer usable after calling this method.
   external void delete();
+  external bool isAliasOf(SkAnimatedImage other);
+  external bool isDeleted();
 }
 
 @JS()
@@ -698,6 +700,8 @@ class SkImage {
   );
   external Uint8List readPixels(SkImageInfo imageInfo, int srcX, int srcY);
   external SkData encodeToData();
+  external bool isAliasOf(SkImage other);
+  external bool isDeleted();
 }
 
 @JS()

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -41,10 +41,16 @@ class CkAnimatedImage implements ui.Image {
 
   // Use a box because `SkImage` may be deleted either due to this object
   // being garbage-collected, or by an explicit call to [delete].
-  late final SkiaObjectBox box;
+  late final RefCountedSkiaObjectBox box;
 
-  CkAnimatedImage(this._skAnimatedImage) {
-    box = SkiaObjectBox(this, _skAnimatedImage as SkDeletable);
+  CkAnimatedImage(SkAnimatedImage skAnimatedImage) : this._(skAnimatedImage, null);
+
+  CkAnimatedImage._(this._skAnimatedImage, RefCountedSkiaObjectBox? boxToClone) {
+    if (boxToClone != null) {
+      box = boxToClone.clone(this);
+    } else {
+      box = RefCountedSkiaObjectBox(this, _skAnimatedImage as SkDeletable);
+    }
   }
 
   @override
@@ -53,13 +59,17 @@ class CkAnimatedImage implements ui.Image {
   }
 
   @override
-  ui.Image clone() => this;
+  ui.Image clone() => CkAnimatedImage._(_skAnimatedImage, box);
 
   @override
-  bool isCloneOf(ui.Image other) => other == this;
+  bool isCloneOf(ui.Image other) {
+    return other is CkAnimatedImage
+        && other._skAnimatedImage == _skAnimatedImage;
+  }
 
   @override
-  List<StackTrace>? debugGetOpenHandleStackTraces() => null;
+  List<StackTrace>? debugGetOpenHandleStackTraces() => box.debugGetStackTraces();
+
   int get frameCount => _skAnimatedImage.getFrameCount();
 
   /// Decodes the next frame and returns the frame duration.
@@ -114,10 +124,16 @@ class CkImage implements ui.Image {
 
   // Use a box because `SkImage` may be deleted either due to this object
   // being garbage-collected, or by an explicit call to [delete].
-  late final SkiaObjectBox box;
+  late final RefCountedSkiaObjectBox box;
 
-  CkImage(this.skImage) {
-    box = SkiaObjectBox(this, skImage as SkDeletable);
+  CkImage(SkImage skImage) : this._(skImage, null);
+
+  CkImage._(this.skImage, RefCountedSkiaObjectBox? boxToClone) {
+    if (boxToClone != null) {
+      box = boxToClone.clone(this);
+    } else {
+      box = RefCountedSkiaObjectBox(this, skImage as SkDeletable);
+    }
   }
 
   @override
@@ -126,13 +142,16 @@ class CkImage implements ui.Image {
   }
 
   @override
-  ui.Image clone() => this;
+  ui.Image clone() => CkImage._(skImage, box);
 
   @override
-  bool isCloneOf(ui.Image other) => other == this;
+  bool isCloneOf(ui.Image other) {
+    return other is CkImage
+        && other.skImage == skImage;
+  }
 
   @override
-  List<StackTrace>? debugGetOpenHandleStackTraces() => null;
+  List<StackTrace>? debugGetOpenHandleStackTraces() => box.debugGetStackTraces();
 
   @override
   int get width => skImage.width();

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -41,15 +41,15 @@ class CkAnimatedImage implements ui.Image {
 
   // Use a box because `SkImage` may be deleted either due to this object
   // being garbage-collected, or by an explicit call to [delete].
-  late final RefCountedSkiaObjectBox box;
+  late final SkiaObjectBox box;
 
   CkAnimatedImage(SkAnimatedImage skAnimatedImage) : this._(skAnimatedImage, null);
 
-  CkAnimatedImage._(this._skAnimatedImage, RefCountedSkiaObjectBox? boxToClone) {
+  CkAnimatedImage._(this._skAnimatedImage, SkiaObjectBox? boxToClone) {
     if (boxToClone != null) {
       box = boxToClone.clone(this);
     } else {
-      box = RefCountedSkiaObjectBox(this, _skAnimatedImage as SkDeletable);
+      box = SkiaObjectBox(this, _skAnimatedImage as SkDeletable);
     }
   }
 
@@ -124,15 +124,15 @@ class CkImage implements ui.Image {
 
   // Use a box because `SkImage` may be deleted either due to this object
   // being garbage-collected, or by an explicit call to [delete].
-  late final RefCountedSkiaObjectBox box;
+  late final SkiaObjectBox box;
 
   CkImage(SkImage skImage) : this._(skImage, null);
 
-  CkImage._(this.skImage, RefCountedSkiaObjectBox? boxToClone) {
+  CkImage._(this.skImage, SkiaObjectBox? boxToClone) {
     if (boxToClone != null) {
       box = boxToClone.clone(this);
     } else {
-      box = RefCountedSkiaObjectBox(this, skImage as SkDeletable);
+      box = SkiaObjectBox(this, skImage as SkDeletable);
     }
   }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -131,7 +131,7 @@ class CkImage implements ui.Image {
 
   CkImage._(this.skImage, SkiaObjectBox? boxToClone) {
     if (boxToClone != null) {
-      assert(boxToClone.skObject == _skAnimatedImage);
+      assert(boxToClone.skObject == skImage);
       box = boxToClone.clone(this);
     } else {
       box = SkiaObjectBox(this, skImage as SkDeletable);

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -47,6 +47,7 @@ class CkAnimatedImage implements ui.Image {
 
   CkAnimatedImage._(this._skAnimatedImage, SkiaObjectBox? boxToClone) {
     if (boxToClone != null) {
+      assert(boxToClone.skObject == _skAnimatedImage);
       box = boxToClone.clone(this);
     } else {
       box = SkiaObjectBox(this, _skAnimatedImage as SkDeletable);
@@ -130,6 +131,7 @@ class CkImage implements ui.Image {
 
   CkImage._(this.skImage, SkiaObjectBox? boxToClone) {
     if (boxToClone != null) {
+      assert(boxToClone.skObject == _skAnimatedImage);
       box = boxToClone.clone(this);
     } else {
       box = SkiaObjectBox(this, skImage as SkDeletable);

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -64,7 +64,7 @@ class CkAnimatedImage implements ui.Image {
   @override
   bool isCloneOf(ui.Image other) {
     return other is CkAnimatedImage
-        && other._skAnimatedImage == _skAnimatedImage;
+        && other._skAnimatedImage.isAliasOf(_skAnimatedImage);
   }
 
   @override
@@ -147,7 +147,7 @@ class CkImage implements ui.Image {
   @override
   bool isCloneOf(ui.Image other) {
     return other is CkImage
-        && other.skImage == skImage;
+        && other.skImage.isAliasOf(skImage);
   }
 
   @override

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -38,6 +38,19 @@ void testMain() {
       expect(image.box.isDeleted, true);
     });
 
+    test('CkAnimatedImage can be cloned and explicitly disposed of', () {
+      final SkAnimatedImage skAnimatedImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
+      final CkAnimatedImage image = CkAnimatedImage(skAnimatedImage);
+      final CkAnimatedImage imageClone = image.clone();
+
+      expect(image.isCloneOf(imageClone), true);
+      expect(image.box.isDeleted, false);
+      image.dispose();
+      expect(image.box.isDeleted, false);
+      imageClone.dispose();
+      expect(image.box.isDeleted, true);
+    });
+
     test('CkImage toString', () {
       final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage).getCurrentFrame();
       final CkImage image = CkImage(skImage);
@@ -52,6 +65,19 @@ void testMain() {
       image.dispose();
       expect(image.box.isDeleted, true);
       image.dispose();
+      expect(image.box.isDeleted, true);
+    });
+
+    test('CkImage can be explicitly disposed of', () {
+      final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage).getCurrentFrame();
+      final CkImage image = CkImage(skImage);
+      final CkAnimatedImage imageClone = image.clone();
+
+      expect(image.isCloneOf(imageClone), true);
+      expect(image.box.isDeleted, false);
+      image.dispose();
+      expect(image.box.isDeleted, false);
+      imageClone.dispose();
       expect(image.box.isDeleted, true);
     });
   // TODO: https://github.com/flutter/flutter/issues/60040

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -38,19 +38,25 @@ void testMain() {
       expect(image.box.isDeleted, true);
     });
 
-    test('CkAnimatedImage can be cloned and explicitly disposed of', () {
+    test('CkAnimatedImage can be cloned and explicitly disposed of', () async {
       final SkAnimatedImage skAnimatedImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
       final CkAnimatedImage image = CkAnimatedImage(skAnimatedImage);
       final CkAnimatedImage imageClone = image.clone();
 
       expect(image.isCloneOf(imageClone), true);
       expect(image.box.isDeleted, false);
+      await Future<void>.delayed(Duration.zero);
+      expect(skAnimatedImage.isDeleted(), false);
       image.dispose();
       expect(image.box.isDeleted, true);
       expect(imageClone.box.isDeleted, false);
+      await Future<void>.delayed(Duration.zero);
+      expect(skAnimatedImage.isDeleted(), false);
       imageClone.dispose();
       expect(image.box.isDeleted, true);
       expect(imageClone.box.isDeleted, true);
+      await Future<void>.delayed(Duration.zero);
+      expect(skAnimatedImage.isDeleted(), true);
     });
 
     test('CkImage toString', () {
@@ -70,19 +76,25 @@ void testMain() {
       expect(image.box.isDeleted, true);
     });
 
-    test('CkImage can be explicitly disposed of', () {
+    test('CkImage can be explicitly disposed of when cloned', () async {
       final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage).getCurrentFrame();
       final CkImage image = CkImage(skImage);
       final CkImage imageClone = image.clone();
 
       expect(image.isCloneOf(imageClone), true);
       expect(image.box.isDeleted, false);
+      await Future<void>.delayed(Duration.zero);
+      expect(skImage.isDeleted(), false);
       image.dispose();
       expect(image.box.isDeleted, true);
       expect(imageClone.box.isDeleted, false);
+      await Future<void>.delayed(Duration.zero);
+      expect(skImage.isDeleted(), false);
       imageClone.dispose();
       expect(image.box.isDeleted, true);
       expect(imageClone.box.isDeleted, true);
+      await Future<void>.delayed(Duration.zero);
+      expect(skImage.isDeleted(), true);
     });
   // TODO: https://github.com/flutter/flutter/issues/60040
   }, skip: isIosSafari);

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -46,9 +46,11 @@ void testMain() {
       expect(image.isCloneOf(imageClone), true);
       expect(image.box.isDeleted, false);
       image.dispose();
-      expect(image.box.isDeleted, false);
+      expect(image.box.isDeleted, true);
+      expect(imageClone.box.isDeleted, false);
       imageClone.dispose();
       expect(image.box.isDeleted, true);
+      expect(imageClone.box.isDeleted, true);
     });
 
     test('CkImage toString', () {
@@ -71,14 +73,16 @@ void testMain() {
     test('CkImage can be explicitly disposed of', () {
       final SkImage skImage = canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage).getCurrentFrame();
       final CkImage image = CkImage(skImage);
-      final CkAnimatedImage imageClone = image.clone();
+      final CkImage imageClone = image.clone();
 
       expect(image.isCloneOf(imageClone), true);
       expect(image.box.isDeleted, false);
       image.dispose();
-      expect(image.box.isDeleted, false);
+      expect(image.box.isDeleted, true);
+      expect(imageClone.box.isDeleted, false);
       imageClone.dispose();
       expect(image.box.isDeleted, true);
+      expect(imageClone.box.isDeleted, true);
     });
   // TODO: https://github.com/flutter/flutter/issues/60040
   }, skip: isIosSafari);

--- a/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
+++ b/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
@@ -198,7 +198,7 @@ class TestOneShotSkiaObject extends OneShotSkiaObject<SkPaint> {
   }
 }
 
-class TestSkiaObject extends ManagedSkiaObject<SkPaint> {
+class TestSkiaObject extends ManagedSkiaObject<SkPaint> implements SkDeletable {
   int createDefaultCount = 0;
   int resurrectCount = 0;
   int deleteCount = 0;

--- a/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
+++ b/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
@@ -159,7 +159,7 @@ void _tests() {
     test('Records stack traces and respects refcounts', () {
       final TestSkiaObject skObject = TestSkiaObject();
       final Object wrapper = Object();
-      final RefCountedSkiaObjectBox box = RefCountedSkiaObjectBox(wrapper, skObject as SkDeletable);
+      final RefCountedSkiaObjectBox box = RefCountedSkiaObjectBox(wrapper, skObject);
 
       expect(box.debugGetStackTraces().length, 1);
 


### PR DESCRIPTION
## Description

Implements `Image.dispose` and `Image.clone` properly so that https://github.com/flutter/flutter/pull/67100 can be relanded.

Creates a `RefCountedSkiaObjectBox` subclass of `SkiaObjectBox` to support this.

## Related Issues

https://github.com/flutter/flutter/pull/67100
https://github.com/flutter/flutter/pull/66688
https://github.com/flutter/flutter/issues/56482
https://github.com/flutter/engine/pull/21057

## Tests

I added the following tests:

Tests that `Image.dispose` and `Image.clone`/`Image.isCloneOf` work properly.

Tests for `clone` and stacktrace functionality on `RefCountedSkiaObjectBox`.
