### PR TITLE
Fix the event size parameters in the Embedder ComplexClip test

### DIFF
--- a/shell/platform/embedder/tests/embedder_unittests_gl.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_gl.cc
@@ -2601,8 +2601,8 @@ TEST_F(EmbedderTest, ComplexClipsAreCorrectlyCalculated) {
 
   FlutterWindowMetricsEvent event = {};
   event.struct_size = sizeof(event);
-  event.width = 400;
-  event.height = 300;
+  event.width = 1024;
+  event.height = 600;
   event.pixel_ratio = 1.0;
   ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
             kSuccess);


### PR DESCRIPTION
The event size did not match the setup. Currently this should not cause any issues because we do the paint culling based on values in Preroll, but soon we will switch to culling during Paint() and these mismatched values will cause the test to fail.

See https://github.com/flutter/engine/pull/22336