### PR TITLE
Remove the wasm library from the sky_engine package

### DIFF
--- a/sky/packages/sky_engine/lib/_embedder.yaml
+++ b/sky/packages/sky_engine/lib/_embedder.yaml
@@ -13,7 +13,6 @@ embedded_libs:
   "dart:math": "math/math.dart"
   "dart:typed_data": "typed_data/typed_data.dart"
   "dart:ui": "ui/ui.dart"
-  "dart:wasm": "wasm/wasm.dart"
 
   "dart:_http": "_http/http.dart"
   "dart:_interceptors": "_interceptors/interceptors.dart"


### PR DESCRIPTION
wasm was removed in a recent Dart roll
(https://github.com/flutter/engine/commit/8d332b7ae3205e33e0c7a9b16bb5a04abc9e786f)
