### PR TITLE
[fuchsia] External view embedder will be shared with platform view

### DIFF
--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -26,10 +26,10 @@ void ChildSceneLayer::Paint(PaintContext& context) const {
   FML_NOTREACHED();
 }
 
-void ChildSceneLayer::UpdateScene(SceneUpdateContext& context) {
+void ChildSceneLayer::UpdateScene(std::shared_ptr<SceneUpdateContext> context) {
   TRACE_EVENT0("flutter", "ChildSceneLayer::UpdateScene");
   FML_DCHECK(needs_system_composite());
-  context.UpdateView(layer_id_, offset_, size_, hit_testable_);
+  context->UpdateView(layer_id_, offset_, size_, hit_testable_);
 }
 
 }  // namespace flutter

--- a/flow/layers/child_scene_layer.h
+++ b/flow/layers/child_scene_layer.h
@@ -26,7 +26,7 @@ class ChildSceneLayer : public Layer {
 
   void Paint(PaintContext& context) const override;
 
-  void UpdateScene(SceneUpdateContext& context) override;
+  void UpdateScene(std::shared_ptr<SceneUpdateContext> context) override;
 
  private:
   zx_koid_t layer_id_ = ZX_KOID_INVALID;

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -41,7 +41,7 @@ void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
 
-void ClipPathLayer::UpdateScene(SceneUpdateContext& context) {
+void ClipPathLayer::UpdateScene(std::shared_ptr<SceneUpdateContext> context) {
   TRACE_EVENT0("flutter", "ClipPathLayer::UpdateScene");
   FML_DCHECK(needs_system_composite());
 

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -22,7 +22,7 @@ class ClipPathLayer : public ContainerLayer {
   }
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-  void UpdateScene(SceneUpdateContext& context) override;
+  void UpdateScene(std::shared_ptr<SceneUpdateContext> context) override;
 #endif
 
  private:

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -36,7 +36,7 @@ void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
 
-void ClipRectLayer::UpdateScene(SceneUpdateContext& context) {
+void ClipRectLayer::UpdateScene(std::shared_ptr<SceneUpdateContext> context) {
   TRACE_EVENT0("flutter", "ClipRectLayer::UpdateScene");
   FML_DCHECK(needs_system_composite());
 

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -21,7 +21,7 @@ class ClipRectLayer : public ContainerLayer {
   }
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-  void UpdateScene(SceneUpdateContext& context) override;
+  void UpdateScene(std::shared_ptr<SceneUpdateContext> context) override;
 #endif
 
  private:

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -37,7 +37,7 @@ void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
 
-void ClipRRectLayer::UpdateScene(SceneUpdateContext& context) {
+void ClipRRectLayer::UpdateScene(std::shared_ptr<SceneUpdateContext> context) {
   TRACE_EVENT0("flutter", "ClipRRectLayer::UpdateScene");
   FML_DCHECK(needs_system_composite());
 

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -22,7 +22,7 @@ class ClipRRectLayer : public ContainerLayer {
   }
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-  void UpdateScene(SceneUpdateContext& context) override;
+  void UpdateScene(std::shared_ptr<SceneUpdateContext> context) override;
 #endif
 
  private:

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -98,18 +98,19 @@ void ContainerLayer::CheckForChildLayerBelow(PrerollContext* context) {
   // All ContainerLayers make the check in PrerollChildren.
 }
 
-void ContainerLayer::UpdateScene(SceneUpdateContext& context) {
+void ContainerLayer::UpdateScene(std::shared_ptr<SceneUpdateContext> context) {
   UpdateSceneChildren(context);
 }
 
-void ContainerLayer::UpdateSceneChildren(SceneUpdateContext& context) {
+void ContainerLayer::UpdateSceneChildren(
+    std::shared_ptr<SceneUpdateContext> context) {
   FML_DCHECK(needs_system_composite());
 
   std::optional<SceneUpdateContext::Frame> frame;
   if (child_layer_exists_below_) {
     frame.emplace(
         context, SkRRect::MakeRect(paint_bounds()), SK_ColorTRANSPARENT,
-        SkScalarRoundToInt(context.alphaf() * 255), "flutter::ContainerLayer");
+        SkScalarRoundToInt(context->alphaf() * 255), "flutter::ContainerLayer");
     frame->AddPaintLayer(this);
   }
 

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -21,7 +21,7 @@ class ContainerLayer : public Layer {
   void Paint(PaintContext& context) const override;
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   void CheckForChildLayerBelow(PrerollContext* context) override;
-  void UpdateScene(SceneUpdateContext& context) override;
+  void UpdateScene(std::shared_ptr<SceneUpdateContext> context) override;
 #endif
 
   const std::vector<std::shared_ptr<Layer>>& layers() const { return layers_; }
@@ -33,7 +33,7 @@ class ContainerLayer : public Layer {
   void PaintChildren(PaintContext& context) const;
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-  void UpdateSceneChildren(SceneUpdateContext& context);
+  void UpdateSceneChildren(std::shared_ptr<SceneUpdateContext> context);
 #endif
 
   // Try to prepare the raster cache for a given layer.

--- a/flow/layers/fuchsia_layer_unittests.cc
+++ b/flow/layers/fuchsia_layer_unittests.cc
@@ -261,7 +261,7 @@ struct TestContext {
   std::unique_ptr<MockSessionWrapper> mock_session_wrapper;
 
   // SceneUpdateContext.
-  std::unique_ptr<SceneUpdateContext> scene_update_context;
+  std::shared_ptr<SceneUpdateContext> scene_update_context;
 
   // PrerollContext.
   MutatorsStack unused_stack;
@@ -286,7 +286,7 @@ std::unique_ptr<TestContext> InitTest() {
       std::make_unique<MockSessionWrapper>(std::move(session_ptr));
 
   // Init SceneUpdateContext.
-  context->scene_update_context = std::make_unique<SceneUpdateContext>(
+  context->scene_update_context = std::make_shared<SceneUpdateContext>(
       "fuchsia_layer_unittest", fuchsia::ui::views::ViewToken(),
       scenic::ViewRefPair::New(), *(context->mock_session_wrapper));
 
@@ -410,7 +410,7 @@ TEST_F(FuchsiaLayerTest, DISABLED_PhysicalShapeLayersAndChildSceneLayers) {
 
   // Create another frame to be the "real" root. Required because
   // UpdateScene() traversal expects there to already be a top node.
-  SceneUpdateContext::Frame frame(*(test_context->scene_update_context),
+  SceneUpdateContext::Frame frame(test_context->scene_update_context,
                                   SkRRect::MakeRect(SkRect::MakeWH(100, 100)),
                                   SK_ColorTRANSPARENT, SK_AlphaOPAQUE,
                                   "fuchsia test root");
@@ -555,7 +555,7 @@ TEST_F(FuchsiaLayerTest, DISABLED_PhysicalShapeLayersAndChildSceneLayers) {
 
   // Finally, UpdateScene(). The MockSession will check the emitted commands
   // against the list above.
-  root->UpdateScene(*(test_context->scene_update_context));
+  root->UpdateScene(test_context->scene_update_context);
 
   test_context->mock_session_wrapper->Present();
 
@@ -626,7 +626,7 @@ TEST_F(FuchsiaLayerTest, DISABLED_OpacityAndTransformLayer) {
 
   // Create another frame to be the "real" root. Required because
   // UpdateScene() traversal expects there to already be a top node.
-  SceneUpdateContext::Frame frame(*(test_context->scene_update_context),
+  SceneUpdateContext::Frame frame(test_context->scene_update_context,
                                   SkRRect::MakeRect(SkRect::MakeWH(100, 100)),
                                   SK_ColorTRANSPARENT, SK_AlphaOPAQUE,
                                   "fuchsia test root");
@@ -737,7 +737,7 @@ TEST_F(FuchsiaLayerTest, DISABLED_OpacityAndTransformLayer) {
 
   // Finally, UpdateScene(). The MockSession will check the emitted
   // commands against the list above.
-  root->UpdateScene(*(test_context->scene_update_context));
+  root->UpdateScene(test_context->scene_update_context);
 
   test_context->mock_session_wrapper->Present();
 

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -67,13 +67,13 @@ void Layer::CheckForChildLayerBelow(PrerollContext* context) {
   }
 }
 
-void Layer::UpdateScene(SceneUpdateContext& context) {
+void Layer::UpdateScene(std::shared_ptr<SceneUpdateContext> context) {
   FML_DCHECK(needs_system_composite());
   FML_DCHECK(child_layer_exists_below_);
 
   SceneUpdateContext::Frame frame(
       context, SkRRect::MakeRect(paint_bounds()), SK_ColorTRANSPARENT,
-      SkScalarRoundToInt(context.alphaf() * 255), "flutter::Layer");
+      SkScalarRoundToInt(context->alphaf() * 255), "flutter::Layer");
 
   frame.AddPaintLayer(this);
 }

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -154,7 +154,7 @@ class Layer {
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   // Updates the system composited scene.
-  virtual void UpdateScene(SceneUpdateContext& context);
+  virtual void UpdateScene(std::shared_ptr<SceneUpdateContext> context);
   virtual void CheckForChildLayerBelow(PrerollContext* context);
 #endif
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -62,11 +62,11 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
 }
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-void LayerTree::UpdateScene(SceneUpdateContext& context) {
+void LayerTree::UpdateScene(std::shared_ptr<SceneUpdateContext> context) {
   TRACE_EVENT0("flutter", "LayerTree::UpdateScene");
 
   // Reset for a new Scene.
-  context.Reset();
+  context->Reset();
 
   const float inv_dpr = 1.0f / device_pixel_ratio_;
   SceneUpdateContext::Transform transform(context, inv_dpr, inv_dpr, 1.0f);
@@ -82,7 +82,7 @@ void LayerTree::UpdateScene(SceneUpdateContext& context) {
   if (root_layer_->needs_painting()) {
     frame.AddPaintLayer(root_layer_.get());
   }
-  context.root_node().AddChild(transform.entity_node());
+  context->root_node().AddChild(transform.entity_node());
 }
 #endif
 

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -32,7 +32,7 @@ class LayerTree {
                bool ignore_raster_cache = false);
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-  void UpdateScene(SceneUpdateContext& context);
+  void UpdateScene(std::shared_ptr<SceneUpdateContext> context);
 #endif
 
   void Paint(CompositorContext::ScopedFrame& frame,

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -85,11 +85,11 @@ void OpacityLayer::Paint(PaintContext& context) const {
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
 
-void OpacityLayer::UpdateScene(SceneUpdateContext& context) {
-  float saved_alpha = context.alphaf();
-  context.set_alphaf(context.alphaf() * (alpha_ / 255.f));
+void OpacityLayer::UpdateScene(std::shared_ptr<SceneUpdateContext> context) {
+  float saved_alpha = context->alphaf();
+  context->set_alphaf(context->alphaf() * (alpha_ / 255.f));
   ContainerLayer::UpdateScene(context);
-  context.set_alphaf(saved_alpha);
+  context->set_alphaf(saved_alpha);
 }
 
 #endif

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -32,7 +32,7 @@ class OpacityLayer : public MergedContainerLayer {
   void Paint(PaintContext& context) const override;
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-  void UpdateScene(SceneUpdateContext& context) override;
+  void UpdateScene(std::shared_ptr<SceneUpdateContext> context) override;
 #endif
 
  private:

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -47,10 +47,11 @@ void PlatformViewLayer::Paint(PaintContext& context) const {
 }
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-void PlatformViewLayer::UpdateScene(SceneUpdateContext& context) {
+void PlatformViewLayer::UpdateScene(
+    std::shared_ptr<SceneUpdateContext> context) {
   TRACE_EVENT0("flutter", "PlatformViewLayer::UpdateScene");
   FML_DCHECK(needs_system_composite());
-  context.UpdateView(view_id_, offset_, size_);
+  context->UpdateView(view_id_, offset_, size_);
 }
 #endif
 

--- a/flow/layers/platform_view_layer.h
+++ b/flow/layers/platform_view_layer.h
@@ -19,7 +19,7 @@ class PlatformViewLayer : public Layer {
   void Paint(PaintContext& context) const override;
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   // Updates the system composited scene.
-  void UpdateScene(SceneUpdateContext& context) override;
+  void UpdateScene(std::shared_ptr<SceneUpdateContext> context) override;
 #endif
 
  private:

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -54,7 +54,7 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
 
-void TransformLayer::UpdateScene(SceneUpdateContext& context) {
+void TransformLayer::UpdateScene(std::shared_ptr<SceneUpdateContext> context) {
   TRACE_EVENT0("flutter", "TransformLayer::UpdateScene");
   FML_DCHECK(needs_system_composite());
 

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -20,7 +20,7 @@ class TransformLayer : public ContainerLayer {
   void Paint(PaintContext& context) const override;
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-  void UpdateScene(SceneUpdateContext& context) override;
+  void UpdateScene(std::shared_ptr<SceneUpdateContext> context) override;
 #endif
 
  private:

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -46,15 +46,15 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
  public:
   class Entity {
    public:
-    Entity(SceneUpdateContext& context);
+    Entity(std::shared_ptr<SceneUpdateContext> context);
     virtual ~Entity();
 
-    SceneUpdateContext& context() { return context_; }
+    std::shared_ptr<SceneUpdateContext> context() { return context_; }
     scenic::EntityNode& entity_node() { return entity_node_; }
     virtual scenic::ContainerNode& embedder_node() { return entity_node_; }
 
    private:
-    SceneUpdateContext& context_;
+    std::shared_ptr<SceneUpdateContext> context_;
     Entity* const previous_entity_;
 
     scenic::EntityNode entity_node_;
@@ -62,8 +62,9 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
 
   class Transform : public Entity {
    public:
-    Transform(SceneUpdateContext& context, const SkMatrix& transform);
-    Transform(SceneUpdateContext& context,
+    Transform(std::shared_ptr<SceneUpdateContext> context,
+              const SkMatrix& transform);
+    Transform(std::shared_ptr<SceneUpdateContext> context,
               float scale_x,
               float scale_y,
               float scale_z);
@@ -79,7 +80,7 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
     // When layer is not nullptr, the frame is associated with a layer subtree
     // rooted with that layer. The frame may then create a surface that will be
     // retained for that layer.
-    Frame(SceneUpdateContext& context,
+    Frame(std::shared_ptr<SceneUpdateContext> context,
           const SkRRect& rrect,
           SkColor color,
           SkAlpha opacity,
@@ -104,7 +105,8 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
 
   class Clip : public Entity {
    public:
-    Clip(SceneUpdateContext& context, const SkRect& shape_bounds);
+    Clip(std::shared_ptr<SceneUpdateContext> context,
+         const SkRect& shape_bounds);
     ~Clip() = default;
   };
 

--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -23,7 +23,7 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
               fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger,
               SessionConnection& session_connection,
               VulkanSurfaceProducer& surface_producer,
-              flutter::SceneUpdateContext& scene_update_context)
+              std::shared_ptr<flutter::SceneUpdateContext> scene_update_context)
       : flutter::CompositorContext::ScopedFrame(context,
                                                 surface_producer.gr_context(),
                                                 canvas,
@@ -39,7 +39,7 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
  private:
   SessionConnection& session_connection_;
   VulkanSurfaceProducer& surface_producer_;
-  flutter::SceneUpdateContext& scene_update_context_;
+  std::shared_ptr<flutter::SceneUpdateContext> scene_update_context_;
 
   flutter::RasterStatus Raster(flutter::LayerTree& layer_tree,
                                bool ignore_raster_cache) override {
@@ -64,7 +64,7 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
       // Flush all pending session ops: create surfaces and enqueue session
       // Image ops for the frame's paint tasks, then Present.
       TRACE_EVENT0("flutter", "SessionPresent");
-      frame_paint_tasks = scene_update_context_.GetPaintTasks();
+      frame_paint_tasks = scene_update_context_->GetPaintTasks();
       for (auto& task : frame_paint_tasks) {
         SkISize physical_size =
             SkISize::Make(layer_tree.device_pixel_ratio() * task.scale_x *
@@ -142,7 +142,7 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
 CompositorContext::CompositorContext(
     SessionConnection& session_connection,
     VulkanSurfaceProducer& surface_producer,
-    flutter::SceneUpdateContext& scene_update_context)
+    std::shared_ptr<flutter::SceneUpdateContext> scene_update_context)
     : session_connection_(session_connection),
       surface_producer_(surface_producer),
       scene_update_context_(scene_update_context) {}

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -21,16 +21,17 @@ namespace flutter_runner {
 // Fuchsia.
 class CompositorContext final : public flutter::CompositorContext {
  public:
-  CompositorContext(SessionConnection& session_connection,
-                    VulkanSurfaceProducer& surface_producer,
-                    flutter::SceneUpdateContext& scene_update_context);
+  CompositorContext(
+      SessionConnection& session_connection,
+      VulkanSurfaceProducer& surface_producer,
+      std::shared_ptr<flutter::SceneUpdateContext> scene_update_context);
 
   ~CompositorContext() override;
 
  private:
   SessionConnection& session_connection_;
   VulkanSurfaceProducer& surface_producer_;
-  flutter::SceneUpdateContext& scene_update_context_;
+  std::shared_ptr<flutter::SceneUpdateContext> scene_update_context_;
 
   // |flutter::CompositorContext|
   std::unique_ptr<ScopedFrame> AcquireFrame(

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -14,6 +14,7 @@
 #include <lib/ui/scenic/cpp/view_ref_pair.h>
 #include <lib/zx/event.h>
 
+#include "flow/embedded_views.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/common/shell.h"
@@ -69,9 +70,9 @@ class Engine final {
 
   std::optional<SessionConnection> session_connection_;
   std::optional<VulkanSurfaceProducer> surface_producer_;
-  std::optional<FuchsiaExternalViewEmbedder> external_view_embedder_;
+  std::shared_ptr<FuchsiaExternalViewEmbedder> external_view_embedder_;
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
-  std::optional<flutter::SceneUpdateContext> legacy_external_view_embedder_;
+  std::shared_ptr<flutter::SceneUpdateContext> legacy_external_view_embedder_;
 #endif
 
   std::unique_ptr<IsolateConfigurator> isolate_configurator_;
@@ -97,6 +98,7 @@ class Engine final {
   void CreateView(int64_t view_id, bool hit_testable, bool focusable);
   void UpdateView(int64_t view_id, bool hit_testable, bool focusable);
   void DestroyView(int64_t view_id);
+  std::shared_ptr<flutter::ExternalViewEmbedder> GetExternalViewEmbedder();
 
   std::unique_ptr<flutter::Surface> CreateSurface();
 

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flow/embedded_views.h"
 #define RAPIDJSON_HAS_STDSTRING 1
 
 #include "platform_view.h"
@@ -66,6 +67,7 @@ PlatformView::PlatformView(
     OnUpdateView on_update_view_callback,
     OnDestroyView on_destroy_view_callback,
     OnCreateSurface on_create_surface_callback,
+    std::shared_ptr<flutter::ExternalViewEmbedder> external_view_embedder,
     fml::TimeDelta vsync_offset,
     zx_handle_t vsync_event_handle)
     : flutter::PlatformView(delegate, std::move(task_runners)),
@@ -80,6 +82,7 @@ PlatformView::PlatformView(
       on_update_view_callback_(std::move(on_update_view_callback)),
       on_destroy_view_callback_(std::move(on_destroy_view_callback)),
       on_create_surface_callback_(std::move(on_create_surface_callback)),
+      external_view_embedder_(external_view_embedder),
       ime_client_(this),
       vsync_offset_(std::move(vsync_offset)),
       vsync_event_handle_(vsync_event_handle) {

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -14,11 +14,13 @@
 #include <map>
 #include <set>
 
+#include "flow/embedded_views.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/shell/common/platform_view.h"
 
 #include "accessibility_bridge.h"
+#include "shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h"
 
 namespace flutter_runner {
 
@@ -61,6 +63,7 @@ class PlatformView final : public flutter::PlatformView,
                OnUpdateView on_update_view_callback,
                OnDestroyView on_destroy_view_callback,
                OnCreateSurface on_create_surface_callback,
+               std::shared_ptr<flutter::ExternalViewEmbedder> view_embedder,
                fml::TimeDelta vsync_offset,
                zx_handle_t vsync_event_handle);
 
@@ -169,6 +172,7 @@ class PlatformView final : public flutter::PlatformView,
   OnUpdateView on_update_view_callback_;
   OnDestroyView on_destroy_view_callback_;
   OnCreateSurface on_create_surface_callback_;
+  std::shared_ptr<flutter::ExternalViewEmbedder> external_view_embedder_;
 
   int current_text_input_client_ = 0;
   fidl::Binding<fuchsia::ui::input::InputMethodEditorClient> ime_client_;

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -184,10 +184,11 @@ TEST_F(PlatformViewTests, CreateSurfaceTest) {
   // Test create surface callback function.
   sk_sp<GrDirectContext> gr_context =
       GrDirectContext::MakeMock(nullptr, GrContextOptions());
-  MockExternalViewEmbedder view_embedder;
+  std::shared_ptr<MockExternalViewEmbedder> view_embedder =
+      std::make_shared<MockExternalViewEmbedder>();
   auto CreateSurfaceCallback = [&view_embedder, gr_context]() {
     return std::make_unique<flutter_runner::Surface>(
-        "PlatformViewTest", &view_embedder, gr_context.get());
+        "PlatformViewTest", view_embedder, gr_context.get());
   };
 
   auto platform_view = flutter_runner::PlatformView(
@@ -205,6 +206,7 @@ TEST_F(PlatformViewTests, CreateSurfaceTest) {
       nullptr,                 // on_update_view_callback,
       nullptr,                 // on_destroy_view_callback,
       CreateSurfaceCallback,   // on_create_surface_callback,
+      view_embedder,           // external_view_embedder,
       fml::TimeDelta::Zero(),  // vsync_offset
       ZX_HANDLE_INVALID        // vsync_event_handle
   );
@@ -213,7 +215,7 @@ TEST_F(PlatformViewTests, CreateSurfaceTest) {
   RunLoopUntilIdle();
 
   EXPECT_EQ(gr_context.get(), delegate.surface()->GetContext());
-  EXPECT_EQ(&view_embedder, delegate.surface()->GetExternalViewEmbedder());
+  EXPECT_EQ(view_embedder.get(), delegate.surface()->GetExternalViewEmbedder());
 }
 
 // This test makes sure that the PlatformView correctly registers Scenic
@@ -248,6 +250,7 @@ TEST_F(PlatformViewTests, SetViewportMetrics) {
       nullptr,                        // on_update_view_callback,
       nullptr,                        // on_destroy_view_callback,
       nullptr,                        // on_create_surface_callback,
+      nullptr,                        // external_view_embedder,
       fml::TimeDelta::Zero(),         // vsync_offset
       ZX_HANDLE_INVALID               // vsync_event_handle
   );
@@ -380,6 +383,7 @@ TEST_F(PlatformViewTests, ChangesAccessibilitySettings) {
       nullptr,                 // on_update_view_callback,
       nullptr,                 // on_destroy_view_callback,
       nullptr,                 // on_create_surface_callback,
+      nullptr,                 // external_view_embedder,
       fml::TimeDelta::Zero(),  // vsync_offset
       ZX_HANDLE_INVALID        // vsync_event_handle
   );
@@ -430,6 +434,7 @@ TEST_F(PlatformViewTests, EnableWireframeTest) {
       nullptr,                  // on_update_view_callback,
       nullptr,                  // on_destroy_view_callback,
       nullptr,                  // on_create_surface_callback,
+      nullptr,                  // external_view_embedder,
       fml::TimeDelta::Zero(),   // vsync_offset
       ZX_HANDLE_INVALID         // vsync_event_handle
   );
@@ -491,6 +496,7 @@ TEST_F(PlatformViewTests, CreateViewTest) {
       nullptr,                 // on_update_view_callback,
       nullptr,                 // on_destroy_view_callback,
       nullptr,                 // on_create_surface_callback,
+      nullptr,                 // external_view_embedder,
       fml::TimeDelta::Zero(),  // vsync_offset
       ZX_HANDLE_INVALID        // vsync_event_handle
   );
@@ -554,6 +560,7 @@ TEST_F(PlatformViewTests, UpdateViewTest) {
       UpdateViewCallback,      // on_update_view_callback,
       nullptr,                 // on_destroy_view_callback,
       nullptr,                 // on_create_surface_callback,
+      nullptr,                 // external_view_embedder,
       fml::TimeDelta::Zero(),  // vsync_offset
       ZX_HANDLE_INVALID        // vsync_event_handle
   );
@@ -617,6 +624,7 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
       nullptr,                 // on_update_view_callback,
       DestroyViewCallback,     // on_destroy_view_callback,
       nullptr,                 // on_create_surface_callback,
+      nullptr,                 // external_view_embedder,
       fml::TimeDelta::Zero(),  // vsync_offset
       ZX_HANDLE_INVALID        // vsync_event_handle
   );
@@ -677,6 +685,7 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
       nullptr,                        // on_update_view_callback,
       nullptr,                        // on_destroy_view_callback,
       nullptr,                        // on_create_surface_callback,
+      nullptr,                        // external_view_embedder,
       fml::TimeDelta::Zero(),         // vsync_offset
       ZX_HANDLE_INVALID               // vsync_event_handle
   );
@@ -759,6 +768,7 @@ TEST_F(PlatformViewTests, RequestFocusTest) {
       nullptr,                    // on_update_view_callback,
       nullptr,                    // on_destroy_view_callback,
       nullptr,                    // on_create_surface_callback,
+      nullptr,                    // external_view_embedder,
       fml::TimeDelta::Zero(),     // vsync_offset
       ZX_HANDLE_INVALID           // vsync_event_handle
   );
@@ -835,6 +845,7 @@ TEST_F(PlatformViewTests, RequestFocusFailTest) {
       nullptr,                    // on_update_view_callback,
       nullptr,                    // on_destroy_view_callback,
       nullptr,                    // on_create_surface_callback,
+      nullptr,                    // external_view_embedder,
       fml::TimeDelta::Zero(),     // vsync_offset
       ZX_HANDLE_INVALID           // vsync_event_handle
   );

--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -14,7 +14,7 @@
 namespace flutter_runner {
 
 Surface::Surface(std::string debug_label,
-                 flutter::ExternalViewEmbedder* view_embedder,
+                 std::shared_ptr<flutter::ExternalViewEmbedder> view_embedder,
                  GrDirectContext* gr_context)
     : debug_label_(std::move(debug_label)),
       view_embedder_(view_embedder),
@@ -53,7 +53,7 @@ SkMatrix Surface::GetRootTransformation() const {
 
 // |flutter::GetViewEmbedder|
 flutter::ExternalViewEmbedder* Surface::GetExternalViewEmbedder() {
-  return view_embedder_;
+  return view_embedder_.get();
 }
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/surface.h
+++ b/shell/platform/fuchsia/flutter/surface.h
@@ -16,14 +16,14 @@ namespace flutter_runner {
 class Surface final : public flutter::Surface {
  public:
   Surface(std::string debug_label,
-          flutter::ExternalViewEmbedder* view_embedder,
+          std::shared_ptr<flutter::ExternalViewEmbedder> view_embedder,
           GrDirectContext* gr_context);
 
   ~Surface() override;
 
  private:
   const std::string debug_label_;
-  flutter::ExternalViewEmbedder* view_embedder_;
+  std::shared_ptr<flutter::ExternalViewEmbedder> view_embedder_;
   GrDirectContext* gr_context_;
 
   // |flutter::Surface|


### PR DESCRIPTION
As it stands today across the various platforms external view
embedder life cycles are managed in arbitrary ways.

This change is part of a larger refactor to remove the tie between
surface and external view embedder. Eventually surface shouldn't have to
be responsible for supplying the external view embedder, the platform
view component will be responsible for that.