### PR TITLE
Add TextRange::Contains tests spanning base/extent

### DIFF
--- a/shell/platform/common/cpp/text_range_unittests.cc
+++ b/shell/platform/common/cpp/text_range_unittests.cc
@@ -107,6 +107,11 @@ TEST(TextRange, ContainsRangePreStartPosition) {
   EXPECT_FALSE(range.Contains(TextRange(0, 1)));
 }
 
+TEST(TextRange, ContainsRangeSpanningStartPosition) {
+  TextRange range(2, 6);
+  EXPECT_FALSE(range.Contains(TextRange(1, 3)));
+}
+
 TEST(TextRange, ContainsRangeStartPosition) {
   TextRange range(2, 6);
   EXPECT_TRUE(range.Contains(TextRange(2)));
@@ -123,6 +128,11 @@ TEST(TextRange, ContainsRangeEndPosition) {
   EXPECT_TRUE(range.Contains(TextRange(6)));
 }
 
+TEST(TextRange, ContainsRangeSpanningEndPosition) {
+  TextRange range(2, 6);
+  EXPECT_FALSE(range.Contains(TextRange(5, 7)));
+}
+
 TEST(TextRange, ContainsRangePostEndPosition) {
   TextRange range(2, 6);
   EXPECT_FALSE(range.Contains(TextRange(6, 7)));
@@ -131,6 +141,11 @@ TEST(TextRange, ContainsRangePostEndPosition) {
 TEST(TextRange, ContainsRangePreStartPositionReversed) {
   TextRange range(6, 2);
   EXPECT_FALSE(range.Contains(TextRange(0, 1)));
+}
+
+TEST(TextRange, ContainsRangeSpanningStartPositionReversed) {
+  TextRange range(6, 2);
+  EXPECT_FALSE(range.Contains(TextRange(1, 3)));
 }
 
 TEST(TextRange, ContainsRangeStartPositionReversed) {
@@ -142,6 +157,11 @@ TEST(TextRange, ContainsRangeMiddlePositionReversed) {
   TextRange range(6, 2);
   EXPECT_TRUE(range.Contains(TextRange(3, 4)));
   EXPECT_TRUE(range.Contains(TextRange(4, 5)));
+}
+
+TEST(TextRange, ContainsRangeSpanningEndPositionReversed) {
+  TextRange range(6, 2);
+  EXPECT_FALSE(range.Contains(TextRange(5, 7)));
 }
 
 TEST(TextRange, ContainsRangeEndPositionReversed) {


### PR DESCRIPTION
## Description

Adds tests for TextRange::Contains(const TextRange&) where the range
being tested spans the base/extent of the testing range.

This was originally intended to land in #21854, but it seems I didn't
push the additional tests before landing.

## Related Issues

Full IME support for Windows (flutter/flutter#65574)
Full IME support for Linux (flutter/flutter#66880)

## Tests

As described above.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*