### PR TITLE
[web] Remove as checks (_generalNullableAsCheckImplementation) / pushSurface calls

### DIFF
--- a/lib/web_ui/lib/src/engine/dom_canvas.dart
+++ b/lib/web_ui/lib/src/engine/dom_canvas.dart
@@ -239,3 +239,12 @@ html.Element _pathToSvgElement(SurfacePath path, SurfacePaintData paint,
   sb.write('</svg>');
   return html.Element.html(sb.toString(), treeSanitizer: _NullTreeSanitizer());
 }
+
+/// TODO: Future optimization. Fingerprint dom canvas draw operations to be
+/// able to reuse DOM nodes.
+class _FingerPrints {
+  static const String drawColor = 'C';
+  static const String drawRect = 'r';
+  static const String drawRRect = 'R';
+  static const String drawParagraph = 'P';
+}

--- a/lib/web_ui/lib/src/engine/dom_canvas.dart
+++ b/lib/web_ui/lib/src/engine/dom_canvas.dart
@@ -239,12 +239,3 @@ html.Element _pathToSvgElement(SurfacePath path, SurfacePaintData paint,
   sb.write('</svg>');
   return html.Element.html(sb.toString(), treeSanitizer: _NullTreeSanitizer());
 }
-
-/// TODO: Future optimization. Fingerprint dom canvas draw operations to be
-/// able to reuse DOM nodes.
-class _FingerPrints {
-  static const String drawColor = 'C';
-  static const String drawRect = 'r';
-  static const String drawRRect = 'R';
-  static const String drawParagraph = 'P';
-}

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -260,7 +260,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
       color.value,
       shadowColor?.value ?? 0xFF000000,
       clipBehavior,
-    )) as ui.PhysicalShapeEngineLayer;
+    ));
   }
 
   /// Add a retained engine layer subtree from previous frames.

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -23,7 +23,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// The surface currently being built.
   PersistedContainerSurface get _currentSurface => _surfaceStack.last;
 
-  ui.EngineLayer _pushSurface(PersistedContainerSurface surface) {
+  T _pushSurface<T extends PersistedContainerSurface>(T surface) {
     // Only attempt to update if the update is requested and the surface is in
     // the live tree.
     if (surface.oldLayer != null) {
@@ -65,7 +65,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     double dy, {
     ui.OffsetEngineLayer? oldLayer,
   }) {
-    return _pushSurface(PersistedOffset(oldLayer as PersistedOffset?, dx, dy)) as ui.OffsetEngineLayer;
+    return _pushSurface<PersistedOffset>(PersistedOffset(oldLayer as PersistedOffset?, dx, dy));
   }
 
   /// Pushes a transform operation onto the operation stack.
@@ -96,7 +96,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     } else {
       matrix = toMatrix32(matrix4);
     }
-    return _pushSurface(PersistedTransform(oldLayer as PersistedTransform?, matrix)) as ui.TransformEngineLayer;
+    return _pushSurface<PersistedTransform>(PersistedTransform(oldLayer as PersistedTransform?, matrix));
   }
 
   /// Pushes a rectangular clip operation onto the operation stack.
@@ -113,8 +113,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   }) {
     assert(clipBehavior != null); // ignore: unnecessary_null_comparison
     assert(clipBehavior != ui.Clip.none);
-    return _pushSurface(PersistedClipRect(oldLayer as PersistedClipRect?, rect, clipBehavior))
-        as ui.ClipRectEngineLayer;
+    return _pushSurface<PersistedClipRect>(PersistedClipRect(oldLayer as PersistedClipRect?, rect, clipBehavior));
   }
 
   /// Pushes a rounded-rectangular clip operation onto the operation stack.
@@ -128,7 +127,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     ui.Clip? clipBehavior,
     ui.ClipRRectEngineLayer? oldLayer,
   }) {
-    return _pushSurface(PersistedClipRRect(oldLayer, rrect, clipBehavior)) as ui.ClipRRectEngineLayer;
+    return _pushSurface<PersistedClipRRect>(PersistedClipRRect(oldLayer, rrect, clipBehavior));
   }
 
   /// Pushes a path clip operation onto the operation stack.
@@ -144,7 +143,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   }) {
     assert(clipBehavior != null); // ignore: unnecessary_null_comparison
     assert(clipBehavior != ui.Clip.none);
-    return _pushSurface(PersistedClipPath(oldLayer as PersistedClipPath?, path, clipBehavior)) as ui.ClipPathEngineLayer;
+    return _pushSurface<PersistedClipPath>(PersistedClipPath(oldLayer as PersistedClipPath?, path, clipBehavior));
   }
 
   /// Pushes an opacity operation onto the operation stack.
@@ -161,7 +160,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     ui.Offset offset = ui.Offset.zero,
     ui.OpacityEngineLayer? oldLayer,
   }) {
-    return _pushSurface(PersistedOpacity(oldLayer as PersistedOpacity?, alpha, offset)) as ui.OpacityEngineLayer;
+    return _pushSurface<PersistedOpacity>(PersistedOpacity(oldLayer as PersistedOpacity?, alpha, offset));
   }
 
   /// Pushes a color filter operation onto the operation stack.
@@ -180,7 +179,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     ui.ColorFilterEngineLayer? oldLayer,
   }) {
     assert(filter != null); // ignore: unnecessary_null_comparison
-    return _pushSurface(PersistedColorFilter(oldLayer as PersistedColorFilter?, filter)) as ui.ColorFilterEngineLayer;
+    return _pushSurface<PersistedColorFilter>(PersistedColorFilter(oldLayer as PersistedColorFilter?, filter));
   }
 
   /// Pushes an image filter operation onto the operation stack.
@@ -199,7 +198,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     ui.ImageFilterEngineLayer? oldLayer,
   }) {
     assert(filter != null); // ignore: unnecessary_null_comparison
-    return _pushSurface(PersistedImageFilter(oldLayer as PersistedImageFilter?, filter)) as ui.ImageFilterEngineLayer;
+    return _pushSurface<PersistedImageFilter>(PersistedImageFilter(oldLayer as PersistedImageFilter?, filter));
   }
 
   /// Pushes a backdrop filter operation onto the operation stack.
@@ -213,7 +212,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     ui.ImageFilter filter, {
     ui.BackdropFilterEngineLayer? oldLayer,
   }) {
-    return _pushSurface(PersistedBackdropFilter(oldLayer as PersistedBackdropFilter?, filter as EngineImageFilter)) as ui.BackdropFilterEngineLayer;
+    return _pushSurface<PersistedBackdropFilter>(PersistedBackdropFilter(oldLayer as PersistedBackdropFilter?, filter as EngineImageFilter));
   }
 
   /// Pushes a shader mask operation onto the operation stack.
@@ -254,7 +253,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     ui.PhysicalShapeEngineLayer? oldLayer,
   }) {
     assert(color != null, 'color must not be null'); // ignore: unnecessary_null_comparison
-    return _pushSurface(PersistedPhysicalShape(
+    return _pushSurface<PersistedPhysicalShape>(PersistedPhysicalShape(
       oldLayer as PersistedPhysicalShape?,
       path as SurfacePath,
       elevation,


### PR DESCRIPTION
## Description

Change pushSurface to use generics to prevent extra 'as' checks at runtime.

## Related Issues

Found while profiling:
https://github.com/flutter/flutter/issues/62596

## Tests

Covered by benchmarks

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
