### PR TITLE
libtxt: Clone an ICU line break iterator for each Paragraph/WordBreaker

### DIFF
--- a/third_party/txt/benchmarks/paragraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/paragraph_benchmarks.cc
@@ -405,7 +405,7 @@ BENCHMARK_DEFINE_F(ParagraphFixture, AddStyleRun)(benchmark::State& state) {
   paint.wordSpacing = text_style.word_spacing;
 
   minikin::LineBreaker breaker;
-  breaker.setLocale(icu::Locale(), nullptr);
+  breaker.setLocale();
   breaker.resize(text.size());
   memcpy(breaker.buffer(), text.data(), text.size() * sizeof(text[0]));
   breaker.setText();

--- a/third_party/txt/src/minikin/LineBreaker.cpp
+++ b/third_party/txt/src/minikin/LineBreaker.cpp
@@ -68,10 +68,10 @@ const float SHRINKABILITY = 1.0 / 3.0;
 // not precisely match the postBreak width.
 const float LIBTXT_WIDTH_ADJUST = 0.00001;
 
-void LineBreaker::setLocale(const icu::Locale& locale, Hyphenator* hyphenator) {
-  mWordBreaker.setLocale(locale);
-  mLocale = locale;
-  mHyphenator = hyphenator;
+void LineBreaker::setLocale() {
+  mWordBreaker.setLocale();
+  mLocale = icu::Locale();
+  mHyphenator = nullptr;
 }
 
 void LineBreaker::setText() {

--- a/third_party/txt/src/minikin/LineBreaker.h
+++ b/third_party/txt/src/minikin/LineBreaker.h
@@ -97,7 +97,10 @@ class LineBreaker {
   // could be here but it's better for performance that it's upstream because of
   // the cost of constructing and comparing the ICU Locale object.
   // Note: caller is responsible for managing lifetime of hyphenator
-  void setLocale(const icu::Locale& locale, Hyphenator* hyphenator);
+  //
+  // libtxt extension: always use the default locale so that a cached instance
+  // of the ICU break iterator can be reused.
+  void setLocale();
 
   void resize(size_t size) {
     mTextBuf.resize(size);

--- a/third_party/txt/src/minikin/WordBreaker.h
+++ b/third_party/txt/src/minikin/WordBreaker.h
@@ -33,7 +33,9 @@ class WordBreaker {
  public:
   ~WordBreaker() { finish(); }
 
-  void setLocale(const icu::Locale& locale);
+  // libtxt extension: always use the default locale so that a cached instance
+  // of the ICU break iterator can be reused.
+  void setLocale();
 
   void setText(const uint16_t* data, size_t size);
 

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -229,7 +229,7 @@ void ParagraphTxt::CodeUnitRun::Shift(double delta) {
 }
 
 ParagraphTxt::ParagraphTxt() {
-  breaker_.setLocale(icu::Locale(), nullptr);
+  breaker_.setLocale();
 }
 
 ParagraphTxt::~ParagraphTxt() = default;


### PR DESCRIPTION
The recent roll to ICU 18.1 introduced some expensive data conversion
during rule-based break iterator construction.  Each instance of
Libtxt's Paragraph class creates a Minikin LineBreaker/WordBreaker
which in turn creates an ICU break iterator.  The increased cost of
calling icu::BreakIterator::createLineInstance caused regressions
on several Flutter benchmarks.

Libtxt always uses the ICU default locale for break iterators.  This
change calls icu::BreakIterator::createLineInstance once to create
a global instance with the default locale and then calls
icu::BreakIterator::clone to create copies for each paragraph.

Fixes https://github.com/flutter/flutter/issues/70623
Fixes https://github.com/flutter/flutter/issues/70700
