### PR TITLE
Updated return-type for PathMetric.extractPath to be non-nullable

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Tetsuhiro Ueda <najeira@gmail.com>
 shoryukenn <naifu.guan@gmail.com>
 SOTEC GmbH & Co. KG <sotec-contributors@sotec.eu>
 Hidenori Matsubayashi <Hidenori.Matsubayashi@sony.com>
+Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2749,7 +2749,7 @@ class PathMetric {
   /// `start` and `end` are clamped to legal values (0..[length])
   /// Returns null if the segment is 0 length or `start` > `stop`.
   /// Begin the segment with a moveTo if `startWithMoveTo` is true.
-  Path? extractPath(double start, double end, {bool startWithMoveTo = true}) {
+  Path extractPath(double start, double end, {bool startWithMoveTo = true}) {
     return _measure.extractPath(contourIndex, start, end, startWithMoveTo: startWithMoveTo);
   }
 

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2744,10 +2744,9 @@ class PathMetric {
     return _measure.getTangentForOffset(contourIndex, distance);
   }
 
-  /// Given a start and stop distance, return the intervening segment(s).
+  /// Given a start and end distance, return the intervening segment(s).
   ///
   /// `start` and `end` are clamped to legal values (0..[length])
-  /// Returns null if the segment is 0 length or `start` > `stop`.
   /// Begin the segment with a moveTo if `startWithMoveTo` is true.
   Path extractPath(double start, double end, {bool startWithMoveTo = true}) {
     return _measure.extractPath(contourIndex, start, end, startWithMoveTo: startWithMoveTo);

--- a/lib/web_ui/lib/src/engine/html/path/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_metrics.dart
@@ -114,7 +114,7 @@ class _SurfacePathMeasure {
     return true;
   }
 
-  ui.Path? extractPath(int contourIndex, double start, double end,
+  ui.Path extractPath(int contourIndex, double start, double end,
       {bool startWithMoveTo = true}) {
     return _contours[contourIndex].extractPath(start, end, startWithMoveTo);
   }
@@ -196,7 +196,7 @@ class _PathContourMeasure {
     return segment.computeTangent(t);
   }
 
-  ui.Path? extractPath(
+  ui.Path extractPath(
       double startDistance, double stopDistance, bool startWithMoveTo) {
     if (startDistance < 0) {
       startDistance = 0;
@@ -204,14 +204,14 @@ class _PathContourMeasure {
     if (stopDistance > _contourLength) {
       stopDistance = _contourLength;
     }
-    if (startDistance > stopDistance || _segments.isEmpty) {
-      return null;
-    }
     final ui.Path path = ui.Path();
+    if (startDistance > stopDistance || _segments.isEmpty) {
+      return path;
+    }
     int startSegmentIndex = _segmentIndexAtDistance(startDistance);
     int stopSegmentIndex = _segmentIndexAtDistance(stopDistance);
     if (startSegmentIndex == -1 || stopSegmentIndex == -1) {
-      return null;
+      return path;
     }
     int currentSegmentIndex = startSegmentIndex;
     _PathSegment seg = _segments[currentSegmentIndex];
@@ -574,13 +574,11 @@ class SurfacePathMetric implements ui.PathMetric {
     return _measure.getTangentForOffset(contourIndex, distance);
   }
 
-  /// Given a start and stop distance, return the intervening segment(s).
+  /// Given a start and end distance, return the intervening segment(s).
   ///
   /// `start` and `end` are pinned to legal values (0..[length])
-  /// Returns null if the segment is 0 length or `start` > `stop`.
   /// Begin the segment with a moveTo if `startWithMoveTo` is true.
-  ui.Path? extractPath(double start, double end,
-      {bool startWithMoveTo = true}) {
+  ui.Path extractPath(double start, double end, {bool startWithMoveTo = true}) {
     return _measure.extractPath(contourIndex, start, end,
         startWithMoveTo: startWithMoveTo);
   }

--- a/lib/web_ui/lib/src/ui/path_metrics.dart
+++ b/lib/web_ui/lib/src/ui/path_metrics.dart
@@ -22,7 +22,7 @@ abstract class PathMetric {
   double get length;
   int get contourIndex;
   Tangent? getTangentForOffset(double distance);
-  Path? extractPath(double start, double end, {bool startWithMoveTo = true});
+  Path extractPath(double start, double end, {bool startWithMoveTo = true});
   bool get isClosed;
 }
 


### PR DESCRIPTION
## Description

Updated return type for **extractPath()** to be `Path` instead of `Path?`. 

Also, the method's behavior differed in web_ui vs ui. So, tried to match web_ui's behavior with that of ui, for the method.

## Related Issues

None

## Tests

None, as this is just a nullability change.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
