### PR TITLE
Fix destruction order in C++ plugin registrar

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h
@@ -51,6 +51,11 @@ class PluginRegistrar {
  protected:
   FlutterDesktopPluginRegistrarRef registrar() { return registrar_; }
 
+  // Destroys all owned plugins. Subclasses should call this at the beginning of
+  // their destructors to prevent the possibility of an owned plugin trying to
+  // access destroyed state during its own destruction.
+  void ClearPlugins();
+
  private:
   // Handle for interacting with the C API's registrar.
   FlutterDesktopPluginRegistrarRef registrar_;

--- a/shell/platform/common/cpp/client_wrapper/plugin_registrar.cc
+++ b/shell/platform/common/cpp/client_wrapper/plugin_registrar.cc
@@ -21,10 +21,20 @@ PluginRegistrar::PluginRegistrar(FlutterDesktopPluginRegistrarRef registrar)
   messenger_ = std::make_unique<BinaryMessengerImpl>(core_messenger);
 }
 
-PluginRegistrar::~PluginRegistrar() {}
+PluginRegistrar::~PluginRegistrar() {
+  // This must always be the first call.
+  ClearPlugins();
+
+  // Explicitly cleared to facilitate testing of destruction order.
+  messenger_.reset();
+}
 
 void PluginRegistrar::AddPlugin(std::unique_ptr<Plugin> plugin) {
   plugins_.insert(std::move(plugin));
+}
+
+void PluginRegistrar::ClearPlugins() {
+  plugins_.clear();
 }
 
 // ===== PluginRegistrarManager =====

--- a/shell/platform/common/cpp/client_wrapper/plugin_registrar_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/plugin_registrar_unittests.cc
@@ -80,7 +80,40 @@ class TestPluginRegistrar : public PluginRegistrar {
   std::function<void()> destruction_callback_;
 };
 
+// A test plugin that tries to access registrar state during destruction and
+// reports it out via a flag provided at construction.
+class TestPlugin : public Plugin {
+ public:
+  // registrar_valid_at_destruction will be set at destruction to indicate
+  // whether or not |registrar->messenger()| was non-null.
+  TestPlugin(PluginRegistrar* registrar, bool* registrar_valid_at_destruction)
+      : registrar_(registrar),
+        registrar_valid_at_destruction_(registrar_valid_at_destruction) {}
+  virtual ~TestPlugin() {
+    *registrar_valid_at_destruction_ = registrar_->messenger() != nullptr;
+  }
+
+ private:
+  PluginRegistrar* registrar_;
+  bool* registrar_valid_at_destruction_;
+};
+
 }  // namespace
+
+// Tests that the registrar runs plugin destructors before its own teardown.
+TEST(PluginRegistrarTest, PluginDestroyedBeforeRegistrar) {
+  auto dummy_registrar_handle =
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1);
+  bool registrar_valid_at_destruction = false;
+  {
+    PluginRegistrar registrar(dummy_registrar_handle);
+
+    auto plugin = std::make_unique<TestPlugin>(&registrar,
+                                               &registrar_valid_at_destruction);
+    registrar.AddPlugin(std::move(plugin));
+  }
+  EXPECT_TRUE(registrar_valid_at_destruction);
+}
 
 // Tests that the registrar returns a messenger that passes Send through to the
 // C API.

--- a/shell/platform/glfw/client_wrapper/BUILD.gn
+++ b/shell/platform/glfw/client_wrapper/BUILD.gn
@@ -76,6 +76,7 @@ executable("client_wrapper_glfw_unittests") {
     "flutter_engine_unittests.cc",
     "flutter_window_controller_unittests.cc",
     "flutter_window_unittests.cc",
+    "plugin_registrar_glfw_unittests.cc",
   ]
 
   defines = [ "FLUTTER_DESKTOP_LIBRARY" ]

--- a/shell/platform/glfw/client_wrapper/include/flutter/plugin_registrar_glfw.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/plugin_registrar_glfw.h
@@ -26,7 +26,12 @@ class PluginRegistrarGlfw : public PluginRegistrar {
         FlutterDesktopPluginRegistrarGetWindow(core_registrar));
   }
 
-  virtual ~PluginRegistrarGlfw() = default;
+  virtual ~PluginRegistrarGlfw() {
+    // Must be the first call.
+    ClearPlugins();
+    // Explicitly cleared to facilitate destruction order testing.
+    window_.reset();
+  }
 
   // Prevent copying.
   PluginRegistrarGlfw(PluginRegistrarGlfw const&) = delete;

