### PR TITLE
Fix engine Xcode projection for newer versions of Xcode.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -398,6 +398,8 @@ def main(argv):
   elif sys.platform == 'darwin':
     # On the Mac, generate an Xcode project by default.
     command.append('--ide=xcode')
+    command.append('--xcode-project=flutter_engine')
+    command.append('--xcode-build-system=new')
   elif sys.platform.startswith('win'):
     # On Windows, generate a Visual Studio project.
     command.append('--ide=vs')


### PR DESCRIPTION
We generate an Xcode project on macOS for all engine translation units. This is so the few developers that prefer Xcode can edit and debug the core engine targets can use Xcode without further setup. However, the Xcode project generated by GN does not seem to work anymore when generated using the default arguments. The errors are:

![Screen Shot 2020-10-08 at 10 54 36 AM](https://user-images.githubusercontent.com/44085/95496693-0d4e3a00-0956-11eb-82ef-9dfed80ae3b4.png)

This patch updates the Xcode project generated by GN for the current versions of Xcode.