### PR TITLE
Reverts 2 commits that remove surface dependance on external view embedder

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -667,6 +667,7 @@ FILE: ../../../flutter/shell/common/vsync_waiter_fallback.cc
 FILE: ../../../flutter/shell/common/vsync_waiter_fallback.h
 FILE: ../../../flutter/shell/common/vsync_waiters_test.cc
 FILE: ../../../flutter/shell/common/vsync_waiters_test.h
+FILE: ../../../flutter/shell/gpu/gpu_surface_delegate.h
 FILE: ../../../flutter/shell/gpu/gpu_surface_gl.cc
 FILE: ../../../flutter/shell/gpu/gpu_surface_gl.h
 FILE: ../../../flutter/shell/gpu/gpu_surface_gl_delegate.cc

--- a/flow/surface.cc
+++ b/flow/surface.cc
@@ -10,6 +10,10 @@ Surface::Surface() = default;
 
 Surface::~Surface() = default;
 
+flutter::ExternalViewEmbedder* Surface::GetExternalViewEmbedder() {
+  return nullptr;
+}
+
 std::unique_ptr<GLContextResult> Surface::MakeRenderContextCurrent() {
   return std::make_unique<GLContextDefaultResult>(true);
 }

--- a/flow/surface.h
+++ b/flow/surface.h
@@ -29,6 +29,8 @@ class Surface {
 
   virtual GrDirectContext* GetContext() = 0;
 
+  virtual flutter::ExternalViewEmbedder* GetExternalViewEmbedder();
+
   virtual std::unique_ptr<GLContextResult> MakeRenderContextCurrent();
 
   virtual bool ClearRenderContext();

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -563,8 +563,6 @@ class PlatformView {
   ComputePlatformResolvedLocales(
       const std::vector<std::string>& supported_locale_data);
 
-  virtual std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder();
-
  protected:
   PlatformView::Delegate& delegate_;
   const TaskRunners task_runners_;
@@ -576,6 +574,8 @@ class PlatformView {
   // Unlike all other methods on the platform view, this is called on the
   // GPU task runner.
   virtual std::unique_ptr<Surface> CreateRenderingSurface();
+
+  virtual std::shared_ptr<ExternalViewEmbedder> CreateExternalViewEmbedder();
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformView);

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -76,8 +76,8 @@ void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
                              user_override_resource_cache_bytes_);
   }
   compositor_context_->OnGrContextCreated();
