### PR TITLE
Reland [ios] Refactor IOSSurface factory and unify surface creation

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1016,6 +1016,8 @@ FILE: ../../../flutter/shell/platform/darwin/ios/ios_render_target_gl.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_render_target_gl.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_factory.h
+FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_factory.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_gl.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_gl.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_metal.h

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -99,6 +99,8 @@ source_set("flutter_framework_source") {
     "ios_render_target_gl.mm",
     "ios_surface.h",
     "ios_surface.mm",
+    "ios_surface_factory.h",
+    "ios_surface_factory.mm",
     "ios_surface_gl.h",
     "ios_surface_gl.mm",
     "ios_surface_software.h",

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -221,6 +221,7 @@ shared_library("ios_test_flutter") {
   deps = [
     ":flutter_framework_source",
     ":ios_test_flutter_mrc",
+    "//flutter/common:common",
     "//flutter/shell/platform/darwin/common:framework_shared",
     "//flutter/third_party/tonic",
     "//flutter/third_party/txt",

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -27,7 +27,7 @@ extern const intptr_t kPlatformStrongDillSize;
 
 static const char* kApplicationKernelSnapshotFileName = "kernel_blob.bin";
 
-static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
+flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
   auto command_line = flutter::CommandLineFromNSProcessInfo();
 
   // Precedence:
@@ -181,7 +181,17 @@ static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
   self = [super init];
 
   if (self) {
-    _settings = DefaultSettingsForProcess(bundle);
+    _settings = FLTDefaultSettingsForBundle(bundle);
+  }
+
+  return self;
+}
+
+- (instancetype)initWithSettings:(const flutter::Settings&)settings {
+  self = [self initWithPrecompiledDartBundle:nil];
+
+  if (self) {
+    _settings = settings;
   }
 
   return self;

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
@@ -12,8 +12,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle = nil);
+
 @interface FlutterDartProject ()
 
+/**
+ * This is currently used for *only for tests* to override settings.
+ */
+- (instancetype)initWithSettings:(const flutter::Settings&)settings;
 - (const flutter::Settings&)settings;
 - (const flutter::PlatformData)defaultPlatformData;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -28,7 +28,9 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/profiler_metrics_ios.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
+#import "flutter/shell/platform/darwin/ios/ios_context.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
+#import "flutter/shell/platform/darwin/ios/ios_surface_factory.h"
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 #include "flutter/shell/profiling/sampling_profiler.h"
@@ -64,6 +66,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   fml::scoped_nsobject<FlutterObservatoryPublisher> _publisher;
 
   std::shared_ptr<flutter::FlutterPlatformViewsController> _platformViewsController;
+  std::shared_ptr<flutter::IOSSurfaceFactory> _surfaceFactory;
   std::unique_ptr<flutter::ProfilerMetricsIOS> _profiler_metrics;
   std::unique_ptr<flutter::SamplingProfiler> _profiler;
 
@@ -128,7 +131,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
   _pluginPublications = [NSMutableDictionary new];
   _registrars = [[NSMutableDictionary alloc] init];
-  _platformViewsController.reset(new flutter::FlutterPlatformViewsController());
+  [self ensurePlatformViewController];
 
   _binaryMessenger = [[FlutterBinaryMessengerRelay alloc] initWithParent:self];
   _connections.reset(new flutter::ConnectionCollection());
@@ -160,6 +163,16 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                object:nil];
 
   return self;
+}
+
+- (void)ensurePlatformViewController {
+  if (!_platformViewsController) {
+    auto renderingApi = flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering);
+    _surfaceFactory = flutter::IOSSurfaceFactory::Create(renderingApi);
+    auto pvc = new flutter::FlutterPlatformViewsController(_surfaceFactory);
+    _surfaceFactory->SetPlatformViewsController(pvc);
+    _platformViewsController.reset(pvc);
+  }
 }
 
 - (void)dealloc {
@@ -520,13 +533,13 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
                  threadHostType};
 
   // Lambda captures by pointers to ObjC objects are fine here because the
-  // create call is
-  // synchronous.
+  // create call is synchronous.
   flutter::Shell::CreateCallback<flutter::PlatformView> on_create_platform_view =
