### PR TITLE
Remove opt outs for dart:ui

### DIFF
--- a/lib/ui/annotations.dart
+++ b/lib/ui/annotations.dart
@@ -5,6 +5,7 @@
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 // TODO(dnfield): Update this if/when we default this to on in the tool,

--- a/lib/ui/annotations.dart
+++ b/lib/ui/annotations.dart
@@ -4,7 +4,6 @@
 
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -5,6 +5,7 @@
 
 // KEEP THIS SYNCHRONIZED WITH ../web_ui/lib/src/ui/channel_buffers.dart
 
+// @dart = 2.12
 part of dart.ui;
 
 /// Signature for [ChannelBuffers.drain]'s `callback` argument.

--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 // KEEP THIS SYNCHRONIZED WITH ../web_ui/lib/src/ui/channel_buffers.dart
 

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 /// An opaque object representing a composited scene.

--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -1,3 +1,4 @@
+// @dart = 2.6
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -1,4 +1,3 @@
-// @dart = 2.6
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 /// Base class for [Size] and [Offset], which are both ways to describe

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 class _HashEnd { const _HashEnd(); }

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -4,7 +4,6 @@
 
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -5,6 +5,7 @@
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 @pragma('vm:entry-point')

--- a/lib/ui/isolate_name_server.dart
+++ b/lib/ui/isolate_name_server.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/isolate_name_server.dart
+++ b/lib/ui/isolate_name_server.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 /// Static methods to allow for simple sharing of [SendPort]s across [Isolate]s.

--- a/lib/ui/lerp.dart
+++ b/lib/ui/lerp.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/lerp.dart
+++ b/lib/ui/lerp.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 /// Linearly interpolate between two numbers, `a` and `b`, by an extrapolation

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -5,6 +5,7 @@
 // TODO(dnfield): remove unused_element ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 // Corelib 'print' implementation.

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -4,7 +4,6 @@
 
 // TODO(dnfield): remove unused_element ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 // Some methods in this file assert that their arguments are not null. These

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.12
 part of dart.ui;
 
 /// Signature of callbacks that have no arguments and return no data.

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 part of dart.ui;
 
 /// Signature of callbacks that have no arguments and return no data.

--- a/lib/ui/plugins.dart
+++ b/lib/ui/plugins.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/plugins.dart
+++ b/lib/ui/plugins.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 /// A wrapper for a raw callback handle.

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 /// How the pointer has changed since the last report.

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 /// The possible actions that can be conveyed from the operating system

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 
 part of dart.ui;
 

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 
+// @dart = 2.12
 part of dart.ui;
 
 /// Whether to slant the glyphs in the font

--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -9,6 +9,7 @@
 /// This library exposes the lowest-level services that Flutter frameworks use
 /// to bootstrap applications, such as classes for driving the input, graphics
 /// text, layout, and rendering subsystems.
+// @dart = 2.12
 library dart.ui;
 
 import 'dart:_internal' hide Symbol; // ignore: unused_import

--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -9,7 +9,6 @@
 /// This library exposes the lowest-level services that Flutter frameworks use
 /// to bootstrap applications, such as classes for driving the input, graphics
 /// text, layout, and rendering subsystems.
-// @dart = 2.10
 library dart.ui;
 
 import 'dart:_internal' hide Symbol; // ignore: unused_import

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
 part of dart.ui;
 
 /// A view into which a Flutter [Scene] is drawn.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.12
 part of dart.ui;
 
 /// A view into which a Flutter [Scene] is drawn.

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
+// @dart = 2.12
 
 // HACK: pretend to be dart.ui in order to access its internals
 library dart.ui;


### PR DESCRIPTION
Remove Dart language version opt-out for `dart:ui` files.  

This is already ignored on a build for `dart:ui`, so it shouldn't change any behavior.  The opt-out appears to be confusing pub analysis though.  @sigurdm @mit-mit 
