### PR TITLE
Revert "Define SK_VULKAN for clang-tidy runs (#21927)"

### DIFF
--- a/ci/bin/lint.dart
+++ b/ci/bin/lint.dart
@@ -28,11 +28,6 @@ https://github.com/flutter/flutter/wiki/Engine-Clang-Tidy-Linter
 
 const String issueUrlPrefix = 'https://github.com/flutter/flutter/issues';
 
-/// Symbol definitions passed to clang-tidy.
-const List<String> clangTidyDefineArgs = <String>[
-  "-DSK_VULKAN", // See: https://github.com/flutter/flutter/issues/68331
-];
-
 class Command {
   Directory directory = Directory('');
   String command = '';
@@ -51,7 +46,6 @@ String calcTidyArgs(Command command) {
   String result = command.command;
   result = result.replaceAll(RegExp(r'\S*clang/bin/clang'), '');
   result = result.replaceAll(RegExp(r'-MF \S*'), '');
-  result += ' ' + clangTidyDefineArgs.join(' ');
   return result;
 }
 

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// FLUTTER_NOLINT: https://github.com/flutter/flutter/issues/68331
+
 #include "vulkan_window.h"
 
 #include <memory>


### PR DESCRIPTION
This breaks linting on other targets that include skia headers that do
ifdef checks on SK_VULKAN.

This reverts commit 25d8fa5a79cb0228e639601822598ada49695ff6.