### PR TITLE
add a bitmap/render hint to transform layers

### DIFF
--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -83,13 +83,14 @@ void ContainerLayer::PaintChildren(PaintContext& context) const {
   }
 }
 
-void ContainerLayer::TryToPrepareRasterCache(PrerollContext* context,
+bool ContainerLayer::TryToPrepareRasterCache(PrerollContext* context,
                                              Layer* layer,
                                              const SkMatrix& matrix) {
   if (!context->has_platform_view && context->raster_cache &&
       SkRect::Intersects(context->cull_rect, layer->paint_bounds())) {
-    context->raster_cache->Prepare(context, layer, matrix);
+    return context->raster_cache->Prepare(context, layer, matrix);
   }
+  return false;
 }
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -43,10 +43,12 @@ class ContainerLayer : public Layer {
   // 2. The context does not have a valid raster cache.
   // 3. The layer's paint bounds does not intersect with the cull rect.
   //
+  // The function returns true iff the rasterization succeeded.
+  //
   // We make this a static function instead of a member function that directy
   // uses the "this" pointer as the layer because we sometimes need to raster
   // cache a child layer and one can't access its child's protected method.
-  static void TryToPrepareRasterCache(PrerollContext* context,
+  static bool TryToPrepareRasterCache(PrerollContext* context,
                                       Layer* layer,
                                       const SkMatrix& matrix);
 

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -40,6 +40,9 @@ static constexpr SkRect kGiantRect = SkRect::MakeLTRB(-1E9F, -1E9F, 1E9F, 1E9F);
 // This should be an exact copy of the Clip enum in painting.dart.
 enum Clip { none, hardEdge, antiAlias, antiAliasWithSaveLayer };
 
+// This should be an exact copy of the TransformMethod enum in painting.dart.
+enum TransformMethod { render, bitmapTransform };
+
 struct PrerollContext {
   RasterCache* raster_cache;
   GrDirectContext* gr_context;

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -8,8 +8,9 @@
 
 namespace flutter {
 
-TransformLayer::TransformLayer(const SkMatrix& transform)
-    : transform_(transform) {
+TransformLayer::TransformLayer(const SkMatrix& transform,
+                               TransformMethod transform_method)
+    : transform_(transform), transform_method_(transform_method) {
   // Checks (in some degree) that SkMatrix transform_ is valid and initialized.
   //
   // If transform_ is uninitialized, this assert may look flaky as it doesn't
@@ -29,15 +30,28 @@ TransformLayer::TransformLayer(const SkMatrix& transform)
 void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "TransformLayer::Preroll");
 
+  SkRect previous_cull_rect = context->cull_rect;
+
+  if (transform_method_ == TransformMethod::bitmapTransform) {
+    context->cull_rect = kGiantRect;
+    SkRect child_paint_bounds = SkRect::MakeEmpty();
+    PrerollChildren(context, matrix, &child_paint_bounds);
+    if (TryToPrepareRasterCache(context, GetCacheableChild(), matrix)) {
+      transform_.mapRect(&child_paint_bounds);
+      set_paint_bounds(child_paint_bounds);
+      context->cull_rect = previous_cull_rect;
+      return;
+    }
+  }
+
   SkMatrix child_matrix;
   child_matrix.setConcat(matrix, transform_);
   context->mutators_stack.PushTransform(transform_);
-  SkRect previous_cull_rect = context->cull_rect;
-  SkMatrix inverse_transform_;
+  SkMatrix inverse_transform;
   // Perspective projections don't produce rectangles that are useful for
   // culling for some reason.
-  if (!transform_.hasPerspective() && transform_.invert(&inverse_transform_)) {
-    inverse_transform_.mapRect(&context->cull_rect);
+  if (!transform_.hasPerspective() && transform_.invert(&inverse_transform)) {
+    inverse_transform.mapRect(&context->cull_rect, previous_cull_rect);
   } else {
     context->cull_rect = kGiantRect;
   }
@@ -71,6 +85,14 @@ void TransformLayer::UpdateScene(SceneUpdateContext& context) {
 void TransformLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "TransformLayer::Paint");
   FML_DCHECK(needs_painting());
+
+  if (transform_method_ == TransformMethod::bitmapTransform &&
+      context.raster_cache &&
+      context.raster_cache->DrawTransformed(
+          GetCacheableChild(), *context.internal_nodes_canvas, transform_)) {
+    TRACE_EVENT_INSTANT0("flutter", "raster cache hit");
+    return;
+  }
 
   SkAutoCanvasRestore save(context.internal_nodes_canvas, true);
   context.internal_nodes_canvas->concat(transform_);

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -11,9 +11,10 @@ namespace flutter {
 
 // Be careful that SkMatrix's default constructor doesn't initialize the matrix
 // at all. Hence |set_transform| must be called with an initialized SkMatrix.
-class TransformLayer : public ContainerLayer {
+class TransformLayer : public MergedContainerLayer {
  public:
-  TransformLayer(const SkMatrix& transform);
+  TransformLayer(const SkMatrix& transform,
+                 TransformMethod transform_method = TransformMethod::render);
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
@@ -25,6 +26,7 @@ class TransformLayer : public ContainerLayer {
 
  private:
   SkMatrix transform_;
+  TransformMethod transform_method_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TransformLayer);
 };

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -35,6 +35,52 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   canvas.drawImage(image_, bounds.fLeft, bounds.fTop, paint);
 }
 
+void RasterCacheResult::drawTransformed(SkCanvas& canvas,
+                                        const SkMatrix& matrix) const {
+  TRACE_EVENT0("flutter", "RasterCacheResult::drawTransformed");
+  SkAutoCanvasRestore auto_restore(&canvas, true);
+  SkIRect bounds =
+      RasterCache::GetDeviceBounds(logical_rect_, canvas.getTotalMatrix());
+  FML_DCHECK(
+      std::abs(bounds.size().width() - image_->dimensions().width()) <= 1 &&
+      std::abs(bounds.size().height() - image_->dimensions().height()) <= 1);
+
+  SkPoint cache_corners[3];
+  cache_corners[0] = SkPoint::Make(bounds.fLeft, bounds.fTop);
+  cache_corners[1] = SkPoint::Make(bounds.fRight, bounds.fTop);
+  cache_corners[2] = SkPoint::Make(bounds.fLeft, bounds.fBottom);
+  // cache_corners are device coordinates of where the cache entry
+  // would have been drawn if we were still using the canvas matrix.
+  // 3 corners are enough to precisely locate the image in an
+  // affine coordinate system (and we would not be caching the
+  // children if the coordinate system was not affine).
+
+  SkMatrix cache_render_matrix;
+  bool invert_success = canvas.getTotalMatrix().invert(&cache_render_matrix);
+  FML_DCHECK(invert_success);
+  SkPoint render_corners[3];
+  cache_render_matrix.mapPoints(render_corners, cache_corners, 3);
+  // render_corners are now the location of the cached image corners
+  // mapped back to the coordinate space of the canvas.
+
+  // Now we look at what would have happened if we were rendering the
+  // child with the specified matrix in addition to the canvas matrix.
+  // We take the location of the cached image in the child coordinate
+  // space (specified by 3 of its corners) and see where those points
+  // would be drawn in device space with the new transform.
+  matrix.mapPoints(render_corners, 3);
+  // render_corners are now relative to the canvas transform.
+  canvas.getTotalMatrix().mapPoints(render_corners, 3);
+  // render_corners are now the device space locations of those same
+  // corners, had they been rendered under the new canvas + matrix
+  cache_render_matrix.setPolyToPoly(cache_corners, render_corners, 3);
+  // cache_render_matrix now maps the original device space corners
+  // to the new device rendering locations of those same corners
+
+  canvas.setMatrix(cache_render_matrix);
+  canvas.drawImage(image_, bounds.fLeft, bounds.fTop, nullptr);
+}
+
 RasterCache::RasterCache(size_t access_threshold,
                          size_t picture_cache_limit_per_frame)
     : access_threshold_(access_threshold),
@@ -135,7 +181,7 @@ std::unique_ptr<RasterCacheResult> RasterCache::RasterizePicture(
                    [=](SkCanvas* canvas) { canvas->drawPicture(picture); });
 }
 
-void RasterCache::Prepare(PrerollContext* context,
+bool RasterCache::Prepare(PrerollContext* context,
                           Layer* layer,
                           const SkMatrix& ctm) {
   LayerRasterCacheKey cache_key(layer->unique_id(), ctm);
@@ -145,6 +191,7 @@ void RasterCache::Prepare(PrerollContext* context,
   if (!entry.image) {
     entry.image = RasterizeLayer(context, layer, ctm, checkerboard_images_);
   }
+  return entry.image.get();
 }
 
 std::unique_ptr<RasterCacheResult> RasterCache::RasterizeLayer(
@@ -255,6 +302,27 @@ bool RasterCache::Draw(const Layer* layer,
 
   if (entry.image) {
     entry.image->draw(canvas, paint);
+    return true;
+  }
+
+  return false;
+}
+
+bool RasterCache::DrawTransformed(const Layer* layer,
+                                  SkCanvas& canvas,
+                                  const SkMatrix& matrix) const {
+  LayerRasterCacheKey cache_key(layer->unique_id(), canvas.getTotalMatrix());
+  auto it = layer_cache_.find(cache_key);
+  if (it == layer_cache_.end()) {
+    return false;
+  }
+
+  Entry& entry = it->second;
+  entry.access_count++;
+  entry.used_this_frame = true;
+
+  if (entry.image) {
+    entry.image->drawTransformed(canvas, matrix);
     return true;
   }
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -24,6 +24,8 @@ class RasterCacheResult {
 
   virtual void draw(SkCanvas& canvas, const SkPaint* paint) const;
 
+  virtual void drawTransformed(SkCanvas& canvas, const SkMatrix& matrix) const;
+
   virtual SkISize image_dimensions() const {
     return image_ ? image_->dimensions() : SkISize::Make(0, 0);
   };
@@ -139,7 +141,7 @@ class RasterCache {
                bool is_complex,
                bool will_change);
 
-  void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
+  bool Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
 
   // Find the raster cache for the picture and draw it to the canvas.
   //
@@ -155,6 +157,14 @@ class RasterCache {
   bool Draw(const Layer* layer,
             SkCanvas& canvas,
             SkPaint* paint = nullptr) const;
+
+  // Find the raster cache for the layer and draw it to the canvas with the
+  // specified transform.
+  //
+  // Return true if the layer raster cache is found and drawn.
+  bool DrawTransformed(const Layer* layer,
+                       SkCanvas& canvas,
+                       const SkMatrix& matrix) const;
 
   void SweepAfterFrame();
 

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -281,18 +281,19 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// See [pop] for details about the operation stack.
   TransformEngineLayer? pushTransform(
     Float64List matrix4, {
+    TransformMethod transformMethod = TransformMethod.render,
     TransformEngineLayer? oldLayer,
   }) {
     assert(_matrix4IsValid(matrix4));
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushTransform'));
     final EngineLayer engineLayer = EngineLayer._();
-    _pushTransform(engineLayer, matrix4);
+    _pushTransform(engineLayer, matrix4, transformMethod.index);
     final TransformEngineLayer layer = TransformEngineLayer._(engineLayer);
     assert(_debugPushLayer(layer));
     return layer;
   }
 
-  void _pushTransform(EngineLayer layer, Float64List matrix4) native 'SceneBuilder_pushTransform';
+  void _pushTransform(EngineLayer layer, Float64List matrix4, int method) native 'SceneBuilder_pushTransform';
 
   /// Pushes an offset operation onto the operation stack.
   ///

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -90,9 +90,13 @@ SceneBuilder::SceneBuilder() {
 SceneBuilder::~SceneBuilder() = default;
 
 void SceneBuilder::pushTransform(Dart_Handle layer_handle,
-                                 tonic::Float64List& matrix4) {
+                                 tonic::Float64List& matrix4,
+                                 int transformMethod) {
   SkMatrix sk_matrix = ToSkMatrix(matrix4);
-  auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix);
+  flutter::TransformMethod transform_method =
+      static_cast<flutter::TransformMethod>(transformMethod);
+  auto layer =
+      std::make_shared<flutter::TransformLayer>(sk_matrix, transform_method);
   PushLayer(layer);
   // matrix4 has to be released before we can return another Dart object
   matrix4.Release();

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -37,7 +37,9 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   }
   ~SceneBuilder() override;
 
-  void pushTransform(Dart_Handle layer_handle, tonic::Float64List& matrix4);
+  void pushTransform(Dart_Handle layer_handle,
+                     tonic::Float64List& matrix4,
+                     int tranformMethod);
   void pushOffset(Dart_Handle layer_handle, double dx, double dy);
   void pushClipRect(Dart_Handle layer_handle,
                     double left,

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1038,6 +1038,17 @@ enum Clip {
   antiAliasWithSaveLayer,
 }
 
+/// A suggestion on how to apply a matrix transform to widget contents.
+enum TransformMethod {
+  /// The contents will be rendered with the transform matrix.
+  render,
+
+  /// The contents will be rendered under some other more general transform
+  /// (typical an identity transform) and then the resulting rendered
+  /// bitmap will be transformed into place using a texture operation.
+  bitmapTransform,
+}
+
 /// A description of the style to use when drawing on a [Canvas].
 ///
 /// Most APIs on [Canvas] take a [Paint] object to describe the style

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -210,6 +210,7 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   @override
   ui.TransformEngineLayer? pushTransform(
     Float64List matrix4, {
+    ui.TransformMethod transformMethod = ui.TransformMethod.render,
     ui.EngineLayer? oldLayer,
   }) {
     final Matrix4 matrix = Matrix4.fromFloat32List(toMatrix32(matrix4));

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -76,6 +76,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   @override
   ui.TransformEngineLayer pushTransform(
     Float64List matrix4, {
+    ui.TransformMethod transformMethod = ui.TransformMethod.render,
     ui.TransformEngineLayer? oldLayer,
   }) {
     if (matrix4.length != 16) {

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -47,6 +47,7 @@ abstract class SceneBuilder {
   });
   TransformEngineLayer? pushTransform(
     Float64List matrix4, {
+    TransformMethod transformMethod = TransformMethod.render,
     TransformEngineLayer? oldLayer,
   });
   ClipRectEngineLayer? pushClipRect(

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -229,6 +229,11 @@ enum Clip {
   antiAliasWithSaveLayer,
 }
 
+enum TransformMethod {
+  render,
+  bitmapTransform,
+}
+
 abstract class Paint {
   factory Paint() => engine.experimentalUseSkia ? engine.CkPaint() : engine.SurfacePaint();
   static bool enableDithering = false;


### PR DESCRIPTION
This PR offers essentially identical performance for animated transforms to a prior PR (https://github.com/flutter/engine/pull/21943) but uses a different mechanism to trigger the performance tradeoff. Please read the description of that PR for an overall description of the problem and the benefits of having the caching being performed by the Transform layers themselves.

These engine changes will eventually enable fixing flutter/flutter#24627

An additional PR for the Framework repo will be required to use these changes, but the new property I added here should be backwards compatible to existing Frameworks as it defaults to the compatibility value (`TransformMethod.render`).

In this solution a "method" hint is added to the transform layers to indicate whether they should use the transform for rendering the child, or to transform the bitmap representation of the child.

See the `TransformMethod` enums (one in Dart and one in C++) for the reference for the API. I would especially like feedback on the naming of the enum and its values. This is logically similar to the `Clip` enum used for the `clipBehavior` properties of the clip layers in that it suggest how to apply the operation. I'll note that I never liked the name `Clip` for the behavior enum for the clipping since it sounds like it is a definition of the clip rather than a suggestion on how to apply it. In this case, it would be inappropriate to name this new enum `Transform` since that is identical to the name of the widget where it will be used, so the naming had to diverge from the `Clip` model.

In the previous PR, the developer could specify a custom transform for caching the child, but in this PR the transform for caching will always be the transform inherited from the ancestor layers. The developer can still achieve control over the transform that the child is cached with by decomposing the transform being animated into a static part applied to the child, and a dynamic part applied as a bitmap to the statically transformed child by nesting two transform layers and only applying the bitmap hint to the outer transform. That nesting technique will not likely be used often except for cases like animating a scale from A to B where the developer may want to cache the child at the larger of (A,B) and then have the outer animating transform be the ratio difference (animating from A/B->1.0, or 1.0->B/A).

The performance is nearly identical to the previous PR, but it seems that I more often get lucky and have the performance of the "cached Transform" animation be closer to ~6.5ms, though the difference is within the margin of error since if I play with the test app for a bit, then sometimes it will perform closer to the ~7ms that I saw with the prior solution. I don't think this is significant other than to point out that this solution performs no worse than the previous solution. If it really is better in the long run, then that would have to be established by collecting benchmark data over time.

Since the API has changed, there is a new test app required which can be seen at this gist: https://gist.github.com/flar/41dbec4b5a610c61c40fa77ce2156b56