### PR TITLE
Enable lazy-async-stacks by-default in all modes (Take 4)

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -59,7 +59,8 @@ static const char* kDartLanguageArgs[] = {
     // clang-format off
     "--enable_mirrors=false",
     "--background_compilation",
-    "--causal_async_stacks",
+    "--no-causal_async_stacks",
+    "--lazy_async_stacks",
     // clang-format on
 };
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -317,6 +317,8 @@ TEST_F(ShellTest, AllowedDartVMFlag) {
   std::vector<const char*> flags = {
       "--enable-isolate-groups",
       "--no-enable-isolate-groups",
+      "--lazy_async_stacks",
+      "--no-causal_async_stacks",
   };
 #if !FLUTTER_RELEASE
   flags.push_back("--max_profile_depth 1");

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -36,9 +36,8 @@ namespace {
 
 const char* kDartVMArgs[] = {
     // clang-format off
-    // TODO(FL-117): Re-enable causal async stack traces when this issue is
-    // addressed.
     "--no_causal_async_stacks",
+    "--lazy_async_stacks",
 
     "--systrace_timeline",
     "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM",

--- a/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
@@ -47,6 +47,7 @@ template("create_aot_snapshot") {
 
     args = [
       "--no_causal_async_stacks",
+      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=vm-aot-assembly",
       "--assembly=" + rebase_path(snapshot_assembly),

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -68,9 +68,8 @@ template("create_kernel_core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
-      # TODO(FL-117): Re-enable causal async stack traces when this issue is
-      # addressed.
       "--no_causal_async_stacks",
+      "--lazy_async_stacks",
       "--enable_mirrors=false",
       "--deterministic",
       "--snapshot_kind=core-jit",

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -58,6 +58,7 @@ template("aot_snapshot") {
 
     args = [
       "--no_causal_async_stacks",
+      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(snapshot_path),

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -402,9 +402,7 @@ Application::Application(
   settings_.task_observer_remove = std::bind(
       &CurrentMessageLoopRemoveAfterTaskObserver, std::placeholders::_1);
 
-  // TODO(FL-117): Re-enable causal async stack traces when this issue is
-  // addressed.
-  settings_.dart_flags = {"--no_causal_async_stacks"};
+  settings_.dart_flags = {"--no_causal_async_stacks", "--lazy_async_stacks"};
 
   // Don't collect CPU samples from Dart VM C++ code.
   settings_.dart_flags.push_back("--no_profile_vm");

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -72,9 +72,8 @@ template("core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
-      # TODO(FL-117): Re-enable causal async stack traces when this issue is
-      # addressed.
       "--no_causal_async_stacks",
+      "--lazy_async_stacks",
       "--enable_mirrors=false",
       "--deterministic",
       "--snapshot_kind=core-jit",

--- a/testing/scenario_app/compile_ios_jit.sh
+++ b/testing/scenario_app/compile_ios_jit.sh
@@ -74,7 +74,8 @@ echo "Compiling JIT Snapshot..."
 
 "$DEVICE_TOOLS/gen_snapshot" --deterministic \
   --enable-asserts \
-  --causal_async_stacks \
+  --no-causal_async_stacks \
+  --lazy_async_stacks \
   --isolate_snapshot_instructions="$OUTDIR/isolate_snapshot_instr" \
   --snapshot_kind=app-jit \
   --load_vm_snapshot_data="$DEVICE_TOOLS/../gen/flutter/lib/snapshot/vm_isolate_snapshot.bin" \

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -128,7 +128,8 @@ template("dart_snapshot_aot") {
     outputs = [ elf_object ]
 
     args = [
-      "--causal_async_stacks",
+      "--no-causal_async_stacks",
+      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(elf_object),


### PR DESCRIPTION
This is a fourth attempt at #16556 which was last reverted in #21043.

A fix for what we believe to have caused the issue that triggered the last rollback has landed upstream in https://github.com/dart-lang/stack_trace/pull/84.

I have manually run and verified that the relevant tests pass locally:

```
$ cd ~/src/flutter/flutter/ 
$ SHARD=tool_tests SUBSHARD=integration \
    ./bin/cache/dart-sdk/bin/dart ./dev/bots/test.dart \
        --local-engine=host_debug \
        --local-engine-src-path ~/src/flutter/engine/src
```

However, do note that the last issue only manifested on Windows.
And while we have tested on Windows the bug is unfortunately inconsistently triggering only in some cases, making it hard to verify.

Original CL description:

> This was already enabled by-default in AOT mode in [0] - which made the
> gen_snapshot invocations use "--lazy-async-stacks --no-causal-async-stacks".
> 
> This change does the same with the engine defaults, which makes this be enabled
> by-default in JIT mode as well.
> 
> See go/dart-10x-faster-async for more information.
> 
> [0] flutter/flutter@3478232