### PR TITLE
[fuchsia] zx::vmar::map migration

### DIFF
--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -481,7 +481,7 @@ class FileInNamespaceBuffer final : public fml::Mapping {
     }
     uintptr_t addr;
     zx_status_t status =
-        zx::vmar::root_self()->map(0, buffer.vmo, 0, buffer.size, flags, &addr);
+        zx::vmar::root_self()->map(flags, 0, buffer.vmo, 0, buffer.size, &addr);
     if (status != ZX_OK) {
       FML_LOG(FATAL) << "Failed to map " << path << ": "
                      << zx_status_get_string(status);

--- a/shell/platform/fuchsia/flutter/runner.cc
+++ b/shell/platform/fuchsia/flutter/runner.cc
@@ -45,9 +45,9 @@ uintptr_t GetICUData(const fuchsia::mem::Buffer& icu_data) {
     return 0u;
 
   uintptr_t data = 0u;
-  zx_status_t status = zx::vmar::root_self()->map(
-      0, icu_data.vmo, 0, static_cast<size_t>(data_size), ZX_VM_PERM_READ,
-      &data);
+  zx_status_t status =
+      zx::vmar::root_self()->map(ZX_VM_PERM_READ, 0, icu_data.vmo, 0,
+                                 static_cast<size_t>(data_size), &data);
   if (status == ZX_OK) {
     return data;
   }

--- a/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/mapped_resource.cc
@@ -82,8 +82,8 @@ bool MappedResource::LoadFromVmo(const std::string& path,
     flags |= ZX_VM_PERM_EXECUTE;
   }
   uintptr_t addr;
-  zx_status_t status = zx::vmar::root_self()->map(
-      0, resource_vmo.vmo, 0, resource_vmo.size, flags, &addr);
+  zx_status_t status = zx::vmar::root_self()->map(flags, 0, resource_vmo.vmo, 0,
+                                                  resource_vmo.size, &addr);
   if (status != ZX_OK) {
     FX_LOGF(ERROR, LOG_TAG, "Failed to map: %s", zx_status_get_string(status));
     return false;


### PR DESCRIPTION
The new map() method receives its arguments in the same order as the
underlying C system call. This patch should not change any behavior.