### PR TITLE
Add cache transform to TransformLayer

### DIFF
--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -8,7 +8,8 @@
 
 namespace flutter {
 
-TransformLayer::TransformLayer(const SkMatrix& transform, const SkMatrix* cache_transform)
+TransformLayer::TransformLayer(const SkMatrix& transform,
+                               const SkMatrix* cache_transform)
     : transform_(transform) {
   // Checks (in some degree) that SkMatrix transform_ is valid and initialized.
   //
@@ -27,7 +28,8 @@ TransformLayer::TransformLayer(const SkMatrix& transform, const SkMatrix* cache_
   if (cache_transform) {
     FML_DCHECK(cache_transform->isFinite());
     if (!cache_transform->isFinite() || !cache_transform->invert(nullptr)) {
-      FML_LOG(ERROR) << "TransformLayer is constructed with an invalid cache matrix.";
+      FML_LOG(ERROR)
+          << "TransformLayer is constructed with an invalid cache matrix.";
       cache_requested_ = false;
     } else {
       cache_transform_ = *cache_transform;
@@ -49,7 +51,8 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkMatrix inverse_transform_;
   // Perspective projections don't produce rectangles that are useful for
   // culling for some reason.
-  if (!child_transform.hasPerspective() && child_transform.invert(&inverse_transform_)) {
+  if (!child_transform.hasPerspective() &&
+      child_transform.invert(&inverse_transform_)) {
     inverse_transform_.mapRect(&context->cull_rect);
   } else {
     context->cull_rect = kGiantRect;
@@ -89,7 +92,9 @@ void TransformLayer::Paint(PaintContext& context) const {
   FML_DCHECK(needs_painting());
 
   if (cache_requested_ && context.raster_cache &&
-      context.raster_cache->Draw(GetCacheableChild(), *context.internal_nodes_canvas, cache_transform_, transform_)) {
+      context.raster_cache->Draw(GetCacheableChild(),
+                                 *context.internal_nodes_canvas,
+                                 cache_transform_, transform_)) {
     TRACE_EVENT_INSTANT0("flutter", "raster cache hit");
     return;
   }

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -11,9 +11,9 @@ namespace flutter {
 
 // Be careful that SkMatrix's default constructor doesn't initialize the matrix
 // at all. Hence |set_transform| must be called with an initialized SkMatrix.
-class TransformLayer : public ContainerLayer {
+class TransformLayer : public MergedContainerLayer {
  public:
-  TransformLayer(const SkMatrix& transform);
+  TransformLayer(const SkMatrix& transform, const SkMatrix* cache_transform = nullptr);
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
@@ -25,6 +25,8 @@ class TransformLayer : public ContainerLayer {
 
  private:
   SkMatrix transform_;
+  SkMatrix cache_transform_;
+  bool cache_requested_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TransformLayer);
 };

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -13,7 +13,8 @@ namespace flutter {
 // at all. Hence |set_transform| must be called with an initialized SkMatrix.
 class TransformLayer : public MergedContainerLayer {
  public:
-  TransformLayer(const SkMatrix& transform, const SkMatrix* cache_transform = nullptr);
+  TransformLayer(const SkMatrix& transform,
+                 const SkMatrix* cache_transform = nullptr);
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 

--- a/flow/layers/transform_layer_unittests.cc
+++ b/flow/layers/transform_layer_unittests.cc
@@ -111,7 +111,8 @@ TEST_F(TransformLayerTest, Cached) {
   EXPECT_TRUE(cache_transform.invert(&inverse_layer_transform));
 
   auto mock_layer = std::make_shared<MockLayer>(child_path, SkPaint());
-  auto layer = std::make_shared<TransformLayer>(layer_transform, &cache_transform);
+  auto layer =
+      std::make_shared<TransformLayer>(layer_transform, &cache_transform);
   layer->Add(mock_layer);
 
   preroll_context()->cull_rect = cull_rect;

--- a/flow/layers/transform_layer_unittests.cc
+++ b/flow/layers/transform_layer_unittests.cc
@@ -26,7 +26,7 @@ TEST_F(TransformLayerTest, PaintingEmptyLayerDies) {
                             "needs_painting\\(\\)");
 }
 
-TEST_F(TransformLayerTest, PaintBeforePreollDies) {
+TEST_F(TransformLayerTest, PaintBeforePrerollDies) {
   SkPath child_path;
   child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
   auto mock_layer = std::make_shared<MockLayer>(child_path, SkPaint());
@@ -88,6 +88,45 @@ TEST_F(TransformLayerTest, Simple) {
             inverse_layer_transform.mapRect(cull_rect));
   EXPECT_EQ(mock_layer->parent_mutators(),
             std::vector({Mutator(layer_transform)}));
+
+  layer->Paint(paint_context());
+  EXPECT_EQ(
+      mock_canvas().draw_calls(),
+      std::vector({MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
+                   MockCanvas::DrawCall{
+                       1, MockCanvas::ConcatMatrixData{layer_transform}},
+                   MockCanvas::DrawCall{
+                       1, MockCanvas::DrawPathData{child_path, SkPaint()}},
+                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+}
+
+TEST_F(TransformLayerTest, Cached) {
+  SkPath child_path;
+  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  SkRect cull_rect = SkRect::MakeXYWH(2.0f, 2.0f, 14.0f, 14.0f);
+  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
+  SkMatrix layer_transform = SkMatrix::Translate(2.5f, 2.5f);
+  SkMatrix cache_transform = SkMatrix::Scale(2.0, 2.0);
+  SkMatrix inverse_layer_transform;
+  EXPECT_TRUE(cache_transform.invert(&inverse_layer_transform));
+
+  auto mock_layer = std::make_shared<MockLayer>(child_path, SkPaint());
+  auto layer = std::make_shared<TransformLayer>(layer_transform, &cache_transform);
+  layer->Add(mock_layer);
+
+  preroll_context()->cull_rect = cull_rect;
+  layer->Preroll(preroll_context(), initial_transform);
+  EXPECT_EQ(mock_layer->paint_bounds(), child_path.getBounds());
+  EXPECT_EQ(layer->paint_bounds(),
+            layer_transform.mapRect(mock_layer->paint_bounds()));
+  EXPECT_TRUE(mock_layer->needs_painting());
+  EXPECT_TRUE(layer->needs_painting());
+  EXPECT_EQ(mock_layer->parent_matrix(),
+            SkMatrix::Concat(initial_transform, cache_transform));
+  EXPECT_EQ(mock_layer->parent_cull_rect(),
+            inverse_layer_transform.mapRect(cull_rect));
+  EXPECT_EQ(mock_layer->parent_mutators(),
+            std::vector({Mutator(cache_transform)}));
 
   layer->Paint(paint_context());
   EXPECT_EQ(

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -35,6 +35,54 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   canvas.drawImage(image_, bounds.fLeft, bounds.fTop, paint);
 }
 
+void RasterCacheResult::drawTransformed(SkCanvas& canvas,
+                                        const SkMatrix& cache_matrix,
+                                        const SkMatrix& render_matrix) const {
+  TRACE_EVENT0("flutter", "RasterCacheResult::drawTransformed");
+  SkAutoCanvasRestore auto_restore(&canvas, true);
+  SkMatrix cache_total_matrix;
+  cache_total_matrix.setConcat(canvas.getTotalMatrix(), cache_matrix);
+  SkIRect bounds =
+      RasterCache::GetDeviceBounds(logical_rect_, cache_total_matrix);
+  FML_DCHECK(
+      std::abs(bounds.size().width() - image_->dimensions().width()) <= 1 &&
+      std::abs(bounds.size().height() - image_->dimensions().height()) <= 1);
+
+  SkPoint cache_corners[3];
+  cache_corners[0] = SkPoint::Make(bounds.fLeft, bounds.fTop);
+  cache_corners[1] = SkPoint::Make(bounds.fRight, bounds.fTop);
+  cache_corners[2] = SkPoint::Make(bounds.fLeft, bounds.fBottom);
+  // cache_corners are device coordinates of where the cache entry
+  // would have been drawn if we were still using cache_matrix.
+  // 3 corners are enough to precisely locate the image in an
+  // affine coordinate system (and we would not be caching the
+  // children if the coordinate system was not affine).
+
+  SkMatrix cache_render_matrix;
+  bool invert_success = cache_total_matrix.invert(&cache_render_matrix);
+  FML_DCHECK(invert_success);
+  SkPoint render_corners[3];
+  cache_render_matrix.mapPoints(render_corners, cache_corners, 3);
+  // render_corners are now the location of the cached image corners
+  // mapped back to the coordinate space of the child.
+
+  // Now we look at what would have happened if we were rendering the
+  // child with render_matrix instead of cache_matrix.  We take the
+  // location of the cached image in the child coordinate space
+  // (specified by 3 of its corners) and see where those points would
+  // be drawn in device space with the new transform.
+  render_matrix.mapPoints(render_corners, 3);
+  // render_corners are now relative to the canvas transform.
+  canvas.getTotalMatrix().mapPoints(render_corners, 3);
+  // render_corners are now the device space locations of those same
+  // corners, had they been rendered under the new render_matrix
+  cache_render_matrix.setPolyToPoly(cache_corners, render_corners, 3);
+  // cache_render_matrix now maps the original device space corners
+  // to the new device rendering locations of those same corners
+  canvas.setMatrix(cache_render_matrix);
+  canvas.drawImage(image_, bounds.fLeft, bounds.fTop, nullptr);
+}
+
 RasterCache::RasterCache(size_t access_threshold,
                          size_t picture_cache_limit_per_frame)
     : access_threshold_(access_threshold),
@@ -255,6 +303,30 @@ bool RasterCache::Draw(const Layer* layer,
 
   if (entry.image) {
     entry.image->draw(canvas, paint);
+    return true;
+  }
+
+  return false;
+}
+
+bool RasterCache::Draw(const Layer* layer,
+                       SkCanvas& canvas,
+                       const SkMatrix& cache_matrix,
+                       const SkMatrix& render_matrix) const {
+  SkMatrix cache_total_matrix;
+  cache_total_matrix.setConcat(canvas.getTotalMatrix(), cache_matrix);
+  LayerRasterCacheKey cache_key(layer->unique_id(), cache_total_matrix);
+  auto it = layer_cache_.find(cache_key);
+  if (it == layer_cache_.end()) {
+    return false;
+  }
+
+  Entry& entry = it->second;
+  entry.access_count++;
+  entry.used_this_frame = true;
+
+  if (entry.image) {
+    entry.image->drawTransformed(canvas, cache_matrix, render_matrix);
     return true;
   }
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -24,6 +24,8 @@ class RasterCacheResult {
 
   virtual void draw(SkCanvas& canvas, const SkPaint* paint) const;
 
+  virtual void drawTransformed(SkCanvas& canvas, const SkMatrix& cache_matrix, const SkMatrix& render_matrix) const;
+
   virtual SkISize image_dimensions() const {
     return image_ ? image_->dimensions() : SkISize::Make(0, 0);
   };
@@ -155,6 +157,17 @@ class RasterCache {
   bool Draw(const Layer* layer,
             SkCanvas& canvas,
             SkPaint* paint = nullptr) const;
+
+  // Find the raster cache for the layer that was originally cached using
+  // the specified [cache_matrix] and draw it to the canvas with the new
+  // specified [render_matrix]. Both matrix arguments are relative to the
+  // matrix installed in the [canvas].
+  //
+  // Return true if the layer raster cache is found and drawn.
+  bool Draw(const Layer* layer,
+            SkCanvas& canvas,
+            const SkMatrix& cache_matrix,
+            const SkMatrix& render_matrix) const;
 
   void SweepAfterFrame();
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -24,7 +24,9 @@ class RasterCacheResult {
 
   virtual void draw(SkCanvas& canvas, const SkPaint* paint) const;
 
-  virtual void drawTransformed(SkCanvas& canvas, const SkMatrix& cache_matrix, const SkMatrix& render_matrix) const;
+  virtual void drawTransformed(SkCanvas& canvas,
+                               const SkMatrix& cache_matrix,
+                               const SkMatrix& render_matrix) const;
 
   virtual SkISize image_dimensions() const {
     return image_ ? image_->dimensions() : SkISize::Make(0, 0);

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -285,6 +285,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     TransformEngineLayer? oldLayer,
   }) {
     assert(_matrix4IsValid(matrix4));
+    assert(_matrix4IsValidOrNull(cacheMatrix4));
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushTransform'));
     final EngineLayer engineLayer = EngineLayer._();
     _pushTransform(engineLayer, matrix4, cacheMatrix4);

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -281,18 +281,19 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// See [pop] for details about the operation stack.
   TransformEngineLayer? pushTransform(
     Float64List matrix4, {
+    Float64List? cacheMatrix4,
     TransformEngineLayer? oldLayer,
   }) {
     assert(_matrix4IsValid(matrix4));
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushTransform'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushTransform(engineLayer, matrix4);
+    _pushTransform(engineLayer, matrix4, cacheMatrix4);
     final TransformEngineLayer layer = TransformEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushTransform(EngineLayer layer, Float64List matrix4) native 'SceneBuilder_pushTransform';
+  void _pushTransform(EngineLayer layer, Float64List matrix4, Float64List? cacheMatrix4) native 'SceneBuilder_pushTransform';
 
   /// Pushes an offset operation onto the operation stack.
   ///

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -101,7 +101,8 @@ void SceneBuilder::pushTransform(Dart_Handle layer_handle,
   } else {
     sk_cache_matrix_ptr = nullptr;
   }
-  auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix, sk_cache_matrix_ptr);
+  auto layer =
+      std::make_shared<flutter::TransformLayer>(sk_matrix, sk_cache_matrix_ptr);
   PushLayer(layer);
   // matrix4 has to be released before we can return another Dart object
   matrix4.Release();

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -90,9 +90,18 @@ SceneBuilder::SceneBuilder() {
 SceneBuilder::~SceneBuilder() = default;
 
 void SceneBuilder::pushTransform(Dart_Handle layer_handle,
-                                 tonic::Float64List& matrix4) {
+                                 tonic::Float64List& matrix4,
+                                 tonic::Float64List& cache_matrix4) {
   SkMatrix sk_matrix = ToSkMatrix(matrix4);
-  auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix);
+  SkMatrix sk_cache_matrix;
+  SkMatrix* sk_cache_matrix_ptr;
+  if (cache_matrix4.num_elements() != 0) {
+    sk_cache_matrix = ToSkMatrix(cache_matrix4);
+    sk_cache_matrix_ptr = &sk_cache_matrix;
+  } else {
+    sk_cache_matrix_ptr = nullptr;
+  }
+  auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix, sk_cache_matrix_ptr);
   PushLayer(layer);
   // matrix4 has to be released before we can return another Dart object
   matrix4.Release();

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -37,7 +37,9 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   }
   ~SceneBuilder() override;
 
-  void pushTransform(Dart_Handle layer_handle, tonic::Float64List& matrix4, tonic::Float64List& cache_matrix4);
+  void pushTransform(Dart_Handle layer_handle,
+                     tonic::Float64List& matrix4,
+                     tonic::Float64List& cache_matrix4);
   void pushOffset(Dart_Handle layer_handle, double dx, double dy);
   void pushClipRect(Dart_Handle layer_handle,
                     double left,

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -37,7 +37,7 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   }
   ~SceneBuilder() override;
 
-  void pushTransform(Dart_Handle layer_handle, tonic::Float64List& matrix4);
+  void pushTransform(Dart_Handle layer_handle, tonic::Float64List& matrix4, tonic::Float64List& cache_matrix4);
   void pushOffset(Dart_Handle layer_handle, double dx, double dy);
   void pushClipRect(Dart_Handle layer_handle,
                     double left,

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -44,6 +44,8 @@ bool _offsetIsValid(Offset offset) {
   return true;
 }
 
+bool _matrix4IsValidOrNull(Float64List? matrix4) => matrix4 == null || _matrix4IsValid(matrix4);
+
 bool _matrix4IsValid(Float64List matrix4) {
   assert(matrix4 != null, 'Matrix4 argument was null.'); // ignore: unnecessary_null_comparison
   assert(matrix4.length == 16, 'Matrix4 must have 16 entries.');

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -210,6 +210,7 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   @override
   ui.TransformEngineLayer? pushTransform(
     Float64List matrix4, {
+    Float64List? cacheMatrix4,
     ui.EngineLayer? oldLayer,
   }) {
     final Matrix4 matrix = Matrix4.fromFloat32List(toMatrix32(matrix4));

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -76,6 +76,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   @override
   ui.TransformEngineLayer pushTransform(
     Float64List matrix4, {
+    Float64List? cacheMatrix4,
     ui.TransformEngineLayer? oldLayer,
   }) {
     if (matrix4.length != 16) {

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -47,6 +47,7 @@ abstract class SceneBuilder {
   });
   TransformEngineLayer? pushTransform(
     Float64List matrix4, {
+    Float64List? cacheMatrix4,
     TransformEngineLayer? oldLayer,
   });
   ClipRectEngineLayer? pushClipRect(


### PR DESCRIPTION
The engine changes that will eventually enable fixing https://github.com/flutter/flutter/issues/24627

An additional PR for the Framework repo will be required to use these changes, but the new property I added here should be backwards compatible to existing Frameworks as it defaults to the compatibility value (null).

This is the engine work preparing for adding a (nullable) cacheTransform property to the Transform widget in the framework.

By default this property will be null and the TransformLayer will do the same thing it has always done. If a Matrix4 value is specified for the cache property, then TransformLayer will use the cacheTransform for populating the cache and then apply the transform property as a texture transform operation on the cache entry.

On an animation test (see below for gist) various techniques for animating a transform produced the following render timings (taken from the Performance Overlay average rendering value):

```
With "complex child" and "child RPB" both enabled:
Transform without caching:       ~56   ms/frame ########################################################
ImageFiltered widget:            ~14.5 ms/frame ##############=
Transform with cacheTransform:    ~7   ms/frame #######

With only "child RPB" enabled (simpler child rendering):
Transform without caching:       ~12.5 ms/frame ############=
ImageFiltered widget:            ~14.5 ms/frame ##############=
Transform with cacheTransform:    ~7   ms/frame #######

(All measurements milliseconds per frame - shorter bars are better)
```

Note that the ImageFiltered solution to animating the transform helps a lot with complex children, but can actually be slightly worse for simple children. But, the new cacheTransform property on the Transform widget is the fastest animation solution for both complex and simple children.

In addition to the improved performance, the cacheTransform property is much easier to use as compared to the ImageFiltered widget. In most cases, the performance can be improved by simply adding `cacheTransform: Matrix4.identity(),` to the Transform widget construction. An issue with needing to query the rendering location of the child and manually adjust for transformation alignment in the ImageFiltered case is also eliminated as the Transform will apply the requested alignment for both transforms consistently and transparently.

Here is the gist of the test used for the numbers shown above. All tests above were run with "child RPB" enabled: https://gist.github.com/flar/49fb1c70b8cc2de16af5bd91dbcd34ac

The test also provides 2 sliders for playing with the rotation and scale of the cacheTransform property which help verify that the location, size, and orientation of the final rendered child will be the same regardless of the caching transform - only the quality of the results might vary with a poorly chosen cache transform (ideally most developers would just use an identity cache matrix, but they might include a scale or rotate if the originating or final state had one). The sliders default to Identity values, but changing them should verify that they won't have any (significant) visual changes in the output, other than pixelization quality changes from dropping the scale slider too low. (You can see an interesting artifact if you drop the scale really low and then play with the rotation slider as you start to see rounding errors as the text code tries to render rotated text with very few pixels to work with.)