### PR TITLE
Define SK_VULKAN for clang-tidy runs

### DIFF
--- a/ci/bin/lint.dart
+++ b/ci/bin/lint.dart
@@ -28,6 +28,11 @@ https://github.com/flutter/flutter/wiki/Engine-Clang-Tidy-Linter
 
 const String issueUrlPrefix = 'https://github.com/flutter/flutter/issues';
 
+/// Symbol definitions passed to clang-tidy.
+const List<String> clangTidyDefineArgs = <String>[
+  "-DSK_VULKAN", // See: https://github.com/flutter/flutter/issues/68331
+];
+
 class Command {
   Directory directory = Directory('');
   String command = '';
@@ -46,6 +51,7 @@ String calcTidyArgs(Command command) {
   String result = command.command;
   result = result.replaceAll(RegExp(r'\S*clang/bin/clang'), '');
   result = result.replaceAll(RegExp(r'-MF \S*'), '');
+  result += ' ' + clangTidyDefineArgs.join(' ');
   return result;
 }
 

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// FLUTTER_NOLINT: https://github.com/flutter/flutter/issues/68331
-
 #include "vulkan_window.h"
 
 #include <memory>


### PR DESCRIPTION
## Description

When linting flutter/vulkan/vulkan_window.cc, the call to GrDirectContext::MakeVulkan is undefined when SK_VULKAN is not defined, triggering a lint error.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/68331 Undefined symbol GrDirectContext::MakeVulkan

## Tests

The linter covers this file and will fail if lints remain.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
