### PR TITLE
Refactor CanvasKit image ref counting; fix a minor memory leak

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -685,14 +685,11 @@ class SkAnimatedImage {
   external SkImage getCurrentFrame();
   external int width();
   external int height();
-  external Uint8List readPixels(SkImageInfo imageInfo, int srcX, int srcY);
-  external SkData encodeToData();
 
   /// Deletes the C++ object.
   ///
   /// This object is no longer usable after calling this method.
   external void delete();
-  external bool isAliasOf(SkAnimatedImage other);
   external bool isDeleted();
 }
 
@@ -1820,6 +1817,7 @@ class SkData {
   external int size();
   external bool isEmpty();
   external Uint8List bytes();
+  external void delete();
 }
 
 @JS()

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -70,10 +70,10 @@ class CkAnimatedImage implements ui.Codec, StackTraceDebugger {
 
   @override
   void dispose() {
-    if (_disposed) {
-      // This method is idempotent.
-      return;
-    }
+    assert(
+      !_disposed,
+      'Cannot dispose a codec that has already been disposed.',
+    );
     _disposed = true;
 
     // This image is no longer usable. Bump the ref count.
@@ -141,9 +141,10 @@ class CkImage implements ui.Image, StackTraceDebugger {
 
   @override
   void dispose() {
-    if (_disposed) {
-      return;
-    }
+    assert(
+      !_disposed,
+      'Cannot dispose an image that has already been disposed.',
+    );
     _disposed = true;
     box.unref(this);
   }

--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -321,8 +321,8 @@ class SkiaObjectBox<R extends StackTraceDebugger, T> {
 
   /// Deletes Skia objects when their wrappers are garbage collected.
   static final SkObjectFinalizationRegistry boxRegistry =
-      SkObjectFinalizationRegistry(js.allowInterop((SkiaObjectBox box) {
-    box._skDeletable.delete();
+      SkObjectFinalizationRegistry(js.allowInterop((SkDeletable deletable) {
+    deletable.delete();
   }));
 
   /// Increases the reference count of this box because a new object began

--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -252,6 +252,15 @@ abstract class OneShotSkiaObject<T extends Object> extends SkiaObject<T> {
   }
 }
 
+/// Interface that classes wrapping [SkiaObjectBox] must implement.
+///
+/// Used to collect stack traces in debug mode.
+abstract class StackTraceDebugger {
+  /// The stack trace pointing to code location that created or upreffed a
+  /// [SkiaObjectBox].
+  StackTrace get debugStackTrace;
+}
+
 /// Uses reference counting to manage the lifecycle of a Skia object owned by a
 /// wrapper object.
 ///
@@ -263,37 +272,47 @@ abstract class OneShotSkiaObject<T extends Object> extends SkiaObject<T> {
 ///
 /// The [delete] method may be called any number of times. The box
 /// will only delete the object once.
-class SkiaObjectBox<T> {
-  SkiaObjectBox(Object wrapper, T skObject)
-      : this._(wrapper, skObject, skObject as SkDeletable, <SkiaObjectBox>{});
-
-  SkiaObjectBox._(Object wrapper, this.skObject, this._skDeletable, this._refs) {
+class SkiaObjectBox<R extends StackTraceDebugger, T> {
+  SkiaObjectBox(R debugWrapper, this.skiaObject) : _skDeletable = skiaObject as SkDeletable {
     if (assertionsEnabled) {
-      _debugStackTrace = StackTrace.current;
+      debugReferrers.add(debugWrapper);
     }
-    _refs.add(this);
     if (browserSupportsFinalizationRegistry) {
-      boxRegistry.register(wrapper, this);
+      boxRegistry.register(this, _skDeletable);
     }
+    assert(refCount == debugReferrers.length);
   }
 
-  /// Reference handles to the same underlying [skObject].
-  final Set<SkiaObjectBox> _refs;
+  /// The number of objects sharing references to this box.
+  ///
+  /// When this count reaches zero, the underlying [skiaObject] is scheduled
+  /// for deletion.
+  int get refCount => _refCount;
+  int _refCount = 1;
 
-  late final StackTrace? _debugStackTrace;
+  /// When assertions are enabled, stores all objects that share this box.
+  ///
+  /// The length of this list is always identical to [refCount].
+  ///
+  /// This list can be used for debugging ref counting issues.
+  final List<R> debugReferrers = <R>[];
+
   /// If asserts are enabled, the [StackTrace]s representing when a reference
   /// was created.
   List<StackTrace>? debugGetStackTraces() {
     if (assertionsEnabled) {
-      return _refs
-          .map<StackTrace>((SkiaObjectBox box) => box._debugStackTrace!)
+      return debugReferrers
+          .map<StackTrace>((R referrer) => referrer.debugStackTrace)
           .toList();
     }
     return null;
   }
 
   /// The Skia object whose lifecycle is being managed.
-  final T skObject;
+  ///
+  /// Do not store this value outside this box. It is memory-managed by
+  /// [SkiaObjectBox]. Storing it may result in use-after-free bugs.
+  final T skiaObject;
   final SkDeletable _skDeletable;
 
   /// Whether this object has been deleted.
@@ -303,16 +322,21 @@ class SkiaObjectBox<T> {
   /// Deletes Skia objects when their wrappers are garbage collected.
   static final SkObjectFinalizationRegistry boxRegistry =
       SkObjectFinalizationRegistry(js.allowInterop((SkiaObjectBox box) {
-    box.delete();
+    box._skDeletable.delete();
   }));
 
-  /// Returns a clone of this object, which increases its reference count.
+  /// Increases the reference count of this box because a new object began
+  /// sharing ownership of the underlying [skiaObject].
   ///
   /// Clones must be [dispose]d when finished.
-  SkiaObjectBox<T> clone(Object wrapper) {
-    assert(!_isDeleted, 'Cannot clone from a deleted handle.');
-    assert(_refs.isNotEmpty);
-    return SkiaObjectBox<T>._(wrapper, skObject, _skDeletable, _refs);
+  void ref(R debugWrapper) {
+    assert(!_isDeleted, 'Cannot increment ref count on a deleted handle.');
+    assert(_refCount > 0);
+    _refCount += 1;
+    if (assertionsEnabled) {
+      debugReferrers.add(debugWrapper);
+    }
+    assert(refCount == debugReferrers.length);
   }
 
   /// Decrements the reference count for the [skObject].
@@ -321,15 +345,13 @@ class SkiaObjectBox<T> {
   ///
   /// If this causes the reference count to drop to zero, deletes the
   /// [skObject].
-  void delete() {
-    if (_isDeleted) {
-      assert(!_refs.contains(this));
-      return;
-    }
-    final bool removed = _refs.remove(this);
-    assert(removed);
-    _isDeleted = true;
-    if (_refs.isEmpty) {
+  void unref(R debugWrapper) {
+    assert(!_isDeleted, 'Attempted to unref an already deleted Skia object.');
+    _refCount -= 1;
+    assert(debugReferrers.remove(debugWrapper));
+    assert(refCount == debugReferrers.length);
+    if (_refCount == 0) {
+      _isDeleted = true;
       _scheduleSkObjectCollection(_skDeletable);
     }
   }
@@ -386,7 +408,7 @@ class SkiaObjects {
   ///
   /// Since it's expensive to resurrect, we shouldn't just delete it after every
   /// frame. Instead, add it to a cache and only delete it when the cache fills.
-  static void manageExpensive(ManagedSkiaObject object) {
+  static void manageExpensive(SkiaObject object) {
     registerCleanupCallback();
     expensiveCache.add(object);
   }

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1187,10 +1187,10 @@ void _canvasTests() {
     final CkImage image = await picture.toImage(1, 1);
     final ByteData rawData =
         await image.toByteData(format: ui.ImageByteFormat.rawRgba);
-    expect(rawData, isNotNull);
+    expect(rawData.lengthInBytes, greaterThan(0));
     final ByteData pngData =
         await image.toByteData(format: ui.ImageByteFormat.png);
-    expect(pngData, isNotNull);
+    expect(pngData.lengthInBytes, greaterThan(0));
   });
 }
 

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -24,9 +24,7 @@ void testMain() {
     });
 
     test('CkAnimatedImage can be explicitly disposed of', () {
-      final SkAnimatedImage skAnimatedImage =
-          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
-      final CkAnimatedImage image = CkAnimatedImage(skAnimatedImage);
+      final CkAnimatedImage image = CkAnimatedImage.decodeFromBytes(kTransparentImage);
       expect(image.box.isDeleted, false);
       expect(image.debugDisposed, false);
       image.dispose();
@@ -38,9 +36,8 @@ void testMain() {
     });
 
     test('CkAnimatedImage can be cloned and explicitly disposed of', () async {
-      final SkAnimatedImage skAnimatedImage =
-          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
-      final CkAnimatedImage image = CkAnimatedImage(skAnimatedImage);
+      final CkAnimatedImage image = CkAnimatedImage.decodeFromBytes(kTransparentImage);
+      final SkAnimatedImage skAnimatedImage = image.box.skiaObject;
       final SkiaObjectBox<CkAnimatedImage, SkAnimatedImage> box = image.box;
       expect(box.refCount, 1);
       expect(box.debugGetStackTraces().length, 1);

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
+import '../matchers.dart';
 import 'common.dart';
 import 'test_data.dart';
 
@@ -30,9 +31,9 @@ void testMain() {
       image.dispose();
       expect(image.box.isDeleted, true);
       expect(image.debugDisposed, true);
-      image.dispose();
-      expect(image.box.isDeleted, true);
-      expect(image.debugDisposed, true);
+
+      // Disallow double-dispose.
+      expect(() => image.dispose(), throwsAssertionError);
     });
 
     test('CkAnimatedImage can be cloned and explicitly disposed of', () async {
@@ -68,9 +69,9 @@ void testMain() {
       image.dispose();
       expect(image.debugDisposed, true);
       expect(image.box.isDeleted, true);
-      image.dispose();
-      expect(image.debugDisposed, true);
-      expect(image.box.isDeleted, true);
+
+      // Disallow double-dispose.
+      expect(() => image.dispose(), throwsAssertionError);
     });
 
     test('CkImage can be explicitly disposed of when cloned', () async {

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -23,14 +23,6 @@ void testMain() {
       await ui.webOnlyInitializePlatform();
     });
 
-    test('CkAnimatedImage toString', () {
-      final SkAnimatedImage skAnimatedImage =
-          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
-      final CkAnimatedImage image = CkAnimatedImage(skAnimatedImage);
-      expect(image.toString(), '[1×1]');
-      image.dispose();
-    });
-
     test('CkAnimatedImage can be explicitly disposed of', () {
       final SkAnimatedImage skAnimatedImage =
           canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
@@ -49,22 +41,15 @@ void testMain() {
       final SkAnimatedImage skAnimatedImage =
           canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
       final CkAnimatedImage image = CkAnimatedImage(skAnimatedImage);
-      final CkAnimatedImage imageClone = image.clone();
+      final SkiaObjectBox<CkAnimatedImage, SkAnimatedImage> box = image.box;
+      expect(box.refCount, 1);
+      expect(box.debugGetStackTraces().length, 1);
 
-      expect(image.isCloneOf(imageClone), true);
-      expect(image.box.isDeleted, false);
-      await Future<void>.delayed(Duration.zero);
-      expect(skAnimatedImage.isDeleted(), false);
       image.dispose();
-      expect(image.box.isDeleted, true);
-      expect(imageClone.box.isDeleted, false);
-      await Future<void>.delayed(Duration.zero);
-      expect(skAnimatedImage.isDeleted(), false);
-      imageClone.dispose();
-      expect(image.box.isDeleted, true);
-      expect(imageClone.box.isDeleted, true);
+      expect(box.isDeleted, true);
       await Future<void>.delayed(Duration.zero);
       expect(skAnimatedImage.isDeleted(), true);
+      expect(box.debugGetStackTraces().length, 0);
     });
 
     test('CkImage toString', () {
@@ -96,28 +81,42 @@ void testMain() {
           canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)
               .getCurrentFrame();
       final CkImage image = CkImage(skImage);
+      final SkiaObjectBox<CkImage, SkImage> box = image.box;
+      expect(box.refCount, 1);
+      expect(box.debugGetStackTraces().length, 1);
+
       final CkImage imageClone = image.clone();
+      expect(box.refCount, 2);
+      expect(box.debugGetStackTraces().length, 2);
 
       expect(image.isCloneOf(imageClone), true);
-      expect(image.box.isDeleted, false);
+      expect(box.isDeleted, false);
       await Future<void>.delayed(Duration.zero);
       expect(skImage.isDeleted(), false);
       image.dispose();
-      expect(image.box.isDeleted, true);
-      expect(imageClone.box.isDeleted, false);
+      expect(box.isDeleted, false);
       await Future<void>.delayed(Duration.zero);
       expect(skImage.isDeleted(), false);
       imageClone.dispose();
-      expect(image.box.isDeleted, true);
-      expect(imageClone.box.isDeleted, true);
+      expect(box.isDeleted, true);
       await Future<void>.delayed(Duration.zero);
       expect(skImage.isDeleted(), true);
+      expect(box.debugGetStackTraces().length, 0);
     });
 
     test('skiaInstantiateWebImageCodec throws exception if given invalid URL',
         () async {
       expect(skiaInstantiateWebImageCodec('invalid-url', null),
           throwsA(isA<ProgressEvent>()));
+    });
+
+    test('CkImage toByteData', () async {
+      final SkImage skImage =
+          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)
+              .getCurrentFrame();
+      final CkImage image = CkImage(skImage);
+      expect((await image.toByteData()).lengthInBytes, greaterThan(0));
+      expect((await image.toByteData(format: ui.ImageByteFormat.png)).lengthInBytes, greaterThan(0));
     });
     // TODO: https://github.com/flutter/flutter/issues/60040
   }, skip: isIosSafari);


### PR DESCRIPTION
## Description

- Make `Image` clones share the same `SkiaObjectBox` and track them using an `int refCount` (list of referrers is still available in debug mode, but in release mode we just increment/decrement `refCount`).
- `SkAnimatedImage` stops implementing `ui.Image` (it doesn't need to).
- Remove `CkAnimatedImageCodec`: it wasn't adding value; instead `CkAnimagedImage` now implements `ui.Codec`.
- Call `SkData.delete` after converting it to a local `Uint8List` in `toByteData`, fixing a memory leak.

## Related Issues

Progress towards https://github.com/flutter/flutter/issues/67148.

## Tests

Updated relevant existing tests.
