### PR TITLE
Use preTranslate when applying offset to matrix

### DIFF
--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -17,7 +17,7 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   FML_DCHECK(!GetChildContainer()->layers().empty());  // We can't be a leaf.
 
   SkMatrix child_matrix = matrix;
-  child_matrix.postTranslate(offset_.fX, offset_.fY);
+  child_matrix.preTranslate(offset_.fX, offset_.fY);
 
   // Similar to what's done in TransformLayer::Preroll, we have to apply the
   // reverse transformation to the cull rect to properly cull child layers.

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -54,6 +54,23 @@ TEST_F(OpacityLayerTest, PaintBeforePreollDies) {
 }
 #endif
 
+TEST_F(OpacityLayerTest, TranslateChildren) {
+  SkPath child_path1;
+  child_path1.addRect(10.0f, 10.0f, 20.0f, 20.f);
+  SkPaint child_paint1(SkColors::kGray);
+  auto layer = std::make_shared<OpacityLayer>(0.5, SkPoint::Make(10, 10));
+  auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
+  layer->Add(mock_layer1);
+
+  auto initial_transform = SkMatrix::Scale(2.0, 2.0);
+  layer->Preroll(preroll_context(), initial_transform);
+
+  SkRect layer_bounds = mock_layer1->paint_bounds();
+  mock_layer1->parent_matrix().mapRect(&layer_bounds);
+
+  EXPECT_EQ(layer_bounds, SkRect::MakeXYWH(40, 40, 20, 20));
+}
+
 TEST_F(OpacityLayerTest, ChildIsCached) {
   const SkAlpha alpha_half = 255 / 2;
   auto initial_transform = SkMatrix::Translate(50.0, 25.5);

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -30,7 +30,7 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
     TRACE_EVENT0("flutter", "PictureLayer::RasterCache (Preroll)");
 
     SkMatrix ctm = matrix;
-    ctm.postTranslate(offset_.x(), offset_.y());
+    ctm.preTranslate(offset_.x(), offset_.y());
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
     ctm = RasterCache::GetIntegralTransCTM(ctm);
 #endif


### PR DESCRIPTION
## Description

`matrix.preTranslate(x,y)` is identical to `matrix.setConcat(matrix, SkMatrix::Translate(x,y))` which is the desired effect.

## Related Issues

https://github.com/flutter/flutter/issues/33939

## Tests

I added the following tests:

OpacityLayerTest.TranslateChildren

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