-      [](flutter::Shell& shell) {
+      [self](flutter::Shell& shell) {
+        [self ensurePlatformViewController];
         return std::make_unique<flutter::PlatformViewIOS>(
             shell, flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering),
-            shell.GetTaskRunners());
+            self->_surfaceFactory, shell.GetTaskRunners());
       };
 
   flutter::Shell::CreateCallback<flutter::Rasterizer> on_create_rasterizer =
@@ -554,9 +567,6 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
     [self setupChannels];
     [self onLocaleUpdated:nil];
     [self initializeDisplays];
-    if (!_platformViewsController) {
-      _platformViewsController.reset(new flutter::FlutterPlatformViewsController());
-    }
     _publisher.reset([[FlutterObservatoryPublisher alloc]
         initWithEnableObservatoryPublication:settings.enable_observatory_publication]);
     [self maybeSetupPlatformViewChannels];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -66,6 +66,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   fml::scoped_nsobject<FlutterObservatoryPublisher> _publisher;
 
   std::shared_ptr<flutter::FlutterPlatformViewsController> _platformViewsController;
+  flutter::IOSRenderingAPI _renderingApi;
   std::shared_ptr<flutter::IOSSurfaceFactory> _surfaceFactory;
   std::unique_ptr<flutter::ProfilerMetricsIOS> _profiler_metrics;
   std::unique_ptr<flutter::SamplingProfiler> _profiler;
@@ -131,7 +132,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 
   _pluginPublications = [NSMutableDictionary new];
   _registrars = [[NSMutableDictionary alloc] init];
-  [self ensurePlatformViewController];
+  [self recreatePlatformViewController];
 
   _binaryMessenger = [[FlutterBinaryMessengerRelay alloc] initWithParent:self];
   _connections.reset(new flutter::ConnectionCollection());
@@ -165,14 +166,15 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   return self;
 }
 
