### PR TITLE
[flutter releases] more 1.24 engine CPs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,7 +45,7 @@ task:
       fetch_framework_script: |
         mkdir -p $FRAMEWORK_PATH
         cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
+        git clone --branch flutter-1.24-candidate.10 https://github.com/flutter/flutter.git
       analyze_framework_script: |
         cd $FRAMEWORK_PATH/flutter
         rm -rf bin/cache/pkg/sky_engine

--- a/DEPS
+++ b/DEPS
@@ -50,7 +50,7 @@ vars = {
   'dart_linter_tag': '0.1.124',
   'dart_oauth2_tag': '1.6.0',
   'dart_protobuf_rev': '3746c8fd3f2b0147623a8e3db89c3ff4330de760',
-  'dart_pub_rev': 'b10966c6a8ad7d95c2023b7842fa2697001d2fdf',
+  'dart_pub_rev': 'c00d4b4abf5b4ff265a7ce6282b748551f1b5b1f',
   'dart_pub_semver_tag': 'v1.4.4',
   'dart_resource_rev': '6b79867d0becf5395e5819a75720963b8298e9a7',
   'dart_root_certificates_rev': '7e5ec82c99677a2e5b95ce296c4d68b0d3378ed8',


### PR DESCRIPTION
- add 1.24 branch info to .cirrus.yml

- bump pub dep since the dart beta update had a pub bump picked.  