### PR TITLE
Add SDK licenses to DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -467,6 +467,17 @@ deps = {
      'dep_type': 'cipd',
    },
 
+  'src/third_party/android_tools/sdk/licenses': {
+     'packages': [
+       {
+        'package': 'flutter_internal/android/sdk/licenses',
+        'version': 'latest',
+       }
+     ],
+    'condition': 'download_android_deps',
+    'dep_type': 'cipd',
+  },
+
   'src/third_party/android_embedding_dependencies': {
      'packages': [
        {


### PR DESCRIPTION
Provides Android SDK licenses, so the step can be removed from the recipes.

## Related Issues

flutter/flutter#70633