### PR TITLE
Switch Linux embedding to proc table embedder API

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -187,10 +187,11 @@ executable("flutter_linux_unittests") {
     "//flutter/shell/platform/linux/config:x11",
   ]
 
-  # Set flag to allow public headers to be directly included (library users should not do this)
   defines = [
-    "FLUTTER_LINUX_COMPILATION",
     "FLUTTER_ENGINE_NO_PROTOTYPES",
+    # Set flag to allow public headers to be directly included
+    # (library users should not do this)
+    "FLUTTER_LINUX_COMPILATION",
   ]
 
   deps = [
@@ -198,6 +199,7 @@ executable("flutter_linux_unittests") {
     ":flutter_linux_sources",
     "//flutter/runtime:libdart",
     "//flutter/shell/platform/embedder:embedder_headers",
+    "//flutter/shell/platform/embedder:embedder_test_utils",
     "//flutter/testing",
   ]
 }

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -119,7 +119,10 @@ source_set("flutter_linux_sources") {
   ]
 
   # Set flag to stop headers being directly included (library users should not do this)
-  defines = [ "FLUTTER_LINUX_COMPILATION" ]
+  defines = [
+    "FLUTTER_LINUX_COMPILATION",
+    "FLUTTER_ENGINE_NO_PROTOTYPES",
+  ]
 
   deps = [
     "//flutter/shell/platform/common/cpp:common_cpp_input",
@@ -137,6 +140,8 @@ source_set("flutter_linux") {
     "//flutter/shell/platform/linux/config:x11",
     "//third_party/khronos:khronos_headers",
   ]
+
+  defines = [ "FLUTTER_ENGINE_NO_PROTOTYPES" ]
 
   public_deps = [ ":flutter_linux_sources" ]
 
@@ -183,7 +188,10 @@ executable("flutter_linux_unittests") {
   ]
 
   # Set flag to allow public headers to be directly included (library users should not do this)
-  defines = [ "FLUTTER_LINUX_COMPILATION" ]
+  defines = [
+    "FLUTTER_LINUX_COMPILATION",
+    "FLUTTER_ENGINE_NO_PROTOTYPES",
+  ]
 
   deps = [
     ":flutter_linux_fixtures",

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -189,6 +189,7 @@ executable("flutter_linux_unittests") {
 
   defines = [
     "FLUTTER_ENGINE_NO_PROTOTYPES",
+
     # Set flag to allow public headers to be directly included
     # (library users should not do this)
     "FLUTTER_LINUX_COMPILATION",

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -437,6 +437,10 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   return TRUE;
 }
 
+FlutterEngineProcTable* fl_engine_get_embedder_api(FlEngine* self) {
+  return &(self->embedder_api);
+}
+
 void fl_engine_set_platform_message_handler(
     FlEngine* self,
     FlEnginePlatformMessageHandler handler,

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -32,6 +32,7 @@ struct _FlEngine {
   FlBinaryMessenger* binary_messenger;
   FlutterEngineAOTData aot_data;
   FLUTTER_API_SYMBOL(FlutterEngine) engine;
+  FlutterEngineProcTable embedder_api;
 
   // Function to call when a platform message is received.
   FlEnginePlatformMessageHandler platform_message_handler;
@@ -127,7 +128,7 @@ static void setup_locales(FlEngine* self) {
   }
   FlutterLocale** locales =
       reinterpret_cast<FlutterLocale**>(locales_array->pdata);
-  FlutterEngineResult result = FlutterEngineUpdateLocales(
+  FlutterEngineResult result = self->embedder_api.UpdateLocales(
       self->engine, const_cast<const FlutterLocale**>(locales),
       locales_array->len);
   if (result != kSuccess) {
@@ -143,7 +144,7 @@ static gboolean flutter_source_dispatch(GSource* source,
   FlEngine* self = fl_source->engine;
 
   FlutterEngineResult result =
-      FlutterEngineRunTask(self->engine, &fl_source->task);
+      self->embedder_api.RunTask(self->engine, &fl_source->task);
   if (result != kSuccess) {
     g_warning("Failed to run Flutter task\n");
   }
@@ -302,12 +303,12 @@ static void fl_engine_dispose(GObject* object) {
   FlEngine* self = FL_ENGINE(object);
 
   if (self->engine != nullptr) {
-    FlutterEngineShutdown(self->engine);
+    self->embedder_api.Shutdown(self->engine);
     self->engine = nullptr;
   }
 
   if (self->aot_data != nullptr) {
-    FlutterEngineCollectAOTData(self->aot_data);
+    self->embedder_api.CollectAOTData(self->aot_data);
     self->aot_data = nullptr;
   }
 
@@ -331,6 +332,9 @@ static void fl_engine_class_init(FlEngineClass* klass) {
 
 static void fl_engine_init(FlEngine* self) {
   self->thread = g_thread_self();
+
+  self->embedder_api.struct_size = sizeof(FlutterEngineProcTable);
+  FlutterEngineGetProcAddresses(&self->embedder_api);
 
   self->binary_messenger = fl_binary_messenger_new(self);
 }
@@ -400,11 +404,12 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
   args.dart_entrypoint_argv =
       reinterpret_cast<const char* const*>(dart_entrypoint_args);
 
-  if (FlutterEngineRunsAOTCompiledDartCode()) {
+  if (self->embedder_api.RunsAOTCompiledDartCode()) {
     FlutterEngineAOTDataSource source = {};
     source.type = kFlutterEngineAOTDataSourceTypeElfPath;
     source.elf_path = fl_dart_project_get_aot_library_path(self->project);
-    if (FlutterEngineCreateAOTData(&source, &self->aot_data) != kSuccess) {
+    if (self->embedder_api.CreateAOTData(&source, &self->aot_data) !=
+        kSuccess) {
       g_set_error(error, fl_engine_error_quark(), FL_ENGINE_ERROR_FAILED,
                   "Failed to create AOT data");
       return FALSE;
@@ -412,7 +417,7 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
     args.aot_data = self->aot_data;
   }
 
-  FlutterEngineResult result = FlutterEngineInitialize(
+  FlutterEngineResult result = self->embedder_api.Initialize(
       FLUTTER_ENGINE_VERSION, &config, &args, self, &self->engine);
   if (result != kSuccess) {
     g_set_error(error, fl_engine_error_quark(), FL_ENGINE_ERROR_FAILED,
@@ -420,7 +425,7 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
     return FALSE;
   }
 
-  result = FlutterEngineRunInitialized(self->engine);
+  result = self->embedder_api.RunInitialized(self->engine);
   if (result != kSuccess) {
     g_set_error(error, fl_engine_error_quark(), FL_ENGINE_ERROR_FAILED,
                 "Failed to run Flutter engine");
@@ -470,7 +475,7 @@ gboolean fl_engine_send_platform_message_response(
     data =
         static_cast<const uint8_t*>(g_bytes_get_data(response, &data_length));
   }
-  FlutterEngineResult result = FlutterEngineSendPlatformMessageResponse(
+  FlutterEngineResult result = self->embedder_api.SendPlatformMessageResponse(
       self->engine, handle, data, data_length);
 
   if (result != kSuccess) {
@@ -501,9 +506,10 @@ void fl_engine_send_platform_message(FlEngine* self,
       return;
     }
 
-    FlutterEngineResult result = FlutterPlatformMessageCreateResponseHandle(
-        self->engine, fl_engine_platform_message_response_cb, task,
-        &response_handle);
+    FlutterEngineResult result =
+        self->embedder_api.PlatformMessageCreateResponseHandle(
+            self->engine, fl_engine_platform_message_response_cb, task,
+            &response_handle);
     if (result != kSuccess) {
       g_task_return_new_error(task, fl_engine_error_quark(),
                               FL_ENGINE_ERROR_FAILED,
@@ -525,7 +531,7 @@ void fl_engine_send_platform_message(FlEngine* self,
   fl_message.message_size = message != nullptr ? g_bytes_get_size(message) : 0;
   fl_message.response_handle = response_handle;
   FlutterEngineResult result =
-      FlutterEngineSendPlatformMessage(self->engine, &fl_message);
+      self->embedder_api.SendPlatformMessage(self->engine, &fl_message);
 
   if (result != kSuccess && task != nullptr) {
     g_task_return_new_error(task, fl_engine_error_quark(),
@@ -535,7 +541,8 @@ void fl_engine_send_platform_message(FlEngine* self,
   }
 
   if (response_handle != nullptr) {
-    FlutterPlatformMessageReleaseResponseHandle(self->engine, response_handle);
+    self->embedder_api.PlatformMessageReleaseResponseHandle(self->engine,
+                                                            response_handle);
   }
 }
 
@@ -563,7 +570,7 @@ void fl_engine_send_window_metrics_event(FlEngine* self,
   event.width = width;
   event.height = height;
   event.pixel_ratio = pixel_ratio;
-  FlutterEngineSendWindowMetricsEvent(self->engine, &event);
+  self->embedder_api.SendWindowMetricsEvent(self->engine, &event);
 }
 
 void fl_engine_send_mouse_pointer_event(FlEngine* self,
@@ -593,7 +600,7 @@ void fl_engine_send_mouse_pointer_event(FlEngine* self,
   fl_event.scroll_delta_y = scroll_delta_y;
   fl_event.device_kind = kFlutterPointerDeviceKindMouse;
   fl_event.buttons = buttons;
-  FlutterEngineSendPointerEvent(self->engine, &fl_event, 1);
+  self->embedder_api.SendPointerEvent(self->engine, &fl_event, 1);
 }
 
 G_MODULE_EXPORT FlBinaryMessenger* fl_engine_get_binary_messenger(

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -56,6 +56,16 @@ typedef gboolean (*FlEnginePlatformMessageHandler)(
 FlEngine* fl_engine_new(FlDartProject* project, FlRenderer* renderer);
 
 /**
+ * fl_engine_get_embedder_api:
+ * @engine: an #FlEngine.
+ *
+ * Gets the embedder API proc table, allowing modificiations for unit testing.
+ *
+ * Returns: a mutable pointer to the embedder API proc table.
+ */
+FlutterEngineProcTable* fl_engine_get_embedder_api(FlEngine* engine);
+
+/**
  * fl_engine_set_platform_message_handler:
  * @engine: an #FlEngine.
  * @handler: function to call when a platform message is received.

--- a/shell/platform/linux/testing/mock_engine.cc
+++ b/shell/platform/linux/testing/mock_engine.cc
@@ -2,6 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This file is a historical legacy, predating the proc table API. It has been
+// updated to continue to work with the proc table, but new tests should not
+// rely on replacements set up here, but instead use test-local replacements
+// for any functions relevant to that test.
+//
+// Over time existing tests should be migrated and this file should be removed.
+
 #include <cstring>
 
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -77,6 +84,8 @@ struct _FlutterTaskRunner {
   }
 };
 
+namespace {
+
 // Send a response from the engine.
 static void send_response(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
@@ -138,31 +147,6 @@ FlutterEngineResult FlutterEngineCollectAOTData(FlutterEngineAOTData data) {
   return kSuccess;
 }
 
-FlutterEngineResult FlutterEngineRun(size_t version,
-                                     const FlutterRendererConfig* config,
-                                     const FlutterProjectArgs* args,
-                                     void* user_data,
-                                     FLUTTER_API_SYMBOL(FlutterEngine) *
-                                         engine_out) {
-  EXPECT_NE(config, nullptr);
-  EXPECT_NE(args, nullptr);
-  EXPECT_NE(user_data, nullptr);
-  EXPECT_NE(engine_out, nullptr);
-
-  FlutterEngineResult result =
-      FlutterEngineInitialize(version, config, args, user_data, engine_out);
-  if (result != kSuccess) {
-    return result;
-  }
-  return FlutterEngineRunInitialized(*engine_out);
-}
-
-FlutterEngineResult FlutterEngineShutdown(FLUTTER_API_SYMBOL(FlutterEngine)
-                                              engine) {
-  delete engine;
-  return kSuccess;
-}
-
 FlutterEngineResult FlutterEngineInitialize(size_t version,
                                             const FlutterRendererConfig* config,
                                             const FlutterProjectArgs* args,
@@ -189,14 +173,39 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
   return kSuccess;
 }
 
-FlutterEngineResult FlutterEngineDeinitialize(FLUTTER_API_SYMBOL(FlutterEngine)
-                                                  engine) {
-  return kSuccess;
-}
-
 FlutterEngineResult FlutterEngineRunInitialized(
     FLUTTER_API_SYMBOL(FlutterEngine) engine) {
   engine->running = true;
+  return kSuccess;
+}
+
+FlutterEngineResult FlutterEngineRun(size_t version,
+                                     const FlutterRendererConfig* config,
+                                     const FlutterProjectArgs* args,
+                                     void* user_data,
+                                     FLUTTER_API_SYMBOL(FlutterEngine) *
+                                         engine_out) {
+  EXPECT_NE(config, nullptr);
+  EXPECT_NE(args, nullptr);
+  EXPECT_NE(user_data, nullptr);
+  EXPECT_NE(engine_out, nullptr);
+
+  FlutterEngineResult result =
+      FlutterEngineInitialize(version, config, args, user_data, engine_out);
+  if (result != kSuccess) {
+    return result;
+  }
+  return FlutterEngineRunInitialized(*engine_out);
+}
+
+FlutterEngineResult FlutterEngineShutdown(FLUTTER_API_SYMBOL(FlutterEngine)
+                                              engine) {
+  delete engine;
+  return kSuccess;
+}
+
+FlutterEngineResult FlutterEngineDeinitialize(FLUTTER_API_SYMBOL(FlutterEngine)
+                                                  engine) {
   return kSuccess;
 }
 
@@ -399,5 +408,52 @@ FlutterEngineResult FlutterEngineUpdateLocales(FLUTTER_API_SYMBOL(FlutterEngine)
                                                    engine,
                                                const FlutterLocale** locales,
                                                size_t locales_count) {
+  return kSuccess;
+}
+
+}  // namespace
+
+FlutterEngineResult FlutterEngineGetProcAddresses(
+    FlutterEngineProcTable* table) {
+  if (!table) {
+    return kInvalidArguments;
+  }
+
+  table->CreateAOTData = &FlutterEngineCreateAOTData;
+  table->CollectAOTData = &FlutterEngineCollectAOTData;
+  table->Run = &FlutterEngineRun;
+  table->Shutdown = &FlutterEngineShutdown;
+  table->Initialize = &FlutterEngineInitialize;
+  table->Deinitialize = &FlutterEngineDeinitialize;
+  table->RunInitialized = &FlutterEngineRunInitialized;
+  table->SendWindowMetricsEvent = &FlutterEngineSendWindowMetricsEvent;
+  table->SendPointerEvent = &FlutterEngineSendPointerEvent;
+  table->SendPlatformMessage = &FlutterEngineSendPlatformMessage;
+  table->PlatformMessageCreateResponseHandle =
+      &FlutterPlatformMessageCreateResponseHandle;
+  table->PlatformMessageReleaseResponseHandle =
+      &FlutterPlatformMessageReleaseResponseHandle;
+  table->SendPlatformMessageResponse = &FlutterEngineSendPlatformMessageResponse;
+  table->RegisterExternalTexture = nullptr;
+  table->UnregisterExternalTexture = nullptr;
+  table->MarkExternalTextureFrameAvailable = nullptr;
+  table->UpdateSemanticsEnabled = nullptr;
+  table->UpdateAccessibilityFeatures = nullptr;
+  table->DispatchSemanticsAction = nullptr;
+  table->OnVsync = nullptr;
+  table->ReloadSystemFonts = nullptr;
+  table->TraceEventDurationBegin = nullptr;
+  table->TraceEventDurationEnd = nullptr;
+  table->TraceEventInstant = nullptr;
+  table->PostRenderThreadTask = nullptr;
+  table->GetCurrentTime = nullptr;
+  table->RunTask = &FlutterEngineRunTask;
+  table->UpdateLocales = &FlutterEngineUpdateLocales;
+  table->RunsAOTCompiledDartCode = &FlutterEngineRunsAOTCompiledDartCode;
+  table->PostDartObject = nullptr;
+  table->NotifyLowMemoryWarning = nullptr;
+  table->PostCallbackOnAllNativeThreads = nullptr;
+  table->NotifyDisplayUpdate = nullptr;
+
   return kSuccess;
 }

--- a/shell/platform/linux/testing/mock_engine.cc
+++ b/shell/platform/linux/testing/mock_engine.cc
@@ -419,6 +419,9 @@ FlutterEngineResult FlutterEngineGetProcAddresses(
     return kInvalidArguments;
   }
 
+  FlutterEngineProcTable empty_table = {};
+  *table = empty_table;
+
   table->CreateAOTData = &FlutterEngineCreateAOTData;
   table->CollectAOTData = &FlutterEngineCollectAOTData;
   table->Run = &FlutterEngineRun;
@@ -434,26 +437,9 @@ FlutterEngineResult FlutterEngineGetProcAddresses(
   table->PlatformMessageReleaseResponseHandle =
       &FlutterPlatformMessageReleaseResponseHandle;
   table->SendPlatformMessageResponse = &FlutterEngineSendPlatformMessageResponse;
-  table->RegisterExternalTexture = nullptr;
-  table->UnregisterExternalTexture = nullptr;
-  table->MarkExternalTextureFrameAvailable = nullptr;
-  table->UpdateSemanticsEnabled = nullptr;
-  table->UpdateAccessibilityFeatures = nullptr;
-  table->DispatchSemanticsAction = nullptr;
-  table->OnVsync = nullptr;
-  table->ReloadSystemFonts = nullptr;
-  table->TraceEventDurationBegin = nullptr;
-  table->TraceEventDurationEnd = nullptr;
-  table->TraceEventInstant = nullptr;
-  table->PostRenderThreadTask = nullptr;
-  table->GetCurrentTime = nullptr;
   table->RunTask = &FlutterEngineRunTask;
   table->UpdateLocales = &FlutterEngineUpdateLocales;
   table->RunsAOTCompiledDartCode = &FlutterEngineRunsAOTCompiledDartCode;
-  table->PostDartObject = nullptr;
-  table->NotifyLowMemoryWarning = nullptr;
-  table->PostCallbackOnAllNativeThreads = nullptr;
-  table->NotifyDisplayUpdate = nullptr;
 
   return kSuccess;
 }

--- a/shell/platform/linux/testing/mock_engine.cc
+++ b/shell/platform/linux/testing/mock_engine.cc
@@ -436,7 +436,8 @@ FlutterEngineResult FlutterEngineGetProcAddresses(
       &FlutterPlatformMessageCreateResponseHandle;
   table->PlatformMessageReleaseResponseHandle =
       &FlutterPlatformMessageReleaseResponseHandle;
-  table->SendPlatformMessageResponse = &FlutterEngineSendPlatformMessageResponse;
+  table->SendPlatformMessageResponse =
+      &FlutterEngineSendPlatformMessageResponse;
   table->RunTask = &FlutterEngineRunTask;
   table->UpdateLocales = &FlutterEngineUpdateLocales;
   table->RunsAOTCompiledDartCode = &FlutterEngineRunsAOTCompiledDartCode;


### PR DESCRIPTION
## Description

Switches the Linux embedding from the standard C API to the new proctable version, to allow for unit testing of the embedding layer separately from the embedder APIs implementation.

## Related Issues

flutter/flutter#66935

## Tests

I added the following tests: New test of message without response, which wasn't previously testable

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
