### PR TITLE
Revert "Add flag to not publish the observatory port over mDNS"

### DIFF
--- a/common/settings.cc
+++ b/common/settings.cc
@@ -46,8 +46,6 @@ std::string Settings::ToString() const {
   stream << "enable_dart_profiling: " << enable_dart_profiling << std::endl;
   stream << "disable_dart_asserts: " << disable_dart_asserts << std::endl;
   stream << "enable_observatory: " << enable_observatory << std::endl;
-  stream << "enable_observatory_publication: " << enable_observatory_publication
-         << std::endl;
   stream << "observatory_host: " << observatory_host << std::endl;
   stream << "observatory_port: " << observatory_port << std::endl;
   stream << "use_test_fonts: " << use_test_fonts << std::endl;

--- a/common/settings.h
+++ b/common/settings.h
@@ -126,11 +126,6 @@ struct Settings {
   // Whether the Dart VM service should be enabled.
   bool enable_observatory = false;
 
-  // Whether to publish the observatory URL over mDNS.
-  // On iOS 14 this prompts a local network permission dialog,
-  // which cannot be accepted or dismissed in a CI environment.
-  bool enable_observatory_publication = true;
-
   // The IP address to which the Dart VM service is bound.
   std::string observatory_host;
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -221,10 +221,6 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.enable_observatory =
       !command_line.HasOption(FlagForSwitch(Switch::DisableObservatory));
 
-  // Enable mDNS Observatory Publication
-  settings.enable_observatory_publication = !command_line.HasOption(
-      FlagForSwitch(Switch::DisableObservatoryPublication));
-
   // Set Observatory Host
   if (command_line.HasOption(FlagForSwitch(Switch::DeviceObservatoryHost))) {
     command_line.GetOptionValue(FlagForSwitch(Switch::DeviceObservatoryHost),

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -79,9 +79,6 @@ DEF_SWITCH(DisableObservatory,
            "disable-observatory",
            "Disable the Dart Observatory. The observatory is never available "
            "in release mode.")
-DEF_SWITCH(DisableObservatoryPublication,
-           "disable-observatory-publication",
-           "Disable mDNS Dart Observatory publication.")
 DEF_SWITCH(IPv6,
            "ipv6",
            "Bind to the IPv6 localhost address for the Dart Observatory. "

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -547,8 +547,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     if (!_platformViewsController) {
       _platformViewsController.reset(new flutter::FlutterPlatformViewsController());
     }
-    _publisher.reset([[FlutterObservatoryPublisher alloc]
-        initWithEnableObservatoryPublication:settings.enable_observatory_publication]);
+    _publisher.reset([[FlutterObservatoryPublisher alloc] init]);
     [self maybeSetupPlatformViewChannels];
     _shell->GetIsGpuDisabledSyncSwitch()->SetSwitch(_isGpuDisabled ? true : false);
     if (profilerEnabled) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.h
@@ -9,11 +9,6 @@
 
 @interface FlutterObservatoryPublisher : NSObject
 
-- (instancetype)initWithEnableObservatoryPublication:(BOOL)enableObservatoryPublication
-    NS_DESIGNATED_INITIALIZER;
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-
 @property(nonatomic, readonly) NSURL* url;
 
 @end


### PR DESCRIPTION
Reverts flutter/engine#21632

Build failure 
```
FAILED: obj/flutter/shell/platform/darwin/ios/framework/Source/flutter_framework_source.FlutterObservatoryPublisher.o 
clang++ -MD -MF obj/flutter/shell/platform/darwin/ios/framework/Source/flutter_framework_source.FlutterObservatoryPublisher.o.d -DFLUTTER_FRAMEWORK=1 -DFLUTTER_SHELL_ENABLE_METAL=1 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DSK_GL -DSK_METAL -DSK_CODEC_DECODES_JPEG -DSK_ENCODE_JPEG -DSK_CODEC_DECODES_PNG -DSK_ENCODE_PNG -DSK_CODEC_DECODES_WEBP -DSK_ENCODE_WEBP -DSK_HAS_WUFFS_LIBRARY -DFLUTTER_RUNTIME_MODE_DEBUG=1 -DFLUTTER_RUNTIME_MODE_PROFILE=2 -DFLUTTER_RUNTIME_MODE_RELEASE=3 -DFLUTTER_RUNTIME_MODE_JIT_RELEASE=4 -DFLUTTER_RUNTIME_MODE=3 -DFLUTTER_RELEASE=1 -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_ENABLE_TRACING=1 -DU_ENABLE_RESOURCE_TRACING=0 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -DUCHAR_TYPE=uint16_t -DSK_DISABLE_REDUCE_OPLIST_SPLITTING -DSK_ENABLE_DUMP_GPU -DSK_DISABLE_AAA -DSK_DISABLE_EFFECT_DESERIALIZATION -DSK_SUPPORT_LEGACY_MATRIX_FACTORIES -DSK_DISABLE_LEGACY_SHADERCONTEXT -DSK_DISABLE_LOWP_RASTER_PIPELINE -DSK_FORCE_RASTER_PIPELINE_BLITTER -DSK_GL -DSK_ASSUME_GL_ES=1 -DRAPIDJSON_HAS_STDSTRING -DRAPIDJSON_HAS_CXX11_RANGE_FOR -DRAPIDJSON_HAS_CXX11_RVALUE_REFS -DRAPIDJSON_HAS_CXX11_TYPETRAITS -DRAPIDJSON_HAS_CXX11_NOEXCEPT -I../.. -Igen -I../.. -I../../flutter/third_party/txt/src -I../../third_party/harfbuzz/src -I../../third_party/icu/source/common -I../../third_party/icu/source/i18n -I../../third_party/skia -I../../third_party/rapidjson -I../../third_party/rapidjson/include -I../../third_party/dart/runtime -I../../third_party/dart/runtime/include -I../../flutter/third_party -I../../flutter -I../../flutter/shell/platform/darwin/common/framework/Headers -isysroot /opt/s/w/ir/cache/osx_sdk/XCode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk -miphoneos-version-min=8.0 -flto -fno-strict-aliasing -fembed-bitcode -arch arm64 -fcolor-diagnostics -Wall -Wextra -Wendif-labels -Werror -Wno-missing-field-initializers -Wno-unused-parameter -Wunguarded-availability -fvisibility=hidden -stdlib=libc++ -Wstring-conversion -Wnewline-eof -Os -fno-ident -g2  -Werror=overriding-method-mismatch -Werror=undeclared-selector -fvisibility-inlines-hidden -fobjc-call-cxx-cdtors -std=c++17 -fno-rtti -fno-exceptions -nostdinc++ -isystem /opt/s/w/ir/cache/osx_sdk/XCode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1 -Wno-unguarded-availability  -c ../../flutter/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm -o obj/flutter/shell/platform/darwin/ios/framework/Source/flutter_framework_source.FlutterObservatoryPublisher.o
../../flutter/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm:11:17: error: method definition for 'initWithEnableObservatoryPublication:' not found [-Werror,-Wincomplete-implementation]
@implementation FlutterObservatoryPublisher
                ^
../../flutter/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.h:12:1: note: method 'initWithEnableObservatoryPublication:' declared here
- (instancetype)initWithEnableObservatoryPublication:(BOOL)enableObservatoryPublication
^
1 error generated.
```
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8866351386787943104/+/steps/build_ios_release/0/stdout