### PR TITLE
Create FlutterFrameBufferProvider class

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1054,6 +1054,8 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterEngin
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterExternalTextureGL.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterExternalTextureGL.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -52,6 +52,8 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterEngine_Internal.h",
     "framework/Source/FlutterExternalTextureGL.h",
     "framework/Source/FlutterExternalTextureGL.mm",
+    "framework/Source/FlutterFrameBufferProvider.h",
+    "framework/Source/FlutterFrameBufferProvider.mm",
     "framework/Source/FlutterMouseCursorPlugin.h",
     "framework/Source/FlutterMouseCursorPlugin.mm",
     "framework/Source/FlutterResizeSynchronizer.h",

--- a/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.h
@@ -1,0 +1,24 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+
+/**
+ * Creates framebuffers and their backing textures.
+ */
+@interface FlutterFrameBufferProvider : NSObject
+
+- (nullable instancetype)initWithOpenGLContext:(nonnull NSOpenGLContext*)opengLContext;
+
+/**
+ * Returns the id of the framebuffer.
+ */
+- (uint32_t)glFrameBufferId;
+
+/**
+ * Returns the id of the backing texture..
+ */
+- (uint32_t)glTextureId;
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.mm
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.h"
+
+#include <OpenGL/gl.h>
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/MacOSGLContextSwitch.h"
+
+@interface FlutterFrameBufferProvider () {
+  uint32_t _frameBufferId;
+  uint32_t _backingTexture;
+}
+@end
+
+@implementation FlutterFrameBufferProvider
+- (instancetype)initWithOpenGLContext:(NSOpenGLContext*)openGLContext {
+  if (self = [super init]) {
+    MacOSGLContextSwitch context_switch(openGLContext);
+
+    glGenFramebuffers(1, &_frameBufferId);
+    glGenTextures(1, &_backingTexture);
+
+    [self createFramebuffer];
+  }
+  return self;
+}
+
+- (void)createFramebuffer {
+  glBindFramebuffer(GL_FRAMEBUFFER, _frameBufferId);
+  glBindTexture(GL_TEXTURE_RECTANGLE_ARB, _backingTexture);
+  glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameterf(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_RECTANGLE_ARB, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+}
+
+- (uint32_t)glFrameBufferId {
+  return _frameBufferId;
+}
+
+- (uint32_t)glTextureId {
+  return _backingTexture;
+}
+
+- (void)dealloc {
+  glDeleteFramebuffers(1, &_frameBufferId);
+  glDeleteTextures(1, &_backingTexture);
+}
+
+@end


### PR DESCRIPTION
Create FlutterFrameBufferProvider class.
FlutterFrameBufferProvider will handle creating framebuffers and their backing textures.

Refactor FlutterSurfaceManager to use FlutterFrameBufferProvider.

FlutterFrameBufferProvider will be used to uncouple FlutterGLCompositor forMacOS and FlutterSurfaceManager.