### PR TITLE
[fuchsia] shader warmup fixes

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -201,6 +201,12 @@ Engine::Engine(Delegate& delegate,
         });
       };
 
+  // Launch the engine in the appropriate configuration.
+  // Note: this initializes the Asset Manager on the global PersistantCache
+  // so it must be called before WarmupSkps() is called below.
+  auto run_configuration = flutter::RunConfiguration::InferFromSettings(
+      settings, task_runners.GetIOTaskRunner());
+
   // Setup the callback that will instantiate the platform view.
   flutter::Shell::CreateCallback<flutter::PlatformView>
       on_create_platform_view = fml::MakeCopyable(
@@ -374,10 +380,6 @@ Engine::Engine(Delegate& delegate,
       intl_property_provider_->GetProfile(get_profile_callback);
     };
   }
-
-  // Launch the engine in the appropriate configuration.
-  auto run_configuration = flutter::RunConfiguration::InferFromSettings(
-      shell_->GetSettings(), shell_->GetTaskRunners().GetIOTaskRunner());
 
   auto on_run_failure = [weak = weak_factory_.GetWeakPtr()]() {
     // The engine could have been killed by the caller right after the
@@ -647,7 +649,7 @@ void Engine::WarmupSkps(fml::BasicTaskRunner* concurrent_task_runner,
 
   // tell concurrent task runner to deserialize all skps available from
   // the asset manager
-  concurrent_task_runner->PostTask([&raster_task_runner, skp_warmup_surface,
+  concurrent_task_runner->PostTask([raster_task_runner, skp_warmup_surface,
                                     &surface_producer]() {
     TRACE_DURATION("flutter", "DeserializeSkps");
     std::vector<std::unique_ptr<fml::Mapping>> skp_mappings =


### PR DESCRIPTION
This change contains a couple of changes that should have been in
github.com/flutter/engine/commit/3105db8ee856ffef281d018774d21a6164c81236
but fell through the cracks

First one lifts the initialization of the flutter::RunConfiguration so that
the asset manager gets set on the persistant cache before the shader
warmup happens. I'm not sure how this didnt end up in the first PR I
think it got mangled during merge conflict resolution. no test coverage
for that code because its in the middle of a 400 line constructor

Second one fixes a race condition that the tests dont catch because the
tests are single threaded.