### PR TITLE
reland support uri launch in android

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -774,13 +774,18 @@ public class FlutterActivity extends Activity
    *
    * If both preferences are set, the {@code Intent} preference takes priority.
    *
+   * <p>If none is set, the {@link FlutterActivityAndFragmentDelegate} retrieves the initial route
+   * from the {@code Intent} through the Intent.getData() instead.
+   *
    * <p>The reason that a {@code <meta-data>} preference is supported is because this {@code
    * Activity} might be the very first {@code Activity} launched, which means the developer won't
    * have control over the incoming {@code Intent}.
    *
    * <p>Subclasses may override this method to directly control the initial route.
+   *
+   * <p>If this method returns null, the {@link FlutterActivityAndFragmentDelegate} retrieves the
+   * initial route from the {@code Intent} through the Intent.getData() instead.
    */
-  @NonNull
   public String getInitialRoute() {
     if (getIntent().hasExtra(EXTRA_INITIAL_ROUTE)) {
       return getIntent().getStringExtra(EXTRA_INITIAL_ROUTE);
@@ -792,9 +797,9 @@ public class FlutterActivity extends Activity
       Bundle metadata = activityInfo.metaData;
       String desiredInitialRoute =
           metadata != null ? metadata.getString(INITIAL_ROUTE_META_DATA_KEY) : null;
-      return desiredInitialRoute != null ? desiredInitialRoute : DEFAULT_INITIAL_ROUTE;
+      return desiredInitialRoute;
     } catch (PackageManager.NameNotFoundException e) {
-      return DEFAULT_INITIAL_ROUTE;
+      return null;
     }
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -781,10 +781,9 @@ public class FlutterActivity extends Activity
    *
    * <p>Subclasses may override this method to directly control the initial route.
    *
-   * <p>If this method returns null and the {@code <meta-data>} has {@link
-   * FlutterActivityAndFragmentDelegate#HANDLE_DEEPLINKING_BUNDLE_KEY} set to true, the {@link
-   * FlutterActivityAndFragmentDelegate} retrieves the initial route from the {@code Intent} through
-   * the Intent.getData() instead.
+   * <p>If this method returns null and the {@code shouldHandleDeeplinking()} returns true, the
+   * {@link FlutterActivityAndFragmentDelegate} retrieves the initial route from the {@code Intent}
+   * through the Intent.getData() instead.
    */
   public String getInitialRoute() {
     if (getIntent().hasExtra(EXTRA_INITIAL_ROUTE)) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -456,7 +456,7 @@ public class FlutterActivity extends Activity
       } else {
         Log.v(TAG, "Using the launch theme as normal theme.");
       }
-    } catch (PackageManager.NameNotFoundException exception) {
+    } catch (RuntimeException exception) {
       Log.e(
           TAG,
           "Could not read meta-data for FlutterActivity. Using the launch theme as normal theme.");
@@ -485,14 +485,14 @@ public class FlutterActivity extends Activity
   @SuppressWarnings("deprecation")
   private Drawable getSplashScreenFromManifest() {
     try {
-      Bundle metadata = getMetaData();
-      int splashScreenId = metadata != null ? metadata.getInt(SPLASH_SCREEN_META_DATA_KEY) : 0;
+      Bundle metaData = getMetaData();
+      int splashScreenId = metaData != null ? metaData.getInt(SPLASH_SCREEN_META_DATA_KEY) : 0;
       return splashScreenId != 0
           ? Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP
               ? getResources().getDrawable(splashScreenId, getTheme())
               : getResources().getDrawable(splashScreenId)
           : null;
-    } catch (PackageManager.NameNotFoundException e) {
+    } catch (RuntimeException e) {
       // This is never expected to happen.
       return null;
     }
@@ -746,11 +746,11 @@ public class FlutterActivity extends Activity
   @NonNull
   public String getDartEntrypointFunctionName() {
     try {
-      Bundle metadata = getMetaData();
+      Bundle metaData = getMetaData();
       String desiredDartEntrypoint =
-          metadata != null ? metadata.getString(DART_ENTRYPOINT_META_DATA_KEY) : null;
+          metaData != null ? metaData.getString(DART_ENTRYPOINT_META_DATA_KEY) : null;
       return desiredDartEntrypoint != null ? desiredDartEntrypoint : DEFAULT_DART_ENTRYPOINT;
-    } catch (PackageManager.NameNotFoundException e) {
+    } catch (RuntimeException e) {
       return DEFAULT_DART_ENTRYPOINT;
     }
   }
@@ -785,11 +785,11 @@ public class FlutterActivity extends Activity
     }
 
     try {
-      Bundle metadata = getMetaData();
+      Bundle metaData = getMetaData();
       String desiredInitialRoute =
-          metadata != null ? metadata.getString(INITIAL_ROUTE_META_DATA_KEY) : null;
+          metaData != null ? metaData.getString(INITIAL_ROUTE_META_DATA_KEY) : null;
       return desiredInitialRoute;
-    } catch (PackageManager.NameNotFoundException e) {
+    } catch (RuntimeException e) {
       return null;
     }
   }
@@ -890,23 +890,16 @@ public class FlutterActivity extends Activity
     return delegate.getFlutterEngine();
   }
 
-  private Bundle cachedMetaData;
-
-  /** Mocks the meta data for testing purposes. */
-  @VisibleForTesting
-  public void setMetaData(Bundle metaData) {
-    cachedMetaData = metaData;
-  };
-
   /** Retrieves the meta data specified in the AndroidManifest.xml. */
   @Nullable
