### PR TITLE
Set strut font to Roboto if the given font hasn't been registered

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -75,7 +75,11 @@ class CkParagraphStyle implements ui.ParagraphStyle {
     EngineStrutStyle style = value as EngineStrutStyle;
     final SkStrutStyleProperties skStrutStyle = SkStrutStyleProperties();
     if (style._fontFamily != null) {
-      final List<String> fontFamilies = <String>[style._fontFamily!];
+      String fontFamily = style._fontFamily!;
+      if (!skiaFontCollection.registeredFamilies.contains(fontFamily)) {
+        fontFamily = 'Roboto';
+      }
+      final List<String> fontFamilies = <String>[fontFamily];
       if (style._fontFamilyFallback != null) {
         fontFamilies.addAll(style._fontFamilyFallback!);
       }
@@ -531,10 +535,10 @@ class CkParagraph extends ManagedSkiaObject<SkParagraph>
     for (int i = 0; i < skRects.length; i++) {
       final List<double> rect = skRects[i];
       result.add(ui.TextBox.fromLTRBD(
-          rect[0],
-          rect[1],
-          rect[2],
-          rect[3],
+        rect[0],
+        rect[1],
+        rect[2],
+        rect[3],
         _paragraphStyle._textDirection!,
       ));
     }
@@ -563,20 +567,10 @@ class CkParagraph extends ManagedSkiaObject<SkParagraph>
     assert(constraints.width != null); // ignore: unnecessary_null_comparison
     _lastLayoutConstraints = constraints;
 
-    // Infinite width breaks layout, just use a very large number instead.
-    // TODO(het): Remove this once https://bugs.chromium.org/p/skia/issues/detail?id=9874
-    //            is fixed.
-    double width;
-    const double largeFiniteWidth = 1000000;
-    if (constraints.width.isInfinite) {
-      width = largeFiniteWidth;
-    } else {
-      width = constraints.width;
-    }
     // TODO(het): CanvasKit throws an exception when laid out with
     // a font that wasn't registered.
     try {
-      skiaObject.layout(width);
+      skiaObject.layout(constraints.width);
     } catch (e) {
       html.window.console.warn('CanvasKit threw an exception while laying '
           'out the paragraph. The font was "${_paragraphStyle._fontFamily}". '


### PR DESCRIPTION
## Description

Sets the strut font to "Roboto" if the given strut font hasn't been registered. This avoids forcing a strut height of `0` in cases where the given font family hasn't been registered.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/68693

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
