### PR TITLE
move deprecation from the PluginRegistry outer interface to inner, v1-specific fields

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -20,12 +20,11 @@ import io.flutter.view.TextureRegistry;
  *
  * <p>This class also contains deprecated v1 embedding APIs used for plugin registration.
  *
- * <p>In v1 Android applications, an auto-generated and auto-updated plugin registrant
- * class (GeneratedPluginRegistrant) makes use of a {@link PluginRegistry} to register
- * contributions from each plugin mentioned in the application's pubspec file. The generated
- * registrant class is, again by default, called from the application's main {@link Activity}, which
- * defaults to an instance of {@link io.flutter.app.FlutterActivity}, itself a {@link
- * PluginRegistry}.
+ * <p>In v1 Android applications, an auto-generated and auto-updated plugin registrant class
+ * (GeneratedPluginRegistrant) makes use of a {@link PluginRegistry} to register contributions from
+ * each plugin mentioned in the application's pubspec file. The generated registrant class is, again
+ * by default, called from the application's main {@link Activity}, which defaults to an instance of
+ * {@link io.flutter.app.FlutterActivity}, itself a {@link PluginRegistry}.
  */
 public interface PluginRegistry {
   /**
@@ -67,8 +66,9 @@ public interface PluginRegistry {
   /**
    * Receiver of registrations from a single plugin.
    *
-   * @deprecated This registrar is for Flutter's v1 embedding. For instructions on migrating a plugin from
-   * Flutter's v1 Android embedding to v2, visit http://flutter.dev/go/android-plugin-migration
+   * @deprecated This registrar is for Flutter's v1 embedding. For instructions on migrating a
+   *     plugin from Flutter's v1 Android embedding to v2, visit
+   *     http://flutter.dev/go/android-plugin-migration
    */
   @Deprecated
   interface Registrar {

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -16,25 +16,26 @@ import io.flutter.view.FlutterView;
 import io.flutter.view.TextureRegistry;
 
 /**
- * Registry used by plugins to set up interaction with Android APIs.
+ * Container class for Android API listeners used by {@link ActivityPluginBinding}.
  *
- * <p>Flutter applications by default include an auto-generated and auto-updated plugin registrant
- * class (GeneratedPluginRegistrant) that makes use of a {@link PluginRegistry} to register
+ * <p>This class also contains deprecated v1 embedding APIs used for plugin registration.
+ *
+ * <p>In v1 Android applications, an auto-generated and auto-updated plugin registrant
+ * class (GeneratedPluginRegistrant) makes use of a {@link PluginRegistry} to register
  * contributions from each plugin mentioned in the application's pubspec file. The generated
  * registrant class is, again by default, called from the application's main {@link Activity}, which
  * defaults to an instance of {@link io.flutter.app.FlutterActivity}, itself a {@link
  * PluginRegistry}.
- *
- * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
  */
-@Deprecated
 public interface PluginRegistry {
   /**
    * Returns a {@link Registrar} for receiving the registrations pertaining to the specified plugin.
    *
    * @param pluginKey a unique String identifying the plugin; typically the fully qualified name of
    *     the plugin's main class.
+   * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
    */
+  @Deprecated
   Registrar registrarFor(String pluginKey);
 
   /**
@@ -43,7 +44,9 @@ public interface PluginRegistry {
    * @param pluginKey a unique String identifying the plugin; typically the fully qualified name of
    *     the plugin's main class.
    * @return true if this registry has handed out a registrar for the specified plugin.
+   * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
    */
+  @Deprecated
   boolean hasPlugin(String pluginKey);
 
   /**
@@ -56,15 +59,18 @@ public interface PluginRegistry {
    * @param pluginKey a unique String identifying the plugin; typically the fully qualified name of
    *     the plugin's main class.
    * @return the published value, possibly null.
+   * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
    */
+  @Deprecated
   <T> T valuePublishedByPlugin(String pluginKey);
 
   /**
    * Receiver of registrations from a single plugin.
    *
-   * <p>This registrar is for Flutter's v1 embedding. For instructions on migrating a plugin from
+   * @deprecated This registrar is for Flutter's v1 embedding. For instructions on migrating a plugin from
    * Flutter's v1 Android embedding to v2, visit http://flutter.dev/go/android-plugin-migration
    */
+  @Deprecated
   interface Registrar {
     /**
      * Returns the {@link Activity} that forms the plugin's operating context.
@@ -336,7 +342,10 @@ public interface PluginRegistry {
    * Delegate interface for handling an {@link Activity}'s onDestroy method being called. A plugin
    * that implements this interface can adopt the FlutterNativeView by retaining a reference and
    * returning true.
+   *
+   * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
    */
+  @Deprecated
   interface ViewDestroyListener {
     boolean onViewDestroy(FlutterNativeView view);
   }
@@ -346,7 +355,10 @@ public interface PluginRegistry {
    *
    * <p>For example, an Application may use this callback interface to provide a background service
    * with a callback for calling its GeneratedPluginRegistrant.registerWith method.
+   *
+   * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
    */
+  @Deprecated
   interface PluginRegistrantCallback {
     void registerWith(PluginRegistry registry);
   }


### PR DESCRIPTION
Tweak https://github.com/flutter/engine/pull/21347.

Fixes https://github.com/flutter/flutter/issues/69898. 

The v2 plugins APIs must have used the v1 callback listener classes for convenience originally. I've changed my initially thought approach in https://github.com/flutter/flutter/issues/69898. Create a second parallel set of v2 listeners will be a colossal refactor since the listener tracking is done in many classes and would lead to error prone double tracking and a big migration. The `io.flutter.plugin.common` namespace itself isn't deprecated and there are still general plugin functionalities like MethodChannel in that folder. 

I've opted to deprecate the v1 specific registry mechanisms like `registrarFor`, `Registrar` etc. But left the ActivityPluginBinding listeners. The slight disadvantage is that the listener name has a soon-to-be impertinent `PluginRegistry` outer class around them. But the alternative is too messy. 

The deprecated fields are now only accessed by v1 classes and the ShimRegistrar. 