### PR TITLE
[web]Update Locale.toString() for web SDK

### DIFF
--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -181,10 +181,10 @@ class Locale {
 
   String _rawToString(String separator) {
     final StringBuffer out = StringBuffer(languageCode);
-    if (scriptCode != null) {
+    if (scriptCode != null && scriptCode!.isNotEmpty) {
       out.write('$separator$scriptCode');
     }
-    if (_countryCode != null) {
+    if (_countryCode != null && _countryCode!.isNotEmpty) {
       out.write('$separator$countryCode');
     }
     return out.toString();


### PR DESCRIPTION
## Description

example: Locale('en', '').toString()
will generate unexpected output for web: en_
btw, it will generate expected output while using outside web: en
The solution is to add isNotEmpty check for scriptCode and _countryCode, 
the same, as regular SDK does.

