### PR TITLE
Fix Linux handling of window exposure events

### DIFF
--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -258,8 +258,7 @@ static void fl_view_size_allocate(GtkWidget* widget,
 }
 
 // Implements GtkWidget::draw.
-static gboolean fl_view_draw(GtkWidget* widget,
-                             cairo_t* cr) {
+static gboolean fl_view_draw(GtkWidget* widget, cairo_t* cr) {
   FlView* self = FL_VIEW(widget);
   // The engine doesn't support exposure events, so instead, force redraw by
   // sending a window metrics event of the same geometry. Since the geometry

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -257,6 +257,17 @@ static void fl_view_size_allocate(GtkWidget* widget,
   fl_view_geometry_changed(self);
 }
 
+// Implements GtkWidget::draw.
+static gboolean fl_view_draw(GtkWidget* widget,
+                             cairo_t* cr) {
+  FlView* self = FL_VIEW(widget);
+  // The engine doesn't support exposure events, so instead, force redraw by
+  // sending a window metrics event of the same geometry. Since the geometry
+  // didn't change, only a frame will be scheduled.
+  fl_view_geometry_changed(self);
+  return TRUE;
+}
+
 // Implements GtkWidget::button_press_event.
 static gboolean fl_view_button_press_event(GtkWidget* widget,
                                            GdkEventButton* event) {
@@ -363,6 +374,7 @@ static void fl_view_class_init(FlViewClass* klass) {
   G_OBJECT_CLASS(klass)->dispose = fl_view_dispose;
   GTK_WIDGET_CLASS(klass)->realize = fl_view_realize;
   GTK_WIDGET_CLASS(klass)->size_allocate = fl_view_size_allocate;
+  GTK_WIDGET_CLASS(klass)->draw = fl_view_draw;
   GTK_WIDGET_CLASS(klass)->button_press_event = fl_view_button_press_event;
   GTK_WIDGET_CLASS(klass)->button_release_event = fl_view_button_release_event;
   GTK_WIDGET_CLASS(klass)->scroll_event = fl_view_scroll_event;


### PR DESCRIPTION
## Description

Currently, the Linux embedder does not handle window exposure events.
This is typically not a problem for users who use compositing window
managers, since they keep the display buffers even if the window is
completely covered. However, for users that don't use a compositor, the
window will not be redrawn by the engine if it was previously covered
until another event triggers the redraw.

This patch implements the GtkWidget draw callback to handle window
exposure events. The callback doesn't actually draw anything, it just
schedule a frame for drawing by the engine.

The engine doesn't support exposure events, so instead, we force redraw
by sending a window metrics event of the same geometry. Since the
geometry didn't change, only a frame will be scheduled.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/68391

## Tests

I haven't added any tests. Any pointers as how I should add tests for this?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
