### PR TITLE
Restore missing call to RuntimeDelegate.OnRootIsolateCreated

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -398,6 +398,9 @@ bool RuntimeController::LaunchRootIsolate(
   }
 
   FML_DCHECK(Dart_CurrentIsolate() == nullptr);
+
+  client_.OnRootIsolateCreated();
+
   return true;
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/68411
