### PR TITLE
Allow parse_and_send to use access tokens

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,16 +40,9 @@ task:
         ninja -C out/host_release
       benchmark_host_script: |
         cd $ENGINE_PATH/src/out/host_release/
-        ./txt_benchmarks --benchmark_format=json > txt_benchmarks.json
-        ./fml_benchmarks --benchmark_format=json > fml_benchmarks.json
-        ./shell_benchmarks --benchmark_format=json > shell_benchmarks.json
-        ./ui_benchmarks --benchmark_format=json > ui_benchmarks.json
+        $ENGINE_PATH/src/flutter/testing/benchmark/generate_metrics.sh
         cd $ENGINE_PATH/src/flutter/testing/benchmark
-        pub get
-        dart bin/parse_and_send.dart ../../../out/host_release/txt_benchmarks.json
-        dart bin/parse_and_send.dart ../../../out/host_release/fml_benchmarks.json
-        dart bin/parse_and_send.dart ../../../out/host_release/shell_benchmarks.json
-        dart bin/parse_and_send.dart ../../../out/host_release/ui_benchmarks.json
+        upload_metrics.sh
 
     # The following test depends on Flutter framework repo. It may fail if the
     # framework repo is currently broken.

--- a/testing/benchmark/bin/parse_and_send.dart
+++ b/testing/benchmark/bin/parse_and_send.dart
@@ -44,12 +44,13 @@ Future<FlutterDestination> connectFlutterDestination() async {
   final Map<String, String> env = Platform.environment;
   if (env.containsKey(kTokenPath) && env.containsKey(kGcpProject)) {
     return FlutterDestination.makeFromAccessToken(
-      env[kTokenPath],
+      File(env[kTokenPath]).readAsStringSync(),
       env[kGcpProject],
     );
   }
   return await FlutterDestination.makeFromCredentialsJson(
-    jsonDecode(Platform.environment['BENCHMARK_GCP_CREDENTIALS']) as Map<String, dynamic>,
+    jsonDecode(Platform.environment['BENCHMARK_GCP_CREDENTIALS'])
+        as Map<String, dynamic>,
   );
 }
 

--- a/testing/benchmark/bin/parse_and_send.dart
+++ b/testing/benchmark/bin/parse_and_send.dart
@@ -38,18 +38,32 @@ Future<List<FlutterEngineMetricPoint>> _parse(String jsonFileName) async {
   return points;
 }
 
+Future<FlutterDestination> connectFlutterDestination() async {
+  const String kTokenPath = 'TOKEN_PATH';
+  const String kGcpProject = 'GCP_PROJECT';
+  final Map<String, String> env = Platform.environment;
+  if (env.containsKey(kTokenPath) && env.containsKey(kGcpProject)) {
+    return FlutterDestination.makeFromAccessToken(
+      env[kTokenPath],
+      env[kGcpProject],
+    );
+  }
+  return await FlutterDestination.makeFromCredentialsJson(
+    jsonDecode(Platform.environment['BENCHMARK_GCP_CREDENTIALS']) as Map<String, dynamic>,
+  );
+}
+
 Future<void> main(List<String> args) async {
   if (args.length != 1) {
     throw 'Must have one argument: <benchmark_json_file>';
   }
   final List<FlutterEngineMetricPoint> points = await _parse(args[0]);
+
   // The data will be sent to the Datastore of the GCP project specified through
-  // environment variable BENCHMARK_GCP_CREDENTIALS. The engine Cirrus job has
-  // currently configured the GCP project to flutter-cirrus for test. We'll
-  // eventually migrate to flutter-infra project once the test is done.
-  final FlutterDestination destination =
-      await FlutterDestination.makeFromCredentialsJson(
-    jsonDecode(Platform.environment['BENCHMARK_GCP_CREDENTIALS']),
-  );
+  // environment variable BENCHMARK_GCP_CREDENTIALS, or TOKEN_PATH/GCP_PROJECT.
+  // The engine Cirrus job has currently configured the GCP project to
+  // flutter-cirrus for test. We'll eventually migrate to flutter-infra project
+  // once the test is done.
+  final FlutterDestination destination = await connectFlutterDestination();
   await destination.update(points);
 }

--- a/testing/benchmark/test/parse_and_send_test.dart
+++ b/testing/benchmark/test/parse_and_send_test.dart
@@ -38,12 +38,13 @@ void main() {
     final String tokenPath =
         path.join(Directory.systemTemp.absolute.path, 'parse_and_send_token');
     File(tokenPath).writeAsStringSync(client.credentials.accessToken.data);
-    Process.runSync('dart', <String>[
+    final ProcessResult result = Process.runSync('dart', <String>[
       'bin/parse_and_send.dart',
       'example/txt_benchmarks.json',
     ], environment: <String, String>{
       'TOKEN_PATH': tokenPath,
       'GCP_PROJECT': testCred['project_id'] as String,
     });
+    expect(result.exitCode, 0);
   });
 }

--- a/testing/benchmark/test/parse_and_send_test.dart
+++ b/testing/benchmark/test/parse_and_send_test.dart
@@ -3,12 +3,16 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:gcloud/src/datastore_impl.dart';
+import 'package:googleapis_auth/auth_io.dart';
+import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 void main() {
-  // In order to run this test, one should download a service account
+  // In order to run these tests, one should download a service account
   // credentials json from a test GCP project, and put that json as
   // `secret/test_gcp_credentials.json`. There's a `flutter-test` project for
   // Flutter team members.
@@ -20,6 +24,26 @@ void main() {
       'example/txt_benchmarks.json',
     ], environment: <String, String>{
       'BENCHMARK_GCP_CREDENTIALS': testCred,
+    });
+  });
+
+  test('parse_and_send succeeds with access token.', () async {
+    final dynamic testCred =
+        jsonDecode(File('secret/test_gcp_credentials.json').readAsStringSync())
+            as Map<String, dynamic>;
+    final AutoRefreshingAuthClient client = await clientViaServiceAccount(
+      ServiceAccountCredentials.fromJson(testCred),
+      DatastoreImpl.SCOPES,
+    );
+    final String tokenPath =
+        path.join(Directory.systemTemp.absolute.path, 'parse_and_send_token');
+    File(tokenPath).writeAsStringSync(client.credentials.accessToken.data);
+    Process.runSync('dart', <String>[
+      'bin/parse_and_send.dart',
+      'example/txt_benchmarks.json',
+    ], environment: <String, String>{
+      'TOKEN_PATH': tokenPath,
+      'GCP_PROJECT': testCred['project_id'] as String,
     });
   });
 }


### PR DESCRIPTION
Related issue: https://github.com/flutter/flutter/issues/67579

This change depends on https://github.com/liyuqian/metrics_center/commit/395a4593cbc3be2031e8aeeff1573066b788bac3