### PR TITLE
WIP: Do not paint layers when outside of cull rect

### DIFF
--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -41,6 +41,10 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
     set_paint_bounds(ComputeShadowBounds(path_.getBounds(), elevation_,
                                          context->frame_device_pixel_ratio));
   }
+
+  if (!context->cull_rect.intersects(paint_bounds())) {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 void PhysicalShapeLayer::Paint(PaintContext& context) const {

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -43,6 +43,22 @@ TEST_F(PhysicalShapeLayerTest, PaintBeforePreollDies) {
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
                             "needs_painting\\(\\)");
 }
+
+TEST_F(PhysicalShapeLayerTest, PaintOutsideCullRectDies) {
+  SkPath child_path;
+  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  auto mock_layer = std::make_shared<MockLayer>(child_path, SkPaint());
+  auto layer =
+      std::make_shared<PhysicalShapeLayer>(SK_ColorBLACK, SK_ColorBLACK,
+                                           0.0f,  // elevation
+                                           child_path, Clip::none);
+  layer->Add(mock_layer);
+
+  preroll_context()->cull_rect = SkRect::MakeEmpty();
+  layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
+                            "needs_painting\\(\\)");
+}
 #endif
 
 TEST_F(PhysicalShapeLayerTest, NonEmptyLayer) {

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -39,7 +39,12 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   }
 
   SkRect bounds = sk_picture->cullRect().makeOffset(offset_.x(), offset_.y());
-  set_paint_bounds(bounds);
+
+  if (context->cull_rect.intersects(bounds)) {
+    set_paint_bounds(bounds);
+  } else {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 void PictureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/picture_layer_unittests.cc
+++ b/flow/layers/picture_layer_unittests.cc
@@ -57,6 +57,19 @@ TEST_F(PictureLayerTest, PaintingEmptyLayerDies) {
   EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
                             "needs_painting\\(\\)");
 }
+
+TEST_F(PictureLayerTest, PaintOutsideCullRectDies) {
+  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
+  const SkRect picture_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
+  auto mock_picture = SkPicture::MakePlaceholder(picture_bounds);
+  auto layer = std::make_shared<PictureLayer>(
+      layer_offset, SkiaGPUObject(mock_picture, unref_queue()), false, false);
+
+  preroll_context()->cull_rect = SkRect::MakeEmpty();
+  layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_DEATH_IF_SUPPORTED(layer->Paint(paint_context()),
+                            "needs_painting\\(\\)");
+}
 #endif
 
 TEST_F(PictureLayerTest, InvalidPictureDies) {

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -28,6 +28,10 @@ void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));
+
+  if (!context->cull_rect.intersects(paint_bounds())) {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 void TextureLayer::Paint(PaintContext& context) const {


### PR DESCRIPTION
## Description

This PR changes preroll behavior for layers that are completely outside cull rect. These layers will have empty paint bounds after preroll. This is desired behavior for partial repaint.

## Related Issues

https://github.com/flutter/flutter/issues/33939

## Tests

I added the following tests:

PhysicalShapeLayerTest.PaintOutsideCullRectDies
PictureLayerTest.PaintOutsideCullRectDies

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
