### PR TITLE
[null-safety] fix return type of _loadFontFromList

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2298,5 +2298,4 @@ FutureOr<void> _sendFontChangeMessage() async {
 /// and [TextStyle.height] is applied as normal. When set to false, the font's
 /// default ascent will be used.
 /// {@endtemplate}
-
-String _loadFontFromList(Uint8List list, _Callback<void> callback, String? fontFamily) native 'loadFontFromList';
+String? _loadFontFromList(Uint8List list, _Callback<void> callback, String? fontFamily) native 'loadFontFromList';


### PR DESCRIPTION
## Description

Surfaced during the gallery migration to null safety: https://github.com/flutter/flutter/pull/69048/checks?check_run_id=1365975773
