### PR TITLE
Forward Error objects to uncaught exception handler if there is one.

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -458,6 +458,7 @@ action("robolectric_tests") {
     "test/io/flutter/embedding/engine/PluginComponentTest.java",
     "test/io/flutter/embedding/engine/RenderingComponentTest.java",
     "test/io/flutter/embedding/engine/dart/DartExecutorTest.java",
+    "test/io/flutter/embedding/engine/dart/DartMessengerTest.java",
     "test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java",
     "test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java",
     "test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java",

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
@@ -129,7 +129,7 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
 
   // Handles `Error` objects which are not supposed to be caught.
   //
-  // We forward them to threads uncaught exception handler if there is one. If not, they
+  // We forward them to the thread's uncaught exception handler if there is one. If not, they
   // are rethrown.
   private static void handleError(Error err) {
     Thread currentThread = Thread.currentThread();

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
@@ -139,7 +139,7 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
     currentThread.getUncaughtExceptionHandler().uncaughtException(currentThread, err);
   }
 
-  private static class Reply implements BinaryMessenger.BinaryReply {
+  static class Reply implements BinaryMessenger.BinaryReply {
     @NonNull private final FlutterJNI flutterJNI;
     private final int replyId;
     private final AtomicBoolean done = new AtomicBoolean(false);

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -16,6 +16,8 @@ import io.flutter.embedding.engine.FlutterEngineConnectionRegistryTest;
 import io.flutter.embedding.engine.FlutterJNITest;
 import io.flutter.embedding.engine.LocalizationPluginTest;
 import io.flutter.embedding.engine.RenderingComponentTest;
+import io.flutter.embedding.engine.dart.DartExecutorTest;
+import io.flutter.embedding.engine.dart.DartMessengerTest;
 import io.flutter.embedding.engine.loader.ApplicationInfoLoaderTest;
 import io.flutter.embedding.engine.loader.FlutterLoaderTest;
 import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorViewTest;
@@ -41,7 +43,6 @@ import org.junit.runners.Suite.SuiteClasses;
 import test.io.flutter.embedding.engine.FlutterEngineTest;
 import test.io.flutter.embedding.engine.FlutterShellArgsTest;
 import test.io.flutter.embedding.engine.PluginComponentTest;
-import test.io.flutter.embedding.engine.dart.DartExecutorTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -49,6 +50,7 @@ import test.io.flutter.embedding.engine.dart.DartExecutorTest;
   AndroidKeyProcessorTest.class,
   ApplicationInfoLoaderTest.class,
   DartExecutorTest.class,
+  DartMessengerTest.class,
   FlutterActivityAndFragmentDelegateTest.class,
   FlutterActivityTest.class,
   FlutterAndroidComponentTest.class,

--- a/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
@@ -1,4 +1,4 @@
-package test.io.flutter.embedding.engine.dart;
+package io.flutter.embedding.engine.dart;
 
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;

--- a/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
@@ -15,7 +15,7 @@ import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
-public class DartExecutorTest {
+public class DartMessengerTest {
   private static class ReportingUncaughtExceptionHandler
       implements Thread.UncaughtExceptionHandler {
     public Throwable latestException;

--- a/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
@@ -1,0 +1,60 @@
+package io.flutter.embedding.engine.dart;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.dart.DartMessenger;
+import io.flutter.plugin.common.BinaryMessenger;
+import io.flutter.plugin.common.BinaryMessenger.BinaryMessageHandler;
+import java.nio.ByteBuffer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class DartExecutorTest {
+  private static class ReportingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+    public Throwable latestException;
+    
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+      latestException = e;
+    }
+  }
+
+  @Test
+  public void itHandlesErrors() {
+    // Setup test.
+    final FlutterJNI fakeFlutterJni = mock(FlutterJNI.class);
+    final Thread currentThread = Thread.currentThread();
+    final Thread.UncaughtExceptionHandler savedHandler = currentThread.getUncaughtExceptionHandler();
+    final ReportingUncaughtExceptionHandler reportingHandler = new ReportingUncaughtExceptionHandler();
+    currentThread.setUncaughtExceptionHandler(reportingHandler);
+
+    // Create object under test.
+    final DartMessenger messenger = new DartMessenger(fakeFlutterJni);
+    final BinaryMessageHandler throwingHandler = mock(BinaryMessageHandler.class);
+    Mockito
+    .doThrow(AssertionError.class)
+    .when(throwingHandler)
+    .onMessage(any(ByteBuffer.class), any(DartMessenger.Reply.class));
+    
+    messenger.setMessageHandler("test", throwingHandler);
+    messenger.handleMessageFromDart("test", new byte[] {}, 0);
+    assertNotNull(reportingHandler.latestException);
+    assertTrue(reportingHandler.latestException instanceof AssertionError);
+    currentThread.setUncaughtExceptionHandler(savedHandler);
+  }
+}

--- a/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
@@ -1,6 +1,7 @@
 package io.flutter.embedding.engine.dart;
 
 import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
@@ -1,23 +1,14 @@
 package io.flutter.embedding.engine.dart;
 
 import static junit.framework.TestCase.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import io.flutter.embedding.engine.FlutterJNI;
-import io.flutter.embedding.engine.dart.DartMessenger;
-import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.BinaryMessenger.BinaryMessageHandler;
 import java.nio.ByteBuffer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -25,9 +16,10 @@ import org.robolectric.annotation.Config;
 @Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public class DartExecutorTest {
-  private static class ReportingUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+  private static class ReportingUncaughtExceptionHandler
+      implements Thread.UncaughtExceptionHandler {
     public Throwable latestException;
-    
+
     @Override
     public void uncaughtException(Thread t, Throwable e) {
       latestException = e;
@@ -39,18 +31,19 @@ public class DartExecutorTest {
     // Setup test.
     final FlutterJNI fakeFlutterJni = mock(FlutterJNI.class);
     final Thread currentThread = Thread.currentThread();
-    final Thread.UncaughtExceptionHandler savedHandler = currentThread.getUncaughtExceptionHandler();
-    final ReportingUncaughtExceptionHandler reportingHandler = new ReportingUncaughtExceptionHandler();
+    final Thread.UncaughtExceptionHandler savedHandler =
+        currentThread.getUncaughtExceptionHandler();
+    final ReportingUncaughtExceptionHandler reportingHandler =
+        new ReportingUncaughtExceptionHandler();
     currentThread.setUncaughtExceptionHandler(reportingHandler);
 
     // Create object under test.
     final DartMessenger messenger = new DartMessenger(fakeFlutterJni);
     final BinaryMessageHandler throwingHandler = mock(BinaryMessageHandler.class);
-    Mockito
-    .doThrow(AssertionError.class)
-    .when(throwingHandler)
-    .onMessage(any(ByteBuffer.class), any(DartMessenger.Reply.class));
-    
+    Mockito.doThrow(AssertionError.class)
+        .when(throwingHandler)
+        .onMessage(any(ByteBuffer.class), any(DartMessenger.Reply.class));
+
     messenger.setMessageHandler("test", throwingHandler);
     messenger.handleMessageFromDart("test", new byte[] {}, 0);
     assertNotNull(reportingHandler.latestException);
@@ -58,3 +51,4 @@ public class DartExecutorTest {
     currentThread.setUncaughtExceptionHandler(savedHandler);
   }
 }
+

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -341,7 +341,7 @@ def AssertExpectedXcodeVersion():
 
 def RunJavaTests(filter, android_variant='android_debug_unopt'):
   """Runs the Java JUnit unit tests for the Android embedding"""
-  #AssertExpectedJavaVersion()
+  AssertExpectedJavaVersion()
   android_out_dir = os.path.join(out_dir, android_variant)
   EnsureJavaTestsAreBuilt(android_out_dir)
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -341,7 +341,7 @@ def AssertExpectedXcodeVersion():
 
 def RunJavaTests(filter, android_variant='android_debug_unopt'):
   """Runs the Java JUnit unit tests for the Android embedding"""
-  AssertExpectedJavaVersion()
+  #AssertExpectedJavaVersion()
   android_out_dir = os.path.join(out_dir, android_variant)
   EnsureJavaTestsAreBuilt(android_out_dir)
 


### PR DESCRIPTION
## Description

When an `Error` object is encountered while handling platform messages, they are captured by the `JNIContext` which makes it an engine crash. This PR changes that behavior to make the `Error`s raised by plugins a normal Java crash. This helps Android OS generate the correct crash reports.

## Related Issues

## Tests

I did not see a reasonable way to test this since it is not possible to test uncaught exception handler behavior.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
