### PR TITLE
Defer Windows arrow key and delete handling

### DIFF
--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -61,35 +61,9 @@ void TextInputPlugin::KeyboardHook(FlutterWindowsView* view,
     return;
   }
   if (action == WM_KEYDOWN) {
+    // Most editing keys (arrow keys, backspace, delete, etc.) are handled in
+    // the framework, so don't need to be handled at this layer.
     switch (key) {
-      case VK_LEFT:
-        if (active_model_->MoveCursorBack()) {
-          SendStateUpdate(*active_model_);
-        }
-        break;
-      case VK_RIGHT:
-        if (active_model_->MoveCursorForward()) {
-          SendStateUpdate(*active_model_);
-        }
-        break;
-      case VK_END:
-        active_model_->MoveCursorToEnd();
-        SendStateUpdate(*active_model_);
-        break;
-      case VK_HOME:
-        active_model_->MoveCursorToBeginning();
-        SendStateUpdate(*active_model_);
-        break;
-      case VK_BACK:
-        if (active_model_->Backspace()) {
-          SendStateUpdate(*active_model_);
-        }
-        break;
-      case VK_DELETE:
-        if (active_model_->Delete()) {
-          SendStateUpdate(*active_model_);
-        }
-        break;
       case VK_RETURN:
         EnterPressed(active_model_.get());
         break;


### PR DESCRIPTION
Description

The framework handles arrow keys, delete, and backspace (and with better
unicode support), so we shouldn't handle them at the embedding level.

## Related Issues

Fixes #69202

## Tests

I added the following tests: None; just removing code.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
