### PR TITLE
Remove uses of Dart VM bytecode mode from Flutter engine

### DIFF
--- a/flutter_frontend_server/lib/server.dart
+++ b/flutter_frontend_server/lib/server.dart
@@ -147,8 +147,6 @@ Future<int> starter(
           '--target=flutter',
           '--track-widget-creation',
           '--enable-asserts',
-          '--gen-bytecode',
-          '--bytecode-options=source-positions,local-var-info,debugger-stops,instance-field-initializers,keep-unreachable-code,avoid-closure-call-instructions',
         ]);
         compiler ??= _FlutterFrontendCompiler(
           output,

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -47,10 +47,6 @@ const char* kDartVMArgs[] = {
     "--precompilation",
 #else
     "--enable_mirrors=false",
-
-    // The interpreter is enabled unconditionally. If an app is built for
-    // debugging (that is, with no bytecode), the VM will fall back on ASTs.
-    "--enable_interpreter",
 #endif
 
     // No asserts in debug or release product.

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -22,10 +22,6 @@ compile_platform("kernel_platform_files") {
   args = [
     "--enable-experiment=non-nullable",
     "--nnbd-agnostic",
-
-    # TODO(dartbug.com/36342): enable bytecode for core libraries when performance of bytecode
-    # pipeline is on par with default pipeline and continuously tracked.
-    # "--bytecode",
     "--target=dart_runner",
     "dart:core",
   ]
@@ -75,7 +71,6 @@ template("create_kernel_core_snapshot") {
       # TODO(FL-117): Re-enable causal async stack traces when this issue is
       # addressed.
       "--no_causal_async_stacks",
-      "--use_bytecode_compiler",
       "--enable_mirrors=false",
       "--deterministic",
       "--snapshot_kind=core-jit",

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -406,10 +406,6 @@ Application::Application(
   // addressed.
   settings_.dart_flags = {"--no_causal_async_stacks"};
 
-  // Disable code collection as it interferes with JIT code warmup
-  // by decreasing usage counters and flushing code which is still useful.
-  settings_.dart_flags.push_back("--no-collect_code");
-
   // Don't collect CPU samples from Dart VM C++ code.
   settings_.dart_flags.push_back("--no_profile_vm");
 

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -410,13 +410,6 @@ Application::Application(
   // by decreasing usage counters and flushing code which is still useful.
   settings_.dart_flags.push_back("--no-collect_code");
 
-  if (!flutter::DartVM::IsRunningPrecompiledCode()) {
-    // The interpreter is enabled unconditionally in JIT mode. If an app is
-    // built for debugging (that is, with no bytecode), the VM will fall back on
-    // ASTs.
-    settings_.dart_flags.push_back("--enable_interpreter");
-  }
-
   // Don't collect CPU samples from Dart VM C++ code.
   settings_.dart_flags.push_back("--no_profile_vm");
 

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -22,10 +22,6 @@ compile_platform("kernel_platform_files") {
   args = [
     "--enable-experiment=non-nullable",
     "--nnbd-agnostic",
-
-    # TODO(dartbug.com/36342): enable bytecode for core libraries when performance of bytecode
-    # pipeline is on par with default pipeline and continuously tracked.
-    # "--bytecode",
     "--target=flutter_runner",
     "dart:core",
   ]
@@ -79,7 +75,6 @@ template("core_snapshot") {
       # TODO(FL-117): Re-enable causal async stack traces when this issue is
       # addressed.
       "--no_causal_async_stacks",
-      "--use_bytecode_compiler",
       "--enable_mirrors=false",
       "--deterministic",
       "--snapshot_kind=core-jit",


### PR DESCRIPTION
## Description

Bytecode mode of Dart VM is deprecated and will be removed soon. This change cleans up remaining uses of bytecode mode in Flutter engine.

Corresponding flutter/flutter cleanup PR: https://github.com/flutter/flutter/pull/67755.

## Tests

This is a pure cleanup and should be covered by existing tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
