### PR TITLE
[macOS] Add plumbing to grab dart entrypoint args

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
@@ -36,6 +36,16 @@ FLUTTER_EXPORT
  */
 @property(nonatomic) bool enableMirrors;
 
+/**
+ * An NSArray of NSStrings to be passed as command line arguments to the Dart entrypoint.
+ *
+ * If this is not explicitly set, this will default to the contents of
+ * [NSProcessInfo arguments], without the binary name.
+ *
+ * Set this to nil to pass no arguments to the Dart entrypoint.
+ */
+@property(nonatomic, nullable) NSArray<NSString*>* dartEntrypointArguments;
+
 @end
 
 #endif  // FLUTTER_FLUTTERDARTPROJECT_H_

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -27,6 +27,10 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
   NSAssert(self, @"Super init cannot be nil");
 
   _dartBundle = bundle ?: [NSBundle bundleWithIdentifier:kAppBundleIdentifier];
+  _dartEntrypointArguments = [[NSProcessInfo processInfo] arguments];
+  // Remove the first element as it's the binary name
+  _dartEntrypointArguments = [_dartEntrypointArguments
+      subarrayWithRange:NSMakeRange(1, _dartEntrypointArguments.count - 1)];
   return self;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -263,6 +263,11 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   std::transform(switches.begin(), switches.end(), std::back_inserter(argv),
                  [](const std::string& arg) -> const char* { return arg.c_str(); });
 
+  std::vector<const char*> dartEntrypointArgs;
+  for (NSString* argument in [_project dartEntrypointArguments]) {
+    dartEntrypointArgs.push_back([argument UTF8String]);
+  }
+
   FlutterProjectArgs flutterArguments = {};
   flutterArguments.struct_size = sizeof(FlutterProjectArgs);
   flutterArguments.assets_path = _project.assetsPath.UTF8String;
@@ -272,6 +277,9 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   flutterArguments.platform_message_callback = (FlutterPlatformMessageCallback)OnPlatformMessage;
   flutterArguments.custom_dart_entrypoint = entrypoint.UTF8String;
   flutterArguments.shutdown_dart_vm_when_done = true;
+  flutterArguments.dart_entrypoint_argc = dartEntrypointArgs.size();
+  flutterArguments.dart_entrypoint_argv = dartEntrypointArgs.data();
+
   static size_t sTaskRunnerIdentifiers = 0;
   const FlutterTaskRunnerDescription cocoa_task_runner_description = {
       .struct_size = sizeof(FlutterTaskRunnerDescription),


### PR DESCRIPTION
## Description

This adds a new property on FlutterDartProject called dartEntrypointArgs. This can be set directly by the app developer, and if not it will default to simply grabbing the process arguments using NSProcessInfo.

## Related Issues

https://github.com/flutter/flutter/issues/32986

## Tests

I added the following tests:

TBD, will follow up with a test in this PR.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.