### PR TITLE
Fix talkback in hybrid composition while using FlutterFragmentActivity

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
@@ -16,6 +16,13 @@ public interface PlatformViewsAccessibilityDelegate {
   View getPlatformViewById(Integer id);
 
   /**
+   * Returns true if the platform view uses virtual displays.
+   *
+   * @hide
+   */
+  boolean usesVirtualDisplay(Integer id);
+
+  /**
    * Attaches an accessibility bridge for this platform views accessibility delegate.
    *
    * <p>Accessibility events originating in platform views belonging to this delegate will be

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -584,6 +584,11 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     return controller.getView();
   }
 
+  @Override
+  public boolean usesVirtualDisplay(Integer id) {
+    return vdControllers.containsKey(id);
+  }
+
   private void lockInputConnection(@NonNull VirtualDisplayController controller) {
     if (textInputPlugin == null) {
       return;

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -34,21 +34,18 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
-/*
+/**
  * A presentation used for hosting a single Android view in a virtual display.
  *
- * This presentation overrides the WindowManager's addView/removeView/updateViewLayout methods, such that views added
- * directly to the WindowManager are added as part of the presentation's view hierarchy (to fakeWindowViewGroup).
+ * <p>This presentation overrides the WindowManager's addView/removeView/updateViewLayout methods,
+ * such that views added directly to the WindowManager are added as part of the presentation's view
+ * hierarchy (to fakeWindowViewGroup).
  *
- * The view hierarchy for the presentation is as following:
+ * <p>The view hierarchy for the presentation is as following:
  *
- *          rootView
- *         /         \
- *        /           \
- *       /             \
- *   container       state.fakeWindowViewGroup
- *      |
- *   EmbeddedView
+ * <p>rootView / \ / \ / \ container state.fakeWindowViewGroup | EmbeddedView
+ *
+ * @hide
  */
 @Keep
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
@@ -303,11 +300,15 @@ public class SingleViewPresentation extends Presentation {
     }
   }
 
-  /** Proxies a Context replacing the WindowManager with our custom instance. */
   // TODO(mklim): This caches the IMM at construction time and won't pick up any changes. In rare
   // cases where the FlutterView changes windows this will return an outdated instance. This
   // should be fixed to instead defer returning the IMM to something that know's FlutterView's
   // true Context.
