### PR TITLE
Reland deeplinking with info.plist check

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -942,6 +942,8 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Info.plist
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelay.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterBinaryMessengerRelayTest.mm

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -208,6 +208,7 @@ shared_library("ios_test_flutter") {
     "//build/config:symbol_visibility_hidden",
   ]
   sources = [
+    "framework/Source/FlutterAppDelegateTest.mm",
     "framework/Source/FlutterBinaryMessengerRelayTest.mm",
     "framework/Source/FlutterDartProjectTest.mm",
     "framework/Source/FlutterEngineTest.mm",

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -4,14 +4,20 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
 
-#include "flutter/fml/logging.h"
+#import "flutter/fml/logging.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate_internal.h"
 
 static NSString* kUIBackgroundMode = @"UIBackgroundModes";
 static NSString* kRemoteNotificationCapabitiliy = @"remote-notification";
 static NSString* kBackgroundFetchCapatibility = @"fetch";
+
+@interface FlutterAppDelegate ()
+@property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
+@end
 
 @implementation FlutterAppDelegate {
   FlutterPluginAppLifeCycleDelegate* _lifeCycleDelegate;
@@ -26,6 +32,7 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
 
 - (void)dealloc {
   [_lifeCycleDelegate release];
+  [_rootFlutterViewControllerGetter release];
   [super dealloc];
 }
 
@@ -41,10 +48,13 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
 
 // Returns the key window's rootViewController, if it's a FlutterViewController.
 // Otherwise, returns nil.
-+ (FlutterViewController*)rootFlutterViewController {
-  UIViewController* viewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-  if ([viewController isKindOfClass:[FlutterViewController class]]) {
-    return (FlutterViewController*)viewController;
+- (FlutterViewController*)rootFlutterViewController {
+  if (_rootFlutterViewControllerGetter != nil) {
+    return _rootFlutterViewControllerGetter();
+  }
+  UIViewController* rootViewController = _window.rootViewController;
+  if ([rootViewController isKindOfClass:[FlutterViewController class]]) {
+    return (FlutterViewController*)rootViewController;
   }
   return nil;
 }
@@ -124,7 +134,28 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
-  return [_lifeCycleDelegate application:application openURL:url options:options];
+  if ([_lifeCycleDelegate application:application openURL:url options:options]) {
+    return YES;
+  } else {
+    FlutterViewController* flutterViewController = [self rootFlutterViewController];
+    if (flutterViewController) {
+      [flutterViewController.engine
+          waitForFirstFrame:3.0
+                   callback:^(BOOL didTimeout) {
+                     if (didTimeout) {
+                       FML_LOG(ERROR)
+                           << "Timeout waiting for the first frame when launching an URL.";
+                     } else {
+                       [flutterViewController.engine.navigationChannel invokeMethod:@"pushRoute"
+                                                                          arguments:url.path];
+                     }
+                   }];
+      return YES;
+    } else {
+      FML_LOG(ERROR) << "Attempting to open an URL without a Flutter RootViewController.";
+      return NO;
+    }
+  }
 }
 
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {
@@ -175,27 +206,25 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
 #pragma mark - FlutterPluginRegistry methods. All delegating to the rootViewController
 
 - (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey {
-  UIViewController* rootViewController = _window.rootViewController;
-  if ([rootViewController isKindOfClass:[FlutterViewController class]]) {
-    return
-        [[(FlutterViewController*)rootViewController pluginRegistry] registrarForPlugin:pluginKey];
+  FlutterViewController* flutterRootViewController = [self rootFlutterViewController];
+  if (flutterRootViewController) {
+    return [[flutterRootViewController pluginRegistry] registrarForPlugin:pluginKey];
   }
   return nil;
 }
 
 - (BOOL)hasPlugin:(NSString*)pluginKey {
-  UIViewController* rootViewController = _window.rootViewController;
-  if ([rootViewController isKindOfClass:[FlutterViewController class]]) {
-    return [[(FlutterViewController*)rootViewController pluginRegistry] hasPlugin:pluginKey];
+  FlutterViewController* flutterRootViewController = [self rootFlutterViewController];
+  if (flutterRootViewController) {
+    return [[flutterRootViewController pluginRegistry] hasPlugin:pluginKey];
   }
   return false;
 }
 
 - (NSObject*)valuePublishedByPlugin:(NSString*)pluginKey {
-  UIViewController* rootViewController = _window.rootViewController;
-  if ([rootViewController isKindOfClass:[FlutterViewController class]]) {
-    return [[(FlutterViewController*)rootViewController pluginRegistry]
-        valuePublishedByPlugin:pluginKey];
+  FlutterViewController* flutterRootViewController = [self rootFlutterViewController];
+  if (flutterRootViewController) {
+    return [[flutterRootViewController pluginRegistry] valuePublishedByPlugin:pluginKey];
   }
   return nil;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -131,9 +131,8 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
   }
 }
 
-static BOOL IsDeepLinkingEnabled() {
-  NSDictionary* infoDict = [[NSBundle mainBundle] infoDictionary];
-  NSNumber* isEnabled = [infoDict objectForKey:@"FlutterDeepLinkingEnabled"];
+static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
+  NSNumber* isEnabled = [infoDictionary objectForKey:@"FlutterDeepLinkingEnabled"];
   if (isEnabled) {
     return [isEnabled boolValue];
   } else {
@@ -143,10 +142,11 @@ static BOOL IsDeepLinkingEnabled() {
 
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options
+    infoPlistGetter:(NSDictionary* (^)())infoPlistGetter {
   if ([_lifeCycleDelegate application:application openURL:url options:options]) {
     return YES;
-  } else if (!IsDeepLinkingEnabled()) {
+  } else if (!IsDeepLinkingEnabled(infoPlistGetter())) {
     return NO;
   } else {
     FlutterViewController* flutterViewController = [self rootFlutterViewController];
@@ -168,6 +168,17 @@ static BOOL IsDeepLinkingEnabled() {
       return NO;
     }
   }
+}
+
+- (BOOL)application:(UIApplication*)application
+            openURL:(NSURL*)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
+  return [self application:application
+                   openURL:url
+                   options:options
+           infoPlistGetter:^NSDictionary*() {
+             return [[NSBundle mainBundle] infoDictionary];
+           }];
 }
 
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -131,11 +131,23 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
   }
 }
 
+static BOOL IsDeepLinkingEnabled() {
+  NSDictionary* infoDict = [[NSBundle mainBundle] infoDictionary];
+  NSNumber* isEnabled = [infoDict objectForKey:@"FlutterDeepLinkingEnabled"];
+  if (isEnabled) {
+    return [isEnabled boolValue];
+  } else {
+    return NO;
+  }
+}
+
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
   if ([_lifeCycleDelegate application:application openURL:url options:options]) {
     return YES;
+  } else if (!IsDeepLinkingEnabled()) {
+    return NO;
   } else {
     FlutterViewController* flutterViewController = [self rootFlutterViewController];
     if (flutterViewController) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h"
+
+FLUTTER_ASSERT_ARC
+
+@interface FlutterAppDelegateTest : XCTestCase
+@end
+
+@implementation FlutterAppDelegateTest
+
+- (void)testLaunchUrl {
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
+  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
+  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
+  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
+  OCMStub([viewController engine]).andReturn(engine);
+  OCMStub([engine waitForFirstFrame:3.0 callback:([OCMArg invokeBlockWithArgs:@(NO), nil])]);
+  appDelegate.rootFlutterViewControllerGetter = ^{
+    return viewController;
+  };
+  NSURL* url = [NSURL URLWithString:@"http://example.com"];
+  NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
+  BOOL result = [appDelegate application:[UIApplication sharedApplication]
+                                 openURL:url
+                                 options:options];
+  XCTAssertTrue(result);
+  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:url.path]);
+}
+
+@end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -33,7 +33,10 @@ FLUTTER_ASSERT_ARC
   NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
   BOOL result = [appDelegate application:[UIApplication sharedApplication]
                                  openURL:url
-                                 options:options];
+                                 options:options
+                         infoPlistGetter:^NSDictionary*() {
+                           return @{@"FlutterDeepLinkingEnabled" : @(YES)};
+                         }];
   XCTAssertTrue(result);
   OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:url.path]);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
@@ -1,0 +1,9 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@class FlutterViewController;
+
+@interface FlutterAppDelegate (Test)
+@property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
+@end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
@@ -6,4 +6,10 @@
 
 @interface FlutterAppDelegate (Test)
 @property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
+
+- (BOOL)application:(UIApplication*)application
+            openURL:(NSURL*)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options
+    infoPlistGetter:(NSDictionary* (^)())infoPlistGetter;
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -914,6 +914,19 @@ static constexpr int kNumProfilerSamplesPerSec = 5;
   [self.localizationChannel invokeMethod:@"setLocale" arguments:localeData];
 }
 
+- (void)waitForFirstFrame:(NSTimeInterval)timeout
+                 callback:(void (^_Nonnull)(BOOL didTimeout))callback {
+  dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0);
+  dispatch_async(queue, ^{
+    fml::TimeDelta waitTime = fml::TimeDelta::FromMilliseconds(timeout * 1000);
+    BOOL didTimeout =
+        self.shell.WaitForFirstFrame(waitTime).code() == fml::StatusCode::kDeadlineExceeded;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      callback(didTimeout);
+    });
+  });
+}
+
 @end
 
 @implementation FlutterEngineRegistrar {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -120,4 +120,18 @@ FLUTTER_ASSERT_ARC
 
   XCTAssertEqual(renderingApi, flutter::IOSRenderingAPI::kSoftware);
 }
