### PR TITLE
[macOS] Disable synchronous resizing until a frame is produced

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -322,7 +322,6 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   [self sendUserLocales];
   [self updateWindowMetrics];
   [self updateDisplayConfig];
-  self.viewController.flutterView.synchronousResizing = YES;
   return YES;
 }
 
@@ -358,9 +357,6 @@ static bool OnAcquireExternalTexture(FlutterEngine* engine,
   if (!controller && !_allowHeadlessExecution) {
     [self shutDownEngine];
     _resourceContext = nil;
-  }
-  if (_engine) {
-    self.viewController.flutterView.synchronousResizing = YES;
   }
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -25,13 +25,6 @@
  */
 @property(readwrite, nonatomic, nonnull) NSOpenGLContext* openGLContext;
 
-/**
- * Controls whether view resizing synchronously updates contents. This can only be enabled
- * after the engine is running and producing frames, because during synchronous view resizing the
- * platform thread is blocked until engine produces frame with requested size.
- */
-@property(readwrite, nonatomic) BOOL synchronousResizing;
-
 - (nullable instancetype)initWithFrame:(NSRect)frame
                           shareContext:(nonnull NSOpenGLContext*)shareContext
                        reshapeListener:(nonnull id<FlutterViewReshapeListener>)reshapeListener

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -71,15 +71,11 @@
 }
 
 - (void)reshaped {
-  if (self.synchronousResizing) {
-    CGSize scaledSize = [self convertSizeToBacking:self.bounds.size];
-    [_resizeSynchronizer beginResize:scaledSize
-                              notify:^{
-                                [_reshapeListener viewDidReshape:self];
-                              }];
-  } else {
-    [_reshapeListener viewDidReshape:self];
-  }
+  CGSize scaledSize = [self convertSizeToBacking:self.bounds.size];
+  [_resizeSynchronizer beginResize:scaledSize
+                            notify:^{
+                              [_reshapeListener viewDidReshape:self];
+                            }];
 }
 
 #pragma mark - NSView overrides


### PR DESCRIPTION
Instead of the synchronousResizing flag which in some cases seems to be set too early, synchronous resizing is postponed until framework produces a frame so ResizeSynchronizer knows for sure that the engine is up and running.

## Related Issues

Fixes: flutter/flutter#70318

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
