### PR TITLE
Remove some obsolete code from RuntimeController

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -69,7 +69,7 @@ RuntimeController::~RuntimeController() {
 }
 
 bool RuntimeController::IsRootIsolateRunning() {
-  std::shared_ptr<DartIsolate> root_isolate = GetRootIsolate().lock();
+  std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   if (root_isolate) {
     return root_isolate->GetPhase() == DartIsolate::Phase::Running;
   }
@@ -196,7 +196,7 @@ bool RuntimeController::ReportTimings(std::vector<int64_t> timings) {
 }
 
 bool RuntimeController::NotifyIdle(int64_t deadline, size_t freed_hint) {
-  std::shared_ptr<DartIsolate> root_isolate = GetRootIsolate().lock();
+  std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   if (!root_isolate) {
     return false;
   }
@@ -256,7 +256,7 @@ bool RuntimeController::DispatchSemanticsAction(int32_t id,
 
 PlatformConfiguration*
 RuntimeController::GetPlatformConfigurationIfAvailable() {
-  std::shared_ptr<DartIsolate> root_isolate = GetRootIsolate().lock();
+  std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   return root_isolate ? root_isolate->platform_configuration() : nullptr;
 }
 
@@ -318,17 +318,17 @@ RuntimeController::ComputePlatformResolvedLocale(
 }
 
 Dart_Port RuntimeController::GetMainPort() {
-  std::shared_ptr<DartIsolate> root_isolate = GetRootIsolate().lock();
+  std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   return root_isolate ? root_isolate->main_port() : ILLEGAL_PORT;
 }
 
 std::string RuntimeController::GetIsolateName() {
-  std::shared_ptr<DartIsolate> root_isolate = GetRootIsolate().lock();
+  std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   return root_isolate ? root_isolate->debug_name() : "";
 }
 
 bool RuntimeController::HasLivePorts() {
-  std::shared_ptr<DartIsolate> root_isolate = GetRootIsolate().lock();
+  std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   if (!root_isolate) {
     return false;
   }
@@ -337,7 +337,7 @@ bool RuntimeController::HasLivePorts() {
 }
 
 tonic::DartErrorHandleType RuntimeController::GetLastError() {
-  std::shared_ptr<DartIsolate> root_isolate = GetRootIsolate().lock();
+  std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   return root_isolate ? root_isolate->GetLastError() : tonic::kNoError;
 }
 
@@ -409,15 +409,6 @@ std::optional<std::string> RuntimeController::GetRootIsolateServiceID() const {
     return isolate->GetServiceId();
   }
   return std::nullopt;
-}
-
-std::weak_ptr<DartIsolate> RuntimeController::GetRootIsolate() {
-  std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
-  if (root_isolate) {
-    return root_isolate_;
-  }
-
-  return root_isolate_;
 }
 
 std::optional<uint32_t> RuntimeController::GetRootIsolateReturnCode() {

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_RUNTIME_RUNTIME_CONTROLLER_H_
 #define FLUTTER_RUNTIME_RUNTIME_CONTROLLER_H_
 
-#include <future>
 #include <memory>
 #include <vector>
 
@@ -506,10 +505,6 @@ class RuntimeController : public PlatformConfigurationClient {
   std::string advisory_script_entrypoint_;
   std::function<void(int64_t)> idle_notification_callback_;
   PlatformData platform_data_;
-  std::future<void> create_and_config_root_isolate_;
-  // Note that `root_isolate_` is created asynchronously from the constructor of
-  // `RuntimeController`, be careful to use it directly while it might have not
-  // been created yet. Call `GetRootIsolate()` instead which guarantees that.
   std::weak_ptr<DartIsolate> root_isolate_;
   std::optional<uint32_t> root_isolate_return_code_;
   const fml::closure isolate_create_callback_;
@@ -551,16 +546,6 @@ class RuntimeController : public PlatformConfigurationClient {
   // |PlatformConfigurationClient|
   std::unique_ptr<std::vector<std::string>> ComputePlatformResolvedLocale(
       const std::vector<std::string>& supported_locale_data) override;
-
-  //----------------------------------------------------------------------------
-  /// @brief      Get a weak pointer to the root Dart isolate. This isolate may
-  ///             only be locked on the UI task runner. Callers use this
-  ///             accessor to transition to the root isolate to the running
-  ///             phase.
-  ///
-  /// @return     The root isolate reference.
-  ///
-  std::weak_ptr<DartIsolate> GetRootIsolate();
 
   FML_DISALLOW_COPY_AND_ASSIGN(RuntimeController);
 };


### PR DESCRIPTION
These changes were introduced by the async CreateRootIsolate patch
(https://github.com/flutter/engine/pull/21747).  They are no longer
needed for the sound null safety snapshot loader
(https://github.com/flutter/engine/pull/21820)
