### PR TITLE
fuchsia: Use GpuSurfaceVulkan

### DIFF
--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -94,21 +94,21 @@ VulkanApplication::VulkanApplication(
 
   VkInstance instance = VK_NULL_HANDLE;
 
-  if (VK_CALL_LOG_ERROR(vk.CreateInstance(&create_info, nullptr, &instance)) !=
-      VK_SUCCESS) {
+  if (VK_CALL_LOG_ERROR(vk_->CreateInstance(&create_info, nullptr,
+                                            &instance)) != VK_SUCCESS) {
     FML_DLOG(INFO) << "Could not create application instance.";
     return;
   }
 
   // Now that we have an instance, setup instance proc table entries.
-  if (!vk.SetupInstanceProcAddresses(instance)) {
+  if (!vk_->SetupInstanceProcAddresses(instance)) {
     FML_DLOG(INFO) << "Could not setup instance proc addresses.";
     return;
   }
 
   instance_ = {instance, [this](VkInstance i) {
                  FML_DLOG(INFO) << "Destroying Vulkan instance";
-                 vk.DestroyInstance(i, nullptr);
+                 vk_->DestroyInstance(i, nullptr);
                }};
 
   if (enable_instance_debugging) {
@@ -149,8 +149,8 @@ std::vector<VkPhysicalDevice> VulkanApplication::GetPhysicalDevices() const {
   }
 
   uint32_t device_count = 0;
-  if (VK_CALL_LOG_ERROR(vk.EnumeratePhysicalDevices(instance_, &device_count,
-                                                    nullptr)) != VK_SUCCESS) {
+  if (VK_CALL_LOG_ERROR(vk_->EnumeratePhysicalDevices(instance_, &device_count,
+                                                      nullptr)) != VK_SUCCESS) {
     FML_DLOG(INFO) << "Could not enumerate physical device.";
     return {};
   }
@@ -165,7 +165,7 @@ std::vector<VkPhysicalDevice> VulkanApplication::GetPhysicalDevices() const {
 
   physical_devices.resize(device_count);
 
-  if (VK_CALL_LOG_ERROR(vk.EnumeratePhysicalDevices(
+  if (VK_CALL_LOG_ERROR(vk_->EnumeratePhysicalDevices(
           instance_, &device_count, physical_devices.data())) != VK_SUCCESS) {
     FML_DLOG(INFO) << "Could not enumerate physical device.";
     return {};
@@ -190,12 +190,12 @@ VulkanApplication::AcquireFirstCompatibleLogicalDevice() const {
 std::vector<VkExtensionProperties>
 VulkanApplication::GetSupportedInstanceExtensions(
     const VulkanProcTable& vk) const {
-  if (!vk.EnumerateInstanceExtensionProperties) {
+  if (!vk_->EnumerateInstanceExtensionProperties) {
     return std::vector<VkExtensionProperties>();
   }
 
   uint32_t count = 0;
-  if (VK_CALL_LOG_ERROR(vk.EnumerateInstanceExtensionProperties(
+  if (VK_CALL_LOG_ERROR(vk_->EnumerateInstanceExtensionProperties(
           nullptr, &count, nullptr)) != VK_SUCCESS) {
     return std::vector<VkExtensionProperties>();
   }
@@ -206,7 +206,7 @@ VulkanApplication::GetSupportedInstanceExtensions(
 
   std::vector<VkExtensionProperties> properties;
   properties.resize(count);
-  if (VK_CALL_LOG_ERROR(vk.EnumerateInstanceExtensionProperties(
+  if (VK_CALL_LOG_ERROR(vk_->EnumerateInstanceExtensionProperties(
           nullptr, &count, properties.data())) != VK_SUCCESS) {
     return std::vector<VkExtensionProperties>();
   }

--- a/vulkan/vulkan_application.h
+++ b/vulkan/vulkan_application.h
@@ -6,27 +6,26 @@
 #define FLUTTER_VULKAN_VULKAN_APPLICATION_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "flutter/fml/macros.h"
+
 #include "vulkan_debug_report.h"
 #include "vulkan_handle.h"
+#include "vulkan_proc_table.h"
 
 namespace vulkan {
 
 static const int kGrCacheMaxCount = 8192;
 static const size_t kGrCacheMaxByteSize = 512 * (1 << 20);
 
-class VulkanDevice;
-class VulkanProcTable;
-
 /// Applications using Vulkan acquire a VulkanApplication that attempts to
 /// create a VkInstance (with debug reporting optionally enabled).
 class VulkanApplication {
  public:
-  VulkanApplication(VulkanProcTable& vk,  // NOLINT
-                    const std::string& application_name,
+  VulkanApplication(const std::string& application_name,
                     std::vector<std::string> enabled_extensions,
                     uint32_t application_version = VK_MAKE_VERSION(1, 0, 0),
                     uint32_t api_version = VK_MAKE_VERSION(1, 0, 0),
@@ -36,21 +35,23 @@ class VulkanApplication {
 
   bool IsValid() const;
 
-  uint32_t GetAPIVersion() const;
-
   const VulkanHandle<VkInstance>& GetInstance() const;
+
+  const VulkanDevice* GetDevice() const;
+
+  uint32_t GetAPIVersion() const;
 
   void ReleaseInstanceOwnership();
 
-  std::unique_ptr<VulkanDevice> AcquireFirstCompatibleLogicalDevice() const;
-
  private:
-  VulkanProcTable& vk;
+  fml::RefPtr<VulkanProcTable> vk_;
   VulkanHandle<VkInstance> instance_;
+
+  std::optional<VulkanDebugReport> debug_report_;
+  std::optional<VulkanDevice> device_;
+
   uint32_t api_version_;
-  std::unique_ptr<VulkanDebugReport> debug_report_;
   bool valid_;
-  bool enable_validation_layers_;
 
   std::vector<VkPhysicalDevice> GetPhysicalDevices() const;
   std::vector<VkExtensionProperties> GetSupportedInstanceExtensions(

--- a/vulkan/vulkan_device.h
+++ b/vulkan/vulkan_device.h
@@ -18,19 +18,19 @@ class VulkanSurface;
 
 class VulkanDevice {
  public:
-  VulkanDevice(VulkanProcTable& vk,
-               VulkanHandle<VkPhysicalDevice> physical_device,
+  VulkanDevice(VulkanHandle<VkPhysicalDevice> physical_device,
+               fml::RefPtr<VulkanProcTable> vk,
                bool enable_validation_layers);
 
   ~VulkanDevice();
 
   bool IsValid() const;
 
-  const VulkanHandle<VkDevice>& GetHandle() const;
+  const VulkanHandle<VkPhysicalDevice>& GetPhysicalDevice() const;
 
-  const VulkanHandle<VkPhysicalDevice>& GetPhysicalDeviceHandle() const;
+  const VulkanHandle<VkDevice>& GetDevice() const;
 
-  const VulkanHandle<VkQueue>& GetQueueHandle() const;
+  const VulkanHandle<VkQueue>& GetQueue() const;
 
   const VulkanHandle<VkCommandPool>& GetCommandPool() const;
 
@@ -65,14 +65,13 @@ class VulkanDevice {
   [[nodiscard]] bool WaitIdle() const;
 
  private:
-  VulkanProcTable& vk;
+  fml::RefPtr<VulkanProcTable> vk_;
   VulkanHandle<VkPhysicalDevice> physical_device_;
   VulkanHandle<VkDevice> device_;
   VulkanHandle<VkQueue> queue_;
   VulkanHandle<VkCommandPool> command_pool_;
   uint32_t graphics_queue_index_;
   bool valid_;
-  bool enable_validation_layers_;
 
   std::vector<VkQueueFamilyProperties> GetQueueFamilyProperties() const;
 

--- a/vulkan/vulkan_window.h
+++ b/vulkan/vulkan_window.h
@@ -6,6 +6,8 @@
 #define FLUTTER_VULKAN_VULKAN_WINDOW_H_
 
 #include <memory>
+#include <optional>
+#include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -31,9 +33,8 @@ class VulkanBackbuffer;
 
 class VulkanWindow {
  public:
-  VulkanWindow(fml::RefPtr<VulkanProcTable> proc_table,
-               std::unique_ptr<VulkanNativeSurface> native_surface,
-               bool render_to_surface);
+  VulkanWindow(fml::RefPtr<VulkanProcTable> vk,
+               std::optional<std::string> surface_extension);
 
   ~VulkanWindow();
 
@@ -47,11 +48,10 @@ class VulkanWindow {
 
  private:
   bool valid_;
-  fml::RefPtr<VulkanProcTable> vk;
-  std::unique_ptr<VulkanApplication> application_;
-  std::unique_ptr<VulkanDevice> logical_device_;
-  std::unique_ptr<VulkanSurface> surface_;
-  std::unique_ptr<VulkanSwapchain> swapchain_;
+  fml::RefPtr<VulkanProcTable> vk_;
+  std::shared_ptr<VulkanApplication> application_;
+  std::optional<VulkanSurface> surface_;
+  std::optional<VulkanSwapchain> swapchain_;
   sk_sp<GrDirectContext> skia_gr_context_;
 
   bool CreateSkiaGrContext();


### PR DESCRIPTION
## Description

First, refactor the Vulkan bindings so that creating and using a Surface is truly optional.

Then, refactor GpuSurfaceVulkan so that the Vulkan state is injected from outside.

Finally, Android and Fuchsia both use the GpuSurfaceVulkan code-path.

## Related Issues

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=53063

## Tests

TODO