### PR TITLE
Rename padding->viewPadding to match framework naming conventions

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -531,10 +531,10 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
         mask = mask | android.view.WindowInsets.Type.statusBars();
       }
       Insets uiInsets = insets.getInsets(mask);
-      viewportMetrics.paddingTop = uiInsets.top;
-      viewportMetrics.paddingRight = uiInsets.right;
-      viewportMetrics.paddingBottom = uiInsets.bottom;
-      viewportMetrics.paddingLeft = uiInsets.left;
+      viewportMetrics.viewPaddingTop = uiInsets.top;
+      viewportMetrics.viewPaddingRight = uiInsets.right;
+      viewportMetrics.viewPaddingBottom = uiInsets.bottom;
+      viewportMetrics.viewPaddingLeft = uiInsets.left;
 
       Insets imeInsets = insets.getInsets(android.view.WindowInsets.Type.ime());
       viewportMetrics.viewInsetTop = imeInsets.top;
@@ -555,21 +555,21 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
       DisplayCutout cutout = insets.getDisplayCutout();
       if (cutout != null) {
         Insets waterfallInsets = cutout.getWaterfallInsets();
-        viewportMetrics.paddingTop =
+        viewportMetrics.viewPaddingTop =
             Math.max(
-                Math.max(viewportMetrics.paddingTop, waterfallInsets.top),
+                Math.max(viewportMetrics.viewPaddingTop, waterfallInsets.top),
                 cutout.getSafeInsetTop());
-        viewportMetrics.paddingRight =
+        viewportMetrics.viewPaddingRight =
             Math.max(
-                Math.max(viewportMetrics.paddingRight, waterfallInsets.right),
+                Math.max(viewportMetrics.viewPaddingRight, waterfallInsets.right),
                 cutout.getSafeInsetRight());
-        viewportMetrics.paddingBottom =
+        viewportMetrics.viewPaddingBottom =
             Math.max(
-                Math.max(viewportMetrics.paddingBottom, waterfallInsets.bottom),
+                Math.max(viewportMetrics.viewPaddingBottom, waterfallInsets.bottom),
                 cutout.getSafeInsetBottom());
-        viewportMetrics.paddingLeft =
+        viewportMetrics.viewPaddingLeft =
             Math.max(
-                Math.max(viewportMetrics.paddingLeft, waterfallInsets.left),
+                Math.max(viewportMetrics.viewPaddingLeft, waterfallInsets.left),
                 cutout.getSafeInsetLeft());
       }
     } else {
@@ -582,16 +582,16 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
 
       // Status bar (top), navigation bar (bottom) and left/right system insets should
       // partially obscure the content (padding).
-      viewportMetrics.paddingTop = statusBarVisible ? insets.getSystemWindowInsetTop() : 0;
-      viewportMetrics.paddingRight =
+      viewportMetrics.viewPaddingTop = statusBarVisible ? insets.getSystemWindowInsetTop() : 0;
+      viewportMetrics.viewPaddingRight =
           zeroSides == ZeroSides.RIGHT || zeroSides == ZeroSides.BOTH
               ? 0
               : insets.getSystemWindowInsetRight();
-      viewportMetrics.paddingBottom =
+      viewportMetrics.viewPaddingBottom =
           navigationBarVisible && guessBottomKeyboardInset(insets) == 0
               ? insets.getSystemWindowInsetBottom()
               : 0;
-      viewportMetrics.paddingLeft =
+      viewportMetrics.viewPaddingLeft =
           zeroSides == ZeroSides.LEFT || zeroSides == ZeroSides.BOTH
               ? 0
               : insets.getSystemWindowInsetLeft();
@@ -607,11 +607,11 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
         TAG,
         "Updating window insets (onApplyWindowInsets()):\n"
             + "Status bar insets: Top: "
-            + viewportMetrics.paddingTop
+            + viewportMetrics.viewPaddingTop
             + ", Left: "
-            + viewportMetrics.paddingLeft
+            + viewportMetrics.viewPaddingLeft
             + ", Right: "
-            + viewportMetrics.paddingRight
+            + viewportMetrics.viewPaddingRight
             + "\n"
             + "Keyboard insets: Bottom: "
             + viewportMetrics.viewInsetBottom
@@ -645,10 +645,10 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   protected boolean fitSystemWindows(@NonNull Rect insets) {
     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
       // Status bar, left/right system insets partially obscure content (padding).
-      viewportMetrics.paddingTop = insets.top;
-      viewportMetrics.paddingRight = insets.right;
-      viewportMetrics.paddingBottom = 0;
-      viewportMetrics.paddingLeft = insets.left;
+      viewportMetrics.viewPaddingTop = insets.top;
+      viewportMetrics.viewPaddingRight = insets.right;
+      viewportMetrics.viewPaddingBottom = 0;
+      viewportMetrics.viewPaddingLeft = insets.left;
 
       // Bottom system inset (keyboard) should adjust scrollable bottom edge (inset).
       viewportMetrics.viewInsetTop = 0;
@@ -660,11 +660,11 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
           TAG,
           "Updating window insets (fitSystemWindows()):\n"
               + "Status bar insets: Top: "
-              + viewportMetrics.paddingTop
+              + viewportMetrics.viewPaddingTop
               + ", Left: "
-              + viewportMetrics.paddingLeft
+              + viewportMetrics.viewPaddingLeft
               + ", Right: "
-              + viewportMetrics.paddingRight
+              + viewportMetrics.viewPaddingRight
               + "\n"
               + "Keyboard insets: Bottom: "
               + viewportMetrics.viewInsetBottom

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -247,13 +247,13 @@ public class FlutterRenderer implements TextureRegistry {
             + viewportMetrics.height
             + "\n"
             + "Padding - L: "
-            + viewportMetrics.paddingLeft
+            + viewportMetrics.viewPaddingLeft
             + ", T: "
-            + viewportMetrics.paddingTop
+            + viewportMetrics.viewPaddingTop
             + ", R: "
-            + viewportMetrics.paddingRight
+            + viewportMetrics.viewPaddingRight
             + ", B: "
-            + viewportMetrics.paddingBottom
+            + viewportMetrics.viewPaddingBottom
             + "\n"
             + "Insets - L: "
             + viewportMetrics.viewInsetLeft
@@ -277,10 +277,10 @@ public class FlutterRenderer implements TextureRegistry {
         viewportMetrics.devicePixelRatio,
         viewportMetrics.width,
         viewportMetrics.height,
-        viewportMetrics.paddingTop,
-        viewportMetrics.paddingRight,
-        viewportMetrics.paddingBottom,
-        viewportMetrics.paddingLeft,
+        viewportMetrics.viewPaddingTop,
+        viewportMetrics.viewPaddingRight,
+        viewportMetrics.viewPaddingBottom,
+        viewportMetrics.viewPaddingLeft,
         viewportMetrics.viewInsetTop,
         viewportMetrics.viewInsetRight,
         viewportMetrics.viewInsetBottom,
@@ -348,10 +348,10 @@ public class FlutterRenderer implements TextureRegistry {
     public float devicePixelRatio = 1.0f;
     public int width = 0;
     public int height = 0;
-    public int paddingTop = 0;
-    public int paddingRight = 0;
-    public int paddingBottom = 0;
-    public int paddingLeft = 0;
+    public int viewPaddingTop = 0;
+    public int viewPaddingRight = 0;
+    public int viewPaddingBottom = 0;
+    public int viewPaddingLeft = 0;
     public int viewInsetTop = 0;
     public int viewInsetRight = 0;
     public int viewInsetBottom = 0;

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -100,10 +100,10 @@ public class FlutterView extends SurfaceView
     float devicePixelRatio = 1.0f;
     int physicalWidth = 0;
     int physicalHeight = 0;
-    int physicalPaddingTop = 0;
-    int physicalPaddingRight = 0;
-    int physicalPaddingBottom = 0;
-    int physicalPaddingLeft = 0;
+    int physicalViewPaddingTop = 0;
+    int physicalViewPaddingRight = 0;
+    int physicalViewPaddingBottom = 0;
+    int physicalViewPaddingLeft = 0;
     int physicalViewInsetTop = 0;
     int physicalViewInsetRight = 0;
     int physicalViewInsetBottom = 0;
@@ -603,10 +603,10 @@ public class FlutterView extends SurfaceView
         mask = mask | android.view.WindowInsets.Type.statusBars();
       }
       Insets uiInsets = insets.getInsets(mask);
-      mMetrics.physicalPaddingTop = uiInsets.top;
-      mMetrics.physicalPaddingRight = uiInsets.right;
-      mMetrics.physicalPaddingBottom = uiInsets.bottom;
-      mMetrics.physicalPaddingLeft = uiInsets.left;
+      mMetrics.physicalViewPaddingTop = uiInsets.top;
+      mMetrics.physicalViewPaddingRight = uiInsets.right;
+      mMetrics.physicalViewPaddingBottom = uiInsets.bottom;
+      mMetrics.physicalViewPaddingLeft = uiInsets.left;
 
       Insets imeInsets = insets.getInsets(android.view.WindowInsets.Type.ime());
       mMetrics.physicalViewInsetTop = imeInsets.top;
@@ -627,21 +627,21 @@ public class FlutterView extends SurfaceView
       DisplayCutout cutout = insets.getDisplayCutout();
       if (cutout != null) {
         Insets waterfallInsets = cutout.getWaterfallInsets();
-        mMetrics.physicalPaddingTop =
+        mMetrics.physicalViewPaddingTop =
             Math.max(
-                Math.max(mMetrics.physicalPaddingTop, waterfallInsets.top),
+                Math.max(mMetrics.physicalViewPaddingTop, waterfallInsets.top),
                 cutout.getSafeInsetTop());
-        mMetrics.physicalPaddingRight =
+        mMetrics.physicalViewPaddingRight =
             Math.max(
-                Math.max(mMetrics.physicalPaddingRight, waterfallInsets.right),
+                Math.max(mMetrics.physicalViewPaddingRight, waterfallInsets.right),
                 cutout.getSafeInsetRight());
-        mMetrics.physicalPaddingBottom =
+        mMetrics.physicalViewPaddingBottom =
             Math.max(
-                Math.max(mMetrics.physicalPaddingBottom, waterfallInsets.bottom),
+                Math.max(mMetrics.physicalViewPaddingBottom, waterfallInsets.bottom),
                 cutout.getSafeInsetBottom());
-        mMetrics.physicalPaddingLeft =
+        mMetrics.physicalViewPaddingLeft =
             Math.max(
-                Math.max(mMetrics.physicalPaddingLeft, waterfallInsets.left),
+                Math.max(mMetrics.physicalViewPaddingLeft, waterfallInsets.left),
                 cutout.getSafeInsetLeft());
       }
     } else {
@@ -654,16 +654,16 @@ public class FlutterView extends SurfaceView
 
       // Status bar (top), navigation bar (bottom) and left/right system insets should
       // partially obscure the content (padding).
-      mMetrics.physicalPaddingTop = statusBarVisible ? insets.getSystemWindowInsetTop() : 0;
-      mMetrics.physicalPaddingRight =
+      mMetrics.physicalViewPaddingTop = statusBarVisible ? insets.getSystemWindowInsetTop() : 0;
+      mMetrics.physicalViewPaddingRight =
           zeroSides == ZeroSides.RIGHT || zeroSides == ZeroSides.BOTH
               ? 0
               : insets.getSystemWindowInsetRight();
-      mMetrics.physicalPaddingBottom =
+      mMetrics.physicalViewPaddingBottom =
           navigationBarVisible && guessBottomKeyboardInset(insets) == 0
               ? insets.getSystemWindowInsetBottom()
               : 0;
-      mMetrics.physicalPaddingLeft =
+      mMetrics.physicalViewPaddingLeft =
           zeroSides == ZeroSides.LEFT || zeroSides == ZeroSides.BOTH
               ? 0
               : insets.getSystemWindowInsetLeft();
@@ -684,10 +684,10 @@ public class FlutterView extends SurfaceView
   protected boolean fitSystemWindows(Rect insets) {
     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
       // Status bar, left/right system insets partially obscure content (padding).
-      mMetrics.physicalPaddingTop = insets.top;
-      mMetrics.physicalPaddingRight = insets.right;
-      mMetrics.physicalPaddingBottom = 0;
-      mMetrics.physicalPaddingLeft = insets.left;
+      mMetrics.physicalViewPaddingTop = insets.top;
+      mMetrics.physicalViewPaddingRight = insets.right;
+      mMetrics.physicalViewPaddingBottom = 0;
+      mMetrics.physicalViewPaddingLeft = insets.left;
 
       // Bottom system inset (keyboard) should adjust scrollable bottom edge (inset).
       mMetrics.physicalViewInsetTop = 0;
@@ -746,10 +746,10 @@ public class FlutterView extends SurfaceView
             mMetrics.devicePixelRatio,
             mMetrics.physicalWidth,
             mMetrics.physicalHeight,
-            mMetrics.physicalPaddingTop,
-            mMetrics.physicalPaddingRight,
-            mMetrics.physicalPaddingBottom,
-            mMetrics.physicalPaddingLeft,
+            mMetrics.physicalViewPaddingTop,
+            mMetrics.physicalViewPaddingRight,
+            mMetrics.physicalViewPaddingBottom,
+            mMetrics.physicalViewPaddingLeft,
             mMetrics.physicalViewInsetTop,
             mMetrics.physicalViewInsetRight,
             mMetrics.physicalViewInsetBottom,

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -234,7 +234,7 @@ public class FlutterViewTest {
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
 
     // Then we simulate the system applying a window inset.
     WindowInsets windowInsets = mock(WindowInsets.class);
@@ -246,11 +246,11 @@ public class FlutterViewTest {
 
     // Verify.
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
     // Padding bottom is always 0.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingLeft);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingLeft);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingRight);
   }
 
   // This test uses the pre-API 30 Algorithm for window insets.
@@ -276,7 +276,7 @@ public class FlutterViewTest {
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
 
     // Then we simulate the system applying a window inset.
     WindowInsets windowInsets = mock(WindowInsets.class);
@@ -288,10 +288,10 @@ public class FlutterViewTest {
 
     // Verify.
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingLeft);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingLeft);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingRight);
   }
 
   // This test uses the API 30+ Algorithm for window insets. The legacy algorithm is
@@ -316,7 +316,7 @@ public class FlutterViewTest {
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
 
     // Then we simulate the system applying a window inset.
     WindowInsets windowInsets = mock(WindowInsets.class);
@@ -329,11 +329,11 @@ public class FlutterViewTest {
     // Verify.
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
     // Top padding is reported as-is.
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingTop);
     // Padding bottom is always 0.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingLeft);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingLeft);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingRight);
   }
 
   // This test uses the pre-API 30 Algorithm for window insets.
@@ -357,7 +357,7 @@ public class FlutterViewTest {
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
 
     // Then we simulate the system applying a window inset.
     WindowInsets windowInsets = mock(WindowInsets.class);
@@ -370,10 +370,10 @@ public class FlutterViewTest {
     // Verify.
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
     // Top padding is reported as-is.
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingTop);
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingLeft);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingLeft);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingRight);
   }
 
   @Test
@@ -402,7 +402,7 @@ public class FlutterViewTest {
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
 
     // Then we simulate the system applying a window inset.
     WindowInsets windowInsets = mock(WindowInsets.class);
@@ -415,12 +415,12 @@ public class FlutterViewTest {
 
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
     // Top padding is removed due to full screen.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
     // Bottom padding is removed due to hide navigation.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
     assertEquals(100, viewportMetricsCaptor.getValue().paddingLeft);
     // Right padding is zero because the rotation is 90deg
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingRight);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingRight);
   }
 
   @Test
