### PR TITLE
Refactor make_mock_engine into fl_test

### DIFF
--- a/shell/platform/linux/fl_basic_message_channel_test.cc
+++ b/shell/platform/linux/fl_basic_message_channel_test.cc
@@ -9,19 +9,8 @@
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_message_codec.h"
+#include "flutter/shell/platform/linux/testing/fl_test.h"
 #include "flutter/shell/platform/linux/testing/mock_renderer.h"
-
-// Creates a mock engine that responds to platform messages.
-static FlEngine* make_mock_engine() {
-  g_autoptr(FlDartProject) project = fl_dart_project_new();
-  g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
-  g_autoptr(FlEngine) engine = fl_engine_new(project, FL_RENDERER(renderer));
-  g_autoptr(GError) engine_error = nullptr;
-  EXPECT_TRUE(fl_engine_start(engine, &engine_error));
-  EXPECT_EQ(engine_error, nullptr);
-
-  return static_cast<FlEngine*>(g_object_ref(engine));
-}
 
 // Called when the message response is received in the SendMessage test.
 static void echo_response_cb(GObject* object,

--- a/shell/platform/linux/fl_binary_messenger_test.cc
+++ b/shell/platform/linux/fl_binary_messenger_test.cc
@@ -10,19 +10,8 @@
 #include "flutter/shell/platform/linux/fl_binary_messenger_private.h"
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h"
+#include "flutter/shell/platform/linux/testing/fl_test.h"
 #include "flutter/shell/platform/linux/testing/mock_renderer.h"
-
-// Creates a mock engine that responds to platform messages.
-static FlEngine* make_mock_engine() {
-  g_autoptr(FlDartProject) project = fl_dart_project_new();
-  g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
-  g_autoptr(FlEngine) engine = fl_engine_new(project, FL_RENDERER(renderer));
-  g_autoptr(GError) engine_error = nullptr;
-  EXPECT_TRUE(fl_engine_start(engine, &engine_error));
-  EXPECT_EQ(engine_error, nullptr);
-
-  return static_cast<FlEngine*>(g_object_ref(engine));
-}
 
 // Checks sending nullptr for a message works.
 TEST(FlBinaryMessengerTest, SendNullptrMessage) {

--- a/shell/platform/linux/fl_key_event_plugin_test.cc
+++ b/shell/platform/linux/fl_key_event_plugin_test.cc
@@ -11,19 +11,8 @@
 #include "flutter/shell/platform/linux/fl_engine_private.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_message_codec.h"
+#include "flutter/shell/platform/linux/testing/fl_test.h"
 #include "flutter/shell/platform/linux/testing/mock_renderer.h"
-
-// Creates a mock engine that responds to platform messages.
-static FlEngine* make_mock_engine() {
-  g_autoptr(FlDartProject) project = fl_dart_project_new();
-  g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
-  g_autoptr(FlEngine) engine = fl_engine_new(project, FL_RENDERER(renderer));
-  g_autoptr(GError) engine_error = nullptr;
-  EXPECT_TRUE(fl_engine_start(engine, &engine_error));
-  EXPECT_EQ(engine_error, nullptr);
-
-  return static_cast<FlEngine*>(g_object_ref(engine));
-}
 
 const char* expected_value = nullptr;
 

--- a/shell/platform/linux/fl_method_channel_test.cc
+++ b/shell/platform/linux/fl_method_channel_test.cc
@@ -11,19 +11,8 @@
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_method_channel.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_standard_method_codec.h"
+#include "flutter/shell/platform/linux/testing/fl_test.h"
 #include "flutter/shell/platform/linux/testing/mock_renderer.h"
-
-// Creates a mock engine that responds to platform messages.
-static FlEngine* make_mock_engine() {
-  g_autoptr(FlDartProject) project = fl_dart_project_new();
-  g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
-  g_autoptr(FlEngine) engine = fl_engine_new(project, FL_RENDERER(renderer));
-  g_autoptr(GError) engine_error = nullptr;
-  EXPECT_TRUE(fl_engine_start(engine, &engine_error));
-  EXPECT_EQ(engine_error, nullptr);
-
-  return static_cast<FlEngine*>(g_object_ref(engine));
-}
 
 // Called when when the method call response is received in the InvokeMethod
 // test.

--- a/shell/platform/linux/testing/fl_test.cc
+++ b/shell/platform/linux/testing/fl_test.cc
@@ -1,8 +1,14 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+// FLUTTER_NOLINT
+
+#include "gtest/gtest.h"
 
 #include "flutter/shell/platform/linux/testing/fl_test.h"
+
+#include "flutter/shell/platform/linux/fl_engine_private.h"
+#include "flutter/shell/platform/linux/testing/mock_renderer.h"
 
 static uint8_t hex_digit_to_int(char value) {
   if (value >= '0' && value <= '9')
@@ -38,4 +44,15 @@ gchar* bytes_to_hex_string(GBytes* bytes) {
   for (size_t i = 0; i < data_length; i++)
     g_string_append_printf(hex_string, "%02x", data[i]);
   return g_string_free(hex_string, FALSE);
+}
+
+FlEngine* make_mock_engine() {
+  g_autoptr(FlDartProject) project = fl_dart_project_new();
+  g_autoptr(FlMockRenderer) renderer = fl_mock_renderer_new();
+  g_autoptr(FlEngine) engine = fl_engine_new(project, FL_RENDERER(renderer));
+  g_autoptr(GError) engine_error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &engine_error));
+  EXPECT_EQ(engine_error, nullptr);
+
+  return static_cast<FlEngine*>(g_object_ref(engine));
 }

--- a/shell/platform/linux/testing/fl_test.h
+++ b/shell/platform/linux/testing/fl_test.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_TEST_H_
 #define FLUTTER_SHELL_PLATFORM_LINUX_FL_TEST_H_
 
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
+
 #include <glib.h>
 #include <stdint.h>
 
@@ -17,6 +19,9 @@ GBytes* hex_string_to_bytes(const gchar* hex_string);
 
 // Helper function to convert GBytes into a hexadecimal string (e.g. "01feab")
 gchar* bytes_to_hex_string(GBytes* bytes);
+
+// Creates a mock engine that responds to platform messages.
+FlEngine* make_mock_engine();
 
 G_END_DECLS
 


### PR DESCRIPTION
## Description

Factors out the duplicated function `make_mock_engine` into `fl_test`. Split out of #20714 as requested by @robert-ancell.

## Related Issues

None

## Tests

No tests neccessary

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
