### PR TITLE
[null-safety] fix Scene.toImage declaration

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -37,7 +37,7 @@ class Scene extends NativeFieldWrapperClass2 {
     );
   }
 
-  String _toImage(int width, int height, _Callback<_Image> callback) native 'Scene_toImage';
+  String? _toImage(int width, int height, _Callback<_Image> callback) native 'Scene_toImage';
 
   /// Releases the resources used by this scene.
   ///


### PR DESCRIPTION
## Description

Same as the others, the native method returns null/void, so the Dart type must match