### PR TITLE
Move common graphics utils to //flutter/common/graphics

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -21,6 +21,12 @@ FILE: ../../../flutter/benchmarking/benchmarking.cc
 FILE: ../../../flutter/benchmarking/benchmarking.h
 FILE: ../../../flutter/common/constants.h
 FILE: ../../../flutter/common/exported_symbols.sym
+FILE: ../../../flutter/common/graphics/gl_context_switch.cc
+FILE: ../../../flutter/common/graphics/gl_context_switch.h
+FILE: ../../../flutter/common/graphics/persistent_cache.cc
+FILE: ../../../flutter/common/graphics/persistent_cache.h
+FILE: ../../../flutter/common/graphics/texture.cc
+FILE: ../../../flutter/common/graphics/texture.h
 FILE: ../../../flutter/common/settings.cc
 FILE: ../../../flutter/common/settings.h
 FILE: ../../../flutter/common/task_runners.cc
@@ -33,8 +39,6 @@ FILE: ../../../flutter/flow/embedded_views.h
 FILE: ../../../flutter/flow/flow_run_all_unittests.cc
 FILE: ../../../flutter/flow/flow_test_utils.cc
 FILE: ../../../flutter/flow/flow_test_utils.h
-FILE: ../../../flutter/flow/gl_context_switch.cc
-FILE: ../../../flutter/flow/gl_context_switch.h
 FILE: ../../../flutter/flow/gl_context_switch_unittests.cc
 FILE: ../../../flutter/flow/instrumentation.cc
 FILE: ../../../flutter/flow/instrumentation.h
@@ -115,8 +119,6 @@ FILE: ../../../flutter/flow/surface.cc
 FILE: ../../../flutter/flow/surface.h
 FILE: ../../../flutter/flow/surface_frame.cc
 FILE: ../../../flutter/flow/surface_frame.h
-FILE: ../../../flutter/flow/texture.cc
-FILE: ../../../flutter/flow/texture.h
 FILE: ../../../flutter/flow/texture_unittests.cc
 FILE: ../../../flutter/flow/view_holder.cc
 FILE: ../../../flutter/flow/view_holder.h
@@ -620,8 +622,6 @@ FILE: ../../../flutter/shell/common/engine_unittests.cc
 FILE: ../../../flutter/shell/common/fixtures/shell_test.dart
 FILE: ../../../flutter/shell/common/fixtures/shelltest_screenshot.png
 FILE: ../../../flutter/shell/common/input_events_unittests.cc
-FILE: ../../../flutter/shell/common/persistent_cache.cc
-FILE: ../../../flutter/shell/common/persistent_cache.h
 FILE: ../../../flutter/shell/common/persistent_cache_unittests.cc
 FILE: ../../../flutter/shell/common/pipeline.cc
 FILE: ../../../flutter/shell/common/pipeline.h

--- a/common/graphics/BUILD.gn
+++ b/common/graphics/BUILD.gn
@@ -1,0 +1,30 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
+
+source_set("graphics") {
+  sources = [
+    "gl_context_switch.cc",
+    "gl_context_switch.h",
+    "persistent_cache.cc",
+    "persistent_cache.h",
+    "texture.cc",
+    "texture.h",
+  ]
+
+  # Heed caution when adding targets to the dependencies. This is a minimal
+  # target containing graphics sources that embedders can depend on. Any
+  # additions here could result in added app sizes across embeddings.
+  deps = [
+    "//flutter/assets",
+    "//flutter/fml",
+    "//flutter/shell/version:version",
+    "//third_party/rapidjson",
+    "//third_party/skia",
+  ]
+
+  public_configs = [ "//flutter:config" ]
+}

