### PR TITLE
Set worker thread priority when launching the dart VM

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -393,6 +393,13 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     args.push_back(settings_.dart_flags[i].c_str());
   }
 
+  // Give worker threads used by the VM a lower priority.
+  // These threads are internally managed by the Dart VM, and are not accessible
+  // via FlutterEnginePostCallbackOnAllNativeThreads.
+  // TODO(dnfield): this won't work on Fuchsia yet, see
+  // https://github.com/dart-lang/sdk/issues/44209
+  args.push_back("--worker-thread-priority=10");
+
   char* flags_error = Dart_SetVMFlags(args.size(), args.data());
   if (flags_error) {
     FML_LOG(FATAL) << "Error while setting Dart VM flags: " << flags_error;


### PR DESCRIPTION
I'm not sure how we should test this. It might be good to grab a worker thread somehow, and check its priority, but I don't know how we'd do that.

We could also assert the arg is passed but ... that seems a little silly to me.

More context:

We currently let the VM worker threads run at a default priority level which can end up competing with the UI/Render/Platform/IO threads and cause jank during GC. This lowers the priority so that GCs will take a bit longer but interrupt less.