### PR TITLE
[embedder] Platform View owns lifecycle of external view embedder

### DIFF
--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -11,10 +11,10 @@ namespace flutter {
 EmbedderSurfaceGL::EmbedderSurfaceGL(
     GLDispatchTable gl_dispatch_table,
     bool fbo_reset_after_present,
-    std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
+    std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
     : gl_dispatch_table_(gl_dispatch_table),
       fbo_reset_after_present_(fbo_reset_after_present),
-      external_view_embedder_(std::move(external_view_embedder)) {
+      external_view_embedder_(external_view_embedder) {
   // Make sure all required members of the dispatch table are checked.
   if (!gl_dispatch_table_.gl_make_current_callback ||
       !gl_dispatch_table_.gl_clear_current_callback ||

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -29,7 +29,7 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   EmbedderSurfaceGL(
       GLDispatchTable gl_dispatch_table,
       bool fbo_reset_after_present,
-      std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
+      std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
 
   ~EmbedderSurfaceGL() override;
 
@@ -38,7 +38,7 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   GLDispatchTable gl_dispatch_table_;
   bool fbo_reset_after_present_;
 
-  std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder_;
+  std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder_;
 
   // |EmbedderSurface|
   bool IsValid() const override;

--- a/shell/platform/embedder/embedder_surface_software.cc
+++ b/shell/platform/embedder/embedder_surface_software.cc
@@ -11,9 +11,9 @@ namespace flutter {
 
 EmbedderSurfaceSoftware::EmbedderSurfaceSoftware(
     SoftwareDispatchTable software_dispatch_table,
-    std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
+    std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
     : software_dispatch_table_(software_dispatch_table),
-      external_view_embedder_(std::move(external_view_embedder)) {
+      external_view_embedder_(external_view_embedder) {
   if (!software_dispatch_table_.software_present_backing_store) {
     return;
   }

--- a/shell/platform/embedder/embedder_surface_software.h
+++ b/shell/platform/embedder/embedder_surface_software.h
@@ -22,7 +22,7 @@ class EmbedderSurfaceSoftware final : public EmbedderSurface,
 
   EmbedderSurfaceSoftware(
       SoftwareDispatchTable software_dispatch_table,
-      std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
+      std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
 
   ~EmbedderSurfaceSoftware() override;
 
@@ -30,7 +30,7 @@ class EmbedderSurfaceSoftware final : public EmbedderSurface,
   bool valid_ = false;
   SoftwareDispatchTable software_dispatch_table_;
   sk_sp<SkSurface> sk_surface_;
-  std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder_;
+  std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder_;
 
   // |EmbedderSurface|
   bool IsValid() const override;

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -11,11 +11,12 @@ PlatformViewEmbedder::PlatformViewEmbedder(
     flutter::TaskRunners task_runners,
     EmbedderSurfaceSoftware::SoftwareDispatchTable software_dispatch_table,
     PlatformDispatchTable platform_dispatch_table,
-    std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
+    std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
     : PlatformView(delegate, std::move(task_runners)),
-      embedder_surface_(std::make_unique<EmbedderSurfaceSoftware>(
-          software_dispatch_table,
-          std::move(external_view_embedder))),
+      external_view_embedder_(external_view_embedder),
+      embedder_surface_(
+          std::make_unique<EmbedderSurfaceSoftware>(software_dispatch_table,
+                                                    external_view_embedder_)),
       platform_dispatch_table_(platform_dispatch_table) {}
 
 #ifdef SHELL_ENABLE_GL
@@ -25,12 +26,13 @@ PlatformViewEmbedder::PlatformViewEmbedder(
     EmbedderSurfaceGL::GLDispatchTable gl_dispatch_table,
     bool fbo_reset_after_present,
     PlatformDispatchTable platform_dispatch_table,
-    std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
+    std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder)
     : PlatformView(delegate, std::move(task_runners)),
-      embedder_surface_(std::make_unique<EmbedderSurfaceGL>(
-          gl_dispatch_table,
-          fbo_reset_after_present,
-          std::move(external_view_embedder))),
+      external_view_embedder_(external_view_embedder),
+      embedder_surface_(
+          std::make_unique<EmbedderSurfaceGL>(gl_dispatch_table,
+                                              fbo_reset_after_present,
+                                              external_view_embedder_)),
       platform_dispatch_table_(platform_dispatch_table) {}
 #endif
 

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -7,6 +7,7 @@
 
 #include <functional>
 
+#include "flow/embedded_views.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -49,7 +50,7 @@ class PlatformViewEmbedder final : public PlatformView {
       flutter::TaskRunners task_runners,
       EmbedderSurfaceSoftware::SoftwareDispatchTable software_dispatch_table,
       PlatformDispatchTable platform_dispatch_table,
-      std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
+      std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
 
 #ifdef SHELL_ENABLE_GL
   // Creates a platform view that sets up an OpenGL rasterizer.
@@ -59,7 +60,7 @@ class PlatformViewEmbedder final : public PlatformView {
       EmbedderSurfaceGL::GLDispatchTable gl_dispatch_table,
       bool fbo_reset_after_present,
       PlatformDispatchTable platform_dispatch_table,
-      std::unique_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
+      std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder);
 #endif
 
   ~PlatformViewEmbedder() override;
@@ -74,6 +75,7 @@ class PlatformViewEmbedder final : public PlatformView {
       fml::RefPtr<flutter::PlatformMessage> message) override;
 
  private:
+  std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder_;
   std::unique_ptr<EmbedderSurface> embedder_surface_;
   PlatformDispatchTable platform_dispatch_table_;
 


### PR DESCRIPTION
Changing it to shared_ptr and migrating the ownership from surface to platform view.
