### PR TITLE
Ensure JNI is not called from raster thread

### DIFF
--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -265,7 +265,7 @@ void AndroidExternalViewEmbedder::BeginFrame(
 
   // The surface size changed. Therefore, destroy existing surfaces as
   // the existing surfaces in the pool can't be recycled.
-  if (frame_size_ != frame_size) {
+  if (frame_size_ != frame_size && raster_thread_merger->IsOnPlatformThread()) {
     surface_pool_->DestroyLayers(jni_facade_);
   }
   frame_size_ = frame_size;

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -268,12 +268,14 @@ void AndroidExternalViewEmbedder::BeginFrame(
   if (frame_size_ != frame_size && raster_thread_merger->IsOnPlatformThread()) {
     surface_pool_->DestroyLayers(jni_facade_);
   }
-  frame_size_ = frame_size;
-  device_pixel_ratio_ = device_pixel_ratio;
+  surface_pool_->SetFrameSize(frame_size);
   // JNI method must be called on the platform thread.
   if (raster_thread_merger->IsOnPlatformThread()) {
     jni_facade_->FlutterViewBeginFrame();
   }
+
+  frame_size_ = frame_size;
+  device_pixel_ratio_ = device_pixel_ratio;
 }
 
 // |ExternalViewEmbedder|

--- a/shell/platform/android/external_view_embedder/surface_pool.cc
+++ b/shell/platform/android/external_view_embedder/surface_pool.cc
@@ -24,6 +24,11 @@ std::shared_ptr<OverlayLayer> SurfacePool::GetLayer(
     std::shared_ptr<AndroidContext> android_context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
     const AndroidSurface::Factory& surface_factory) {
+  // Destroy current layers in the pool if the frame size has changed.
+  if (requested_frame_size_ != current_frame_size_) {
+    DestroyLayers(jni_facade);
+  }
+
   intptr_t gr_context_key = reinterpret_cast<intptr_t>(gr_context);
   // Allocate a new surface if there isn't one available.
   if (available_layer_index_ >= layers_.size()) {
@@ -63,6 +68,7 @@ std::shared_ptr<OverlayLayer> SurfacePool::GetLayer(
     layer->surface = std::move(surface);
   }
   available_layer_index_++;
+  current_frame_size_ = requested_frame_size_;
   return layer;
 }
 
@@ -85,6 +91,10 @@ std::vector<std::shared_ptr<OverlayLayer>> SurfacePool::GetUnusedLayers() {
     results.push_back(layers_[i]);
   }
   return results;
+}
+
+void SurfacePool::SetFrameSize(SkISize frame_size) {
+  requested_frame_size_ = frame_size;
 }
 
 }  // namespace flutter

--- a/shell/platform/android/external_view_embedder/surface_pool.h
+++ b/shell/platform/android/external_view_embedder/surface_pool.h
@@ -67,6 +67,11 @@ class SurfacePool {
   // Destroys all the layers in the pool.
   void DestroyLayers(std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
 
+  // Sets the frame size used by the layers in the pool.
+  // If the current layers in the pool have a different frame size,
+  // then they are deallocated as soon as |GetLayer| is called.
+  void SetFrameSize(SkISize frame_size);
+
  private:
   // The index of the entry in the layers_ vector that determines the beginning
   // of the unused layers. For example, consider the following vector:
@@ -81,7 +86,15 @@ class SurfacePool {
   //  This indicates that entries starting from 1 can be reused meanwhile the
   //  entry at position 0 cannot be reused.
   size_t available_layer_index_ = 0;
+
+  // The layers in the pool.
   std::vector<std::shared_ptr<OverlayLayer>> layers_;
+
+  // The frame size of the layers in the pool.
+  SkISize current_frame_size_;
+
+  // The frame size to be used by future layers.
+  SkISize requested_frame_size_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
## Description

`FlutterViewDestroyOverlaySurfaces` was called from the raster thread.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/67213


## Tests

I added the following tests: Unit test

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
