### PR TITLE
fixing the autofill overlay problem (blue area for chrome)

### DIFF
--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -307,6 +307,18 @@ flt-glass-pane * {
 ''', sheet.cssRules.length);
     }
 
+    if(browserHasAutofillOverlay()) {
+        sheet.insertRule('''
+.transparentTextEditing:-webkit-autofill,
+.transparentTextEditing:-webkit-autofill:hover,
+.transparentTextEditing:-webkit-autofill:focus,
+.transparentTextEditing:-webkit-autofill:active {
+    -webkit-transition-delay: 99999s;
+}
+''', sheet.cssRules.length);
+    }
+
+
     final html.BodyElement bodyElement = html.document.body!;
     setElementStyle(bodyElement, 'position', 'fixed');
     setElementStyle(bodyElement, 'top', '0');

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -307,6 +307,9 @@ flt-glass-pane * {
 ''', sheet.cssRules.length);
     }
 
+    // This css prevents an autofill overlay brought by the browser during
+    // text field autofill by delaying the transition effect.
+    // See: https://github.com/flutter/flutter/issues/61132.
     if(browserHasAutofillOverlay()) {
         sheet.insertRule('''
 .transparentTextEditing:-webkit-autofill,

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -11,6 +11,16 @@ bool _debugVisibleTextEditing = false;
 /// The `keyCode` of the "Enter" key.
 const int _kReturnKeyCode = 13;
 
+/// Blink and Webkit engines, bring an overlay on top of the text field when it
+/// is autofilled.
+bool browserHasAutofillOverlay() =>
+    browserEngine == BrowserEngine.blink ||
+    browserEngine == BrowserEngine.webkit;
+
+/// `transparentTextEditing` class is configured to make the autofill overlay
+/// transparent.
+const String transparentTextEditingClass = 'transparentTextEditing';
+
 void _emptyCallback(dynamic _) {}
 
 /// These style attributes are constant throughout the life time of an input
@@ -39,7 +49,11 @@ void _setStaticStyleAttributes(html.HtmlElement domElement) {
     ..overflow = 'hidden'
     ..transformOrigin = '0 0 0';
 
-  /// This property makes the input's blinking cursor transparent.
+  if (browserHasAutofillOverlay()) {
+    domElement.classes.add(transparentTextEditingClass);
+  }
+
+  // This property makes the input's blinking cursor transparent.
   elementStyle.setProperty('caret-color', 'transparent');
 
   if (_debugVisibleTextEditing) {
@@ -78,6 +92,10 @@ void _hideAutofillElements(html.HtmlElement domElement,
     elementStyle
       ..top = '-9999px'
       ..left = '-9999px';
+  }
+
+  if (browserHasAutofillOverlay()) {
+    domElement.classes.add(transparentTextEditingClass);
   }
 
   /// This property makes the input's blinking cursor transparent.

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -1343,6 +1343,18 @@ void testMain() {
         '500 12px sans-serif',
       );
 
+      // For `blink` and `webkit` browser engines the overlay would be hidden.
+      if (browserEngine == BrowserEngine.blink ||
+          browserEngine == BrowserEngine.webkit) {
+        expect(textEditing.editingElement.domElement.classes,
+            contains('transparentTextEditing'));
+      } else {
+        expect(
+            textEditing.editingElement.domElement.classes.any(
+                (element) => element.toString() == 'transparentTextEditing'),
+            isFalse);
+      }
+
       const MethodCall clearClient = MethodCall('TextInput.clearClient');
       sendFrameworkMessage(codec.encodeMethodCall(clearClient));
     },
@@ -1806,6 +1818,17 @@ void testMain() {
       final CssStyleDeclaration css = firstElement.style;
       expect(css.color, 'transparent');
       expect(css.backgroundColor, 'transparent');
+
+      // For `blink` and `webkit` browser engines the overlay would be hidden.
+      if (browserEngine == BrowserEngine.blink ||
+          browserEngine == BrowserEngine.webkit) {
+        expect(firstElement.classes, contains('transparentTextEditing'));
+      } else {
+        expect(
+            firstElement.classes.any(
+                (element) => element.toString() == 'transparentTextEditing'),
+            isFalse);
+      }
     });
 
     test('validate multi element form ids sorted for form id', () {


### PR DESCRIPTION
## Description

Fixing the autofill overlay problem (blue area for chrome, and yellow for safari).

tried other css properties (-webkit-text-fill-color or  -webkit-box-shadow) however this is the only one that resolves the overlay that blocks the framework text).

Previously: 
![Screen Shot 2020-10-05 at 3 07 50 PM](https://user-images.githubusercontent.com/50856934/95370988-72d6f380-088e-11eb-8621-ecee3b524a4a.png)

after the pr: 
![Screen Shot 2020-10-05 at 3 08 48 PM](https://user-images.githubusercontent.com/50856934/95371014-79fe0180-088e-11eb-9a1f-cbbd0280d564.png)



## Related Issues

Fixes: https://github.com/flutter/flutter/issues/61132

## Tests

I added unit tests which tests for the following cases:

1) focused input element.
2) other input elements added for autofill form.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
