### PR TITLE
updating integration tests version.

### DIFF
--- a/e2etests/web/regular_integration_tests/pubspec.yaml
+++ b/e2etests/web/regular_integration_tests/pubspec.yaml
@@ -13,7 +13,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  integration_test: ^0.9.2
+  integration_test: ^0.9.2+2
   http: 0.12.0+2
   web_test_utils:
     path: ../../../web_sdk/web_test_utils


### PR DESCRIPTION
Increasing the version for integration test to `0.9.2+2`

e2e tests runs with this dependency on the framework repo: https://github.com/flutter/flutter/pull/69067/files#diff-e214e612867710015271dea4431b197a2164acf3f31f0cae82298798f4b1c6bbR22