-- (void)ensurePlatformViewController {
-  if (!_platformViewsController) {
-    auto renderingApi = flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering);
-    _surfaceFactory = flutter::IOSSurfaceFactory::Create(renderingApi);
-    auto pvc = new flutter::FlutterPlatformViewsController(_surfaceFactory);
-    _surfaceFactory->SetPlatformViewsController(pvc);
-    _platformViewsController.reset(pvc);
-  }
+- (void)recreatePlatformViewController {
+  _renderingApi = flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering);
+  _surfaceFactory = flutter::IOSSurfaceFactory::Create(_renderingApi);
+  _platformViewsController.reset(new flutter::FlutterPlatformViewsController(_surfaceFactory));
+  _surfaceFactory->SetPlatformViewsController(_platformViewsController);
+}
+
+- (flutter::IOSRenderingAPI)platformViewsRenderingAPI {
+  return _renderingApi;
 }
 
 - (void)dealloc {
@@ -536,10 +538,9 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   // create call is synchronous.
   flutter::Shell::CreateCallback<flutter::PlatformView> on_create_platform_view =
       [self](flutter::Shell& shell) {
-        [self ensurePlatformViewController];
+        [self recreatePlatformViewController];
         return std::make_unique<flutter::PlatformViewIOS>(
-            shell, flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering),
-            self->_surfaceFactory, shell.GetTaskRunners());
+            shell, self->_renderingApi, self->_surfaceFactory, shell.GetTaskRunners());
       };
 
   flutter::Shell::CreateCallback<flutter::Rasterizer> on_create_rasterizer =

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -67,6 +67,7 @@ class MockDelegate : public PlatformView::Delegate {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
 
   id project = OCMClassMock([FlutterDartProject class]);

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -5,8 +5,10 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#import "flutter/common/settings.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h"
 
 FLUTTER_ASSERT_ARC
@@ -111,6 +113,25 @@ FLUTTER_ASSERT_ARC
                      }
                    }];
   [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testPlatformViewsControllerRenderingMetalBackend {
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine run];
+  flutter::IOSRenderingAPI renderingApi = [engine platformViewsRenderingAPI];
+
+  XCTAssertEqual(renderingApi, flutter::IOSRenderingAPI::kMetal);
+}
+
+- (void)testPlatformViewsControllerRenderingSoftware {
+  auto settings = FLTDefaultSettingsForBundle();
+  settings.enable_software_rendering = true;
+  FlutterDartProject* project = [[FlutterDartProject alloc] initWithSettings:settings];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
+  [engine run];
+  flutter::IOSRenderingAPI renderingApi = [engine platformViewsRenderingAPI];
+
+  XCTAssertEqual(renderingApi, flutter::IOSRenderingAPI::kSoftware);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
+#include "shell/platform/darwin/ios/rendering_api_selection.h"
 
 @class FlutterBinaryMessengerRelay;
 
@@ -10,4 +11,5 @@
 @interface FlutterEngine (Test) <FlutterBinaryMessenger>
 - (void)setBinaryMessenger:(FlutterBinaryMessengerRelay*)binaryMessenger;
 - (void)waitForFirstFrame:(NSTimeInterval)timeout callback:(void (^)(BOOL didTimeout))callback;
+- (flutter::IOSRenderingAPI)platformViewsRenderingAPI;
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
@@ -35,8 +35,6 @@
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithContentsScale:(CGFloat)contentsScale;
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSContext>)ios_context;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -62,14 +62,6 @@
   return [FlutterView layerClass];
 }
 
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSContext>)ios_context {
-  return flutter::IOSSurface::Create(std::move(ios_context),                              // context
-                                     fml::scoped_nsobject<CALayer>{[self.layer retain]},  // layer
-                                     nullptr  // platform views controller
-  );
-}
-
 // TODO(amirh): implement drawLayer to support snapshotting.
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -16,6 +16,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
+#import "flutter/shell/platform/darwin/ios/ios_surface_factory.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface_gl.h"
 
 namespace flutter {
@@ -32,8 +33,8 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewLayerPool::GetLayer
       overlay_view.reset([[FlutterOverlayView alloc] init]);
       overlay_view_wrapper.reset([[FlutterOverlayView alloc] init]);
 
-      std::unique_ptr<IOSSurface> ios_surface =
-          [overlay_view.get() createSurface:std::move(ios_context)];
+      auto ca_layer = fml::scoped_nsobject<CALayer>{[[overlay_view.get() layer] retain]};
+      std::unique_ptr<IOSSurface> ios_surface = ios_surface_factory_->CreateSurface(ca_layer);
       std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface();
 
       layer = std::make_shared<FlutterPlatformViewLayer>(
@@ -44,8 +45,8 @@ std::shared_ptr<FlutterPlatformViewLayer> FlutterPlatformViewLayerPool::GetLayer
       overlay_view.reset([[FlutterOverlayView alloc] initWithContentsScale:screenScale]);
       overlay_view_wrapper.reset([[FlutterOverlayView alloc] initWithContentsScale:screenScale]);
 
-      std::unique_ptr<IOSSurface> ios_surface =
-          [overlay_view.get() createSurface:std::move(ios_context)];
+      auto ca_layer = fml::scoped_nsobject<CALayer>{[[overlay_view.get() layer] retain]};
+      std::unique_ptr<IOSSurface> ios_surface = ios_surface_factory_->CreateSurface(ca_layer);
       std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface(gr_context);
 
       layer = std::make_shared<FlutterPlatformViewLayer>(

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -437,6 +437,12 @@ void FlutterPlatformViewsController::Reset() {
   for (UIView* sub_view in [flutter_view subviews]) {
     [sub_view removeFromSuperview];
   }
+  // See: https://github.com/flutter/flutter/issues/69305
+  for (auto it = touch_interceptors_.begin(); it != touch_interceptors_.end(); it++) {
+    FlutterTouchInterceptingView* view = it->second.get();
+    [view removeFromSuperview];
+  }
+  touch_interceptors_.clear();
   views_.clear();
   composition_order_.clear();
   active_composition_order_.clear();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -121,12 +121,16 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                                /*raster=*/thread_task_runner,
                                /*ui=*/thread_task_runner,
                                /*io=*/thread_task_runner);
+  auto surface_factory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*ios_surface_factory=*/surface_factory,
       /*task_runners=*/runners);
 
-  auto flutterPlatformViewsController = std::make_unique<flutter::FlutterPlatformViewsController>();
+  auto flutterPlatformViewsController =
+      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -175,12 +179,16 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                                /*raster=*/thread_task_runner,
                                /*ui=*/thread_task_runner,
                                /*io=*/thread_task_runner);
+  auto surface_factory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*ios_surface_factory=*/surface_factory,
       /*task_runners=*/runners);
 
-  auto flutterPlatformViewsController = std::make_unique<flutter::FlutterPlatformViewsController>();
+  auto flutterPlatformViewsController =
+      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -230,12 +238,16 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                                /*raster=*/thread_task_runner,
                                /*ui=*/thread_task_runner,
                                /*io=*/thread_task_runner);
