### PR TITLE
Upgrade to latest process runner, fix commands that throw to fail test

### DIFF
--- a/ci/bin/lint.dart
+++ b/ci/bin/lint.dart
@@ -245,11 +245,15 @@ void main(List<String> arguments) async {
   final ProcessPool pool = ProcessPool();
 
   await for (final WorkerJob job in pool.startWorkers(jobs)) {
-    if (job.result?.stdout.isEmpty ?? true) {
+    if (job.result?.exitCode == 0) {
       continue;
     }
-    print('❌ Failures for ${job.name}:');
-    print(job.result.stdout);
+    if (job.result == null) {
+      print('❗ The clang-tidy job failed to run:\n${job.exception}');
+    } else {
+      print('❌ Failures for ${job.name}:');
+      print(job.result.stdout);
+    }
     exitCode = 1;
   }
   print('\n');

--- a/ci/bin/lint.dart
+++ b/ci/bin/lint.dart
@@ -11,7 +11,7 @@
 
 import 'dart:async' show Completer;
 import 'dart:convert' show jsonDecode, utf8, LineSplitter;
-import 'dart:io' show File, exit, Directory, FileSystemEntity, Platform, stderr;
+import 'dart:io' show File, exit, Directory, FileSystemEntity, Platform, stderr, exitCode;
 
 import 'package:args/args.dart';
 import 'package:path/path.dart' as path;
@@ -223,7 +223,6 @@ void main(List<String> arguments) async {
         'commands associated with them and can be lint checked.');
   }
 
-  int exitCode = 0;
   final List<WorkerJob> jobs = <WorkerJob>[];
   for (Command command in changedFileBuildCommands) {
     final String relativePath = path.relative(command.file.path, from: repoPath.parent.path);
@@ -249,7 +248,9 @@ void main(List<String> arguments) async {
       continue;
     }
     if (job.result == null) {
-      print('❗ The clang-tidy job failed to run:\n${job.exception}');
+      print('\n❗ A clang-tidy job failed to run, aborting:\n${job.exception}');
+      exitCode = 1;
+      break;
     } else {
       print('❌ Failures for ${job.name}:');
       print(job.result.stdout);
@@ -260,5 +261,4 @@ void main(List<String> arguments) async {
   if (exitCode == 0) {
     print('No lint problems found.');
   }
-  exit(exitCode);
 }

--- a/ci/pubspec.yaml
+++ b/ci/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   args: ^1.6.0
   path: ^1.7.0
   isolate: ^2.0.3
-  process_runner: ^3.0.0
+  process_runner: ^3.1.0
 
 environment:
   sdk: '>=2.8.0 <3.0.0'


### PR DESCRIPTION
## Description

This fixes the lint script to fail when the clang-tidy command itself fails to execute, and print the exception that was raised.

## Related Issues

- Fixes flutter/flutter#68053