+
+- (void)testWaitForFirstFrameTimeout {
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
+  [engine run];
+  XCTestExpectation* timeoutFirstFrame = [self expectationWithDescription:@"timeoutFirstFrame"];
+  [engine waitForFirstFrame:0.1
+                   callback:^(BOOL didTimeout) {
+                     if (timeoutFirstFrame) {
+                       [timeoutFirstFrame fulfill];
+                     }
+                   }];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -48,6 +48,7 @@
 - (void)notifyLowMemory;
 - (flutter::PlatformViewIOS*)iosPlatformView;
 
+- (void)waitForFirstFrame:(NSTimeInterval)timeout callback:(void (^)(BOOL didTimeout))callback;
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERENGINE_INTERNAL_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
@@ -5,8 +5,11 @@
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
 #import "flutter/shell/platform/darwin/ios/rendering_api_selection.h"
 
+@class FlutterBinaryMessengerRelay;
+
 // Category to add test-only visibility.
 @interface FlutterEngine (Test) <FlutterBinaryMessenger>
 - (void)setBinaryMessenger:(FlutterBinaryMessengerRelay*)binaryMessenger;
 - (flutter::IOSRenderingAPI)platformViewsRenderingAPI;
+- (void)waitForFirstFrame:(NSTimeInterval)timeout callback:(void (^)(BOOL didTimeout))callback;
 @end


### PR DESCRIPTION
## Description

If you look at the first commit in the PR, it's just relanding https://github.com/flutter/engine/pull/22337.  The second commit turns it off by default unless you turn it on with the Info.plist.

## Related Issues

https://github.com/flutter/flutter/issues/66294#issuecomment-696413821

## Tests

I added the following tests:

Same tests we had for https://github.com/flutter/engine/pull/22337

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
