### PR TITLE
Add D3D9 fallback path for ANGLE and ensure fallbacks are actually attempted

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/windows/angle_surface_manager.h"
 
 #include <iostream>
+#include <vector>
 
 namespace flutter {
 
@@ -19,6 +20,31 @@ AngleSurfaceManager::~AngleSurfaceManager() {
   CleanUp();
 }
 
+bool AngleSurfaceManager::InitializeEGL(const EGLint* attributes) {
+  PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
+      reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
+          eglGetProcAddress("eglGetPlatformDisplayEXT"));
+  if (!eglGetPlatformDisplayEXT) {
+    std::cerr << "EGL: eglGetPlatformDisplayEXT not available" << std::endl;
+    return false;
+  }
+
+  egl_display_ =
+      eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, attributes);
+
+  if (egl_display_ == EGL_NO_DISPLAY) {
+    std::cerr << "EGL: Failed to get a compatible EGLdisplay" << std::endl;
+    return false;
+  }
+
+  if (eglInitialize(egl_display_, nullptr, nullptr) == EGL_FALSE) {
+    std::cerr << "EGL: Failed to initialize";
+    return false;
+  }
+
+  return true;
+}
+
 bool AngleSurfaceManager::Initialize() {
   const EGLint configAttributes[] = {EGL_RED_SIZE,   8, EGL_GREEN_SIZE,   8,
                                      EGL_BLUE_SIZE,  8, EGL_ALPHA_SIZE,   8,
@@ -28,10 +54,11 @@ bool AngleSurfaceManager::Initialize() {
   const EGLint display_context_attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 2,
                                                EGL_NONE};
 
-  const EGLint default_display_attributes[] = {
-      // These are prefered display attributes and request ANGLE's D3D11
-      // renderer. eglInitialize will only succeed with these attributes if the
-      // hardware supports D3D11 Feature Level 10_0+.
+
+  // These are prefered display attributes and request ANGLE's D3D11
+  // renderer. eglInitialize will only succeed with these attributes if the
+  // hardware supports D3D11 Feature Level 10_0+.
+  const EGLint d3d11_display_attributes[] = {
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
 
@@ -43,9 +70,9 @@ bool AngleSurfaceManager::Initialize() {
       EGL_NONE,
   };
 
-  const EGLint fl9_3_display_attributes[] = {
-      // These are used to request ANGLE's D3D11 renderer, with D3D11 Feature
-      // Level 9_3.
+  // These are used to request ANGLE's D3D11 renderer, with D3D11 Feature
+  // Level 9_3.
+  const EGLint d3d11_fl_9_3_display_attributes[] = {
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
       EGL_PLATFORM_ANGLE_MAX_VERSION_MAJOR_ANGLE,
@@ -57,9 +84,9 @@ bool AngleSurfaceManager::Initialize() {
       EGL_NONE,
   };
 
-  const EGLint warp_display_attributes[] = {
-      // These attributes request D3D11 WARP (software rendering fallback) in case
-      // hardware-backed D3D11 is unavailable.
+  // These attributes request D3D11 WARP (software rendering fallback) in case
+  // hardware-backed D3D11 is unavailable.
+  const EGLint d3d11_warp_display_attributes[] = {
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D11_ANGLE,
       EGL_PLATFORM_ANGLE_ENABLE_AUTOMATIC_TRIM_ANGLE,
@@ -67,69 +94,27 @@ bool AngleSurfaceManager::Initialize() {
       EGL_NONE,
   };
 
+  // These are used to request ANGLE's D3D9 renderer as a fallback if D3D11
+  // is not available.
   const EGLint d3d9_display_attributes[] = {
-      // These are used to request ANGLE's D3D9 renderer as a fallback if D3D11
-      // is not available.
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D9_ANGLE,
       EGL_TRUE,
       EGL_NONE,
   };
 
-  PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
-      reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(
-          eglGetProcAddress("eglGetPlatformDisplayEXT"));
-  if (!eglGetPlatformDisplayEXT) {
-    std::cerr << "EGL: eglGetPlatformDisplayEXT not available" << std::endl;
-    return false;
-  }
+  std::vector<const EGLint*> display_attributes_configs = {
+      d3d11_display_attributes,
+      d3d11_fl_9_3_display_attributes,
+      d3d11_warp_display_attributes,
+      d3d9_display_attributes,
+  };
 
-  // Try to initialize EGL to D3D11 Feature Level 10_0+.
-  egl_display_ =
-      eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY,
-                               default_display_attributes);
-  if (egl_display_ == EGL_NO_DISPLAY) {
-    std::cerr << "EGL: Failed to get a compatible EGLdisplay" << std::endl;
-  }
-
-  if (eglInitialize(egl_display_, nullptr, nullptr) == EGL_FALSE) {
-    // If above failed, try to initialize EGL to D3D11 Feature Level 9_3, if
-    // 10_0+ is unavailable.
-    egl_display_ =
-        eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY,
-                                 fl9_3_display_attributes);
-    if (egl_display_ == EGL_NO_DISPLAY) {
-      std::cerr << "EGL: Failed to get a compatible 9.3 EGLdisplay"
-                << std::endl;
-    }
-
-    if (eglInitialize(egl_display_, nullptr, nullptr) == EGL_FALSE) {
-      // If hardware rendering fails, attempt D3D11 Feature Level 11_0 on WARP
-      egl_display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                              EGL_DEFAULT_DISPLAY,
-                                              warp_display_attributes);
-      if (egl_display_ == EGL_NO_DISPLAY) {
-        std::cerr << "EGL: Failed to get a compatible WARP EGLdisplay"
-                  << std::endl;
-      }
-
-      if (eglInitialize(egl_display_, nullptr, nullptr) == EGL_FALSE) {
-        // Finally, attempt D3D9 if all D3D11 paths have failed.
-        egl_display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
-                                                EGL_DEFAULT_DISPLAY,
-                                                d3d9_display_attributes);
-        
-        if (egl_display_ == EGL_NO_DISPLAY) {
-          std::cerr << "EGL: Failed to get a compatible D3D9 display"
-                    << std::endl;
-          return false;
-        }
-
-        if (eglInitialize(egl_display_, nullptr, nullptr) == EGL_FALSE) {
-          std::cerr << "EGL: Failed to initialize EGL" << std::endl;
-          return false;
-        }
-      }
+  // Attempt to initialize ANGLE's renderer in order of: D3D11, D3D11 Feature Level 9_3,
+  // D3D11 WARP and finally D3D9.
+  for (auto config : display_attributes_configs) {
+    if (InitializeEGL(config)) {
+      break;
     }
   }
 

--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -29,8 +29,8 @@ bool AngleSurfaceManager::InitializeEGL(const EGLint* attributes) {
     return false;
   }
 
-  egl_display_ =
-      eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE, EGL_DEFAULT_DISPLAY, attributes);
+  egl_display_ = eglGetPlatformDisplayEXT(EGL_PLATFORM_ANGLE_ANGLE,
+                                          EGL_DEFAULT_DISPLAY, attributes);
 
   if (egl_display_ == EGL_NO_DISPLAY) {
     std::cerr << "EGL: Failed to get a compatible EGLdisplay" << std::endl;
@@ -53,7 +53,6 @@ bool AngleSurfaceManager::Initialize() {
 
   const EGLint display_context_attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 2,
                                                EGL_NONE};
-
 
   // These are prefered display attributes and request ANGLE's D3D11
   // renderer. eglInitialize will only succeed with these attributes if the
@@ -110,8 +109,8 @@ bool AngleSurfaceManager::Initialize() {
       d3d9_display_attributes,
   };
 
-  // Attempt to initialize ANGLE's renderer in order of: D3D11, D3D11 Feature Level 9_3,
-  // D3D11 WARP and finally D3D9.
+  // Attempt to initialize ANGLE's renderer in order of: D3D11, D3D11 Feature
+  // Level 9_3, D3D11 WARP and finally D3D9.
   for (auto config : display_attributes_configs) {
     if (InitializeEGL(config)) {
       break;

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -75,6 +75,9 @@ class AngleSurfaceManager {
   void CleanUp();
 
  private:
+  // Attempts to initialize EGL with a particular ANGLE configuration.
+  bool InitializeEGL(const EGLint* attributes);
+
   // EGL representation of native display.
   EGLDisplay egl_display_;
 


### PR DESCRIPTION
## Description

The current code doesn't attempt the fallback paths (feature level 9.3 or WARP) as we early return when `eglGetPlatformDisplayEXT` fails. This removes those early returns and adds an extra fallback step after D3D11 WARP for D3D9.

## Related Issues

https://github.com/flutter/flutter/issues/51286
https://github.com/flutter/flutter/issues/66374

## Tests

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
