### PR TITLE
Service extension to dump skia memory statistics

### DIFF
--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -20,6 +20,8 @@
 
 namespace flutter {
 
+const std::string_view ServiceProtocol::kDumpSkiaMemoryExtensionName =
+    "_flutter.dumpSkiaMemory";
 const std::string_view ServiceProtocol::kScreenshotExtensionName =
     "_flutter.screenshot";
 const std::string_view ServiceProtocol::kScreenshotSkpExtensionName =
@@ -48,6 +50,7 @@ ServiceProtocol::ServiceProtocol()
           kListViewsExtensionName,
 
           // Public
+          kDumpSkiaMemoryExtensionName,
           kScreenshotExtensionName,
           kScreenshotSkpExtensionName,
           kRunInViewExtensionName,

--- a/runtime/service_protocol.h
+++ b/runtime/service_protocol.h
@@ -21,6 +21,7 @@ namespace flutter {
 
 class ServiceProtocol {
  public:
+  static const std::string_view kDumpSkiaMemoryExtensionName;
   static const std::string_view kScreenshotExtensionName;
   static const std::string_view kScreenshotSkpExtensionName;
   static const std::string_view kRunInViewExtensionName;

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -16,6 +16,7 @@
 #include "third_party/skia/include/core/SkSerialProcs.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkSurfaceCharacterization.h"
+#include "third_party/skia/include/core/SkTraceMemoryDump.h"
 #include "third_party/skia/include/utils/SkBase64.h"
 
 // When screenshotting we want to ensure we call the base method for
@@ -682,9 +683,7 @@ void Rasterizer::SetResourceCacheMaxBytes(size_t max_bytes, bool from_user) {
 
   GrDirectContext* context = surface_->GetContext();
   if (context) {
-    int max_resources;
-    context->getResourceCacheLimits(&max_resources, nullptr);
-    context->setResourceCacheLimits(max_resources, max_bytes);
+    context->setResourceCacheLimit(max_bytes);
   }
 }
 
@@ -699,6 +698,61 @@ std::optional<size_t> Rasterizer::GetResourceCacheMaxBytes() const {
     return max_bytes;
   }
   return std::nullopt;
+}
+
+class SkTraceMemoryDumpJson : public SkTraceMemoryDump {
+ public:
+  SkTraceMemoryDumpJson(rapidjson::Document* response)
+      : values_(rapidjson::kArrayType), response_(response) {}
+
+  void dumpNumericValue(const char* dumpName,
+                        const char* valueName,
+                        const char* units,
+                        uint64_t value) override {
+    rapidjson::Value json;
+    json.SetObject();
+    json.AddMember("dumpName", std::string(dumpName),
+                   response_->GetAllocator());
+    json.AddMember("valueName", std::string(valueName),
+                   response_->GetAllocator());
+    json.AddMember("units", std::string(units), response_->GetAllocator());
+    json.AddMember("value", value, response_->GetAllocator());
+    values_.PushBack(json, response_->GetAllocator());
+  }
+  void setMemoryBacking(const char* dumpName,
+                        const char* backingType,
+                        const char* backingObjectId) override {}
+  void setDiscardableMemoryBacking(
+      const char* dumpName,
+      const SkDiscardableMemory& discardableMemoryObject) override {}
+  LevelOfDetail getRequestedDetails() const override {
+    return SkTraceMemoryDump::kObjectsBreakdowns_LevelOfDetail;
+  }
+  bool shouldDumpWrappedObjects() const override { return true; }
+
+  void finish() {
+    response_->AddMember("data", values_, response_->GetAllocator());
+  }
+
+ private:
+  rapidjson::Value values_;
+  rapidjson::Document* response_;
+};
+
+void Rasterizer::WriteGraphicsContextStatistics(rapidjson::Document* response) {
+  if (!surface_) {
+    response->AddMember<bool>("hasContext", false, response->GetAllocator());
+    return;
+  }
+  auto context = surface_->GetContext();
+  if (!context) {
+    response->AddMember<bool>("hasContext", false, response->GetAllocator());
+    return;
+  }
+  response->AddMember<bool>("hasContext", true, response->GetAllocator());
+  SkTraceMemoryDumpJson traceMemoryDump(response);
+  context->dumpMemoryStatistics(&traceMemoryDump);
+  traceMemoryDump.finish();
 }
 
 Rasterizer::Screenshot::Screenshot() {}

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -23,6 +23,7 @@
 #include "flutter/fml/time/time_point.h"
 #include "flutter/lib/ui/snapshot_delegate.h"
 #include "flutter/shell/common/pipeline.h"
+#include "rapidjson/document.h"
 
 namespace flutter {
 
@@ -432,6 +433,15 @@ class Rasterizer final : public SnapshotDelegate {
   /// @see        `ExternalViewEmbedder`
   ///
   void DisableThreadMergerIfNeeded();
+
+  //----------------------------------------------------------------------------
+  /// @brief       Writes an array of Skia memory usage information to the
+  ///              `response`. This method is intended for use with the
+  ///              `_flutter.dumpSkiaMemory` service protocol extension.
+  ///
+  /// @param[out]  response  The JSON document to write an array of Skia memory
+  ///                        statistics into.
+  void WriteGraphicsContextStatistics(rapidjson::Document* response);
 
  private:
   Delegate& delegate_;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -572,6 +572,11 @@ class Shell final : public PlatformView::Delegate,
       const override;
 
   // Service protocol handler
+  bool OnServiceProtocolDumpSkiaMemory(
+      const ServiceProtocol::Handler::ServiceProtocolMap& params,
+      rapidjson::Document* response);
+
+  // Service protocol handler
   bool OnServiceProtocolScreenshot(
       const ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document* response);

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -247,6 +247,9 @@ void ShellTest::OnServiceProtocol(
   fml::TaskRunner::RunNowOrPostTask(
       task_runner, [shell, some_protocol, params, response, &finished]() {
         switch (some_protocol) {
+          case ServiceProtocolEnum::kDumpSkiaMemory:
+            shell->OnServiceProtocolDumpSkiaMemory(params, response);
+            break;
           case ServiceProtocolEnum::kGetSkSLs:
             shell->OnServiceProtocolGetSkSLs(params, response);
             break;

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -97,6 +97,7 @@ class ShellTest : public FixtureTest {
     kEstimateRasterCacheMemory,
     kSetAssetBundlePath,
     kRunInView,
+    kDumpSkiaMemory,
   };
 
   // Helper method to test private method Shell::OnServiceProtocolGetSkSLs.

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2023,6 +2023,26 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
   DestroyShell(std::move(shell));
 }
 
+TEST_F(ShellTest, OnServiceProtocolDumpSkiaMemoryWorks) {
+  Settings settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  ServiceProtocol::Handler::ServiceProtocolMap empty_params;
+  rapidjson::Document document;
+  OnServiceProtocol(shell.get(), ServiceProtocolEnum::kDumpSkiaMemory,
+                    shell->GetTaskRunners().GetRasterTaskRunner(), empty_params,
+                    &document);
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  document.Accept(writer);
+  std::string expected_json =
+      "{\"type\":\"DumpSkiaMemory\",\"hasContext\":false}";
+  std::string actual_json = buffer.GetString();
+  ASSERT_EQ(actual_json, expected_json);
+
+  DestroyShell(std::move(shell));
+}
+
 TEST_F(ShellTest, DiscardLayerTreeOnResize) {
   auto settings = CreateSettingsForFixture();
 


### PR DESCRIPTION
This dumps information from `GrContext::dumpMemoryStatistics` to JSON. The implementation is a little tightly coupled, but I'm not sure what other use cases we'd have for this and would rather not over-engineer it.

One thing I see that's concerning is that this can cause segfaults if run when the device screen is turned off. I think that may be a NPE issue on the Skia side.