### PR TITLE
Add missing ninja call to analyze.sh so it can be run locally easily

### DIFF
--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -59,6 +59,7 @@ function analyze() (
 )
 
 echo "Analyzing dart:ui library..."
+autoninja -C "$SRC_DIR/out/host_debug_unopt" generate_dart_ui
 analyze \
   --options "$FLUTTER_DIR/analysis_options.yaml" \
   --enable-experiment=non-nullable \
@@ -79,7 +80,7 @@ analyze \
 
 echo "Analyzing testing/dart..."
 "$FLUTTER_DIR/tools/gn" --unoptimized
-ninja -C "$SRC_DIR/out/host_debug_unopt" sky_engine sky_services
+autoninja -C "$SRC_DIR/out/host_debug_unopt" sky_engine sky_services
 (cd "$FLUTTER_DIR/testing/dart" && "$PUB" get)
 analyze \
   --packages="$FLUTTER_DIR/testing/dart/.dart_tool/package_config.json" \


### PR DESCRIPTION
## Description

This just adds a missing call to `autoninja` to generate the dart_ui so that developers don't have to remember to do that before running it. Also switches to use autoninja to get the best performance.