### PR TITLE
Revert "fuchsia: Don't send ViewportMetrics w/ 0 DPR"

### DIFF
--- a/lib/ui/window/viewport_metrics.cc
+++ b/lib/ui/window/viewport_metrics.cc
@@ -12,13 +12,6 @@ ViewportMetrics::ViewportMetrics() = default;
 
 ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
                                  double p_physical_width,
-                                 double p_physical_height)
-    : device_pixel_ratio(p_device_pixel_ratio),
-      physical_width(p_physical_width),
-      physical_height(p_physical_height) {}
-
-ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
-                                 double p_physical_width,
                                  double p_physical_height,
                                  double p_physical_padding_top,
                                  double p_physical_padding_right,
@@ -51,42 +44,11 @@ ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
       physical_system_gesture_inset_left(p_physical_system_gesture_inset_left) {
 }
 
-bool operator==(const ViewportMetrics& a, const ViewportMetrics& b) {
-  return a.device_pixel_ratio == b.device_pixel_ratio &&
-         a.physical_width == b.physical_width &&
-         a.physical_height == b.physical_height &&
-         a.physical_padding_top == b.physical_padding_top &&
-         a.physical_padding_right == b.physical_padding_right &&
-         a.physical_padding_bottom == b.physical_padding_bottom &&
-         a.physical_padding_left == b.physical_padding_left &&
-         a.physical_view_inset_top == b.physical_view_inset_top &&
-         a.physical_view_inset_right == b.physical_view_inset_right &&
-         a.physical_view_inset_bottom == b.physical_view_inset_bottom &&
-         a.physical_view_inset_left == b.physical_view_inset_left &&
-         a.physical_system_gesture_inset_top ==
-             b.physical_system_gesture_inset_top &&
-         a.physical_system_gesture_inset_right ==
-             b.physical_system_gesture_inset_right &&
-         a.physical_system_gesture_inset_bottom ==
-             b.physical_system_gesture_inset_bottom &&
-         a.physical_system_gesture_inset_left ==
-             b.physical_system_gesture_inset_left;
-}
-
-std::ostream& operator<<(std::ostream& os, const ViewportMetrics& a) {
-  os << "DPR: " << a.device_pixel_ratio << " "
-     << "Size: [" << a.physical_width << "W " << a.physical_height << "H] "
-     << "Padding: [" << a.physical_padding_top << "T "
-     << a.physical_padding_right << "R " << a.physical_padding_bottom << "B "
-     << a.physical_padding_left << "L] "
-     << "Insets: [" << a.physical_view_inset_top << "T "
-     << a.physical_view_inset_right << "R " << a.physical_view_inset_bottom
-     << "B " << a.physical_view_inset_left << "L] "
-     << "Gesture Insets: [" << a.physical_system_gesture_inset_top << "T "
-     << a.physical_system_gesture_inset_right << "R "
-     << a.physical_system_gesture_inset_bottom << "B "
-     << a.physical_system_gesture_inset_left << "L]";
-  return os;
-}
+ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
+                                 double p_physical_width,
+                                 double p_physical_height)
+    : device_pixel_ratio(p_device_pixel_ratio),
+      physical_width(p_physical_width),
+      physical_height(p_physical_height) {}
 
 }  // namespace flutter

--- a/lib/ui/window/viewport_metrics.h
+++ b/lib/ui/window/viewport_metrics.h
@@ -5,15 +5,10 @@
 #ifndef FLUTTER_LIB_UI_WINDOW_VIEWPORT_METRICS_H_
 #define FLUTTER_LIB_UI_WINDOW_VIEWPORT_METRICS_H_
 
