### PR TITLE
running web tests only on DEPS and web directories

### DIFF
--- a/ci/dev/try_builders.json
+++ b/ci/dev/try_builders.json
@@ -29,13 +29,29 @@
          "name":"Linux Web Engine",
          "repo":"engine",
          "enabled": true,
-         "run_if": ["DEPS", "lib/web_ui/**", "web_sdk/**"]
+         "run_if": [
+            "DEPS",
+            "lib/web_ui/**",
+            "web_sdk/**",
+            "e2etests/web/**",
+            "tools/**",
+            "ci/**",
+            "flutter_frontend_server/**"
+         ]
       },
       {
         "name":"Linux Web Framework tests",
         "repo":"engine",
         "enabled": true,
-        "run_if": ["DEPS", "lib/web_ui/**", "web_sdk/**"]
+        "run_if": [
+            "DEPS",
+            "lib/web_ui/**",
+            "web_sdk/**",
+            "e2etests/web/**",
+            "tools/**",
+            "ci/**",
+            "flutter_frontend_server/**"
+        ]
       },
       {
          "name":"Mac Android AOT Engine",
@@ -61,7 +77,15 @@
          "name":"Mac Web Engine",
          "repo":"engine",
          "enabled": true,
-         "run_if": ["DEPS", "lib/web_ui/**", "web_sdk/**"]
+         "run_if": [
+             "DEPS",
+             "lib/web_ui/**",
+             "web_sdk/**",
+             "e2etests/web/**",
+             "tools/**",
+             "ci/**",
+             "flutter_frontend_server/**"
+         ]
       },
       {
          "name":"Windows Android AOT Engine",

--- a/ci/dev/try_builders.json
+++ b/ci/dev/try_builders.json
@@ -28,7 +28,8 @@
       {
          "name":"Linux Web Engine",
          "repo":"engine",
-         "enabled": true
+         "enabled": true,
+         "run_if": ["DEPS", "lib/web_ui/**", "web_sdk/**"]
       },
       {
         "name":"Linux Web Framework tests",
@@ -59,7 +60,8 @@
       {
          "name":"Mac Web Engine",
          "repo":"engine",
-         "enabled": true
+         "enabled": true,
+         "run_if": ["DEPS", "lib/web_ui/**", "web_sdk/**"]
       },
       {
          "name":"Windows Android AOT Engine",
@@ -74,7 +76,8 @@
       {
          "name":"Windows Web Engine",
          "repo":"engine",
-         "enabled": true
+         "enabled": true,
+         "run_if": ["DEPS", "lib/web_ui/**", "web_sdk/**"]
       }
    ]
 }


### PR DESCRIPTION
I suggest we run the web tests only on certain directories.

Today, Linux Web Builders were very busy and it was hard to do test_harness development. Unless we have other reasons to run tests on all changes, I believe it's better to keep our list small as we did in cirrus.