+  auto surface_factory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*ios_surface_factory=*/surface_factory,
       /*task_runners=*/runners);
 
-  auto flutterPlatformViewsController = std::make_unique<flutter::FlutterPlatformViewsController>();
+  auto flutterPlatformViewsController =
+      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -301,12 +313,16 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                                /*raster=*/thread_task_runner,
                                /*ui=*/thread_task_runner,
                                /*io=*/thread_task_runner);
+  auto surface_factory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*ios_surface_factory=*/surface_factory,
       /*task_runners=*/runners);
 
-  auto flutterPlatformViewsController = std::make_unique<flutter::FlutterPlatformViewsController>();
+  auto flutterPlatformViewsController =
+      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -373,12 +389,16 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                                /*raster=*/thread_task_runner,
                                /*ui=*/thread_task_runner,
                                /*io=*/thread_task_runner);
+  auto surface_factory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*ios_surface_factory=*/surface_factory,
       /*task_runners=*/runners);
 
-  auto flutterPlatformViewsController = std::make_unique<flutter::FlutterPlatformViewsController>();
+  auto flutterPlatformViewsController =
+      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -445,12 +465,16 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                                /*raster=*/thread_task_runner,
                                /*ui=*/thread_task_runner,
                                /*io=*/thread_task_runner);
+  auto surface_factory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*ios_surface_factory=*/surface_factory,
       /*task_runners=*/runners);
 
-  auto flutterPlatformViewsController = std::make_unique<flutter::FlutterPlatformViewsController>();
+  auto flutterPlatformViewsController =
+      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -518,12 +542,16 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                                /*raster=*/thread_task_runner,
                                /*ui=*/thread_task_runner,
                                /*io=*/thread_task_runner);
+  auto surface_factory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*ios_surface_factory=*/surface_factory,
       /*task_runners=*/runners);
 
-  auto flutterPlatformViewsController = std::make_unique<flutter::FlutterPlatformViewsController>();
+  auto flutterPlatformViewsController =
+      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -129,8 +129,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*task_runners=*/runners);
 
   auto flutterPlatformViewsController =
-      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
-  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
+      std::make_shared<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController);
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -187,8 +187,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*task_runners=*/runners);
 
   auto flutterPlatformViewsController =
-      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
-  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
+      std::make_shared<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController);
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -246,8 +246,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*task_runners=*/runners);
 
   auto flutterPlatformViewsController =
-      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
-  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
+      std::make_shared<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController);
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -321,8 +321,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*task_runners=*/runners);
 
   auto flutterPlatformViewsController =
-      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
-  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
+      std::make_shared<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController);
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -397,8 +397,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*task_runners=*/runners);
 
   auto flutterPlatformViewsController =
-      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
-  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
+      std::make_shared<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController);
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -473,8 +473,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*task_runners=*/runners);
 
   auto flutterPlatformViewsController =
-      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
-  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
+      std::make_shared<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController);
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
@@ -550,8 +550,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       /*task_runners=*/runners);
 
   auto flutterPlatformViewsController =
-      std::make_unique<flutter::FlutterPlatformViewsController>(surface_factory);
-  surface_factory->SetPlatformViewsController(flutterPlatformViewsController.get());
+      std::make_shared<flutter::FlutterPlatformViewsController>(surface_factory);
+  surface_factory->SetPlatformViewsController(flutterPlatformViewsController);
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -61,6 +61,7 @@ void ResetAnchor(CALayer* layer);
 
 class IOSContextGL;
 class IOSSurface;
