### PR TITLE
makes android semanticsnode to ignore hittest if it is not focusable

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -207,6 +207,11 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
   // beneath a stylus or mouse cursor.
   @Nullable private SemanticsNode hoveredObject;
 
+  @VisibleForTesting
+  public int getHoveredObjectId() {
+    return hoveredObject.id;
+  }
+
   // A Java/Android cached representation of the Flutter app's navigation stack. The Flutter
   // navigation stack is tracked so that accessibility announcements can be made during Flutter's
   // navigation changes.

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -2180,7 +2180,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
           return result;
         }
       }
-      return this;
+      return isFocusable() ? this : null;
     }
 
     // TODO(goderbauer): This should be decided by the framework once we have more information


### PR DESCRIPTION
## Description

The semantics order is determined by the rect and its location. This can be a problem for sliver app bar because the flexablespace may have different rect when it collapses or expands, and it can change the semantics order of the flexablespace and appbar when it does so.

Therefore, we enforce semantics order for the flexablespace and appbar by adding additional semantics nodes with sortKey.
https://github.com/flutter/flutter/blob/470346f77591d38234fa2930583a6f4f582e77e7/packages/flutter/lib/src/material/app_bar.dart#L692

This however introduces an additional semantics node for both flexablespace and appbar. This become a problem if the appbar does not contribute any node to the semantics tree. In this case, we will still create an empty semantics node with sortKey for the appbar which will absorb the hittest of flexablespace, and make flexablespace unfocusable through hittest.

As far as I know, there are two ways we can fix this.
1. On framework side, we only add semantics node with sortKey when we detect subtree has contributed any semantics node.
2. On engine side, makes the android accessibility hittest to ignore nodes that does not have any semantics information.

This PR implements 2.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/69145

## Tests

I added the following tests:

No test for now until we agree this is the right approach.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