@@ -449,7 +449,7 @@ public class FlutterViewTest {
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
 
     // Then we simulate the system applying a window inset.
     WindowInsets windowInsets = mock(WindowInsets.class);
@@ -462,12 +462,12 @@ public class FlutterViewTest {
 
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
     // Top padding is removed due to full screen.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
     // Bottom padding is removed due to hide navigation.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
     // Left padding is zero because the rotation is 270deg
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingLeft);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingLeft);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingRight);
   }
 
   // This test uses the API 30+ Algorithm for window insets. The legacy algorithm is
@@ -500,7 +500,7 @@ public class FlutterViewTest {
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
 
     Insets insets = Insets.of(100, 100, 100, 100);
     // Then we simulate the system applying a window inset.
@@ -515,12 +515,12 @@ public class FlutterViewTest {
 
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
     // Top padding is removed due to full screen.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
     // Padding bottom is always 0.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
     // Left padding is zero because the rotation is 270deg
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingLeft);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingRight);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingLeft);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingRight);
   }
 
   // This test uses the pre-API 30 Algorithm for window insets.
@@ -552,7 +552,7 @@ public class FlutterViewTest {
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
 
     // Then we simulate the system applying a window inset.
     WindowInsets windowInsets = mock(WindowInsets.class);
@@ -565,12 +565,12 @@ public class FlutterViewTest {
 
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
     // Top padding is removed due to full screen.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
     // Bottom padding is removed due to hide navigation.
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
     // Left padding is zero because the rotation is 270deg
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingLeft);
-    assertEquals(103, viewportMetricsCaptor.getValue().paddingRight);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingLeft);
+    assertEquals(103, viewportMetricsCaptor.getValue().viewPaddingRight);
   }
 
   // This test uses the API 30+ Algorithm for window insets. The legacy algorithm is
