### PR TITLE
[web] Restore the ability to set a custom url strategy

### DIFF
--- a/e2etests/web/regular_integration_tests/lib/url_strategy_main.dart
+++ b/e2etests/web/regular_integration_tests/lib/url_strategy_main.dart
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+final GlobalKey<NavigatorState> navKey = GlobalKey(debugLabel: 'mainNavigator');
+Map<String, WidgetBuilder> appRoutes;
+
+final Map<String, WidgetBuilder> _defaultAppRoutes = <String, WidgetBuilder>{
+  '/': (context) => Container(),
+};
+
+void main() {
+  runApp(MyApp(appRoutes ?? _defaultAppRoutes));
+}
+
+class MyApp extends StatelessWidget {
+  MyApp(this.routes);
+
+  final Map<String, WidgetBuilder> routes;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      key: const Key('mainapp'),
+      navigatorKey: navKey,
+      theme: ThemeData(fontFamily: 'RobotoMono'),
+      title: 'Integration Test App',
+      routes: routes,
+    );
+  }
+}

--- a/e2etests/web/regular_integration_tests/pubspec.yaml
+++ b/e2etests/web/regular_integration_tests/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
 
 dev_dependencies:
   flutter_driver:

--- a/e2etests/web/regular_integration_tests/test_driver/url_strategy_integration.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/url_strategy_integration.dart
@@ -1,0 +1,185 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:html' as html;
+import 'dart:ui' as ui;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:regular_integration_tests/url_strategy_main.dart' as app;
+import 'package:flutter/material.dart';
+
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  // final IntegrationTestWidgetsFlutterBinding binding =
+      IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
+
+  testWidgets('Can customize url strategy', (WidgetTester tester) async {
+    final TestUrlStrategy strategy = TestUrlStrategy.fromEntry(
+      const TestHistoryEntry('initial state', null, '/initial'),
+    );
+    setUrlStrategy(strategy);
+
+    app.appRoutes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => Container(),
+      '/foo': (BuildContext context) => Container(),
+    };
+    app.main();
+    await tester.pumpAndSettle();
+
+    expect(strategy.getPath(), '/');
+
+    final NavigatorState navigator = app.navKey.currentState;
+    navigator.pushNamed('/foo');
+    await tester.pump();
+    expect(strategy.getPath(), '/foo');
+  });
+}
+
+/// This URL strategy mimics the browser's history as closely as possible
+/// while doing it all in memory with no interaction with the browser.
+///
+/// It keeps a list of history entries and event listeners in memory and
+/// manipulates them in order to achieve the desired functionality.
+class TestUrlStrategy extends UrlStrategy {
+  /// Creates a instance of [TestUrlStrategy] with an empty string as the
+  /// path.
+  factory TestUrlStrategy() => TestUrlStrategy.fromEntry(TestHistoryEntry(null, null, ''));
+
+  /// Creates an instance of [TestUrlStrategy] and populates it with a list
+  /// that has [initialEntry] as the only item.
+  TestUrlStrategy.fromEntry(TestHistoryEntry initialEntry)
+      : _currentEntryIndex = 0,
+        history = <TestHistoryEntry>[initialEntry];
+
+  @override
+  String getPath() => currentEntry.url;
+
+  @override
+  dynamic getState() => currentEntry.state;
+
+  int _currentEntryIndex;
+  int get currentEntryIndex => _currentEntryIndex;
+
+  final List<TestHistoryEntry> history;
+
+  TestHistoryEntry get currentEntry {
+    assert(withinAppHistory);
+    return history[_currentEntryIndex];
+  }
+
+  set currentEntry(TestHistoryEntry entry) {
+    assert(withinAppHistory);
+    history[_currentEntryIndex] = entry;
+  }
+
+  /// Whether we are still within the history of the Flutter Web app. This
+  /// remains true until we go back in history beyond the entry where the app
+  /// started.
+  bool get withinAppHistory => _currentEntryIndex >= 0;
+
+  @override
+  void pushState(dynamic state, String title, String url) {
+    assert(withinAppHistory);
+    _currentEntryIndex++;
+    // When pushing a new state, we need to remove all entries that exist after
+    // the current entry.
+    //
+    // If the user goes A -> B -> C -> D, then goes back to B and pushes a new
+    // entry called E, we should end up with: A -> B -> E in the history list.
+    history.removeRange(_currentEntryIndex, history.length);
+    history.add(TestHistoryEntry(state, title, url));
+  }
+
+  @override
+  void replaceState(dynamic state, String title, String url) {
+    assert(withinAppHistory);
+    if (url == null || url == '') {
+      url = currentEntry.url;
+    }
+    currentEntry = TestHistoryEntry(state, title, url);
+  }
+
+  /// This simulates the case where a user types in a url manually. It causes
+  /// a new state to be pushed, and all event listeners will be invoked.
+  Future<void> simulateUserTypingUrl(String url) {
+    assert(withinAppHistory);
+    return _nextEventLoop(() {
+      pushState(null, '', url);
+      _firePopStateEvent();
+    });
+  }
+
+  @override
+  Future<void> go(int count) {
+    assert(withinAppHistory);
+    // Browsers don't move in history immediately. They do it at the next
+    // event loop. So let's simulate that.
+    return _nextEventLoop(() {
+      _currentEntryIndex = _currentEntryIndex + count;
+      if (withinAppHistory) {
+        _firePopStateEvent();
+      }
+    });
+  }
+
+  final List<html.EventListener> listeners = <html.EventListener>[];
+
+  @override
+  ui.VoidCallback addPopStateListener(html.EventListener fn) {
+    listeners.add(fn);
+    return () {
+      // Schedule a micro task here to avoid removing the listener during
+      // iteration in [_firePopStateEvent].
+      scheduleMicrotask(() => listeners.remove(fn));
+    };
+  }
+
+  /// Simulates the scheduling of a new event loop by creating a delayed future.
+  /// Details explained here: https://webdev.dartlang.org/articles/performance/event-loop
+  Future<void> _nextEventLoop(ui.VoidCallback callback) {
+    return Future<void>.delayed(Duration.zero).then((_) => callback());
+  }
+
+  /// Invokes all the attached event listeners in order of
+  /// attaching. This method should be called asynchronously to make it behave
+  /// like a real browser.
+  void _firePopStateEvent() {
+    assert(withinAppHistory);
+    final html.PopStateEvent event = html.PopStateEvent(
+      'popstate',
+      <String, dynamic>{'state': currentEntry.state},
+    );
+    for (int i = 0; i < listeners.length; i++) {
+      listeners[i](event);
+    }
+  }
+
+  @override
+  String prepareExternalUrl(String internalUrl) => internalUrl;
+
+  @override
+  String toString() {
+    final List<String> lines = <String>[];
+    for (int i = 0; i < history.length; i++) {
+      final TestHistoryEntry entry = history[i];
+      lines.add(_currentEntryIndex == i ? '* $entry' : '  $entry');
+    }
+    return '$runtimeType: [\n${lines.join('\n')}\n]';
+  }
+}
+
+class TestHistoryEntry {
+  final dynamic state;
+  final String title;
+  final String url;
+
+  const TestHistoryEntry(this.state, this.title, this.url);
+
+  @override
+  String toString() {
+    return '$runtimeType(state:$state, title:"$title", url:"$url")';
+  }
+}

