### PR TITLE
[ios] Surface factory holds the canonical reference to the external view embedder

### DIFF
--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -28,7 +28,7 @@ class IOSSurface {
   static std::unique_ptr<IOSSurface> Create(
       std::shared_ptr<IOSContext> context,
       fml::scoped_nsobject<CALayer> layer,
-      const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
+      const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder);
 
   std::shared_ptr<IOSContext> GetContext() const;
 
@@ -49,7 +49,7 @@ class IOSSurface {
 
  protected:
   IOSSurface(std::shared_ptr<IOSContext> ios_context,
-             const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
+             const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder);
 
  private:
   std::shared_ptr<IOSContext> ios_context_;

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -18,7 +18,7 @@ namespace flutter {
 std::unique_ptr<IOSSurface> IOSSurface::Create(
     std::shared_ptr<IOSContext> context,
     fml::scoped_nsobject<CALayer> layer,
-    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller) {
+    const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder) {
   FML_DCHECK(layer);
   FML_DCHECK(context);
 
@@ -27,7 +27,7 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(
         fml::scoped_nsobject<CAEAGLLayer>(
             reinterpret_cast<CAEAGLLayer*>([layer.get() retain])),  // EAGL layer
         std::move(context),                                         // context
-        platform_views_controller                                   // platform views controller
+        external_view_embedder                                      // external view embedder
     );
   }
 
@@ -38,26 +38,22 @@ std::unique_ptr<IOSSurface> IOSSurface::Create(
           fml::scoped_nsobject<CAMetalLayer>(
               reinterpret_cast<CAMetalLayer*>([layer.get() retain])),  // Metal layer
           std::move(context),                                          // context
-          platform_views_controller                                    // platform views controller
+          external_view_embedder                                       // external view embedder
       );
     }
   }
 #endif  // FLUTTER_SHELL_ENABLE_METAL
 
-  return std::make_unique<IOSSurfaceSoftware>(
-      std::move(layer),          // layer
-      std::move(context),        // context
-      platform_views_controller  // platform views controller
+  return std::make_unique<IOSSurfaceSoftware>(std::move(layer),       // layer
+                                              std::move(context),     // context
+                                              external_view_embedder  // external view embedder
   );
 }
 
-IOSSurface::IOSSurface(
-    std::shared_ptr<IOSContext> ios_context,
-    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller)
-    : ios_context_(std::move(ios_context)) {
+IOSSurface::IOSSurface(std::shared_ptr<IOSContext> ios_context,
+                       const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder)
+    : ios_context_(std::move(ios_context)), external_view_embedder_(external_view_embedder) {
   FML_DCHECK(ios_context_);
-  external_view_embedder_ =
-      std::make_shared<IOSExternalViewEmbedder>(platform_views_controller, ios_context_);
 }
 
 IOSSurface::~IOSSurface() = default;

--- a/shell/platform/darwin/ios/ios_surface_factory.h
+++ b/shell/platform/darwin/ios/ios_surface_factory.h
@@ -9,6 +9,7 @@
 
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
+#include "shell/platform/darwin/ios/ios_external_view_embedder.h"
 
 namespace flutter {
 
@@ -28,8 +29,10 @@ class IOSSurfaceFactory {
   std::unique_ptr<IOSSurface> CreateSurface(
       fml::scoped_nsobject<CALayer> ca_layer);
 
+  std::shared_ptr<IOSExternalViewEmbedder> GetExternalViewEmbedder();
+
  private:
-  std::shared_ptr<FlutterPlatformViewsController> platform_views_controller_;
+  std::shared_ptr<IOSExternalViewEmbedder> external_view_embedder_;
   std::shared_ptr<IOSContext> ios_context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceFactory);

--- a/shell/platform/darwin/ios/ios_surface_factory.mm
+++ b/shell/platform/darwin/ios/ios_surface_factory.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/ios/ios_surface_factory.h"
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
+#include "shell/platform/darwin/ios/ios_external_view_embedder.h"
 
 namespace flutter {
 
@@ -19,12 +20,17 @@ IOSSurfaceFactory::~IOSSurfaceFactory() = default;
 
 void IOSSurfaceFactory::SetPlatformViewsController(
     const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller) {
-  platform_views_controller_ = platform_views_controller;
+  external_view_embedder_.reset(
+      new IOSExternalViewEmbedder(platform_views_controller, ios_context_));
+}
+
+std::shared_ptr<IOSExternalViewEmbedder> IOSSurfaceFactory::GetExternalViewEmbedder() {
+  return external_view_embedder_;
 }
 
 std::unique_ptr<IOSSurface> IOSSurfaceFactory::CreateSurface(
     fml::scoped_nsobject<CALayer> ca_layer) {
-  return flutter::IOSSurface::Create(ios_context_, ca_layer, platform_views_controller_);
+  return flutter::IOSSurface::Create(ios_context_, ca_layer, external_view_embedder_);
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -18,10 +18,9 @@ namespace flutter {
 
 class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
  public:
-  IOSSurfaceGL(
-      fml::scoped_nsobject<CAEAGLLayer> layer,
-      std::shared_ptr<IOSContext> context,
-      const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller = nullptr);
+  IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
+               std::shared_ptr<IOSContext> context,
+               const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder = nullptr);
 
   ~IOSSurfaceGL() override;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -14,11 +14,10 @@ static IOSContextGL* CastToGLContext(const std::shared_ptr<IOSContext>& context)
   return reinterpret_cast<IOSContextGL*>(context.get());
 }
 
-IOSSurfaceGL::IOSSurfaceGL(
-    fml::scoped_nsobject<CAEAGLLayer> layer,
-    std::shared_ptr<IOSContext> context,
-    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller)
-    : IOSSurface(context, platform_views_controller) {
+IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
+                           std::shared_ptr<IOSContext> context,
+                           const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder)
+    : IOSSurface(context, external_view_embedder) {
   render_target_ = CastToGLContext(context)->CreateRenderTarget(std::move(layer));
 }
 

--- a/shell/platform/darwin/ios/ios_surface_metal.h
+++ b/shell/platform/darwin/ios/ios_surface_metal.h
@@ -19,7 +19,7 @@ class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetal final : public IOSSurface,
  public:
   IOSSurfaceMetal(fml::scoped_nsobject<CAMetalLayer> layer,
                   std::shared_ptr<IOSContext> context,
-                  const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
+                  const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder);
 
   // |IOSSurface|
   ~IOSSurfaceMetal() override;

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -16,8 +16,8 @@ static IOSContextMetal* CastToMetalContext(const std::shared_ptr<IOSContext>& co
 IOSSurfaceMetal::IOSSurfaceMetal(
     fml::scoped_nsobject<CAMetalLayer> layer,
     std::shared_ptr<IOSContext> context,
-    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller)
-    : IOSSurface(std::move(context), platform_views_controller), layer_(std::move(layer)) {
+    const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder)
+    : IOSSurface(std::move(context), external_view_embedder), layer_(std::move(layer)) {
   if (!layer_) {
     return;
   }

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -18,10 +18,9 @@ namespace flutter {
 
 class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDelegate {
  public:
-  IOSSurfaceSoftware(
-      fml::scoped_nsobject<CALayer> layer,
-      std::shared_ptr<IOSContext> context,
-      const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller);
+  IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
+                     std::shared_ptr<IOSContext> context,
+                     const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder);
 
   ~IOSSurfaceSoftware() override;
 

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -18,8 +18,8 @@ namespace flutter {
 IOSSurfaceSoftware::IOSSurfaceSoftware(
     fml::scoped_nsobject<CALayer> layer,
     std::shared_ptr<IOSContext> context,
-    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller)
-    : IOSSurface(std::move(context), platform_views_controller), layer_(std::move(layer)) {}
+    const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder)
+    : IOSSurface(std::move(context), external_view_embedder), layer_(std::move(layer)) {}
 
 IOSSurfaceSoftware::~IOSSurfaceSoftware() = default;
 


### PR DESCRIPTION
This furthers the refactor of making platform view hold the reference to the external view embedder on iOS.