### PR TITLE
[ios] Convert FlutterPlatformViewsController to smart pointer

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -63,7 +63,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   fml::WeakPtr<FlutterViewController> _viewController;
   fml::scoped_nsobject<FlutterObservatoryPublisher> _publisher;
 
-  std::unique_ptr<flutter::FlutterPlatformViewsController> _platformViewsController;
+  std::shared_ptr<flutter::FlutterPlatformViewsController> _platformViewsController;
   std::unique_ptr<flutter::ProfilerMetricsIOS> _profiler_metrics;
   std::unique_ptr<flutter::SamplingProfiler> _profiler;
 
@@ -311,8 +311,8 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (FlutterPlatformPlugin*)platformPlugin {
   return _platformPlugin.get();
 }
-- (flutter::FlutterPlatformViewsController*)platformViewsController {
-  return _platformViewsController.get();
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController {
+  return _platformViewsController;
 }
 - (FlutterTextInputPlugin*)textInputPlugin {
   return _textInputPlugin.get();

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -311,7 +311,7 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
 - (FlutterPlatformPlugin*)platformPlugin {
   return _platformPlugin.get();
 }
-- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController {
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController {
   return _platformViewsController;
 }
 - (FlutterTextInputPlugin*)textInputPlugin {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -38,7 +38,7 @@
                                  base64Encode:(bool)base64Encode;
 
 - (FlutterPlatformPlugin*)platformPlugin;
-- (flutter::FlutterPlatformViewsController*)platformViewsController;
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController;
 - (FlutterTextInputPlugin*)textInputPlugin;
 - (void)launchEngine:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
 - (BOOL)createShell:(NSString*)entrypoint

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -38,7 +38,7 @@
                                  base64Encode:(bool)base64Encode;
 
 - (FlutterPlatformPlugin*)platformPlugin;
-- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController;
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
 - (FlutterTextInputPlugin*)textInputPlugin;
 - (void)launchEngine:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
 - (BOOL)createShell:(NSString*)entrypoint

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -884,16 +884,16 @@ void FlutterPlatformViewsController::CommitCATransactionIfNeeded() {
 }
 
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
-  [_platformViewsController.get()->getFlutterViewController() touchesBegan:touches withEvent:event];
+  [_platformViewsController->getFlutterViewController() touchesBegan:touches withEvent:event];
   _currentTouchPointersCount += touches.count;
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
-  [_platformViewsController.get()->getFlutterViewController() touchesMoved:touches withEvent:event];
+  [_platformViewsController->getFlutterViewController() touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
-  [_platformViewsController.get()->getFlutterViewController() touchesEnded:touches withEvent:event];
+  [_platformViewsController->getFlutterViewController() touchesEnded:touches withEvent:event];
   _currentTouchPointersCount -= touches.count;
   // Touches in one touch sequence are sent to the touchesEnded method separately if different
   // fingers stop touching the screen at different time. So one touchesEnded method triggering does
@@ -905,8 +905,7 @@ void FlutterPlatformViewsController::CommitCATransactionIfNeeded() {
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
-  [_platformViewsController.get()->getFlutterViewController() touchesCancelled:touches
-                                                                     withEvent:event];
+  [_platformViewsController->getFlutterViewController() touchesCancelled:touches withEvent:event];
   _currentTouchPointersCount = 0;
   self.state = UIGestureRecognizerStateFailed;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -20,7 +20,7 @@
 - (flutter::Rasterizer::Screenshot)takeScreenshot:(flutter::Rasterizer::ScreenshotType)type
                                   asBase64Encoded:(BOOL)base64Encode;
 
-- (flutter::FlutterPlatformViewsController*)platformViewsController;
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController;
 @end
 
 @interface FlutterView : UIView

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -20,7 +20,7 @@
 - (flutter::Rasterizer::Screenshot)takeScreenshot:(flutter::Rasterizer::ScreenshotType)type
                                   asBase64Encoded:(BOOL)base64Encode;
 
-- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController;
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
 @end
 
 @interface FlutterView : UIView

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1332,7 +1332,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
 #pragma mark - Platform views
 
-- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController {
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController {
   return [_engine.get() platformViewsController];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1332,7 +1332,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
 #pragma mark - Platform views
 
-- (flutter::FlutterPlatformViewsController*)platformViewsController {
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController {
   return [_engine.get() platformViewsController];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -26,7 +26,7 @@ extern NSNotificationName const FlutterViewControllerShowHomeIndicator;
 
 @property(nonatomic, readonly) BOOL isPresentingViewController;
 - (fml::WeakPtr<FlutterViewController>)getWeakPtr;
-- (flutter::FlutterPlatformViewsController*)platformViewsController;
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -26,7 +26,7 @@ extern NSNotificationName const FlutterViewControllerShowHomeIndicator;
 
 @property(nonatomic, readonly) BOOL isPresentingViewController;
 - (fml::WeakPtr<FlutterViewController>)getWeakPtr;
-- (std::shared_ptr<flutter::FlutterPlatformViewsController>)platformViewsController;
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -557,8 +557,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   // `accessibilityContainer` and `accessibilityElementAtIndex`.
   if (self = [super initWithAccessibilityContainer:object.bridge->view()]) {
     _semanticsObject = object;
-    flutter::FlutterPlatformViewsController* controller =
-        object.bridge->GetPlatformViewsController();
+    auto controller = object.bridge->GetPlatformViewsController();
     if (controller) {
       _platformView = [[controller->GetPlatformViewByID(object.node.platformViewId) view] retain];
     }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -39,7 +39,9 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   }
   void AccessibilityObjectDidBecomeFocused(int32_t id) override {}
   void AccessibilityObjectDidLoseFocus(int32_t id) override {}
-  FlutterPlatformViewsController* GetPlatformViewsController() const override { return nil; }
+  std::shared_ptr<FlutterPlatformViewsController> GetPlatformViewsController() const override {
+    return nil;
+  }
   std::vector<SemanticsActionObservation> observations;
 
  private:

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -51,7 +51,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
 
   AccessibilityBridge(FlutterViewController* view_controller,
                       PlatformViewIOS* platform_view,
-                      FlutterPlatformViewsController* platform_views_controller,
+                      std::shared_ptr<FlutterPlatformViewsController> platform_views_controller,
                       std::unique_ptr<IosDelegate> ios_delegate = nullptr);
   ~AccessibilityBridge();
 
@@ -70,7 +70,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
 
   fml::WeakPtr<AccessibilityBridge> GetWeakPtr();
 
-  FlutterPlatformViewsController* GetPlatformViewsController() const override {
+  std::shared_ptr<FlutterPlatformViewsController> GetPlatformViewsController() const override {
     return platform_views_controller_;
   };
 
@@ -85,7 +85,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
 
   FlutterViewController* view_controller_;
   PlatformViewIOS* platform_view_;
-  FlutterPlatformViewsController* platform_views_controller_;
+  const std::shared_ptr<FlutterPlatformViewsController> platform_views_controller_;
   // If the this id is kSemanticObjectIdInvalid, it means either nothing has
   // been focused or the focus is currently outside of the flutter application
   // (i.e. the status bar or keyboard)

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -36,10 +36,11 @@ class DefaultIosDelegate : public AccessibilityBridge::IosDelegate {
 };
 }  // namespace
 
-AccessibilityBridge::AccessibilityBridge(FlutterViewController* view_controller,
-                                         PlatformViewIOS* platform_view,
-                                         FlutterPlatformViewsController* platform_views_controller,
-                                         std::unique_ptr<IosDelegate> ios_delegate)
+AccessibilityBridge::AccessibilityBridge(
+    FlutterViewController* view_controller,
+    PlatformViewIOS* platform_view,
+    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller,
+    std::unique_ptr<IosDelegate> ios_delegate)
     : view_controller_(view_controller),
       platform_view_(platform_view),
       platform_views_controller_(platform_views_controller),
@@ -126,7 +127,7 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     }
 
     if (object.node.IsPlatformViewNode()) {
-      FlutterPlatformViewsController* controller = GetPlatformViewsController();
+      auto controller = GetPlatformViewsController();
       if (controller) {
         object.platformViewSemanticsContainer = [[[FlutterPlatformViewSemanticsContainer alloc]
             initWithSemanticsObject:object] autorelease];

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_ACCESSIBILITY_BRIDGE_IOS_H_
 #define SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_ACCESSIBILITY_BRIDGE_IOS_H_
 
+#include <memory>
 #include <vector>
 
 #include "flutter/lib/ui/semantics/semantics_node.h"
@@ -36,7 +37,7 @@ class AccessibilityBridgeIos {
    * The input id is the uid of the newly focused SemanticObject.
    */
   virtual void AccessibilityObjectDidLoseFocus(int32_t id) = 0;
-  virtual FlutterPlatformViewsController* GetPlatformViewsController() const = 0;
+  virtual std::shared_ptr<FlutterPlatformViewsController> GetPlatformViewsController() const = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -234,7 +234,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     std::string label = "some label";
 
     auto flutterPlatformViewsController =
-        std::make_unique<flutter::FlutterPlatformViewsController>();
+        std::make_shared<flutter::FlutterPlatformViewsController>();
     flutterPlatformViewsController->SetFlutterView(mockFlutterView);
 
     MockFlutterPlatformFactory* factory = [[MockFlutterPlatformFactory new] autorelease];
@@ -252,7 +252,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
     auto bridge = std::make_unique<flutter::AccessibilityBridge>(
         /*view_controller=*/mockFlutterViewController,
         /*platform_view=*/platform_view.get(),
-        /*platform_views_controller=*/flutterPlatformViewsController.get());
+        /*platform_views_controller=*/flutterPlatformViewsController);
 
     flutter::SemanticsNodeUpdates nodes;
     flutter::SemanticsNode semantics_node;

--- a/shell/platform/darwin/ios/ios_external_view_embedder.h
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.h
@@ -13,14 +13,15 @@ namespace flutter {
 class IOSExternalViewEmbedder : public ExternalViewEmbedder {
  public:
   IOSExternalViewEmbedder(
-      FlutterPlatformViewsController* platform_views_controller,
+      std::shared_ptr<FlutterPlatformViewsController> platform_views_controller,
       std::shared_ptr<IOSContext> context);
 
   // |ExternalViewEmbedder|
   virtual ~IOSExternalViewEmbedder() override;
 
  private:
-  FlutterPlatformViewsController* platform_views_controller_;
+  const std::shared_ptr<FlutterPlatformViewsController>
+      platform_views_controller_;
   std::shared_ptr<IOSContext> ios_context_;
 
   // |ExternalViewEmbedder|

--- a/shell/platform/darwin/ios/ios_external_view_embedder.h
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.h
@@ -12,15 +12,15 @@ namespace flutter {
 
 class IOSExternalViewEmbedder : public ExternalViewEmbedder {
  public:
-  IOSExternalViewEmbedder(
-      std::shared_ptr<FlutterPlatformViewsController> platform_views_controller,
-      std::shared_ptr<IOSContext> context);
+  IOSExternalViewEmbedder(const std::shared_ptr<FlutterPlatformViewsController>&
+                              platform_views_controller,
+                          std::shared_ptr<IOSContext> context);
 
   // |ExternalViewEmbedder|
   virtual ~IOSExternalViewEmbedder() override;
 
  private:
-  const std::shared_ptr<FlutterPlatformViewsController>
+  const std::shared_ptr<FlutterPlatformViewsController>&
       platform_views_controller_;
   std::shared_ptr<IOSContext> ios_context_;
 

--- a/shell/platform/darwin/ios/ios_external_view_embedder.mm
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.mm
@@ -7,7 +7,7 @@
 namespace flutter {
 
 IOSExternalViewEmbedder::IOSExternalViewEmbedder(
-    FlutterPlatformViewsController* platform_views_controller,
+    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller,
     std::shared_ptr<IOSContext> context)
     : platform_views_controller_(platform_views_controller), ios_context_(context) {
   FML_CHECK(ios_context_);

--- a/shell/platform/darwin/ios/ios_external_view_embedder.mm
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.mm
@@ -7,7 +7,7 @@
 namespace flutter {
 
 IOSExternalViewEmbedder::IOSExternalViewEmbedder(
-    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller,
+    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller,
     std::shared_ptr<IOSContext> context)
     : platform_views_controller_(platform_views_controller), ios_context_(context) {
   FML_CHECK(ios_context_);

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -28,7 +28,7 @@ class IOSSurface {
   static std::unique_ptr<IOSSurface> Create(
       std::shared_ptr<IOSContext> context,
       fml::scoped_nsobject<CALayer> layer,
-      FlutterPlatformViewsController* platform_views_controller);
+      std::shared_ptr<FlutterPlatformViewsController> platform_views_controller);
 
   std::shared_ptr<IOSContext> GetContext() const;
 
@@ -49,7 +49,7 @@ class IOSSurface {
 
  protected:
   IOSSurface(std::shared_ptr<IOSContext> ios_context,
-             FlutterPlatformViewsController* platform_views_controller);
+             std::shared_ptr<FlutterPlatformViewsController> platform_views_controller);
 
  private:
   std::shared_ptr<IOSContext> ios_context_;

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -28,7 +28,7 @@ class IOSSurface {
   static std::unique_ptr<IOSSurface> Create(
       std::shared_ptr<IOSContext> context,
       fml::scoped_nsobject<CALayer> layer,
-      std::shared_ptr<FlutterPlatformViewsController> platform_views_controller);
+      const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
 
   std::shared_ptr<IOSContext> GetContext() const;
 
@@ -49,7 +49,7 @@ class IOSSurface {
 
  protected:
   IOSSurface(std::shared_ptr<IOSContext> ios_context,
-             std::shared_ptr<FlutterPlatformViewsController> platform_views_controller);
+             const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
 
  private:
   std::shared_ptr<IOSContext> ios_context_;

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -18,7 +18,7 @@ namespace flutter {
 std::unique_ptr<IOSSurface> IOSSurface::Create(
     std::shared_ptr<IOSContext> context,
     fml::scoped_nsobject<CALayer> layer,
-    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller) {
+    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller) {
   FML_DCHECK(layer);
   FML_DCHECK(context);
 
@@ -51,8 +51,9 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(
   );
 }
 
-IOSSurface::IOSSurface(std::shared_ptr<IOSContext> ios_context,
-                       std::shared_ptr<FlutterPlatformViewsController> platform_views_controller)
+IOSSurface::IOSSurface(
+    std::shared_ptr<IOSContext> ios_context,
+    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller)
     : ios_context_(std::move(ios_context)) {
   FML_DCHECK(ios_context_);
   external_view_embedder_ =

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -18,7 +18,7 @@ namespace flutter {
 std::unique_ptr<IOSSurface> IOSSurface::Create(
     std::shared_ptr<IOSContext> context,
     fml::scoped_nsobject<CALayer> layer,
-    FlutterPlatformViewsController* platform_views_controller) {
+    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller) {
   FML_DCHECK(layer);
   FML_DCHECK(context);
 
@@ -52,7 +52,7 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(
 }
 
 IOSSurface::IOSSurface(std::shared_ptr<IOSContext> ios_context,
-                       FlutterPlatformViewsController* platform_views_controller)
+                       std::shared_ptr<FlutterPlatformViewsController> platform_views_controller)
     : ios_context_(std::move(ios_context)) {
   FML_DCHECK(ios_context_);
   external_view_embedder_ =

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -20,7 +20,7 @@ class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
  public:
   IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
                std::shared_ptr<IOSContext> context,
-               FlutterPlatformViewsController* platform_views_controller = nullptr);
+               std::shared_ptr<FlutterPlatformViewsController> platform_views_controller = nullptr);
 
   ~IOSSurfaceGL() override;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -18,9 +18,10 @@ namespace flutter {
 
 class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
  public:
-  IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-               std::shared_ptr<IOSContext> context,
-               std::shared_ptr<FlutterPlatformViewsController> platform_views_controller = nullptr);
+  IOSSurfaceGL(
+      fml::scoped_nsobject<CAEAGLLayer> layer,
+      std::shared_ptr<IOSContext> context,
+      const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller = nullptr);
 
   ~IOSSurfaceGL() override;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -14,9 +14,10 @@ static IOSContextGL* CastToGLContext(const std::shared_ptr<IOSContext>& context)
   return reinterpret_cast<IOSContextGL*>(context.get());
 }
 
-IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-                           std::shared_ptr<IOSContext> context,
-                           FlutterPlatformViewsController* platform_views_controller)
+IOSSurfaceGL::IOSSurfaceGL(
+    fml::scoped_nsobject<CAEAGLLayer> layer,
+    std::shared_ptr<IOSContext> context,
+    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller)
     : IOSSurface(context, platform_views_controller) {
   render_target_ = CastToGLContext(context)->CreateRenderTarget(std::move(layer));
 }

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -17,7 +17,7 @@ static IOSContextGL* CastToGLContext(const std::shared_ptr<IOSContext>& context)
 IOSSurfaceGL::IOSSurfaceGL(
     fml::scoped_nsobject<CAEAGLLayer> layer,
     std::shared_ptr<IOSContext> context,
-    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller)
+    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller)
     : IOSSurface(context, platform_views_controller) {
   render_target_ = CastToGLContext(context)->CreateRenderTarget(std::move(layer));
 }

--- a/shell/platform/darwin/ios/ios_surface_metal.h
+++ b/shell/platform/darwin/ios/ios_surface_metal.h
@@ -19,7 +19,7 @@ class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetal final : public IOSSurface,
  public:
   IOSSurfaceMetal(fml::scoped_nsobject<CAMetalLayer> layer,
                   std::shared_ptr<IOSContext> context,
-                  std::shared_ptr<FlutterPlatformViewsController> platform_views_controller);
+                  const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
 
   // |IOSSurface|
   ~IOSSurfaceMetal() override;

--- a/shell/platform/darwin/ios/ios_surface_metal.h
+++ b/shell/platform/darwin/ios/ios_surface_metal.h
@@ -19,7 +19,7 @@ class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetal final : public IOSSurface,
  public:
   IOSSurfaceMetal(fml::scoped_nsobject<CAMetalLayer> layer,
                   std::shared_ptr<IOSContext> context,
-                  FlutterPlatformViewsController* platform_views_controller);
+                  std::shared_ptr<FlutterPlatformViewsController> platform_views_controller);
 
   // |IOSSurface|
   ~IOSSurfaceMetal() override;

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -16,7 +16,7 @@ static IOSContextMetal* CastToMetalContext(const std::shared_ptr<IOSContext>& co
 IOSSurfaceMetal::IOSSurfaceMetal(
     fml::scoped_nsobject<CAMetalLayer> layer,
     std::shared_ptr<IOSContext> context,
-    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller)
+    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller)
     : IOSSurface(std::move(context), platform_views_controller), layer_(std::move(layer)) {
   if (!layer_) {
     return;

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -13,9 +13,10 @@ static IOSContextMetal* CastToMetalContext(const std::shared_ptr<IOSContext>& co
   return reinterpret_cast<IOSContextMetal*>(context.get());
 }
 
-IOSSurfaceMetal::IOSSurfaceMetal(fml::scoped_nsobject<CAMetalLayer> layer,
-                                 std::shared_ptr<IOSContext> context,
-                                 FlutterPlatformViewsController* platform_views_controller)
+IOSSurfaceMetal::IOSSurfaceMetal(
+    fml::scoped_nsobject<CAMetalLayer> layer,
+    std::shared_ptr<IOSContext> context,
+    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller)
     : IOSSurface(std::move(context), platform_views_controller), layer_(std::move(layer)) {
   if (!layer_) {
     return;

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -20,7 +20,7 @@ class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDel
  public:
   IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
                      std::shared_ptr<IOSContext> context,
-                     FlutterPlatformViewsController* platform_views_controller);
+                     std::shared_ptr<FlutterPlatformViewsController> platform_views_controller);
 
   ~IOSSurfaceSoftware() override;
 

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -20,7 +20,7 @@ class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDel
  public:
   IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
                      std::shared_ptr<IOSContext> context,
-                     std::shared_ptr<FlutterPlatformViewsController> platform_views_controller);
+                     const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
 
   ~IOSSurfaceSoftware() override;
 

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -18,9 +18,10 @@ namespace flutter {
 
 class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDelegate {
  public:
-  IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
-                     std::shared_ptr<IOSContext> context,
-                     const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
+  IOSSurfaceSoftware(
+      fml::scoped_nsobject<CALayer> layer,
+      std::shared_ptr<IOSContext> context,
+      const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
 
   ~IOSSurfaceSoftware() override;
 

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -18,7 +18,7 @@ namespace flutter {
 IOSSurfaceSoftware::IOSSurfaceSoftware(
     fml::scoped_nsobject<CALayer> layer,
     std::shared_ptr<IOSContext> context,
-    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller)
+    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller)
     : IOSSurface(std::move(context), platform_views_controller), layer_(std::move(layer)) {}
 
 IOSSurfaceSoftware::~IOSSurfaceSoftware() = default;

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -15,9 +15,10 @@
 
 namespace flutter {
 
-IOSSurfaceSoftware::IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
-                                       std::shared_ptr<IOSContext> context,
-                                       FlutterPlatformViewsController* platform_views_controller)
+IOSSurfaceSoftware::IOSSurfaceSoftware(
+    fml::scoped_nsobject<CALayer> layer,
+    std::shared_ptr<IOSContext> context,
+    std::shared_ptr<FlutterPlatformViewsController> platform_views_controller)
     : IOSSurface(std::move(context), platform_views_controller), layer_(std::move(layer)) {}
 
 IOSSurfaceSoftware::~IOSSurfaceSoftware() = default;


### PR DESCRIPTION
Prior to this change `FlutterPlatformViewsController` was passed around as a raw pointer. This change makes it so that this is instead shared as a shared_ptr. This also makes the current `unique_ptr` hold in `FlutterEngine.mm` to be a shared one.