### PR TITLE
Plumb through Dart entrypoint arguments on the Linux embedder

### DIFF
--- a/shell/platform/linux/fl_dart_project.cc
+++ b/shell/platform/linux/fl_dart_project.cc
@@ -19,6 +19,8 @@ struct _FlDartProject {
   gchar* aot_library_path;
   gchar* assets_path;
   gchar* icu_data_path;
+  int dart_entrypoint_argc;
+  const char** dart_entrypoint_argv;
 };
 
 G_DEFINE_TYPE(FlDartProject, fl_dart_project, G_TYPE_OBJECT)
@@ -43,6 +45,9 @@ static void fl_dart_project_dispose(GObject* object) {
   g_clear_pointer(&self->assets_path, g_free);
   g_clear_pointer(&self->icu_data_path, g_free);
 
+  // We don't have ownership of this, so can just null it out
+  self->dart_entrypoint_argv = nullptr;
+
   G_OBJECT_CLASS(fl_dart_project_parent_class)->dispose(object);
 }
 
@@ -63,6 +68,9 @@ G_MODULE_EXPORT FlDartProject* fl_dart_project_new() {
       g_build_filename(executable_dir, "data", "flutter_assets", nullptr);
   self->icu_data_path =
       g_build_filename(executable_dir, "data", "icudtl.dat", nullptr);
+
+  self->dart_entrypoint_argc = 0;
+  self->dart_entrypoint_argv = nullptr;
 
   return self;
 }
