### PR TITLE
Update more class names from GrContext to GrDirectContext

### DIFF
--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -60,9 +60,9 @@ class IOSExternalTextureGL final : public Texture {
 
   void CreateRGBATextureFromPixelBuffer();
 
-  sk_sp<SkImage> CreateImageFromYUVTextures(GrContext* context, const SkRect& bounds);
+  sk_sp<SkImage> CreateImageFromYUVTextures(GrDirectContext* context, const SkRect& bounds);
 
-  sk_sp<SkImage> CreateImageFromRGBATexture(GrContext* context, const SkRect& bounds);
+  sk_sp<SkImage> CreateImageFromRGBATexture(GrDirectContext* context, const SkRect& bounds);
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSExternalTextureGL);
 };

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -95,7 +95,7 @@ void IOSExternalTextureGL::CreateYUVTexturesFromPixelBuffer() {
   }
 }
 
-sk_sp<SkImage> IOSExternalTextureGL::CreateImageFromRGBATexture(GrContext* context,
+sk_sp<SkImage> IOSExternalTextureGL::CreateImageFromRGBATexture(GrDirectContext* context,
                                                                 const SkRect& bounds) {
   GrGLTextureInfo textureInfo = {CVOpenGLESTextureGetTarget(texture_ref_),
                                  CVOpenGLESTextureGetName(texture_ref_), GL_RGBA8_OES};
@@ -106,7 +106,7 @@ sk_sp<SkImage> IOSExternalTextureGL::CreateImageFromRGBATexture(GrContext* conte
   return image;
 }
 
-sk_sp<SkImage> IOSExternalTextureGL::CreateImageFromYUVTextures(GrContext* context,
+sk_sp<SkImage> IOSExternalTextureGL::CreateImageFromYUVTextures(GrDirectContext* context,
                                                                 const SkRect& bounds) {
   GrGLTextureInfo yTextureInfo = {CVOpenGLESTextureGetTarget(y_texture_ref_),
                                   CVOpenGLESTextureGetName(y_texture_ref_), GR_GL_LUMINANCE8};

--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -14,7 +14,7 @@ namespace flutter_runner {
 class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
  public:
   ScopedFrame(CompositorContext& context,
-              GrContext* gr_context,
+              GrDirectContext* gr_context,
               SkCanvas* canvas,
               flutter::ExternalViewEmbedder* view_embedder,
               const SkMatrix& root_surface_transformation,

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -160,7 +160,7 @@ void VulkanSurfaceProducer::OnSurfacesPresented(
 
   // Do a single flush for all canvases derived from the context.
   {
-    TRACE_EVENT0("flutter", "GrContext::flushAndSignalSemaphores");
+    TRACE_EVENT0("flutter", "GrDirectContext::flushAndSignalSemaphores");
     context_->flushAndSubmit();
   }
 


### PR DESCRIPTION
This name change has to do with SkDeferredDisplayList, which Flutter
does not use. As far as Flutter is concerned, this is a no-op.

Continuation of the migration started in #19962.