### PR TITLE
Use the gpu config for shell_unittests to declare SHELL_ENABLE_{GL,VULKAN}

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -144,14 +144,6 @@ template("shell_host_executable") {
 }
 
 if (enable_unittests) {
-  config("test_enable_gl_config") {
-    defines = [ "SHELL_ENABLE_GL" ]
-  }
-
-  config("test_enable_vulkan_config") {
-    defines = [ "SHELL_ENABLE_VULKAN" ]
-  }
-
   shell_gpu_configuration("shell_unittests_gpu_configuration") {
     enable_software = test_enable_software
     enable_vulkan = test_enable_vulkan
@@ -217,7 +209,10 @@ if (enable_unittests) {
       "//third_party/skia",
     ]
 
-    public_configs = [ ":shell_test_fixture_sources_config" ]
+    public_configs = [
+      ":shell_test_fixture_sources_config",
+      ":shell_unittests_gpu_configuration_config",
+    ]
 
     # SwiftShader only supports x86/x64_64
     if (target_cpu == "x86" || target_cpu == "x64") {
@@ -226,8 +221,6 @@ if (enable_unittests) {
           "shell_test_platform_view_gl.cc",
           "shell_test_platform_view_gl.h",
         ]
-
-        public_configs += [ ":test_enable_gl_config" ]
 
         public_deps += [ "//flutter/testing:opengl" ]
       }
@@ -238,8 +231,6 @@ if (enable_unittests) {
         "shell_test_platform_view_vulkan.cc",
         "shell_test_platform_view_vulkan.h",
       ]
-
-      public_configs += [ ":test_enable_vulkan_config" ]
 
       public_deps += [ "//flutter/vulkan" ]
     }


### PR DESCRIPTION
Quick cleanup PR. I moved the logic for adding `SHELL_ENABLE_{GL,VULKAN}` into `gpu.gni` and just defragging `shell_unittests` to use this too.