### PR TITLE
Reland: "Make `PlatformDispatcher.locale` and `locales` return consistent values (#22267)"

### DIFF
--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -551,12 +551,7 @@ class PlatformDispatcher {
   ///
   /// This is equivalent to `locales.first` and will provide an empty non-null
   /// locale if the [locales] list has not been set or is empty.
-  Locale? get locale {
-    if (locales != null && locales!.isNotEmpty) {
-      return locales!.first;
-    }
-    return null;
-  }
+  Locale get locale => locales.first;
 
   /// The full system-reported supported locales of the device.
   ///
@@ -573,7 +568,7 @@ class PlatformDispatcher {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
-  List<Locale>? get locales => configuration.locales;
+  List<Locale> get locales => configuration.locales;
 
   /// Performs the platform-native locale resolution.
   ///
@@ -649,12 +644,7 @@ class PlatformDispatcher {
   }
 
   // Called from the engine, via hooks.dart
-  String _localeClosure() {
-    if (locale == null) {
-      return '';
-    }
-    return locale.toString();
-  }
+  String _localeClosure() => locale.toString();
 
   /// The lifecycle state immediately after dart isolate initialization.
   ///

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -340,7 +340,7 @@ class SingletonFlutterWindow extends FlutterWindow {
   ///
   /// This is equivalent to `locales.first` and will provide an empty non-null
   /// locale if the [locales] list has not been set or is empty.
-  Locale? get locale => platformDispatcher.locale;
+  Locale get locale => platformDispatcher.locale;
 
   /// The full system-reported supported locales of the device.
   ///
@@ -358,7 +358,7 @@ class SingletonFlutterWindow extends FlutterWindow {
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this value changes.
-  List<Locale>? get locales => platformDispatcher.locales;
+  List<Locale> get locales => platformDispatcher.locales;
 
   /// Performs the platform-native locale resolution.
   ///
@@ -850,11 +850,11 @@ class Window extends SingletonFlutterWindow {
 
   @override
   // ignore: unnecessary_overrides
-  Locale? get locale => super.locale;
+  Locale get locale => super.locale;
 
   @override
   // ignore: unnecessary_overrides
-  List<Locale>? get locales => super.locales;
+  List<Locale> get locales => super.locales;
 
   @override
   // ignore: unnecessary_overrides


### PR DESCRIPTION
## Description

This reverts commit d37b86216a56727190c03e013e1b2b9048a654b5, relanding #22267, now that https://github.com/flutter/flutter/pull/70252 has landed to prevent the problems it had the first time.

Here is the original PR description:

For some reason (probably a bad merge on my part), the return values for `locale` and `locales` are not the same on web as they are on other platforms for the `PlatformDispatcher` and `SingletonFlutterWindow` classes.  The web versions are non-nullable and the others are nullable.

This converts them to be the same (non-nullable) values.