### PR TITLE
[flutter_release] Flutter 1.22.4 engine cherry-pick build error fix

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -582,16 +582,12 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
                                /*raster=*/thread_task_runner,
                                /*ui=*/thread_task_runner,
                                /*io=*/thread_task_runner);
-  auto surface_factory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
   auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
       /*delegate=*/mock_delegate,
       /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
-      /*ios_surface_factory=*/surface_factory,
       /*task_runners=*/runners);
 
-  auto flutterPlatformViewsController =
-      std::make_shared<flutter::FlutterPlatformViewsController>(surface_factory);
-  surface_factory->SetPlatformViewsController(flutterPlatformViewsController);
+  auto flutterPlatformViewsController = std::make_shared<flutter::FlutterPlatformViewsController>();
 
   FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
       [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];


### PR DESCRIPTION
## Description

Fixes

```
../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm:585:35: error: no member named 'IOSSurfaceFactory' in namespace 'flutter'
  auto surface_factory = flutter::IOSSurfaceFactory::Create(flutter::IOSRenderingAPI::kSoftware);
                         ~~~~~~~~~^
1 error generated.
ninja: build stopped: subcommand failed.
```

This is caused because https://github.com/flutter/engine/commit/fb72023d38c752367840247d379bf1fe43a31712 depends on https://github.com/flutter/engine/commit/6a3b5feb62cf29481545c1154c14eb2e3890a0cd, and https://github.com/flutter/engine/commit/6a3b5feb62cf29481545c1154c14eb2e3890a0cd is not cherry-picked.

This fix is to use the old API instead of the new api introduced in https://github.com/flutter/engine/commit/6a3b5feb62cf29481545c1154c14eb2e3890a0cd

## Related Issues

release

## Tests

I added the following tests:

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
