### PR TITLE
Break the reference cycle between the surface factory and the external view embedder

### DIFF
--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -25,20 +25,17 @@ namespace flutter {
 class AndroidSurfaceFactoryImpl : public AndroidSurfaceFactory {
  public:
   AndroidSurfaceFactoryImpl(std::shared_ptr<AndroidContext> context,
-                            std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
+                            std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
+                            std::weak_ptr<AndroidExternalViewEmbedder> external_view_embedder);
 
   ~AndroidSurfaceFactoryImpl() override;
 
   std::unique_ptr<AndroidSurface> CreateSurface() override;
 
-  void SetExternalViewEmbedder(
-      std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder);
-
  private:
   std::shared_ptr<AndroidContext> android_context_;
   std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
-  std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
-
+  std::weak_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
 };
 
 class PlatformViewAndroid final : public PlatformView {
@@ -99,6 +96,7 @@ class PlatformViewAndroid final : public PlatformView {
 
  private:
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
+  std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
   std::shared_ptr<AndroidSurfaceFactoryImpl> surface_factory_;
 
   PlatformViewAndroidDelegate platform_view_android_delegate_;


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/68315
