### PR TITLE
Add FML_UNREACHABLE to declare points in code that should never be reached.

### DIFF
--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -22,9 +22,7 @@ void ChildSceneLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   CheckForChildLayerBelow(context);
 }
 
-void ChildSceneLayer::Paint(PaintContext& context) const {
-  FML_NOTREACHED();
-}
+void ChildSceneLayer::Paint(PaintContext& context) const {}
 
 void ChildSceneLayer::UpdateScene(SceneUpdateContext& context) {
   TRACE_EVENT0("flutter", "ChildSceneLayer::UpdateScene");

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -249,6 +249,7 @@ if (enable_unittests) {
       "command_line_unittest.cc",
       "file_unittest.cc",
       "hash_combine_unittests.cc",
+      "logging_unittests.cc",
       "memory/ref_counted_unittest.cc",
       "memory/task_runner_checker_unittest.cc",
       "memory/weak_ptr_unittest.cc",

--- a/fml/logging.cc
+++ b/fml/logging.cc
@@ -93,7 +93,7 @@ LogMessage::~LogMessage() {
 #endif
 
   if (severity_ >= LOG_FATAL) {
-    abort();
+    KillProcess();
   }
 }
 
@@ -103,6 +103,10 @@ int GetVlogVerbosity() {
 
 bool ShouldCreateLogMessage(LogSeverity severity) {
   return severity >= GetMinLogLevel();
+}
+
+void KillProcess() {
+  abort();
 }
 
 }  // namespace fml

--- a/fml/logging.h
+++ b/fml/logging.h
@@ -43,6 +43,8 @@ int GetVlogVerbosity();
 // LOG_FATAL and above is always true.
 bool ShouldCreateLogMessage(LogSeverity severity);
 
+[[noreturn]] void KillProcess();
+
 }  // namespace fml
 
 #define FML_LOG_STREAM(severity) \
@@ -87,9 +89,10 @@ bool ShouldCreateLogMessage(LogSeverity severity);
 #define FML_DCHECK(condition) FML_EAT_STREAM_PARAMETERS(condition)
 #endif
 
-#define FML_NOTREACHED() FML_DCHECK(false)
-
-#define FML_NOTIMPLEMENTED() \
-  FML_LOG(ERROR) << "Not implemented in: " << __PRETTY_FUNCTION__
+#define FML_UNREACHABLE()                          \
+  {                                                \
+    FML_LOG(ERROR) << "Reached unreachable code."; \
+    ::fml::KillProcess();                          \
+  }
 
 #endif  // FLUTTER_FML_LOGGING_H_

--- a/fml/logging_unittests.cc
+++ b/fml/logging_unittests.cc
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/logging.h"
+#include "gtest/gtest.h"
+
+namespace fml {
+namespace testing {
+
+int UnreachableScopeWithoutReturnDoesNotMakeCompilerMad() {
+  KillProcess();
+  // return 0; <--- Missing but compiler is fine.
+}
+
+int UnreachableScopeWithMacroWithoutReturnDoesNotMakeCompilerMad() {
+  FML_UNREACHABLE();
+  // return 0; <--- Missing but compiler is fine.
+}
+
+TEST(LoggingTest, UnreachableKillProcess) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_DEATH(KillProcess(), "");
+}
+
+TEST(LoggingTest, UnreachableKillProcessWithMacro) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_DEATH({ FML_UNREACHABLE(); }, "");
+}
+
+}  // namespace testing
+}  // namespace fml


### PR DESCRIPTION
A version of this macro is present in most code-bases. The use of this macro
must satisfy two requirements:

1: If reached, the process must be terminated in all runtime modes and at all
   optimization levels.
2: If the compiler requires a value to be returned from the function,
   encountering this macro should not make the compiler insist on a return value
  (since the process is about to die anyway).

We used to have a version of this macro that wasn't widely used and didn't
satisfy the two requirements. I have removed the same and another unused macro
in fml/logging.h

Fixes https://github.com/flutter/flutter/issues/68164.