### PR TITLE
Includes roles for links, checkboxes, and radio buttons in semantics

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -160,6 +160,10 @@ fuchsia::accessibility::semantics::Role AccessibilityBridge::GetNodeRole(
     return fuchsia::accessibility::semantics::Role::TEXT_FIELD;
   }
 
+  if (node.HasFlag(flutter::SemanticsFlags::kIsLink)) {
+    return fuchsia::accessibility::semantics::Role::LINK;
+  }
+
   if (node.HasFlag(flutter::SemanticsFlags::kIsSlider)) {
     return fuchsia::accessibility::semantics::Role::SLIDER;
   }
@@ -170,6 +174,7 @@ fuchsia::accessibility::semantics::Role AccessibilityBridge::GetNodeRole(
   if (node.HasFlag(flutter::SemanticsFlags::kIsImage)) {
     return fuchsia::accessibility::semantics::Role::IMAGE;
   }
+
   // If a flutter node supports the kIncrease or kDecrease actions, it can be
   // treated as a slider control by assistive technology. This is important
   // because users have special gestures to deal with sliders, and Fuchsia API
@@ -178,6 +183,18 @@ fuchsia::accessibility::semantics::Role AccessibilityBridge::GetNodeRole(
       node.HasAction(flutter::SemanticsAction::kDecrease)) {
     return fuchsia::accessibility::semantics::Role::SLIDER;
   }
+
+  // If a flutter node has a checked state, then we assume it is either a
+  // checkbox or a radio button. We distinguish between checkboxes and
+  // radio buttons based on membership in a mutually exclusive group.
+  if (node.HasFlag(flutter::SemanticsFlags::kHasCheckedState)) {
+    if (node.HasFlag(flutter::SemanticsFlags::kIsInMutuallyExclusiveGroup)) {
+      return fuchsia::accessibility::semantics::Role::RADIO_BUTTON;
+    } else {
+      return fuchsia::accessibility::semantics::Role::CHECK_BOX;
+    }
+  }
+
   return fuchsia::accessibility::semantics::Role::UNKNOWN;
 }
 

--- a/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
@@ -109,8 +109,8 @@ TEST_F(AccessibilityBridgeTest, UpdatesNodeRoles) {
   flutter::SemanticsNode node0;
   node0.id = 0;
   node0.flags |= static_cast<int>(flutter::SemanticsFlags::kIsButton);
-  node0.childrenInTraversalOrder = {1, 2, 3, 4};
-  node0.childrenInHitTestOrder = {1, 2, 3, 4};
+  node0.childrenInTraversalOrder = {1, 2, 3, 4, 5, 6, 7};
+  node0.childrenInHitTestOrder = {1, 2, 3, 4, 5, 6, 7};
   updates.emplace(0, node0);
 
   flutter::SemanticsNode node1;
@@ -141,6 +141,29 @@ TEST_F(AccessibilityBridgeTest, UpdatesNodeRoles) {
   node4.flags |= static_cast<int>(flutter::SemanticsFlags::kIsSlider);
   updates.emplace(4, node4);
 
+  flutter::SemanticsNode node5;
+  node5.childrenInTraversalOrder = {};
+  node5.childrenInHitTestOrder = {};
+  node5.id = 5;
+  node5.flags |= static_cast<int>(flutter::SemanticsFlags::kIsLink);
+  updates.emplace(5, node5);
+
+  flutter::SemanticsNode node6;
+  node6.childrenInTraversalOrder = {};
+  node6.childrenInHitTestOrder = {};
+  node6.id = 6;
+  node6.flags |= static_cast<int>(flutter::SemanticsFlags::kHasCheckedState);
+  node6.flags |=
+      static_cast<int>(flutter::SemanticsFlags::kIsInMutuallyExclusiveGroup);
+  updates.emplace(6, node6);
+
+  flutter::SemanticsNode node7;
+  node7.childrenInTraversalOrder = {};
+  node7.childrenInHitTestOrder = {};
+  node7.id = 7;
+  node7.flags |= static_cast<int>(flutter::SemanticsFlags::kHasCheckedState);
+  updates.emplace(7, node7);
+
   accessibility_bridge_->AddSemanticsNodeUpdate(std::move(updates), 1.f);
   RunLoopUntilIdle();
 
@@ -150,12 +173,15 @@ TEST_F(AccessibilityBridgeTest, UpdatesNodeRoles) {
           {1u, fuchsia::accessibility::semantics::Role::HEADER},
           {2u, fuchsia::accessibility::semantics::Role::IMAGE},
           {3u, fuchsia::accessibility::semantics::Role::TEXT_FIELD},
-          {4u, fuchsia::accessibility::semantics::Role::SLIDER}};
+          {4u, fuchsia::accessibility::semantics::Role::SLIDER},
+          {5u, fuchsia::accessibility::semantics::Role::LINK},
+          {6u, fuchsia::accessibility::semantics::Role::RADIO_BUTTON},
+          {7u, fuchsia::accessibility::semantics::Role::CHECK_BOX}};
 
   EXPECT_EQ(0, semantics_manager_.DeleteCount());
   EXPECT_EQ(1, semantics_manager_.UpdateCount());
   EXPECT_EQ(1, semantics_manager_.CommitCount());
-  EXPECT_EQ(5U, semantics_manager_.LastUpdatedNodes().size());
+  EXPECT_EQ(8u, semantics_manager_.LastUpdatedNodes().size());
   for (const auto& node : semantics_manager_.LastUpdatedNodes()) {
     ExpectNodeHasRole(node, roles_by_node_id);
   }


### PR DESCRIPTION
updates.

## Description

This change populates the LINK, CHECK_BOX, and RADIO_BUTTON fuchsia roles in semantics updates.

## Related Issues

N/A

## Tests

I added the following tests:

Added coverage for the three new roles to existing UT.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
