### PR TITLE
Ignore several import_of_legacy_library_into_null_safe

### DIFF
--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -17,8 +17,8 @@ import 'dart:js_util' as js_util;
 import 'dart:math' as math;
 import 'dart:typed_data';
 
-import 'package:js/js.dart';
-import 'package:meta/meta.dart';
+import 'package:js/js.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:meta/meta.dart'; // ignore: import_of_legacy_library_into_null_safe
 
 import '../ui.dart' as ui;
 

--- a/lib/web_ui/test/engine/path_metrics_test.dart
+++ b/lib/web_ui/test/engine/path_metrics_test.dart
@@ -4,11 +4,11 @@
 
 import 'dart:math' as math;
 
-import 'package:test/bootstrap/browser.dart';
-import 'package:test/test.dart';
-import 'package:ui/ui.dart';
+import 'package:test/bootstrap/browser.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:test/test.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:ui/ui.dart'; // ignore: import_of_legacy_library_into_null_safe
 
-import '../matchers.dart';
+import '../matchers.dart'; // ignore: import_of_legacy_library_into_null_safe
 
 const double kTolerance = 0.001;
 

--- a/lib/web_ui/test/engine/surface/path/path_iterator_test.dart
+++ b/lib/web_ui/test/engine/surface/path/path_iterator_test.dart
@@ -5,8 +5,8 @@
 import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart';
-import 'package:test/bootstrap/browser.dart';
-import 'package:test/test.dart';
+import 'package:test/bootstrap/browser.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:test/test.dart'; // ignore: import_of_legacy_library_into_null_safe
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);

--- a/lib/web_ui/test/engine/surface/path/path_winding_test.dart
+++ b/lib/web_ui/test/engine/surface/path/path_winding_test.dart
@@ -5,8 +5,8 @@
 // @dart = 2.10
 
 import 'dart:math' as math;
-import 'package:test/bootstrap/browser.dart';
-import 'package:test/test.dart';
+import 'package:test/bootstrap/browser.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:test/test.dart'; // ignore: import_of_legacy_library_into_null_safe
 import 'package:ui/ui.dart' hide window;
 import 'package:ui/src/engine.dart';
 

--- a/lib/web_ui/test/engine/ulps_test.dart
+++ b/lib/web_ui/test/engine/ulps_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:typed_data';
-import 'package:test/bootstrap/browser.dart';
-import 'package:test/test.dart';
+import 'package:test/bootstrap/browser.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:test/test.dart'; // ignore: import_of_legacy_library_into_null_safe
 import 'package:ui/src/engine.dart';
 
 void main() {

--- a/lib/web_ui/test/golden_tests/engine/color_filter_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/color_filter_golden_test.dart
@@ -6,12 +6,12 @@
 import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 
-import 'package:test/bootstrap/browser.dart';
-import 'package:test/test.dart';
+import 'package:test/bootstrap/browser.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:test/test.dart'; // ignore: import_of_legacy_library_into_null_safe
 import 'package:ui/ui.dart';
 import 'package:ui/src/engine.dart';
 
-import 'package:web_engine_tester/golden_tester.dart';
+import 'package:web_engine_tester/golden_tester.dart'; // ignore: import_of_legacy_library_into_null_safe
 
 final Rect region = Rect.fromLTWH(0, 0, 500, 500);
 

--- a/lib/web_ui/test/lerp_test.dart
+++ b/lib/web_ui/test/lerp_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 // @dart = 2.10
-import 'package:test/bootstrap/browser.dart';
-import 'package:test/test.dart';
+import 'package:test/bootstrap/browser.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:test/test.dart'; // ignore: import_of_legacy_library_into_null_safe
 
 import 'package:ui/ui.dart';
 

--- a/lib/web_ui/test/path_test.dart
+++ b/lib/web_ui/test/path_test.dart
@@ -7,12 +7,12 @@
 import 'dart:js_util' as js_util;
 import 'dart:html' as html;
 import 'dart:typed_data';
-import 'package:test/bootstrap/browser.dart';
-import 'package:test/test.dart';
+import 'package:test/bootstrap/browser.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:test/test.dart'; // ignore: import_of_legacy_library_into_null_safe
 import 'package:ui/ui.dart' hide window;
 import 'package:ui/src/engine.dart';
 
-import 'matchers.dart';
+import 'matchers.dart'; // ignore: import_of_legacy_library_into_null_safe
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);

--- a/lib/web_ui/test/text/line_breaker_test.dart
+++ b/lib/web_ui/test/text/line_breaker_test.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 // @dart = 2.10
-import 'package:test/bootstrap/browser.dart';
-import 'package:test/test.dart';
+import 'package:test/bootstrap/browser.dart'; // ignore: import_of_legacy_library_into_null_safe
+import 'package:test/test.dart'; // ignore: import_of_legacy_library_into_null_safe
 
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';


### PR DESCRIPTION
We want to enforce the migration order, and show when a legacy library is migrated into a Null Safe library.
See https://dart-review.googlesource.com/c/sdk/+/170441

There are several violations in Flutter.
I'd like to ignore them, and land the analyzer CL to prevent further regressions.