### PR TITLE
[iOS] Skip unnecessary canvas operations

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -497,7 +497,7 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
         int64_t current_platform_view_id = composition_order_[j - 1];
         SkRect platform_view_rect = GetPlatformViewRect(current_platform_view_id);
         std::list<SkRect> intersection_rects =
-        rtree->searchNonOverlappingDrawnRects(platform_view_rect);
+            rtree->searchNonOverlappingDrawnRects(platform_view_rect);
         auto allocation_size = intersection_rects.size();
 
         // For testing purposes, the overlay id is used to find the overlay view.
@@ -538,7 +538,7 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
                                                                      joined_rect,               //
                                                                      current_platform_view_id,  //
                                                                      overlay_id                 //
-                                                                     );
+          );
           did_submit &= layer->did_submit_last_frame;
           platform_view_layers[current_platform_view_id].push_back(layer);
           overlay_id++;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -479,7 +479,6 @@ bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
 
   if (num_platform_views > 0) {
     SkCanvas* background_canvas = frame->SkiaCanvas();
-
     // Resolve all pending GPU operations before allocating a new surface.
     background_canvas->flush();
     // Clipping the background canvas before drawing the picture recorders requires to


### PR DESCRIPTION
## Description

After https://github.com/flutter/engine/pull/20671 merged, `ExternalViewEmbedder` always has value, 
https://github.com/flutter/engine/blob/b22809b084345daecb2c2160cba5c9de9637c3f8/shell/common/rasterizer.cc#L472-L474
so we always call platform_views_controller_'s `SubmitFrame` even if not exit platform view, we need to bypass these unnecessary operations.
https://github.com/flutter/engine/blob/b22809b084345daecb2c2160cba5c9de9637c3f8/shell/platform/darwin/ios/ios_external_view_embedder.mm#L79

## Related Issues

https://github.com/flutter/engine/pull/20671 cc @cyanglaz .

## Tests

I added the following tests:

N/A.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
