### PR TITLE
Fix _lerpInt precision bug

### DIFF
--- a/lib/ui/lerp.dart
+++ b/lib/ui/lerp.dart
@@ -34,7 +34,7 @@ double _lerpDouble(double a, double b, double t) {
 ///
 /// Same as [lerpDouble] but specialized for non-null `int` type.
 double _lerpInt(int a, int b, double t) {
-  return a * (1.0 - t) + b * t;
+  return a + (b - a) * t;
 }
 
 /// Same as [num.clamp] but specialized for non-null [int].

--- a/testing/dart/color_test.dart
+++ b/testing/dart/color_test.dart
@@ -77,6 +77,12 @@ void main() {
       Color.lerp(const Color(0x00000000), const Color(0xFFFFFFFF), 1.1),
       const Color(0xFFFFFFFF),
     );
+
+    // Prevent regression: https://github.com/flutter/flutter/issues/67423
+    expect(
+      Color.lerp(const Color(0xFFFFFFFF), const Color(0xFFFFFFFF), 0.04),
+      const Color(0xFFFFFFFF),
+    );
   });
 
   test('Color.alphaBlend', () {


### PR DESCRIPTION
## Description

Fixes a precision bug was introduced in 784e6d7, which improved the precision of `lerpDouble` when the extrema differed significantly in magnitude.

`_lerpInt` doesn't have this issue since the extrema are passed as 64-bit twos-complement values, therefore the difference will always be accurate so long as it doesn't overflow. This reverts the `_lerpInt` implementation to the original `a + (b - a) * t`, but adds a test to avoid a regression if anyone is tempted to make it consistent with the others.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/67423

## Tests

I added the following tests:

Test `Color.lerp()` with colour values and an interpolation value that trigger the precision bug in `_lerpInt`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
