### PR TITLE
Implement image resurrection

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -99,6 +99,23 @@ class CanvasKit {
   /// Creates an [SkPath] using commands obtained from [SkPath.toCmds].
   // TODO(yjbanov): switch to CanvasKit.Path.MakeFromCmds when it's available.
   external SkPath MakePathFromCmds(List<dynamic> pathCommands);
+
+  /// Creates an image from decoded pixels represented as a list of bytes.
+  ///
+  /// The pixel data must match the [width], [height], [alphaType], [colorType],
+  /// and [colorSpace].
+  ///
+  /// Typically pixel data is obtained using [SkImage.readPixels]. The
+  /// parameters specified in [SkImageInfo] passed [SkImage.readPixels] much
+  /// match the arguments passed to this method.
+  external SkImage MakeImage(
+    Uint8List imageData,
+    int width,
+    int height,
+    SkAlphaType alphaType,
+    SkColorType colorType,
+    ColorSpace colorSpace,
+  );
 }
 
 @JS('window.CanvasKitInit')
@@ -1726,48 +1743,159 @@ class TypefaceFontProviderNamespace {
   external TypefaceFontProvider Make();
 }
 
-Timer? _skObjectCollector;
-List<SkDeletable> _skObjectDeleteQueue = <SkDeletable>[];
+/// Collects Skia objects that are no longer necessary.
+abstract class Collector {
+  /// The production collector implementation.
+  static final Collector _productionInstance = ProductionCollector();
 
-final SkObjectFinalizationRegistry skObjectFinalizationRegistry =
-    SkObjectFinalizationRegistry(js.allowInterop((SkDeletable deletable) {
-  _scheduleSkObjectCollection(deletable);
-}));
+  /// The collector implementation currently in use.
+  static Collector get instance => _instance;
+  static Collector _instance = _productionInstance;
 
-/// Schedules a Skia object for deletion in an asap timer.
+  /// In tests overrides the collector implementation.
+  static void debugOverrideCollector(Collector override) {
+    _instance = override;
+  }
+
+  /// In tests restores the collector to the production implementation.
+  static void debugRestoreCollector() {
+    _instance = _productionInstance;
+  }
+
+  /// Registers a [deletable] for collection when the [wrapper] object is
+  /// garbage collected.
+  ///
+  /// The [debugLabel] is used to track the origin of the deletable.
+  void register(Object wrapper, SkDeletable deletable);
+
+  /// Deletes the [deletable].
+  ///
+  /// The exact timing of the deletion is implementation-specific. For example,
+  /// a production implementation may want to batch deletables and schedule a
+  /// timer to collect them instead of deleting right away.
+  ///
+  /// A test implementation may want a collection strategy that's less efficient
+  /// but more predictable.
+  void collect(SkDeletable deletable);
+}
+
+/// Uses the browser's real `FinalizationRegistry` to collect objects.
 ///
