### PR TITLE
[android] Refactor surface factory and wire in external view embedder

### DIFF
--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -22,11 +22,8 @@ constexpr char kEmulatorRendererPrefix[] =
 AndroidSurfaceGL::AndroidSurfaceGL(
     std::shared_ptr<AndroidContext> android_context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-    const AndroidSurface::Factory& surface_factory)
-    : external_view_embedder_(
-          std::make_unique<AndroidExternalViewEmbedder>(android_context,
-                                                        jni_facade,
-                                                        surface_factory)),
+    std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder)
+    : external_view_embedder_(external_view_embedder),
       android_context_(
           std::static_pointer_cast<AndroidContextGL>(android_context)),
       native_window_(nullptr),

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -22,9 +22,10 @@ namespace flutter {
 class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
                                public AndroidSurface {
  public:
-  AndroidSurfaceGL(std::shared_ptr<AndroidContext> android_context,
-                   std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-                   const AndroidSurface::Factory& surface_factory);
+  AndroidSurfaceGL(
+      std::shared_ptr<AndroidContext> android_context,
+      std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
+      std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder);
 
   ~AndroidSurfaceGL() override;
 
@@ -69,7 +70,7 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   sk_sp<const GrGLInterface> GetGLInterface() const override;
 
  private:
-  const std::unique_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
+  const std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
   const std::shared_ptr<AndroidContextGL> android_context_;
 
   fml::RefPtr<AndroidNativeWindow> native_window_;

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -40,11 +40,8 @@ bool GetSkColorType(int32_t buffer_format,
 AndroidSurfaceSoftware::AndroidSurfaceSoftware(
     std::shared_ptr<AndroidContext> android_context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-    AndroidSurface::Factory surface_factory)
-    : external_view_embedder_(
-          std::make_unique<AndroidExternalViewEmbedder>(android_context,
-                                                        jni_facade,
-                                                        surface_factory)) {
+    std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder)
+    : external_view_embedder_(external_view_embedder) {
   GetSkColorType(WINDOW_FORMAT_RGBA_8888, &target_color_type_,
                  &target_alpha_type_);
 }

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -18,9 +18,10 @@ namespace flutter {
 class AndroidSurfaceSoftware final : public AndroidSurface,
                                      public GPUSurfaceSoftwareDelegate {
  public:
-  AndroidSurfaceSoftware(std::shared_ptr<AndroidContext> android_context,
-                         std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-                         AndroidSurface::Factory surface_factory);
+  AndroidSurfaceSoftware(
+      std::shared_ptr<AndroidContext> android_context,
+      std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
+      std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder);
 
   ~AndroidSurfaceSoftware() override;
 
@@ -56,7 +57,7 @@ class AndroidSurfaceSoftware final : public AndroidSurface,
   ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
  private:
-  const std::unique_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
+  const std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
 
   sk_sp<SkSurface> sk_surface_;
   fml::RefPtr<AndroidNativeWindow> native_window_;

--- a/shell/platform/android/android_surface_vulkan.cc
+++ b/shell/platform/android/android_surface_vulkan.cc
@@ -15,11 +15,8 @@ namespace flutter {
 AndroidSurfaceVulkan::AndroidSurfaceVulkan(
     std::shared_ptr<AndroidContext> android_context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-    AndroidSurface::Factory surface_factory)
-    : external_view_embedder_(
-          std::make_unique<AndroidExternalViewEmbedder>(android_context,
-                                                        jni_facade,
-                                                        surface_factory)),
+    std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder)
+    : external_view_embedder_(external_view_embedder),
       proc_table_(fml::MakeRefCounted<vulkan::VulkanProcTable>()) {}
 
 AndroidSurfaceVulkan::~AndroidSurfaceVulkan() = default;

--- a/shell/platform/android/android_surface_vulkan.h
+++ b/shell/platform/android/android_surface_vulkan.h
@@ -21,9 +21,10 @@ namespace flutter {
 class AndroidSurfaceVulkan : public AndroidSurface,
                              public GPUSurfaceVulkanDelegate {
  public:
-  AndroidSurfaceVulkan(std::shared_ptr<AndroidContext> android_context,
-                       std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-                       AndroidSurface::Factory surface_factory);
+  AndroidSurfaceVulkan(
+      std::shared_ptr<AndroidContext> android_context,
+      std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
+      std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder);
 
   ~AndroidSurfaceVulkan() override;
 
@@ -56,8 +57,7 @@ class AndroidSurfaceVulkan : public AndroidSurface,
   fml::RefPtr<vulkan::VulkanProcTable> vk() override;
 
  private:
-  const std::unique_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
-
+  const std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
   fml::RefPtr<vulkan::VulkanProcTable> proc_table_;
   fml::RefPtr<AndroidNativeWindow> native_window_;
 

--- a/shell/platform/android/external_view_embedder/BUILD.gn
+++ b/shell/platform/android/external_view_embedder/BUILD.gn
@@ -44,6 +44,7 @@ executable("android_external_view_embedder_unittests") {
     "//flutter/flow",
     "//flutter/shell/gpu:gpu_surface_gl",
     "//flutter/shell/platform/android/jni:jni_mock",
+    "//flutter/shell/platform/android/surface",
     "//flutter/shell/platform/android/surface:surface_mock",
     "//flutter/testing",
     "//flutter/testing:dart",

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -5,13 +5,14 @@
 #include "flutter/shell/platform/android/external_view_embedder/external_view_embedder.h"
 
 #include "flutter/fml/trace_event.h"
+#include "flutter/shell/platform/android/surface/android_surface.h"
 
 namespace flutter {
 
 AndroidExternalViewEmbedder::AndroidExternalViewEmbedder(
     std::shared_ptr<AndroidContext> android_context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-    const AndroidSurface::Factory& surface_factory)
+    std::shared_ptr<AndroidSurfaceFactory> surface_factory)
     : ExternalViewEmbedder(),
       android_context_(android_context),
       jni_facade_(jni_facade),

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -12,6 +12,7 @@
 #include "flutter/shell/platform/android/context/android_context.h"
 #include "flutter/shell/platform/android/external_view_embedder/surface_pool.h"
 #include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
+#include "flutter/shell/platform/android/surface/android_surface.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 
 namespace flutter {
@@ -31,7 +32,7 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
   AndroidExternalViewEmbedder(
       std::shared_ptr<AndroidContext> android_context,
       std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-      const AndroidSurface::Factory& surface_factory);
+      std::shared_ptr<AndroidSurfaceFactory> surface_factory);
 
   // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
@@ -93,7 +94,7 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
 
   // Allows to create surfaces.
-  const AndroidSurface::Factory surface_factory_;
+  const std::shared_ptr<AndroidSurfaceFactory> surface_factory_;
 
   // Holds surfaces. Allows to recycle surfaces or allocate new ones.
   const std::unique_ptr<SurfacePool> surface_pool_;

--- a/shell/platform/android/external_view_embedder/surface_pool.cc
+++ b/shell/platform/android/external_view_embedder/surface_pool.cc
@@ -23,7 +23,7 @@ std::shared_ptr<OverlayLayer> SurfacePool::GetLayer(
     GrDirectContext* gr_context,
     std::shared_ptr<AndroidContext> android_context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-    const AndroidSurface::Factory& surface_factory) {
+    std::shared_ptr<AndroidSurfaceFactory> surface_factory) {
   // Destroy current layers in the pool if the frame size has changed.
   if (requested_frame_size_ != current_frame_size_) {
     DestroyLayers(jni_facade);
@@ -33,7 +33,7 @@ std::shared_ptr<OverlayLayer> SurfacePool::GetLayer(
   // Allocate a new surface if there isn't one available.
   if (available_layer_index_ >= layers_.size()) {
     std::unique_ptr<AndroidSurface> android_surface =
-        surface_factory(android_context, jni_facade);
+        surface_factory->CreateSurface();
 
     FML_CHECK(android_surface && android_surface->IsValid())
         << "Could not create an OpenGL, Vulkan or Software surface to setup "

--- a/shell/platform/android/external_view_embedder/surface_pool.h
+++ b/shell/platform/android/external_view_embedder/surface_pool.h
@@ -55,7 +55,7 @@ class SurfacePool {
       GrDirectContext* gr_context,
       std::shared_ptr<AndroidContext> android_context,
       std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-      const AndroidSurface::Factory& surface_factory);
+      std::shared_ptr<AndroidSurfaceFactory> surface_factory);
 
   // Gets the layers in the pool that aren't currently used.
   // This method doesn't mark the layers as unused.

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -14,6 +14,8 @@
 #include "flutter/shell/platform/android/android_external_texture_gl.h"
 #include "flutter/shell/platform/android/android_surface_gl.h"
 #include "flutter/shell/platform/android/android_surface_software.h"
+#include "shell/platform/android/external_view_embedder/external_view_embedder.h"
+#include "shell/platform/android/surface/android_surface.h"
 
 #if SHELL_ENABLE_VULKAN
 #include "flutter/shell/platform/android/android_surface_vulkan.h"
@@ -26,22 +28,35 @@
 
 namespace flutter {
 
-std::unique_ptr<AndroidSurface> SurfaceFactory(
-    std::shared_ptr<AndroidContext> android_context,
+AndroidSurfaceFactory::AndroidSurfaceFactory(
+    std::shared_ptr<AndroidContext> context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade) {
-  FML_CHECK(SurfaceFactory);
-  switch (android_context->RenderingApi()) {
+  android_context_ = context;
+  jni_facade_ = jni_facade;
+}
+
+AndroidSurfaceFactory::~AndroidSurfaceFactory() = default;
+
+void AndroidSurfaceFactory::SetExternalViewEmbedder(
+    std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder) {
+  external_view_embedder_ = external_view_embedder;
+}
+
+std::unique_ptr<AndroidSurface> AndroidSurfaceFactory::CreateSurface() {
+  FML_CHECK(external_view_embedder_);
+  switch (android_context_->RenderingApi()) {
     case AndroidRenderingAPI::kSoftware:
       return std::make_unique<AndroidSurfaceSoftware>(
-          android_context, jni_facade, SurfaceFactory);
+          android_context_, jni_facade_, external_view_embedder_);
     case AndroidRenderingAPI::kOpenGLES:
-      return std::make_unique<AndroidSurfaceGL>(android_context, jni_facade,
-                                                SurfaceFactory);
+      return std::make_unique<AndroidSurfaceGL>(android_context_, jni_facade_,
+                                                external_view_embedder_);
     case AndroidRenderingAPI::kVulkan:
 #if SHELL_ENABLE_VULKAN
-      return std::make_unique<AndroidSurfaceVulkan>(android_context, jni_facade,
-                                                    SurfaceFactory);
+      return std::make_unique<AndroidSurfaceVulkan>(
+          android_context_, jni_facade_, external_view_embedder_);
 #endif  // SHELL_ENABLE_VULKAN
+    default:
       return nullptr;
   }
   return nullptr;
@@ -72,7 +87,13 @@ PlatformViewAndroid::PlatformViewAndroid(
   FML_CHECK(android_context && android_context->IsValid())
       << "Could not create an Android context.";
 
-  android_surface_ = SurfaceFactory(std::move(android_context), jni_facade);
+  surface_factory_ =
+      std::make_shared<AndroidSurfaceFactory>(android_context, jni_facade);
+  surface_factory_->SetExternalViewEmbedder(
+      std::make_shared<AndroidExternalViewEmbedder>(android_context, jni_facade,
+                                                    surface_factory_));
+
+  android_surface_ = surface_factory_->CreateSurface();
   FML_CHECK(android_surface_ && android_surface_->IsValid())
       << "Could not create an OpenGL, Vulkan or Software surface to setup "
          "rendering.";

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -28,21 +28,21 @@
 
 namespace flutter {
 
-AndroidSurfaceFactory::AndroidSurfaceFactory(
+AndroidSurfaceFactoryImpl::AndroidSurfaceFactoryImpl(
     std::shared_ptr<AndroidContext> context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade) {
   android_context_ = context;
   jni_facade_ = jni_facade;
 }
 
-AndroidSurfaceFactory::~AndroidSurfaceFactory() = default;
+AndroidSurfaceFactoryImpl::~AndroidSurfaceFactoryImpl() = default;
 
-void AndroidSurfaceFactory::SetExternalViewEmbedder(
+void AndroidSurfaceFactoryImpl::SetExternalViewEmbedder(
     std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder) {
   external_view_embedder_ = external_view_embedder;
 }
 
-std::unique_ptr<AndroidSurface> AndroidSurfaceFactory::CreateSurface() {
+std::unique_ptr<AndroidSurface> AndroidSurfaceFactoryImpl::CreateSurface() {
   FML_CHECK(external_view_embedder_);
   switch (android_context_->RenderingApi()) {
     case AndroidRenderingAPI::kSoftware:
@@ -88,7 +88,7 @@ PlatformViewAndroid::PlatformViewAndroid(
       << "Could not create an Android context.";
 
   surface_factory_ =
-      std::make_shared<AndroidSurfaceFactory>(android_context, jni_facade);
+      std::make_shared<AndroidSurfaceFactoryImpl>(android_context, jni_facade);
   surface_factory_->SetExternalViewEmbedder(
       std::make_shared<AndroidExternalViewEmbedder>(android_context, jni_facade,
                                                     surface_factory_));

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -22,6 +22,25 @@
 
 namespace flutter {
 
+class AndroidSurfaceFactoryImpl : public AndroidSurfaceFactory {
+ public:
+  AndroidSurfaceFactoryImpl(std::shared_ptr<AndroidContext> context,
+                            std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
+
+  ~AndroidSurfaceFactoryImpl() override;
+
+  std::unique_ptr<AndroidSurface> CreateSurface() override;
+
+  void SetExternalViewEmbedder(
+      std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder);
+
+ private:
+  std::shared_ptr<AndroidContext> android_context_;
+  std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
+  std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
+
+};
+
 class PlatformViewAndroid final : public PlatformView {
  public:
   static bool Register(JNIEnv* env);
@@ -80,7 +99,7 @@ class PlatformViewAndroid final : public PlatformView {
 
  private:
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
-  std::shared_ptr<AndroidSurfaceFactory> surface_factory_;
+  std::shared_ptr<AndroidSurfaceFactoryImpl> surface_factory_;
 
   PlatformViewAndroidDelegate platform_view_android_delegate_;
 

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -80,6 +80,7 @@ class PlatformViewAndroid final : public PlatformView {
 
  private:
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
+  std::shared_ptr<AndroidSurfaceFactory> surface_factory_;
 
   PlatformViewAndroidDelegate platform_view_android_delegate_;
 

--- a/shell/platform/android/surface/android_surface.h
+++ b/shell/platform/android/surface/android_surface.h
@@ -39,20 +39,11 @@ class AndroidSurface {
 
 class AndroidSurfaceFactory {
  public:
-  AndroidSurfaceFactory(std::shared_ptr<AndroidContext> context,
-                        std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
+  AndroidSurfaceFactory() = default;
 
-  ~AndroidSurfaceFactory();
+  virtual ~AndroidSurfaceFactory() = default;
 
-  void SetExternalViewEmbedder(
-      std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder);
-
-  std::unique_ptr<AndroidSurface> CreateSurface();
-
- private:
-  std::shared_ptr<AndroidContext> android_context_;
-  std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
-  std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
+  virtual std::unique_ptr<AndroidSurface> CreateSurface() = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/android/surface/android_surface.h
+++ b/shell/platform/android/surface/android_surface.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_SURFACE_H_
 #define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_SURFACE_H_
 
+#include "flutter/flow/embedded_views.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/android/context/android_context.h"
@@ -14,12 +15,10 @@
 
 namespace flutter {
 
+class AndroidExternalViewEmbedder;
+
 class AndroidSurface {
  public:
-  using Factory = std::function<std::unique_ptr<AndroidSurface>(
-      std::shared_ptr<AndroidContext> android_context,
-      std::shared_ptr<PlatformViewAndroidJNI> jni_facade)>;
-
   virtual ~AndroidSurface();
 
   virtual bool IsValid() const = 0;
@@ -36,6 +35,24 @@ class AndroidSurface {
   virtual bool ResourceContextClearCurrent() = 0;
 
   virtual bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) = 0;
+};
+
+class AndroidSurfaceFactory {
+ public:
+  AndroidSurfaceFactory(std::shared_ptr<AndroidContext> context,
+                        std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
+
+  ~AndroidSurfaceFactory();
+
+  void SetExternalViewEmbedder(
+      std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder);
+
+  std::unique_ptr<AndroidSurface> CreateSurface();
+
+ private:
+  std::shared_ptr<AndroidContext> android_context_;
+  std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
+  std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
This removes the cyclic dependency between surfaces and surface factories.

Prior to this change it was:

- SurfaceFactory <-> Surface <-> EVEmbedder (cycle)

Now:

- SurfaceFactory -> Surface
- SurfaceFactory <-> EVEmbedder (cycle)

This smaller cycle will soon be gone when we refactor EVEmbedder out of surface.