@@ -96,6 +104,20 @@ G_MODULE_EXPORT const gchar* fl_dart_project_get_icu_data_path(
     FlDartProject* self) {
   g_return_val_if_fail(FL_IS_DART_PROJECT(self), nullptr);
   return self->icu_data_path;
+}
+
+G_MODULE_EXPORT const char** fl_dart_project_get_dart_entrypoint_arguments(
+    FlDartProject* self, int* argc) {
+  g_return_if_fail(FL_IS_DART_PROJECT(self));
+  *argc = self->dart_entrypoint_argc;
+  return self->dart_entrypoint_argv;
+}
+
+G_MODULE_EXPORT void fl_dart_project_set_dart_entrypoint_arguments(
+    FlDartProject* self, int argc, const char** argv) {
+  g_return_if_fail(FL_IS_DART_PROJECT(self));
+  self->dart_entrypoint_argc = argc;
+  self->dart_entrypoint_argv = argv;
 }
 
 GPtrArray* fl_dart_project_get_switches(FlDartProject* self) {

--- a/shell/platform/linux/fl_dart_project.cc
+++ b/shell/platform/linux/fl_dart_project.cc
@@ -107,7 +107,8 @@ G_MODULE_EXPORT gchar** fl_dart_project_get_dart_entrypoint_arguments(
 }
 
 G_MODULE_EXPORT void fl_dart_project_set_dart_entrypoint_arguments(
-    FlDartProject* self, char** argv) {
+    FlDartProject* self,
+    char** argv) {
   g_return_if_fail(FL_IS_DART_PROJECT(self));
   g_clear_pointer(&self->dart_entrypoint_args, g_strfreev);
   self->dart_entrypoint_args = g_strdupv(argv);

--- a/shell/platform/linux/fl_dart_project.cc
+++ b/shell/platform/linux/fl_dart_project.cc
@@ -19,7 +19,7 @@ struct _FlDartProject {
   gchar* aot_library_path;
   gchar* assets_path;
   gchar* icu_data_path;
-  GPtrArray* dart_entrypoint_args;
+  gchar** dart_entrypoint_args;
 };
 
 G_DEFINE_TYPE(FlDartProject, fl_dart_project, G_TYPE_OBJECT)
@@ -43,7 +43,7 @@ static void fl_dart_project_dispose(GObject* object) {
   g_clear_pointer(&self->aot_library_path, g_free);
   g_clear_pointer(&self->assets_path, g_free);
   g_clear_pointer(&self->icu_data_path, g_free);
-  g_ptr_array_unref(self->dart_entrypoint_args);
+  g_clear_pointer(&self->dart_entrypoint_args, g_strfreev);
 
   G_OBJECT_CLASS(fl_dart_project_parent_class)->dispose(object);
 }
@@ -65,8 +65,6 @@ G_MODULE_EXPORT FlDartProject* fl_dart_project_new() {
       g_build_filename(executable_dir, "data", "flutter_assets", nullptr);
   self->icu_data_path =
       g_build_filename(executable_dir, "data", "icudtl.dat", nullptr);
-
-  self->dart_entrypoint_args = g_ptr_array_new_with_free_func(g_free);
 
   return self;
 }
@@ -102,19 +100,17 @@ G_MODULE_EXPORT const gchar* fl_dart_project_get_icu_data_path(
   return self->icu_data_path;
 }
 
-G_MODULE_EXPORT GPtrArray* fl_dart_project_get_dart_entrypoint_arguments(
+G_MODULE_EXPORT gchar** fl_dart_project_get_dart_entrypoint_arguments(
     FlDartProject* self) {
   g_return_val_if_fail(FL_IS_DART_PROJECT(self), nullptr);
-  return g_ptr_array_ref(self->dart_entrypoint_args);
+  return self->dart_entrypoint_args;
 }
 
 G_MODULE_EXPORT void fl_dart_project_set_dart_entrypoint_arguments(
-    FlDartProject* self, int argc, const char** argv) {
+    FlDartProject* self, char** argv) {
   g_return_if_fail(FL_IS_DART_PROJECT(self));
-  g_ptr_array_remove_range(self->dart_entrypoint_args, 0, self->dart_entrypoint_args->len);
-  for (int i = 0; i < argc; ++i) {
-    g_ptr_array_add(self->dart_entrypoint_args, g_strdup(argv[i]));
-  }
+  g_clear_pointer(&self->dart_entrypoint_args, g_strfreev);
+  self->dart_entrypoint_args = g_strdupv(argv);
 }
 
 GPtrArray* fl_dart_project_get_switches(FlDartProject* self) {

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -395,7 +395,8 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   args.custom_task_runners = &custom_task_runners;
   args.shutdown_dart_vm_when_done = true;
   args.dart_entrypoint_argc = g_strv_length(dart_entrypoint_args);
-  args.dart_entrypoint_argv = reinterpret_cast<const char* const*>(dart_entrypoint_args);
+  args.dart_entrypoint_argv =
+      reinterpret_cast<const char* const*>(dart_entrypoint_args);
 
   if (FlutterEngineRunsAOTCompiledDartCode()) {
     FlutterEngineAOTDataSource source = {};

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -381,6 +381,9 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   // so that all switches are used.
   g_ptr_array_insert(command_line_args, 0, g_strdup("flutter"));
 
+  g_autoptr(GPtrArray) dart_entrypoint_args =
+      fl_dart_project_get_dart_entrypoint_arguments(self->project);
+
   FlutterProjectArgs args = {};
   args.struct_size = sizeof(FlutterProjectArgs);
   args.assets_path = fl_dart_project_get_assets_path(self->project);
@@ -391,7 +394,8 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   args.platform_message_callback = fl_engine_platform_message_cb;
   args.custom_task_runners = &custom_task_runners;
   args.shutdown_dart_vm_when_done = true;
-  args.dart_entrypoint_argv = fl_dart_project_get_dart_entrypoint_arguments(self->project, &args.dart_entrypoint_argc);
+  args.dart_entrypoint_argc = dart_entrypoint_args->len;
+  args.dart_entrypoint_argv = reinterpret_cast<const char* const*>(dart_entrypoint_args->pdata);
 
   if (FlutterEngineRunsAOTCompiledDartCode()) {
     FlutterEngineAOTDataSource source = {};

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -381,7 +381,7 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   // so that all switches are used.
   g_ptr_array_insert(command_line_args, 0, g_strdup("flutter"));
 
-  g_autoptr(GPtrArray) dart_entrypoint_args =
+  gchar** dart_entrypoint_args =
       fl_dart_project_get_dart_entrypoint_arguments(self->project);
 
   FlutterProjectArgs args = {};
@@ -394,8 +394,8 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   args.platform_message_callback = fl_engine_platform_message_cb;
   args.custom_task_runners = &custom_task_runners;
   args.shutdown_dart_vm_when_done = true;
-  args.dart_entrypoint_argc = dart_entrypoint_args->len;
-  args.dart_entrypoint_argv = reinterpret_cast<const char* const*>(dart_entrypoint_args->pdata);
+  args.dart_entrypoint_argc = g_strv_length(dart_entrypoint_args);
+  args.dart_entrypoint_argv = reinterpret_cast<const char* const*>(dart_entrypoint_args);
 
   if (FlutterEngineRunsAOTCompiledDartCode()) {
     FlutterEngineAOTDataSource source = {};

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -391,6 +391,7 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   args.platform_message_callback = fl_engine_platform_message_cb;
   args.custom_task_runners = &custom_task_runners;
   args.shutdown_dart_vm_when_done = true;
+  args.dart_entrypoint_argv = fl_dart_project_get_dart_entrypoint_arguments(self->project, &args.dart_entrypoint_argc);
 
   if (FlutterEngineRunsAOTCompiledDartCode()) {
     FlutterEngineAOTDataSource source = {};

--- a/shell/platform/linux/public/flutter_linux/fl_dart_project.h
+++ b/shell/platform/linux/public/flutter_linux/fl_dart_project.h
@@ -105,24 +105,21 @@ const gchar* fl_dart_project_get_icu_data_path(FlDartProject* project);
  * Sets the command line arguments to be passed through to the Dart
  * entrypoint function.
  *
- * FlDartProject will not keep a deep copy nor ownership of these arguments;
- * the caller is responsible for ensuring that they are not freed before the
- * Flutter Engine is initialized, at which point they will be copied and can
- * be safely freed.
+ * FlDartProject makes a deep copy of the arguments passed in here. The caller can
+ * safely deallocate their copy as soon as this call returns.
  */
 void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project, int argc, const char** argv);
 
 /**
  * fl_dart_project_get_dart_entrypoint_arguments:
  * @project: an #FlDartProject.
- * @argc: a pointer to an int which will be set to the number of command line arguments
  *
  * Gets the command line arguments to be passed through to the Dart entrypoint function.
  *
- * Returns: a pointer to an array of C strings containing the command line arguments. This
- * should not be deallocated by the caller.
+ * Returns: a GPtrArray containing the command line arguments to be passed to the Dart
+ * entrypoint.
  */
-const char** fl_dart_project_get_dart_entrypoint_arguments(FlDartProject* project, int* argc);
+GPtrArray* fl_dart_project_get_dart_entrypoint_arguments(FlDartProject* project);
 
 G_END_DECLS
 

--- a/shell/platform/linux/public/flutter_linux/fl_dart_project.h
+++ b/shell/platform/linux/public/flutter_linux/fl_dart_project.h
@@ -99,21 +99,24 @@ const gchar* fl_dart_project_get_icu_data_path(FlDartProject* project);
 /**
  * fl_dart_project_set_dart_entrypoint_arguments:
  * @project: an #FlDartProject.
- * @argv: a pointer to a NULL-terminated array of C strings containing the command line arguments.
+ * @argv: a pointer to a NULL-terminated array of C strings containing the
+ * command line arguments.
  *
  * Sets the command line arguments to be passed through to the Dart
  * entrypoint function.
  */
-void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project, char** argv);
+void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project,
+                                                   char** argv);
 
 /**
  * fl_dart_project_get_dart_entrypoint_arguments:
  * @project: an #FlDartProject.
  *
- * Gets the command line arguments to be passed through to the Dart entrypoint function.
+ * Gets the command line arguments to be passed through to the Dart entrypoint
+ * function.
  *
- * Returns: a NULL-terminated array of strings containing the command line arguments
- * to be passed to the Dart entrypoint.
+ * Returns: a NULL-terminated array of strings containing the command line
+ * arguments to be passed to the Dart entrypoint.
  */
 gchar** fl_dart_project_get_dart_entrypoint_arguments(FlDartProject* project);
 

--- a/shell/platform/linux/public/flutter_linux/fl_dart_project.h
+++ b/shell/platform/linux/public/flutter_linux/fl_dart_project.h
@@ -99,16 +99,12 @@ const gchar* fl_dart_project_get_icu_data_path(FlDartProject* project);
 /**
  * fl_dart_project_set_dart_entrypoint_arguments:
  * @project: an #FlDartProject.
- * @argc: the number of command line arguments in @argv
- * @argv: a pointer to an array of C strings containing the command line arguments.
+ * @argv: a pointer to a NULL-terminated array of C strings containing the command line arguments.
  *
  * Sets the command line arguments to be passed through to the Dart
  * entrypoint function.
- *
- * FlDartProject makes a deep copy of the arguments passed in here. The caller can
- * safely deallocate their copy as soon as this call returns.
  */
-void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project, int argc, const char** argv);
+void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project, char** argv);
 
 /**
  * fl_dart_project_get_dart_entrypoint_arguments:
@@ -116,10 +112,10 @@ void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project, int a
  *
  * Gets the command line arguments to be passed through to the Dart entrypoint function.
  *
- * Returns: a GPtrArray containing the command line arguments to be passed to the Dart
- * entrypoint.
+ * Returns: a NULL-terminated array of strings containing the command line arguments
+ * to be passed to the Dart entrypoint.
  */
-GPtrArray* fl_dart_project_get_dart_entrypoint_arguments(FlDartProject* project);
+gchar** fl_dart_project_get_dart_entrypoint_arguments(FlDartProject* project);
 
 G_END_DECLS
 

--- a/shell/platform/linux/public/flutter_linux/fl_dart_project.h
+++ b/shell/platform/linux/public/flutter_linux/fl_dart_project.h
@@ -96,6 +96,34 @@ const gchar* fl_dart_project_get_assets_path(FlDartProject* project);
  */
 const gchar* fl_dart_project_get_icu_data_path(FlDartProject* project);
 
+/**
+ * fl_dart_project_set_dart_entrypoint_arguments:
+ * @project: an #FlDartProject.
+ * @argc: the number of command line arguments in @argv
+ * @argv: a pointer to an array of C strings containing the command line arguments.
+ *
+ * Sets the command line arguments to be passed through to the Dart
+ * entrypoint function.
+ *
+ * FlDartProject will not keep a deep copy nor ownership of these arguments;
+ * the caller is responsible for ensuring that they are not freed before the
+ * Flutter Engine is initialized, at which point they will be copied and can
+ * be safely freed.
+ */
+void fl_dart_project_set_dart_entrypoint_arguments(FlDartProject* project, int argc, const char** argv);
+
+/**
+ * fl_dart_project_get_dart_entrypoint_arguments:
+ * @project: an #FlDartProject.
+ * @argc: a pointer to an int which will be set to the number of command line arguments
+ *
+ * Gets the command line arguments to be passed through to the Dart entrypoint function.
+ *
+ * Returns: a pointer to an array of C strings containing the command line arguments. This
+ * should not be deallocated by the caller.
+ */
+const char** fl_dart_project_get_dart_entrypoint_arguments(FlDartProject* project, int* argc);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_DART_PROJECT_H_


### PR DESCRIPTION
## Description

Adds a couple of new APIs on FlDartProject to set/get the command line arguments for the Dart entrypoint.

I have modelled this on https://developer.gnome.org/gio/stable/GApplicationCommandLine.html#g-application-command-line-get-arguments, but with normal C types instead of glib types.

I have also chosen to design this such that FlDartProject doesn't own the memory used by argv; it's unnecessary and they're copied out once passed into the FlutterEngine. This is reflected in the documentation.

## Related Issues

https://github.com/flutter/flutter/issues/32986

## Tests

No tests yet. I'm still figuring out the best way to deal with this in the Linux template app.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