-/// A timer is used for the following reasons:
-///
-///  - Deleting the object immediately may lead to dangling pointer as the Skia
-///    object may still be used by a function in the current frame. For example,
-///    a `CkPaint` + `SkPaint` pair may be created by the framework, passed to
-///    the engine, and the `CkPaint` dropped immediately. Because GC can kick in
-///    any time, including in the middle of the event, we may delete `SkPaint`
-///    prematurely.
-///  - A microtask, while solves the problem above, would prevent the event from
-///    yielding to the graphics system to render the frame on the screen if there
-///    is a large number of objects to delete, causing jank.
-///
-/// Because scheduling a timer is expensive, the timer is shared by all objects
-/// deleted this frame. No timer is created if no objects were scheduled for
-/// deletion.
-void _scheduleSkObjectCollection(SkDeletable deletable) {
-  _skObjectDeleteQueue.add(deletable);
-  _skObjectCollector ??= Timer(Duration.zero, () {
+/// Uses timers to delete objects in batches and outside the animation frame.
+class ProductionCollector implements Collector {
+  ProductionCollector() {
+    _skObjectFinalizationRegistry = SkObjectFinalizationRegistry(js.allowInterop((SkDeletable deletable) {
+      // This is called when GC decides to collect the wrapper object and
+      // notify us, which may happen after the object is already deleted
+      // explicitly, e.g. when its ref count drops to zero. When that happens
+      // skip collection of this object.
+      if (!deletable.isDeleted()) {
+        collect(deletable);
+      }
+    }));
+  }
+
+  late final SkObjectFinalizationRegistry _skObjectFinalizationRegistry;
+  List<SkDeletable> _skiaObjectCollectionQueue = <SkDeletable>[];
+  Timer? _skiaObjectCollectionTimer;
+
+  @override
+  void register(Object wrapper, SkDeletable deletable) {
+    _skObjectFinalizationRegistry.register(wrapper, deletable);
+  }
+
+  /// Schedules a Skia object for deletion in an asap timer.
+  ///
+  /// A timer is used for the following reasons:
+  ///
+  ///  - Deleting the object immediately may lead to dangling pointer as the Skia
+  ///    object may still be used by a function in the current frame. For example,
+  ///    a `CkPaint` + `SkPaint` pair may be created by the framework, passed to
+  ///    the engine, and the `CkPaint` dropped immediately. Because GC can kick in
+  ///    any time, including in the middle of the event, we may delete `SkPaint`
+  ///    prematurely.
+  ///  - A microtask, while solves the problem above, would prevent the event from
+  ///    yielding to the graphics system to render the frame on the screen if there
+  ///    is a large number of objects to delete, causing jank.
+  ///
+  /// Because scheduling a timer is expensive, the timer is shared by all objects
+  /// deleted this frame. No timer is created if no objects were scheduled for
+  /// deletion.
+  @override
+  void collect(SkDeletable deletable) {
+    assert(
+      !deletable.isDeleted(),
+      'Attempted to delete an already deleted Skia object.',
+    );
+    _skiaObjectCollectionQueue.add(deletable);
+
+    _skiaObjectCollectionTimer ??= Timer(Duration.zero, () {
+      // Null out the timer so we can schedule a new one next time objects are
+      // scheduled for deletion.
+      _skiaObjectCollectionTimer = null;
+      collectSkiaObjectsNow();
+    });
+  }
+
+  /// Deletes all Skia objects pending deletion synchronously.
+  ///
+  /// After calling this method [_skiaObjectCollectionQueue] is empty.
+  ///
+  /// Throws a [SkiaObjectCollectionError] if CanvasKit fails to delete at least
+  /// one object. The error is populated with information about the first failed
+  /// object. Upon an error the collection continues and the collection queue is
+  /// emptied out to prevent memory leaks. This may happen, for example, when the
+  /// same object is deleted more than once.
+  void collectSkiaObjectsNow() {
     html.window.performance.mark('SkObject collection-start');
-    final int length = _skObjectDeleteQueue.length;
+    final int length = _skiaObjectCollectionQueue.length;
+    dynamic firstError;
+    StackTrace? firstStackTrace;
     for (int i = 0; i < length; i++) {
-      _skObjectDeleteQueue[i].delete();
+      final SkDeletable deletable = _skiaObjectCollectionQueue[i];
+      if (deletable.isDeleted()) {
+        // Some Skia objects are ref counted and are deleted before GC and/or
+        // the collection timer begins collecting them. So we have to check
+        // again if the objects is worth collecting.
+        continue;
+      }
+      try {
+        deletable.delete();
+      } catch (error, stackTrace) {
+        // Remember the error, but keep going. If for some reason CanvasKit fails
+        // to delete an object we still want to delete other objects and empty
+        // out the queue. Otherwise, the queue will never be flushed and keep
+        // accumulating objects, a.k.a. memory leak.
+        if (firstError == null) {
+          firstError = error;
+          firstStackTrace = stackTrace;
+        }
+      }
     }
-    _skObjectDeleteQueue = <SkDeletable>[];
+    _skiaObjectCollectionQueue = <SkDeletable>[];
 
-    // Null out the timer so we can schedule a new one next time objects are
-    // scheduled for deletion.
-    _skObjectCollector = null;
     html.window.performance.mark('SkObject collection-end');
     html.window.performance.measure('SkObject collection',
         'SkObject collection-start', 'SkObject collection-end');
-  });
+
+    // It's safe to throw the error here, now that we've processed the queue.
+    if (firstError != null) {
+      throw SkiaObjectCollectionError(firstError, firstStackTrace);
+    }
+  }
+}
+
+/// Thrown by [ProductionCollector] when Skia object collection fails.
+class SkiaObjectCollectionError implements Error {
+  SkiaObjectCollectionError(this.error, this.stackTrace);
+
+  final dynamic error;
+
+  @override
+  final StackTrace? stackTrace;
+
+  @override
+  String toString() => 'SkiaObjectCollectionError: $error\n$stackTrace';
 }
 
 /// Any Skia object that has a `delete` method.
@@ -1776,6 +1904,9 @@ void _scheduleSkObjectCollection(SkDeletable deletable) {
 class SkDeletable {
   /// Deletes the C++ side object.
   external void delete();
+
+  /// Returns whether the correcponding C++ object has been deleted.
+  external bool isDeleted();
 }
 
 /// Attaches a weakly referenced object to another object and calls a finalizer

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -20,13 +20,7 @@ void main() {
 
 void testMain() {
   group('CanvasKit API', () {
-    setUpAll(() async {
-      await ui.webOnlyInitializePlatform();
-    });
-
-    test('Using CanvasKit', () {
-      expect(useCanvasKit, true);
-    });
+    setUpCanvasKitTest();
 
     _blendModeTests();
     _paintStyleTests();

--- a/lib/web_ui/test/canvaskit/common.dart
+++ b/lib/web_ui/test/canvaskit/common.dart
@@ -2,10 +2,161 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+import 'package:test/test.dart';
+
 import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
 
 /// Whether we are running on iOS Safari.
 // TODO: https://github.com/flutter/flutter/issues/60040
 bool get isIosSafari => browserEngine == BrowserEngine.webkit &&
           operatingSystem == OperatingSystem.iOs;
+
+/// Used in tests instead of [ProductionCollector] to control Skia object
+/// collection explicitly, and to prevent leaks across tests.
+///
+/// See [TestCollector] for usage.
+late TestCollector testCollector;
+
+/// Common test setup for all CanvasKit unit-tests.
+void setUpCanvasKitTest() {
+  setUpAll(() async {
+    expect(useCanvasKit, true,
+      reason: 'This test must run in CanvasKit mode.');
+    debugResetBrowserSupportsFinalizationRegistry();
+    await ui.webOnlyInitializePlatform();
+  });
+
+  setUp(() async {
+    testCollector = TestCollector();
+    Collector.debugOverrideCollector(testCollector);
+  });
+
+  tearDown(() {
+    testCollector.cleanUpAfterTest();
+    debugResetBrowserSupportsFinalizationRegistry();
+  });
+
+  tearDownAll(() {
+    debugResetBrowserSupportsFinalizationRegistry();
+  });
+}
+
+class _TestFinalizerRegistration {
+  _TestFinalizerRegistration(this.wrapper, this.deletable, this.stackTrace);
+
+  final Object wrapper;
+  final SkDeletable deletable;
+  final StackTrace stackTrace;
+}
+
+class _TestCollection {
+  _TestCollection(this.deletable, this.stackTrace);
+
+  final SkDeletable deletable;
+  final StackTrace stackTrace;
+}
+
+/// Provides explicit synchronous API for collecting Skia objects in tests.
+///
+/// [ProductionCollector] relies on `FinalizationRegistry` and timers to
+/// delete Skia objects, which makes it more precise and efficient. However,
+/// it also makes it unpredictable. For example, an object created in one
+/// test may be collected while running another test because the timing is
+/// subject to browser-specific GC scheduling.
+///
+/// Tests should use [collectNow] and [collectAfterTest] to trigger collections.
+class TestCollector implements Collector {
+  final List<_TestFinalizerRegistration> _activeRegistrations = <_TestFinalizerRegistration>[];
+  final List<_TestFinalizerRegistration> _collectedRegistrations = <_TestFinalizerRegistration>[];
+
+  final List<_TestCollection> _pendingCollections = <_TestCollection>[];
+  final List<_TestCollection> _completedCollections = <_TestCollection>[];
+
+  @override
+  void register(Object wrapper, SkDeletable deletable) {
+    _activeRegistrations.add(
+      _TestFinalizerRegistration(wrapper, deletable, StackTrace.current),
+    );
+  }
+
+  @override
+  void collect(SkDeletable deletable) {
+    _pendingCollections.add(
+      _TestCollection(deletable, StackTrace.current),
+    );
+  }
+
+  /// Deletes all Skia objects scheduled for collection.
+  void collectNow() {
+    for (_TestCollection collection in _pendingCollections) {
+      late final _TestFinalizerRegistration? activeRegistration;
+      for (_TestFinalizerRegistration registration in _activeRegistrations) {
+        if (identical(registration.deletable, collection.deletable)) {
+          activeRegistration = registration;
+          break;
+        }
+      }
+      if (activeRegistration == null) {
+        late final _TestFinalizerRegistration? collectedRegistration;
+        for (_TestFinalizerRegistration registration in _collectedRegistrations) {
+          if (identical(registration.deletable, collection.deletable)) {
+            collectedRegistration = registration;
+            break;
+          }
+        }
+        if (collectedRegistration == null) {
+          fail(
+            'Attempted to collect an object that was never registered for finalization.\n'
+            'The collection was requested here:\n'
+            '${collection.stackTrace}'
+          );
+        } else {
+          final _TestCollection firstCollection = _completedCollections.firstWhere(
+            (_TestCollection completedCollection) {
+              return identical(completedCollection.deletable, collection.deletable);
+            }
+          );
+          fail(
+            'Attempted to collect an object that was previously collected.\n'
+            'The object was registered for finalization here:\n'
+            '${collection.stackTrace}\n\n'
+            'The first collection was requested here:\n'
+            '${firstCollection.stackTrace}\n\n'
+            'The second collection was requested here:\n'
+            '${collection.stackTrace}'
+          );
+        }
+      } else {
+        _collectedRegistrations.add(activeRegistration);
+        _activeRegistrations.remove(activeRegistration);
+        _completedCollections.add(collection);
+        if (!collection.deletable.isDeleted()) {
+          collection.deletable.delete();
+        }
+      }
+    }
+    _pendingCollections.clear();
+  }
+
+  /// Deletes all Skia objects with registered finalizers.
+  ///
+  /// This also deletes active objects that have not been scheduled for
+  /// collection, to prevent objects leaking across tests.
+  void cleanUpAfterTest() {
+    for (_TestCollection collection in _pendingCollections) {
+      if (!collection.deletable.isDeleted()) {
+        collection.deletable.delete();
+      }
+    }
+    for (_TestFinalizerRegistration registration in _activeRegistrations) {
+      if (!registration.deletable.isDeleted()) {
+        registration.deletable.delete();
+      }
+    }
+    _activeRegistrations.clear();
+    _collectedRegistrations.clear();
+    _pendingCollections.clear();
+    _completedCollections.clear();
+  }
+}

--- a/lib/web_ui/test/canvaskit/filter_test.dart
+++ b/lib/web_ui/test/canvaskit/filter_test.dart
@@ -47,9 +47,7 @@ void testMain() {
   }
 
   group('ImageFilters', () {
-    setUpAll(() async {
-      await ui.webOnlyInitializePlatform();
-    });
+    setUpCanvasKitTest();
 
     test('can be constructed', () {
       final CkImageFilter imageFilter = CkImageFilter.blur(sigmaX: 5, sigmaY: 10);

--- a/lib/web_ui/test/canvaskit/frame_timings_test.dart
+++ b/lib/web_ui/test/canvaskit/frame_timings_test.dart
@@ -5,8 +5,6 @@
 // @dart = 2.6
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
-import 'package:ui/src/engine.dart';
-import 'package:ui/ui.dart' as ui;
 
 import 'common.dart';
 import '../frame_timings_common.dart';
@@ -17,13 +15,7 @@ void main() {
 
 void testMain() {
   group('frame timings', () {
-    setUpAll(() async {
-      await ui.webOnlyInitializePlatform();
-    });
-
-    test('Using CanvasKit', () {
-      expect(useCanvasKit, true);
-    });
+    setUpCanvasKitTest();
 
     test('collects frame timings', () async {
       await runFrameTimingsTest();

--- a/lib/web_ui/test/canvaskit/path_test.dart
+++ b/lib/web_ui/test/canvaskit/path_test.dart
@@ -17,14 +17,7 @@ void main() {
 
 void testMain() {
   group('CkPath', () {
-    setUpAll(() async {
-      debugResetBrowserSupportsFinalizationRegistry();
-      await ui.webOnlyInitializePlatform();
-    });
-
-    tearDown(() {
-      debugResetBrowserSupportsFinalizationRegistry();
-    });
+    setUpCanvasKitTest();
 
     test('Using CanvasKit', () {
       expect(useCanvasKit, true);

--- a/lib/web_ui/test/canvaskit/shader_test.dart
+++ b/lib/web_ui/test/canvaskit/shader_test.dart
@@ -19,9 +19,7 @@ void main() {
 
 void testMain() {
   group('CanvasKit shaders', () {
-    setUpAll(() async {
-      await ui.webOnlyInitializePlatform();
-    });
+    setUpCanvasKitTest();
 
     test('Sweep gradient', () {
       final CkGradientSweep gradient = ui.Gradient.sweep(

--- a/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
+++ b/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
@@ -8,7 +8,6 @@ import 'package:mockito/mockito.dart';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 
-import 'package:ui/ui.dart' as ui;
 import 'package:ui/src/engine.dart';
 
 import '../matchers.dart';
@@ -27,19 +26,13 @@ void testMain() {
 
 void _tests() {
   SkiaObjects.maximumCacheSize = 4;
-  bool originalBrowserSupportsFinalizationRegistry;
 
-  setUpAll(() async {
-    await ui.webOnlyInitializePlatform();
+  setUpCanvasKitTest();
 
+  setUp(() async {
     // Pretend the browser does not support FinalizationRegistry so we can test the
     // resurrection logic.
-    originalBrowserSupportsFinalizationRegistry = browserSupportsFinalizationRegistry;
     browserSupportsFinalizationRegistry = false;
-  });
-
-  tearDownAll(() {
-    browserSupportsFinalizationRegistry = originalBrowserSupportsFinalizationRegistry;
   });
 
   group(ManagedSkiaObject, () {
@@ -158,11 +151,12 @@ void _tests() {
   group(SkiaObjectBox, () {
     test('Records stack traces and respects refcounts', () async {
       TestSkDeletable.deleteCount = 0;
+      TestBoxWrapper.resurrectCount = 0;
       final TestBoxWrapper original = TestBoxWrapper();
 
       expect(original.box.debugGetStackTraces().length, 1);
       expect(original.box.refCount, 1);
-      expect(original.box.isDeleted, false);
+      expect(original.box.isDeletedPermanently, false);
 
       final TestBoxWrapper clone = original.clone();
       expect(clone.box, same(original.box));
@@ -170,12 +164,11 @@ void _tests() {
       expect(clone.box.refCount, 2);
       expect(original.box.debugGetStackTraces().length, 2);
       expect(original.box.refCount, 2);
-      expect(original.box.isDeleted, false);
+      expect(original.box.isDeletedPermanently, false);
 
       original.dispose();
 
-      // Let Skia object delete queue run.
-      await Future<void>.delayed(Duration.zero);
+      testCollector.collectNow();
       expect(TestSkDeletable.deleteCount, 0);
 
       expect(clone.box.debugGetStackTraces().length, 1);
@@ -184,18 +177,62 @@ void _tests() {
       expect(original.box.refCount, 1);
 
       clone.dispose();
-
-      // Let Skia object delete queue run.
-      await Future<void>.delayed(Duration.zero);
-      expect(TestSkDeletable.deleteCount, 1);
-
       expect(clone.box.debugGetStackTraces().length, 0);
       expect(clone.box.refCount, 0);
       expect(original.box.debugGetStackTraces().length, 0);
       expect(original.box.refCount, 0);
-      expect(original.box.isDeleted, true);
+      expect(original.box.isDeletedPermanently, true);
+
+      testCollector.collectNow();
+      expect(TestSkDeletable.deleteCount, 1);
+      expect(TestBoxWrapper.resurrectCount, 0);
 
       expect(() => clone.box.unref(clone), throwsAssertionError);
+    });
+
+    test('Can resurrect Skia objects', () async {
+      TestSkDeletable.deleteCount = 0;
+      TestBoxWrapper.resurrectCount = 0;
+      final TestBoxWrapper object = TestBoxWrapper();
+      expect(TestSkDeletable.deleteCount, 0);
+      expect(TestBoxWrapper.resurrectCount, 0);
+
+      // Test 3 cycles of delete/resurrect.
+      for (int i = 0; i < 3; i++) {
+        object.box.delete();
+        object.box.didDelete();
+        expect(TestSkDeletable.deleteCount, i + 1);
+        expect(TestBoxWrapper.resurrectCount, i);
+        expect(object.box.isDeletedTemporarily, true);
+        expect(object.box.isDeletedPermanently, false);
+
+        expect(object.box.skiaObject, isNotNull);
+        expect(TestSkDeletable.deleteCount, i + 1);
+        expect(TestBoxWrapper.resurrectCount, i + 1);
+        expect(object.box.isDeletedTemporarily, false);
+        expect(object.box.isDeletedPermanently, false);
+      }
+
+      object.dispose();
+      expect(object.box.isDeletedPermanently, true);
+    });
+
+    test('Can dispose temporarily deleted object', () async {
+      TestSkDeletable.deleteCount = 0;
+      TestBoxWrapper.resurrectCount = 0;
+      final TestBoxWrapper object = TestBoxWrapper();
+      expect(TestSkDeletable.deleteCount, 0);
+      expect(TestBoxWrapper.resurrectCount, 0);
+
+      object.box.delete();
+      object.box.didDelete();
+      expect(TestSkDeletable.deleteCount, 1);
+      expect(TestBoxWrapper.resurrectCount, 0);
+      expect(object.box.isDeletedTemporarily, true);
+      expect(object.box.isDeletedPermanently, false);
+
+      object.dispose();
+      expect(object.box.isDeletedPermanently, true);
     });
   });
 }
@@ -204,11 +241,20 @@ void _tests() {
 ///
 /// Can be [clone]d such that the clones share the same ref counted box.
 class TestBoxWrapper implements StackTraceDebugger {
+  static int resurrectCount = 0;
+
   TestBoxWrapper() {
     if (assertionsEnabled) {
       _debugStackTrace = StackTrace.current;
     }
-    box = SkiaObjectBox<TestBoxWrapper, TestSkDeletable>(this, TestSkDeletable());
+    box = SkiaObjectBox<TestBoxWrapper, TestSkDeletable>.resurrectable(
+      this,
+      TestSkDeletable(),
+      () {
+        resurrectCount += 1;
+        return TestSkDeletable();
+      }
+    );
   }
 
   TestBoxWrapper.cloneOf(this.box) {
@@ -236,7 +282,14 @@ class TestSkDeletable implements SkDeletable {
   static int deleteCount = 0;
 
   @override
+  bool isDeleted() => _isDeleted;
+  bool _isDeleted = false;
+
+  @override
   void delete() {
+    expect(_isDeleted, isFalse,
+      reason: 'CanvasKit does not allow deleting the same object more than once.');
+    _isDeleted = true;
     deleteCount++;
   }
 }
@@ -247,7 +300,13 @@ class TestOneShotSkiaObject extends OneShotSkiaObject<SkPaint> implements SkDele
   TestOneShotSkiaObject() : super(SkPaint());
 
   @override
+  bool isDeleted() => _isDeleted;
+  bool _isDeleted = false;
+
+  @override
   void delete() {
+    expect(_isDeleted, isFalse,
+      reason: 'CanvasKit does not allow deleting the same object more than once.');
     rawSkiaObject?.delete();
     deleteCount++;
   }

--- a/lib/web_ui/test/canvaskit/vertices_test.dart
+++ b/lib/web_ui/test/canvaskit/vertices_test.dart
@@ -16,9 +16,7 @@ void main() {
 
 void testMain() {
   group('Vertices', () {
-    setUpAll(() async {
-      await ui.webOnlyInitializePlatform();
-    });
+    setUpCanvasKitTest();
 
     test('can be constructed, drawn, and deleted', () {
       final CkVertices vertices = _testVertices();


### PR DESCRIPTION
## Description

- Teach `SkiaObjectBox` to resurrect its underlying Skia object and make `CkImage` resurrectable. This should plug leaking images that are not held onto by pictures. Fixing pictures will be a future PR.
- Consolidate finalization logic into an abstract `Collector` class with a `ProductionCollector` implementation for production usage, and `TestCollector` implementation for tests.
- Add a `setUpCanvasKitTest` that performs validation and clean-up of Skia objects, making sure test state does not leak from test to test (GC is unpredictable, sometimes causing one test collecting objects created by another tests, resulting in hard-to-explain test failures).

## Related Issues

Progress towards https://github.com/flutter/flutter/issues/67148.

## Tests

Updated `image_test.dart` and `skia_object_cache_test.dart`.