### PR TITLE
Fix native constructor of list of zircon handles and remove unused list factory specializations.

### DIFF
--- a/lib/ui/text/text_box.h
+++ b/lib/ui/text/text_box.h
@@ -25,18 +25,4 @@ struct TextBox {
 
 }  // namespace flutter
 
-namespace tonic {
-
-template <>
-struct DartConverter<flutter::TextBox> {
-  static Dart_Handle ToDart(const flutter::TextBox& val);
-};
-
-template <>
-struct DartListFactory<flutter::TextBox> {
-  static Dart_Handle NewList(intptr_t length);
-};
-
-}  // namespace tonic
-
 #endif  // FLUTTER_LIB_UI_TEXT_TEXT_BOX_H_

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
@@ -98,7 +98,8 @@ Dart_Handle MakeHandleList(const std::vector<zx_handle_t>& in_handles) {
   tonic::DartClassLibrary& class_library =
       tonic::DartState::Current()->class_library();
   Dart_Handle handle_type = class_library.GetClass("zircon", "Handle");
-  Dart_Handle list = Dart_NewListOfType(handle_type, in_handles.size());
+  Dart_Handle list = Dart_NewListOfTypeFilled(
+      handle_type, Handle::CreateInvalid(), in_handles.size());
   if (Dart_IsError(list))
     return list;
   for (size_t i = 0; i < in_handles.size(); i++) {

--- a/third_party/tonic/dart_wrappable.h
+++ b/third_party/tonic/dart_wrappable.h
@@ -166,18 +166,6 @@ struct DartConverter<PTR<T>> {
   }
 };
 
-template <template <typename T> class PTR, typename T>
-struct DartListFactory<
-    PTR<T>,
-    typename std::enable_if<
-        std::is_convertible<T*, const DartWrappable*>::value>::type> {
-  static Dart_Handle NewList(intptr_t length) {
-    Dart_PersistentHandle type = T::GetDartType(DartState::Current());
-    TONIC_DCHECK(!LogIfError(type));
-    return Dart_NewListOfType(Dart_HandleFromPersistent(type), length);
-  }
-};
-
 template <typename T>
 inline T* GetReceiver(Dart_NativeArguments args) {
   intptr_t receiver;


### PR DESCRIPTION
The Fuchsia specific Dart utilities don't use Tonic and hence are
unaffected by the recent changes to the engine for sound null-safety.
This patch fixes the creation of lists of non-nullable Zircon handles.

While looking for potential unpatched call-sites that create lists of
non-nullable handles from native code, I also found a couple of unused
and incomplete specializations. I have removed the same.

Fixes https://github.com/flutter/flutter/issues/68496