+class IOSSurfaceFactory;
 
 struct FlutterPlatformViewLayer {
   FlutterPlatformViewLayer(fml::scoped_nsobject<UIView> overlay_view,
@@ -87,7 +88,9 @@ struct FlutterPlatformViewLayer {
 // This class isn't thread safe.
 class FlutterPlatformViewLayerPool {
  public:
-  FlutterPlatformViewLayerPool() = default;
+  FlutterPlatformViewLayerPool(std::shared_ptr<IOSSurfaceFactory> ios_surface_factory)
+      : ios_surface_factory_(ios_surface_factory) {}
+
   ~FlutterPlatformViewLayerPool() = default;
 
   // Gets a layer from the pool if available, or allocates a new one.
@@ -118,12 +121,14 @@ class FlutterPlatformViewLayerPool {
   size_t available_layer_index_ = 0;
   std::vector<std::shared_ptr<FlutterPlatformViewLayer>> layers_;
 
+  const std::shared_ptr<IOSSurfaceFactory> ios_surface_factory_;
+
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterPlatformViewLayerPool);
 };
 
 class FlutterPlatformViewsController {
  public:
-  FlutterPlatformViewsController();
+  FlutterPlatformViewsController(std::shared_ptr<IOSSurfaceFactory> surface_factory);
 
   ~FlutterPlatformViewsController();
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -23,8 +23,9 @@ FlutterPlatformViewLayer::FlutterPlatformViewLayer(
 
 FlutterPlatformViewLayer::~FlutterPlatformViewLayer() = default;
 
-FlutterPlatformViewsController::FlutterPlatformViewsController()
-    : layer_pool_(std::make_unique<FlutterPlatformViewLayerPool>()),
+FlutterPlatformViewsController::FlutterPlatformViewsController(
+    std::shared_ptr<IOSSurfaceFactory> surface_factory)
+    : layer_pool_(std::make_unique<FlutterPlatformViewLayerPool>(surface_factory)),
       weak_factory_(std::make_unique<fml::WeakPtrFactory<FlutterPlatformViewsController>>(this)){};
 
 FlutterPlatformViewsController::~FlutterPlatformViewsController() = default;

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -32,7 +32,6 @@
 
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate
                           opaque:(BOOL)opaque NS_DESIGNATED_INITIALIZER;
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:(std::shared_ptr<flutter::IOSContext>)context;
 
 // Set by FlutterEngine or FlutterViewController to override software rendering.
 @property(class, nonatomic) BOOL forceSoftwareRendering;

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -83,15 +83,6 @@ static BOOL _forceSoftwareRendering;
       flutter::GetRenderingAPIForProcess(FlutterView.forceSoftwareRendering));
 }
 
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSContext>)ios_context {
-  return flutter::IOSSurface::Create(
-      std::move(ios_context),                              // context
-      fml::scoped_nsobject<CALayer>{[self.layer retain]},  // layer
-      [_delegate platformViewsController]                  // platform views controller
-  );
-}
-
 - (void)drawLayer:(CALayer*)layer inContext:(CGContextRef)context {
   TRACE_EVENT0("flutter", "SnapshotFlutterView");
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -137,6 +137,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   auto bridge =
       std::make_unique<flutter::AccessibilityBridge>(/*view=*/nil,
@@ -156,6 +157,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
@@ -182,6 +184,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
@@ -224,9 +227,12 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                                  /*raster=*/thread_task_runner,
                                  /*ui=*/thread_task_runner,
                                  /*io=*/thread_task_runner);
+
+    auto surfaceFactory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
     auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
         /*delegate=*/mock_delegate,
         /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+        /*ios_surface_factory=*/surfaceFactory,
         /*task_runners=*/runners);
     id mockFlutterView = OCMClassMock([FlutterView class]);
     id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
@@ -234,8 +240,9 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     std::string label = "some label";
 
     auto flutterPlatformViewsController =
-        std::make_shared<flutter::FlutterPlatformViewsController>();
+        std::make_shared<flutter::FlutterPlatformViewsController>(surfaceFactory);
     flutterPlatformViewsController->SetFlutterView(mockFlutterView);
+    surfaceFactory->SetPlatformViewsController(flutterPlatformViewsController.get());
 
     MockFlutterPlatformFactory* factory = [[MockFlutterPlatformFactory new] autorelease];
     flutterPlatformViewsController->RegisterViewFactory(
@@ -279,6 +286,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
@@ -516,6 +524,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
@@ -583,6 +592,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
   id mockFlutterView = OCMClassMock([FlutterView class]);
@@ -649,6 +659,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
   id mockFlutterView = OCMClassMock([FlutterView class]);
@@ -721,6 +732,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
   id mockFlutterView = OCMClassMock([FlutterView class]);
@@ -795,6 +807,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
   id mockFlutterView = OCMClassMock([FlutterView class]);
@@ -865,6 +878,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
@@ -932,6 +946,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   fml::AutoResetWaitableEvent latch;
   thread_task_runner->PostTask([&] {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -242,7 +242,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     auto flutterPlatformViewsController =
         std::make_shared<flutter::FlutterPlatformViewsController>(surfaceFactory);
     flutterPlatformViewsController->SetFlutterView(mockFlutterView);
-    surfaceFactory->SetPlatformViewsController(flutterPlatformViewsController.get());
+    surfaceFactory->SetPlatformViewsController(flutterPlatformViewsController);
 
     MockFlutterPlatformFactory* factory = [[MockFlutterPlatformFactory new] autorelease];
     flutterPlatformViewsController->RegisterViewFactory(
@@ -352,6 +352,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
@@ -435,6 +436,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware),
       /*task_runners=*/runners);
   id mockFlutterView = OCMClassMock([FlutterView class]);
   id mockFlutterViewController = OCMClassMock([FlutterViewController class]);

--- a/shell/platform/darwin/ios/ios_surface_factory.h
+++ b/shell/platform/darwin/ios/ios_surface_factory.h
@@ -1,0 +1,39 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS__SURFACE_FACTORY_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS__SURFACE_FACTORY_H_
+
+#include <memory>
+
+#import "flutter/shell/platform/darwin/ios/ios_surface.h"
+#import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
+
+namespace flutter {
+
+class IOSSurfaceFactory {
+ public:
+  static std::shared_ptr<IOSSurfaceFactory> Create(
+      IOSRenderingAPI rendering_api);
+
+  explicit IOSSurfaceFactory(std::shared_ptr<IOSContext> ios_context);
+
+  ~IOSSurfaceFactory();
+
+  void SetPlatformViewsController(
+      FlutterPlatformViewsController* platform_views_controller);
+
+  std::unique_ptr<IOSSurface> CreateSurface(
+      fml::scoped_nsobject<CALayer> ca_layer);
+
+ private:
+  FlutterPlatformViewsController* platform_views_controller_;
+  std::shared_ptr<IOSContext> ios_context_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceFactory);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS__SURFACE_FACTORY_H_

--- a/shell/platform/darwin/ios/ios_surface_factory.h
+++ b/shell/platform/darwin/ios/ios_surface_factory.h
@@ -22,13 +22,14 @@ class IOSSurfaceFactory {
   ~IOSSurfaceFactory();
 
   void SetPlatformViewsController(
-      FlutterPlatformViewsController* platform_views_controller);
+      const std::shared_ptr<FlutterPlatformViewsController>&
+          platform_views_controller);
 
   std::unique_ptr<IOSSurface> CreateSurface(
       fml::scoped_nsobject<CALayer> ca_layer);
 
  private:
-  FlutterPlatformViewsController* platform_views_controller_;
+  std::shared_ptr<FlutterPlatformViewsController> platform_views_controller_;
   std::shared_ptr<IOSContext> ios_context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceFactory);

--- a/shell/platform/darwin/ios/ios_surface_factory.mm
+++ b/shell/platform/darwin/ios/ios_surface_factory.mm
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/ios/ios_surface_factory.h"
+#import "flutter/shell/platform/darwin/ios/ios_context.h"
+
+namespace flutter {
+
+IOSSurfaceFactory::IOSSurfaceFactory(std::shared_ptr<IOSContext> ios_context)
+    : ios_context_(ios_context) {}
+
+std::shared_ptr<IOSSurfaceFactory> IOSSurfaceFactory::Create(IOSRenderingAPI rendering_api) {
+  std::shared_ptr<IOSContext> ios_context = IOSContext::Create(rendering_api);
+  return std::make_shared<IOSSurfaceFactory>(ios_context);
+}
+
+IOSSurfaceFactory::~IOSSurfaceFactory() = default;
+
+void IOSSurfaceFactory::SetPlatformViewsController(
+    FlutterPlatformViewsController* platform_views_controller) {
+  platform_views_controller_ = platform_views_controller;
+}
+
+std::unique_ptr<IOSSurface> IOSSurfaceFactory::CreateSurface(
+    fml::scoped_nsobject<CALayer> ca_layer) {
+  return flutter::IOSSurface::Create(ios_context_, ca_layer, platform_views_controller_);
+}
+
+}  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_factory.mm
+++ b/shell/platform/darwin/ios/ios_surface_factory.mm
@@ -18,7 +18,7 @@ std::shared_ptr<IOSSurfaceFactory> IOSSurfaceFactory::Create(IOSRenderingAPI ren
 IOSSurfaceFactory::~IOSSurfaceFactory() = default;
 
 void IOSSurfaceFactory::SetPlatformViewsController(
-    FlutterPlatformViewsController* platform_views_controller) {
+    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller) {
   platform_views_controller_ = platform_views_controller;
 }
 

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -19,6 +19,7 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/platform_message_router.h"
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
+#import "flutter/shell/platform/darwin/ios/ios_surface_factory.h"
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 
 @class FlutterViewController;
@@ -41,6 +42,7 @@ class PlatformViewIOS final : public PlatformView {
  public:
   explicit PlatformViewIOS(PlatformView::Delegate& delegate,
                            IOSRenderingAPI rendering_api,
+                           std::shared_ptr<IOSSurfaceFactory> surface_factory,
                            flutter::TaskRunners task_runners);
 
   ~PlatformViewIOS() override;
@@ -124,6 +126,7 @@ class PlatformViewIOS final : public PlatformView {
   std::mutex ios_surface_mutex_;
   std::unique_ptr<IOSSurface> ios_surface_;
   std::shared_ptr<IOSContext> ios_context_;
+  std::shared_ptr<IOSSurfaceFactory> ios_surface_factory_;
   PlatformMessageRouter platform_message_router_;
   AccessibilityBridgePtr accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
+#include <memory>
 
 #include <utility>
 
@@ -46,9 +47,11 @@ void PlatformViewIOS::AccessibilityBridgePtr::reset(AccessibilityBridge* bridge)
 
 PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate,
                                  IOSRenderingAPI rendering_api,
+                                 std::shared_ptr<IOSSurfaceFactory> surface_factory,
                                  flutter::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)),
       ios_context_(IOSContext::Create(rendering_api)),
+      ios_surface_factory_(surface_factory),
       accessibility_bridge_([this](bool enabled) { PlatformView::SetSemanticsEnabled(enabled); }) {}
 
 PlatformViewIOS::~PlatformViewIOS() = default;
@@ -102,8 +105,9 @@ void PlatformViewIOS::attachView() {
   FML_DCHECK(owner_controller_.get().isViewLoaded)
       << "FlutterViewController's view should be loaded "
          "before attaching to PlatformViewIOS.";
-  ios_surface_ =
-      [static_cast<FlutterView*>(owner_controller_.get().view) createSurface:ios_context_];
+  auto flutter_view = static_cast<FlutterView*>(owner_controller_.get().view);
+  auto ca_layer = fml::scoped_nsobject<CALayer>{[[flutter_view layer] retain]};
+  ios_surface_ = ios_surface_factory_->CreateSurface(ca_layer);
   FML_DCHECK(ios_surface_ != nullptr);
 
   if (accessibility_bridge_) {

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -332,6 +332,7 @@
 /* Begin XCBuildConfiguration section */
 		0D6AB6D022BB05E200EEE540 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -391,6 +392,7 @@
 		};
 		0D6AB6D122BB05E200EEE540 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -484,7 +486,6 @@
 		};
 		0D6AB6D622BB05E200EEE540 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
@@ -528,7 +529,6 @@
 		};
 		0D6AB6D722BB05E200EEE540 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
@@ -28,6 +28,13 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       systemAttachmentLifetime = "keepNever">
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/testing/ios/IosUnitTests/README.md
+++ b/testing/ios/IosUnitTests/README.md
@@ -9,7 +9,7 @@ also run in LUCI builds.
 testing/run_tests.py [--type=objc]
 ```
 
-After the `ios_flutter_test` target is built you can also run the tests inside
+After the `ios_test_flutter` target is built you can also run the tests inside
 of Xcode with `testing/ios/IosUnitTests/IosUnitTests.xcodeproj`. If you
 modify the test or under-test files, you'll have to run `run_tests.py` again.
 
@@ -17,5 +17,5 @@ modify the test or under-test files, you'll have to run `run_tests.py` again.
 
 When you add a new unit test file, also add a reference to that file in
 shell/platform/darwin/ios/BUILD.gn, under the `sources` list of the
-`ios_flutter_test` target. Once it's there, it will execute with the other
+`ios_test_flutter` target. Once it's there, it will execute with the other
 tests.


### PR DESCRIPTION
This refactor is to enable the separation of Surface from External View Embedder. As it stands Surface has `GetExternalViewEmbedder` which inturn has the ability to create surfaces. This refactor enables us to separate these concepts.

This is driven by the goal to share some components between ios and macOS.