### PR TITLE
Platform views have CreateExternalViewEmbedder

### DIFF
--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -136,6 +136,13 @@ std::unique_ptr<Surface> PlatformView::CreateRenderingSurface() {
   return nullptr;
 }
 
+std::shared_ptr<ExternalViewEmbedder>
+PlatformView::CreateExternalViewEmbedder() {
+  FML_DLOG(WARNING)
+      << "This platform doesn't support embedding external views.";
+  return nullptr;
+}
+
 void PlatformView::SetNextFrameCallback(const fml::closure& closure) {
   if (!closure) {
     return;

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "flow/embedded_views.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/flow/surface.h"
 #include "flutter/flow/texture.h"
@@ -592,6 +593,8 @@ class PlatformView {
   // Unlike all other methods on the platform view, this is called on the
   // GPU task runner.
   virtual std::unique_ptr<Surface> CreateRenderingSurface();
+
+  virtual std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder();
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformView);

--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -38,6 +38,12 @@ std::unique_ptr<Surface> ShellTestPlatformViewGL::CreateRenderingSurface() {
 }
 
 // |PlatformView|
+std::shared_ptr<ExternalViewEmbedder>
+ShellTestPlatformViewGL::CreateExternalViewEmbedder() {
+  return shell_test_external_view_embedder_;
+}
+
+// |PlatformView|
 PointerDataDispatcherMaker ShellTestPlatformViewGL::GetDispatcherMaker() {
   return [](DefaultPointerDataDispatcher::Delegate& delegate) {
     return std::make_unique<SmoothPointerDataDispatcher>(delegate);

--- a/shell/common/shell_test_platform_view_gl.h
+++ b/shell/common/shell_test_platform_view_gl.h
@@ -41,6 +41,9 @@ class ShellTestPlatformViewGL : public ShellTestPlatformView,
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |PlatformView|
+  std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder() override;
+
+  // |PlatformView|
   std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;
 
   // |PlatformView|

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -40,6 +40,12 @@ std::unique_ptr<Surface> ShellTestPlatformViewVulkan::CreateRenderingSurface() {
 }
 
 // |PlatformView|
+std::shared_ptr<ExternalViewEmbedder>
+ShellTestPlatformViewVulkan::CreateExternalViewEmbedder() {
+  return shell_test_external_view_embedder_;
+}
+
+// |PlatformView|
 PointerDataDispatcherMaker ShellTestPlatformViewVulkan::GetDispatcherMaker() {
   return [](DefaultPointerDataDispatcher::Delegate& delegate) {
     return std::make_unique<SmoothPointerDataDispatcher>(delegate);

--- a/shell/common/shell_test_platform_view_vulkan.h
+++ b/shell/common/shell_test_platform_view_vulkan.h
@@ -77,6 +77,9 @@ class ShellTestPlatformViewVulkan : public ShellTestPlatformView {
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |PlatformView|
+  std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder() override;
+
+  // |PlatformView|
   std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;
 
   // |PlatformView|

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -308,6 +308,12 @@ std::unique_ptr<Surface> PlatformViewAndroid::CreateRenderingSurface() {
 }
 
 // |PlatformView|
+std::shared_ptr<ExternalViewEmbedder>
+PlatformViewAndroid::CreateExternalViewEmbedder() {
+  return external_view_embedder_;
+}
+
+// |PlatformView|
 sk_sp<GrDirectContext> PlatformViewAndroid::CreateResourceContext() const {
   if (!android_surface_) {
     return nullptr;

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -128,6 +128,9 @@ class PlatformViewAndroid final : public PlatformView {
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |PlatformView|
+  std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder() override;
+
+  // |PlatformView|
   sk_sp<GrDirectContext> CreateResourceContext() const override;
 
   // |PlatformView|

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -141,6 +141,9 @@ class PlatformViewIOS final : public PlatformView {
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |PlatformView|
+  std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder() override;
+
+  // |PlatformView|
   sk_sp<GrDirectContext> CreateResourceContext() const override;
 
   // |PlatformView|

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -141,6 +141,11 @@ std::unique_ptr<Surface> PlatformViewIOS::CreateRenderingSurface() {
 }
 
 // |PlatformView|
+std::shared_ptr<ExternalViewEmbedder> PlatformViewIOS::CreateExternalViewEmbedder() {
+  return ios_surface_factory_->GetExternalViewEmbedder();
+}
+
+// |PlatformView|
 sk_sp<GrDirectContext> PlatformViewIOS::CreateResourceContext() const {
   return ios_context_->CreateResourceContext();
 }

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -78,6 +78,12 @@ std::unique_ptr<Surface> PlatformViewEmbedder::CreateRenderingSurface() {
 }
 
 // |PlatformView|
+std::shared_ptr<ExternalViewEmbedder>
+PlatformViewEmbedder::CreateExternalViewEmbedder() {
+  return external_view_embedder_;
+}
+
+// |PlatformView|
 sk_sp<GrDirectContext> PlatformViewEmbedder::CreateResourceContext() const {
   if (embedder_surface_ == nullptr) {
     FML_LOG(ERROR) << "Embedder surface was null.";

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -83,6 +83,9 @@ class PlatformViewEmbedder final : public PlatformView {
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |PlatformView|
+  std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder() override;
+
+  // |PlatformView|
   sk_sp<GrDirectContext> CreateResourceContext() const override;
 
   // |PlatformView|

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -587,6 +587,12 @@ std::unique_ptr<flutter::Surface> PlatformView::CreateRenderingSurface() {
 }
 
 // |flutter::PlatformView|
+std::shared_ptr<flutter::ExternalViewEmbedder>
+PlatformView::CreateExternalViewEmbedder() {
+  return external_view_embedder_;
+}
+
+// |flutter::PlatformView|
 void PlatformView::HandlePlatformMessage(
     fml::RefPtr<flutter::PlatformMessage> message) {
   if (!message) {

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -122,6 +122,10 @@ class PlatformView final : public flutter::PlatformView,
   std::unique_ptr<flutter::Surface> CreateRenderingSurface() override;
 
   // |flutter::PlatformView|
+  std::shared_ptr<flutter::ExternalViewEmbedder> CreateExternalViewEmbedder()
+      override;
+
+  // |flutter::PlatformView|
   void HandlePlatformMessage(
       fml::RefPtr<flutter::PlatformMessage> message) override;
 


### PR DESCRIPTION
This is the last change before we can remove GetExternalViewEmbedder from the Surface APIs.

This furthers the effort to share the surfaces between macOS and iOS.