### PR TITLE
Made flutter_view_ atomic 

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -5,16 +5,18 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_
 
-#include "flutter/flow/embedded_views.h"
-#include "flutter/flow/rtree.h"
-#include "flutter/fml/platform/darwin/scoped_nsobject.h"
-#include "flutter/shell/common/shell.h"
+#import <atomic>
+
+#import "flutter/flow/embedded_views.h"
+#import "flutter/flow/rtree.h"
+#import "flutter/fml/platform/darwin/scoped_nsobject.h"
+#import "flutter/shell/common/shell.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h"
 #import "flutter/shell/platform/darwin/ios/ios_context.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
+#import "third_party/skia/include/core/SkPictureRecorder.h"
 
 @class FlutterTouchInterceptingView;
 
@@ -205,7 +207,7 @@ class FlutterPlatformViewsController {
   std::map<int64_t, std::unique_ptr<SkPictureRecorder>> picture_recorders_;
 
   fml::scoped_nsobject<FlutterMethodChannel> channel_;
-  fml::scoped_nsobject<UIView> flutter_view_;
+  std::atomic<UIView*> flutter_view_ = nil;
   fml::scoped_nsobject<UIViewController> flutter_view_controller_;
   std::map<std::string, fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>> factories_;
   std::map<int64_t, fml::scoped_nsobject<NSObject<FlutterPlatformView>>> views_;
@@ -293,13 +295,14 @@ class FlutterPlatformViewsController {
                                                      sk_sp<SkPicture> picture,
                                                      SkRect rect,
                                                      int64_t view_id,
-                                                     int64_t overlay_id);
+                                                     int64_t overlay_id,
+                                                     UIView* flutter_view);
   // Removes overlay views and platform views that aren't needed in the current frame.
   // Must run on the platform thread.
   void RemoveUnusedLayers();
   // Appends the overlay views and platform view and sets their z index based on the composition
   // order.
-  void BringLayersIntoView(LayersMap layer_map);
+  void BringLayersIntoView(LayersMap layer_map, UIView* flutter_view);
 
   // Begin a CATransaction.
   // This transaction needs to be balanced with |CommitCATransactionIfNeeded|.

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -28,7 +28,9 @@ FlutterPlatformViewsController::FlutterPlatformViewsController(
     : layer_pool_(std::make_unique<FlutterPlatformViewLayerPool>(surface_factory)),
       weak_factory_(std::make_unique<fml::WeakPtrFactory<FlutterPlatformViewsController>>(this)){};
 
-FlutterPlatformViewsController::~FlutterPlatformViewsController() = default;
+FlutterPlatformViewsController::~FlutterPlatformViewsController() {
+  [flutter_view_.load() release];
+}
 
 fml::WeakPtr<flutter::FlutterPlatformViewsController> FlutterPlatformViewsController::GetWeakPtr() {
   return weak_factory_->GetWeakPtr();


### PR DESCRIPTION
## Description

I made flutter_view_ atomic to provide a minimal amount of thread synchronization to avoid a race condition crash.  This is the simplest, least intrusive thing I could think of that would reduce the risk of the race condition and fix it for me.

The outcome isn't ideal, but it's preferable to crashing.  We don't even know how much these situations happen in the wild.  The crash was happening for me in my add-to-app prototypes that were probably atypical usage.  @cyanglaz says this code is on the chopping block for refactoring so hopefully we can do something more correct then.

## Related Issues

https://github.com/flutter/flutter/issues/69449

## Tests

Existing tests should cover base behavior.  I added an issue to try to implement stress testing that could chase down these race conditions: https://github.com/flutter/flutter/issues/69626

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
