### PR TITLE
Revert Linux Fuchsia SDK rolls to 10/8

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -536,7 +536,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': 'gdo4mZ5oIjOnOe5b2i_V0-JD4DlOuemCMcbgxx-Q5EoC'
+        'version': 'ZJHmp3INUrLtYTJzHkJ-mTGQ7F59bfv1usLDP7xS-XgC'
        }
      ],
      'condition': 'host_os == "linux"',

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: 8228f7eacf4039e8da93d0a6a32c0396
+Signature: e794e6ce4652a9fdd105bddcb6799529
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
This PR rolls the Linux Fuchsia SDK back to before https://github.com/flutter/flutter/issues/67942 started happening.