### PR TITLE
Use X11 display to create EGL display

### DIFF
--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -50,11 +50,7 @@ static gboolean fl_renderer_x11_setup_window_attr(
 
 // Implements FlRenderer::create_display.
 static EGLDisplay fl_renderer_x11_create_display(FlRenderer* renderer) {
-  // Note the use of EGL_DEFAULT_DISPLAY rather than sharing the existing
-  // display connection from GTK. This is because this EGL display is going to
-  // be accessed by a thread from Flutter. The GTK/X11 display connection is not
-  // thread safe and would cause a crash.
-  return eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  return eglGetDisplay(gdk_x11_get_default_xdisplay());
 }
 
 // Implements FlRenderer::create_surfaces.


### PR DESCRIPTION
## Description
Use the X11 display to create the EGL display. This brings the implementation in line with the Wayland renderer, and maybe fixes https://github.com/flutter/flutter/issues/60429 (I can't reproduce that, so I do not know for sure). I don't *think* this raises any thread safety problems, as the display is used with different contexts on each thread.

## Related Issues

https://github.com/flutter/flutter/issues/60429

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