-  protected Bundle getMetaData() throws PackageManager.NameNotFoundException {
-    if (cachedMetaData == null) {
+  protected Bundle getMetaData() throws RuntimeException {
+    try {
       ActivityInfo activityInfo =
           getPackageManager().getActivityInfo(getComponentName(), PackageManager.GET_META_DATA);
-      cachedMetaData = activityInfo.metaData;
+      return activityInfo.metaData;
+    } catch (PackageManager.NameNotFoundException e) {
+      throw new RuntimeException(e.getMessage());
     }
-    return cachedMetaData;
   }
 
   @Nullable
@@ -989,17 +982,18 @@ public class FlutterActivity extends Activity
    * Whether to handle the deeplinking from the {@code Intent} automatically if the {@code
    * getInitialRoute} returns null.
    *
-   * <p>The default implementation looks for the value of the key `flutter_handle_deeplinking` in
-   * the AndroidManifest.xml.
+   * <p>The default implementation looks {@code <meta-data>} called {@link
+   * FlutterActivityLaunchConfigs#HANDLE_DEEPLINKING_META_DATA_KEY} within the Android manifest
+   * definition for this {@code FlutterActivity}.
    */
   @Override
   public boolean shouldHandleDeeplinking() {
     try {
-      Bundle metadata = getMetaData();
+      Bundle metaData = getMetaData();
       boolean shouldHandleDeeplinking =
-          metadata != null ? metadata.getBoolean(HANDLE_DEEPLINKING_META_DATA_KEY) : false;
+          metaData != null ? metaData.getBoolean(HANDLE_DEEPLINKING_META_DATA_KEY) : false;
       return shouldHandleDeeplinking;
-    } catch (PackageManager.NameNotFoundException e) {
+    } catch (RuntimeException e) {
       return false;
     }
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -13,6 +13,7 @@ import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_CA
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_DESTROY_ENGINE_WITH_ACTIVITY;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_ENABLE_STATE_RESTORATION;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.EXTRA_INITIAL_ROUTE;
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.HANDLE_DEEPLINKING_META_DATA_KEY;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.INITIAL_ROUTE_META_DATA_KEY;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.NORMAL_THEME_META_DATA_KEY;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.SPLASH_SCREEN_META_DATA_KEY;
@@ -774,17 +775,16 @@ public class FlutterActivity extends Activity
    *
    * If both preferences are set, the {@code Intent} preference takes priority.
    *
-   * <p>If none is set, the {@link FlutterActivityAndFragmentDelegate} retrieves the initial route
-   * from the {@code Intent} through the Intent.getData() instead.
-   *
    * <p>The reason that a {@code <meta-data>} preference is supported is because this {@code
    * Activity} might be the very first {@code Activity} launched, which means the developer won't
    * have control over the incoming {@code Intent}.
    *
    * <p>Subclasses may override this method to directly control the initial route.
    *
-   * <p>If this method returns null, the {@link FlutterActivityAndFragmentDelegate} retrieves the
-   * initial route from the {@code Intent} through the Intent.getData() instead.
+   * <p>If this method returns null and the {@code <meta-data>} has {@link
+   * FlutterActivityAndFragmentDelegate#HANDLE_DEEPLINKING_BUNDLE_KEY} set to true, the {@link
+   * FlutterActivityAndFragmentDelegate} retrieves the initial route from the {@code Intent} through
+   * the Intent.getData() instead.
    */
   public String getInitialRoute() {
     if (getIntent().hasExtra(EXTRA_INITIAL_ROUTE)) {
@@ -973,6 +973,20 @@ public class FlutterActivity extends Activity
   @Override
   public boolean shouldAttachEngineToActivity() {
     return true;
+  }
+
+  @Override
+  public boolean shouldHandleDeeplinking() {
+    try {
+      ActivityInfo activityInfo =
+          getPackageManager().getActivityInfo(getComponentName(), PackageManager.GET_META_DATA);
+      Bundle metadata = activityInfo.metaData;
+      boolean shouldHandleDeeplinking =
+          metadata != null ? metadata.getBoolean(HANDLE_DEEPLINKING_META_DATA_KEY) : false;
+      return shouldHandleDeeplinking;
+    } catch (PackageManager.NameNotFoundException e) {
+      return false;
+    }
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -456,7 +456,7 @@ public class FlutterActivity extends Activity
       } else {
         Log.v(TAG, "Using the launch theme as normal theme.");
       }
-    } catch (RuntimeException exception) {
+    } catch (PackageManager.NameNotFoundException exception) {
       Log.e(
           TAG,
           "Could not read meta-data for FlutterActivity. Using the launch theme as normal theme.");
@@ -492,7 +492,7 @@ public class FlutterActivity extends Activity
               ? getResources().getDrawable(splashScreenId, getTheme())
               : getResources().getDrawable(splashScreenId)
           : null;
-    } catch (RuntimeException e) {
+    } catch (PackageManager.NameNotFoundException e) {
       // This is never expected to happen.
       return null;
     }
@@ -750,7 +750,7 @@ public class FlutterActivity extends Activity
       String desiredDartEntrypoint =
           metaData != null ? metaData.getString(DART_ENTRYPOINT_META_DATA_KEY) : null;
       return desiredDartEntrypoint != null ? desiredDartEntrypoint : DEFAULT_DART_ENTRYPOINT;
-    } catch (RuntimeException e) {
+    } catch (PackageManager.NameNotFoundException e) {
       return DEFAULT_DART_ENTRYPOINT;
     }
   }
@@ -789,7 +789,7 @@ public class FlutterActivity extends Activity
       String desiredInitialRoute =
           metaData != null ? metaData.getString(INITIAL_ROUTE_META_DATA_KEY) : null;
       return desiredInitialRoute;
-    } catch (RuntimeException e) {
+    } catch (PackageManager.NameNotFoundException e) {
       return null;
     }
   }
@@ -892,14 +892,10 @@ public class FlutterActivity extends Activity
 
   /** Retrieves the meta data specified in the AndroidManifest.xml. */
   @Nullable
-  protected Bundle getMetaData() throws RuntimeException {
-    try {
-      ActivityInfo activityInfo =
-          getPackageManager().getActivityInfo(getComponentName(), PackageManager.GET_META_DATA);
-      return activityInfo.metaData;
-    } catch (PackageManager.NameNotFoundException e) {
-      throw new RuntimeException(e.getMessage());
-    }
+  protected Bundle getMetaData() throws PackageManager.NameNotFoundException {
+    ActivityInfo activityInfo =
+        getPackageManager().getActivityInfo(getComponentName(), PackageManager.GET_META_DATA);
+    return activityInfo.metaData;
   }
 
   @Nullable
@@ -993,7 +989,7 @@ public class FlutterActivity extends Activity
       boolean shouldHandleDeeplinking =
           metaData != null ? metaData.getBoolean(HANDLE_DEEPLINKING_META_DATA_KEY) : false;
       return shouldHandleDeeplinking;
-    } catch (RuntimeException e) {
+    } catch (PackageManager.NameNotFoundException e) {
       return false;
     }
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -9,6 +9,7 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -362,18 +363,21 @@ import java.util.Arrays;
       // So this is expected behavior in many cases.
       return;
     }
