### PR TITLE
Adjust asset resolver preservation logic for Android

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -112,10 +112,16 @@ bool Engine::UpdateAssetManager(
     return false;
   }
 
-  asset_manager_ = new_asset_manager;
+  auto old_asset_manager = asset_manager_ asset_manager_ = new_asset_manager;
 
   if (!asset_manager_) {
     return false;
+  }
+  // Add the original asset resolvers to the new manager so that unmodified
+  // assets bundled with the application specific format (APK, IPA) can be used
+  // without syncing to the Dart devFS.
+  if (old_asset_manager != nullptr) {
+    asset_manager->PushBack(old_asset_manager);
   }
 
   // Using libTXT as the text engine.

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -122,7 +122,7 @@ bool Engine::UpdateAssetManager(
   // assets bundled with the application specific format (APK, IPA) can be used
   // without syncing to the Dart devFS.
   if (old_asset_manager != nullptr) {
-    asset_manager->PushBack(old_asset_manager);
+    asset_manager_->PushBack(old_asset_manager);
   }
 
   // Using libTXT as the text engine.

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -112,7 +112,8 @@ bool Engine::UpdateAssetManager(
     return false;
   }
 
-  auto old_asset_manager = asset_manager_ asset_manager_ = new_asset_manager;
+  auto old_asset_manager = asset_manager_;
+  asset_manager_ = new_asset_manager;
 
   if (!asset_manager_) {
     return false;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1404,7 +1404,6 @@ bool Shell::OnServiceProtocolRunInView(
   configuration.AddAssetResolver(
       std::make_unique<DirectoryAssetBundle>(fml::OpenDirectory(
           asset_directory_path.c_str(), false, fml::FilePermission::kRead)));
-  configuration.AddAssetResolver(RestoreOriginalAssetResolver());
 
   auto& allocator = response->GetAllocator();
   response->SetObject();
@@ -1517,7 +1516,6 @@ bool Shell::OnServiceProtocolSetAssetBundlePath(
 
   auto asset_manager = std::make_shared<AssetManager>();
 
-  asset_manager->PushFront(RestoreOriginalAssetResolver());
   asset_manager->PushFront(std::make_unique<DirectoryAssetBundle>(
       fml::OpenDirectory(params.at("assetDirectory").data(), false,
                          fml::FilePermission::kRead)));
@@ -1623,17 +1621,5 @@ void Shell::OnDisplayUpdates(DisplayUpdateType update_type,
                              std::vector<Display> displays) {
   display_manager_->HandleDisplayUpdates(update_type, displays);
 }
-
-// Add the original asset directory to the resolvers so that unmodified assets
-// bundled with the application specific format (APK, IPA) can be used without
-// syncing to the Dart devFS.
-std::unique_ptr<DirectoryAssetBundle> Shell::RestoreOriginalAssetResolver() {
-  if (fml::UniqueFD::traits_type::IsValid(settings_.assets_dir)) {
-    return std::make_unique<DirectoryAssetBundle>(
-        fml::Duplicate(settings_.assets_dir));
-  }
-  return std::make_unique<DirectoryAssetBundle>(fml::OpenDirectory(
-      settings_.assets_path.c_str(), false, fml::FilePermission::kRead));
-};
 
 }  // namespace flutter

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -613,10 +613,6 @@ class Shell final : public PlatformView::Delegate,
       const ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document* response);
 
-  // Creates an asset bundle from the original settings asset path or
-  // directory.
-  std::unique_ptr<DirectoryAssetBundle> RestoreOriginalAssetResolver();
-
   // For accessing the Shell via the raster thread, necessary for various
   // rasterizer callbacks.
   std::unique_ptr<fml::TaskRunnerAffineWeakPtrFactory<Shell>> weak_factory_gpu_;


### PR DESCRIPTION
## Description

Always append the old asset resolver to the end of the new asset resolver

The Android embedding has a distinct implementation of the AssetResolver that is provided through JNI to the Run configuration directly; it cannot be recreated from the settings alone.
