### PR TITLE
Refactor MacOS to use MacOSCompositor for creating backing stores.

### DIFF
--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -52,6 +52,8 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterEngine_Internal.h",
     "framework/Source/FlutterExternalTextureGL.h",
     "framework/Source/FlutterExternalTextureGL.mm",
+    "framework/Source/FlutterMacOSGLCompositor.h",
+    "framework/Source/FlutterMacOSGLCompositor.mm",
     "framework/Source/FlutterMouseCursorPlugin.h",
     "framework/Source/FlutterMouseCursorPlugin.mm",
     "framework/Source/FlutterTextInputModel.h",
@@ -62,14 +64,17 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterView.mm",
     "framework/Source/FlutterViewController.mm",
     "framework/Source/FlutterViewController_Internal.h",
+    "framework/Source/FlutterViewController_Internal.h",
   ]
 
   sources += _flutter_framework_headers
 
   deps = [
+    "//flutter/fml",
     "//flutter/shell/platform/common/cpp:common_cpp_switches",
     "//flutter/shell/platform/darwin/common:framework_shared",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
+    "//third_party/skia",
   ]
 
   public_configs = [ "//flutter:config" ]
@@ -104,7 +109,9 @@ executable("flutter_desktop_darwin_unittests") {
 
   sources = [
     "framework/Source/FlutterEngineUnittests.mm",
+    "framework/Source/FlutterMacOSGLCompositorUnittests.mm",
     "framework/Source/FlutterViewControllerTest.mm",
+    "framework/Source/MockFlutterViewController.h",
   ]
 
   cflags_objcc = [ "-fobjc-arc" ]

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -10,6 +10,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterExternalTextureGL.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMacOSGLCompositor.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/embedder/embedder.h"
 
@@ -202,6 +203,9 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
 
   // Pointer to the Dart AOT snapshot and instruction data.
   UniqueAotDataPtr _aotData;
+
+  // FlutterMacOSGLCompositor is created by the engine.
+  std::unique_ptr<flutter::FlutterMacOSGLCompositor> _macOSCompositor;
 }
 
 - (instancetype)initWithName:(NSString*)labelPrefix project:(FlutterDartProject*)project {
@@ -306,6 +310,13 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
     flutterArguments.aot_data = _aotData.get();
   }
 
+  // Only create a Compositor if we have a ViewController.
+  if (_viewController) {
+    FlutterCompositor compositor = {};
+    [self setupCompositor:&compositor];
+    flutterArguments.compositor = &compositor;
+  }
+
   FlutterEngineResult result = FlutterEngineInitialize(
       FLUTTER_ENGINE_VERSION, &rendererConfig, &flutterArguments, (__bridge void*)(self), &_engine);
   if (result != kSuccess) {
@@ -363,6 +374,40 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
     _resourceContext = nil;
   }
   [self updateWindowMetrics];
+}
+
+- (void)setupCompositor:(FlutterCompositor*)compositor {
+  [_mainOpenGLContext makeCurrentContext];
+
+  _macOSCompositor = std::make_unique<flutter::FlutterMacOSGLCompositor>(_viewController);
+
+  compositor->struct_size = sizeof(FlutterCompositor);
+  compositor->user_data = _macOSCompositor.get();
+
+  compositor->create_backing_store_callback = [](const FlutterBackingStoreConfig* config,  //
+                                                 FlutterBackingStore* backing_store_out,   //
+                                                 void* user_data                           //
+                                              ) {
+    return reinterpret_cast<flutter::FlutterMacOSGLCompositor*>(user_data)->CreateBackingStore(
+        config, backing_store_out);
+  };
+
+  compositor->collect_backing_store_callback = [](const FlutterBackingStore* backing_store,  //
+                                                  void* user_data                            //
+                                               ) {
+    return reinterpret_cast<flutter::FlutterMacOSGLCompositor*>(user_data)->CollectBackingStore(
+        backing_store);
+  };
+
+  compositor->present_layers_callback = [](const FlutterLayer** layers,  //
+                                           size_t layers_count,          //
+                                           void* user_data               //
+                                        ) {
+    return reinterpret_cast<flutter::FlutterMacOSGLCompositor*>(user_data)->Present(layers,
+                                                                                    layers_count);
+  };
+
+  _macOSCompositor->SetPresentCallback([self]() { return [self engineCallbackOnPresent]; });
 }
 
 - (id<FlutterBinaryMessenger>)binaryMessenger {

--- a/shell/platform/darwin/macos/framework/Source/FlutterMacOSGLCompositor.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMacOSGLCompositor.h
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <vector>
+
+#include "flutter/fml/macros.h"
+#include "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
+
+namespace flutter {
+
+class FlutterMacOSGLCompositor {
+ public:
+  FlutterMacOSGLCompositor(FlutterViewController* view_controller);
+
+  virtual ~FlutterMacOSGLCompositor();
+
+  bool CreateBackingStore(const FlutterBackingStoreConfig* config,
+                          FlutterBackingStore* backing_store_out);
+
+  bool CollectBackingStore(const FlutterBackingStore* backing_store);
+
+  bool Present(const FlutterLayer** layers, size_t layers_count);
+
+  using PresentCallback = std::function<bool()>;
+
+  void SetPresentCallback(const PresentCallback& present_callback);
+
+ protected:
+  sk_sp<GrDirectContext> context_;
+  FlutterViewController* view_controller_;
+  PresentCallback present_callback_;
+
+  bool CreateSoftwareRenderSurface(const FlutterBackingStoreConfig* config,
+                                   FlutterBackingStore* renderer_out);
+
+  bool CreateGLRenderSurface(const FlutterBackingStoreConfig* config,
+                             FlutterBackingStore* backing_store_out);
+
+  bool CreateFramebuffer(const FlutterBackingStoreConfig* config,
+                             FlutterBackingStore* backing_store_out);
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterMacOSGLCompositor);
+};
+
+}  // namespace flutter

