### PR TITLE
Store selection base/extent as size_t

### DIFF
--- a/shell/platform/common/cpp/text_input_model.h
+++ b/shell/platform/common/cpp/text_input_model.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_CPP_TEXT_INPUT_MODEL_H_
 #define FLUTTER_SHELL_PLATFORM_CPP_TEXT_INPUT_MODEL_H_
 
+#include <algorithm>
 #include <memory>
 #include <string>
 
@@ -103,32 +104,26 @@ class TextInputModel {
   int GetCursorOffset() const;
 
   // The position where the selection starts.
-  int selection_base() const {
-    return static_cast<int>(selection_base_ - text_.begin());
-  }
+  int selection_base() const { return selection_base_; }
 
   // The position of the cursor.
-  int selection_extent() const {
-    return static_cast<int>(selection_extent_ - text_.begin());
-  }
+  int selection_extent() const { return selection_extent_; }
 
  private:
   void DeleteSelected();
 
   std::u16string text_;
-  std::u16string::iterator selection_base_;
-  std::u16string::iterator selection_extent_;
+  size_t selection_base_ = 0;
+  size_t selection_extent_ = 0;
 
   // Returns the left hand side of the selection.
-  std::u16string::iterator selection_start() {
-    return selection_base_ < selection_extent_ ? selection_base_
-                                               : selection_extent_;
+  size_t selection_start() {
+    return std::min(selection_base_, selection_extent_);
   }
 
   // Returns the right hand side of the selection.
-  std::u16string::iterator selection_end() {
-    return selection_base_ > selection_extent_ ? selection_base_
-                                               : selection_extent_;
+  size_t selection_end() {
+    return std::max(selection_base_, selection_extent_);
   }
 };
 


### PR DESCRIPTION
## Description

Previously, the selection base and extent were stored in `TextInputModel` as iterators over `text_`. Since iterators must be treated as invalidated whenever the underlying container changes, this requires that `selection_base_` and `selection_extent_` be re-assigned after every change to `text_`.

This is not currently particularly problematic, but once we add fields to track the base and extent of the composing region for multi-step input method support, as well as support for the sub-range within the composing region to which edits/completions apply, we end up having to regenerate a lot of iterators with each change, many of which are logically unchanged in position.

A side benefit is that this simplifies inspection of these fields when debugging.

## Related Issues

* Full IME support for Windows (flutter/flutter#65574)
* Full IME support for Linux (flutter/flutter#66880)

## Tests

This is an implementation refactoring with no new functionality or bugfix. The current tests have been verified to pass.