### PR TITLE
Revert "Make `PlatformDispatcher.locale` and `locales` return consistent values"

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -551,7 +551,12 @@ class PlatformDispatcher {
   ///
   /// This is equivalent to `locales.first` and will provide an empty non-null
   /// locale if the [locales] list has not been set or is empty.
-  Locale get locale => locales.first;
+  Locale? get locale {
+    if (locales != null && locales!.isNotEmpty) {
+      return locales!.first;
+    }
+    return null;
+  }
 
   /// The full system-reported supported locales of the device.
   ///
@@ -568,7 +573,7 @@ class PlatformDispatcher {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
-  List<Locale> get locales => configuration.locales;
+  List<Locale>? get locales => configuration.locales;
 
   /// Performs the platform-native locale resolution.
   ///
@@ -644,7 +649,12 @@ class PlatformDispatcher {
   }
 
   // Called from the engine, via hooks.dart
-  String _localeClosure() => locale.toString();
+  String _localeClosure() {
+    if (locale == null) {
+      return '';
+    }
+    return locale.toString();
+  }
 
   /// The lifecycle state immediately after dart isolate initialization.
   ///

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -340,7 +340,7 @@ class SingletonFlutterWindow extends FlutterWindow {
   ///
   /// This is equivalent to `locales.first` and will provide an empty non-null
   /// locale if the [locales] list has not been set or is empty.
-  Locale get locale => platformDispatcher.locale;
+  Locale? get locale => platformDispatcher.locale;
 
   /// The full system-reported supported locales of the device.
   ///
@@ -358,7 +358,7 @@ class SingletonFlutterWindow extends FlutterWindow {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
-  List<Locale> get locales => platformDispatcher.locales;
+  List<Locale>? get locales => platformDispatcher.locales;
 
   /// Performs the platform-native locale resolution.
   ///
@@ -850,11 +850,11 @@ class Window extends SingletonFlutterWindow {
 
   @override
   // ignore: unnecessary_overrides
-  Locale get locale => super.locale;
+  Locale? get locale => super.locale;
 
   @override
   // ignore: unnecessary_overrides
-  List<Locale> get locales => super.locales;
+  List<Locale>? get locales => super.locales;
 
   @override
   // ignore: unnecessary_overrides


### PR DESCRIPTION
Reverts flutter/engine#22267

This is causing errors in the test/integration.shard/test_test.dart tests. See https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8863863902747895072/+/steps/run_test.dart_for_tool_tests_shard_and_subshard_integration/0/stdout