### PR TITLE
make CkContourMeasureIter and CkContourMeasure resurrectable

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1158,8 +1158,9 @@ class SkPath {
 
 @JS('window.flutterCanvasKit.SkContourMeasureIter')
 class SkContourMeasureIter {
-  external SkContourMeasureIter(SkPath path, bool forceClosed, int startIndex);
+  external SkContourMeasureIter(SkPath path, bool forceClosed, double resScale);
   external SkContourMeasure? next();
+  external void delete();
 }
 
 @JS()
@@ -1168,6 +1169,7 @@ class SkContourMeasure {
   external Float32List getPosTan(double distance);
   external bool isClosed();
   external double length();
+  external void delete();
 }
 
 // TODO(hterkelsen): Use a shared malloc'ed array for performance.
@@ -1778,6 +1780,11 @@ external Object? get _finalizationRegistryConstructor;
 /// Whether the current browser supports `FinalizationRegistry`.
 bool browserSupportsFinalizationRegistry =
     _finalizationRegistryConstructor != null;
+
+/// Sets the value of [browserSupportsFinalizationRegistry] to its true value.
+void debugResetBrowserSupportsFinalizationRegistry() {
+  browserSupportsFinalizationRegistry = _finalizationRegistryConstructor != null;
+}
 
 @JS()
 class SkData {

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -786,7 +786,7 @@ void _pathTests() {
 
   test('SkContourMeasureIter/SkContourMeasure', () {
     final SkContourMeasureIter iter =
-        SkContourMeasureIter(_testClosedSkPath(), false, 0);
+        SkContourMeasureIter(_testClosedSkPath(), false, 1.0);
     final SkContourMeasure measure1 = iter.next();
     expect(measure1.length(), 40);
     expect(measure1.getPosTan(5), Float32List.fromList(<double>[15, 10, 1, 0]));


### PR DESCRIPTION
## Description

Make `CkContourMeasureIter` and `CkContourMeasure` resurrectable.

## Related Issues

Progress towards https://github.com/flutter/flutter/issues/66614

## Tests

Added new tests in `path_test.dart`.