### PR TITLE
[web] Fix for firefox custom clipping

### DIFF
--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -333,9 +333,17 @@ String _pathToSvgClipPath(ui.Path path,
   sb.write('<defs>');
 
   final String clipId = 'svgClip$_clipIdCounter';
-  sb.write('<clipPath id=$clipId clipPathUnits="objectBoundingBox">');
 
-  sb.write('<path transform="scale($scaleX, $scaleY)" fill="#FFFFFF" d="');
+  if (browserEngine == BrowserEngine.firefox) {
+    // Firefox objectBoundingBox fails to scale to 1x1 units, instead use
+    // no clipPathUnits but write the path in target units.
+    sb.write('<clipPath id=$clipId>');
+    sb.write('<path fill="#FFFFFF" d="');
+  } else {
+    sb.write('<clipPath id=$clipId clipPathUnits="objectBoundingBox">');
+    sb.write('<path transform="scale($scaleX, $scaleY)" fill="#FFFFFF" d="');
+  }
+
   pathToSvg(path as SurfacePath, sb, offsetX: offsetX, offsetY: offsetY);
   sb.write('"></path></clipPath></defs></svg');
   return sb.toString();


### PR DESCRIPTION
## Description

Fixes bug due to Firefox handling of clipPathUnits="objectBoundingBox". Unlike other browsers using 1x1 units for the path that map to target element, it seems to be effected by transform stack. Switched to using target units instead.

## Related Issues

https://github.com/flutter/flutter/issues/58397
https://github.com/flutter/flutter/issues/57801
https://github.com/flutter/flutter/issues/50508

## Tests

Covered by compositing_golden_test.dart pushPhysicalShape that uses roundrect as clip path, but unit test screenshots for firefox not available.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