-  if (external_view_embedder_ &&
-      external_view_embedder_->SupportsDynamicThreadMerging() &&
+  if (surface_->GetExternalViewEmbedder() &&
+      surface_->GetExternalViewEmbedder()->SupportsDynamicThreadMerging() &&
       !raster_thread_merger_) {
     const auto platform_id =
         delegate_.GetTaskRunners().GetPlatformTaskRunner()->GetTaskQueueId();
@@ -191,9 +191,9 @@ void Rasterizer::Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline,
   }
 
   // EndFrame should perform cleanups for the external_view_embedder.
-  if (external_view_embedder_) {
-    external_view_embedder_->EndFrame(should_resubmit_frame,
-                                      raster_thread_merger_);
+  if (surface_ != nullptr && surface_->GetExternalViewEmbedder() != nullptr) {
+    surface_->GetExternalViewEmbedder()->EndFrame(should_resubmit_frame,
+                                                  raster_thread_merger_);
   }
 
   // Consume as many pipeline items as possible. But yield the event loop
@@ -423,12 +423,14 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
   // for instrumentation.
   compositor_context_->ui_time().SetLapTime(layer_tree.build_time());
 
+  auto* external_view_embedder = surface_->GetExternalViewEmbedder();
+
   SkCanvas* embedder_root_canvas = nullptr;
-  if (external_view_embedder_) {
-    external_view_embedder_->BeginFrame(
+  if (external_view_embedder != nullptr) {
+    external_view_embedder->BeginFrame(
         layer_tree.frame_size(), surface_->GetContext(),
         layer_tree.device_pixel_ratio(), raster_thread_merger_);
-    embedder_root_canvas = external_view_embedder_->GetRootCanvas();
+    embedder_root_canvas = external_view_embedder->GetRootCanvas();
   }
 
   // On Android, the external view embedder deletes surfaces in `BeginFrame`.
@@ -451,13 +453,13 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
       embedder_root_canvas ? embedder_root_canvas : frame->SkiaCanvas();
 
   auto compositor_frame = compositor_context_->AcquireFrame(
-      surface_->GetContext(),         // skia GrContext
-      root_surface_canvas,            // root surface canvas
-      external_view_embedder_.get(),  // external view embedder
-      root_surface_transformation,    // root surface transformation
-      true,                           // instrumentation enabled
-      frame->supports_readback(),     // surface supports pixel reads
-      raster_thread_merger_           // thread merger
+      surface_->GetContext(),       // skia GrContext
+      root_surface_canvas,          // root surface canvas
+      external_view_embedder,       // external view embedder
+      root_surface_transformation,  // root surface transformation
+      true,                         // instrumentation enabled
+      frame->supports_readback(),   // surface supports pixel reads
+      raster_thread_merger_         // thread merger
   );
 
   if (compositor_frame) {
@@ -466,11 +468,11 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
         raster_status == RasterStatus::kSkipAndRetry) {
       return raster_status;
     }
-    if (external_view_embedder_ &&
+    if (external_view_embedder != nullptr &&
         (!raster_thread_merger_ || raster_thread_merger_->IsMerged())) {
       FML_DCHECK(!frame->IsSubmitted());
-      external_view_embedder_->SubmitFrame(surface_->GetContext(),
-                                           std::move(frame));
+      external_view_embedder->SubmitFrame(surface_->GetContext(),
+                                          std::move(frame));
     } else {
       frame->Submit();
     }
@@ -649,11 +651,6 @@ Rasterizer::Screenshot Rasterizer::ScreenshotLastLayerTree(
 
 void Rasterizer::SetNextFrameCallback(const fml::closure& callback) {
   next_frame_callback_ = callback;
-}
-
-void Rasterizer::SetExternalViewEmbedder(
-    const std::shared_ptr<ExternalViewEmbedder>& view_embedder) {
-  external_view_embedder_ = view_embedder;
 }
 
 void Rasterizer::FireNextFrameCallbackIfPresent() {

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <optional>
 
-#include "flow/embedded_views.h"
 #include "flutter/common/settings.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/flow/compositor_context.h"
@@ -351,16 +350,6 @@ class Rasterizer final : public SnapshotDelegate {
   void SetNextFrameCallback(const fml::closure& callback);
 
   //----------------------------------------------------------------------------
-  /// @brief Set the External View Embedder. This is done on shell
-  ///        initialization. This is non-null on platforms that support
-  ///        embedding externally composited views.
-  ///
-  /// @param[in] view_embedder The external view embedder object.
-  ///
-  void SetExternalViewEmbedder(
-      const std::shared_ptr<ExternalViewEmbedder>& view_embedder);
-
-  //----------------------------------------------------------------------------
   /// @brief      Returns a pointer to the compositor context used by this
   ///             rasterizer. This pointer will never be `nullptr`.
   ///
@@ -448,7 +437,6 @@ class Rasterizer final : public SnapshotDelegate {
   std::optional<size_t> max_cache_bytes_;
   fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger_;
   fml::TaskRunnerAffineWeakPtrFactory<Rasterizer> weak_factory_;
-  std::shared_ptr<ExternalViewEmbedder> external_view_embedder_;
 
   // |SnapshotDelegate|
   sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,

--- a/shell/common/rasterizer_unittests.cc
+++ b/shell/common/rasterizer_unittests.cc
@@ -113,9 +113,9 @@ TEST(RasterizerTest,
   auto rasterizer = std::make_unique<Rasterizer>(delegate);
   auto surface = std::make_unique<MockSurface>();
 
-  std::shared_ptr<MockExternalViewEmbedder> external_view_embedder =
-      std::make_shared<MockExternalViewEmbedder>();
-  rasterizer->SetExternalViewEmbedder(external_view_embedder);
+  MockExternalViewEmbedder external_view_embedder;
+  EXPECT_CALL(*surface, GetExternalViewEmbedder())
+      .WillRepeatedly(Return(&external_view_embedder));
 
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, /*supports_readback=*/true,
@@ -123,15 +123,15 @@ TEST(RasterizerTest,
   EXPECT_CALL(*surface, AcquireFrame(SkISize()))
       .WillOnce(Return(ByMove(std::move(surface_frame))));
 
-  EXPECT_CALL(*external_view_embedder,
+  EXPECT_CALL(external_view_embedder,
               BeginFrame(/*frame_size=*/SkISize(), /*context=*/nullptr,
                          /*device_pixel_ratio=*/2.0,
                          /*raster_thread_merger=*/
                          fml::RefPtr<fml::RasterThreadMerger>(nullptr)))
       .Times(1);
-  EXPECT_CALL(*external_view_embedder, SubmitFrame).Times(1);
+  EXPECT_CALL(external_view_embedder, SubmitFrame).Times(1);
   EXPECT_CALL(
-      *external_view_embedder,
+      external_view_embedder,
       EndFrame(/*should_resubmit_frame=*/false,
                /*raster_thread_merger=*/fml::RefPtr<fml::RasterThreadMerger>(
                    nullptr)))
@@ -170,10 +170,10 @@ TEST(
   EXPECT_CALL(delegate, OnFrameRasterized(_));
   auto rasterizer = std::make_unique<Rasterizer>(delegate);
   auto surface = std::make_unique<MockSurface>();
-  std::shared_ptr<MockExternalViewEmbedder> external_view_embedder =
-      std::make_shared<MockExternalViewEmbedder>();
-  rasterizer->SetExternalViewEmbedder(external_view_embedder);
-  EXPECT_CALL(*external_view_embedder, SupportsDynamicThreadMerging)
+  MockExternalViewEmbedder external_view_embedder;
+  EXPECT_CALL(*surface, GetExternalViewEmbedder())
+      .WillRepeatedly(Return(&external_view_embedder));
+  EXPECT_CALL(external_view_embedder, SupportsDynamicThreadMerging)
       .WillRepeatedly(Return(true));
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, /*supports_readback=*/true,
@@ -181,14 +181,14 @@ TEST(
   EXPECT_CALL(*surface, AcquireFrame(SkISize()))
       .WillOnce(Return(ByMove(std::move(surface_frame))));
 
-  EXPECT_CALL(*external_view_embedder,
+  EXPECT_CALL(external_view_embedder,
               BeginFrame(/*frame_size=*/SkISize(), /*context=*/nullptr,
                          /*device_pixel_ratio=*/2.0,
                          /*raster_thread_merger=*/_))
       .Times(1);
-  EXPECT_CALL(*external_view_embedder, SubmitFrame).Times(0);
-  EXPECT_CALL(*external_view_embedder, EndFrame(/*should_resubmit_frame=*/false,
-                                                /*raster_thread_merger=*/_))
+  EXPECT_CALL(external_view_embedder, SubmitFrame).Times(0);
+  EXPECT_CALL(external_view_embedder, EndFrame(/*should_resubmit_frame=*/false,
+                                               /*raster_thread_merger=*/_))
       .Times(1);
 
   rasterizer->Setup(std::move(surface));
@@ -229,26 +229,26 @@ TEST(
   auto rasterizer = std::make_unique<Rasterizer>(delegate);
   auto surface = std::make_unique<MockSurface>();
 
-  std::shared_ptr<MockExternalViewEmbedder> external_view_embedder =
-      std::make_shared<MockExternalViewEmbedder>();
-  rasterizer->SetExternalViewEmbedder(external_view_embedder);
+  MockExternalViewEmbedder external_view_embedder;
+  EXPECT_CALL(*surface, GetExternalViewEmbedder())
+      .WillRepeatedly(Return(&external_view_embedder));
 
   auto surface_frame = std::make_unique<SurfaceFrame>(
       /*surface=*/nullptr, /*supports_readback=*/true,
       /*submit_callback=*/[](const SurfaceFrame&, SkCanvas*) { return true; });
   EXPECT_CALL(*surface, AcquireFrame(SkISize()))
       .WillOnce(Return(ByMove(std::move(surface_frame))));
-  EXPECT_CALL(*external_view_embedder, SupportsDynamicThreadMerging)
+  EXPECT_CALL(external_view_embedder, SupportsDynamicThreadMerging)
       .WillRepeatedly(Return(true));
 
-  EXPECT_CALL(*external_view_embedder,
+  EXPECT_CALL(external_view_embedder,
               BeginFrame(/*frame_size=*/SkISize(), /*context=*/nullptr,
                          /*device_pixel_ratio=*/2.0,
                          /*raster_thread_merger=*/_))
       .Times(1);
-  EXPECT_CALL(*external_view_embedder, SubmitFrame).Times(1);
-  EXPECT_CALL(*external_view_embedder, EndFrame(/*should_resubmit_frame=*/false,
-                                                /*raster_thread_merger=*/_))
+  EXPECT_CALL(external_view_embedder, SubmitFrame).Times(1);
+  EXPECT_CALL(external_view_embedder, EndFrame(/*should_resubmit_frame=*/false,
+                                               /*raster_thread_merger=*/_))
       .Times(1);
 
   rasterizer->Setup(std::move(surface));

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -547,10 +547,6 @@ bool Shell::Setup(std::unique_ptr<PlatformView> platform_view,
   rasterizer_ = std::move(rasterizer);
   io_manager_ = std::move(io_manager);
 
-  // Set the external view embedder for the rasterizer.
-  auto view_embedder = platform_view_->CreateExternalViewEmbedder();
-  rasterizer_->SetExternalViewEmbedder(view_embedder);
-
   // The weak ptr must be generated in the platform thread which owns the unique
   // ptr.
   weak_engine_ = engine_->GetWeakPtr();

--- a/shell/common/shell_test_platform_view_gl.cc
+++ b/shell/common/shell_test_platform_view_gl.cc
@@ -79,5 +79,10 @@ ShellTestPlatformViewGL::GetGLProcResolver() const {
   };
 }
 
+// |GPUSurfaceGLDelegate|
+ExternalViewEmbedder* ShellTestPlatformViewGL::GetExternalViewEmbedder() {
+  return shell_test_external_view_embedder_.get();
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/common/shell_test_platform_view_gl.h
+++ b/shell/common/shell_test_platform_view_gl.h
@@ -64,6 +64,9 @@ class ShellTestPlatformViewGL : public ShellTestPlatformView,
   // |GPUSurfaceGLDelegate|
   GLProcResolver GetGLProcResolver() const override;
 
+  // |GPUSurfaceGLDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTestPlatformViewGL);
 };
 

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -198,5 +198,10 @@ SkMatrix ShellTestPlatformViewVulkan::OffScreenSurface::GetRootTransformation()
   return matrix;
 }
 
+flutter::ExternalViewEmbedder*
+ShellTestPlatformViewVulkan::OffScreenSurface::GetExternalViewEmbedder() {
+  return shell_test_external_view_embedder_.get();
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/common/shell_test_platform_view_vulkan.h
+++ b/shell/common/shell_test_platform_view_vulkan.h
@@ -47,6 +47,8 @@ class ShellTestPlatformViewVulkan : public ShellTestPlatformView {
     // |Surface|
     GrDirectContext* GetContext() override;
 
+    flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
    private:
     bool valid_;
     fml::RefPtr<vulkan::VulkanProcTable> vk_;

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -16,6 +16,7 @@ gpu_common_deps = [
 
 source_set("gpu_surface_software") {
   sources = [
+    "gpu_surface_delegate.h",
     "gpu_surface_software.cc",
     "gpu_surface_software.h",
     "gpu_surface_software_delegate.cc",
@@ -27,6 +28,7 @@ source_set("gpu_surface_software") {
 
 source_set("gpu_surface_gl") {
   sources = [
+    "gpu_surface_delegate.h",
     "gpu_surface_gl.cc",
     "gpu_surface_gl.h",
     "gpu_surface_gl_delegate.cc",
@@ -38,6 +40,7 @@ source_set("gpu_surface_gl") {
 
 source_set("gpu_surface_vulkan") {
   sources = [
+    "gpu_surface_delegate.h",
     "gpu_surface_vulkan.cc",
     "gpu_surface_vulkan.h",
     "gpu_surface_vulkan_delegate.cc",
@@ -49,6 +52,7 @@ source_set("gpu_surface_vulkan") {
 
 source_set("gpu_surface_metal") {
   sources = [
+    "gpu_surface_delegate.h",
     "gpu_surface_metal.h",
     "gpu_surface_metal.mm",
   ]

--- a/shell/gpu/gpu_surface_delegate.h
+++ b/shell/gpu/gpu_surface_delegate.h
@@ -1,0 +1,28 @@
+#ifndef FLUTTER_SHELL_GPU_GPU_SURFACE_DELEGATE_H_
+#define FLUTTER_SHELL_GPU_GPU_SURFACE_DELEGATE_H_
+
+#include "flutter/flow/embedded_views.h"
+
+namespace flutter {
+
+class GPUSurfaceDelegate {
+ public:
+  virtual ~GPUSurfaceDelegate() {}
+
+  //----------------------------------------------------------------------------
+  /// @brief      Gets the view embedder that controls how the Flutter layer
+  ///             hierarchy split into multiple chunks should be composited back
+  ///             on-screen. This field is optional and the Flutter rasterizer
+  ///             will render into a single on-screen surface if this call
+  ///             returns a null external view embedder. This happens on the GPU
+  ///             thread.
+  ///
+  /// @return     The external view embedder, or, null if Flutter is rendering
+  ///             into a single on-screen surface.
+  ///
+  virtual ExternalViewEmbedder* GetExternalViewEmbedder() = 0;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_GPU_GPU_SURFACE_DELEGATE_H_

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -334,6 +334,11 @@ GrDirectContext* GPUSurfaceGL::GetContext() {
 }
 
 // |Surface|
+flutter::ExternalViewEmbedder* GPUSurfaceGL::GetExternalViewEmbedder() {
+  return delegate_->GetExternalViewEmbedder();
+}
+
+// |Surface|
 std::unique_ptr<GLContextResult> GPUSurfaceGL::MakeRenderContextCurrent() {
   return delegate_->GLContextMakeCurrent();
 }

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -43,6 +43,9 @@ class GPUSurfaceGL : public Surface {
   GrDirectContext* GetContext() override;
 
   // |Surface|
+  flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
+  // |Surface|
   std::unique_ptr<GLContextResult> MakeRenderContextCurrent() override;
 
   // |Surface|

--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -99,4 +99,8 @@ GPUSurfaceGLDelegate::GetDefaultPlatformGLInterface() {
   return CreateGLInterface(nullptr);
 }
 
+ExternalViewEmbedder* GPUSurfaceGLDelegate::GetExternalViewEmbedder() {
+  return nullptr;
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -8,6 +8,7 @@
 #include "flutter/common/graphics/gl_context_switch.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/fml/macros.h"
+#include "flutter/shell/gpu/gpu_surface_delegate.h"
 #include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/skia/include/gpu/gl/GrGLInterface.h"
 
@@ -20,9 +21,12 @@ struct GLFrameInfo {
   uint32_t height;
 };
 
-class GPUSurfaceGLDelegate {
+class GPUSurfaceGLDelegate : public GPUSurfaceDelegate {
  public:
-  ~GPUSurfaceGLDelegate();
+  ~GPUSurfaceGLDelegate() override;
+
+  // |GPUSurfaceDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // Called to make the main GL context current on the current thread.
   virtual std::unique_ptr<GLContextResult> GLContextMakeCurrent() = 0;

--- a/shell/gpu/gpu_surface_metal.h
+++ b/shell/gpu/gpu_surface_metal.h
@@ -10,6 +10,7 @@
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
+#include "flutter/shell/gpu/gpu_surface_delegate.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 #include "third_party/skia/include/gpu/mtl/GrMtlTypes.h"
 
@@ -19,14 +20,16 @@ namespace flutter {
 
 class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetal : public Surface {
  public:
-  GPUSurfaceMetal(fml::scoped_nsobject<CAMetalLayer> layer,
+  GPUSurfaceMetal(GPUSurfaceDelegate* delegate,
+                  fml::scoped_nsobject<CAMetalLayer> layer,
                   sk_sp<GrDirectContext> context,
                   fml::scoped_nsprotocol<id<MTLCommandQueue>> command_queue);
 
   // |Surface|
-  ~GPUSurfaceMetal();
+  ~GPUSurfaceMetal() override;
 
  private:
+  GPUSurfaceDelegate* delegate_;
   fml::scoped_nsobject<CAMetalLayer> layer_;
   sk_sp<GrDirectContext> context_;
   fml::scoped_nsprotocol<id<MTLCommandQueue>> command_queue_;
@@ -43,6 +46,9 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetal : public Surface {
 
   // |Surface|
   GrDirectContext* GetContext() override;
+
+  // |Surface|
+  flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // |Surface|
   std::unique_ptr<GLContextResult> MakeRenderContextCurrent() override;

--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -15,10 +15,12 @@ static_assert(!__has_feature(objc_arc), "ARC must be disabled.");
 
 namespace flutter {
 
-GPUSurfaceMetal::GPUSurfaceMetal(fml::scoped_nsobject<CAMetalLayer> layer,
+GPUSurfaceMetal::GPUSurfaceMetal(GPUSurfaceDelegate* delegate,
+                                 fml::scoped_nsobject<CAMetalLayer> layer,
                                  sk_sp<GrDirectContext> context,
                                  fml::scoped_nsprotocol<id<MTLCommandQueue>> command_queue)
-    : layer_(std::move(layer)),
+    : delegate_(delegate),
+      layer_(std::move(layer)),
       context_(std::move(context)),
       command_queue_(std::move(command_queue)) {
   layer_.get().pixelFormat = MTLPixelFormatBGRA8Unorm;
@@ -117,6 +119,11 @@ SkMatrix GPUSurfaceMetal::GetRootTransformation() const {
 // |Surface|
 GrDirectContext* GPUSurfaceMetal::GetContext() {
   return context_.get();
+}
+
+// |Surface|
+flutter::ExternalViewEmbedder* GPUSurfaceMetal::GetExternalViewEmbedder() {
+  return delegate_->GetExternalViewEmbedder();
 }
 
 // |Surface|

--- a/shell/gpu/gpu_surface_software.cc
+++ b/shell/gpu/gpu_surface_software.cc
@@ -87,4 +87,9 @@ GrDirectContext* GPUSurfaceSoftware::GetContext() {
   return nullptr;
 }
 
+// |Surface|
+flutter::ExternalViewEmbedder* GPUSurfaceSoftware::GetExternalViewEmbedder() {
+  return delegate_->GetExternalViewEmbedder();
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_software.h
+++ b/shell/gpu/gpu_surface_software.h
@@ -31,6 +31,9 @@ class GPUSurfaceSoftware : public Surface {
   // |Surface|
   GrDirectContext* GetContext() override;
 
+  // |Surface|
+  flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
  private:
   GPUSurfaceSoftwareDelegate* delegate_;
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an

--- a/shell/gpu/gpu_surface_software_delegate.cc
+++ b/shell/gpu/gpu_surface_software_delegate.cc
@@ -8,4 +8,8 @@ namespace flutter {
 
 GPUSurfaceSoftwareDelegate::~GPUSurfaceSoftwareDelegate() = default;
 
+ExternalViewEmbedder* GPUSurfaceSoftwareDelegate::GetExternalViewEmbedder() {
+  return nullptr;
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_software_delegate.h
+++ b/shell/gpu/gpu_surface_software_delegate.h
@@ -7,6 +7,7 @@
 
 #include "flutter/flow/embedded_views.h"
 #include "flutter/fml/macros.h"
+#include "flutter/shell/gpu/gpu_surface_delegate.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
@@ -24,9 +25,12 @@ namespace flutter {
 /// @see        |IOSurfaceSoftware|, |AndroidSurfaceSoftware|,
 ///             |EmbedderSurfaceSoftware|.
 ///
-class GPUSurfaceSoftwareDelegate {
+class GPUSurfaceSoftwareDelegate : public GPUSurfaceDelegate {
  public:
-  ~GPUSurfaceSoftwareDelegate();
+  ~GPUSurfaceSoftwareDelegate() override;
+
+  // |GPUSurfaceDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   //----------------------------------------------------------------------------
   /// @brief      Called when the GPU surface needs a new buffer to render a new

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -13,6 +13,7 @@ GPUSurfaceVulkan::GPUSurfaceVulkan(
     std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,
     bool render_to_surface)
     : window_(delegate->vk(), std::move(native_surface), render_to_surface),
+      delegate_(delegate),
       render_to_surface_(render_to_surface),
       weak_factory_(this) {}
 
@@ -64,6 +65,10 @@ SkMatrix GPUSurfaceVulkan::GetRootTransformation() const {
 
 GrDirectContext* GPUSurfaceVulkan::GetContext() {
   return window_.GetSkiaGrContext();
+}
+
+flutter::ExternalViewEmbedder* GPUSurfaceVulkan::GetExternalViewEmbedder() {
+  return delegate_->GetExternalViewEmbedder();
 }
 
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_vulkan.h
+++ b/shell/gpu/gpu_surface_vulkan.h
@@ -36,8 +36,12 @@ class GPUSurfaceVulkan : public Surface {
   // |Surface|
   GrDirectContext* GetContext() override;
 
+  // |Surface|
+  flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
  private:
   vulkan::VulkanWindow window_;
+  GPUSurfaceVulkanDelegate* delegate_;
   const bool render_to_surface_;
 
   fml::WeakPtrFactory<GPUSurfaceVulkan> weak_factory_;

--- a/shell/gpu/gpu_surface_vulkan_delegate.cc
+++ b/shell/gpu/gpu_surface_vulkan_delegate.cc
@@ -8,4 +8,8 @@ namespace flutter {
 
 GPUSurfaceVulkanDelegate::~GPUSurfaceVulkanDelegate() = default;
 
+ExternalViewEmbedder* GPUSurfaceVulkanDelegate::GetExternalViewEmbedder() {
+  return nullptr;
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_vulkan_delegate.h
+++ b/shell/gpu/gpu_surface_vulkan_delegate.h
@@ -6,13 +6,17 @@
 #define FLUTTER_SHELL_GPU_GPU_SURFACE_VULKAN_DELEGATE_H_
 
 #include "flutter/fml/memory/ref_ptr.h"
+#include "flutter/shell/gpu/gpu_surface_delegate.h"
 #include "flutter/vulkan/vulkan_proc_table.h"
 
 namespace flutter {
 
-class GPUSurfaceVulkanDelegate {
+class GPUSurfaceVulkanDelegate : public GPUSurfaceDelegate {
  public:
-  ~GPUSurfaceVulkanDelegate();
+  ~GPUSurfaceVulkanDelegate() override;
+
+  // |GPUSurfaceDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // Obtain a reference to the Vulkan implementation's proc table.
   virtual fml::RefPtr<vulkan::VulkanProcTable> vk() = 0;

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -133,6 +133,11 @@ intptr_t AndroidSurfaceGL::GLContextFBO(GLFrameInfo frame_info) const {
 }
 
 // |GPUSurfaceGLDelegate|
+ExternalViewEmbedder* AndroidSurfaceGL::GetExternalViewEmbedder() {
+  return external_view_embedder_.get();
+}
+
+// |GPUSurfaceGLDelegate|
 sk_sp<const GrGLInterface> AndroidSurfaceGL::GetGLInterface() const {
   // This is a workaround for a bug in the Android emulator EGL/GLES
   // implementation.  Some versions of the emulator will not update the

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -64,6 +64,9 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
 
   // |GPUSurfaceGLDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
+  // |GPUSurfaceGLDelegate|
   sk_sp<const GrGLInterface> GetGLInterface() const override;
 
  private:

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -141,6 +141,11 @@ bool AndroidSurfaceSoftware::PresentBackingStore(
   return true;
 }
 
+// |GPUSurfaceSoftwareDelegate|
+ExternalViewEmbedder* AndroidSurfaceSoftware::GetExternalViewEmbedder() {
+  return external_view_embedder_.get();
+}
+
 void AndroidSurfaceSoftware::TeardownOnScreenContext() {}
 
 bool AndroidSurfaceSoftware::OnScreenSurfaceResize(const SkISize& size) {

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -53,6 +53,9 @@ class AndroidSurfaceSoftware final : public AndroidSurface,
   // |GPUSurfaceSoftwareDelegate|
   bool PresentBackingStore(sk_sp<SkSurface> backing_store) override;
 
+  // |GPUSurfaceSoftwareDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
  private:
   const std::shared_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
 

--- a/shell/platform/android/android_surface_vulkan.cc
+++ b/shell/platform/android/android_surface_vulkan.cc
@@ -77,6 +77,10 @@ bool AndroidSurfaceVulkan::SetNativeWindow(
   return native_window_ && native_window_->IsValid();
 }
 
+ExternalViewEmbedder* AndroidSurfaceVulkan::GetExternalViewEmbedder() {
+  return external_view_embedder_.get();
+}
+
 fml::RefPtr<vulkan::VulkanProcTable> AndroidSurfaceVulkan::vk() {
   return proc_table_;
 }

--- a/shell/platform/android/android_surface_vulkan.h
+++ b/shell/platform/android/android_surface_vulkan.h
@@ -51,6 +51,9 @@ class AndroidSurfaceVulkan : public AndroidSurface,
   bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
 
   // |GPUSurfaceVulkanDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
+  // |GPUSurfaceVulkanDelegate|
   fml::RefPtr<vulkan::VulkanProcTable> vk() override;
 
  private:

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -52,6 +52,11 @@ class SurfaceMock : public Surface {
 
   MOCK_METHOD(GrDirectContext*, GetContext, (), (override));
 
+  MOCK_METHOD(flutter::ExternalViewEmbedder*,
+              GetExternalViewEmbedder,
+              (),
+              (override));
+
   MOCK_METHOD(std::unique_ptr<GLContextResult>,
               MakeRenderContextCurrent,
               (),

--- a/shell/platform/android/surface/android_surface_mock.cc
+++ b/shell/platform/android/surface/android_surface_mock.cc
@@ -22,4 +22,8 @@ intptr_t AndroidSurfaceMock::GLContextFBO(GLFrameInfo frame_info) const {
   return 0;
 }
 
+ExternalViewEmbedder* AndroidSurfaceMock::GetExternalViewEmbedder() {
+  return nullptr;
+}
+
 }  // namespace flutter

--- a/shell/platform/android/surface/android_surface_mock.h
+++ b/shell/platform/android/surface/android_surface_mock.h
@@ -49,6 +49,9 @@ class AndroidSurfaceMock final : public GPUSurfaceGLDelegate,
 
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO(GLFrameInfo frame_info) const override;
+
+  // |GPUSurfaceGLDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
 };
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -48,6 +48,9 @@ class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
   // |GPUSurfaceGLDelegate|
   bool SurfaceSupportsReadback() const override;
 
+  // |GPUSurfaceGLDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
  private:
   std::unique_ptr<IOSRenderTargetGL> render_target_;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -82,4 +82,9 @@ bool IOSSurfaceGL::GLContextPresent(uint32_t fbo_id) {
   return IsValid() && render_target_->PresentRenderBuffer();
 }
 
+// |GPUSurfaceGLDelegate|
+ExternalViewEmbedder* IOSSurfaceGL::GetExternalViewEmbedder() {
+  return GetSurfaceExternalViewEmbedder().get();
+}
+
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_metal.h
+++ b/shell/platform/darwin/ios/ios_surface_metal.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SURFACE_METAL_H_
 
 #include "flutter/fml/macros.h"
+#include "flutter/shell/gpu/gpu_surface_delegate.h"
 #import "flutter/shell/platform/darwin/ios/ios_surface.h"
 #include "third_party/skia/include/gpu/mtl/GrMtlTypes.h"
 
@@ -13,14 +14,15 @@
 
 namespace flutter {
 
-class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetal final : public IOSSurface {
+class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetal final : public IOSSurface,
+                                                              public GPUSurfaceDelegate {
  public:
   IOSSurfaceMetal(fml::scoped_nsobject<CAMetalLayer> layer,
                   std::shared_ptr<IOSContext> context,
                   const std::shared_ptr<IOSExternalViewEmbedder>& external_view_embedder);
 
   // |IOSSurface|
-  ~IOSSurfaceMetal();
+  ~IOSSurfaceMetal() override;
 
  private:
   fml::scoped_nsobject<CAMetalLayer> layer_;
@@ -34,6 +36,9 @@ class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetal final : public IOSSurface 
 
   // |IOSSurface|
   std::unique_ptr<Surface> CreateGPUSurface(GrDirectContext* gr_context) override;
+
+  // |GPUSurfaceDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceMetal);
 };

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -47,10 +47,16 @@ void IOSSurfaceMetal::UpdateStorageSizeIfNecessary() {
 std::unique_ptr<Surface> IOSSurfaceMetal::CreateGPUSurface(GrDirectContext* /* unused */) {
   auto metal_context = CastToMetalContext(GetContext());
 
-  return std::make_unique<GPUSurfaceMetal>(layer_,                               // layer
+  return std::make_unique<GPUSurfaceMetal>(this,    // Metal surface delegate
+                                           layer_,  // layer
                                            metal_context->GetMainContext(),      // context
                                            metal_context->GetMainCommandQueue()  // command queue
   );
+}
+
+// |GPUSurfaceDelegate|
+ExternalViewEmbedder* IOSSurfaceMetal::GetExternalViewEmbedder() {
+  return GetSurfaceExternalViewEmbedder().get();
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -39,6 +39,9 @@ class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDel
   // |GPUSurfaceSoftwareDelegate|
   bool PresentBackingStore(sk_sp<SkSurface> backing_store) override;
 
+  // |GPUSurfaceSoftwareDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
  private:
   fml::scoped_nsobject<CALayer> layer_;
   sk_sp<SkSurface> sk_surface_;

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -123,4 +123,9 @@ bool IOSSurfaceSoftware::PresentBackingStore(sk_sp<SkSurface> backing_store) {
   return true;
 }
 
+// |GPUSurfaceSoftwareDelegate|
+ExternalViewEmbedder* IOSSurfaceSoftware::GetExternalViewEmbedder() {
+  return GetSurfaceExternalViewEmbedder().get();
+}
+
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -71,6 +71,11 @@ SkMatrix EmbedderSurfaceGL::GLContextSurfaceTransformation() const {
 }
 
 // |GPUSurfaceGLDelegate|
+ExternalViewEmbedder* EmbedderSurfaceGL::GetExternalViewEmbedder() {
+  return external_view_embedder_.get();
+}
+
+// |GPUSurfaceGLDelegate|
 EmbedderSurfaceGL::GLProcResolver EmbedderSurfaceGL::GetGLProcResolver() const {
   return gl_dispatch_table_.gl_proc_resolver;
 }

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -68,6 +68,9 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   SkMatrix GLContextSurfaceTransformation() const override;
 
   // |GPUSurfaceGLDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
+  // |GPUSurfaceGLDelegate|
   GLProcResolver GetGLProcResolver() const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderSurfaceGL);

--- a/shell/platform/embedder/embedder_surface_software.cc
+++ b/shell/platform/embedder/embedder_surface_software.cc
@@ -106,4 +106,9 @@ bool EmbedderSurfaceSoftware::PresentBackingStore(
   );
 }
 
+// |GPUSurfaceSoftwareDelegate|
+ExternalViewEmbedder* EmbedderSurfaceSoftware::GetExternalViewEmbedder() {
+  return external_view_embedder_.get();
+}
+
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_surface_software.h
+++ b/shell/platform/embedder/embedder_surface_software.h
@@ -47,6 +47,9 @@ class EmbedderSurfaceSoftware final : public EmbedderSurface,
   // |GPUSurfaceSoftwareDelegate|
   bool PresentBackingStore(sk_sp<SkSurface> backing_store) override;
 
+  // |GPUSurfaceSoftwareDelegate|
+  ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderSurfaceSoftware);
 };
 

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -80,10 +80,6 @@ class PlatformView final : public flutter::PlatformView,
   // |PlatformView|
   flutter::PointerDataDispatcherMaker GetDispatcherMaker() override;
 
-  // |flutter::PlatformView|
-  std::shared_ptr<flutter::ExternalViewEmbedder> CreateExternalViewEmbedder()
-      override;
-
  private:
   void RegisterPlatformMessageHandlers();
 
@@ -124,6 +120,10 @@ class PlatformView final : public flutter::PlatformView,
 
   // |flutter::PlatformView|
   std::unique_ptr<flutter::Surface> CreateRenderingSurface() override;
+
+  // |flutter::PlatformView|
+  std::shared_ptr<flutter::ExternalViewEmbedder> CreateExternalViewEmbedder()
+      override;
 
   // |flutter::PlatformView|
   void HandlePlatformMessage(

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -215,8 +215,7 @@ TEST_F(PlatformViewTests, CreateSurfaceTest) {
   RunLoopUntilIdle();
 
   EXPECT_EQ(gr_context.get(), delegate.surface()->GetContext());
-  EXPECT_EQ(view_embedder.get(),
-            platform_view.CreateExternalViewEmbedder().get());
+  EXPECT_EQ(view_embedder.get(), delegate.surface()->GetExternalViewEmbedder());
 }
 
 // This test makes sure that the PlatformView correctly registers Scenic

--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -51,4 +51,9 @@ SkMatrix Surface::GetRootTransformation() const {
   return matrix;
 }
 
+// |flutter::GetViewEmbedder|
+flutter::ExternalViewEmbedder* Surface::GetExternalViewEmbedder() {
+  return view_embedder_.get();
+}
+
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/surface.h
+++ b/shell/platform/fuchsia/flutter/surface.h
@@ -39,6 +39,9 @@ class Surface final : public flutter::Surface {
   // |flutter::Surface|
   SkMatrix GetRootTransformation() const override;
 
+  // |flutter::Surface|
+  flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(Surface);
 };
 


### PR DESCRIPTION
Reverts

- 5419f70f173db1c9f2d5db4c289560e68ce9b77b
- f95df42e6e3d80f17c2024e9956768be9416717f


See: https://github.com/flutter/flutter/issues/70384