--- a/shell/platform/darwin/macos/framework/Source/FlutterMacOSGLCompositor.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMacOSGLCompositor.mm
@@ -1,0 +1,99 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMacOSGLCompositor.h"
+
+#import <OpenGL/gl.h>
+#import "flutter/fml/logging.h"
+#import "flutter/fml/platform/darwin/cf_utils.h"
+#import "third_party/skia/include/core/SkCanvas.h"
+#import "third_party/skia/include/core/SkSurface.h"
+#import "third_party/skia/include/gpu/gl/GrGLAssembleInterface.h"
+#import "third_party/skia/include/utils/mac/SkCGUtils.h"
+
+namespace flutter {
+
+FlutterMacOSGLCompositor::FlutterMacOSGLCompositor(FlutterViewController* view_controller)
+    : view_controller_(view_controller) {
+  auto interface = GrGLMakeNativeInterface();
+  GrContextOptions options;
+  context_ = GrDirectContext::MakeGL(GrGLMakeNativeInterface(), options);
+}
+
+FlutterMacOSGLCompositor::~FlutterMacOSGLCompositor() = default;
+
+bool FlutterMacOSGLCompositor::CreateBackingStore(const FlutterBackingStoreConfig* config,
+                                                FlutterBackingStore* backing_store_out) {
+  return CreateFramebuffer(config, backing_store_out);
+}
+
+bool FlutterMacOSGLCompositor::CollectBackingStore(const FlutterBackingStore* backing_store) {
+  // We have already set the destruction callback for the various backing
+  // stores. Our user_data is just the canvas from that backing store and does
+  // not need to be explicitly collected. Embedders might have some other state
+  // they want to collect though.
+  return true;
+}
+
+bool FlutterMacOSGLCompositor::Present(const FlutterLayer** layers, size_t layers_count) {
+  return present_callback_();
+}
+
+bool FlutterMacOSGLCompositor::CreateFramebuffer(const FlutterBackingStoreConfig* config,
+                                               FlutterBackingStore* backing_store_out) {
+  GrGLFramebufferInfo framebuffer_info = {};
+  framebuffer_info.fFBOID = 0;
+  framebuffer_info.fFormat = GL_RGBA8;
+  const SkColorType color_type = kN32_SkColorType;
+
+  GrBackendRenderTarget render_target(config->size.width,   // width
+                                      config->size.height,  // height
+                                      1,                    // sample count
+                                      0,                    // stencil bits
+                                      framebuffer_info      // framebuffer info
+  );
+
+  if (!render_target.isValid()) {
+    FML_LOG(ERROR) << "Backend render target was invalid.";
+    return false;
+  }
+
+  sk_sp<SkColorSpace> colorspace = SkColorSpace::MakeSRGB();
+  SkSurfaceProps surface_props(0, kUnknown_SkPixelGeometry);
+
+  auto surface = SkSurface::MakeFromBackendRenderTarget(
+      context_.get(),                                // gr context
+      render_target,                                 // render target
+      GrSurfaceOrigin::kBottomLeft_GrSurfaceOrigin,  // origin
+      color_type,                                    // color type
+      colorspace,                                    // colorspace
+      &surface_props                                 // surface properties
+  );
+
+  if (!surface) {
+    FML_LOG(ERROR) << "Could not create render target for compositor layer.";
+    return false;
+  }
+
+  backing_store_out->type = kFlutterBackingStoreTypeOpenGL;
+  backing_store_out->user_data = surface.get();
+  backing_store_out->open_gl.type = kFlutterOpenGLTargetTypeFramebuffer;
+  backing_store_out->open_gl.framebuffer.target = framebuffer_info.fFormat;
+  backing_store_out->open_gl.framebuffer.name = framebuffer_info.fFBOID;
+  // The balancing unref is in the destruction callback.
+  surface->ref();
+  backing_store_out->open_gl.framebuffer.user_data = surface.get();
+  backing_store_out->open_gl.framebuffer.destruction_callback = [](void* user_data) {
+    reinterpret_cast<SkSurface*>(user_data)->unref();
+  };
+
+  return true;
+}
+
+void FlutterMacOSGLCompositor::SetPresentCallback(
+    const FlutterMacOSGLCompositor::PresentCallback& present_callback) {
+  present_callback_ = present_callback;
+}
+
+}  // namespace flutter

