### PR TITLE
Explicitly make the X connection for EGL.

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -129,6 +129,7 @@ source_set("flutter_linux") {
     "//flutter/shell/platform/linux/config:gtk",
     "//flutter/shell/platform/linux/config:egl",
     "//flutter/shell/platform/linux/config:wayland-egl",
+    "//flutter/shell/platform/linux/config:x11",
     "//third_party/khronos:khronos_headers",
   ]
 
@@ -172,6 +173,7 @@ executable("flutter_linux_unittests") {
   configs += [
     "//flutter/shell/platform/linux/config:gtk",
     "//flutter/shell/platform/linux/config:wayland-egl",
+    "//flutter/shell/platform/linux/config:x11",
   ]
 
   # Set flag to allow public headers to be directly included (library users should not do this)

--- a/shell/platform/linux/config/BUILD.gn
+++ b/shell/platform/linux/config/BUILD.gn
@@ -5,10 +5,8 @@
 import("//build/config/linux/pkg_config.gni")
 import("//flutter/shell/platform/glfw/config.gni")
 
-if (build_glfw_shell) {
-  pkg_config("x11") {
-    packages = [ "x11" ]
-  }
+pkg_config("x11") {
+  packages = [ "x11" ]
 }
 
 pkg_config("gtk") {

--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -12,7 +12,7 @@
 struct _FlRendererX11 {
   FlRenderer parent_instance;
 
-  /// Connection to the X server.
+  // Connection to the X server.
   Display* display;
 };
 
@@ -68,9 +68,9 @@ static gboolean fl_renderer_x11_setup_window_attr(
 static EGLDisplay fl_renderer_x11_create_display(FlRenderer* renderer) {
   FlRendererX11* self = FL_RENDERER_X11(renderer);
 
-  // We make our own connection to the X server because the EGL calls are made
-  // from Flutter on a different thread to GTK. If we re-used the existing GTK
-  // connection then this would crash as Xlib is not thread safe.
+  // Create a dedicated connection to the X server because the EGL calls are
+  // made from Flutter on a different thread to GTK. Re-using the existing
+  // GTK X11 connection would crash as Xlib is not thread safe.
   if (self->display == nullptr) {
     Display* display = gdk_x11_get_default_xdisplay();
     self->display = XOpenDisplay(DisplayString(display));

--- a/shell/platform/linux/fl_renderer_x11.cc
+++ b/shell/platform/linux/fl_renderer_x11.cc
@@ -5,13 +5,29 @@
 #include "fl_renderer_x11.h"
 #ifdef GDK_WINDOWING_X11
 
+#include <X11/X.h>
+
 #include "flutter/shell/platform/linux/egl_utils.h"
 
 struct _FlRendererX11 {
   FlRenderer parent_instance;
+
+  /// Connection to the X server.
+  Display* display;
 };
 
 G_DEFINE_TYPE(FlRendererX11, fl_renderer_x11, fl_renderer_get_type())
+
+static void fl_renderer_x11_dispose(GObject* object) {
+  FlRendererX11* self = FL_RENDERER_X11(object);
+
+  if (self->display != nullptr) {
+    XCloseDisplay(self->display);
+    self->display = nullptr;
+  }
+
+  G_OBJECT_CLASS(fl_renderer_x11_parent_class)->dispose(object);
+}
 
 // Implements FlRenderer::setup_window_attr.
 static gboolean fl_renderer_x11_setup_window_attr(
@@ -50,11 +66,17 @@ static gboolean fl_renderer_x11_setup_window_attr(
 
 // Implements FlRenderer::create_display.
 static EGLDisplay fl_renderer_x11_create_display(FlRenderer* renderer) {
-  // Note the use of EGL_DEFAULT_DISPLAY rather than sharing the existing
-  // display connection from GTK. This is because this EGL display is going to
-  // be accessed by a thread from Flutter. The GTK/X11 display connection is not
-  // thread safe and would cause a crash.
-  return eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  FlRendererX11* self = FL_RENDERER_X11(renderer);
+
+  // We make our own connection to the X server because the EGL calls are made
+  // from Flutter on a different thread to GTK. If we re-used the existing GTK
+  // connection then this would crash as Xlib is not thread safe.
+  if (self->display == nullptr) {
+    Display* display = gdk_x11_get_default_xdisplay();
+    self->display = XOpenDisplay(DisplayString(display));
+  }
+
+  return eglGetDisplay(self->display);
 }
 
 // Implements FlRenderer::create_surfaces.
@@ -99,6 +121,7 @@ static gboolean fl_renderer_x11_create_surfaces(FlRenderer* renderer,
 }
 
 static void fl_renderer_x11_class_init(FlRendererX11Class* klass) {
+  G_OBJECT_CLASS(klass)->dispose = fl_renderer_x11_dispose;
   FL_RENDERER_CLASS(klass)->setup_window_attr =
       fl_renderer_x11_setup_window_attr;
   FL_RENDERER_CLASS(klass)->create_display = fl_renderer_x11_create_display;


### PR DESCRIPTION
## Description

Explicitly make the X connection for EGL.
EGL can mistakenly choose the GBM backend when using EGL_DEFAULT_DISPLAY.

## Related Issues

https://github.com/flutter/flutter/issues/60429

## Tests

No tests changed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
