### PR TITLE
Remove extra method in ComputePlatformResolvedLocale

### DIFF
--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -210,25 +210,6 @@ class PlatformView {
     ///
     virtual void OnPlatformViewMarkTextureFrameAvailable(
         int64_t texture_id) = 0;
-
-    //--------------------------------------------------------------------------
-    /// @brief      Directly invokes platform-specific APIs to compute the
-    ///             locale the platform would have natively resolved to.
-    ///
-    /// @param[in]  supported_locale_data  The vector of strings that represents
-    ///                                    the locales supported by the app.
-    ///                                    Each locale consists of three
-    ///                                    strings: languageCode, countryCode,
-    ///                                    and scriptCode in that order.
-    ///
-    /// @return     A vector of 3 strings languageCode, countryCode, and
-    ///             scriptCode that represents the locale selected by the
-    ///             platform. Empty strings mean the value was unassigned. Empty
-    ///             vector represents a null locale.
-    ///
-    virtual std::unique_ptr<std::vector<std::string>>
-    ComputePlatformViewResolvedLocale(
-        const std::vector<std::string>& supported_locale_data) = 0;
   };
 
   //----------------------------------------------------------------------------

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1182,13 +1182,6 @@ void Shell::SetNeedsReportTimings(bool value) {
 // |Engine::Delegate|
 std::unique_ptr<std::vector<std::string>> Shell::ComputePlatformResolvedLocale(
     const std::vector<std::string>& supported_locale_data) {
-  return ComputePlatformViewResolvedLocale(supported_locale_data);
-}
-
-// |PlatformView::Delegate|
-std::unique_ptr<std::vector<std::string>>
-Shell::ComputePlatformViewResolvedLocale(
-    const std::vector<std::string>& supported_locale_data) {
   return platform_view_->ComputePlatformResolvedLocales(supported_locale_data);
 }
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -507,10 +507,6 @@ class Shell final : public PlatformView::Delegate,
   // |PlatformView::Delegate|
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) override;
 
-  // |PlatformView::Delegate|
-  std::unique_ptr<std::vector<std::string>> ComputePlatformViewResolvedLocale(
-      const std::vector<std::string>& supported_locale_data) override;
-
   // |Animator::Delegate|
   void OnAnimatorBeginFrame(fml::TimePoint frame_target_time) override;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -33,12 +33,6 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewRegisterTexture(std::shared_ptr<Texture> texture) override {}
   void OnPlatformViewUnregisterTexture(int64_t texture_id) override {}
   void OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) override {}
-
-  std::unique_ptr<std::vector<std::string>> ComputePlatformViewResolvedLocale(
-      const std::vector<std::string>& supported_locale_data) override {
-    std::unique_ptr<std::vector<std::string>> out = std::make_unique<std::vector<std::string>>();
-    return out;
-  }
 };
 
 }  // namespace

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -89,12 +89,6 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewRegisterTexture(std::shared_ptr<Texture> texture) override {}
   void OnPlatformViewUnregisterTexture(int64_t texture_id) override {}
   void OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) override {}
-
-  std::unique_ptr<std::vector<std::string>> ComputePlatformViewResolvedLocale(
-      const std::vector<std::string>& supported_locale_data) override {
-    std::unique_ptr<std::vector<std::string>> out = std::make_unique<std::vector<std::string>>();
-    return out;
-  }
 };
 
 }  // namespace

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -86,12 +86,6 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewRegisterTexture(std::shared_ptr<Texture> texture) override {}
   void OnPlatformViewUnregisterTexture(int64_t texture_id) override {}
   void OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) override {}
-
-  std::unique_ptr<std::vector<std::string>> ComputePlatformViewResolvedLocale(
-      const std::vector<std::string>& supported_locale_data) override {
-    std::unique_ptr<std::vector<std::string>> out = std::make_unique<std::vector<std::string>>();
-    return out;
-  }
 };
 
 class MockIosDelegate : public AccessibilityBridge::IosDelegate {


### PR DESCRIPTION
Shell::ComputePlatformResolvedLocale can directly call instead of passing though an extra method.

This results in no functional change in the logic.