@@ -601,7 +601,7 @@ public class FlutterViewTest {
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
 
     Insets insets = Insets.of(100, 100, 100, 100);
     Insets systemGestureInsets = Insets.of(110, 110, 110, 110);
@@ -626,10 +626,10 @@ public class FlutterViewTest {
     flutterView.onApplyWindowInsets(windowInsets);
 
     verify(flutterRenderer, times(2)).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(150, viewportMetricsCaptor.getValue().paddingTop);
-    assertEquals(150, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(200, viewportMetricsCaptor.getValue().paddingLeft);
-    assertEquals(200, viewportMetricsCaptor.getValue().paddingRight);
+    assertEquals(150, viewportMetricsCaptor.getValue().viewPaddingTop);
+    assertEquals(150, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(200, viewportMetricsCaptor.getValue().viewPaddingLeft);
+    assertEquals(200, viewportMetricsCaptor.getValue().viewPaddingRight);
 
     assertEquals(100, viewportMetricsCaptor.getValue().viewInsetTop);
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -418,7 +418,7 @@ public class FlutterViewTest {
     assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
     // Bottom padding is removed due to hide navigation.
     assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
-    assertEquals(100, viewportMetricsCaptor.getValue().paddingLeft);
+    assertEquals(100, viewportMetricsCaptor.getValue().viewPaddingLeft);
     // Right padding is zero because the rotation is 90deg
     assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingRight);
   }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1071,8 +1071,8 @@ public class TextInputPluginTest {
     imeSyncCallback.onApplyWindowInsets(testView, noneInsets);
 
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
     assertEquals(0, viewportMetricsCaptor.getValue().viewInsetBottom);
     assertEquals(0, viewportMetricsCaptor.getValue().viewInsetTop);
 
@@ -1084,24 +1084,24 @@ public class TextInputPluginTest {
 
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
     // No change, as deferredInset is stored to be passed in onEnd()
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingTop);
     assertEquals(0, viewportMetricsCaptor.getValue().viewInsetBottom);
     assertEquals(0, viewportMetricsCaptor.getValue().viewInsetTop);
 
     imeSyncCallback.onProgress(imeInsets0, animationList);
 
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(40, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(10, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(40, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(10, viewportMetricsCaptor.getValue().viewPaddingTop);
     assertEquals(60, viewportMetricsCaptor.getValue().viewInsetBottom);
     assertEquals(0, viewportMetricsCaptor.getValue().viewInsetTop);
 
     imeSyncCallback.onProgress(imeInsets1, animationList);
 
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
-    assertEquals(40, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(10, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(40, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(10, viewportMetricsCaptor.getValue().viewPaddingTop);
     assertEquals(0, viewportMetricsCaptor.getValue().viewInsetBottom); // Cannot be negative
     assertEquals(0, viewportMetricsCaptor.getValue().viewInsetTop);
 
@@ -1109,8 +1109,8 @@ public class TextInputPluginTest {
 
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
     // Values should be of deferredInsets, not imeInsets2
-    assertEquals(0, viewportMetricsCaptor.getValue().paddingBottom);
-    assertEquals(10, viewportMetricsCaptor.getValue().paddingTop);
+    assertEquals(0, viewportMetricsCaptor.getValue().viewPaddingBottom);
+    assertEquals(10, viewportMetricsCaptor.getValue().viewPaddingTop);
     assertEquals(200, viewportMetricsCaptor.getValue().viewInsetBottom);
     assertEquals(0, viewportMetricsCaptor.getValue().viewInsetTop);
   }


### PR DESCRIPTION
## Description

Renames `padding` to `viewPadding` in the engine to avoid confusion. The framework exposes this value as `viewPadding` (see https://api.flutter.dev/flutter/widgets/MediaQueryData-class.html) while before this, we called it `padding` in the engine. Since the framework also has a parallel value called `padding`, this naming was prone to confusion. This PR brings the engine naming in sync with the framework.

## Tests

No logic changes made, only renaming.