--- a/e2etests/web/regular_integration_tests/test_driver/url_strategy_integration.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/url_strategy_integration.dart
@@ -13,8 +13,7 @@ import 'package:flutter/material.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
-  // final IntegrationTestWidgetsFlutterBinding binding =
-      IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized() as IntegrationTestWidgetsFlutterBinding;
 
   testWidgets('Can customize url strategy', (WidgetTester tester) async {
     final TestUrlStrategy strategy = TestUrlStrategy.fromEntry(

--- a/e2etests/web/regular_integration_tests/test_driver/url_strategy_integration_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/url_strategy_integration_test.dart
@@ -1,0 +1,9 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:regular_integration_tests/screenshot_support.dart' as test;
+
+Future<void> main() async {
+  await test.runTestWithScreenshots();
+}

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -174,6 +174,10 @@ void initializeEngine() {
     return;
   }
 
+  // Setup the hook that allows users to customize URL strategy before running
+  // the app.
+  _addUrlStrategyListener();
+
   // Called by the Web runtime just before hot restarting the app.
   //
   // This extension cleans up resources that are registered with browser's
@@ -245,6 +249,16 @@ void initializeEngine() {
 
   Keyboard.initialize();
   MouseCursor.initialize();
+}
+
+void _addUrlStrategyListener() {
+  _jsSetUrlStrategy = allowInterop((JsUrlStrategy? jsStrategy) {
+    customUrlStrategy =
+        jsStrategy == null ? null : CustomUrlStrategy.fromJs(jsStrategy);
+  });
+  registerHotRestartListener(() {
+    _jsSetUrlStrategy = null;
+  });
 }
 
 class _NullTreeSanitizer implements html.NodeTreeSanitizer {

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -9,7 +9,8 @@ import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
-import 'package:ui/src/engine.dart';
+import 'package:ui/src/engine.dart' hide window;
+import 'package:ui/ui.dart' as ui;
 
 import 'engine/history_test.dart';
 import 'matchers.dart';
@@ -23,8 +24,16 @@ void main() {
 }
 
 void testMain() {
+  EngineSingletonFlutterWindow window;
+
+  setUp(() {
+    ui.webOnlyInitializeEngine();
+    window = EngineSingletonFlutterWindow(0, EnginePlatformDispatcher.instance);
+  });
+
   tearDown(() async {
     await window.debugResetHistory();
+    window = null;
   });
 
   test('window.defaultRouteName should not change', () async {


### PR DESCRIPTION
## Description

Due to a recent change in the initialization logic, the `window` object is no longer instantiated during engine initialization. This was causing the JS custom URL strategy setter to be undefined before `runApp` and preventing users from providing a custom URL strategy.

In this PR:
1. Basic integration test for custom URL strategies.
2. Setup the custom URL strategy setter during the initialization sequence instead of in the `Window` constructor.
3. In the `Window` constructor, just check if there was a custom URL strategy set by the user.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/69254