### PR TITLE
Altgr

### DIFF
--- a/e2etests/web/regular_integration_tests/test_driver/text_editing_integration.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/text_editing_integration.dart
@@ -177,6 +177,21 @@ void main() {
       'cancelable': true,
     });
 
+    // Press and release AltGr key.
+    // Regression test for https://github.com/flutter/flutter/issues/58979.
+    dispatchKeyboardEvent(input, 'keydown', <String, dynamic>{
+      'key': 'AltGraph',
+      'code': 'AltRight',
+      'bubbles': true,
+      'cancelable': true,
+    });
+    dispatchKeyboardEvent(input, 'keyup', <String, dynamic>{
+      'key': 'AltGraph',
+      'code': 'AltRight',
+      'bubbles': true,
+      'cancelable': true,
+    });
+
     // Press Tab. The focus should move to the next TextFormField.
     dispatchKeyboardEvent(input, 'keydown', <String, dynamic>{
       'key': 'Tab',

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -177,7 +177,7 @@ int _getMetaState(html.KeyboardEvent event) {
   if (event.getModifierState('Shift')) {
     metaState |= _modifierShift;
   }
-  if (event.getModifierState('Alt')) {
+  if (event.getModifierState('Alt') || event.getModifierState('AltGraph')) {
     metaState |= _modifierAlt;
   }
   if (event.getModifierState('Control')) {


### PR DESCRIPTION
## Description

Fixed AltGr key crash due to metastate not being set on AltGraph modifierState.

## Related Issues

https://github.com/flutter/flutter/issues/58979

## Tests

Updated text_editing_integration.dart.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
