### PR TITLE
Fix FlTextInputPlugin tear down

### DIFF
--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -423,11 +423,6 @@ static void method_call_cb(FlMethodChannel* channel,
   }
 }
 
-static void view_weak_notify_cb(gpointer user_data, GObject* object) {
-  FlTextInputPlugin* self = FL_TEXT_INPUT_PLUGIN(object);
-  self->view = nullptr;
-}
-
 static void fl_text_input_plugin_dispose(GObject* object) {
   FlTextInputPlugin* self = FL_TEXT_INPUT_PLUGIN(object);
 
@@ -438,6 +433,7 @@ static void fl_text_input_plugin_dispose(GObject* object) {
     delete self->text_model;
     self->text_model = nullptr;
   }
+  self->view = nullptr;
 
   G_OBJECT_CLASS(fl_text_input_plugin_parent_class)->dispose(object);
 }
@@ -483,7 +479,6 @@ FlTextInputPlugin* fl_text_input_plugin_new(FlBinaryMessenger* messenger,
   fl_method_channel_set_method_call_handler(self->channel, method_call_cb, self,
                                             nullptr);
   self->view = view;
-  g_object_weak_ref(G_OBJECT(view), view_weak_notify_cb, self);
 
   return self;
 }


### PR DESCRIPTION
## Description

Fix FlTextInputPlugin tear down

Closing a Flutter app on Linux with the latest master throws a warning:

    invalid cast from 'FlView' to 'FlTextInputPlugin'

Remarks:
- `view_weak_notify_cb()` was trying to cast `FlView` as `FlTextInputPlugin`
- `fl_text_input_plugin_dispose()` was missing `g_object_weak_unref()`

A weak ref from `FlTextInputPlugin` to `FlView` seems unnecessary, though,
because the `FlTextInputPlugin` instance is managed by `FlView`. It is
created in `fl_view_constructed()`, and destroyed in `fl_view_dispose()`.
In other words, the `FlTextInputPlugin` instance cannot outlive `FlView`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
