### PR TITLE
Add plumbing for command line arguments on Windows

### DIFF
--- a/shell/platform/windows/client_wrapper/flutter_engine.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine.cc
@@ -25,7 +25,8 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
       std::back_inserter(entrypoint_argv),
       [](const std::string& arg) -> const char* { return arg.c_str(); });
 
-  c_engine_properties.dart_entrypoint_argc = static_cast<int>(entrypoint_argv.size());
+  c_engine_properties.dart_entrypoint_argc =
+      static_cast<int>(entrypoint_argv.size());
   c_engine_properties.dart_entrypoint_argv =
       entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
 

--- a/shell/platform/windows/client_wrapper/flutter_engine.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine.cc
@@ -25,7 +25,7 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
       std::back_inserter(entrypoint_argv),
       [](const std::string& arg) -> const char* { return arg.c_str(); });
 
-  c_engine_properties.dart_entrypoint_argc = (int)entrypoint_argv.size();
+  c_engine_properties.dart_entrypoint_argc = static_cast<int>(entrypoint_argv.size());
   c_engine_properties.dart_entrypoint_argv =
       entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
 

--- a/shell/platform/windows/client_wrapper/flutter_engine.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine.cc
@@ -17,6 +17,18 @@ FlutterEngine::FlutterEngine(const DartProject& project) {
   c_engine_properties.icu_data_path = project.icu_data_path().c_str();
   c_engine_properties.aot_library_path = project.aot_library_path().c_str();
 
+  const std::vector<std::string>& entrypoint_args =
+      project.dart_entrypoint_arguments();
+  std::vector<const char*> entrypoint_argv;
+  std::transform(
+      entrypoint_args.begin(), entrypoint_args.end(),
+      std::back_inserter(entrypoint_argv),
+      [](const std::string& arg) -> const char* { return arg.c_str(); });
+
+  c_engine_properties.dart_entrypoint_argc = (int)entrypoint_argv.size();
+  c_engine_properties.dart_entrypoint_argv =
+      entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
+
   engine_ = FlutterDesktopEngineCreate(c_engine_properties);
 
   auto core_messenger = FlutterDesktopEngineGetMessenger(engine_);

--- a/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
@@ -21,10 +21,12 @@ class TestFlutterWindowsApi : public testing::StubFlutterWindowsApi {
       const FlutterDesktopEngineProperties& engine_properties) {
     create_called_ = true;
 
-    // dart_entrypoint_argv is only guaranteed to exist until this method returns, so copy it here for unit test validation
+    // dart_entrypoint_argv is only guaranteed to exist until this method
+    // returns, so copy it here for unit test validation
     dart_entrypoint_argv.clear();
     for (int i = 0; i < engine_properties.dart_entrypoint_argc; i++) {
-      dart_entrypoint_arguments_.push_back(std::string(engine_properties.dart_entrypoint_argv[i]));
+      dart_entrypoint_arguments_.push_back(
+          std::string(engine_properties.dart_entrypoint_argv[i]));
     }
     return reinterpret_cast<FlutterDesktopEngineRef>(1);
   }
@@ -55,7 +57,9 @@ class TestFlutterWindowsApi : public testing::StubFlutterWindowsApi {
 
   bool reload_fonts_called() { return reload_fonts_called_; }
 
-  const std::vector<std::string>& dart_entrypoint_arguments() { return dart_entrypoint_arguments_; }
+  const std::vector<std::string>& dart_entrypoint_arguments() {
+    return dart_entrypoint_arguments_;
+  }
 
  private:
   bool create_called_ = false;
@@ -136,11 +140,12 @@ TEST(FlutterEngineTest, DartEntrypointArgs) {
   auto test_api = static_cast<TestFlutterWindowsApi*>(scoped_api_stub.stub());
 
   DartProject project(L"data");
-  std::vector<std::string> arguments = { "one", "two" };
+  std::vector<std::string> arguments = {"one", "two"};
   project.set_dart_entrypoint_arguments(arguments);
 
   FlutterEngine engine(project);
-  const std::vector<std::string>& arguments_ref = test_api->dart_entrypoint_arguments();
+  const std::vector<std::string>& arguments_ref =
+      test_api->dart_entrypoint_arguments();
   ASSERT_EQ(2, arguments_ref.size());
   EXPECT_TRUE(arguments[0] == arguments_ref[0]);
   EXPECT_TRUE(arguments[1] == arguments_ref[1]);

--- a/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
@@ -23,7 +23,7 @@ class TestFlutterWindowsApi : public testing::StubFlutterWindowsApi {
 
     // dart_entrypoint_argv is only guaranteed to exist until this method
     // returns, so copy it here for unit test validation
-    dart_entrypoint_argv.clear();
+    dart_entrypoint_arguments_.clear();
     for (int i = 0; i < engine_properties.dart_entrypoint_argc; i++) {
       dart_entrypoint_arguments_.push_back(
           std::string(engine_properties.dart_entrypoint_argv[i]));

--- a/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
@@ -22,6 +22,7 @@ class TestFlutterWindowsApi : public testing::StubFlutterWindowsApi {
     create_called_ = true;
 
     // dart_entrypoint_argv is only guaranteed to exist until this method returns, so copy it here for unit test validation
+    dart_entrypoint_argv.clear();
     for (int i = 0; i < engine_properties.dart_entrypoint_argc; i++) {
       dart_entrypoint_arguments_.push_back(std::string(engine_properties.dart_entrypoint_argv[i]));
     }
@@ -130,20 +131,19 @@ TEST(FlutterEngineTest, GetMessenger) {
 }
 
 TEST(FlutterEngineTest, DartEntrypointArgs) {
-  DartProject project(L"data");
-  std::vector<std::string> arguments(2);
-  arguments[0] = "one";
-  arguments[1] = "two";
-  project.set_dart_entrypoint_arguments(arguments);
   testing::ScopedStubFlutterWindowsApi scoped_api_stub(
       std::make_unique<TestFlutterWindowsApi>());
   auto test_api = static_cast<TestFlutterWindowsApi*>(scoped_api_stub.stub());
 
+  DartProject project(L"data");
+  std::vector<std::string> arguments = { "one", "two" };
+  project.set_dart_entrypoint_arguments(arguments);
+
   FlutterEngine engine(project);
   const std::vector<std::string>& arguments_ref = test_api->dart_entrypoint_arguments();
+  ASSERT_EQ(2, arguments_ref.size());
   EXPECT_TRUE(arguments[0] == arguments_ref[0]);
   EXPECT_TRUE(arguments[1] == arguments_ref[1]);
-  EXPECT_EQ(2, arguments_ref.size());
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
@@ -29,6 +29,18 @@ class DartProject {
 
   ~DartProject() = default;
 
+  // Sets the command line arguments that should be passed to the Dart
+  // entrypoint.
+  void set_dart_entrypoint_arguments(std::vector<std::string> arguments) {
+    dart_entrypoint_arguments_ = std::move(arguments);
+  }
+
+  // Returns any command line arguments that should be passed to the Dart
+  // entrypoint.
+  const std::vector<std::string>& dart_entrypoint_arguments() const {
+    return dart_entrypoint_arguments_;
+  }
+
  private:
   // Accessors for internals are private, so that they can be changed if more
   // flexible options for project structures are needed later without it
@@ -49,6 +61,8 @@ class DartProject {
   // The path to the AOT library. This will always return a path, but non-AOT
   // builds will not be expected to actually have a library at that path.
   std::wstring aot_library_path_;
+  // The list of arguments to pass through to the Dart entrypoint.
+  std::vector<std::string> dart_entrypoint_arguments_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_project_bundle.cc
+++ b/shell/platform/windows/flutter_project_bundle.cc
@@ -20,6 +20,10 @@ FlutterProjectBundle::FlutterProjectBundle(
     aot_library_path_ = std::filesystem::path(properties.aot_library_path);
   }
 
+  for (int i = 0; i < properties.dart_entrypoint_argc; i++) {
+    dart_entrypoint_arguments_.push_back(std::string(properties.dart_entrypoint_argv[i]));
+  }
+
   // Resolve any relative paths.
   if (assets_path_.is_relative() || icu_path_.is_relative() ||
       (!aot_library_path_.empty() && aot_library_path_.is_relative())) {

--- a/shell/platform/windows/flutter_project_bundle.cc
+++ b/shell/platform/windows/flutter_project_bundle.cc
@@ -21,7 +21,8 @@ FlutterProjectBundle::FlutterProjectBundle(
   }
 
   for (int i = 0; i < properties.dart_entrypoint_argc; i++) {
-    dart_entrypoint_arguments_.push_back(std::string(properties.dart_entrypoint_argv[i]));
+    dart_entrypoint_arguments_.push_back(
+        std::string(properties.dart_entrypoint_argv[i]));
   }
 
   // Resolve any relative paths.

--- a/shell/platform/windows/flutter_project_bundle.h
+++ b/shell/platform/windows/flutter_project_bundle.h
@@ -51,8 +51,11 @@ class FlutterProjectBundle {
   // Logs and returns nullptr on failure.
   UniqueAotDataPtr LoadAotData();
 
-  // Returns the command line arguments to be passed through to the Dart entrypoint.
-  const std::vector<std::string>& dart_entrypoint_arguments() const { return dart_entrypoint_arguments_; }
+  // Returns the command line arguments to be passed through to the Dart
+  // entrypoint.
+  const std::vector<std::string>& dart_entrypoint_arguments() const {
+    return dart_entrypoint_arguments_;
+  }
 
  private:
   std::filesystem::path assets_path_;

--- a/shell/platform/windows/flutter_project_bundle.h
+++ b/shell/platform/windows/flutter_project_bundle.h
@@ -51,12 +51,18 @@ class FlutterProjectBundle {
   // Logs and returns nullptr on failure.
   UniqueAotDataPtr LoadAotData();
 
+  // Returns the command line arguments to be passed through to the Dart entrypoint.
+  const std::vector<std::string>& dart_entrypoint_arguments() const { return dart_entrypoint_arguments_; }
+
  private:
   std::filesystem::path assets_path_;
   std::filesystem::path icu_path_;
 
   // Path to the AOT library file, if any.
   std::filesystem::path aot_library_path_;
+
+  // Dart entrypoint arguments.
+  std::vector<std::string> dart_entrypoint_arguments_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -143,10 +143,12 @@ bool FlutterWindowsEngine::RunWithEntrypoint(const char* entrypoint) {
       switches.begin(), switches.end(), std::back_inserter(argv),
       [](const std::string& arg) -> const char* { return arg.c_str(); });
 
-  const std::vector<std::string>& entrypoint_args = project_->dart_entrypoint_arguments();
+  const std::vector<std::string>& entrypoint_args =
+      project_->dart_entrypoint_arguments();
   std::vector<const char*> entrypoint_argv;
   std::transform(
-      entrypoint_args.begin(), entrypoint_args.end(), std::back_inserter(entrypoint_argv),
+      entrypoint_args.begin(), entrypoint_args.end(),
+      std::back_inserter(entrypoint_argv),
       [](const std::string& arg) -> const char* { return arg.c_str(); });
 
   // Configure task runners.
@@ -173,7 +175,8 @@ bool FlutterWindowsEngine::RunWithEntrypoint(const char* entrypoint) {
   args.command_line_argc = static_cast<int>(argv.size());
   args.command_line_argv = argv.size() > 0 ? argv.data() : nullptr;
   args.dart_entrypoint_argc = static_cast<int>(entrypoint_argv.size());
-  args.dart_entrypoint_argv = entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
+  args.dart_entrypoint_argv =
+      entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
   args.platform_message_callback =
       [](const FlutterPlatformMessage* engine_message,
          void* user_data) -> void {

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -143,6 +143,12 @@ bool FlutterWindowsEngine::RunWithEntrypoint(const char* entrypoint) {
       switches.begin(), switches.end(), std::back_inserter(argv),
       [](const std::string& arg) -> const char* { return arg.c_str(); });
 
+  const std::vector<std::string>& entrypoint_args = project_->dart_entrypoint_arguments();
+  std::vector<const char*> entrypoint_argv;
+  std::transform(
+      entrypoint_args.begin(), entrypoint_args.end(), std::back_inserter(entrypoint_argv),
+      [](const std::string& arg) -> const char* { return arg.c_str(); });
+
   // Configure task runners.
   FlutterTaskRunnerDescription platform_task_runner = {};
   platform_task_runner.struct_size = sizeof(FlutterTaskRunnerDescription);
@@ -166,6 +172,8 @@ bool FlutterWindowsEngine::RunWithEntrypoint(const char* entrypoint) {
   args.icu_data_path = icu_path_string.c_str();
   args.command_line_argc = static_cast<int>(argv.size());
   args.command_line_argv = argv.size() > 0 ? argv.data() : nullptr;
+  args.dart_entrypoint_argc = static_cast<int>(entrypoint_argv.size());
+  args.dart_entrypoint_argv = entrypoint_argv.size() > 0 ? entrypoint_argv.data() : nullptr;
   args.platform_message_callback =
       [](const FlutterPlatformMessage* engine_message,
          void* user_data) -> void {

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -47,9 +47,11 @@ typedef struct {
   // it will be ignored in that case.
   const wchar_t* aot_library_path;
 
-  // nullptr-terminated array of Dart entrypoint arguments. This is deep copied
-  // during the call to FlutterDesktopEngineCreate.
+  // Number of elements in the array passed in as dart_entrypoint_argv.
   int dart_entrypoint_argc;
+
+  // Array of Dart entrypoint arguments. This is deep copied during the call
+  // to FlutterDesktopEngineCreate.
   const char** dart_entrypoint_argv;
 } FlutterDesktopEngineProperties;
 

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -46,6 +46,11 @@ typedef struct {
   // containing the executable. This can be nullptr for a non-AOT build, as
   // it will be ignored in that case.
   const wchar_t* aot_library_path;
+
+  // nullptr-terminated array of Dart entrypoint arguments. This is deep copied
+  // during the call to FlutterDesktopEngineCreate.
+  int dart_entrypoint_argc;
+  const char** dart_entrypoint_argv;
 } FlutterDesktopEngineProperties;
 
 // ========== View Controller ==========


### PR DESCRIPTION
## Description

Adds code to pass through command line arguments on Windows.

Unfortunately because of the C++ (client_wrapper) -> C (flutter_windows) -> C++ (flutter_project_bundle) -> C (embedder API) -> C++ (engine) we have to keep copying and changing between C-style and C++ style arguments :(

## Related Issues

https://github.com/flutter/flutter/issues/32986

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
