### PR TITLE
[web] fix type error during hot restart in font manager

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -17,7 +17,7 @@ const String _robotoUrl =
 class SkiaFontCollection {
   /// Fonts that have been registered but haven't been loaded yet.
   final List<Future<_RegisteredFont?>> _unloadedFonts =
-      <Future<_RegisteredFont>>[];
+      <Future<_RegisteredFont?>>[];
 
   /// Fonts which have been registered and loaded.
   final List<_RegisteredFont> _registeredFonts = <_RegisteredFont>[];


### PR DESCRIPTION
## Description

```
For a more detailed help message, press "h". To quit, press "q".
Failed to load font MaterialIcons at assets/fonts/MaterialIcons-Regular.otf
null
Error: Expected a value of type 'Future<_RegisteredFont>', but got one of type '_Future<_RegisteredFont?>'
    at Object.throw_ [as throw] (http://localhost:55937/dart_sdk.js:4193:11)
    at Object.castError (http://localhost:55937/dart_sdk.js:4166:15)
    at Object.cast [as as] (http://localhost:55937/dart_sdk.js:4475:17)
    at Function.as_C [as as] (http://localhost:55937/dart_sdk.js:4122:19)
    at Array.[dartx.add] (http://localhost:55937/dart_sdk.js:14333:11)
    at _engine.SkiaFontCollection.new.registerFonts (http://localhost:55937/dart_sdk.js:130488:39)
    at registerFonts.next (<anonymous>)
    at http://localhost:55937/dart_sdk.js:36140:33
    at _RootZone.runUnary (http://localhost:55937/dart_sdk.js:36008:59)
    at _FutureListener.thenAwait.handleValue (http://localhost:55937/dart_sdk.js:31237:29)
    at handleValueCallback (http://localhost:55937/dart_sdk.js:31752:49)
    at Function._propagateToListeners (http://localhost:55937/dart_sdk.js:31790:17)
    at _Future.new.[_completeWithValue] (http://localhost:55937/dart_sdk.js:31638:23)
    at async._AsyncCallbackEntry.new.callback (http://localhost:55937/dart_sdk.js:31659:35)
    at Object._microtaskLoop (http://localhost:55937/dart_sdk.js:36245:13)
    at _startMicrotaskLoop (http://localhost:55937/dart_sdk.js:36251:13)
    at http://localhost:55937/dart_sdk.js:31999:9
```