--- a/common/graphics/gl_context_switch.cc
+++ b/common/graphics/gl_context_switch.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/flow/gl_context_switch.h"
+#include "flutter/common/graphics/gl_context_switch.h"
 
 namespace flutter {
 

--- a/common/graphics/gl_context_switch.h
+++ b/common/graphics/gl_context_switch.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_FLOW_GL_CONTEXT_SWITCH_H_
-#define FLUTTER_FLOW_GL_CONTEXT_SWITCH_H_
+#ifndef FLUTTER_COMMON_GRAPHICS_GL_CONTEXT_SWITCH_H_
+#define FLUTTER_COMMON_GRAPHICS_GL_CONTEXT_SWITCH_H_
 
 #include <functional>
 #include <memory>
@@ -111,4 +111,4 @@ class GLContextSwitch final : public GLContextResult {
 
 }  // namespace flutter
 
-#endif  // FLUTTER_FLOW_GL_CONTEXT_SWITCH_H_
+#endif  // FLUTTER_COMMON_GRAPHICS_GL_CONTEXT_SWITCH_H_

--- a/common/graphics/persistent_cache.cc
+++ b/common/graphics/persistent_cache.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/shell/common/persistent_cache.h"
+#include "flutter/common/graphics/persistent_cache.h"
 
 #include <future>
 #include <memory>

--- a/common/graphics/persistent_cache.h
+++ b/common/graphics/persistent_cache.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_SHELL_COMMON_PERSISTENT_CACHE_H_
-#define FLUTTER_SHELL_COMMON_PERSISTENT_CACHE_H_
+#ifndef FLUTTER_COMMON_GRAPHICS_PERSISTENT_CACHE_H_
+#define FLUTTER_COMMON_GRAPHICS_PERSISTENT_CACHE_H_
 
 #include <memory>
 #include <mutex>
@@ -134,4 +134,4 @@ class PersistentCache : public GrContextOptions::PersistentCache {
 
 }  // namespace flutter
 
-#endif  // FLUTTER_SHELL_COMMON_PERSISTENT_CACHE_H_
+#endif  // FLUTTER_COMMON_GRAPHICS_PERSISTENT_CACHE_H_

--- a/common/graphics/texture.cc
+++ b/common/graphics/texture.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/flow/texture.h"
+#include "flutter/common/graphics/texture.h"
 
 namespace flutter {
 

--- a/common/graphics/texture.h
+++ b/common/graphics/texture.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef FLUTTER_FLOW_TEXTURE_H_
-#define FLUTTER_FLOW_TEXTURE_H_
+#ifndef FLUTTER_COMMON_GRAPHICS_TEXTURE_H_
+#define FLUTTER_COMMON_GRAPHICS_TEXTURE_H_
 
 #include <map>
 
@@ -74,4 +74,4 @@ class TextureRegistry {
 
 }  // namespace flutter
 
-#endif  // FLUTTER_FLOW_TEXTURE_H_
+#endif  // FLUTTER_COMMON_GRAPHICS_TEXTURE_H_

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -12,8 +12,6 @@ source_set("flow") {
     "compositor_context.h",
     "embedded_views.cc",
     "embedded_views.h",
-    "gl_context_switch.cc",
-    "gl_context_switch.h",
     "instrumentation.cc",
     "instrumentation.h",
     "layers/backdrop_filter_layer.cc",
@@ -66,14 +64,13 @@ source_set("flow") {
     "surface.h",
     "surface_frame.cc",
     "surface_frame.h",
-    "texture.cc",
-    "texture.h",
   ]
 
   public_configs = [ "//flutter:config" ]
 
   deps = [
     "//flutter/common",
+    "//flutter/common/graphics",
     "//flutter/fml",
     "//third_party/skia",
   ]
@@ -124,7 +121,10 @@ if (enable_unittests) {
       "//third_party/googletest:gtest",
     ]
 
-    deps = [ ":flow" ]
+    deps = [
+      ":flow",
+      "//flutter/common/graphics",
+    ]
   }
 
   executable("flow_unittests") {
@@ -167,6 +167,7 @@ if (enable_unittests) {
       ":flow",
       ":flow_fixtures",
       ":flow_testing",
+      "//flutter/common/graphics",
       "//flutter/fml",
       "//flutter/testing:skia",
       "//flutter/testing:testing_lib",

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -8,10 +8,10 @@
 #include <memory>
 #include <string>
 
+#include "flutter/common/graphics/texture.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/instrumentation.h"
 #include "flutter/flow/raster_cache.h"
-#include "flutter/flow/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/raster_thread_merger.h"
 #include "third_party/skia/include/core/SkCanvas.h"

--- a/flow/gl_context_switch_unittests.cc
+++ b/flow/gl_context_switch_unittests.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 #define FML_USED_ON_EMBEDDER
 
-#include "flutter/flow/gl_context_switch.h"
+#include "flutter/common/graphics/gl_context_switch.h"
 
 #include <functional>
 #include <future>

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -8,10 +8,10 @@
 #include <memory>
 #include <vector>
 
+#include "flutter/common/graphics/texture.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/instrumentation.h"
 #include "flutter/flow/raster_cache.h"
-#include "flutter/flow/texture.h"
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/logging.h"

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/flow/layers/texture_layer.h"
 
-#include "flutter/flow/texture.h"
+#include "flutter/common/graphics/texture.h"
 
 namespace flutter {
 

--- a/flow/surface.h
+++ b/flow/surface.h
@@ -7,8 +7,8 @@
 
 #include <memory>
 
+#include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/flow/embedded_views.h"
-#include "flutter/flow/gl_context_switch.h"
 #include "flutter/flow/surface_frame.h"
 #include "flutter/fml/macros.h"
 

--- a/flow/surface_frame.h
+++ b/flow/surface_frame.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-#include "flutter/flow/gl_context_switch.h"
+#include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkSurface.h"

--- a/flow/testing/gl_context_switch_test.h
+++ b/flow/testing/gl_context_switch_test.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_RENDERER_CONTEXT_TEST_H_
 #define FLUTTER_SHELL_RENDERER_CONTEXT_TEST_H_
 
-#include "flutter/flow/gl_context_switch.h"
+#include "flutter/common/graphics/gl_context_switch.h"
 #include "gtest/gtest.h"
 
 namespace flutter {

--- a/flow/testing/mock_texture.h
+++ b/flow/testing/mock_texture.h
@@ -5,7 +5,7 @@
 #include <ostream>
 #include <vector>
 
-#include "flutter/flow/texture.h"
+#include "flutter/common/graphics/texture.h"
 #include "flutter/testing/assertions_skia.h"
 
 namespace flutter {

--- a/flow/texture_unittests.cc
+++ b/flow/texture_unittests.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/flow/texture.h"
+#include "flutter/common/graphics/texture.h"
 
 #include "flutter/flow/testing/mock_texture.h"
 #include "gtest/gtest.h"

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -69,8 +69,6 @@ source_set("common") {
     "display_manager.h",
     "engine.cc",
     "engine.h",
-    "persistent_cache.cc",
-    "persistent_cache.h",
     "pipeline.cc",
     "pipeline.h",
     "platform_view.cc",
@@ -111,6 +109,7 @@ source_set("common") {
   deps = [
     "//flutter/assets",
     "//flutter/common",
+    "//flutter/common/graphics",
     "//flutter/flow",
     "//flutter/fml",
     "//flutter/lib/ui",
@@ -189,6 +188,7 @@ if (enable_unittests) {
     ]
 
     public_deps = [
+      "//flutter/common/graphics",
       "//flutter/flow",
       "//flutter/fml/dart",
       "//flutter/runtime",
@@ -253,6 +253,7 @@ if (enable_unittests) {
       ":shell_test_fixture_sources",
       ":shell_unittests_fixtures",
       "//flutter/assets",
+      "//flutter/common/graphics",
       "//flutter/shell/version",
       "//third_party/googletest:gmock",
     ]

--- a/shell/common/persistent_cache_unittests.cc
+++ b/shell/common/persistent_cache_unittests.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "flutter/shell/common/persistent_cache.h"
+#include "flutter/common/graphics/persistent_cache.h"
 
 #include <memory>
 

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -8,9 +8,9 @@
 #include <memory>
 
 #include "flow/embedded_views.h"
+#include "flutter/common/graphics/texture.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/flow/surface.h"
-#include "flutter/flow/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/lib/ui/semantics/custom_accessibility_action.h"

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -6,9 +6,9 @@
 
 #include <utility>
 
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/time/time_point.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/serialization_callbacks.h"
 #include "third_party/skia/include/core/SkEncodedImageFormat.h"
 #include "third_party/skia/include/core/SkImageEncoder.h"

--- a/shell/common/run_configuration.cc
+++ b/shell/common/run_configuration.cc
@@ -7,10 +7,10 @@
 #include <sstream>
 
 #include "flutter/assets/directory_asset_bundle.h"
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/unique_fd.h"
 #include "flutter/runtime/dart_vm.h"
-#include "flutter/shell/common/persistent_cache.h"
 
 namespace flutter {
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "flutter/assets/directory_asset_bundle.h"
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/icu_util.h"
 #include "flutter/fml/log_settings.h"
@@ -21,7 +22,6 @@
 #include "flutter/fml/unique_fd.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/engine.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/skia_event_tracer_impl.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/common/vsync_waiter.h"

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -11,10 +11,10 @@
 #include <unordered_map>
 
 #include "flutter/assets/directory_asset_bundle.h"
+#include "flutter/common/graphics/texture.h"
 #include "flutter/common/settings.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/flow/surface.h"
-#include "flutter/flow/texture.h"
 #include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_ptr.h"

--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -4,9 +4,9 @@
 
 #include "flutter/shell/common/shell_io_manager.h"
 
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/message_loop.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "third_party/skia/include/gpu/gl/GrGLInterface.h"
 
 namespace flutter {

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -9,13 +9,13 @@
 
 #include <memory>
 
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/common/settings.h"
 #include "flutter/flow/layers/container_layer.h"
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/time/time_point.h"
 #include "flutter/lib/ui/window/platform_message.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/run_configuration.h"
 #include "flutter/shell/common/shell_test_external_view_embedder.h"
 #include "flutter/shell/common/thread_host.h"

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/shell/common/shell_test_platform_view_vulkan.h"
 
-#include "flutter/shell/common/persistent_cache.h"
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/vulkan/vulkan_utilities.h"
 
 namespace flutter {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -11,6 +11,7 @@
 #include <memory>
 
 #include "assets/directory_asset_bundle.h"
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/flow/layers/layer_tree.h"
 #include "flutter/flow/layers/picture_layer.h"
 #include "flutter/flow/layers/transform_layer.h"
@@ -21,7 +22,6 @@
 #include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/runtime/dart_vm.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/common/rasterizer.h"
 #include "flutter/shell/common/shell_test.h"

--- a/shell/common/skp_shader_warmup_unittests.cc
+++ b/shell/common/skp_shader_warmup_unittests.cc
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include "flutter/assets/directory_asset_bundle.h"
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/flow/layers/container_layer.h"
 #include "flutter/flow/layers/layer.h"
 #include "flutter/flow/layers/physical_shape_layer.h"
@@ -13,7 +14,6 @@
 #include "flutter/fml/file.h"
 #include "flutter/fml/log_settings.h"
 #include "flutter/fml/unique_fd.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/serialization_callbacks.h"
 #include "flutter/shell/common/shell_test.h"
 #include "flutter/shell/common/switches.h"

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -7,6 +7,7 @@ import("//flutter/shell/config.gni")
 
 gpu_common_deps = [
   "//flutter/common",
+  "//flutter/common/graphics",
   "//flutter/flow",
   "//flutter/fml",
   "//flutter/shell/common",

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -4,11 +4,11 @@
 
 #include "flutter/shell/gpu/gpu_surface_gl.h"
 
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/base32.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/size.h"
 #include "flutter/fml/trace_event.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -8,8 +8,8 @@
 #include <functional>
 #include <memory>
 
+#include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/flow/embedded_views.h"
-#include "flutter/flow/gl_context_switch.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_SHELL_GPU_GPU_SURFACE_GL_DELEGATE_H_
 #define FLUTTER_SHELL_GPU_GPU_SURFACE_GL_DELEGATE_H_
 
+#include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/flow/embedded_views.h"
-#include "flutter/flow/gl_context_switch.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/gpu/gpu_surface_delegate.h"
 #include "third_party/skia/include/core/SkMatrix.h"

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -55,6 +55,7 @@ shared_library("flutter_shell_native") {
     ":icudtl_object",
     "//flutter/assets",
     "//flutter/common",
+    "//flutter/common/graphics",
     "//flutter/flow",
     "//flutter/fml",
     "//flutter/lib/ui",

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -7,7 +7,7 @@
 
 #include <GLES/gl.h>
 
-#include "flutter/flow/texture.h"
+#include "flutter/common/graphics/texture.h"
 #include "flutter/fml/platform/android/jni_weak_ref.h"
 #include "flutter/shell/platform/android/platform_view_android_jni_impl.h"
 

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -133,6 +133,7 @@ source_set("flutter_framework_source") {
   deps = [
     ":ios_gpu_configuration",
     "//flutter/common",
+    "//flutter/common/graphics",
     "//flutter/flow",
     "//flutter/fml",
     "//flutter/lib/ui",

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -9,9 +9,9 @@
 #include <memory>
 #include <string>
 
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/flow/rtree.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
-#include "flutter/shell/common/persistent_cache.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -7,8 +7,8 @@
 
 #include <memory>
 
-#include "flutter/flow/gl_context_switch.h"
-#include "flutter/flow/texture.h"
+#include "flutter/common/graphics/gl_context_switch.h"
+#include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h"

--- a/shell/platform/darwin/ios/ios_context_metal.mm
+++ b/shell/platform/darwin/ios/ios_context_metal.mm
@@ -4,8 +4,8 @@
 
 #import "flutter/shell/platform/darwin/ios/ios_context_metal.h"
 
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/logging.h"
-#include "flutter/shell/common/persistent_cache.h"
 #import "flutter/shell/platform/darwin/ios/ios_external_texture_metal.h"
 #include "third_party/skia/include/gpu/GrContextOptions.h"
 

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_GL_H_
 #define FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_GL_H_
 
-#include "flutter/flow/texture.h"
+#include "flutter/common/graphics/texture.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterTexture.h"

--- a/shell/platform/darwin/ios/ios_external_texture_metal.h
+++ b/shell/platform/darwin/ios/ios_external_texture_metal.h
@@ -9,7 +9,7 @@
 
 #import <CoreVideo/CoreVideo.h>
 
-#include "flutter/flow/texture.h"
+#include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"

--- a/shell/platform/darwin/ios/ios_switchable_gl_context.h
+++ b/shell/platform/darwin/ios/ios_switchable_gl_context.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SWITCHABLE_GL_CONTEXT_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SWITCHABLE_GL_CONTEXT_H_
 
-#include "flutter/flow/gl_context_switch.h"
+#include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/thread_checker.h"
 #include "flutter/fml/memory/weak_ptr.h"

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -76,6 +76,7 @@ template("embedder_source_set") {
       ":embedder_gpu_configuration",
       "//flutter/assets",
       "//flutter/common",
+      "//flutter/common/graphics",
       "//flutter/flow",
       "//flutter/fml",
       "//flutter/lib/ui",

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -36,6 +36,7 @@ extern const intptr_t kPlatformStrongDillSize;
 }
 
 #include "flutter/assets/directory_asset_bundle.h"
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/file.h"
@@ -43,7 +44,6 @@ extern const intptr_t kPlatformStrongDillSize;
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/paths.h"
 #include "flutter/fml/trace_event.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/rasterizer.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"

--- a/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/shell/platform/embedder/embedder_external_texture_gl.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_EXTERNAL_TEXTURE_GL_H_
 #define FLUTTER_SHELL_PLATFORM_EMBEDDER_EMBEDDER_EXTERNAL_TEXTURE_GL_H_
 
-#include "flutter/flow/texture.h"
+#include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSize.h"

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -104,6 +104,7 @@ template("runner_sources") {
     # The use of these dependencies is temporary and will be moved behind the
     # embedder API.
     flutter_public_deps = [
+      "//flutter/common/graphics",
       "//flutter/flow",
       "//flutter/lib/ui",
       "//flutter/runtime",
@@ -460,6 +461,7 @@ executable("flutter_runner_unittests") {
   # embedder API.
   flutter_deps = [
     "//flutter/assets:assets",
+    "//flutter/common/graphics",
     "//flutter/flow",
     "//flutter/lib/ui",
     "//flutter/shell/common",

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -9,12 +9,12 @@
 
 #include "../runtime/dart/utils/files.h"
 #include "flow/embedded_views.h"
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/runtime/dart_vm_lifecycle.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/rasterizer.h"
 #include "flutter/shell/common/run_configuration.h"
 #include "flutter/shell/common/serialization_callbacks.h"

--- a/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
@@ -9,10 +9,10 @@
 #include <lib/sys/cpp/component_context.h>
 
 #include "assets/directory_asset_bundle.h"
+#include "flutter/common/graphics/persistent_cache.h"
 #include "flutter/fml/memory/ref_ptr.h"
 #include "flutter/fml/message_loop_impl.h"
 #include "flutter/fml/task_runner.h"
-#include "flutter/shell/common/persistent_cache.h"
 #include "flutter/shell/common/serialization_callbacks.h"
 #include "flutter/shell/platform/fuchsia/flutter/logging.h"
 #include "flutter/shell/platform/fuchsia/flutter/runner.h"


### PR DESCRIPTION
    Move common graphics utils to //flutter/common/graphics

    This change creates a new source set //flutter/common/graphics
    with minimal dependencies.

    The intention with this target is to be later consumed in a
    darwin common graphics target across the desktop boundary.

    Also unifies some of the graphics utilities under the same folder.