### PR TITLE
Prevent a race between SurfaceTexture.release and updateTexImage

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -766,6 +766,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/plugin
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterUiDisplayListener.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/renderer/RenderSurface.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -182,6 +182,7 @@ android_java_sources = [
   "io/flutter/embedding/engine/renderer/FlutterRenderer.java",
   "io/flutter/embedding/engine/renderer/FlutterUiDisplayListener.java",
   "io/flutter/embedding/engine/renderer/RenderSurface.java",
+  "io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java",
   "io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java",
   "io/flutter/embedding/engine/systemchannels/KeyEventChannel.java",
   "io/flutter/embedding/engine/systemchannels/LifecycleChannel.java",

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -23,6 +23,7 @@ import io.flutter.embedding.engine.dart.PlatformMessageHandler;
 import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 import io.flutter.embedding.engine.renderer.RenderSurface;
+import io.flutter.embedding.engine.renderer.SurfaceTextureWrapper;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.localization.LocalizationPlugin;
 import io.flutter.plugin.platform.PlatformViewsController;
@@ -581,14 +582,14 @@ public class FlutterJNI {
    * within Flutter's UI.
    */
   @UiThread
-  public void registerTexture(long textureId, @NonNull SurfaceTexture surfaceTexture) {
+  public void registerTexture(long textureId, @NonNull SurfaceTextureWrapper textureWrapper) {
     ensureRunningOnMainThread();
     ensureAttachedToNative();
-    nativeRegisterTexture(nativePlatformViewId, textureId, surfaceTexture);
+    nativeRegisterTexture(nativePlatformViewId, textureId, textureWrapper);
   }
 
   private native void nativeRegisterTexture(
-      long nativePlatformViewId, long textureId, @NonNull SurfaceTexture surfaceTexture);
+      long nativePlatformViewId, long textureId, @NonNull SurfaceTextureWrapper textureWrapper);
 
   /**
    * Call this method to inform Flutter that a texture previously registered with {@link

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
@@ -1,0 +1,69 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.embedding.engine.renderer;
+
+import android.graphics.SurfaceTexture;
+import androidx.annotation.Keep;
+import androidx.annotation.NonNull;
+
+/**
+ * A wrapper for a SurfaceTexture that tracks whether the texture has been released.
+ *
+ * <p>The engine calls {@code SurfaceTexture.release} on the platform thread, but {@code
+ * updateTexImage} is called on the raster thread. This wrapper will prevent {@code updateTexImage}
+ * calls on an abandoned texture.
+ */
+@Keep
+public class SurfaceTextureWrapper {
+  private SurfaceTexture surfaceTexture;
+  private boolean released;
+
+  public SurfaceTextureWrapper(@NonNull SurfaceTexture surfaceTexture) {
+    this.surfaceTexture = surfaceTexture;
+    this.released = false;
+  }
+
+  @NonNull
+  public SurfaceTexture surfaceTexture() {
+    return surfaceTexture;
+  }
+
+  // Called by native.
+  @SuppressWarnings("unused")
+  public void updateTexImage() {
+    synchronized (this) {
+      if (!released) {
+        surfaceTexture.updateTexImage();
+      }
+    }
+  }
+
+  public void release() {
+    synchronized (this) {
+      if (!released) {
+        surfaceTexture.release();
+        released = true;
+      }
+    }
+  }
+
+  // Called by native.
+  @SuppressWarnings("unused")
+  public void attachToGLContext(int texName) {
+    surfaceTexture.attachToGLContext(texName);
+  }
+
+  // Called by native.
+  @SuppressWarnings("unused")
+  public void detachFromGLContext() {
+    surfaceTexture.detachFromGLContext();
+  }
+
+  // Called by native.
+  @SuppressWarnings("unused")
+  public void getTransformMatrix(float[] mtx) {
+    surfaceTexture.getTransformMatrix(mtx);
+  }
+}

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -53,7 +53,7 @@ static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_callback_info_class =
 
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_jni_class = nullptr;
 
-static fml::jni::ScopedJavaGlobalRef<jclass>* g_surface_texture_class = nullptr;
+static fml::jni::ScopedJavaGlobalRef<jclass>* g_texture_wrapper_class = nullptr;
 
 // Called By Native
 
@@ -613,7 +613,8 @@ bool RegisterApi(JNIEnv* env) {
       },
       {
           .name = "nativeRegisterTexture",
-          .signature = "(JJLandroid/graphics/SurfaceTexture;)V",
+          .signature = "(JJLio/flutter/embedding/engine/renderer/"
+                       "SurfaceTextureWrapper;)V",
           .fnPtr = reinterpret_cast<void*>(&RegisterTexture),
       },
       {
@@ -857,15 +858,16 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
     return false;
   }
 
-  g_surface_texture_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
-      env, env->FindClass("android/graphics/SurfaceTexture"));
-  if (g_surface_texture_class->is_null()) {
-    FML_LOG(ERROR) << "Could not locate SurfaceTexture class";
+  g_texture_wrapper_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
+      env, env->FindClass(
+               "io/flutter/embedding/engine/renderer/SurfaceTextureWrapper"));
+  if (g_texture_wrapper_class->is_null()) {
+    FML_LOG(ERROR) << "Could not locate SurfaceTextureWrapper class";
     return false;
   }
 
   g_attach_to_gl_context_method = env->GetMethodID(
-      g_surface_texture_class->obj(), "attachToGLContext", "(I)V");
+      g_texture_wrapper_class->obj(), "attachToGLContext", "(I)V");
 
   if (g_attach_to_gl_context_method == nullptr) {
     FML_LOG(ERROR) << "Could not locate attachToGlContext method";
@@ -873,7 +875,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
   }
 
   g_update_tex_image_method =
