### PR TITLE
Ignore analysis warning for doc comment

### DIFF
--- a/testing/scenario_app/lib/src/scenarios.dart
+++ b/testing/scenario_app/lib/src/scenarios.dart
@@ -14,7 +14,7 @@ import 'scenario.dart';
 import 'send_text_focus_semantics.dart';
 import 'touches_scenario.dart';
 
-typedef ScenarioFactory = Scenario Function();
+typedef ScenarioFactory = Scenario Function(); // ignore: public_member_api_docs
 
 int _viewId = 0;
 


### PR DESCRIPTION
This is to unblock a Dart -> engine roll.