-#include <ostream>
-
 namespace flutter {
 
 struct ViewportMetrics {
   ViewportMetrics();
-  ViewportMetrics(double p_device_pixel_ratio,
-                  double p_physical_width,
-                  double p_physical_height);
   ViewportMetrics(double p_device_pixel_ratio,
                   double p_physical_width,
                   double p_physical_height,
@@ -29,6 +24,12 @@ struct ViewportMetrics {
                   double p_physical_system_gesture_inset_right,
                   double p_physical_system_gesture_inset_bottom,
                   double p_physical_system_gesture_inset_left);
+
+  // Create a ViewportMetrics instance that doesn't include depth, padding, or
+  // insets.
+  ViewportMetrics(double p_device_pixel_ratio,
+                  double p_physical_width,
+                  double p_physical_height);
 
   double device_pixel_ratio = 1.0;
   double physical_width = 0;
@@ -47,8 +48,24 @@ struct ViewportMetrics {
   double physical_system_gesture_inset_left = 0;
 };
 
-bool operator==(const ViewportMetrics& a, const ViewportMetrics& b);
-std::ostream& operator<<(std::ostream& os, const ViewportMetrics& a);
+struct LogicalSize {
+  double width = 0.0;
+  double height = 0.0;
+};
+
+struct LogicalInset {
+  double left = 0.0;
+  double top = 0.0;
+  double right = 0.0;
+  double bottom = 0.0;
+};
+
+struct LogicalMetrics {
+  LogicalSize size;
+  double scale = 1.0;
+  LogicalInset padding;
+  LogicalInset view_inset;
+};
 
 }  // namespace flutter
 

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -9,7 +9,6 @@
 #include <fuchsia/ui/scenic/cpp/fidl.h>
 #include <lib/fidl/cpp/binding.h>
 #include <lib/fit/function.h>
-#include <lib/ui/scenic/cpp/id.h>
 
 #include <map>
 #include <set>
@@ -20,6 +19,8 @@
 
 #include "accessibility_bridge.h"
 
+#include <lib/ui/scenic/cpp/id.h>  // nogncheck
+
 namespace flutter_runner {
 
 using OnEnableWireframe = fit::function<void(bool)>;
@@ -28,22 +29,16 @@ using OnUpdateView = fit::function<void(int64_t, bool, bool)>;
 using OnDestroyView = fit::function<void(int64_t)>;
 using OnCreateSurface = fit::function<std::unique_ptr<flutter::Surface>()>;
 
-// PlatformView is the per-engine component residing on the platform thread that
-// is responsible for all platform specific integrations -- particularly
-// integration with the platform's accessibility, input, and windowing features.
-//
-// PlatformView communicates with the Dart code via "platform messages" handled
-// in HandlePlatformMessage.  This communication is bidirectional.  Platform
-// messages are notably responsible for communication related to input and
-// external views / windowing.
+// The per engine component residing on the platform thread is responsible for
+// all platform specific integrations.
 //
 // The PlatformView implements SessionListener and gets Session events but it
-// does *not* actually own the Session itself; that is owned by the
-// FuchsiaExternalViewEmbedder on the raster thread.
+// does *not* actually own the Session itself; that is owned by the Compositor
+// thread.
 class PlatformView final : public flutter::PlatformView,
-                           public AccessibilityBridge::Delegate,
                            private fuchsia::ui::scenic::SessionListener,
-                           private fuchsia::ui::input::InputMethodEditorClient {
+                           public fuchsia::ui::input::InputMethodEditorClient,
+                           public AccessibilityBridge::Delegate {
  public:
   PlatformView(flutter::PlatformView::Delegate& delegate,
                std::string debug_label,
@@ -78,6 +73,51 @@ class PlatformView final : public flutter::PlatformView,
   flutter::PointerDataDispatcherMaker GetDispatcherMaker() override;
 
  private:
+  const std::string debug_label_;
+  // TODO(MI4-2490): remove once ViewRefControl is passed to Scenic and kept
+  // alive there
+  const fuchsia::ui::views::ViewRef view_ref_;
+  fuchsia::ui::views::FocuserPtr focuser_;
+  std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
+
+  fidl::Binding<fuchsia::ui::scenic::SessionListener> session_listener_binding_;
+  fit::closure session_listener_error_callback_;
+  OnEnableWireframe wireframe_enabled_callback_;
+  OnCreateView on_create_view_callback_;
+  OnUpdateView on_update_view_callback_;
+  OnDestroyView on_destroy_view_callback_;
+  OnCreateSurface on_create_surface_callback_;
+
+  int current_text_input_client_ = 0;
+  fidl::Binding<fuchsia::ui::input::InputMethodEditorClient> ime_client_;
+  fuchsia::ui::input::InputMethodEditorPtr ime_;
+  fuchsia::ui::input::ImeServicePtr text_sync_service_;
+
+  fuchsia::sys::ServiceProviderPtr parent_environment_service_provider_;
+
+  // last_text_state_ is the last state of the text input as reported by the IME
+  // or initialized by Flutter. We set it to null if Flutter doesn't want any
+  // input, since then there is no text input state at all.
+  std::unique_ptr<fuchsia::ui::input::TextInputState> last_text_state_;
+
+  std::set<int> down_pointers_;
+  std::map<
+      std::string /* channel */,
+      fit::function<void(
+          fml::RefPtr<flutter::PlatformMessage> /* message */)> /* handler */>
+      platform_message_handlers_;
+  // These are the channels that aren't registered and have been notified as
+  // such. Notifying via logs multiple times results in log-spam. See:
+  // https://github.com/flutter/flutter/issues/55966
+  std::set<std::string /* channel */> unregistered_channels_;
+
+  fml::TimeDelta vsync_offset_;
+  zx_handle_t vsync_event_handle_ = 0;
+
+  float view_width_ = 0.0f;        // Width in logical pixels.
+  float view_height_ = 0.0f;       // Height in logical pixels.
+  float view_pixel_ratio_ = 0.0f;  // Logical / physical pixel ratio.
+
   void RegisterPlatformMessageHandlers();
 
   // |fuchsia::ui::input::InputMethodEditorClient|
@@ -144,57 +184,6 @@ class PlatformView final : public flutter::PlatformView,
   // Channel handler for kPlatformViewsChannel.
   void HandleFlutterPlatformViewsChannelPlatformMessage(
       fml::RefPtr<flutter::PlatformMessage> message);
-
-  const std::string debug_label_;
-  // TODO(MI4-2490): remove once ViewRefControl is passed to Scenic and kept
-  // alive there
-  const fuchsia::ui::views::ViewRef view_ref_;
-  fuchsia::ui::views::FocuserPtr focuser_;
-  std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
-
-  // Logical size and logical->physical ratio.  These are optional to provide
-  // an "unset" state during program startup, before Scenic has sent any
-  // metrics-related events to provide initial values for these.
-  //
-  // The engine internally uses a default size of (0.f 0.f) with a default 1.f
-  // ratio, so there is no need to emit events until Scenic has actually sent a
-  // valid size and ratio.
-  std::optional<std::pair<float, float>> view_logical_size_;
-  std::optional<float> view_pixel_ratio_;
-
-  fidl::Binding<fuchsia::ui::scenic::SessionListener> session_listener_binding_;
-  fit::closure session_listener_error_callback_;
-  OnEnableWireframe wireframe_enabled_callback_;
-  OnCreateView on_create_view_callback_;
-  OnUpdateView on_update_view_callback_;
-  OnDestroyView on_destroy_view_callback_;
-  OnCreateSurface on_create_surface_callback_;
-
-  int current_text_input_client_ = 0;
-  fidl::Binding<fuchsia::ui::input::InputMethodEditorClient> ime_client_;
-  fuchsia::ui::input::InputMethodEditorPtr ime_;
-  fuchsia::ui::input::ImeServicePtr text_sync_service_;
-
-  fuchsia::sys::ServiceProviderPtr parent_environment_service_provider_;
-
-  // last_text_state_ is the last state of the text input as reported by the IME
-  // or initialized by Flutter. We set it to null if Flutter doesn't want any
-  // input, since then there is no text input state at all.
-  std::unique_ptr<fuchsia::ui::input::TextInputState> last_text_state_;
-
-  std::set<int> down_pointers_;
-  std::map<
-      std::string /* channel */,
-      fit::function<void(
-          fml::RefPtr<flutter::PlatformMessage> /* message */)> /* handler */>
-      platform_message_handlers_;
-  // These are the channels that aren't registered and have been notified as
-  // such. Notifying via logs multiple times results in log-spam. See:
-  // https://github.com/flutter/flutter/issues/55966
-  std::set<std::string /* channel */> unregistered_channels_;
-
-  fml::TimeDelta vsync_offset_;
-  zx_handle_t vsync_event_handle_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformView);
 };

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -4,35 +4,50 @@
 
 #include "flutter/shell/platform/fuchsia/flutter/platform_view.h"
 
-#include <fuchsia/ui/gfx/cpp/fidl.h>
-#include <fuchsia/ui/scenic/cpp/fidl.h>
 #include <fuchsia/ui/views/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/async-loop/default.h>
 #include <lib/async/default.h>
 #include <lib/fidl/cpp/binding_set.h>
+#include <lib/fidl/cpp/interface_request.h>
 #include <lib/sys/cpp/testing/service_directory_provider.h>
-#include <lib/ui/scenic/cpp/view_ref_pair.h>
 
 #include <memory>
-#include <ostream>
-#include <string>
 #include <vector>
 
 #include "flutter/flow/embedded_views.h"
 #include "flutter/lib/ui/window/platform_message.h"
-#include "flutter/lib/ui/window/viewport_metrics.h"
+#include "flutter/lib/ui/window/window.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 #include "surface.h"
 #include "task_runner_adapter.h"
 
-namespace flutter_runner::testing {
-namespace {
+namespace flutter_runner_test::flutter_runner_a11y_test {
+
+class PlatformViewTests : public testing::Test {
+ protected:
+  PlatformViewTests() : loop_(&kAsyncLoopConfigAttachToCurrentThread) {}
+
+  async_dispatcher_t* dispatcher() { return loop_.dispatcher(); }
+
+  void RunLoopUntilIdle() {
+    loop_.RunUntilIdle();
+    loop_.ResetQuit();
+  }
+
+ private:
+  async::Loop loop_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewTests);
+};
 
 class MockExternalViewEmbedder : public flutter::ExternalViewEmbedder {
  public:
+  MockExternalViewEmbedder() = default;
+  ~MockExternalViewEmbedder() override = default;
+
   SkCanvas* GetRootCanvas() override { return nullptr; }
   std::vector<SkCanvas*> GetCurrentCanvases() override {
     return std::vector<SkCanvas*>();
@@ -67,9 +82,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) {}
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewSetViewportMetrics(
-      const flutter::ViewportMetrics& metrics) {
-    metrics_ = metrics;
-  }
+      const flutter::ViewportMetrics& metrics) {}
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchPlatformMessage(
       fml::RefPtr<flutter::PlatformMessage> message) {
@@ -100,45 +113,43 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
   // |flutter::PlatformView::Delegate|
   std::unique_ptr<std::vector<std::string>> ComputePlatformViewResolvedLocale(
       const std::vector<std::string>& supported_locale_data) {
-    return nullptr;
+    std::unique_ptr<std::vector<std::string>> out =
+        std::make_unique<std::vector<std::string>>();
+    return out;
   }
 
+  bool SemanticsEnabled() const { return semantics_enabled_; }
+  int32_t SemanticsFeatures() const { return semantics_features_; }
   flutter::Surface* surface() const { return surface_.get(); }
-  flutter::PlatformMessage* message() const { return message_.get(); }
-  const flutter::ViewportMetrics& metrics() const { return metrics_; }
-  int32_t semantics_features() const { return semantics_features_; }
-  bool semantics_enabled() const { return semantics_enabled_; }
+  fml::RefPtr<flutter::PlatformMessage>& message() { return message_; }
 
  private:
   std::unique_ptr<flutter::Surface> surface_;
-  fml::RefPtr<flutter::PlatformMessage> message_;
-  flutter::ViewportMetrics metrics_;
-  int32_t semantics_features_ = 0;
   bool semantics_enabled_ = false;
+  int32_t semantics_features_ = 0;
+  fml::RefPtr<flutter::PlatformMessage> message_;
 };
 
 class MockFocuser : public fuchsia::ui::views::Focuser {
  public:
-  MockFocuser(bool fail_request_focus = false)
-      : fail_request_focus_(fail_request_focus) {}
+  MockFocuser() = default;
+  ~MockFocuser() override = default;
 
-  bool request_focus_called() const { return request_focus_called_; }
+  bool request_focus_called = false;
+  bool fail_request_focus = false;
 
  private:
   void RequestFocus(fuchsia::ui::views::ViewRef view_ref,
                     RequestFocusCallback callback) override {
-    request_focus_called_ = true;
+    request_focus_called = true;
     auto result =
-        fail_request_focus_
+        fail_request_focus
             ? fuchsia::ui::views::Focuser_RequestFocus_Result::WithErr(
                   fuchsia::ui::views::Error::DENIED)
             : fuchsia::ui::views::Focuser_RequestFocus_Result::WithResponse(
                   fuchsia::ui::views::Focuser_RequestFocus_Response());
     callback(std::move(result));
   }
-
-  bool request_focus_called_ = false;
-  bool fail_request_focus_ = false;
 };
 
 class MockResponse : public flutter::PlatformMessageResponse {
@@ -147,228 +158,25 @@ class MockResponse : public flutter::PlatformMessageResponse {
   MOCK_METHOD0(CompleteEmpty, void());
 };
 
-}  // namespace
-
-class PlatformViewTests : public ::testing::Test {
- protected:
-  PlatformViewTests() : loop_(&kAsyncLoopConfigAttachToCurrentThread) {}
-
-  async_dispatcher_t* dispatcher() { return loop_.dispatcher(); }
-
-  void RunLoopUntilIdle() {
-    loop_.RunUntilIdle();
-    loop_.ResetQuit();
-  }
-
- private:
-  async::Loop loop_;
-
-  FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewTests);
-};
-
-// This test makes sure that the PlatformView correctly returns a Surface
-// instance that can surface the provided gr_context and view_embedder.
-TEST_F(PlatformViewTests, CreateSurfaceTest) {
-  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
-  MockPlatformViewDelegate delegate;
-
-  flutter::TaskRunners task_runners =
-      flutter::TaskRunners("test_runners",  // label
-                           nullptr,         // platform
-                           flutter_runner::CreateFMLTaskRunner(
-                               async_get_default_dispatcher()),  // raster
-                           nullptr,                              // ui
-                           nullptr                               // io
-      );
-
-  // Test create surface callback function.
-  sk_sp<GrDirectContext> gr_context =
-      GrDirectContext::MakeMock(nullptr, GrContextOptions());
-  MockExternalViewEmbedder view_embedder;
-  auto CreateSurfaceCallback = [&view_embedder, gr_context]() {
-    return std::make_unique<flutter_runner::Surface>(
-        "PlatformViewTest", &view_embedder, gr_context.get());
-  };
-
-  auto platform_view = flutter_runner::PlatformView(
-      delegate,                               // delegate
-      "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
-      std::move(task_runners),                // task_runners
-      services_provider.service_directory(),  // runner_services
-      nullptr,                 // parent_environment_service_provider_handle
-      nullptr,                 // session_listener_request
-      nullptr,                 // focuser,
-      nullptr,                 // on_session_listener_error_callback
-      nullptr,                 // on_enable_wireframe_callback,
-      nullptr,                 // on_create_view_callback,
-      nullptr,                 // on_update_view_callback,
-      nullptr,                 // on_destroy_view_callback,
-      CreateSurfaceCallback,   // on_create_surface_callback,
-      fml::TimeDelta::Zero(),  // vsync_offset
-      ZX_HANDLE_INVALID        // vsync_event_handle
-  );
-  platform_view.NotifyCreated();
-
-  RunLoopUntilIdle();
-
-  EXPECT_EQ(gr_context.get(), delegate.surface()->GetContext());
-  EXPECT_EQ(&view_embedder, delegate.surface()->GetExternalViewEmbedder());
-}
-
-// This test makes sure that the PlatformView correctly registers Scenic
-// MetricsEvents sent to it via FIDL, correctly parses the metrics it receives,
-// and calls the SetViewportMetrics callback with the appropriate parameters.
-TEST_F(PlatformViewTests, SetViewportMetrics) {
-  constexpr float invalid_pixel_ratio = -0.75f;
-  constexpr float valid_pixel_ratio = 0.75f;
-  constexpr float invalid_max_bound = -0.75f;
-  constexpr float valid_max_bound = 0.75f;
-
-  MockPlatformViewDelegate delegate;
-  EXPECT_EQ(delegate.metrics(), flutter::ViewportMetrics());
-
-  fuchsia::ui::scenic::SessionListenerPtr session_listener;
-  std::vector<fuchsia::ui::scenic::Event> events;
-  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
-  flutter::TaskRunners task_runners("test_runners", nullptr, nullptr, nullptr,
-                                    nullptr);
-  flutter_runner::PlatformView platform_view(
-      delegate,                               // delegate
-      "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
-      std::move(task_runners),                // task_runners
-      services_provider.service_directory(),  // runner_services
-      nullptr,  // parent_environment_service_provider_handle
-      session_listener.NewRequest(),  // session_listener_request
-      nullptr,                        // focuser,
-      nullptr,                        // on_session_listener_error_callback
-      nullptr,                        // on_enable_wireframe_callback,
-      nullptr,                        // on_create_view_callback,
-      nullptr,                        // on_update_view_callback,
-      nullptr,                        // on_destroy_view_callback,
-      nullptr,                        // on_create_surface_callback,
-      fml::TimeDelta::Zero(),         // vsync_offset
-      ZX_HANDLE_INVALID               // vsync_event_handle
-  );
-  RunLoopUntilIdle();
-  EXPECT_EQ(delegate.metrics(), flutter::ViewportMetrics());
-
-  // Test updating with an invalid pixel ratio.  The final metrics should be
-  // unchanged.
-  events.clear();
-  events.emplace_back(fuchsia::ui::scenic::Event::WithGfx(
-      fuchsia::ui::gfx::Event::WithMetrics(fuchsia::ui::gfx::MetricsEvent{
-          .node_id = 0,
-          .metrics =
-              fuchsia::ui::gfx::Metrics{
-                  .scale_x = invalid_pixel_ratio,
-                  .scale_y = 1.f,
-                  .scale_z = 1.f,
-              },
-      })));
-  session_listener->OnScenicEvent(std::move(events));
-  RunLoopUntilIdle();
-  EXPECT_EQ(delegate.metrics(), flutter::ViewportMetrics());
-
-  // Test updating with an invalid size.  The final metrics should be unchanged.
-  events.clear();
-  events.emplace_back(
-      fuchsia::ui::scenic::Event::WithGfx(
-          fuchsia::ui::gfx::Event::WithViewPropertiesChanged(
-              fuchsia::ui::gfx::ViewPropertiesChangedEvent{
-                  .view_id = 0,
-                  .properties =
-                      fuchsia::ui::gfx::ViewProperties{
-                          .bounding_box =
-                              fuchsia::ui::gfx::BoundingBox{
-                                  .min =
-                                      fuchsia::ui::gfx::vec3{
-                                          .x = 0.f,
-                                          .y = 0.f,
-                                          .z = 0.f,
-                                      },
-                                  .max =
-                                      fuchsia::ui::gfx::vec3{
-                                          .x = invalid_max_bound,
-                                          .y = invalid_max_bound,
-                                          .z = invalid_max_bound,
-                                      },
-                              },
-                      },
-              })));
-  session_listener->OnScenicEvent(std::move(events));
-  RunLoopUntilIdle();
-  EXPECT_EQ(delegate.metrics(), flutter::ViewportMetrics());
-
-  // Test updating the size only.  The final metrics should be unchanged until
-  // both pixel ratio and size are updated.
-  events.clear();
-  events.emplace_back(
-      fuchsia::ui::scenic::Event::WithGfx(
-          fuchsia::ui::gfx::Event::WithViewPropertiesChanged(
-              fuchsia::ui::gfx::ViewPropertiesChangedEvent{
-                  .view_id = 0,
-                  .properties =
-                      fuchsia::ui::gfx::ViewProperties{
-                          .bounding_box =
-                              fuchsia::ui::gfx::BoundingBox{
-                                  .min =
-                                      fuchsia::ui::gfx::vec3{
-                                          .x = 0.f,
-                                          .y = 0.f,
-                                          .z = 0.f,
-                                      },
-                                  .max =
-                                      fuchsia::ui::gfx::vec3{
-                                          .x = valid_max_bound,
-                                          .y = valid_max_bound,
-                                          .z = valid_max_bound,
-                                      },
-                              },
-                      },
-              })));
-  session_listener->OnScenicEvent(std::move(events));
-  RunLoopUntilIdle();
-  EXPECT_EQ(delegate.metrics(), flutter::ViewportMetrics());
-
-  // Test updating the pixel ratio only.  The final metrics should change now.
-  events.clear();
-  events.emplace_back(fuchsia::ui::scenic::Event::WithGfx(
-      fuchsia::ui::gfx::Event::WithMetrics(fuchsia::ui::gfx::MetricsEvent{
-          .node_id = 0,
-          .metrics =
-              fuchsia::ui::gfx::Metrics{
-                  .scale_x = valid_pixel_ratio,
-                  .scale_y = 1.f,
-                  .scale_z = 1.f,
-              },
-      })));
-  session_listener->OnScenicEvent(std::move(events));
-  RunLoopUntilIdle();
-  EXPECT_EQ(delegate.metrics(),
-            flutter::ViewportMetrics(valid_pixel_ratio,
-                                     valid_pixel_ratio * valid_max_bound,
-                                     valid_pixel_ratio * valid_max_bound));
-}
-
-// This test makes sure that the PlatformView correctly registers semantics
-// settings changes applied to it and calls the SetSemanticsEnabled /
-// SetAccessibilityFeatures callbacks with the appropriate parameters.
 TEST_F(PlatformViewTests, ChangesAccessibilitySettings) {
   sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
 
   MockPlatformViewDelegate delegate;
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
   flutter::TaskRunners task_runners =
       flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
 
-  EXPECT_FALSE(delegate.semantics_enabled());
-  EXPECT_EQ(delegate.semantics_features(), 0);
+  EXPECT_FALSE(delegate.SemanticsEnabled());
+  EXPECT_EQ(delegate.SemanticsFeatures(), 0);
 
   auto platform_view = flutter_runner::PlatformView(
       delegate,                               // delegate
       "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
+      std::move(view_ref),                    // view_ref
       std::move(task_runners),                // task_runners
       services_provider.service_directory(),  // runner_services
       nullptr,                 // parent_environment_service_provider_handle
@@ -388,22 +196,28 @@ TEST_F(PlatformViewTests, ChangesAccessibilitySettings) {
 
   platform_view.SetSemanticsEnabled(true);
 
-  EXPECT_TRUE(delegate.semantics_enabled());
-  EXPECT_EQ(delegate.semantics_features(),
+  EXPECT_TRUE(delegate.SemanticsEnabled());
+  EXPECT_EQ(delegate.SemanticsFeatures(),
             static_cast<int32_t>(
                 flutter::AccessibilityFeatureFlag::kAccessibleNavigation));
 
   platform_view.SetSemanticsEnabled(false);
 
-  EXPECT_FALSE(delegate.semantics_enabled());
-  EXPECT_EQ(delegate.semantics_features(), 0);
+  EXPECT_FALSE(delegate.SemanticsEnabled());
+  EXPECT_EQ(delegate.SemanticsFeatures(), 0);
 }
 
-// This test makes sure that the PlatformView forwards messages on the
-// "flutter/platform_views" channel for EnableWireframe.
+// Test to make sure that PlatformView correctly registers messages sent on
+// the "flutter/platform_views" channel, correctly parses the JSON it receives
+// and calls the EnableWireframeCallback with the appropriate args.
 TEST_F(PlatformViewTests, EnableWireframeTest) {
   sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
   MockPlatformViewDelegate delegate;
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
   flutter::TaskRunners task_runners =
       flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
 
@@ -418,7 +232,7 @@ TEST_F(PlatformViewTests, EnableWireframeTest) {
   auto platform_view = flutter_runner::PlatformView(
       delegate,                               // delegate
       "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
+      std::move(view_ref),                    // view_refs
       std::move(task_runners),                // task_runners
       services_provider.service_directory(),  // runner_services
       nullptr,                  // parent_environment_service_provider_handle
@@ -460,11 +274,17 @@ TEST_F(PlatformViewTests, EnableWireframeTest) {
   EXPECT_TRUE(wireframe_enabled);
 }
 
-// This test makes sure that the PlatformView forwards messages on the
-// "flutter/platform_views" channel for Createview.
+// Test to make sure that PlatformView correctly registers messages sent on
+// the "flutter/platform_views" channel, correctly parses the JSON it receives
+// and calls the CreateViewCallback with the appropriate args.
 TEST_F(PlatformViewTests, CreateViewTest) {
   sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
   MockPlatformViewDelegate delegate;
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
   flutter::TaskRunners task_runners =
       flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
 
@@ -479,7 +299,7 @@ TEST_F(PlatformViewTests, CreateViewTest) {
   auto platform_view = flutter_runner::PlatformView(
       delegate,                               // delegate
       "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
+      std::move(view_ref),                    // view_refs
       std::move(task_runners),                // task_runners
       services_provider.service_directory(),  // runner_services
       nullptr,                 // parent_environment_service_provider_handle
@@ -523,11 +343,17 @@ TEST_F(PlatformViewTests, CreateViewTest) {
   EXPECT_TRUE(create_view_called);
 }
 
-// This test makes sure that the PlatformView forwards messages on the
-// "flutter/platform_views" channel for UpdateView.
+// Test to make sure that PlatformView correctly registers messages sent on
+// the "flutter/platform_views" channel, correctly parses the JSON it receives
+// and calls the UdpateViewCallback with the appropriate args.
 TEST_F(PlatformViewTests, UpdateViewTest) {
   sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
   MockPlatformViewDelegate delegate;
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
   flutter::TaskRunners task_runners =
       flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
 
@@ -542,7 +368,7 @@ TEST_F(PlatformViewTests, UpdateViewTest) {
   auto platform_view = flutter_runner::PlatformView(
       delegate,                               // delegate
       "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
+      std::move(view_ref),                    // view_refs
       std::move(task_runners),                // task_runners
       services_provider.service_directory(),  // runner_services
       nullptr,                 // parent_environment_service_provider_handle
@@ -586,11 +412,17 @@ TEST_F(PlatformViewTests, UpdateViewTest) {
   EXPECT_TRUE(update_view_called);
 }
 
-// This test makes sure that the PlatformView forwards messages on the
-// "flutter/platform_views" channel for DestroyView.
+// Test to make sure that PlatformView correctly registers messages sent on
+// the "flutter/platform_views" channel, correctly parses the JSON it receives
+// and calls the DestroyViewCallback with the appropriate args.
 TEST_F(PlatformViewTests, DestroyViewTest) {
   sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
   MockPlatformViewDelegate delegate;
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
   flutter::TaskRunners task_runners =
       flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
 
@@ -605,7 +437,7 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
   auto platform_view = flutter_runner::PlatformView(
       delegate,                               // delegate
       "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
+      std::move(view_ref),                    // view_refs
       std::move(task_runners),                // task_runners
       services_provider.service_directory(),  // runner_services
       nullptr,                 // parent_environment_service_provider_handle
@@ -647,9 +479,173 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
   EXPECT_TRUE(destroy_view_called);
 }
 
-// This test makes sure that the PlatformView forwards messages on the
-// "flutter/platform_views" channel for ViewConnected, ViewDisconnected, and
-// ViewStateChanged events.
+// Test to make sure that PlatformView correctly registers messages sent on
+// the "flutter/platform_views" channel, correctly parses the JSON it receives
+// and calls the focuser's RequestFocus with the appropriate args.
+TEST_F(PlatformViewTests, RequestFocusTest) {
+  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
+  MockPlatformViewDelegate delegate;
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
+  flutter::TaskRunners task_runners =
+      flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
+
+  MockFocuser mock_focuser;
+  fidl::BindingSet<fuchsia::ui::views::Focuser> focuser_bindings;
+  auto focuser_handle = focuser_bindings.AddBinding(&mock_focuser);
+
+  auto platform_view = flutter_runner::PlatformView(
+      delegate,                               // delegate
+      "test_platform_view",                   // label
+      std::move(view_ref),                    // view_refs
+      std::move(task_runners),                // task_runners
+      services_provider.service_directory(),  // runner_services
+      nullptr,                    // parent_environment_service_provider_handle
+      nullptr,                    // session_listener_request
+      std::move(focuser_handle),  // focuser,
+      nullptr,                    // on_session_listener_error_callback
+      nullptr,                    // on_enable_wireframe_callback,
+      nullptr,                    // on_create_view_callback,
+      nullptr,                    // on_update_view_callback,
+      nullptr,                    // on_destroy_view_callback,
+      nullptr,                    // on_create_surface_callback,
+      fml::TimeDelta::Zero(),     // vsync_offset
+      ZX_HANDLE_INVALID           // vsync_event_handle
+  );
+
+  // Cast platform_view to its base view so we can have access to the public
+  // "HandlePlatformMessage" function.
+  auto base_view = dynamic_cast<flutter::PlatformView*>(&platform_view);
+  EXPECT_TRUE(base_view);
+
+  // JSON for the message to be passed into the PlatformView.
+  char buff[254];
+  snprintf(buff, sizeof(buff),
+           "{"
+           "    \"method\":\"View.requestFocus\","
+           "    \"args\": {"
+           "       \"viewRef\":%u"
+           "    }"
+           "}",
+           b.get());
+
+  // Define a custom gmock matcher to capture the response to platform message.
+  struct DataArg {
+    void Complete(std::unique_ptr<fml::Mapping> data) {
+      this->data = std::move(data);
+    }
+    std::unique_ptr<fml::Mapping> data;
+  };
+  DataArg data_arg;
+  fml::RefPtr<MockResponse> response = fml::MakeRefCounted<MockResponse>();
+  EXPECT_CALL(*response, Complete(testing::_))
+      .WillOnce(testing::Invoke(&data_arg, &DataArg::Complete));
+
+  fml::RefPtr<flutter::PlatformMessage> message =
+      fml::MakeRefCounted<flutter::PlatformMessage>(
+          "flutter/platform_views",
+          std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
+  base_view->HandlePlatformMessage(message);
+
+  RunLoopUntilIdle();
+
+  EXPECT_TRUE(mock_focuser.request_focus_called);
+  auto result = std::string((const char*)data_arg.data->GetMapping(),
+                            data_arg.data->GetSize());
+  EXPECT_EQ(std::string("[0]"), result);
+}
+
+// Test to make sure that PlatformView correctly registers messages sent on
+// the "flutter/platform_views" channel, correctly parses the JSON it receives
+// and calls the focuser's RequestFocus with the appropriate args.
+TEST_F(PlatformViewTests, RequestFocusFailTest) {
+  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
+  MockPlatformViewDelegate delegate;
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
+  flutter::TaskRunners task_runners =
+      flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
+
+  MockFocuser mock_focuser;
+  mock_focuser.fail_request_focus = true;
+  fidl::BindingSet<fuchsia::ui::views::Focuser> focuser_bindings;
+  auto focuser_handle = focuser_bindings.AddBinding(&mock_focuser);
+
+  auto platform_view = flutter_runner::PlatformView(
+      delegate,                               // delegate
+      "test_platform_view",                   // label
+      std::move(view_ref),                    // view_refs
+      std::move(task_runners),                // task_runners
+      services_provider.service_directory(),  // runner_services
+      nullptr,                    // parent_environment_service_provider_handle
+      nullptr,                    // session_listener_request
+      std::move(focuser_handle),  // focuser,
+      nullptr,                    // on_session_listener_error_callback
+      nullptr,                    // on_enable_wireframe_callback,
+      nullptr,                    // on_create_view_callback,
+      nullptr,                    // on_update_view_callback,
+      nullptr,                    // on_destroy_view_callback,
+      nullptr,                    // on_create_surface_callback,
+      fml::TimeDelta::Zero(),     // vsync_offset
+      ZX_HANDLE_INVALID           // vsync_event_handle
+  );
+
+  // Cast platform_view to its base view so we can have access to the public
+  // "HandlePlatformMessage" function.
+  auto base_view = dynamic_cast<flutter::PlatformView*>(&platform_view);
+  EXPECT_TRUE(base_view);
+
+  // JSON for the message to be passed into the PlatformView.
+  char buff[254];
+  snprintf(buff, sizeof(buff),
+           "{"
+           "    \"method\":\"View.requestFocus\","
+           "    \"args\": {"
+           "       \"viewRef\":%u"
+           "    }"
+           "}",
+           b.get());
+
+  // Define a custom gmock matcher to capture the response to platform message.
+  struct DataArg {
+    void Complete(std::unique_ptr<fml::Mapping> data) {
+      this->data = std::move(data);
+    }
+    std::unique_ptr<fml::Mapping> data;
+  };
+  DataArg data_arg;
+  fml::RefPtr<MockResponse> response = fml::MakeRefCounted<MockResponse>();
+  EXPECT_CALL(*response, Complete(testing::_))
+      .WillOnce(testing::Invoke(&data_arg, &DataArg::Complete));
+
+  fml::RefPtr<flutter::PlatformMessage> message =
+      fml::MakeRefCounted<flutter::PlatformMessage>(
+          "flutter/platform_views",
+          std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
+  base_view->HandlePlatformMessage(message);
+
+  RunLoopUntilIdle();
+
+  EXPECT_TRUE(mock_focuser.request_focus_called);
+  auto result = std::string((const char*)data_arg.data->GetMapping(),
+                            data_arg.data->GetSize());
+  std::ostringstream out;
+  out << "["
+      << static_cast<std::underlying_type_t<fuchsia::ui::views::Error>>(
+             fuchsia::ui::views::Error::DENIED)
+      << "]";
+  EXPECT_EQ(out.str(), result);
+}
+
+// Test to make sure that PlatformView forward messages on the
+// "flutter/platform_views" channel, for viewConnected/viewDisconnected and
+// viewStateChanged events.
 TEST_F(PlatformViewTests, ViewEventsTest) {
   MockPlatformViewDelegate delegate;
 
@@ -665,7 +661,7 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
   auto platform_view = flutter_runner::PlatformView(
       delegate,                               // delegate
       "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
+      fuchsia::ui::views::ViewRef{},          // view_ref
       std::move(task_runners),                // task_runners
       services_provider.service_directory(),  // runner_services
       nullptr,  // parent_environment_service_provider_handle
@@ -732,161 +728,58 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
   EXPECT_EQ(expected, call);
 }
 
-// This test makes sure that the PlatformView forwards messages on the
-// "flutter/platform_views" channel for RequestFocus.
-TEST_F(PlatformViewTests, RequestFocusTest) {
+// Test to make sure that PlatformView correctly returns a Surface instance
+// that can surface the provided gr_context and view_embedder.
+TEST_F(PlatformViewTests, CreateSurfaceTest) {
   sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
   MockPlatformViewDelegate delegate;
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
   flutter::TaskRunners task_runners =
-      flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
+      flutter::TaskRunners("test_runners",  // label
+                           nullptr,         // platform
+                           flutter_runner::CreateFMLTaskRunner(
+                               async_get_default_dispatcher()),  // raster
+                           nullptr,                              // ui
+                           nullptr                               // io
+      );
 
-  MockFocuser mock_focuser;
-  fidl::BindingSet<fuchsia::ui::views::Focuser> focuser_bindings;
-  auto focuser_handle = focuser_bindings.AddBinding(&mock_focuser);
+  // Test create surface callback function.
+  sk_sp<GrDirectContext> gr_context =
+      GrDirectContext::MakeMock(nullptr, GrContextOptions());
+  MockExternalViewEmbedder view_embedder;
+  auto CreateSurfaceCallback = [&view_embedder, gr_context]() {
+    return std::make_unique<flutter_runner::Surface>(
+        "PlatformViewTest", &view_embedder, gr_context.get());
+  };
 
   auto platform_view = flutter_runner::PlatformView(
       delegate,                               // delegate
       "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
+      std::move(view_ref),                    // view_refs
       std::move(task_runners),                // task_runners
       services_provider.service_directory(),  // runner_services
-      nullptr,                    // parent_environment_service_provider_handle
-      nullptr,                    // session_listener_request
-      std::move(focuser_handle),  // focuser,
-      nullptr,                    // on_session_listener_error_callback
-      nullptr,                    // on_enable_wireframe_callback,
-      nullptr,                    // on_create_view_callback,
-      nullptr,                    // on_update_view_callback,
-      nullptr,                    // on_destroy_view_callback,
-      nullptr,                    // on_create_surface_callback,
-      fml::TimeDelta::Zero(),     // vsync_offset
-      ZX_HANDLE_INVALID           // vsync_event_handle
+      nullptr,                 // parent_environment_service_provider_handle
+      nullptr,                 // session_listener_request
+      nullptr,                 // focuser,
+      nullptr,                 // on_session_listener_error_callback
+      nullptr,                 // on_enable_wireframe_callback,
+      nullptr,                 // on_create_view_callback,
+      nullptr,                 // on_update_view_callback,
+      nullptr,                 // on_destroy_view_callback,
+      CreateSurfaceCallback,   // on_create_surface_callback,
+      fml::TimeDelta::Zero(),  // vsync_offset
+      ZX_HANDLE_INVALID        // vsync_event_handle
   );
-
-  // Cast platform_view to its base view so we can have access to the public
-  // "HandlePlatformMessage" function.
-  auto base_view = dynamic_cast<flutter::PlatformView*>(&platform_view);
-  EXPECT_TRUE(base_view);
-
-  // This "Mock" ViewRef serves as the target for the RequestFocus operation.
-  auto mock_view_ref_pair = scenic::ViewRefPair::New();
-
-  // JSON for the message to be passed into the PlatformView.
-  char buff[254];
-  snprintf(buff, sizeof(buff),
-           "{"
-           "    \"method\":\"View.requestFocus\","
-           "    \"args\": {"
-           "       \"viewRef\":%u"
-           "    }"
-           "}",
-           mock_view_ref_pair.view_ref.reference.get());
-
-  // Define a custom gmock matcher to capture the response to platform message.
-  struct DataArg {
-    void Complete(std::unique_ptr<fml::Mapping> data) {
-      this->data = std::move(data);
-    }
-    std::unique_ptr<fml::Mapping> data;
-  };
-  DataArg data_arg;
-  fml::RefPtr<MockResponse> response = fml::MakeRefCounted<MockResponse>();
-  EXPECT_CALL(*response, Complete(::testing::_))
-      .WillOnce(::testing::Invoke(&data_arg, &DataArg::Complete));
-
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
-          "flutter/platform_views",
-          std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
-  base_view->HandlePlatformMessage(message);
+  platform_view.NotifyCreated();
 
   RunLoopUntilIdle();
 
-  EXPECT_TRUE(mock_focuser.request_focus_called());
-  auto result = std::string((const char*)data_arg.data->GetMapping(),
-                            data_arg.data->GetSize());
-  EXPECT_EQ(std::string("[0]"), result);
+  EXPECT_EQ(gr_context.get(), delegate.surface()->GetContext());
+  EXPECT_EQ(&view_embedder, delegate.surface()->GetExternalViewEmbedder());
 }
 
-// This test makes sure that the PlatformView correctly replies with an error
-// response when a RequestFocus call fails.
-TEST_F(PlatformViewTests, RequestFocusFailTest) {
-  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
-  MockPlatformViewDelegate delegate;
-  flutter::TaskRunners task_runners =
-      flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
-
-  MockFocuser mock_focuser(true /*fail_request_focus*/);
-  fidl::BindingSet<fuchsia::ui::views::Focuser> focuser_bindings;
-  auto focuser_handle = focuser_bindings.AddBinding(&mock_focuser);
-
-  auto platform_view = flutter_runner::PlatformView(
-      delegate,                               // delegate
-      "test_platform_view",                   // label
-      fuchsia::ui::views::ViewRef(),          // view_ref
-      std::move(task_runners),                // task_runners
-      services_provider.service_directory(),  // runner_services
-      nullptr,                    // parent_environment_service_provider_handle
-      nullptr,                    // session_listener_request
-      std::move(focuser_handle),  // focuser,
-      nullptr,                    // on_session_listener_error_callback
-      nullptr,                    // on_enable_wireframe_callback,
-      nullptr,                    // on_create_view_callback,
-      nullptr,                    // on_update_view_callback,
-      nullptr,                    // on_destroy_view_callback,
-      nullptr,                    // on_create_surface_callback,
-      fml::TimeDelta::Zero(),     // vsync_offset
-      ZX_HANDLE_INVALID           // vsync_event_handle
-  );
-
-  // Cast platform_view to its base view so we can have access to the public
-  // "HandlePlatformMessage" function.
-  auto base_view = dynamic_cast<flutter::PlatformView*>(&platform_view);
-  EXPECT_TRUE(base_view);
-
-  // This "Mock" ViewRef serves as the target for the RequestFocus operation.
-  auto mock_view_ref_pair = scenic::ViewRefPair::New();
-
-  // JSON for the message to be passed into the PlatformView.
-  char buff[254];
-  snprintf(buff, sizeof(buff),
-           "{"
-           "    \"method\":\"View.requestFocus\","
-           "    \"args\": {"
-           "       \"viewRef\":%u"
-           "    }"
-           "}",
-           mock_view_ref_pair.view_ref.reference.get());
-
-  // Define a custom gmock matcher to capture the response to platform message.
-  struct DataArg {
-    void Complete(std::unique_ptr<fml::Mapping> data) {
-      this->data = std::move(data);
-    }
-    std::unique_ptr<fml::Mapping> data;
-  };
-  DataArg data_arg;
-  fml::RefPtr<MockResponse> response = fml::MakeRefCounted<MockResponse>();
-  EXPECT_CALL(*response, Complete(::testing::_))
-      .WillOnce(::testing::Invoke(&data_arg, &DataArg::Complete));
-
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
-          "flutter/platform_views",
-          std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
-  base_view->HandlePlatformMessage(message);
-
-  RunLoopUntilIdle();
-
-  EXPECT_TRUE(mock_focuser.request_focus_called());
-  auto result = std::string((const char*)data_arg.data->GetMapping(),
-                            data_arg.data->GetSize());
-  std::ostringstream out;
-  out << "["
-      << static_cast<std::underlying_type_t<fuchsia::ui::views::Error>>(
-             fuchsia::ui::views::Error::DENIED)
-      << "]";
-  EXPECT_EQ(out.str(), result);
-}
-
-}  // namespace flutter_runner::testing
+}  // namespace flutter_runner_test::flutter_runner_a11y_test


### PR DESCRIPTION
Reverts flutter/engine#21392

"Linux Web Engine" post-submit failed after this commit. See https://ci.chromium.org/p/flutter/builders/prod/Linux%20Web%20Engine/2082 and https://ci.chromium.org/p/flutter/builders/prod/Linux%20Web%20Engine/2081.

This failure can also be reproduced locally, where the test would pass without this commit. So this is unlikely an infra issue, or an unrelated issue caused by any external packages.