### PR TITLE
[fuchsia] opt-out null-safety in standalone scripts

### DIFF
--- a/shell/platform/fuchsia/dart/compiler.dart
+++ b/shell/platform/fuchsia/dart/compiler.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:io';
 

--- a/shell/platform/fuchsia/flutter/collect_traces.dart
+++ b/shell/platform/fuchsia/flutter/collect_traces.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import 'dart:io';
 import 'dart:convert';
 

--- a/shell/platform/fuchsia/flutter/kernel/extract_far.dart
+++ b/shell/platform/fuchsia/flutter/kernel/extract_far.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 import "dart:io";
 
 import "package:args/args.dart";

--- a/shell/platform/fuchsia/runtime/dart/profiler_symbols/dart_profiler_symbols.dart
+++ b/shell/platform/fuchsia/runtime/dart/profiler_symbols/dart_profiler_symbols.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.9
+
 // On Fuchsia, in lieu of the ELF dynamic symbol table consumed through dladdr,
 // the Dart VM profiler consumes symbols produced by this tool, which have the
 // format


### PR DESCRIPTION
## Description

Opts out the standalone fuchsia scripts out of null-safety. 

## Related Issues
https://github.com/dart-lang/sdk/issues/43868