### PR TITLE
Determine null-safety isolate flags for launches of the service isolate.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -175,6 +175,14 @@ struct Settings {
   // call is made.
   fml::closure root_isolate_shutdown_callback;
   fml::closure isolate_shutdown_callback;
+  // A callback made in the isolate scope of the service isolate when it is
+  // launched. Care must be taken to ensure that callers are assigning callbacks
+  // to the settings object used to launch the VM. If an existing VM is used to
+  // launch an isolate using these settings, the callback will be ignored as the
+  // service isolate has already been launched. Also, this callback will only be
+  // made in the modes in which the service isolate is eligible for launch
+  // (debug and profile).
+  fml::closure service_isolate_create_callback;
   // The callback made on the UI thread in an isolate scope when the engine
   // detects that the framework is idle. The VM also uses this time to perform
   // tasks suitable when idling. Due to this, embedders are still advised to be

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -697,8 +697,14 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
                                 nullptr, nullptr, nullptr, nullptr);
 
   flags->load_vmservice_library = true;
+
+#if (FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_DEBUG)
+  // TODO(68663): The service isolate in debug mode is always launched without
+  // sound null safety. Fix after the isolate snapshot data is created with the
+  // right flags.
   flags->null_safety =
       vm_data->GetIsolateSnapshot()->IsNullSafetyEnabled(nullptr);
+#endif
 
   std::weak_ptr<DartIsolate> weak_service_isolate =
       DartIsolate::CreateRootIsolate(

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -697,6 +697,8 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
                                 nullptr, nullptr, nullptr, nullptr);
 
   flags->load_vmservice_library = true;
+  flags->null_safety =
+      vm_data->GetIsolateSnapshot()->IsNullSafetyEnabled(nullptr);
 
   std::weak_ptr<DartIsolate> weak_service_isolate =
       DartIsolate::CreateRootIsolate(
@@ -737,6 +739,10 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
     // Error is populated by call to startup.
     FML_DLOG(ERROR) << *error;
     return nullptr;
+  }
+
+  if (auto callback = vm_data->GetSettings().service_isolate_create_callback) {
+    callback();
   }
 
   if (auto service_protocol = DartVMRef::GetServiceProtocol()) {


### PR DESCRIPTION
Previously, there was as assumption was that the service isolate launch flags
would be inherited from the parent isolate (the root isolate). This does not
seem to be the case the isolate launch flags must specify the null-safety
characteristics. Since the application kernel for the service isolate is not
available, it is unclear of the VM is able to determine the same from the
isolate snapshot. The added test seems to indicate that it does. However, it
would be good to get a clarification from the VM team as to weather this usage
is correct.

Fixes https://github.com/flutter/flutter/issues/68561