### PR TITLE
Revert "support uri intent launcher in android (#21275)"

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -774,18 +774,13 @@ public class FlutterActivity extends Activity
    *
    * If both preferences are set, the {@code Intent} preference takes priority.
    *
-   * <p>If none is set, the {@link FlutterActivityAndFragmentDelegate} retrieves the initial route
-   * from the {@code Intent} through the Intent.getData() instead.
-   *
    * <p>The reason that a {@code <meta-data>} preference is supported is because this {@code
    * Activity} might be the very first {@code Activity} launched, which means the developer won't
    * have control over the incoming {@code Intent}.
    *
    * <p>Subclasses may override this method to directly control the initial route.
-   *
-   * <p>If this method returns null, the {@link FlutterActivityAndFragmentDelegate} retrieves the
-   * initial route from the {@code Intent} through the Intent.getData() instead.
    */
+  @NonNull
   public String getInitialRoute() {
     if (getIntent().hasExtra(EXTRA_INITIAL_ROUTE)) {
       return getIntent().getStringExtra(EXTRA_INITIAL_ROUTE);
@@ -797,9 +792,9 @@ public class FlutterActivity extends Activity
       Bundle metadata = activityInfo.metaData;
       String desiredInitialRoute =
           metadata != null ? metadata.getString(INITIAL_ROUTE_META_DATA_KEY) : null;
-      return desiredInitialRoute;
+      return desiredInitialRoute != null ? desiredInitialRoute : DEFAULT_INITIAL_ROUTE;
     } catch (PackageManager.NameNotFoundException e) {
-      return null;
+      return DEFAULT_INITIAL_ROUTE;
     }
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -9,7 +9,6 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -363,21 +362,18 @@ import java.util.Arrays;
       // So this is expected behavior in many cases.
       return;
     }
-    String initialRoute = host.getInitialRoute();
-    if (initialRoute == null) {
-      initialRoute = getInitialRouteFromIntent(host.getActivity().getIntent());
-    }
+
     Log.v(
         TAG,
         "Executing Dart entrypoint: "
             + host.getDartEntrypointFunctionName()
             + ", and sending initial route: "
-            + initialRoute);
+            + host.getInitialRoute());
 
     // The engine needs to receive the Flutter app's initial route before executing any
     // Dart code to ensure that the initial route arrives in time to be applied.
-    if (initialRoute != null) {
-      flutterEngine.getNavigationChannel().setInitialRoute(initialRoute);
+    if (host.getInitialRoute() != null) {
+      flutterEngine.getNavigationChannel().setInitialRoute(host.getInitialRoute());
     }
 
     String appBundlePathOverride = host.getAppBundlePath();
@@ -390,14 +386,6 @@ import java.util.Arrays;
         new DartExecutor.DartEntrypoint(
             appBundlePathOverride, host.getDartEntrypointFunctionName());
     flutterEngine.getDartExecutor().executeDartEntrypoint(entrypoint);
-  }
-
-  private String getInitialRouteFromIntent(Intent intent) {
-    Uri data = intent.getData();
-    if (data != null && !data.toString().isEmpty()) {
-      return data.toString();
-    }
-    return null;
   }
 
   /**
@@ -634,12 +622,8 @@ import java.util.Arrays;
   void onNewIntent(@NonNull Intent intent) {
     ensureAlive();
     if (flutterEngine != null) {
-      Log.v(TAG, "Forwarding onNewIntent() to FlutterEngine and sending pushRoute message.");
+      Log.v(TAG, "Forwarding onNewIntent() to FlutterEngine.");
       flutterEngine.getActivityControlSurface().onNewIntent(intent);
-      String initialRoute = getInitialRouteFromIntent(intent);
-      if (initialRoute != null && !initialRoute.isEmpty()) {
-        flutterEngine.getNavigationChannel().pushRoute(initialRoute);
-      }
     } else {
       Log.w(TAG, "onNewIntent() invoked before FlutterFragment was attached to an Activity.");
     }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -646,18 +646,13 @@ public class FlutterFragmentActivity extends FragmentActivity
    *
    * If both preferences are set, the {@code Intent} preference takes priority.
    *
-   * <p>If none is set, the {@link FlutterActivityAndFragmentDelegate} retrieves the initial route
-   * from the {@code Intent} through the Intent.getData() instead.
-   *
    * <p>The reason that a {@code <meta-data>} preference is supported is because this {@code
    * Activity} might be the very first {@code Activity} launched, which means the developer won't
    * have control over the incoming {@code Intent}.
    *
    * <p>Subclasses may override this method to directly control the initial route.
-   *
-   * <p>If this method returns null, the {@link FlutterActivityAndFragmentDelegate} retrieves the
-   * initial route from the {@code Intent} through the Intent.getData() instead.
    */
+  @NonNull
   protected String getInitialRoute() {
     if (getIntent().hasExtra(EXTRA_INITIAL_ROUTE)) {
       return getIntent().getStringExtra(EXTRA_INITIAL_ROUTE);
@@ -669,9 +664,9 @@ public class FlutterFragmentActivity extends FragmentActivity
       Bundle metadata = activityInfo.metaData;
       String desiredInitialRoute =
           metadata != null ? metadata.getString(INITIAL_ROUTE_META_DATA_KEY) : null;
-      return desiredInitialRoute;
+      return desiredInitialRoute != null ? desiredInitialRoute : DEFAULT_INITIAL_ROUTE;
     } catch (PackageManager.NameNotFoundException e) {
-      return null;
+      return DEFAULT_INITIAL_ROUTE;
     }
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.when;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 import io.flutter.FlutterInjector;
@@ -44,7 +43,6 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -426,50 +424,6 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Verify that the call was forwarded to the engine.
     verify(mockFlutterEngine.getActivityControlSurface(), times(1))
         .onRequestPermissionsResult(any(Integer.class), any(String[].class), any(int[].class));
-  }
-
-  @Test
-  public void itSendsInitialRouteFromIntentOnStartIfnoInitialRouteFromActivity() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
-    intent.setData(Uri.parse("http://myApp/custom/route"));
-
-    ActivityController<FlutterActivity> activityController =
-        Robolectric.buildActivity(FlutterActivity.class, intent);
-    FlutterActivity flutterActivity = activityController.get();
-
-    when(mockHost.getActivity()).thenReturn(flutterActivity);
-    when(mockHost.getInitialRoute()).thenReturn(null);
-    // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
-
-    // --- Execute the behavior under test ---
-    // The FlutterEngine is setup in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
-    // Emulate app start.
-    delegate.onStart();
-
-    // Verify that the navigation channel was given the initial route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(1))
-        .setInitialRoute("http://myApp/custom/route");
-  }
-
-  @Test
-  public void itSendsPushRouteMessageWhenOnNewIntent() {
-    // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
-
-    // --- Execute the behavior under test ---
-    // The FlutterEngine is setup in onAttach().
-    delegate.onAttach(RuntimeEnvironment.application);
-
-    Intent mockIntent = mock(Intent.class);
-    when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route"));
-    // Emulate the host and call the method that we expect to be forwarded.
-    delegate.onNewIntent(mockIntent);
-
-    // Verify that the navigation channel was given the push route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(1))
-        .pushRoute("http://myApp/custom/route");
   }
 
   @Test


### PR DESCRIPTION
This reverts commit 742dfbefad8cddcd209a430e789d2d55791fcd57.

## Description

Commit end up being a breaking change. Revert it to unblock customer for now.

## Related Issues

https://github.com/flutter/flutter/issues/69786

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
