### PR TITLE
Simplify API for scheduling Skia object deletions

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -316,8 +316,7 @@ class SkiaObjectBox {
     assert(removed);
     _isDeleted = true;
     if (_refs.isEmpty) {
-      _skObjectDeleteQueue.add(skObject);
-      _skObjectCollector ??= _scheduleSkObjectCollection();
+      _scheduleSkObjectCollection(skObject);
     }
   }
 }


### PR DESCRIPTION
## Description

Remove the need for call sites to deal with the delete queue and the timer.

## Tests

Covered by existing tests. This is purely a clean-up.