### PR TITLE
Revert "Remove the Window class now that it is no longer used."

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -795,6 +795,220 @@ class AccessibilityFeatures {
   int get hashCode => _index.hashCode;
 }
 
+/// A soon-to-be deprecated class that is wholly replaced by
+/// [SingletonFlutterWindow].
+///
+/// This class will be removed once the framework no longer refers to it.
+// In order for the documentation build to succeed, this interface duplicates
+// all of the methods with documentation, overrides them, and calls the super
+// implementation. Once this merges into the framework and the framework
+// references to it can be updated, this class will be removed entirely.
+class Window extends SingletonFlutterWindow {
+  Window._(Object windowId, PlatformDispatcher platformDispatcher)
+      : super._(windowId, platformDispatcher);
+
+  @override
+  // ignore: unnecessary_overrides
+  double get devicePixelRatio => super.devicePixelRatio;
+
+  @override
+  // ignore: unnecessary_overrides
+  Rect get physicalGeometry => super.physicalGeometry;
+
+  @override
+  // ignore: unnecessary_overrides
+  Size get physicalSize => super.physicalSize;
+
+  @override
+  // ignore: unnecessary_overrides
+  WindowPadding get viewInsets => super.viewInsets;
+
+  @override
+  // ignore: unnecessary_overrides
+  WindowPadding get viewPadding => super.viewPadding;
+
+  @override
+  // ignore: unnecessary_overrides
+  WindowPadding get systemGestureInsets => super.systemGestureInsets;
+
+  @override
+  // ignore: unnecessary_overrides
+  WindowPadding get padding => super.padding;
+
+  @override
+  // ignore: unnecessary_overrides
+  void render(Scene scene) => super.render(scene);
+
+  @override
+  // ignore: unnecessary_overrides
+  VoidCallback? get onMetricsChanged => super.onMetricsChanged;
+  @override
+  // ignore: unnecessary_overrides
+  set onMetricsChanged(VoidCallback? callback) {
+    super.onMetricsChanged = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  Locale get locale => super.locale;
+
+  @override
+  // ignore: unnecessary_overrides
+  List<Locale> get locales => super.locales;
+
+  @override
+  // ignore: unnecessary_overrides
+  Locale? computePlatformResolvedLocale(List<Locale> supportedLocales) {
+    return super.computePlatformResolvedLocale(supportedLocales);
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  VoidCallback? get onLocaleChanged => super.onLocaleChanged;
+  @override
+  // ignore: unnecessary_overrides
+  set onLocaleChanged(VoidCallback? callback) {
+    super.onLocaleChanged = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  String get initialLifecycleState => super.initialLifecycleState;
+
+  @override
+  // ignore: unnecessary_overrides
+  double get textScaleFactor => super.textScaleFactor;
+
+  @override
+  // ignore: unnecessary_overrides
+  bool get alwaysUse24HourFormat => super.alwaysUse24HourFormat;
+
+  @override
+  // ignore: unnecessary_overrides
+  VoidCallback? get onTextScaleFactorChanged => super.onTextScaleFactorChanged;
+  @override
+  // ignore: unnecessary_overrides
+  set onTextScaleFactorChanged(VoidCallback? callback) {
+    super.onTextScaleFactorChanged = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  Brightness get platformBrightness => super.platformBrightness;
+
+  @override
+  // ignore: unnecessary_overrides
+  VoidCallback? get onPlatformBrightnessChanged => super.onPlatformBrightnessChanged;
+  @override
+  // ignore: unnecessary_overrides
+  set onPlatformBrightnessChanged(VoidCallback? callback) {
+    super.onPlatformBrightnessChanged = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  FrameCallback? get onBeginFrame => super.onBeginFrame;
+  @override
+  // ignore: unnecessary_overrides
+  set onBeginFrame(FrameCallback? callback) {
+    super.onBeginFrame = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  VoidCallback? get onDrawFrame => super.onDrawFrame;
+  @override
+  // ignore: unnecessary_overrides
+  set onDrawFrame(VoidCallback? callback) {
+    super.onDrawFrame = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  TimingsCallback? get onReportTimings => super.onReportTimings;
+  @override
+  // ignore: unnecessary_overrides
+  set onReportTimings(TimingsCallback? callback) {
+    super.onReportTimings = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  PointerDataPacketCallback? get onPointerDataPacket => super.onPointerDataPacket;
+  @override
+  // ignore: unnecessary_overrides
+  set onPointerDataPacket(PointerDataPacketCallback? callback) {
+    super.onPointerDataPacket = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  String get defaultRouteName => super.defaultRouteName;
+
+  @override
+  // ignore: unnecessary_overrides
+  void scheduleFrame() => super.scheduleFrame();
+
+  @override
+  // ignore: unnecessary_overrides
+  bool get semanticsEnabled => super.semanticsEnabled;
+
+  @override
+  // ignore: unnecessary_overrides
+  VoidCallback? get onSemanticsEnabledChanged => super.onSemanticsEnabledChanged;
+  @override
+  // ignore: unnecessary_overrides
+  set onSemanticsEnabledChanged(VoidCallback? callback) {
+    super.onSemanticsEnabledChanged = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  SemanticsActionCallback? get onSemanticsAction => super.onSemanticsAction;
+  @override
+  // ignore: unnecessary_overrides
+  set onSemanticsAction(SemanticsActionCallback? callback) {
+    super.onSemanticsAction = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  AccessibilityFeatures get accessibilityFeatures => super.accessibilityFeatures;
+
+  @override
+  // ignore: unnecessary_overrides
+  VoidCallback? get onAccessibilityFeaturesChanged =>
+      super.onAccessibilityFeaturesChanged;
+  @override
+  // ignore: unnecessary_overrides
+  set onAccessibilityFeaturesChanged(VoidCallback? callback) {
+    super.onAccessibilityFeaturesChanged = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  void updateSemantics(SemanticsUpdate update) => super.updateSemantics(update);
+
+  @override
+  // ignore: unnecessary_overrides
+  void sendPlatformMessage(String name, ByteData? data, PlatformMessageResponseCallback? callback) {
+    super.sendPlatformMessage(name, data, callback);
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  PlatformMessageCallback? get onPlatformMessage => super.onPlatformMessage;
+  @override
+  // ignore: unnecessary_overrides
+  set onPlatformMessage(PlatformMessageCallback? callback) {
+    super.onPlatformMessage = callback;
+  }
+
+  @override
+  // ignore: unnecessary_overrides
+  void setIsolateDebugName(String name) => super.setIsolateDebugName(name);
+}
+
 /// Describes the contrast of a theme or color palette.
 enum Brightness {
   /// The color is dark and will require a light text color to achieve readable
@@ -839,4 +1053,4 @@ enum Brightness {
 /// * [PlatformDispatcher.views], contains the current list of Flutter windows
 ///   belonging to the application, including top level application windows like
 ///   this one.
-final SingletonFlutterWindow window = SingletonFlutterWindow._(0, PlatformDispatcher.instance);
+final Window window = Window._(0, PlatformDispatcher.instance);

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -307,12 +307,13 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///  - 0x08: visualizeEngineStatistics - graph UI thread frame times
   /// Set enabledOptions to 0x0F to enable all the currently defined features.
   ///
-  /// The "UI thread" is the thread that includes all the execution of the main
-  /// Dart isolate (the isolate that can call [FlutterView.render]). The UI
-  /// thread frame time is the total time spent executing the
-  /// [FlutterView.onBeginFrame] callback. The "raster thread" is the thread
-  /// (running on the CPU) that subsequently processes the [Scene] provided by
-  /// the Dart code to turn it into GPU commands and send it to the GPU.
+  /// The "UI thread" is the thread that includes all the execution of
+  /// the main Dart isolate (the isolate that can call
+  /// [Window.render]). The UI thread frame time is the total time
+  /// spent executing the [Window.onBeginFrame] callback. The "raster
+  /// thread" is the thread (running on the CPU) that subsequently
+  /// processes the [Scene] provided by the Dart code to turn it into
+  /// GPU commands and send it to the GPU.
   ///
   /// See also the [PerformanceOverlayOption] enum in the rendering library.
   /// for more details.
@@ -521,7 +522,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// Returns a [Scene] containing the objects that have been added to
   /// this scene builder. The [Scene] can then be displayed on the
-  /// screen with [FlutterView.render].
+  /// screen with [Window.render].
   ///
   /// After calling this function, the scene builder object is invalid and
   /// cannot be used further.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -174,7 +174,7 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// rasterized frames.
   ///
   /// It's preferred to use [SchedulerBinding.addTimingsCallback] than to use
-  /// [PlatformDispatcher.onReportTimings] directly because
+  /// [Window.onReportTimings] directly because
   /// [SchedulerBinding.addTimingsCallback] allows multiple callbacks.
   ///
   /// This can be used to see if the application has missed frames (through


### PR DESCRIPTION
Reverts flutter/engine#22505

That change breaks the docs builds as per: https://ci.chromium.org/p/flutter/builders/try/Linux%20docs/4661?