### PR TITLE
Ensure root isolate create callback is invoked before the isolate is in the running phase.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -59,6 +59,8 @@ using MappingsCallback = std::function<Mappings(void)>;
 
 using FrameRasterizedCallback = std::function<void(const FrameTiming&)>;
 
+class DartIsolate;
+
 struct Settings {
   Settings();
 
@@ -169,7 +171,9 @@ struct Settings {
   TaskObserverRemove task_observer_remove;
   // The main isolate is current when this callback is made. This is a good spot
   // to perform native Dart bindings for libraries not built in.
-  fml::closure root_isolate_create_callback;
+  std::function<void(const DartIsolate&)> root_isolate_create_callback;
+  // TODO(68738): Update isolate callbacks in settings to accept an additional
+  // DartIsolate parameter.
   fml::closure isolate_create_callback;
   // The isolate is not current and may have already been destroyed when this
   // call is made.

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -148,19 +148,19 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRunningRootIsolate(
     return {};
   }
 
-  if (!isolate->RunFromLibrary(dart_entrypoint_library,               //
-                               dart_entrypoint,                       //
-                               settings.dart_entrypoint_args,         //
-                               settings.root_isolate_create_callback  //
+  if (settings.root_isolate_create_callback) {
+    // Isolate callbacks always occur in isolate scope and before user code has
+    // had a chance to run.
+    tonic::DartState::Scope scope(isolate.get());
+    settings.root_isolate_create_callback(*isolate.get());
+  }
+
+  if (!isolate->RunFromLibrary(dart_entrypoint_library,       //
+                               dart_entrypoint,               //
+                               settings.dart_entrypoint_args  //
                                )) {
     FML_LOG(ERROR) << "Could not run the run main Dart entrypoint.";
     return {};
-  }
-
-  if (settings.root_isolate_create_callback) {
-    // Isolate callbacks always occur in isolate scope.
-    tonic::DartState::Scope scope(isolate.get());
-    settings.root_isolate_create_callback();
   }
 
   if (settings.root_isolate_shutdown_callback) {
@@ -617,8 +617,7 @@ bool DartIsolate::MarkIsolateRunnable() {
 
 bool DartIsolate::RunFromLibrary(std::optional<std::string> library_name,
                                  std::optional<std::string> entrypoint,
-                                 const std::vector<std::string>& args,
-                                 const fml::closure& on_run) {
+                                 const std::vector<std::string>& args) {
   TRACE_EVENT0("flutter", "DartIsolate::RunFromLibrary");
   if (phase_ != Phase::Ready) {
     return false;
@@ -644,9 +643,6 @@ bool DartIsolate::RunFromLibrary(std::optional<std::string> library_name,
 
   phase_ = Phase::Running;
 
-  if (on_run) {
-    on_run();
-  }
   return true;
 }
 

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -342,20 +342,14 @@ class DartIsolate : public UIDartState {
   ///                           supplied entrypoint.
   /// @param[in]  entrypoint    The entrypoint in `library_name`
   /// @param[in]  args          A list of string arguments to the entrypoint.
-  /// @param[in]  on_run        A callback to run in isolate scope after the
-  ///                           main entrypoint has been invoked. There is no
-  ///                           isolate scope current on the thread once this
-  ///                           method returns.
   ///
   /// @return     If the isolate successfully transitioned to the running phase
   ///             and the main entrypoint was invoked.
   ///
   [[nodiscard]] bool RunFromLibrary(std::optional<std::string> library_name,
                                     std::optional<std::string> entrypoint,
-                                    const std::vector<std::string>& args,
-                                    const fml::closure& on_run = nullptr);
+                                    const std::vector<std::string>& args);
 
- public:
   //----------------------------------------------------------------------------
   /// @brief      Transition the isolate to the `Phase::Shutdown` phase. The
   ///             only thing left to do is to collect the isolate.

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -841,9 +841,8 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
   if (SAFE_ACCESS(args, root_isolate_create_callback, nullptr) != nullptr) {
     VoidCallback callback =
         SAFE_ACCESS(args, root_isolate_create_callback, nullptr);
-    settings.root_isolate_create_callback = [callback, user_data]() {
-      callback(user_data);
-    };
+    settings.root_isolate_create_callback =
+        [callback, user_data](const auto& isolate) { callback(user_data); };
   }
 
   flutter::PlatformViewEmbedder::UpdateSemanticsNodesCallback


### PR DESCRIPTION
Embedders that have access to the Dart native API (only Fuchsia now) may perform
library setup in the isolate create callback. The engine used to depend on the
fact the root isolate entrypoint is invoked in the next iteration of message
loop (via the `_startIsolate` trampoline in `isolate_patch.dart`) to ensure that
library setup occur before the main entrypoint was invoked. However, due to
differences in the way in which message loops are setup in Fuchsia, this
entrypoint was run before the callback could be executed. Dart code on Fuchsia
also has the ability to access the underlying event loops directly. This patch
moves the invocation of the create callback to before user dart code has a
chance to run. This difference in behavior on Fuchsia became an issue when the
isolate initialization was reworked in https://github.com/flutter/engine/pull/21820
for null-safety.

Another issue was discovered in that the callback was being invoked twice, I
fixed that too and added a test.

Fixes https://github.com/flutter/flutter/issues/68732