### PR TITLE
Update FLUTTER_NOLINT uses to include issue link

### DIFF
--- a/shell/platform/linux/fl_json_message_codec.cc
+++ b/shell/platform/linux/fl_json_message_codec.cc
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(cbracken): lint disabled due to rapidjson null deref issue.
-// https://github.com/flutter/flutter/issues/65676
-// FLUTTER_NOLINT
-
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_json_message_codec.h"
 
 #include <gmodule.h>

--- a/shell/version/version.cc
+++ b/shell/version/version.cc
@@ -1,7 +1,8 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
+
+// FLUTTER_NOLINT: https://github.com/flutter/flutter/issues/68332
 
 #include "flutter/shell/version/version.h"
 

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -1,7 +1,8 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// FLUTTER_NOLINT
+
+// FLUTTER_NOLINT: https://github.com/flutter/flutter/issues/68331
 
 #include "vulkan_window.h"
 


### PR DESCRIPTION
## Description

In an upcoming patch, we'll enable enforcement that all FLUTTER_NOLINT comments include an issue link. This migrates the remaining uses to that format.

Also deletes a FLUTTER_NOLINT that no longer causes linter errors.

## Related Issues

https://github.com/flutter/flutter/issues/68273: Update engine linter to require a bug URL on FLUTTER_NOLINT lines

## Tests

This only touches comments and is a no-op. Testing is done by the linter.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