--- a/shell/platform/glfw/client_wrapper/plugin_registrar_glfw_unittests.cc
+++ b/shell/platform/glfw/client_wrapper/plugin_registrar_glfw_unittests.cc
@@ -1,0 +1,60 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <memory>
+#include <string>
+
+#include "flutter/shell/platform/glfw/client_wrapper/include/flutter/plugin_registrar_glfw.h"
+#include "flutter/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+
+namespace {
+
+// A test plugin that tries to access registrar state during destruction and
+// reports it out via a flag provided at construction.
+class TestPlugin : public Plugin {
+ public:
+  // registrar_valid_at_destruction will be set at destruction to indicate
+  // whether or not |registrar->window()| was non-null.
+  TestPlugin(PluginRegistrarGlfw* registrar,
+             bool* registrar_valid_at_destruction)
+      : registrar_(registrar),
+        registrar_valid_at_destruction_(registrar_valid_at_destruction) {}
+  virtual ~TestPlugin() {
+    *registrar_valid_at_destruction_ = registrar_->window() != nullptr;
+  }
+
+ private:
+  PluginRegistrarGlfw* registrar_;
+  bool* registrar_valid_at_destruction_;
+};
+
+}  // namespace
+
+TEST(PluginRegistrarGlfwTest, GetView) {
+  testing::ScopedStubFlutterGlfwApi scoped_api_stub(
+      std::make_unique<testing::StubFlutterGlfwApi>());
+  PluginRegistrarGlfw registrar(
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
+  EXPECT_NE(registrar.window(), nullptr);
+}
+
+// Tests that the registrar runs plugin destructors before its own teardown.
+TEST(PluginRegistrarGlfwTest, PluginDestroyedBeforeRegistrar) {
+  auto dummy_registrar_handle =
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1);
+  bool registrar_valid_at_destruction = false;
+  {
+    PluginRegistrarGlfw registrar(dummy_registrar_handle);
+
+    auto plugin = std::make_unique<TestPlugin>(&registrar,
+                                               &registrar_valid_at_destruction);
+    registrar.AddPlugin(std::move(plugin));
+  }
+  EXPECT_TRUE(registrar_valid_at_destruction);
+}
+
+}  // namespace flutter

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -183,6 +183,12 @@ FlutterDesktopPluginRegistrarRef FlutterDesktopGetPluginRegistrar(
   return reinterpret_cast<FlutterDesktopPluginRegistrarRef>(2);
 }
 
+FlutterDesktopWindowRef FlutterDesktopPluginRegistrarGetWindow(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  // The stub ignores this, so just return an arbitrary non-zero value.
+  return reinterpret_cast<FlutterDesktopWindowRef>(3);
+}
+
 void FlutterDesktopPluginRegistrarEnableInputBlocking(
     FlutterDesktopPluginRegistrarRef registrar,
     const char* channel) {

--- a/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
@@ -36,7 +36,12 @@ class PluginRegistrarWindows : public PluginRegistrar {
         FlutterDesktopPluginRegistrarGetView(core_registrar));
   }
 
-  virtual ~PluginRegistrarWindows() = default;
+  virtual ~PluginRegistrarWindows() {
+    // Must be the first call.
+    ClearPlugins();
+    // Explicitly cleared to facilitate destruction order testing.
+    view_.reset();
+  }
 
   // Prevent copying.
   PluginRegistrarWindows(PluginRegistrarWindows const&) = delete;

--- a/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
+++ b/shell/platform/windows/client_wrapper/plugin_registrar_windows_unittests.cc
@@ -43,6 +43,25 @@ class TestWindowsApi : public testing::StubFlutterWindowsApi {
   void* last_registered_user_data_ = nullptr;
 };
 
+// A test plugin that tries to access registrar state during destruction and
+// reports it out via a flag provided at construction.
+class TestPlugin : public Plugin {
+ public:
+  // registrar_valid_at_destruction will be set at destruction to indicate
+  // whether or not |registrar->GetView()| was non-null.
+  TestPlugin(PluginRegistrarWindows* registrar,
+             bool* registrar_valid_at_destruction)
+      : registrar_(registrar),
+        registrar_valid_at_destruction_(registrar_valid_at_destruction) {}
+  virtual ~TestPlugin() {
+    *registrar_valid_at_destruction_ = registrar_->GetView() != nullptr;
+  }
+
+ private:
+  PluginRegistrarWindows* registrar_;
+  bool* registrar_valid_at_destruction_;
+};
+
 }  // namespace
 
 TEST(PluginRegistrarWindowsTest, GetView) {
@@ -52,6 +71,21 @@ TEST(PluginRegistrarWindowsTest, GetView) {
   PluginRegistrarWindows registrar(
       reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1));
   EXPECT_NE(registrar.GetView(), nullptr);
+}
+
+// Tests that the registrar runs plugin destructors before its own teardown.
+TEST(PluginRegistrarWindowsTest, PluginDestroyedBeforeRegistrar) {
+  auto dummy_registrar_handle =
+      reinterpret_cast<FlutterDesktopPluginRegistrarRef>(1);
+  bool registrar_valid_at_destruction = false;
+  {
+    PluginRegistrarWindows registrar(dummy_registrar_handle);
+
+    auto plugin = std::make_unique<TestPlugin>(&registrar,
+                                               &registrar_valid_at_destruction);
+    registrar.AddPlugin(std::move(plugin));
+  }
+  EXPECT_TRUE(registrar_valid_at_destruction);
 }
 
 TEST(PluginRegistrarWindowsTest, RegisterUnregister) {


### PR DESCRIPTION
## Description

The C++ wrapper's plugin registrar can own plugins to provide lifetime
management. However, plugins expect the registrar to be valid for the
life of the object, including during destruction, so any owned plugins
must be explicitly cleared before any registrar-specific destruction
happens.

## Related Issues

Fixes https://github.com/google/flutter-desktop-embedding/issues/806

## Tests

I added the following tests: Explicit destruction ordering tests for all three registrar wrappers (base, Windows, and GLFW).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
