### PR TITLE
Update const finder test to match the new signature shaker

### DIFF
--- a/tools/const_finder/test/const_finder_test.dart
+++ b/tools/const_finder/test/const_finder_test.dart
@@ -123,6 +123,11 @@ void _checkNonConsts() {
         <String, dynamic>{
           'file': 'file://$fixtures/lib/consts_and_non.dart',
           'line': 17,
+          'column': 41,
+        },
+        <String, dynamic>{
+          'file': 'file://$fixtures/lib/consts_and_non.dart',
+          'line': 17,
           'column': 26,
         },
         <String, dynamic>{

--- a/tools/const_finder/test/fixtures/lib/consts.dart
+++ b/tools/const_finder/test/fixtures/lib/consts.dart
@@ -45,6 +45,9 @@ class IgnoreMe {
   const IgnoreMe([this.target]);
 
   final Target target;
+
+  @override
+  String toString() => target.toString();
 }
 
 class StaticConstInitializer {

--- a/tools/const_finder/test/fixtures/lib/consts_and_non.dart
+++ b/tools/const_finder/test/fixtures/lib/consts_and_non.dart
@@ -38,6 +38,9 @@ class IgnoreMe {
   const IgnoreMe([this.target]);
 
   final Target target;
+
+  @override
+  String toString() => target.toString();
 }
 
 void blah(Target target) {


### PR DESCRIPTION
Updates the const finder test to match the new Dart AOT signature shaker optimization that was landed in https://dart.googlesource.com/sdk/+/23ee425de7533bab8e55957377dbf9e407609df6.