### PR TITLE
Perform selection check in DeleteSelected

### DIFF
--- a/shell/platform/common/cpp/text_input_model.cc
+++ b/shell/platform/common/cpp/text_input_model.cc
@@ -52,10 +52,14 @@ bool TextInputModel::SetSelection(size_t base, size_t extent) {
   return true;
 }
 
-void TextInputModel::DeleteSelected() {
+bool TextInputModel::DeleteSelected() {
+  if (selection_base_ == selection_extent_) {
+    return false;
+  }
   text_.erase(selection_start(), selection_end() - selection_start());
   selection_base_ = selection_start();
   selection_extent_ = selection_base_;
+  return true;
 }
 
 void TextInputModel::AddCodePoint(char32_t c) {
@@ -73,9 +77,7 @@ void TextInputModel::AddCodePoint(char32_t c) {
 }
 
 void TextInputModel::AddText(const std::u16string& text) {
-  if (selection_base_ != selection_extent_) {
-    DeleteSelected();
-  }
+  DeleteSelected();
   text_.insert(selection_extent_, text);
   selection_extent_ += text.length();
   selection_base_ = selection_extent_;
@@ -89,8 +91,7 @@ void TextInputModel::AddText(const std::string& text) {
 
 bool TextInputModel::Backspace() {
   // If there's a selection, delete it.
-  if (selection_base_ != selection_extent_) {
-    DeleteSelected();
+  if (DeleteSelected()) {
     return true;
   }
   // There's no selection; delete the preceding codepoint.
@@ -106,8 +107,7 @@ bool TextInputModel::Backspace() {
 
 bool TextInputModel::Delete() {
   // If there's a selection, delete it.
-  if (selection_base_ != selection_extent_) {
-    DeleteSelected();
+  if (DeleteSelected()) {
     return true;
   }
   // There's no selection; delete the following codepoint.

--- a/shell/platform/common/cpp/text_input_model.h
+++ b/shell/platform/common/cpp/text_input_model.h
@@ -110,7 +110,11 @@ class TextInputModel {
   int selection_extent() const { return selection_extent_; }
 
  private:
-  void DeleteSelected();
+  // Deletes the current selection, if any.
+  //
+  // Returns true if any text is deleted. The selection base and extent are
+  // reset to the start of the selected range.
+  bool DeleteSelected();
 
   std::u16string text_;
   size_t selection_base_ = 0;


### PR DESCRIPTION
## Description

At every call site for TextInputModel::DeleteSelected, we perform a
check for a collapsed selection. This moves that check into the method
itself.

## Related Issues

* Full IME support for Windows (flutter/flutter#65574)
* Full IME support for Linux (flutter/flutter#66880)

## Tests

No behavioural changes, just a minor refactoring to a private method. Existing tests cover this change.