-
+    String initialRoute = host.getInitialRoute();
+    if (initialRoute == null) {
+      initialRoute = getInitialRouteFromIntent(host.getActivity().getIntent());
+    }
     Log.v(
         TAG,
         "Executing Dart entrypoint: "
             + host.getDartEntrypointFunctionName()
             + ", and sending initial route: "
-            + host.getInitialRoute());
+            + initialRoute);
 
     // The engine needs to receive the Flutter app's initial route before executing any
     // Dart code to ensure that the initial route arrives in time to be applied.
-    if (host.getInitialRoute() != null) {
-      flutterEngine.getNavigationChannel().setInitialRoute(host.getInitialRoute());
+    if (initialRoute != null) {
+      flutterEngine.getNavigationChannel().setInitialRoute(initialRoute);
     }
 
     String appBundlePathOverride = host.getAppBundlePath();
@@ -386,6 +390,14 @@ import java.util.Arrays;
         new DartExecutor.DartEntrypoint(
             appBundlePathOverride, host.getDartEntrypointFunctionName());
     flutterEngine.getDartExecutor().executeDartEntrypoint(entrypoint);
+  }
+
+  private String getInitialRouteFromIntent(Intent intent) {
+    Uri data = intent.getData();
+    if (data != null && !data.toString().isEmpty()) {
+      return data.toString();
+    }
+    return null;
   }
 
   /**
@@ -622,8 +634,12 @@ import java.util.Arrays;
   void onNewIntent(@NonNull Intent intent) {
     ensureAlive();
     if (flutterEngine != null) {
-      Log.v(TAG, "Forwarding onNewIntent() to FlutterEngine.");
+      Log.v(TAG, "Forwarding onNewIntent() to FlutterEngine and sending pushRoute message.");
       flutterEngine.getActivityControlSurface().onNewIntent(intent);
+      String initialRoute = getInitialRouteFromIntent(intent);
+      if (initialRoute != null && !initialRoute.isEmpty()) {
+        flutterEngine.getNavigationChannel().pushRoute(initialRoute);
+      }
     } else {
       Log.w(TAG, "onNewIntent() invoked before FlutterFragment was attached to an Activity.");
     }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -5,6 +5,7 @@
 package io.flutter.embedding.android;
 
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DEFAULT_INITIAL_ROUTE;
 
 import android.app.Activity;
 import android.content.Context;
@@ -366,6 +367,9 @@ import java.util.Arrays;
     String initialRoute = host.getInitialRoute();
     if (initialRoute == null) {
       initialRoute = maybeGetInitialRouteFromIntent(host.getActivity().getIntent());
+      if (initialRoute == null) {
+        initialRoute = DEFAULT_INITIAL_ROUTE;
+      }
     }
     Log.v(
         TAG,
@@ -376,9 +380,7 @@ import java.util.Arrays;
 
     // The engine needs to receive the Flutter app's initial route before executing any
     // Dart code to ensure that the initial route arrives in time to be applied.
-    if (initialRoute != null) {
-      flutterEngine.getNavigationChannel().setInitialRoute(initialRoute);
-    }
+    flutterEngine.getNavigationChannel().setInitialRoute(initialRoute);
 
     String appBundlePathOverride = host.getAppBundlePath();
     if (appBundlePathOverride == null || appBundlePathOverride.isEmpty()) {
@@ -753,11 +755,7 @@ import java.util.Arrays;
     @NonNull
     Context getContext();
 
-    /**
-     * Returns true if the {@link FlutterActivityAndFragmentDelegate} should send the deeplinking
-     * URL to the framework through the {@code NavigationChannel.setInitialRoute} or {@code
-     * NavigationChannel.pushRoute}.
-     */
+    /** Returns true if the delegate should retrieve the initial route from the {@link Intent}. */
     @Nullable
     boolean shouldHandleDeeplinking();
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
@@ -16,7 +16,8 @@ public class FlutterActivityLaunchConfigs {
       "io.flutter.embedding.android.SplashScreenDrawable";
   /* package */ static final String NORMAL_THEME_META_DATA_KEY =
       "io.flutter.embedding.android.NormalTheme";
-  /* package */ static final String HANDLE_DEEPLINKING_META_DATA_KEY = "flutter_handle_deeplinking";
+  /* package */ static final String HANDLE_DEEPLINKING_META_DATA_KEY =
+      "flutter_deeplinking_enabled";
   // Intent extra arguments.
   /* package */ static final String EXTRA_INITIAL_ROUTE = "route";
   /* package */ static final String EXTRA_BACKGROUND_MODE = "background_mode";

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
@@ -16,7 +16,7 @@ public class FlutterActivityLaunchConfigs {
       "io.flutter.embedding.android.SplashScreenDrawable";
   /* package */ static final String NORMAL_THEME_META_DATA_KEY =
       "io.flutter.embedding.android.NormalTheme";
-
+  /* package */ static final String HANDLE_DEEPLINKING_META_DATA_KEY = "flutter_handle_deeplinking";
   // Intent extra arguments.
   /* package */ static final String EXTRA_INITIAL_ROUTE = "route";
   /* package */ static final String EXTRA_BACKGROUND_MODE = "background_mode";

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -227,7 +227,10 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
       return this;
     }
 
-    /** Whether the activity delegate should handle the deeplinking request. */
+    /**
+     * Whether to handle the deeplinking from the {@code Intent} automatically if the {@code
+     * getInitialRoute} returns null.
+     */
     @NonNull
     public NewEngineFragmentBuilder handleDeeplinking(@NonNull Boolean handleDeeplinking) {
       this.handleDeeplinking = handleDeeplinking;
@@ -472,7 +475,10 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
       return this;
     }
 
-    /** Whether the activity delegate should handle the deeplinking request. */
+    /**
+     * Whether to handle the deeplinking from the {@code Intent} automatically if the {@code
+     * getInitialRoute} returns null.
+     */
     @NonNull
     public CachedEngineFragmentBuilder handleDeeplinking(@NonNull Boolean handleDeeplinking) {
       this.handleDeeplinking = handleDeeplinking;
@@ -1037,10 +1043,8 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
   }
 
   /**
-   * See {@link NewEngineFragmentBuilder#shouldHandleDeeplinking()} and {@link
-   * CachedEngineFragmentBuilder#shouldHandleDeeplinking()}.
-   *
-   * <p>Used by this {@code FlutterFragment}'s {@link FlutterActivityAndFragmentDelegate}
+   * Whether to handle the deeplinking from the {@code Intent} automatically if the {@code
+   * getInitialRoute} returns null.
    */
   @Override
   public boolean shouldHandleDeeplinking() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -88,6 +88,8 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
   protected static final String ARG_DART_ENTRYPOINT = "dart_entrypoint";
   /** Initial Flutter route that is rendered in a Navigator widget. */
   protected static final String ARG_INITIAL_ROUTE = "initial_route";
+  /** Whether the activity delegate should handle the deeplinking request. */
+  protected static final String ARG_HANDLE_DEEPLINKING = "handle_deeplinking";
   /** Path to Flutter's Dart code. */
   protected static final String ARG_APP_BUNDLE_PATH = "app_bundle_path";
   /** Flutter shell arguments. */
@@ -185,6 +187,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
     private final Class<? extends FlutterFragment> fragmentClass;
     private String dartEntrypoint = "main";
     private String initialRoute = "/";
+    private boolean handleDeeplinking = false;
     private String appBundlePath = null;
     private FlutterShellArgs shellArgs = null;
     private RenderMode renderMode = RenderMode.surface;
@@ -221,6 +224,13 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
     @NonNull
     public NewEngineFragmentBuilder initialRoute(@NonNull String initialRoute) {
       this.initialRoute = initialRoute;
+      return this;
+    }
+
+    /** Whether the activity delegate should handle the deeplinking request. */
+    @NonNull
+    public NewEngineFragmentBuilder handleDeeplinking(@NonNull Boolean handleDeeplinking) {
+      this.handleDeeplinking = handleDeeplinking;
       return this;
     }
 
@@ -316,6 +326,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
     protected Bundle createArgs() {
       Bundle args = new Bundle();
       args.putString(ARG_INITIAL_ROUTE, initialRoute);
+      args.putBoolean(ARG_HANDLE_DEEPLINKING, handleDeeplinking);
       args.putString(ARG_APP_BUNDLE_PATH, appBundlePath);
       args.putString(ARG_DART_ENTRYPOINT, dartEntrypoint);
       // TODO(mattcarroll): determine if we should have an explicit FlutterTestFragment instead of
@@ -409,6 +420,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
     private final Class<? extends FlutterFragment> fragmentClass;
     private final String engineId;
     private boolean destroyEngineWithFragment = false;
+    private boolean handleDeeplinking = false;
     private RenderMode renderMode = RenderMode.surface;
     private TransparencyMode transparencyMode = TransparencyMode.transparent;
     private boolean shouldAttachEngineToActivity = true;
@@ -457,6 +469,13 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
     public CachedEngineFragmentBuilder transparencyMode(
         @NonNull TransparencyMode transparencyMode) {
       this.transparencyMode = transparencyMode;
+      return this;
+    }
+
+    /** Whether the activity delegate should handle the deeplinking request. */
+    @NonNull
+    public CachedEngineFragmentBuilder handleDeeplinking(@NonNull Boolean handleDeeplinking) {
+      this.handleDeeplinking = handleDeeplinking;
       return this;
     }
 
@@ -512,6 +531,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
       Bundle args = new Bundle();
       args.putString(ARG_CACHED_ENGINE_ID, engineId);
       args.putBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, destroyEngineWithFragment);
+      args.putBoolean(ARG_HANDLE_DEEPLINKING, handleDeeplinking);
       args.putString(
           ARG_FLUTTERVIEW_RENDER_MODE,
           renderMode != null ? renderMode.name() : RenderMode.surface.name());
@@ -1014,6 +1034,17 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
   @Override
   public boolean shouldAttachEngineToActivity() {
     return getArguments().getBoolean(ARG_SHOULD_ATTACH_ENGINE_TO_ACTIVITY);
+  }
+
+  /**
+   * See {@link NewEngineFragmentBuilder#shouldHandleDeeplinking()} and {@link
+   * CachedEngineFragmentBuilder#shouldHandleDeeplinking()}.
+   *
+   * <p>Used by this {@code FlutterFragment}'s {@link FlutterActivityAndFragmentDelegate}
+   */
+  @Override
+  public boolean shouldHandleDeeplinking() {
+    return getArguments().getBoolean(ARG_HANDLE_DEEPLINKING);
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -646,13 +646,18 @@ public class FlutterFragmentActivity extends FragmentActivity
    *
    * If both preferences are set, the {@code Intent} preference takes priority.
    *
+   * <p>If none is set, the {@link FlutterActivityAndFragmentDelegate} retrieves the initial route
+   * from the {@code Intent} through the Intent.getData() instead.
+   *
    * <p>The reason that a {@code <meta-data>} preference is supported is because this {@code
    * Activity} might be the very first {@code Activity} launched, which means the developer won't
    * have control over the incoming {@code Intent}.
    *
    * <p>Subclasses may override this method to directly control the initial route.
+   *
+   * <p>If this method returns null, the {@link FlutterActivityAndFragmentDelegate} retrieves the
+   * initial route from the {@code Intent} through the Intent.getData() instead.
    */
-  @NonNull
   protected String getInitialRoute() {
     if (getIntent().hasExtra(EXTRA_INITIAL_ROUTE)) {
       return getIntent().getStringExtra(EXTRA_INITIAL_ROUTE);
@@ -664,9 +669,9 @@ public class FlutterFragmentActivity extends FragmentActivity
       Bundle metadata = activityInfo.metaData;
       String desiredInitialRoute =
           metadata != null ? metadata.getString(INITIAL_ROUTE_META_DATA_KEY) : null;
-      return desiredInitialRoute != null ? desiredInitialRoute : DEFAULT_INITIAL_ROUTE;
+      return desiredInitialRoute;
     } catch (PackageManager.NameNotFoundException e) {
-      return DEFAULT_INITIAL_ROUTE;
+      return null;
     }
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -668,10 +668,9 @@ public class FlutterFragmentActivity extends FragmentActivity
    *
    * <p>Subclasses may override this method to directly control the initial route.
    *
-   * <p>If this method returns null and the {@code <meta-data>} has {@link
-   * FlutterActivityAndFragmentDelegate#HANDLE_DEEPLINKING_BUNDLE_KEY} set to true, the {@link
-   * FlutterActivityAndFragmentDelegate} retrieves the initial route from the {@code Intent} through
-   * the Intent.getData() instead.
+   * <p>If this method returns null and the {@code shouldHandleDeeplinking()} returns true, the
+   * {@link FlutterActivityAndFragmentDelegate} retrieves the initial route from the {@code Intent}
+   * through the Intent.getData() instead.
    */
   protected String getInitialRoute() {
     if (getIntent().hasExtra(EXTRA_INITIAL_ROUTE)) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -290,7 +290,7 @@ public class FlutterFragmentActivity extends FragmentActivity
       } else {
         Log.v(TAG, "Using the launch theme as normal theme.");
       }
-    } catch (RuntimeException exception) {
+    } catch (PackageManager.NameNotFoundException exception) {
       Log.e(
           TAG,
           "Could not read meta-data for FlutterFragmentActivity. Using the launch theme as normal theme.");
@@ -327,7 +327,7 @@ public class FlutterFragmentActivity extends FragmentActivity
               ? getResources().getDrawable(splashScreenId, getTheme())
               : getResources().getDrawable(splashScreenId)
           : null;
-    } catch (RuntimeException e) {
+    } catch (PackageManager.NameNotFoundException e) {
       // This is never expected to happen.
       return null;
     }
@@ -561,7 +561,7 @@ public class FlutterFragmentActivity extends FragmentActivity
       boolean shouldHandleDeeplinking =
           metaData != null ? metaData.getBoolean(HANDLE_DEEPLINKING_META_DATA_KEY) : false;
       return shouldHandleDeeplinking;
-    } catch (RuntimeException e) {
+    } catch (PackageManager.NameNotFoundException e) {
       return false;
     }
   }
