### PR TITLE
[null-safety] fix build rule to produce sound dill

### DIFF
--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -369,7 +369,7 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk_outline_sound") {
 
   args = [
     "--enable-experiment=non-nullable",
-    "--sound-null-safety ",
+    "--sound-null-safety",
     "--summary-only",
     "--target",
     "ddc",


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/67964

The space in the argument name was causing this argument to be dropped and the sound and unsound dills to be identical.