### PR TITLE
Rasterizer is initialized with an external view embedder

### DIFF
--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -582,6 +582,8 @@ class PlatformView {
   ComputePlatformResolvedLocales(
       const std::vector<std::string>& supported_locale_data);
 
+  virtual std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder();
+
  protected:
   PlatformView::Delegate& delegate_;
   const TaskRunners task_runners_;
@@ -593,8 +595,6 @@ class PlatformView {
   // Unlike all other methods on the platform view, this is called on the
   // GPU task runner.
   virtual std::unique_ptr<Surface> CreateRenderingSurface();
-
-  virtual std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder();
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformView);

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 
+#include "flow/embedded_views.h"
 #include "flutter/common/settings.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/flow/compositor_context.h"
@@ -350,6 +351,16 @@ class Rasterizer final : public SnapshotDelegate {
   void SetNextFrameCallback(const fml::closure& callback);
 
   //----------------------------------------------------------------------------
+  /// @brief Set the External View Embedder. This is done on shell
+  ///        initialization. This is non-null on platforms that support
+  ///        embedding externally composited views.
+  ///
+  /// @param[in] view_embedder The external view embedder object.
+  ///
+  void SetExternalViewEmbedder(
+      const std::shared_ptr<ExternalViewEmbedder>& view_embedder);
+
+  //----------------------------------------------------------------------------
   /// @brief      Returns a pointer to the compositor context used by this
   ///             rasterizer. This pointer will never be `nullptr`.
   ///
@@ -437,6 +448,7 @@ class Rasterizer final : public SnapshotDelegate {
   std::optional<size_t> max_cache_bytes_;
   fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger_;
   fml::TaskRunnerAffineWeakPtrFactory<Rasterizer> weak_factory_;
+  std::shared_ptr<ExternalViewEmbedder> external_view_embedder_;
 
   // |SnapshotDelegate|
   sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -108,13 +108,13 @@ TEST(RasterizerTest, drawWithExternalViewEmbedder) {
   EXPECT_CALL(delegate, OnFrameRasterized(_));
   auto rasterizer = std::make_unique<Rasterizer>(delegate);
   auto surface = std::make_unique<MockSurface>();
-  MockExternalViewEmbedder external_view_embedder;
-  EXPECT_CALL(*surface, GetExternalViewEmbedder())
-      .WillRepeatedly(Return(&external_view_embedder));
-  EXPECT_CALL(external_view_embedder,
+  std::shared_ptr<MockExternalViewEmbedder> external_view_embedder =
+      std::make_shared<MockExternalViewEmbedder>();
+  rasterizer->SetExternalViewEmbedder(external_view_embedder);
+  EXPECT_CALL(*external_view_embedder,
               BeginFrame(SkISize(), nullptr, 2.0,
                          fml::RefPtr<fml::RasterThreadMerger>(nullptr)));
-  EXPECT_CALL(external_view_embedder,
+  EXPECT_CALL(*external_view_embedder,
               EndFrame(false, fml::RefPtr<fml::RasterThreadMerger>(nullptr)));
   rasterizer->Setup(std::move(surface));
   fml::AutoResetWaitableEvent latch;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -547,6 +547,10 @@ bool Shell::Setup(std::unique_ptr<PlatformView> platform_view,
   rasterizer_ = std::move(rasterizer);
   io_manager_ = std::move(io_manager);
 
+  // Set the external view embedder for the rasterizer.
+  auto view_embedder = platform_view_->CreateExternalViewEmbedder();
+  rasterizer_->SetExternalViewEmbedder(view_embedder);
+
   // The weak ptr must be generated in the platform thread which owns the unique
   // ptr.
   weak_engine_ = engine_->GetWeakPtr();


### PR DESCRIPTION
This allows us to not rely on surface methods for getting the external view embedder.
