### PR TITLE
Upgrades to felt (running on multiple modes, multiple backends, single test target option)

### DIFF
--- a/e2etests/web/regular_integration_tests/lib/profile_diagnostics_main.dart
+++ b/e2etests/web/regular_integration_tests/lib/profile_diagnostics_main.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 
 void main() {
   runApp(MyApp());

--- a/e2etests/web/regular_integration_tests/pubspec.yaml
+++ b/e2etests/web/regular_integration_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: regular_integration_tests
 publish_to: none
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: ">=2.11.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/e2etests/web/regular_integration_tests/test_driver/platform_messages_integration.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/platform_messages_integration.dart
@@ -28,7 +28,7 @@ void main() async {
     await tester.tap(find.byKey(const Key('input')));
     // Focus in input, otherwise clipboard will fail with
     // 'document is not focused' platform exception.
-    html.document.querySelector('input').focus();
+    html.document.querySelector('input')?.focus();
     await Clipboard.setData(const ClipboardData(text: 'sample text'));
   }, skip: true); // https://github.com/flutter/flutter/issues/54296
 

--- a/e2etests/web/regular_integration_tests/test_driver/platform_messages_integration.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/platform_messages_integration.dart
@@ -46,12 +46,12 @@ void main() async {
     app.main();
     await tester.pumpAndSettle();
     final Map<String, dynamic> createArgs = <String, dynamic>{
-      'id': '567',
+      'id': 567,
       'viewType': 'MyView',
     };
     await SystemChannels.platform_views.invokeMethod<void>('create', createArgs);
     final Map<String, dynamic> disposeArgs = <String, dynamic>{
-      'id': '567',
+      'id': 567,
     };
     await SystemChannels.platform_views.invokeMethod<void>('dispose', disposeArgs);
     expect(viewInstanceCount, 1);

--- a/e2etests/web/regular_integration_tests/test_driver/platform_messages_integration.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/platform_messages_integration.dart
@@ -36,7 +36,7 @@ void main() async {
       (WidgetTester tester) async {
     int viewInstanceCount = 0;
 
-    final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+    platformViewsRegistry.getNextPlatformViewId();
     // ignore: undefined_prefixed_name
     ui.platformViewRegistry.registerViewFactory('MyView', (int viewId) {
       ++viewInstanceCount;
@@ -50,10 +50,7 @@ void main() async {
       'viewType': 'MyView',
     };
     await SystemChannels.platform_views.invokeMethod<void>('create', createArgs);
-    final Map<String, dynamic> disposeArgs = <String, dynamic>{
-      'id': 567,
-    };
-    await SystemChannels.platform_views.invokeMethod<void>('dispose', disposeArgs);
+    await SystemChannels.platform_views.invokeMethod<void>('dispose', 567);
     expect(viewInstanceCount, 1);
   });
 }

--- a/e2etests/web/regular_integration_tests/test_driver/text_editing_integration.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/text_editing_integration.dart
@@ -13,7 +13,9 @@ import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  final IntegrationTestWidgetsFlutterBinding binding = IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
+  final IntegrationTestWidgetsFlutterBinding binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized()
+          as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('Focused text field creates a native input element',
       (WidgetTester tester) async {
@@ -38,7 +40,7 @@ void main() {
 
     // Change the value of the TextFormField.
     final TextFormField textFormField = tester.widget(finder);
-    textFormField.controller.text = 'New Value';
+    textFormField.controller?.text = 'New Value';
     // DOM element's value also changes.
     expect(input.value, 'New Value');
 
@@ -68,7 +70,7 @@ void main() {
 
     // Change the value of the TextFormField.
     final TextFormField textFormField = tester.widget(finder);
-    textFormField.controller.text = 'New Value';
+    textFormField.controller?.text = 'New Value';
     // DOM element's value also changes.
     expect(input.value, 'New Value');
   });
@@ -145,9 +147,9 @@ void main() {
     expect(input2.value, 'Text2');
   });
 
-  testWidgets('Jump between TextFormFields with tab key after CapsLock is'
-      'activated',
-          (WidgetTester tester) async {
+  testWidgets(
+      'Jump between TextFormFields with tab key after CapsLock is'
+      'activated', (WidgetTester tester) async {
     app.main();
     await tester.pumpAndSettle();
 
@@ -163,7 +165,7 @@ void main() {
     final List<Node> nodeList = document.getElementsByTagName('input');
     expect(nodeList.length, equals(1));
     final InputElement input =
-    document.getElementsByTagName('input')[0] as InputElement;
+        document.getElementsByTagName('input')[0] as InputElement;
 
     // Press and release CapsLock.
     dispatchKeyboardEvent(input, 'keydown', <String, dynamic>{
@@ -207,7 +209,7 @@ void main() {
     // A native input element for the next TextField should be attached to the
     // DOM.
     final InputElement input2 =
-    document.getElementsByTagName('input')[0] as InputElement;
+        document.getElementsByTagName('input')[0] as InputElement;
     expect(input2.value, 'Text2');
   });
 
@@ -243,8 +245,8 @@ void main() {
     expect(input.hasAttribute('readonly'), isTrue);
 
     // Make sure the entire text is selected.
-    TextRange range =
-        TextRange(start: input.selectionStart, end: input.selectionEnd);
+    TextRange range = TextRange(
+        start: input.selectionStart ?? 0, end: input.selectionEnd ?? 0);
     expect(range.textInside(text), text);
 
     // Double tap to select the first word.
@@ -257,7 +259,8 @@ void main() {
     await gesture.up();
     await gesture.down(firstWordOffset);
     await gesture.up();
-    range = TextRange(start: input.selectionStart, end: input.selectionEnd);
+    range = TextRange(
+        start: input.selectionStart ?? 0, end: input.selectionEnd ?? 0);
     expect(range.textInside(text), 'Lorem');
 
     // Double tap to select the last word.
@@ -270,7 +273,8 @@ void main() {
     await gesture.up();
     await gesture.down(lastWordOffset);
     await gesture.up();
-    range = TextRange(start: input.selectionStart, end: input.selectionEnd);
+    range = TextRange(
+        start: input.selectionStart ?? 0, end: input.selectionEnd ?? 0);
     expect(range.textInside(text), 'amet');
   });
 }

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -449,6 +449,9 @@ class ChromeIntegrationArguments extends IntegrationArguments {
     String statementToRun = 'flutter drive '
         '--target=test_driver/${testName} -d web-server --$mode '
         '--browser-name=chrome --local-engine=host_debug_unopt';
+    if (isCanvaskitBackend) {
+      statementToRun = '$statementToRun --web-renderer=canvaskit';
+    }
     if (isLuci) {
       statementToRun = '$statementToRun --chrome-binary='
           '${preinstalledChromeExecutable()}';
@@ -475,8 +478,12 @@ class FirefoxIntegrationArguments extends IntegrationArguments {
   }
 
   String getCommandToRun(String testName, String mode,
-          {bool isCanvaskitBackend = false}) =>
-      'flutter ${getTestArguments(testName, mode).join(' ')}';
+      {bool isCanvaskitBackend = false}) {
+    final String arguments =
+        getTestArguments(testName, mode, isCanvaskitBackend: isCanvaskitBackend)
+            .join(' ');
+    return 'flutter $arguments';
+  }
 }
 
 /// Arguments to give `flutter drive` to run the integration tests on Safari.
@@ -498,8 +505,12 @@ class SafariIntegrationArguments extends IntegrationArguments {
   }
 
   String getCommandToRun(String testName, String mode,
-          {bool isCanvaskitBackend = false}) =>
-      'flutter ${getTestArguments(testName, mode).join(' ')}';
+      {bool isCanvaskitBackend = false}) {
+    final String arguments =
+        getTestArguments(testName, mode, isCanvaskitBackend: isCanvaskitBackend)
+            .join(' ');
+    return 'flutter $arguments';
+  }
 }
 
 /// Parses additional options that can be used when running integration tests.
@@ -646,5 +657,6 @@ const Map<String, List<String>> blockedTestsListsMapForModes =
 const Map<String, List<String>> blockedTestsListsMapForRenderBackends =
     <String, List<String>>{
   'html': [],
-  'canvaskit': [],
+  // This test failed on canvaskit on all three build modes.
+  'canvaskit': ['image_loading_integration.dart'],
 };

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -218,14 +218,14 @@ class IntegrationTestsManager {
         IntegrationArguments.fromBrowser(_browser);
     final int exitCode = await runProcess(
       executable,
-      arguments.getTestArguments(testName, mode,
-          isCanvaskitBackend: canvaskitBackend),
+      arguments.getTestArguments(testName, mode, canvaskitBackend),
       workingDirectory: directory.path,
       environment: enviroment,
     );
 
     if (exitCode != 0) {
-      final String command = arguments.getCommandToRun(testName, mode);
+      final String command =
+          arguments.getCommandToRun(testName, mode, canvaskitBackend);
       io.stderr
           .writeln('ERROR: Failed to run test. Exited with exit code $exitCode'
               '. To run $testName locally use the following command:'
@@ -422,16 +422,16 @@ abstract class IntegrationArguments {
     }
   }
 
-  List<String> getTestArguments(String testName, String mode,
-      {bool isCanvaskitBackend = false});
+  List<String> getTestArguments(
+      String testName, String mode, bool isCanvaskitBackend);
 
-  String getCommandToRun(String testName, String mode);
+  String getCommandToRun(String testName, String mode, bool isCanvaskitBackend);
 }
 
 /// Arguments to give `flutter drive` to run the integration tests on Chrome.
 class ChromeIntegrationArguments extends IntegrationArguments {
-  List<String> getTestArguments(String testName, String mode,
-      {bool isCanvaskitBackend = false}) {
+  List<String> getTestArguments(
+      String testName, String mode, bool isCanvaskitBackend) {
     return <String>[
       'drive',
       '--target=test_driver/${testName}',
@@ -446,8 +446,8 @@ class ChromeIntegrationArguments extends IntegrationArguments {
     ];
   }
 
-  String getCommandToRun(String testName, String mode,
-      {bool isCanvaskitBackend = false}) {
+  String getCommandToRun(
+      String testName, String mode, bool isCanvaskitBackend) {
     String statementToRun = 'flutter drive '
         '--target=test_driver/${testName} -d web-server --$mode '
         '--browser-name=chrome --local-engine=host_debug_unopt';
@@ -464,8 +464,8 @@ class ChromeIntegrationArguments extends IntegrationArguments {
 
 /// Arguments to give `flutter drive` to run the integration tests on Firefox.
 class FirefoxIntegrationArguments extends IntegrationArguments {
-  List<String> getTestArguments(String testName, String mode,
-      {bool isCanvaskitBackend = false}) {
+  List<String> getTestArguments(
+      String testName, String mode, bool isCanvaskitBackend) {
     return <String>[
       'drive',
       '--target=test_driver/${testName}',
@@ -479,11 +479,10 @@ class FirefoxIntegrationArguments extends IntegrationArguments {
     ];
   }
 
-  String getCommandToRun(String testName, String mode,
-      {bool isCanvaskitBackend = false}) {
+  String getCommandToRun(
+      String testName, String mode, bool isCanvaskitBackend) {
     final String arguments =
-        getTestArguments(testName, mode, isCanvaskitBackend: isCanvaskitBackend)
-            .join(' ');
+        getTestArguments(testName, mode, isCanvaskitBackend).join(' ');
     return 'flutter $arguments';
   }
 }
@@ -492,8 +491,8 @@ class FirefoxIntegrationArguments extends IntegrationArguments {
 class SafariIntegrationArguments extends IntegrationArguments {
   SafariIntegrationArguments();
 
-  List<String> getTestArguments(String testName, String mode,
-      {bool isCanvaskitBackend = false}) {
+  List<String> getTestArguments(
+      String testName, String mode, bool isCanvaskitBackend) {
     return <String>[
       'drive',
       '--target=test_driver/${testName}',
@@ -506,11 +505,10 @@ class SafariIntegrationArguments extends IntegrationArguments {
     ];
   }
 
-  String getCommandToRun(String testName, String mode,
-      {bool isCanvaskitBackend = false}) {
+  String getCommandToRun(
+      String testName, String mode, bool isCanvaskitBackend) {
     final String arguments =
-        getTestArguments(testName, mode, isCanvaskitBackend: isCanvaskitBackend)
-            .join(' ');
+        getTestArguments(testName, mode, isCanvaskitBackend).join(' ');
     return 'flutter $arguments';
   }
 }
@@ -538,9 +536,10 @@ class IntegrationTestsArgumentParser {
   /// `blockedTestsListsMapForModes` list for the relevant compile mode.
   String buildMode;
 
-  /// Whether to use html or canvaskit backend.
+  /// Whether to use html, canvaskit or auto for web renderer.
   ///
-  /// If not set html rendering backend will be used.
+  /// If not set all backends will be used one after another for integration
+  /// tests. If set only the provided option will be used.
   String webRenderer;
 
   void populateOptions(ArgParser argParser) {

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -359,10 +359,10 @@ class IntegrationTestsManager {
       !IntegrationTestsArgumentParser.instance.buildMode.isEmpty;
 
   bool get _renderingBackendSelected =>
-      !IntegrationTestsArgumentParser.instance.renderingBackend.isEmpty;
+      !IntegrationTestsArgumentParser.instance.webRenderer.isEmpty;
 
   bool get _renderingBackendHtml =>
-      IntegrationTestsArgumentParser.instance.renderingBackend == 'html';
+      IntegrationTestsArgumentParser.instance.webRenderer == 'html';
 
   bool get _runAllTestTargets =>
       IntegrationTestsArgumentParser.instance.testTarget.isEmpty;
@@ -541,7 +541,7 @@ class IntegrationTestsArgumentParser {
   /// Whether to use html or canvaskit backend.
   ///
   /// If not set html rendering backend will be used.
-  String renderingBackend;
+  String webRenderer;
 
   void populateOptions(ArgParser argParser) {
     argParser
@@ -566,12 +566,13 @@ class IntegrationTestsArgumentParser {
               'tests will only be run using that mode. '
               'See https://flutter.dev/docs/testing/build-modes for more '
               'details on the build modes.')
-      ..addOption('rendering-backend',
+      ..addOption('web-renderer',
           defaultsTo: '',
-          help: 'By default both `html` and `canvaskit` rendering backends are '
-              ' tested when running integration tests. If this option is set '
-              ' only one of these backends will be used. `canvaskit` and `html`'
-              ' are the only available options. ');
+          help: 'By default all three options (`html`, `canvaskit`, `auto`) '
+              ' for rendering backends are tested when running integration '
+              ' tests. If this option is set only the backend provided by this '
+              ' option will be used. `auto`, `canvaskit` and `html`'
+              ' are the available options. ');
   }
 
   /// Populate browser with results of the arguments passed.
@@ -579,16 +580,17 @@ class IntegrationTestsArgumentParser {
     testTarget = argResults['target'] as String;
     buildMode = argResults['build-mode'] as String;
     if (!buildMode.isEmpty &&
-        buildMode.toLowerCase() != 'debug' &&
-        buildMode.toLowerCase() != 'profile' &&
-        buildMode.toLowerCase() != 'release') {
+        buildMode != 'debug' &&
+        buildMode != 'profile' &&
+        buildMode != 'release') {
       throw ArgumentError('Unexpected build mode: $buildMode');
     }
-    renderingBackend = argResults['rendering-backend'] as String;
-    if (!renderingBackend.isEmpty &&
-        renderingBackend.toLowerCase() != 'html' &&
-        renderingBackend.toLowerCase() != 'canvaskit') {
-      throw ArgumentError('Unexpected rendering backend: $renderingBackend');
+    webRenderer = argResults['web-renderer'] as String;
+    if (!webRenderer.isEmpty &&
+        webRenderer != 'html' &&
+        webRenderer != 'canvaskit' &&
+        webRenderer != 'auto') {
+      throw ArgumentError('Unexpected rendering backend: $webRenderer');
     }
   }
 }
@@ -638,7 +640,7 @@ const Map<String, List<String>> blockedTestsListsMap = <String, List<String>>{
 
 /// Tests blocked for one of the build modes.
 ///
-/// If a test is not suppose to run for one of the modes also add that test
+/// If a test is not supposed to run for one of the modes also add that test
 /// to the corresponding list.
 // TODO(nurhan): Remove the failing test after fixing.
 const Map<String, List<String>> blockedTestsListsMapForModes =

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -236,7 +236,8 @@ class IntegrationTestsManager {
       final String mode = IntegrationTestsArgumentParser.instance.webRenderer;
       renderingBackends = <String>{mode};
     } else {
-      renderingBackends = {'auto', 'html', 'canvaskit'};
+      // TODO(nurhan): Enable `auto` when recipe is sharded.
+      renderingBackends = {'html', 'canvaskit'};
     }
     return renderingBackends;
   }
@@ -251,9 +252,10 @@ class IntegrationTestsManager {
         buildModes = <String>{mode};
       }
     } else {
+      // TODO(nurhan): Enable `release` when recipe is sharded.
       buildModes = _browser == 'chrome'
-          ? {'debug', 'profile', 'release'}
-          : {'profile', 'release'};
+          ? {'debug', 'profile'}
+          : {'profile'};
     }
     return buildModes;
   }
@@ -632,6 +634,7 @@ const Map<String, List<String>> blockedTestsListsMapForModes =
   'debug': [
     'treeshaking_integration.dart',
     'text_editing_integration.dart',
+    'url_strategy_integration.dart',
   ],
   'profile': [],
   'release': [],

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -144,8 +144,10 @@ class IntegrationTestsManager {
           }
         }
       }
-      print(
-          'INFO: In project ${directory} ${e2eTestsToRun.length} tests to run.');
+      if (isVerboseLoggingEnabled) {
+        print(
+            'INFO: In project ${directory} ${e2eTestsToRun.length} tests to run.');
+      }
     } else {
       // If a target is specified it will run regardless of if it's blocked or
       // not. There will be an info note to warn the developer.
@@ -154,7 +156,7 @@ class IntegrationTestsManager {
       final io.File file =
           entities.singleWhere((f) => pathlib.basename(f.path) == targetTest);
       final String basename = pathlib.basename(file.path);
-      if (blockedTests.contains(basename)) {
+      if (blockedTests.contains(basename) && isVerboseLoggingEnabled) {
         print('INFO: Test $basename do not run on CI environments. Please '
             'remove it from the blocked tests list if you want to enable this '
             'test on CI.');
@@ -557,7 +559,7 @@ class IntegrationTestsArgumentParser {
               ' are the available options. ');
   }
 
-  /// Populate browser with results of the arguments passed.
+  /// Populate results of the arguments passed.
   void parseOptions(ArgResults argResults) {
     testTarget = argResults['target'] as String;
     buildMode = argResults['build-mode'] as String;

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -155,7 +155,9 @@ class IntegrationTestsManager {
           entities.singleWhere((f) => pathlib.basename(f.path) == targetTest);
       final String basename = pathlib.basename(file.path);
       if (blockedTests.contains(basename)) {
-        print('INFO: Test $basename do not run on CI environments.');
+        print('INFO: Test $basename do not run on CI environments. Please '
+            'remove it from the blocked tests list if you want to enable this '
+            'test on CI.');
       }
       e2eTestsToRun.add(basename);
     }

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -144,7 +144,9 @@ class IntegrationTestsManager {
 
     int numberOfPassedTests = 0;
     int numberOfFailedTests = 0;
-    final Set<String> buildModes = {'debug', 'profile', 'release'};
+    final Set<String> buildModes = _browser == 'chrome'
+        ? {'debug', 'profile', 'release'}
+        : {'profile', 'release'};
     for (String fileName in e2eTestsToRun) {
       for (String mode in buildModes) {
         if (!blockedTestsListsMapForModes[mode].contains(fileName)) {

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -148,8 +148,6 @@ class TestCommand extends Command<bool> with ArgUtils {
       case TestTypesRequested.unit:
         return runUnitTests();
       case TestTypesRequested.integration:
-        // Parse additional arguments specific for integration testing.
-        IntegrationTestsArgumentParser.instance.parseOptions(argResults);
         return runIntegrationTests();
       case TestTypesRequested.all:
         if (runAllTests && isIntegrationTestsAvailable) {
@@ -168,6 +166,8 @@ class TestCommand extends Command<bool> with ArgUtils {
   }
 
   Future<bool> runIntegrationTests() async {
+    // Parse additional arguments specific for integration testing.
+    IntegrationTestsArgumentParser.instance.parseOptions(argResults);
     if(!_testPreparationReady) {
       await _prepare();
     }

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -90,6 +90,7 @@ class TestCommand extends Command<bool> with ArgUtils {
 
     SupportedBrowsers.instance.argParsers
         .forEach((t) => t.populateOptions(argParser));
+    IntegrationTestsArgumentParser.instance.populateOptions(argParser);
   }
 
   @override
@@ -147,6 +148,8 @@ class TestCommand extends Command<bool> with ArgUtils {
       case TestTypesRequested.unit:
         return runUnitTests();
       case TestTypesRequested.integration:
+        // Parse additional arguments specific for integration testing.
+        IntegrationTestsArgumentParser.instance.parseOptions(argResults);
         return runIntegrationTests();
       case TestTypesRequested.all:
         if (runAllTests && isIntegrationTestsAvailable) {
@@ -165,9 +168,9 @@ class TestCommand extends Command<bool> with ArgUtils {
   }
 
   Future<bool> runIntegrationTests() async {
-    if(!_testPreparationReady) {
-      await _prepare();
-    }
+    // if(!_testPreparationReady) {
+    //   await _prepare();
+    // }
     return IntegrationTestsManager(
             browser, useSystemFlutter, doUpdateScreenshotGoldens)
         .runTests();
@@ -204,7 +207,7 @@ class TestCommand extends Command<bool> with ArgUtils {
 
     // If screenshot tests are available, fetch the screenshot goldens.
     if (isScreenshotTestsAvailable) {
-      print('screenshot tests available');
+      print('INFO: Screenshot tests available');
       final GoldensRepoFetcher goldensRepoFetcher = GoldensRepoFetcher(
           environment.webUiGoldensRepositoryDirectory,
           path.join(environment.webUiDevDir.path, 'goldens_lock.yaml'));

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -168,9 +168,9 @@ class TestCommand extends Command<bool> with ArgUtils {
   }
 
   Future<bool> runIntegrationTests() async {
-    // if(!_testPreparationReady) {
-    //   await _prepare();
-    // }
+    if(!_testPreparationReady) {
+      await _prepare();
+    }
     return IntegrationTestsManager(
             browser, useSystemFlutter, doUpdateScreenshotGoldens)
         .runTests();

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -90,6 +90,7 @@ class TestCommand extends Command<bool> with ArgUtils {
 
     SupportedBrowsers.instance.argParsers
         .forEach((t) => t.populateOptions(argParser));
+    GeneralTestsArgumentParser.instance.populateOptions(argParser);
     IntegrationTestsArgumentParser.instance.populateOptions(argParser);
   }
 
@@ -134,6 +135,7 @@ class TestCommand extends Command<bool> with ArgUtils {
   Future<bool> run() async {
     SupportedBrowsers.instance
       ..argParsers.forEach((t) => t.parseOptions(argResults));
+    GeneralTestsArgumentParser.instance.parseOptions(argResults);
 
     // Check the flags to see what type of integration tests are requested.
     testTypesRequested = findTestType();
@@ -207,7 +209,9 @@ class TestCommand extends Command<bool> with ArgUtils {
 
     // If screenshot tests are available, fetch the screenshot goldens.
     if (isScreenshotTestsAvailable) {
-      print('INFO: Screenshot tests available');
+      if (isVerboseLoggingEnabled) {
+        print('INFO: Screenshot tests available');
+      }
       final GoldensRepoFetcher goldensRepoFetcher = GoldensRepoFetcher(
           environment.webUiGoldensRepositoryDirectory,
           path.join(environment.webUiDevDir.path, 'goldens_lock.yaml'));

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -6,6 +6,7 @@
 import 'dart:async';
 import 'dart:io' as io;
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
@@ -184,6 +185,37 @@ mixin ArgUtils<T> on Command<T> {
     return value;
   }
 }
+
+/// Parses additional options that can be used for all tests.
+class GeneralTestsArgumentParser {
+  static final GeneralTestsArgumentParser _singletonInstance =
+      GeneralTestsArgumentParser._();
+
+  /// The [GeneralTestsArgumentParser] singleton.
+  static GeneralTestsArgumentParser get instance => _singletonInstance;
+
+  GeneralTestsArgumentParser._();
+
+  /// If target name is provided integration tests can run that one test
+  /// instead of running all the tests.
+  bool verbose = false;
+
+  void populateOptions(ArgParser argParser) {
+    argParser
+      ..addFlag(
+        'verbose',
+        defaultsTo: false,
+        help: 'Flag to indicate extra logs should also be printed.',
+      );
+  }
+
+  /// Populate results of the arguments passed.
+  void parseOptions(ArgResults argResults) {
+    verbose = argResults['verbose'] as bool;
+  }
+}
+
+bool get isVerboseLoggingEnabled => GeneralTestsArgumentParser.instance.verbose;
 
 /// There might be proccesses started during the tests.
 ///

--- a/web_sdk/web_test_utils/pubspec.yaml
+++ b/web_sdk/web_test_utils/pubspec.yaml
@@ -1,7 +1,7 @@
 name: web_test_utils
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.11.0-0 <3.0.0"
 
 dependencies:
   path: 1.8.0-nullsafety.3


### PR DESCRIPTION
## Description

Changing felt :
- run integration tests on all three build modes for Chrome and profile/release mode for other browsers. 
- run integration tests on both rendering backends (html and canvaskit)
- adding a blocked list for cases where the tests are not passing/suppose to run on this platform.
- adding a flag to be able to control the rendering backend via felt
- adding a flag to run one single target instead of all integration tests
- adding a flag to run on a selected mode (previously only profile mode was available) 

TODO: I'll send another PR for updating all the documentations!

## Related Issues

Fixes: https://github.com/flutter/flutter/issues/52987
Fixes: https://github.com/flutter/flutter/issues/69734

## Tests

Running on LUCI: https://ci.chromium.org/p/flutter/builders/try/Linux%20Web%20Engine/11477? 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
