### PR TITLE
Use absolute path in ios_test_flutter target

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -159,7 +159,7 @@ source_set("flutter_framework_source") {
 }
 
 ios_test_flutter_path = rebase_path("$root_out_dir/libios_test_flutter.dylib")
-platform_frameworks_path = "$ios_sdk_path/../../Library/Frameworks/"
+platform_frameworks_path = rebase_path("$ios_sdk_path/../../Library/Frameworks/")
 
 # For tests that rely on manual reference counting.
 source_set("ios_test_flutter_mrc") {

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -159,7 +159,8 @@ source_set("flutter_framework_source") {
 }
 
 ios_test_flutter_path = rebase_path("$root_out_dir/libios_test_flutter.dylib")
-platform_frameworks_path = rebase_path("$ios_sdk_path/../../Library/Frameworks/")
+platform_frameworks_path =
+    rebase_path("$ios_sdk_path/../../Library/Frameworks/")
 
 # For tests that rely on manual reference counting.
 source_set("ios_test_flutter_mrc") {


### PR DESCRIPTION
## Description

If we specify `-F/Applications/Xcode11.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator14.0/../../Library/Frameworks` where `iPhoneSimulator14.0` is a symlink, clang starts to look for frameworks in a dir relative to the actual directory that the symlink points to, instead of `/Applications/Xcode11.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks`.

An alternative is to avoid using `..` and use `xcrun -sdk iphoneos --show-sdk-platform-path`, but that requires making changes in the buildroot repo.

## Related Issues

https://github.com/flutter/flutter/issues/65901#

## Tests

I added the following tests:

Not sure if this needs a test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