--- a/shell/platform/darwin/macos/framework/Source/FlutterMacOSGLCompositorUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMacOSGLCompositorUnittests.mm
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterMacOSGLCompositor.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/MockFlutterViewController.h"
+#import "flutter/testing/testing.h"
+
+namespace flutter::testing {
+
+TEST(FlutterMacOSGLCompositorTest, TestPresent) {
+  id mockViewController = CreateMockViewController(nil);
+
+  std::unique_ptr<flutter::FlutterMacOSGLCompositor> macos_compositor = std::make_unique<FlutterMacOSGLCompositor>(mockViewController);
+
+  bool flag = false;
+  macos_compositor->SetPresentCallback([f = &flag]() {
+    *f = true;
+    return true;
+  });
+
+  ASSERT_TRUE(macos_compositor->Present(nil, 0));
+  ASSERT_TRUE(flag);
+}
+
+}  // flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -9,34 +9,14 @@
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/MockFlutterViewController.h"
 #include "flutter/testing/testing.h"
 
 namespace flutter::testing {
 
-// Returns a mock FlutterViewController that is able to work in environments
-// without a real pasteboard.
-id mockViewController(NSString* pasteboardString) {
-  NSString* fixtures = @(testing::GetFixturesPath());
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithAssetsPath:fixtures
-             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
-  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
-
-  // Mock pasteboard so that this test will work in environments without a
-  // real pasteboard.
-  id pasteboardMock = OCMClassMock([NSPasteboard class]);
-  OCMExpect([pasteboardMock stringForType:[OCMArg any]]).andDo(^(NSInvocation* invocation) {
-    NSString* returnValue = pasteboardString.length > 0 ? pasteboardString : nil;
-    [invocation setReturnValue:&returnValue];
-  });
-  id viewControllerMock = OCMPartialMock(viewController);
-  OCMStub([viewControllerMock pasteboard]).andReturn(pasteboardMock);
-  return viewControllerMock;
-}
-
 TEST(FlutterViewControllerTest, HasStringsWhenPasteboardEmpty) {
   // Mock FlutterViewController so that it behaves like the pasteboard is empty.
-  id viewControllerMock = mockViewController(nil);
+  id viewControllerMock = CreateMockViewController(nil);
 
   // Call hasStrings and expect it to be false.
   __block bool calledAfterClear = false;
@@ -56,7 +36,7 @@ TEST(FlutterViewControllerTest, HasStringsWhenPasteboardEmpty) {
 TEST(FlutterViewControllerTest, HasStringsWhenPasteboardFull) {
   // Mock FlutterViewController so that it behaves like the pasteboard has a
   // valid string.
-  id viewControllerMock = mockViewController(@"some string");
+  id viewControllerMock = CreateMockViewController(@"some string");
 
   // Call hasStrings and expect it to be true.
   __block bool called = false;

--- a/shell/platform/darwin/macos/framework/Source/MockFlutterViewController.h
+++ b/shell/platform/darwin/macos/framework/Source/MockFlutterViewController.h
@@ -1,0 +1,31 @@
+#import <Foundation/NSString.h>
+#import <OCMock/OCMock.h>
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
+#import "flutter/testing/testing.h"
+
+namespace flutter::testing {
+
+// Returns a mock FlutterViewController that is able to work in environments
+// without a real pasteboard.
+static id CreateMockViewController(NSString* pasteboardString) {
+  NSString* fixtures = @(testing::GetFixturesPath());
+  FlutterDartProject* project = [[FlutterDartProject alloc]
+      initWithAssetsPath:fixtures
+             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+
+  // Mock pasteboard so that this test will work in environments without a
+  // real pasteboard.
+  id pasteboardMock = OCMClassMock([NSPasteboard class]);
+  OCMExpect([pasteboardMock stringForType:[OCMArg any]]).andDo(^(NSInvocation* invocation) {
+    NSString* returnValue = pasteboardString.length > 0 ? pasteboardString : nil;
+    [invocation setReturnValue:&returnValue];
+  });
+  id viewControllerMock = OCMPartialMock(viewController);
+  OCMStub([viewControllerMock pasteboard]).andReturn(pasteboardMock);
+  return viewControllerMock;
+}
+
+}


### PR DESCRIPTION
Description

This PR is the first step in supporting embedded platform views for MacOS.
MacOSCompositor was created and backing stores are now created using the MacOSCompositor.
Overall behaviour should remain unchanged. The MacOSCompositor will be extended to support embedding platform views.

## Related Issues

https://github.com/flutter/flutter/issues/41722

## Tests

I added the following tests:

Added unit tests for FlutterMacOSCompositor

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
