### PR TITLE
Fix typos and fix some env var state leakage in tests

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2225,7 +2225,7 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
   ///
   /// The `scale` parameter will scale the `width` and `height` by the specified amount,
   /// and keep track of the scale. The scales of placeholders added can be accessed
-  /// through [placeholderScales]. This is primarily used for acessibility scaling.
+  /// through [placeholderScales]. This is primarily used for accessibility scaling.
   void addPlaceholder(double width, double height, PlaceholderAlignment alignment, {
     double scale = 1.0,
     double? baselineOffset,

--- a/shell/platform/common/cpp/engine_switches.cc
+++ b/shell/platform/common/cpp/engine_switches.cc
@@ -19,8 +19,10 @@ std::vector<std::string> GetSwitchesFromEnvironment() {
   const char* switch_count_key = "FLUTTER_ENGINE_SWITCHES";
   const int kMaxSwitchCount = 50;
   const char* switch_count_string = std::getenv(switch_count_key);
-  int switch_count = std::min(
-      kMaxSwitchCount, switch_count_string ? atoi(switch_count_string) : 0);
+  if (!switch_count_string) {
+    return switches;
+  }
+  int switch_count = std::min(kMaxSwitchCount, atoi(switch_count_string));
   for (int i = 1; i <= switch_count; ++i) {
     std::ostringstream switch_key;
     switch_key << "FLUTTER_ENGINE_SWITCH_" << i;

--- a/shell/platform/linux/fl_basic_message_channel.cc
+++ b/shell/platform/linux/fl_basic_message_channel.cc
@@ -33,7 +33,7 @@ struct _FlBasicMessageChannelResponseHandle {
   FlBinaryMessengerResponseHandle* response_handle;
 };
 
-// Added here to stop the compiler from optimising this function away.
+// Added here to stop the compiler from optimizing this function away.
 G_MODULE_EXPORT GType fl_basic_message_channel_get_type();
 
 G_DEFINE_TYPE(FlBasicMessageChannel, fl_basic_message_channel, G_TYPE_OBJECT)

--- a/shell/platform/linux/fl_binary_messenger_test.cc
+++ b/shell/platform/linux/fl_binary_messenger_test.cc
@@ -175,7 +175,7 @@ TEST(FlBinaryMessengerTest, ReceiveMessage) {
   fl_binary_messenger_set_message_handler_on_channel(
       messenger, "test/responses", response_cb, loop, nullptr);
 
-  // Triggger the engine to send a message.
+  // Trigger the engine to send a message.
   const char* text = "Marco!";
   g_autoptr(GBytes) message = g_bytes_new(text, strlen(text));
   fl_binary_messenger_send_on_channel(messenger, "test/send-message", message,

--- a/shell/platform/linux/fl_dart_project_test.cc
+++ b/shell/platform/linux/fl_dart_project_test.cc
@@ -63,5 +63,9 @@ TEST(FlDartProjectTest, Switches) {
                "--abc");
   EXPECT_STREQ(static_cast<const char*>(g_ptr_array_index(switches, 1)),
                "--foo=\"bar, baz\"");
+
+  unsetenv("FLUTTER_ENGINE_SWITCHES");
+  unsetenv("FLUTTER_ENGINE_SWITCH_1");
+  unsetenv("FLUTTER_ENGINE_SWITCH_2");
 }
 #endif  // !FLUTTER_RELEASE

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -484,7 +484,7 @@ gboolean fl_engine_send_platform_message_response(
 
   if (result != kSuccess) {
     g_set_error(error, fl_engine_error_quark(), FL_ENGINE_ERROR_FAILED,
-                "Failed to send platorm message response");
+                "Failed to send platform message response");
     return FALSE;
   }
 

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -73,7 +73,7 @@ FlutterEngineProcTable* fl_engine_get_embedder_api(FlEngine* engine);
  * @destroy_notify: (allow-none): a function which gets called to free
  * @user_data, or %NULL.
  *
- * Registers the function called when a platform message is reveived. Call
+ * Registers the function called when a platform message is received. Call
  * fl_engine_send_platform_message_response() with the response to this message.
  * Ownership of #FlutterPlatformMessageResponseHandle is
  * transferred to the caller, and the message must be responded to to avoid

--- a/shell/platform/linux/fl_event_channel.cc
+++ b/shell/platform/linux/fl_event_channel.cc
@@ -37,7 +37,7 @@ struct _FlEventChannelResponseHandle {
   FlBinaryMessengerResponseHandle* response_handle;
 };
 
-// Added here to stop the compiler from optimising this function away.
+// Added here to stop the compiler from optimizing this function away.
 G_MODULE_EXPORT GType fl_event_channel_get_type();
 
 G_DEFINE_TYPE(FlEventChannel, fl_event_channel, G_TYPE_OBJECT)

--- a/shell/platform/linux/fl_json_method_codec.cc
+++ b/shell/platform/linux/fl_json_method_codec.cc
@@ -62,7 +62,7 @@ static gboolean fl_json_method_codec_decode_method_call(FlMethodCodec* codec,
 
   if (fl_value_get_type(value) != FL_VALUE_TYPE_MAP) {
     g_set_error(error, FL_MESSAGE_CODEC_ERROR, FL_MESSAGE_CODEC_ERROR_FAILED,
-                "Expected JSON map in method resonse, got %d instead",
+                "Expected JSON map in method response, got %d instead",
                 fl_value_get_type(value));
     return FALSE;
   }
@@ -70,7 +70,7 @@ static gboolean fl_json_method_codec_decode_method_call(FlMethodCodec* codec,
   FlValue* method_value = fl_value_lookup_string(value, kMethodKey);
   if (method_value == nullptr) {
     g_set_error(error, FL_MESSAGE_CODEC_ERROR, FL_MESSAGE_CODEC_ERROR_FAILED,
-                "Missing JSON method field in method resonse");
+                "Missing JSON method field in method response");
     return FALSE;
   }
   if (fl_value_get_type(method_value) != FL_VALUE_TYPE_STRING) {
@@ -138,7 +138,7 @@ static FlMethodResponse* fl_json_method_codec_decode_response(
 
   if (fl_value_get_type(value) != FL_VALUE_TYPE_LIST) {
     g_set_error(error, FL_MESSAGE_CODEC_ERROR, FL_MESSAGE_CODEC_ERROR_FAILED,
-                "Expected JSON list in method resonse, got %d instead",
+                "Expected JSON list in method response, got %d instead",
                 fl_value_get_type(value));
     return nullptr;
   }

--- a/shell/platform/linux/fl_message_codec.cc
+++ b/shell/platform/linux/fl_message_codec.cc
@@ -8,7 +8,7 @@
 
 G_DEFINE_QUARK(fl_message_codec_error_quark, fl_message_codec_error)
 
-// Added here to stop the compiler from optimising this function away.
+// Added here to stop the compiler from optimizing this function away.
 G_MODULE_EXPORT GType fl_message_codec_get_type();
 
 G_DEFINE_TYPE(FlMessageCodec, fl_message_codec, G_TYPE_OBJECT)

--- a/shell/platform/linux/fl_method_channel.cc
+++ b/shell/platform/linux/fl_method_channel.cc
@@ -31,7 +31,7 @@ struct _FlMethodChannel {
   GDestroyNotify method_call_handler_destroy_notify;
 };
 
-// Added here to stop the compiler from optimising this function away.
+// Added here to stop the compiler from optimizing this function away.
 G_MODULE_EXPORT GType fl_method_channel_get_type();
 
 G_DEFINE_TYPE(FlMethodChannel, fl_method_channel, G_TYPE_OBJECT)

--- a/shell/platform/linux/fl_method_codec.cc
+++ b/shell/platform/linux/fl_method_codec.cc
@@ -7,7 +7,7 @@
 
 #include <gmodule.h>
 
-// Added here to stop the compiler from optimising this function away.
+// Added here to stop the compiler from optimizing this function away.
 G_MODULE_EXPORT GType fl_method_codec_get_type();
 
 G_DEFINE_TYPE(FlMethodCodec, fl_method_codec, G_TYPE_OBJECT)

--- a/shell/platform/linux/fl_method_response.cc
+++ b/shell/platform/linux/fl_method_response.cc
@@ -26,7 +26,7 @@ struct _FlMethodNotImplementedResponse {
   FlMethodResponse parent_instance;
 };
 
-// Added here to stop the compiler from optimising these functions away.
+// Added here to stop the compiler from optimizing these functions away.
 G_MODULE_EXPORT GType fl_method_response_get_type();
 G_MODULE_EXPORT GType fl_method_success_response_get_type();
 G_MODULE_EXPORT GType fl_method_error_response_get_type();

--- a/shell/platform/linux/fl_plugin_registrar.cc
+++ b/shell/platform/linux/fl_plugin_registrar.cc
@@ -17,7 +17,7 @@ struct _FlPluginRegistrar {
   FlBinaryMessenger* messenger;
 };
 
-// Added here to stop the compiler from optimising this function away.
+// Added here to stop the compiler from optimizing this function away.
 G_MODULE_EXPORT GType fl_plugin_registrar_get_type();
 
 G_DEFINE_TYPE(FlPluginRegistrar, fl_plugin_registrar, G_TYPE_OBJECT)

--- a/shell/platform/linux/fl_plugin_registry.cc
+++ b/shell/platform/linux/fl_plugin_registry.cc
@@ -6,7 +6,7 @@
 
 #include <gmodule.h>
 
-// Added here to stop the compiler from optimising this function away.
+// Added here to stop the compiler from optimizing this function away.
 G_MODULE_EXPORT GType fl_plugin_registry_get_type();
 
 G_DEFINE_INTERFACE(FlPluginRegistry, fl_plugin_registry, G_TYPE_OBJECT)

--- a/shell/platform/linux/fl_value.cc
+++ b/shell/platform/linux/fl_value.cc
@@ -81,7 +81,7 @@ static void fl_value_destroy(gpointer value) {
 }
 
 // Finds the index of a key in a FlValueMap.
-// FIXME(robert-ancell) This is highly inefficient, and should be optimised if
+// FIXME(robert-ancell) This is highly inefficient, and should be optimized if
 // necessary.
 static ssize_t fl_value_lookup_index(FlValue* self, FlValue* key) {
   g_return_val_if_fail(self->type == FL_VALUE_TYPE_MAP, -1);

--- a/shell/platform/linux/public/flutter_linux/fl_value.h
+++ b/shell/platform/linux/public/flutter_linux/fl_value.h
@@ -543,7 +543,7 @@ FlValue* fl_value_get_map_value(FlValue* value, size_t index);
  * fl_value_equal(). Calling this with an #FlValue that is not of type
  * #FL_VALUE_TYPE_MAP is a programming error.
  *
- * Map lookups are not optimised for performance - if you have a large map or
+ * Map lookups are not optimized for performance - if you have a large map or
  * need frequent access you should copy the data into another structure, e.g.
  * #GHashTable.
  *
@@ -560,7 +560,7 @@ FlValue* fl_value_lookup(FlValue* value, FlValue* key);
  * fl_value_equal(). Calling this with an #FlValue that is not of type
  * #FL_VALUE_TYPE_MAP is a programming error.
  *
- * Map lookups are not optimised for performance - if you have a large map or
+ * Map lookups are not optimized for performance - if you have a large map or
  * need frequent access you should copy the data into another structure, e.g.
  * #GHashTable.
  *

--- a/shell/platform/linux/public/flutter_linux/fl_view.h
+++ b/shell/platform/linux/public/flutter_linux/fl_view.h
@@ -30,7 +30,7 @@ G_DECLARE_FINAL_TYPE(FlView, fl_view, FL, VIEW, GtkWidget)
  *   gtk_widget_show (GTK_WIDGET (view));
  *   gtk_container_add (GTK_CONTAINER (parent), view);
  *
- *   FlBinaryMessenger *mesenger =
+ *   FlBinaryMessenger *messenger =
  *     fl_engine_get_binary_messenger (fl_view_get_engine (view));
  *   setup_channels_or_plugins (messenger);
  * ]|


### PR DESCRIPTION
## Description

This just fixes some typos, and a small state leak in some of the tests that set env variables.

