### PR TITLE
Made tools/gn error out if it can't find goma

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -226,10 +226,9 @@ def to_gn_args(args):
     elif args.goma and os.path.exists(depot_tools_bin_dir):
       gn_args['use_goma'] = True
       gn_args['goma_dir'] = depot_tools_bin_dir
-    elif args.goma:
-      print("GOMA usage was specified but can't be found, set the GOMA_DIR environment variable.")
-      sys.exit(1)
     else:
+      if args.goma:
+        print("GOMA usage was specified but can't be found, falling back go local builds. Set the GOMA_DIR environment variable to fix GOMA.")
       gn_args['use_goma'] = False
       gn_args['goma_dir'] = None
 

--- a/tools/gn
+++ b/tools/gn
@@ -228,7 +228,7 @@ def to_gn_args(args):
       gn_args['goma_dir'] = depot_tools_bin_dir
     else:
       if args.goma:
-        print("GOMA usage was specified but can't be found, falling back go local builds. Set the GOMA_DIR environment variable to fix GOMA.")
+        print("GOMA usage was specified but can't be found, falling back to local builds. Set the GOMA_DIR environment variable to fix GOMA.")
       gn_args['use_goma'] = False
       gn_args['goma_dir'] = None
 

--- a/tools/gn
+++ b/tools/gn
@@ -3,6 +3,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import argparse
 import subprocess
 import sys
@@ -222,6 +226,9 @@ def to_gn_args(args):
     elif args.goma and os.path.exists(depot_tools_bin_dir):
       gn_args['use_goma'] = True
       gn_args['goma_dir'] = depot_tools_bin_dir
+    elif args.goma:
+      print("GOMA usage was specified but can't be found, set the GOMA_DIR environment variable.")
+      sys.exit(1)
     else:
       gn_args['use_goma'] = False
       gn_args['goma_dir'] = None
@@ -417,11 +424,11 @@ def main(argv):
   out_dir = get_out_dir(args)
   command.append(out_dir)
   command.append('--args=%s' % ' '.join(gn_args))
-  print "Generating GN files in: %s" % out_dir
+  print("Generating GN files in: %s" % out_dir)
   try:
     gn_call_result = subprocess.call(command, cwd=SRC_ROOT)
   except subprocess.CalledProcessError as exc:
-    print "Failed to generate gn files: ", exc.returncode, exc.output
+    print("Failed to generate gn files: ", exc.returncode, exc.output)
     sys.exit(1)
 
   if gn_call_result == 0:
@@ -442,7 +449,7 @@ def main(argv):
     try:
       contents = subprocess.check_output(compile_cmd_gen_cmd, cwd=SRC_ROOT)
     except subprocess.CalledProcessError as exc:
-      print "Failed to run ninja: ", exc.returncode, exc.output
+      print("Failed to run ninja: ", exc.returncode, exc.output)
       sys.exit(1)
     compile_commands = open('%s/out/compile_commands.json' % SRC_ROOT, 'w+')
     compile_commands.write(contents)


### PR DESCRIPTION
## Description

This also futurized the script.  This might break some people's invocations if the've been relying on broken GOMA setups to fallback to local builds.  The fix is just to specify `--no-goma`.

## Related Issues

## Tests

I added the following tests:

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
