### PR TITLE
Reformat some files that were not auto-formatted

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import android.content.res.AssetManager;
 import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.FlutterJNI;
-import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.dart.DartExecutor.DartEntrypoint;
 import io.flutter.embedding.engine.loader.FlutterLoader;
 import java.nio.ByteBuffer;

--- a/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/dart/DartMessengerTest.java
@@ -52,4 +52,3 @@ public class DartMessengerTest {
     currentThread.setUncaughtExceptionHandler(savedHandler);
   }
 }
-

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -153,10 +153,9 @@ VulkanSwapchain::VulkanSwapchain(const VulkanProcTable& p_vk,
                                          nullptr);
                 }};
 
-  if (!CreateSwapchainImages(skia_context,
-                             format_infos[format_index].color_type_,
-                             format_infos[format_index].color_space_,
-                             usage_flags)) {
+  if (!CreateSwapchainImages(
+          skia_context, format_infos[format_index].color_type_,
+          format_infos[format_index].color_space_, usage_flags)) {
     FML_DLOG(INFO) << "Could not create swapchain images.";
     return;
   }


### PR DESCRIPTION
The ci/format.sh script was not applying diffs for a few days when it
was using version 3.1.0 of the process_runner package.
