### PR TITLE
Show OSK on GNOME+Wayland

### DIFF
--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -258,6 +258,11 @@ static FlMethodResponse* set_client(FlTextInputPlugin* self, FlValue* args) {
 
 // Shows the input method.
 static FlMethodResponse* show(FlTextInputPlugin* self) {
+  // Set the top-level window used for system input method windows.
+  GdkWindow* window =
+      gtk_widget_get_window(gtk_widget_get_toplevel(GTK_WIDGET(self->view)));
+  gtk_im_context_set_client_window(self->im_context, window);
+
   gtk_im_context_focus_in(self->im_context);
 
   return FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));


### PR DESCRIPTION
## Description

It appears this isn't needed for any underlying Wayland reason, but setting the client window triggers the same callbacks in GTK as GTK's native text view, and that in tern triggers the sequence of requests GNOME requires before showing the OSK. I suspect the OSK was already working in non-GNOME environments. None of the other compositors I normally test with support OSKs at all so I don't know for sure.

It doesn't work perfectly. Sometimes you have to give a text box an extra tap before the OSK pops up but I'd blame GNOME weirdness for that. Should go away if/when https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/3285 gets fixed. For the time being it's not too much of a problem.

Edit: whether intended behavior or not, normal GTK apps also require an extra tap to bring up the OSK, so not an issue with our code.

Ping @robert-ancell @jpnurmi 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/67785

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
