### PR TITLE
Make the AndroidContext superclass destructor virtual

### DIFF
--- a/shell/platform/android/context/android_context.h
+++ b/shell/platform/android/context/android_context.h
@@ -22,7 +22,7 @@ class AndroidContext {
  public:
   explicit AndroidContext(AndroidRenderingAPI rendering_api);
 
-  ~AndroidContext();
+  virtual ~AndroidContext();
 
   AndroidRenderingAPI RenderingApi() const;
 

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -35,7 +35,6 @@ class AndroidSurfaceFactoryImpl : public AndroidSurfaceFactory {
  private:
   const AndroidContext& android_context_;
   std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
-  std::weak_ptr<AndroidExternalViewEmbedder> external_view_embedder_;
 };
 
 class PlatformViewAndroid final : public PlatformView {


### PR DESCRIPTION
Also remove an obsolete external_view_embedder reference from
AndroidSurfaceFactoryImpl.

Fixes https://github.com/flutter/flutter/issues/70621