-      env->GetMethodID(g_surface_texture_class->obj(), "updateTexImage", "()V");
+      env->GetMethodID(g_texture_wrapper_class->obj(), "updateTexImage", "()V");
 
   if (g_update_tex_image_method == nullptr) {
     FML_LOG(ERROR) << "Could not locate updateTexImage method";
@@ -881,7 +883,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
   }
 
   g_get_transform_matrix_method = env->GetMethodID(
-      g_surface_texture_class->obj(), "getTransformMatrix", "([F)V");
+      g_texture_wrapper_class->obj(), "getTransformMatrix", "([F)V");
 
   if (g_get_transform_matrix_method == nullptr) {
     FML_LOG(ERROR) << "Could not locate getTransformMatrix method";
@@ -889,7 +891,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
   }
 
   g_detach_from_gl_context_method = env->GetMethodID(
-      g_surface_texture_class->obj(), "detachFromGLContext", "()V");
+      g_texture_wrapper_class->obj(), "detachFromGLContext", "()V");
 
   if (g_detach_from_gl_context_method == nullptr) {
     FML_LOG(ERROR) << "Could not locate detachFromGlContext method";

--- a/tools/android_lint/baseline.xml
+++ b/tools/android_lint/baseline.xml
@@ -188,4 +188,26 @@
             column="24"/>
     </issue>
 
+    <issue
+        id="Recycle"
+        message="This `SurfaceTexture` should be freed up after use with `#release()`"
+        errorLine1="    final SurfaceTexture surfaceTexture = new SurfaceTexture(0);"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../flutter/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java"
+            line="97"
+            column="43"/>
+    </issue>
+
+    <issue
+        id="Recycle"
+        message="This `SurfaceTexture` should be freed up after use with `#release()`"
+        errorLine1="    final SurfaceTexture surfaceTexture = new SurfaceTexture(0);"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="../../../flutter/shell/platform/android/io/flutter/view/FlutterView.java"
+            line="876"
+            column="43"/>
+    </issue>
+
 </issues>


### PR DESCRIPTION
SurfaceTexture.release is called on the platform thread, but
updateTexImage is called on the raster thread.  An updateTexImage call
that happens after the texture is released will fail.

See internal bug b/156301251
