### PR TITLE
Fixes Edge trigger route change announcement

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1357,7 +1357,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     // Dispatch a TYPE_WINDOW_STATE_CHANGED event if the most recent route id changed from the
     // previously cached route id.
 
-    // Finds the first route that are not in the previous routes.
+    // Finds the last route that is not in the previous routes.
     SemanticsNode lastAdded = null;
     for (SemanticsNode semanticsNode : newRoutes) {
       if (!flutterNavigationStack.contains(semanticsNode.id)) {

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1356,16 +1356,29 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
     // Dispatch a TYPE_WINDOW_STATE_CHANGED event if the most recent route id changed from the
     // previously cached route id.
+
+    // Finds the first route that are not in the previous routes.
     SemanticsNode lastAdded = null;
     for (SemanticsNode semanticsNode : newRoutes) {
       if (!flutterNavigationStack.contains(semanticsNode.id)) {
         lastAdded = semanticsNode;
       }
     }
+
+    // If all the routes are in the previous route, get the last route.
     if (lastAdded == null && newRoutes.size() > 0) {
       lastAdded = newRoutes.get(newRoutes.size() - 1);
     }
-    if (lastAdded != null && lastAdded.id != previousRouteId) {
+
+    // There are two cases if lastAdded != nil
+    // 1. lastAdded is not in previous routes. In this case,
+    //    lastAdded.id != previousRouteId
+    // 2. All new routes are in previous routes and
+    //    lastAdded = newRoutes.last.
+    // In the first case, we need to announce new route. In the second case,
+    // we need to announce if one list is shorter than the other.
+    if (lastAdded != null
+        && (lastAdded.id != previousRouteId || newRoutes.size() != flutterNavigationStack.size())) {
       previousRouteId = lastAdded.id;
       sendWindowChangeEvent(lastAdded);
     }

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -143,6 +143,134 @@ public class AccessibilityBridgeTest {
   }
 
   @Test
+  public void itAnnouncesRouteNameWhenAddingNewRoute() {
+    AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    View mockRootView = mock(View.class);
+    Context context = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(context);
+    when(context.getPackageName()).thenReturn("test");
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(mockRootView, mockManager, mockViewEmbedder);
+    ViewParent mockParent = mock(ViewParent.class);
+    when(mockRootView.getParent()).thenReturn(mockParent);
+    when(mockManager.isEnabled()).thenReturn(true);
+
+    TestSemanticsNode root = new TestSemanticsNode();
+    root.id = 0;
+    TestSemanticsNode node1 = new TestSemanticsNode();
+    node1.id = 1;
+    node1.addFlag(AccessibilityBridge.Flag.SCOPES_ROUTE);
+    node1.addFlag(AccessibilityBridge.Flag.NAMES_ROUTE);
+    node1.label = "node1";
+    root.children.add(node1);
+    TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
+    accessibilityBridge.updateSemantics(testSemanticsUpdate.buffer, testSemanticsUpdate.strings);
+
+    ArgumentCaptor<AccessibilityEvent> eventCaptor =
+        ArgumentCaptor.forClass(AccessibilityEvent.class);
+    verify(mockParent, times(2))
+        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+    AccessibilityEvent event = eventCaptor.getAllValues().get(0);
+    assertEquals(event.getEventType(), AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
+    List<CharSequence> sentences = event.getText();
+    assertEquals(sentences.size(), 1);
+    assertEquals(sentences.get(0).toString(), "node1");
+
+    TestSemanticsNode new_root = new TestSemanticsNode();
+    new_root.id = 0;
+    TestSemanticsNode new_node1 = new TestSemanticsNode();
+    new_node1.id = 1;
+    new_node1.addFlag(AccessibilityBridge.Flag.SCOPES_ROUTE);
+    new_node1.addFlag(AccessibilityBridge.Flag.NAMES_ROUTE);
+    new_node1.label = "new_node1";
+    new_root.children.add(new_node1);
+    TestSemanticsNode new_node2 = new TestSemanticsNode();
+    new_node2.id = 2;
+    new_node2.addFlag(AccessibilityBridge.Flag.SCOPES_ROUTE);
+    new_node2.addFlag(AccessibilityBridge.Flag.NAMES_ROUTE);
+    new_node2.label = "new_node2";
+    new_node1.children.add(new_node2);
+    testSemanticsUpdate = new_root.toUpdate();
+    accessibilityBridge.updateSemantics(testSemanticsUpdate.buffer, testSemanticsUpdate.strings);
+
+    eventCaptor = ArgumentCaptor.forClass(AccessibilityEvent.class);
+    verify(mockParent, times(4))
+        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+    event = eventCaptor.getAllValues().get(2);
+    assertEquals(event.getEventType(), AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
+    sentences = event.getText();
+    assertEquals(sentences.size(), 1);
+    assertEquals(sentences.get(0).toString(), "new_node2");
+  }
+
+  @Test
+  public void itAnnouncesRouteNameWhenRemoveARoute() {
+    AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
+    AccessibilityManager mockManager = mock(AccessibilityManager.class);
+    View mockRootView = mock(View.class);
+    Context context = mock(Context.class);
+    when(mockRootView.getContext()).thenReturn(context);
+    when(context.getPackageName()).thenReturn("test");
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(mockRootView, mockManager, mockViewEmbedder);
+    ViewParent mockParent = mock(ViewParent.class);
+    when(mockRootView.getParent()).thenReturn(mockParent);
+    when(mockManager.isEnabled()).thenReturn(true);
+
+    TestSemanticsNode root = new TestSemanticsNode();
+    root.id = 0;
+    TestSemanticsNode node1 = new TestSemanticsNode();
+    node1.id = 1;
+    node1.addFlag(AccessibilityBridge.Flag.SCOPES_ROUTE);
+    node1.addFlag(AccessibilityBridge.Flag.NAMES_ROUTE);
+    node1.label = "node1";
+    root.children.add(node1);
+    TestSemanticsNode node2 = new TestSemanticsNode();
+    node2.id = 2;
+    node2.addFlag(AccessibilityBridge.Flag.SCOPES_ROUTE);
+    node2.addFlag(AccessibilityBridge.Flag.NAMES_ROUTE);
+    node2.label = "node2";
+    node1.children.add(node2);
+    TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
+    accessibilityBridge.updateSemantics(testSemanticsUpdate.buffer, testSemanticsUpdate.strings);
+
+    ArgumentCaptor<AccessibilityEvent> eventCaptor =
+        ArgumentCaptor.forClass(AccessibilityEvent.class);
+    verify(mockParent, times(2))
+        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+    AccessibilityEvent event = eventCaptor.getAllValues().get(0);
+    assertEquals(event.getEventType(), AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
+    List<CharSequence> sentences = event.getText();
+    assertEquals(sentences.size(), 1);
+    assertEquals(sentences.get(0).toString(), "node2");
+
+    TestSemanticsNode new_root = new TestSemanticsNode();
+    new_root.id = 0;
+    TestSemanticsNode new_node1 = new TestSemanticsNode();
+    new_node1.id = 1;
+    new_node1.label = "new_node1";
+    new_root.children.add(new_node1);
+    TestSemanticsNode new_node2 = new TestSemanticsNode();
+    new_node2.id = 2;
+    new_node2.addFlag(AccessibilityBridge.Flag.SCOPES_ROUTE);
+    new_node2.addFlag(AccessibilityBridge.Flag.NAMES_ROUTE);
+    new_node2.label = "new_node2";
+    new_node1.children.add(new_node2);
+    testSemanticsUpdate = new_root.toUpdate();
+    accessibilityBridge.updateSemantics(testSemanticsUpdate.buffer, testSemanticsUpdate.strings);
+
+    eventCaptor = ArgumentCaptor.forClass(AccessibilityEvent.class);
+    verify(mockParent, times(4))
+        .requestSendAccessibilityEvent(eq(mockRootView), eventCaptor.capture());
+    event = eventCaptor.getAllValues().get(2);
+    assertEquals(event.getEventType(), AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
+    sentences = event.getText();
+    assertEquals(sentences.size(), 1);
+    assertEquals(sentences.get(0).toString(), "new_node2");
+  }
+
+  @Test
   public void itAnnouncesWhiteSpaceWhenNoNamesRoute() {
     AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
     AccessibilityManager mockManager = mock(AccessibilityManager.class);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -167,7 +167,7 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     }
     NSMutableArray<SemanticsObject*>* newRoutes = [[[NSMutableArray alloc] init] autorelease];
     [root collectRoutes:newRoutes];
-    // Finds the first route that are not in the previous routes.
+    // Finds the last route that is not in the previous routes.
     for (SemanticsObject* route in newRoutes) {
       if (std::find(previous_routes_.begin(), previous_routes_.end(), [route uid]) ==
           previous_routes_.end()) {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -167,17 +167,27 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     }
     NSMutableArray<SemanticsObject*>* newRoutes = [[[NSMutableArray alloc] init] autorelease];
     [root collectRoutes:newRoutes];
+    // Finds the first route that are not in the previous routes.
     for (SemanticsObject* route in newRoutes) {
-      if (std::find(previous_routes_.begin(), previous_routes_.end(), [route uid]) !=
+      if (std::find(previous_routes_.begin(), previous_routes_.end(), [route uid]) ==
           previous_routes_.end()) {
         lastAdded = route;
       }
     }
+    // If all the routes are in the previous route, get the last route.
     if (lastAdded == nil && [newRoutes count] > 0) {
       int index = [newRoutes count] - 1;
       lastAdded = [newRoutes objectAtIndex:index];
     }
-    if (lastAdded != nil && [lastAdded uid] != previous_route_id_) {
+    // There are two cases if lastAdded != nil
+    // 1. lastAdded is not in previous routes. In this case,
+    //    [lastAdded uid] != previous_route_id_
+    // 2. All new routes are in previous routes and
+    //    lastAdded = newRoutes.last.
+    // In the first case, we need to announce new route. In the second case,
+    // we need to announce if one list is shorter than the other.
+    if (lastAdded != nil &&
+        ([lastAdded uid] != previous_route_id_ || [newRoutes count] != previous_routes_.size())) {
       previous_route_id_ = [lastAdded uid];
       routeChanged = true;
     }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -344,7 +344,6 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
-      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
@@ -428,7 +427,6 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
-      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -333,6 +333,180 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                  UIAccessibilityScreenChangedNotification);
 }
 
+- (void)testAnnouncesRouteChangesWhenAddAdditionalRoute {
+  flutter::MockDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
+      /*task_runners=*/runners);
+  id mockFlutterView = OCMClassMock([FlutterView class]);
+  id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
+
+  NSMutableArray<NSDictionary<NSString*, id>*>* accessibility_notifications =
+      [[[NSMutableArray alloc] init] autorelease];
+  auto ios_delegate = std::make_unique<flutter::MockIosDelegate>();
+  ios_delegate->on_PostAccessibilityNotification_ =
+      [accessibility_notifications](UIAccessibilityNotifications notification, id argument) {
+        [accessibility_notifications addObject:@{
+          @"notification" : @(notification),
+          @"argument" : argument ? argument : [NSNull null],
+        }];
+      };
+  __block auto bridge =
+      std::make_unique<flutter::AccessibilityBridge>(/*view_controller=*/mockFlutterViewController,
+                                                     /*platform_view=*/platform_view.get(),
+                                                     /*platform_views_controller=*/nil,
+                                                     /*ios_delegate=*/std::move(ios_delegate));
+
+  flutter::CustomAccessibilityActionUpdates actions;
+  flutter::SemanticsNodeUpdates nodes;
+
+  flutter::SemanticsNode node1;
+  node1.id = 1;
+  node1.label = "node1";
+  node1.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute) |
+                static_cast<int32_t>(flutter::SemanticsFlags::kNamesRoute);
+  nodes[node1.id] = node1;
+  flutter::SemanticsNode root_node;
+  root_node.id = kRootNodeId;
+  root_node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute);
+  root_node.childrenInTraversalOrder = {1};
+  root_node.childrenInHitTestOrder = {1};
+  nodes[root_node.id] = root_node;
+  bridge->UpdateSemantics(/*nodes=*/nodes, /*actions=*/actions);
+
+  XCTAssertEqual([accessibility_notifications count], 1ul);
+  XCTAssertEqualObjects(accessibility_notifications[0][@"argument"], @"node1");
+  XCTAssertEqual([accessibility_notifications[0][@"notification"] unsignedIntValue],
+                 UIAccessibilityScreenChangedNotification);
+
+  flutter::SemanticsNodeUpdates new_nodes;
+
+  flutter::SemanticsNode new_node1;
+  new_node1.id = 1;
+  new_node1.label = "new_node1";
+  new_node1.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute) |
+                    static_cast<int32_t>(flutter::SemanticsFlags::kNamesRoute);
+  new_node1.childrenInTraversalOrder = {2};
+  new_node1.childrenInHitTestOrder = {2};
+  new_nodes[new_node1.id] = new_node1;
+  flutter::SemanticsNode new_node2;
+  new_node2.id = 2;
+  new_node2.label = "new_node2";
+  new_node2.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute) |
+                    static_cast<int32_t>(flutter::SemanticsFlags::kNamesRoute);
+  new_nodes[new_node2.id] = new_node2;
+  flutter::SemanticsNode new_root_node;
+  new_root_node.id = kRootNodeId;
+  new_root_node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute);
+  new_root_node.childrenInTraversalOrder = {1};
+  new_root_node.childrenInHitTestOrder = {1};
+  new_nodes[new_root_node.id] = new_root_node;
+  bridge->UpdateSemantics(/*nodes=*/new_nodes, /*actions=*/actions);
+  XCTAssertEqual([accessibility_notifications count], 2ul);
+  XCTAssertEqualObjects(accessibility_notifications[1][@"argument"], @"new_node2");
+  XCTAssertEqual([accessibility_notifications[1][@"notification"] unsignedIntValue],
+                 UIAccessibilityScreenChangedNotification);
+}
+
+- (void)testAnnouncesRouteChangesRemoveRouteInMiddle {
+  flutter::MockDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
+      /*task_runners=*/runners);
+  id mockFlutterView = OCMClassMock([FlutterView class]);
+  id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
+
+  NSMutableArray<NSDictionary<NSString*, id>*>* accessibility_notifications =
+      [[[NSMutableArray alloc] init] autorelease];
+  auto ios_delegate = std::make_unique<flutter::MockIosDelegate>();
+  ios_delegate->on_PostAccessibilityNotification_ =
+      [accessibility_notifications](UIAccessibilityNotifications notification, id argument) {
+        [accessibility_notifications addObject:@{
+          @"notification" : @(notification),
+          @"argument" : argument ? argument : [NSNull null],
+        }];
+      };
+  __block auto bridge =
+      std::make_unique<flutter::AccessibilityBridge>(/*view_controller=*/mockFlutterViewController,
+                                                     /*platform_view=*/platform_view.get(),
+                                                     /*platform_views_controller=*/nil,
+                                                     /*ios_delegate=*/std::move(ios_delegate));
+
+  flutter::CustomAccessibilityActionUpdates actions;
+  flutter::SemanticsNodeUpdates nodes;
+
+  flutter::SemanticsNode node1;
+  node1.id = 1;
+  node1.label = "node1";
+  node1.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute) |
+                static_cast<int32_t>(flutter::SemanticsFlags::kNamesRoute);
+  node1.childrenInTraversalOrder = {2};
+  node1.childrenInHitTestOrder = {2};
+  nodes[node1.id] = node1;
+  flutter::SemanticsNode node2;
+  node2.id = 2;
+  node2.label = "node2";
+  node2.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute) |
+                static_cast<int32_t>(flutter::SemanticsFlags::kNamesRoute);
+  nodes[node2.id] = node2;
+  flutter::SemanticsNode root_node;
+  root_node.id = kRootNodeId;
+  root_node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute);
+  root_node.childrenInTraversalOrder = {1};
+  root_node.childrenInHitTestOrder = {1};
+  nodes[root_node.id] = root_node;
+  bridge->UpdateSemantics(/*nodes=*/nodes, /*actions=*/actions);
+
+  XCTAssertEqual([accessibility_notifications count], 1ul);
+  XCTAssertEqualObjects(accessibility_notifications[0][@"argument"], @"node2");
+  XCTAssertEqual([accessibility_notifications[0][@"notification"] unsignedIntValue],
+                 UIAccessibilityScreenChangedNotification);
+
+  flutter::SemanticsNodeUpdates new_nodes;
+
+  flutter::SemanticsNode new_node1;
+  new_node1.id = 1;
+  new_node1.label = "new_node1";
+  new_node1.childrenInTraversalOrder = {2};
+  new_node1.childrenInHitTestOrder = {2};
+  new_nodes[new_node1.id] = new_node1;
+  flutter::SemanticsNode new_node2;
+  new_node2.id = 2;
+  new_node2.label = "new_node2";
+  new_node2.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute) |
+                    static_cast<int32_t>(flutter::SemanticsFlags::kNamesRoute);
+  new_nodes[new_node2.id] = new_node2;
+  flutter::SemanticsNode new_root_node;
+  new_root_node.id = kRootNodeId;
+  new_root_node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kScopesRoute);
+  new_root_node.childrenInTraversalOrder = {1};
+  new_root_node.childrenInHitTestOrder = {1};
+  new_nodes[new_root_node.id] = new_root_node;
+  bridge->UpdateSemantics(/*nodes=*/new_nodes, /*actions=*/actions);
+  XCTAssertEqual([accessibility_notifications count], 2ul);
+  XCTAssertEqualObjects(accessibility_notifications[1][@"argument"], @"new_node2");
+  XCTAssertEqual([accessibility_notifications[1][@"notification"] unsignedIntValue],
+                 UIAccessibilityScreenChangedNotification);
+}
+
 - (void)testAnnouncesRouteChangesWhenNoNamesRoute {
   flutter::MockDelegate mock_delegate;
   auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");


### PR DESCRIPTION
## Description

According to this doc https://docs.google.com/document/d/1EnsBkScApwOCFgXjb4_Zj3MR0izQxWUi2x3m0ceJ0Yg/edit#

There are some mismatch between the code and the design doc

1. iOS does not correctly find the last route that is in the new route list but not in the previous route list.
2. iOS does not consider the case where a route is removed in the middle.
3. android does not consider the case where a route is removed in the middle.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66308

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