@@ -631,14 +631,10 @@ public class FlutterFragmentActivity extends FragmentActivity
 
   /** Retrieves the meta data specified in the AndroidManifest.xml. */
   @Nullable
-  protected Bundle getMetaData() throws RuntimeException {
-    try {
-      ActivityInfo activityInfo =
-          getPackageManager().getActivityInfo(getComponentName(), PackageManager.GET_META_DATA);
-      return activityInfo.metaData;
-    } catch (PackageManager.NameNotFoundException e) {
-      throw new RuntimeException(e.getMessage());
-    }
+  protected Bundle getMetaData() throws PackageManager.NameNotFoundException {
+    ActivityInfo activityInfo =
+        getPackageManager().getActivityInfo(getComponentName(), PackageManager.GET_META_DATA);
+    return activityInfo.metaData;
   }
 
   /**
@@ -657,7 +653,7 @@ public class FlutterFragmentActivity extends FragmentActivity
       String desiredDartEntrypoint =
           metaData != null ? metaData.getString(DART_ENTRYPOINT_META_DATA_KEY) : null;
       return desiredDartEntrypoint != null ? desiredDartEntrypoint : DEFAULT_DART_ENTRYPOINT;
-    } catch (RuntimeException e) {
+    } catch (PackageManager.NameNotFoundException e) {
       return DEFAULT_DART_ENTRYPOINT;
     }
   }
@@ -696,7 +692,7 @@ public class FlutterFragmentActivity extends FragmentActivity
       String desiredInitialRoute =
           metaData != null ? metaData.getString(INITIAL_ROUTE_META_DATA_KEY) : null;
       return desiredInitialRoute;
-    } catch (RuntimeException e) {
+    } catch (PackageManager.NameNotFoundException e) {
       return null;
     }
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -548,7 +548,7 @@ public class FlutterFragmentActivity extends FragmentActivity
     return true;
   }
 
-  public boolean shouldHandleDeeplinking() {
+  protected boolean shouldHandleDeeplinking() {
     try {
       ActivityInfo activityInfo =
           getPackageManager().getActivityInfo(getComponentName(), PackageManager.GET_META_DATA);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 import io.flutter.FlutterInjector;
@@ -43,6 +44,7 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
 @Config(manifest = Config.NONE)
@@ -424,6 +426,50 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Verify that the call was forwarded to the engine.
     verify(mockFlutterEngine.getActivityControlSurface(), times(1))
         .onRequestPermissionsResult(any(Integer.class), any(String[].class), any(int[].class));
+  }
+
+  @Test
+  public void itSendsInitialRouteFromIntentOnStartIfnoInitialRouteFromActivity() {
+    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    intent.setData(Uri.parse("http://myApp/custom/route"));
+
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    when(mockHost.getActivity()).thenReturn(flutterActivity);
+    when(mockHost.getInitialRoute()).thenReturn(null);
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is setup in onAttach().
+    delegate.onAttach(RuntimeEnvironment.application);
+    // Emulate app start.
+    delegate.onStart();
+
+    // Verify that the navigation channel was given the initial route message.
+    verify(mockFlutterEngine.getNavigationChannel(), times(1))
+        .setInitialRoute("http://myApp/custom/route");
+  }
+
+  @Test
+  public void itSendsPushRouteMessageWhenOnNewIntent() {
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is setup in onAttach().
+    delegate.onAttach(RuntimeEnvironment.application);
+
+    Intent mockIntent = mock(Intent.class);
+    when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route"));
+    // Emulate the host and call the method that we expect to be forwarded.
+    delegate.onNewIntent(mockIntent);
+
+    // Verify that the navigation channel was given the push route message.
+    verify(mockFlutterEngine.getNavigationChannel(), times(1))
+        .pushRoute("http://myApp/custom/route");
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -73,6 +73,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     when(mockHost.getTransparencyMode()).thenReturn(TransparencyMode.transparent);
     when(mockHost.provideFlutterEngine(any(Context.class))).thenReturn(mockFlutterEngine);
     when(mockHost.shouldAttachEngineToActivity()).thenReturn(true);
+    when(mockHost.shouldHandleDeeplinking()).thenReturn(false);
     when(mockHost.shouldDestroyEngineWithHost()).thenReturn(true);
   }
 
@@ -429,7 +430,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   }
 
   @Test
-  public void itSendsInitialRouteFromIntentOnStartIfnoInitialRouteFromActivity() {
+  public void itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivity() {
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
     intent.setData(Uri.parse("http://myApp/custom/route"));
 
@@ -439,6 +440,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     when(mockHost.getActivity()).thenReturn(flutterActivity);
     when(mockHost.getInitialRoute()).thenReturn(null);
+    when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
@@ -455,6 +457,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
   @Test
   public void itSendsPushRouteMessageWhenOnNewIntent() {
+    when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -430,7 +430,8 @@ public class FlutterActivityAndFragmentDelegateTest {
   }
 
   @Test
-  public void itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivity() {
+  public void
+      itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinking() {
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
     intent.setData(Uri.parse("http://myApp/custom/route"));
 
@@ -453,6 +454,31 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Verify that the navigation channel was given the initial route message.
     verify(mockFlutterEngine.getNavigationChannel(), times(1))
         .setInitialRoute("http://myApp/custom/route");
+  }
+
+  @Test
+  public void itSendsdefaultInitialRouteOnStartIfNotDeepLinkingFromIntent() {
+    // Creates an empty intent without launch uri.
+    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    when(mockHost.getActivity()).thenReturn(flutterActivity);
+    when(mockHost.getInitialRoute()).thenReturn(null);
+    when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is setup in onAttach().
+    delegate.onAttach(RuntimeEnvironment.application);
+    // Emulate app start.
+    delegate.onStart();
+
+    // Verify that the navigation channel was given the default initial route message.
+    verify(mockFlutterEngine.getNavigationChannel(), times(1)).setInitialRoute("/");
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -1,5 +1,6 @@
 package io.flutter.embedding.android;
 
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.HANDLE_DEEPLINKING_META_DATA_KEY;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -114,6 +115,52 @@ public class FlutterActivityTest {
     assertEquals(BackgroundMode.transparent, flutterActivity.getBackgroundMode());
     assertEquals(RenderMode.texture, flutterActivity.getRenderMode());
     assertEquals(TransparencyMode.transparent, flutterActivity.getTransparencyMode());
+  }
+
+  @Test
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase1() {
+    Intent intent =
+        FlutterActivity.withNewEngine()
+            .backgroundMode(BackgroundMode.transparent)
+            .build(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+    Bundle bundle = new Bundle();
+    bundle.putBoolean(HANDLE_DEEPLINKING_META_DATA_KEY, true);
+    flutterActivity.setMetaData(bundle);
+    assertTrue(flutterActivity.shouldHandleDeeplinking());
+  }
+
+  @Test
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase2() {
+    Intent intent =
+        FlutterActivity.withNewEngine()
+            .backgroundMode(BackgroundMode.transparent)
+            .build(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+    Bundle bundle = new Bundle();
+    bundle.putBoolean(HANDLE_DEEPLINKING_META_DATA_KEY, false);
+    flutterActivity.setMetaData(bundle);
+    assertFalse(flutterActivity.shouldHandleDeeplinking());
+  }
+
+  @Test
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase3() {
+    Intent intent =
+        FlutterActivity.withNewEngine()
+            .backgroundMode(BackgroundMode.transparent)
+            .build(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+    // Creates an empty bundle.
+    Bundle bundle = new Bundle();
+    flutterActivity.setMetaData(bundle);
+    // Empty bundle should return false.
+    assertFalse(flutterActivity.shouldHandleDeeplinking());
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -118,7 +119,8 @@ public class FlutterActivityTest {
   }
 
   @Test
-  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase1() {
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase1()
+      throws RuntimeException {
     Intent intent =
         FlutterActivity.withNewEngine()
             .backgroundMode(BackgroundMode.transparent)
@@ -128,12 +130,14 @@ public class FlutterActivityTest {
     FlutterActivity flutterActivity = activityController.get();
     Bundle bundle = new Bundle();
     bundle.putBoolean(HANDLE_DEEPLINKING_META_DATA_KEY, true);
-    flutterActivity.setMetaData(bundle);
-    assertTrue(flutterActivity.shouldHandleDeeplinking());
+    FlutterActivity spyFlutterActivity = spy(flutterActivity);
+    when(spyFlutterActivity.getMetaData()).thenReturn(bundle);
+    assertTrue(spyFlutterActivity.shouldHandleDeeplinking());
   }
 
   @Test
-  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase2() {
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase2()
+      throws RuntimeException {
     Intent intent =
         FlutterActivity.withNewEngine()
             .backgroundMode(BackgroundMode.transparent)
@@ -143,12 +147,14 @@ public class FlutterActivityTest {
     FlutterActivity flutterActivity = activityController.get();
     Bundle bundle = new Bundle();
     bundle.putBoolean(HANDLE_DEEPLINKING_META_DATA_KEY, false);
-    flutterActivity.setMetaData(bundle);
-    assertFalse(flutterActivity.shouldHandleDeeplinking());
+    FlutterActivity spyFlutterActivity = spy(flutterActivity);
+    when(spyFlutterActivity.getMetaData()).thenReturn(bundle);
+    assertFalse(spyFlutterActivity.shouldHandleDeeplinking());
   }
 
   @Test
-  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase3() {
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase3()
+      throws RuntimeException {
     Intent intent =
         FlutterActivity.withNewEngine()
             .backgroundMode(BackgroundMode.transparent)
@@ -158,9 +164,10 @@ public class FlutterActivityTest {
     FlutterActivity flutterActivity = activityController.get();
     // Creates an empty bundle.
     Bundle bundle = new Bundle();
-    flutterActivity.setMetaData(bundle);
+    FlutterActivity spyFlutterActivity = spy(flutterActivity);
+    when(spyFlutterActivity.getMetaData()).thenReturn(bundle);
     // Empty bundle should return false.
-    assertFalse(flutterActivity.shouldHandleDeeplinking());
+    assertFalse(spyFlutterActivity.shouldHandleDeeplinking());
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -120,7 +121,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase1()
-      throws RuntimeException {
+      throws PackageManager.NameNotFoundException {
     Intent intent =
         FlutterActivity.withNewEngine()
             .backgroundMode(BackgroundMode.transparent)
@@ -137,7 +138,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase2()
-      throws RuntimeException {
+      throws PackageManager.NameNotFoundException {
     Intent intent =
         FlutterActivity.withNewEngine()
             .backgroundMode(BackgroundMode.transparent)
@@ -154,7 +155,7 @@ public class FlutterActivityTest {
 
   @Test
   public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase3()
-      throws RuntimeException {
+      throws PackageManager.NameNotFoundException {
     Intent intent =
         FlutterActivity.withNewEngine()
             .backgroundMode(BackgroundMode.transparent)

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -359,6 +359,11 @@ public class FlutterAndroidComponentTest {
     }
 
     @Override
+    public boolean shouldHandleDeeplinking() {
+      return false;
+    }
+
+    @Override
     public boolean shouldRestoreAndSaveState() {
       return true;
     }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -88,7 +89,7 @@ public class FlutterFragmentActivityTest {
 
   @Test
   public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase1()
-      throws RuntimeException {
+      throws PackageManager.NameNotFoundException {
     FlutterFragmentActivity activity =
         Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get();
     assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
@@ -101,7 +102,7 @@ public class FlutterFragmentActivityTest {
 
   @Test
   public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase2()
-      throws RuntimeException {
+      throws PackageManager.NameNotFoundException {
     FlutterFragmentActivity activity =
         Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get();
     assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
@@ -114,7 +115,7 @@ public class FlutterFragmentActivityTest {
 
   @Test
   public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase3()
-      throws RuntimeException {
+      throws PackageManager.NameNotFoundException {
     FlutterFragmentActivity activity =
         Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get();
     assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
@@ -86,37 +87,43 @@ public class FlutterFragmentActivityTest {
   }
 
   @Test
-  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase1() {
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase1()
+      throws RuntimeException {
     FlutterFragmentActivity activity =
         Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get();
     assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
     Bundle bundle = new Bundle();
     bundle.putBoolean(HANDLE_DEEPLINKING_META_DATA_KEY, true);
-    activity.setMetaData(bundle);
-    assertTrue(activity.shouldHandleDeeplinking());
+    FlutterFragmentActivity spyFlutterActivity = spy(activity);
+    when(spyFlutterActivity.getMetaData()).thenReturn(bundle);
+    assertTrue(spyFlutterActivity.shouldHandleDeeplinking());
   }
 
   @Test
-  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase2() {
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase2()
+      throws RuntimeException {
     FlutterFragmentActivity activity =
         Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get();
     assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
     Bundle bundle = new Bundle();
     bundle.putBoolean(HANDLE_DEEPLINKING_META_DATA_KEY, false);
-    activity.setMetaData(bundle);
-    assertFalse(activity.shouldHandleDeeplinking());
+    FlutterFragmentActivity spyFlutterActivity = spy(activity);
+    when(spyFlutterActivity.getMetaData()).thenReturn(bundle);
+    assertFalse(spyFlutterActivity.shouldHandleDeeplinking());
   }
 
   @Test
-  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase3() {
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase3()
+      throws RuntimeException {
     FlutterFragmentActivity activity =
         Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get();
     assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
     // Creates an empty bundle.
     Bundle bundle = new Bundle();
-    activity.setMetaData(bundle);
+    FlutterFragmentActivity spyFlutterActivity = spy(activity);
+    when(spyFlutterActivity.getMetaData()).thenReturn(bundle);
     // Empty bundle should return false.
-    assertFalse(activity.shouldHandleDeeplinking());
+    assertFalse(spyFlutterActivity.shouldHandleDeeplinking());
   }
 
   static class FlutterFragmentActivityWithProvidedEngine extends FlutterFragmentActivity {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -119,6 +119,11 @@ public class FlutterFragmentActivityTest {
     protected String getAppBundlePath() {
       return "";
     }
+
+    @Override
+    protected boolean shouldHandleDeeplinking() {
+      return false;
+    }
   }
 
   // This is just a compile time check to ensure that it's possible for FlutterFragmentActivity

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -1,12 +1,15 @@
 package io.flutter.embedding.android;
 
+import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.HANDLE_DEEPLINKING_META_DATA_KEY;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
@@ -80,6 +83,40 @@ public class FlutterFragmentActivityTest {
     List<FlutterEngine> registeredEngines = GeneratedPluginRegistrant.getRegisteredEngines();
     assertEquals(1, registeredEngines.size());
     assertEquals(activity.getFlutterEngine(), registeredEngines.get(0));
+  }
+
+  @Test
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase1() {
+    FlutterFragmentActivity activity =
+        Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get();
+    assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
+    Bundle bundle = new Bundle();
+    bundle.putBoolean(HANDLE_DEEPLINKING_META_DATA_KEY, true);
+    activity.setMetaData(bundle);
+    assertTrue(activity.shouldHandleDeeplinking());
+  }
+
+  @Test
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase2() {
+    FlutterFragmentActivity activity =
+        Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get();
+    assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
+    Bundle bundle = new Bundle();
+    bundle.putBoolean(HANDLE_DEEPLINKING_META_DATA_KEY, false);
+    activity.setMetaData(bundle);
+    assertFalse(activity.shouldHandleDeeplinking());
+  }
+
+  @Test
+  public void itReturnsValueFromMetaDataWhenCallsShouldHandleDeepLinkingCase3() {
+    FlutterFragmentActivity activity =
+        Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get();
+    assertTrue(GeneratedPluginRegistrant.getRegisteredEngines().isEmpty());
+    // Creates an empty bundle.
+    Bundle bundle = new Bundle();
+    activity.setMetaData(bundle);
+    // Empty bundle should return false.
+    assertFalse(activity.shouldHandleDeeplinking());
   }
 
   static class FlutterFragmentActivityWithProvidedEngine extends FlutterFragmentActivity {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -27,6 +27,7 @@ public class FlutterFragmentTest {
     assertEquals("/", fragment.getInitialRoute());
     assertArrayEquals(new String[] {}, fragment.getFlutterShellArgs().toArray());
     assertTrue(fragment.shouldAttachEngineToActivity());
+    assertFalse(fragment.shouldHandleDeeplinking());
     assertNull(fragment.getCachedEngineId());
     assertTrue(fragment.shouldDestroyEngineWithHost());
     assertEquals(RenderMode.surface, fragment.getRenderMode());
@@ -40,6 +41,7 @@ public class FlutterFragmentTest {
             .dartEntrypoint("custom_entrypoint")
             .initialRoute("/custom/route")
             .shouldAttachEngineToActivity(false)
+            .handleDeeplinking(true)
             .renderMode(RenderMode.texture)
             .transparencyMode(TransparencyMode.opaque)
             .build();
@@ -49,6 +51,7 @@ public class FlutterFragmentTest {
     assertEquals("/custom/route", fragment.getInitialRoute());
     assertArrayEquals(new String[] {}, fragment.getFlutterShellArgs().toArray());
     assertFalse(fragment.shouldAttachEngineToActivity());
+    assertTrue(fragment.shouldAttachEngineToActivity());
     assertNull(fragment.getCachedEngineId());
     assertTrue(fragment.shouldDestroyEngineWithHost());
     assertEquals(RenderMode.texture, fragment.getRenderMode());

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -51,7 +51,7 @@ public class FlutterFragmentTest {
     assertEquals("/custom/route", fragment.getInitialRoute());
     assertArrayEquals(new String[] {}, fragment.getFlutterShellArgs().toArray());
     assertFalse(fragment.shouldAttachEngineToActivity());
-    assertTrue(fragment.shouldAttachEngineToActivity());
+    assertTrue(fragment.shouldHandleDeeplinking());
     assertNull(fragment.getCachedEngineId());
     assertTrue(fragment.shouldDestroyEngineWithHost());
     assertEquals(RenderMode.texture, fragment.getRenderMode());


### PR DESCRIPTION
## Description

The previous PR is reverted due to it being a breaking change. This PR add a flag to turn on and off the new behavior.
To enable deeplinking, just add the following to the android manifest
```xml
            <meta-data android:name="flutter_handle_deeplinking" android:value="true" />
            <intent-filter>
              <action android:name="android.intent.action.VIEW" />
              <category android:name="android.intent.category.DEFAULT" />
              <category android:name="android.intent.category.BROWSABLE" />
              <data android:scheme="http" android:host="flutterbooksample.com" android:pathPrefix="/" />
            </intent-filter>
```

## Related Issues

fixes https://github.com/flutter/flutter/issues/69786
fixes https://github.com/flutter/flutter/issues/21255

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