+  /**
+   * Proxies a Context replacing the WindowManager with our custom instance.
+   *
+   * @hide
+   */
   public static class PresentationContext extends ContextWrapper {
     private @NonNull final WindowManagerHandler windowManagerHandler;
     private @Nullable WindowManager windowManager;

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -52,7 +52,7 @@ import java.lang.reflect.Proxy;
  */
 @Keep
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
-class SingleViewPresentation extends Presentation {
+public class SingleViewPresentation extends Presentation {
 
   /*
    * When an embedded view is resized in Flutterverse we move the Android view to a new virtual display
@@ -308,7 +308,7 @@ class SingleViewPresentation extends Presentation {
   // cases where the FlutterView changes windows this will return an outdated instance. This
   // should be fixed to instead defer returning the IMM to something that know's FlutterView's
   // true Context.
-  private static class PresentationContext extends ContextWrapper {
+  public static class PresentationContext extends ContextWrapper {
     private @NonNull final WindowManagerHandler windowManagerHandler;
     private @Nullable WindowManager windowManager;
     private final Context flutterAppWindowContext;

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -34,16 +34,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
-/**
+/*
  * A presentation used for hosting a single Android view in a virtual display.
  *
- * <p>This presentation overrides the WindowManager's addView/removeView/updateViewLayout methods,
- * such that views added directly to the WindowManager are added as part of the presentation's view
- * hierarchy (to fakeWindowViewGroup).
+ * This presentation overrides the WindowManager's addView/removeView/updateViewLayout methods, such that views added
+ * directly to the WindowManager are added as part of the presentation's view hierarchy (to fakeWindowViewGroup).
  *
- * <p>The view hierarchy for the presentation is as following:
+ * The view hierarchy for the presentation is as following:
  *
- * <pre>
  *          rootView
  *         /         \
  *        /           \
@@ -51,13 +49,10 @@ import java.lang.reflect.Proxy;
  *   container       state.fakeWindowViewGroup
  *      |
  *   EmbeddedView
- * </pre>
- *
- * @hide
  */
 @Keep
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
-public class SingleViewPresentation extends Presentation {
+class SingleViewPresentation extends Presentation {
 
   /*
    * When an embedded view is resized in Flutterverse we move the Android view to a new virtual display
@@ -308,16 +303,12 @@ public class SingleViewPresentation extends Presentation {
     }
   }
 
+  /** Proxies a Context replacing the WindowManager with our custom instance. */
   // TODO(mklim): This caches the IMM at construction time and won't pick up any changes. In rare
   // cases where the FlutterView changes windows this will return an outdated instance. This
   // should be fixed to instead defer returning the IMM to something that know's FlutterView's
   // true Context.
-  /**
-   * Proxies a Context replacing the WindowManager with our custom instance.
-   *
-   * @hide
-   */
-  public static class PresentationContext extends ContextWrapper {
+  private static class PresentationContext extends ContextWrapper {
     private @NonNull final WindowManagerHandler windowManagerHandler;
     private @Nullable WindowManager windowManager;
     private final Context flutterAppWindowContext;

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -43,7 +43,15 @@ import java.lang.reflect.Proxy;
  *
  * <p>The view hierarchy for the presentation is as following:
  *
- * <p>rootView / \ / \ / \ container state.fakeWindowViewGroup | EmbeddedView
+ * <pre>
+ *          rootView
+ *         /         \
+ *        /           \
+ *       /             \
+ *   container       state.fakeWindowViewGroup
+ *      |
+ *   EmbeddedView
+ * </pre>
  *
  * @hide
  */

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -30,7 +30,6 @@ import io.flutter.BuildConfig;
 import io.flutter.Log;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.platform.PlatformViewsAccessibilityDelegate;
-import io.flutter.plugin.platform.SingleViewPresentation.PresentationContext;
 import io.flutter.util.Predicate;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -558,8 +557,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     if (semanticsNode.platformViewId != -1) {
       View embeddedView =
           platformViewsAccessibilityDelegate.getPlatformViewById(semanticsNode.platformViewId);
-      boolean childUsesVirtualDisplay = embeddedView.getContext() instanceof PresentationContext;
-      if (childUsesVirtualDisplay) {
+      if (platformViewsAccessibilityDelegate.usesVirtualDisplay(semanticsNode.platformViewId)) {
         Rect bounds = semanticsNode.getGlobalRect();
         return accessibilityViewEmbedder.getRootNode(embeddedView, semanticsNode.id, bounds);
       }
@@ -853,8 +851,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         // mirrored.
         //
         // See the case above for how virtual displays are handled.
-        boolean childUsesVirtualDisplay = embeddedView.getContext() instanceof PresentationContext;
-        if (!childUsesVirtualDisplay) {
+        if (!platformViewsAccessibilityDelegate.usesVirtualDisplay(child.platformViewId)) {
           result.addChild(embeddedView);
           continue;
         }

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -4,8 +4,6 @@
 
 package io.flutter.view;
 
-import static io.flutter.plugin.platform.SingleViewPresentation.PresentationContext;
-
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.ContentResolver;
@@ -32,6 +30,7 @@ import io.flutter.BuildConfig;
 import io.flutter.Log;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.platform.PlatformViewsAccessibilityDelegate;
+import io.flutter.plugin.platform.SingleViewPresentation.PresentationContext;
 import io.flutter.util.Predicate;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -856,7 +856,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         // See the case above for how virtual displays are handled.
         boolean childUsesVirtualDisplay = embeddedView.getContext() instanceof PresentationContext;
         if (!childUsesVirtualDisplay) {
-          io.flutter.Log.d("flutter", "!childUsesVirtualDisplay");
           result.addChild(embeddedView);
           continue;
         }

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -4,6 +4,8 @@
 
 package io.flutter.view;
 
+import static io.flutter.plugin.platform.SingleViewPresentation.PresentationContext;
+
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.ContentResolver;
@@ -28,7 +30,6 @@ import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.BuildConfig;
 import io.flutter.Log;
-import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.platform.PlatformViewsAccessibilityDelegate;
 import io.flutter.util.Predicate;
@@ -558,7 +559,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     if (semanticsNode.platformViewId != -1) {
       View embeddedView =
           platformViewsAccessibilityDelegate.getPlatformViewById(semanticsNode.platformViewId);
-      boolean childUsesVirtualDisplay = !(embeddedView.getContext() instanceof FlutterActivity);
+      boolean childUsesVirtualDisplay = embeddedView.getContext() instanceof PresentationContext;
       if (childUsesVirtualDisplay) {
         Rect bounds = semanticsNode.getGlobalRect();
         return accessibilityViewEmbedder.getRootNode(embeddedView, semanticsNode.id, bounds);
@@ -853,8 +854,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         // mirrored.
         //
         // See the case above for how virtual displays are handled.
-        boolean childUsesHybridComposition = embeddedView.getContext() instanceof FlutterActivity;
-        if (childUsesHybridComposition) {
+        boolean childUsesVirtualDisplay = embeddedView.getContext() instanceof PresentationContext;
+        if (!childUsesVirtualDisplay) {
+          io.flutter.Log.d("flutter", "!childUsesVirtualDisplay");
           result.addChild(embeddedView);
           continue;
         }

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.graphics.Rect;
@@ -27,11 +26,8 @@ import android.view.ViewParent;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
-import io.flutter.embedding.android.FlutterActivity;
-import io.flutter.embedding.android.FlutterFragmentActivity;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.platform.PlatformViewsAccessibilityDelegate;
-import io.flutter.plugin.platform.SingleViewPresentation.PresentationContext;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -398,7 +394,7 @@ public class AccessibilityBridgeTest {
   }
 
   @Test
-  public void itProducesPlatformViewNodeForHybridComposition__usingFlutterActivity() {
+  public void itProducesPlatformViewNodeForHybridComposition() {
     PlatformViewsAccessibilityDelegate accessibilityDelegate =
         mock(PlatformViewsAccessibilityDelegate.class);
 
@@ -432,102 +428,7 @@ public class AccessibilityBridgeTest {
 
     View embeddedView = mock(View.class);
     when(accessibilityDelegate.getPlatformViewById(1)).thenReturn(embeddedView);
-
-    when(embeddedView.getContext()).thenReturn(mock(FlutterActivity.class));
-
-    AccessibilityNodeInfo nodeInfo = mock(AccessibilityNodeInfo.class);
-    when(embeddedView.createAccessibilityNodeInfo()).thenReturn(nodeInfo);
-
-    AccessibilityNodeInfo result = accessibilityBridge.createAccessibilityNodeInfo(0);
-    assertNotNull(result);
-    assertEquals(result.getChildCount(), 1);
-    assertEquals(result.getClassName(), "android.view.View");
-  }
-
-  @Test
-  public void itProducesPlatformViewNodeForHybridComposition__usingFlutterFragmentActivity() {
-    PlatformViewsAccessibilityDelegate accessibilityDelegate =
-        mock(PlatformViewsAccessibilityDelegate.class);
-
-    Context context = RuntimeEnvironment.application.getApplicationContext();
-    View rootAccessibilityView = new View(context);
-    AccessibilityViewEmbedder accessibilityViewEmbedder = mock(AccessibilityViewEmbedder.class);
-    AccessibilityBridge accessibilityBridge =
-        setUpBridge(
-            rootAccessibilityView,
-            /*accessibilityChannel=*/ null,
-            /*accessibilityManager=*/ null,
-            /*contentResolver=*/ null,
-            accessibilityViewEmbedder,
-            accessibilityDelegate);
-
-    TestSemanticsNode root = new TestSemanticsNode();
-    root.id = 0;
-
-    TestSemanticsNode platformView = new TestSemanticsNode();
-    platformView.id = 1;
-    platformView.platformViewId = 1;
-    root.addChild(platformView);
-
-    TestSemanticsUpdate testSemanticsRootUpdate = root.toUpdate();
-    accessibilityBridge.updateSemantics(
-        testSemanticsRootUpdate.buffer, testSemanticsRootUpdate.strings);
-
-    TestSemanticsUpdate testSemanticsPlatformViewUpdate = platformView.toUpdate();
-    accessibilityBridge.updateSemantics(
-        testSemanticsPlatformViewUpdate.buffer, testSemanticsPlatformViewUpdate.strings);
-
-    View embeddedView = mock(View.class);
-    when(accessibilityDelegate.getPlatformViewById(1)).thenReturn(embeddedView);
-
-    when(embeddedView.getContext()).thenReturn(mock(FlutterFragmentActivity.class));
-
-    AccessibilityNodeInfo nodeInfo = mock(AccessibilityNodeInfo.class);
-    when(embeddedView.createAccessibilityNodeInfo()).thenReturn(nodeInfo);
-
-    AccessibilityNodeInfo result = accessibilityBridge.createAccessibilityNodeInfo(0);
-    assertNotNull(result);
-    assertEquals(result.getChildCount(), 1);
-    assertEquals(result.getClassName(), "android.view.View");
-  }
-
-  @Test
-  public void itProducesPlatformViewNodeForHybridComposition__usingAnyActivity() {
-    PlatformViewsAccessibilityDelegate accessibilityDelegate =
-        mock(PlatformViewsAccessibilityDelegate.class);
-
-    Context context = RuntimeEnvironment.application.getApplicationContext();
-    View rootAccessibilityView = new View(context);
-    AccessibilityViewEmbedder accessibilityViewEmbedder = mock(AccessibilityViewEmbedder.class);
-    AccessibilityBridge accessibilityBridge =
-        setUpBridge(
-            rootAccessibilityView,
-            /*accessibilityChannel=*/ null,
-            /*accessibilityManager=*/ null,
-            /*contentResolver=*/ null,
-            accessibilityViewEmbedder,
-            accessibilityDelegate);
-
-    TestSemanticsNode root = new TestSemanticsNode();
-    root.id = 0;
-
-    TestSemanticsNode platformView = new TestSemanticsNode();
-    platformView.id = 1;
-    platformView.platformViewId = 1;
-    root.addChild(platformView);
-
-    TestSemanticsUpdate testSemanticsRootUpdate = root.toUpdate();
-    accessibilityBridge.updateSemantics(
-        testSemanticsRootUpdate.buffer, testSemanticsRootUpdate.strings);
-
-    TestSemanticsUpdate testSemanticsPlatformViewUpdate = platformView.toUpdate();
-    accessibilityBridge.updateSemantics(
-        testSemanticsPlatformViewUpdate.buffer, testSemanticsPlatformViewUpdate.strings);
-
-    View embeddedView = mock(View.class);
-    when(accessibilityDelegate.getPlatformViewById(1)).thenReturn(embeddedView);
-
-    when(embeddedView.getContext()).thenReturn(mock(Activity.class));
+    when(accessibilityDelegate.usesVirtualDisplay(1)).thenReturn(false);
 
     AccessibilityNodeInfo nodeInfo = mock(AccessibilityNodeInfo.class);
     when(embeddedView.createAccessibilityNodeInfo()).thenReturn(nodeInfo);
@@ -560,7 +461,7 @@ public class AccessibilityBridgeTest {
 
     View embeddedView = mock(View.class);
     when(accessibilityDelegate.getPlatformViewById(1)).thenReturn(embeddedView);
-    when(embeddedView.getContext()).thenReturn(mock(PresentationContext.class));
+    when(accessibilityDelegate.usesVirtualDisplay(1)).thenReturn(true);
 
     accessibilityBridge.createAccessibilityNodeInfo(0);
     verify(accessibilityViewEmbedder).getRootNode(eq(embeddedView), eq(0), any(Rect.class));

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -4,7 +4,6 @@
 
 package io.flutter.view;
 
-import static io.flutter.plugin.platform.SingleViewPresentation.PresentationContext;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.eq;
@@ -32,6 +31,7 @@ import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.android.FlutterFragmentActivity;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.platform.PlatformViewsAccessibilityDelegate;
+import io.flutter.plugin.platform.SingleViewPresentation.PresentationContext;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
To support TalkBack while using platform views, we detect whether the view is in a virtual display or in the view hierarchy. Currently, we assume that if the view is in a `FlutterActivity` context, then it's in a view hierarchy.

This breaks cases like `FlutterFragmentActivity` or hosting a `FlutterView` in a custom `Activity` (add-to-app).

Fixes https://github.com/flutter/flutter/issues/68970