### PR TITLE
Add and use --quiet flag on the license checker

### DIFF
--- a/ci/licenses.sh
+++ b/ci/licenses.sh
@@ -33,6 +33,14 @@ SRC_DIR="$(cd "$SCRIPT_DIR/../.."; pwd -P)"
 DART_BIN="$SRC_DIR/third_party/dart/tools/sdks/dart-sdk/bin"
 PATH="$DART_BIN:$PATH"
 
+# Use:
+#   env VERBOSE=1 ./ci/licenses.sh
+# to turn on verbose progress report printing.
+QUIET="--quiet"
+if [[ "${VERBOSE}" == "1" ]]; then
+  QUIET=""
+fi
+
 echo "Verifying license script is still happy..."
 echo "Using pub from $(command -v pub), dart from $(command -v dart)"
 
@@ -58,7 +66,8 @@ function collect_licenses() (
   dart --enable-asserts lib/main.dart         \
     --src ../../..                            \
     --out ../../../out/license_script_output  \
-    --golden ../../ci/licenses_golden
+    --golden ../../ci/licenses_golden \
+    "${QUIET}"
 )
 
 # Verifies the licenses in the repo.

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 1f9d73861a9bb353a12cfa2ba38f6a12
+Signature: 164585dad7317491c0f98b96519f87c7
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -2319,7 +2319,7 @@ class _RepositoryRoot extends _RepositoryDirectory {
 
 
 class _Progress {
-  _Progress(this.max) {
+  _Progress(this.max, {bool quiet = false}) : _quiet = quiet {
     // This may happen when a git client contains left-over empty component
     // directories after DEPS file changes.
     if (max <= 0)
@@ -2327,6 +2327,7 @@ class _Progress {
   }
 
   final int max;
+  final bool _quiet;
   int get withLicense => _withLicense;
   int _withLicense = 0;
   int get withoutLicense => _withoutLicense;
@@ -2354,11 +2355,15 @@ class _Progress {
   void update({bool flush = false}) {
     if (_lastUpdate == null || _lastUpdate.elapsedMilliseconds > 90 || flush) {
       _lastUpdate ??= Stopwatch();
-      final String line = toString();
-      system.stderr.write('\r$line');
-      if (_lastLength > line.length)
-        system.stderr.write(' ' * (_lastLength - line.length));
-      _lastLength = line.length;
+      if (_quiet) {
+        system.stderr.write('.');
+      } else {
+        final String line = toString();
+        system.stderr.write('\r$line');
+        if (_lastLength > line.length)
+          system.stderr.write(' ' * (_lastLength - line.length));
+        _lastLength = line.length;
+      }
       _lastUpdate.reset();
       _lastUpdate.start();
     }
@@ -2423,6 +2428,7 @@ Future<void> _collectLicensesForComponent(_RepositoryDirectory componentRoot, {
   String outputGoldenPath,
   bool writeSignature,
   bool force,
+  bool quiet,
 }) async {
   // Check whether the golden file matches the signature of the current contents of this directory.
   final String goldenSignature = await _readSignature(inputGoldenPath);
@@ -2432,7 +2438,7 @@ Future<void> _collectLicensesForComponent(_RepositoryDirectory componentRoot, {
     return;
   }
 
-  final _Progress progress = _Progress(componentRoot.fileCount);
+  final _Progress progress = _Progress(componentRoot.fileCount, quiet: quiet);
 
   final system.File outFile = system.File(outputGoldenPath);
   final system.IOSink sink = outFile.openWrite();
@@ -2506,9 +2512,11 @@ Future<void> main(List<String> arguments) async {
     ..addOption('src', help: 'The root of the engine source')
     ..addOption('out', help: 'The directory where output is written')
     ..addOption('golden', help: 'The directory containing golden results')
+    ..addFlag('quiet', help: 'If set, the diagnostic output is much less verbose')
     ..addFlag('release', help: 'Print output in the format used for product releases');
 
   final ArgResults argResults = parser.parse(arguments);
+  final bool quiet = argResults['quiet'];
   final bool releaseMode = argResults['release'];
   if (argResults['src'] == null) {
     print('Flutter license script: Must provide --src directory');
@@ -2538,7 +2546,8 @@ Future<void> main(List<String> arguments) async {
 
     if (releaseMode) {
       system.stderr.writeln('Collecting licenses...');
-      final _Progress progress = _Progress(root.fileCount);
+      system.stderr.writeln('quiet: $quiet');
+      final _Progress progress = _Progress(root.fileCount, quiet: quiet);
       final List<License> licenses = Set<License>.from(root.getLicenses(progress).toList()).toList();
       if (progress.hadErrors)
         throw 'Had failures while collecting licenses.';
@@ -2596,6 +2605,7 @@ Future<void> main(List<String> arguments) async {
             outputGoldenPath: path.join(argResults['out'], goldenFileName),
             writeSignature: component.io.name != 'flutter',
             force: forceRunAll || component.io.name == 'flutter',
+            quiet: quiet,
         );
         usedGoldens.add(goldenFileName);
       }


### PR DESCRIPTION
## Description

The license checker output looks particularly bad on CI by
default, as it prints thousands of lines of output for files
that do *not* need licensing attention.

This change introduces a flag '--quiet' which instructs the license
checker to print a dot per each examined file instead of the full
progress bar.

It also starts using the flag on CI immediately, since it seems
to reduce the visual clutter.

Manual invocations can get the verbose output like so:

    env VERBOSE=1 ./ci/licenses.sh

Issue: https://github.com/flutter/flutter/issues/70411

## Related Issues

* Issue: https://github.com/flutter/flutter/issues/70411

## Tests

Tested manually.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
