### PR TITLE
loadFontFromList returns void instead of string

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2299,4 +2299,4 @@ FutureOr<void> _sendFontChangeMessage() async {
 /// default ascent will be used.
 /// {@endtemplate}
 
-String _loadFontFromList(Uint8List list, _Callback<void> callback, String? fontFamily) native 'loadFontFromList';
+void _loadFontFromList(Uint8List list, _Callback<void> callback, String? fontFamily) native 'loadFontFromList';

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2264,7 +2264,9 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
 ///  If this is not provided, then the family name will be extracted from the font file.
 Future<void> loadFontFromList(Uint8List list, {String? fontFamily}) {
   return _futurize(
-    (_Callback<void> callback) => _loadFontFromList(list, callback, fontFamily)
+    (_Callback<void> callback) {
+      _loadFontFromList(list, callback, fontFamily);
+    }
   ).then((_) => _sendFontChangeMessage());
 }
 


### PR DESCRIPTION
I was seeing this issue in the Gallery test.  `font_loading_test.dart` isn't capturing this issues because it opted out of null safety.