### PR TITLE
[flutter] add intercept_all_input flag support

### DIFF
--- a/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
+++ b/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
@@ -20,24 +20,24 @@ FlutterRunnerProductConfiguration::FlutterRunnerProductConfiguration(
   // Parse out all values we're expecting.
   if (document.HasMember("vsync_offset_in_us")) {
     auto& val = document["vsync_offset_in_us"];
-    ZX_ASSERT(val.IsInt());
-    vsync_offset_ = fml::TimeDelta::FromMicroseconds(val.GetInt());
+    if (val.IsInt())
+      vsync_offset_ = fml::TimeDelta::FromMicroseconds(val.GetInt());
   }
   if (document.HasMember("max_frames_in_flight")) {
     auto& val = document["max_frames_in_flight"];
-    ZX_ASSERT(val.IsInt());
-    max_frames_in_flight_ = val.GetInt();
+    if (val.IsInt())
+      max_frames_in_flight_ = val.GetInt();
   }
   if (document.HasMember("intercept_all_input")) {
     auto& val = document["intercept_all_input"];
-    ZX_ASSERT(val.IsBool());
-    intercept_all_input_ = val.GetBool();
+    if (val.IsBool())
+      intercept_all_input_ = val.GetBool();
   }
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   if (document.HasMember("use_legacy_renderer")) {
     auto& val = document["use_legacy_renderer"];
-    ZX_ASSERT(val.IsBool());
-    use_legacy_renderer_ = val.GetBool();
+    if (val.IsBool())
+      use_legacy_renderer_ = val.GetBool();
   }
 #endif
 }

--- a/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
+++ b/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter_runner_product_configuration.h"
+#include <zircon/assert.h>
 
 #include "rapidjson/document.h"
 
@@ -17,14 +18,25 @@ FlutterRunnerProductConfiguration::FlutterRunnerProductConfiguration(
     return;
 
   // Parse out all values we're expecting.
-  if (auto& val = document["vsync_offset_in_us"]; val.IsInt()) {
+  if (document.HasMember("vsync_offset_in_us")) {
+    auto& val = document["vsync_offset_in_us"];
+    ZX_ASSERT(val.IsInt());
     vsync_offset_ = fml::TimeDelta::FromMicroseconds(val.GetInt());
   }
-  if (auto& val = document["max_frames_in_flight"]; val.IsInt()) {
+  if (document.HasMember("max_frames_in_flight")) {
+    auto& val = document["max_frames_in_flight"];
+    ZX_ASSERT(val.IsInt());
     max_frames_in_flight_ = val.GetInt();
   }
+  if (document.HasMember("intercept_all_input")) {
+    auto& val = document["intercept_all_input"];
+    ZX_ASSERT(val.IsBool());
+    intercept_all_input_ = val.GetBool();
+  }
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-  if (auto& val = document["use_legacy_renderer"]; val.IsBool()) {
+  if (document.HasMember("use_legacy_renderer")) {
+    auto& val = document["use_legacy_renderer"];
+    ZX_ASSERT(val.IsBool());
     use_legacy_renderer_ = val.GetBool();
   }
 #endif

--- a/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h
+++ b/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h
@@ -16,6 +16,7 @@ class FlutterRunnerProductConfiguration {
 
   fml::TimeDelta get_vsync_offset() { return vsync_offset_; }
   uint64_t get_max_frames_in_flight() { return max_frames_in_flight_; }
+  bool get_intercept_all_input() { return intercept_all_input_; }
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   bool use_legacy_renderer() { return use_legacy_renderer_; }
 #endif
@@ -23,6 +24,7 @@ class FlutterRunnerProductConfiguration {
  private:
   fml::TimeDelta vsync_offset_ = fml::TimeDelta::Zero();
   uint64_t max_frames_in_flight_ = 3;
+  bool intercept_all_input_ = false;
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   bool use_legacy_renderer_ = true;
 #endif

--- a/shell/platform/fuchsia/flutter/tests/flutter_runner_product_configuration_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flutter_runner_product_configuration_unittests.cc
@@ -88,4 +88,26 @@ TEST_F(FlutterRunnerProductConfigurationTest, MissingMaxFramesInFlight) {
             minimum_reasonable_max_frames_in_flight);
 }
 
+TEST_F(FlutterRunnerProductConfigurationTest, ValidInterceptAllInput) {
+  const std::string json_string = "{ \"intercept_all_input\" : true } ";
+  const uint64_t expected_intercept_all_input = true;
+
+  FlutterRunnerProductConfiguration product_config =
+      FlutterRunnerProductConfiguration(json_string);
+
+  EXPECT_EQ(expected_intercept_all_input,
+            product_config.get_intercept_all_input());
+}
+
+TEST_F(FlutterRunnerProductConfigurationTest, MissingInterceptAllInput) {
+  const std::string json_string = "{ \"intercept_all_input\" : } ";
+  const uint64_t expected_intercept_all_input = false;
+
+  FlutterRunnerProductConfiguration product_config =
+      FlutterRunnerProductConfiguration(json_string);
+
+  EXPECT_EQ(expected_intercept_all_input,
+            product_config.get_intercept_all_input());
+}
+
 }  // namespace flutter_runner_test


### PR DESCRIPTION
This change also fixes an issue where FlutterRunnerProductConfiguration
crashes when a field is missing, when building with --unopt.

Test: Added unit tests
Bug: fxb/61466, fxb/61942