### PR TITLE
Add a style note about Linux embedding style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,17 @@ contributing guide.
 
 The Flutter engine follows Google style for the languages it uses:
 - [C++](https://google.github.io/styleguide/cppguide.html)
+  - **Note**: The Linux embedding generally follows idiomatic GObject-based C style.
+    Use of C++ is discouraged in that embedding to avoid creating hybrid code that
+    feels unfamiliar to either developers used to working with GObject or C++ developers.
+    E.g., do not use STL collections or std::string. Exceptions:
+      - C-style casts are forbidden; use C++ casts.
+      - Use `nullptr` rather than `NULL`.
 - [Objective-C](https://google.github.io/styleguide/objcguide.html) (including
   [Objective-C++](https://google.github.io/styleguide/objcguide.html#objective-c))
 - [Java](https://google.github.io/styleguide/javaguide.html)
 
-C++ and Objective-C/C++ files are formatted with `clang-format`, and GN files with `gn format`.
+C/C++ and Objective-C/C++ files are formatted with `clang-format`, and GN files with `gn format`.
 
 [build_status]: https://cirrus-ci.com/github/flutter/engine
 [code_of_conduct]: https://github.com/flutter/flutter/blob/master/CODE_OF_CONDUCT.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ The Flutter engine follows Google style for the languages it uses:
     E.g., do not use STL collections or std::string. Exceptions:
       - C-style casts are forbidden; use C++ casts.
       - Use `nullptr` rather than `NULL`.
+      - Avoid `#define`; for internal constants use `static constexpr` instead.
 - [Objective-C](https://google.github.io/styleguide/objcguide.html) (including
   [Objective-C++](https://google.github.io/styleguide/objcguide.html#objective-c))
 - [Java](https://google.github.io/styleguide/javaguide.html)


### PR DESCRIPTION
## Description

While the files are C++, it doesn't follow usual C++ conventions, so should be called out explicitly.

## Related Issues

None

## Tests

I added the following tests: N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
