### PR TITLE
Fix race condition in key event handling on Android

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/AndroidKeyProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidKeyProcessor.java
@@ -85,27 +85,27 @@ public class AndroidKeyProcessor {
    * @return true if the key event should not be propagated to other Android components. Delayed
    *     synthesis events will return false, so that other components may handle them.
    */
-  public boolean onKeyEvent(@NonNull KeyEvent event) {
-    int action = event.getAction();
-    if (action != event.ACTION_DOWN && action != event.ACTION_UP) {
+  public boolean onKeyEvent(@NonNull KeyEvent keyEvent) {
+    int action = keyEvent.getAction();
+    if (action != KeyEvent.ACTION_DOWN && action != KeyEvent.ACTION_UP) {
       // There is theoretically a KeyEvent.ACTION_MULTIPLE, but theoretically
       // that isn't sent by Android anymore, so this is just for protection in
       // case the theory is wrong.
       return false;
     }
-    if (eventResponder.isHeadEvent(event)) {
-      // If the event is at the head of the queue of pending events we've seen,
-      // and has the same id, then we know that this is a re-dispatched event, and
+    if (eventResponder.isHeadEvent(keyEvent)) {
+      // If the keyEvent is at the head of the queue of pending events we've seen,
+      // and has the same id, then we know that this is a re-dispatched keyEvent, and
       // we shouldn't respond to it, but we should remove it from tracking now.
       eventResponder.removeHeadEvent();
       return false;
     }
 
-    Character complexCharacter = applyCombiningCharacterToBaseCharacter(event.getUnicodeChar());
+    Character complexCharacter = applyCombiningCharacterToBaseCharacter(keyEvent.getUnicodeChar());
     KeyEventChannel.FlutterKeyEvent flutterEvent =
-        new KeyEventChannel.FlutterKeyEvent(event, complexCharacter);
+        new KeyEventChannel.FlutterKeyEvent(keyEvent, complexCharacter);
 
-    eventResponder.addEvent(event);
+    eventResponder.addEvent(keyEvent);
     if (action == KeyEvent.ACTION_DOWN) {
       keyEventChannel.keyDown(flutterEvent);
     } else {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -739,11 +739,6 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     } else if (event.getAction() == KeyEvent.ACTION_UP) {
       // Stop tracking the event.
       getKeyDispatcherState().handleUpEvent(event);
-      if (!event.isTracking() || event.isCanceled()) {
-        // Don't send the event to the key processor if it was canceled, or no
-        // longer being tracked.
-        return super.dispatchKeyEvent(event);
-      }
     }
     // If the key processor doesn't handle it, then send it on to the
     // superclass. The key processor will typically handle all events except

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
@@ -225,16 +225,29 @@ public class KeyEventChannel {
      * The unique id for this Flutter key event.
      *
      * <p>This id is used to identify pending events when results are received from the framework.
-     * This ID does not come from Android.
+     * This ID does not come from Android, but instead is derived from attributes of this event that
+     * can be recognized if the event is re-dispatched.
      */
     public final long eventId;
 
-    public FlutterKeyEvent(@NonNull KeyEvent androidKeyEvent, long eventId) {
-      this(androidKeyEvent, null, eventId);
+    /**
+     * Creates a unique id for a Flutter key event from an Android KeyEvent.
+     *
+     * <p>This id is used to identify pending key events when results are received from the
+     * framework.
+     */
+    public static long computeEventId(@NonNull KeyEvent event) {
+      return (event.getEventTime() & 0xffffffff)
+          | ((long) (event.getAction() == KeyEvent.ACTION_DOWN ? 0x1 : 0x0)) << 32
+          | ((long) (event.getScanCode() & 0xffff)) << 33;
+    }
+
+    public FlutterKeyEvent(@NonNull KeyEvent androidKeyEvent) {
+      this(androidKeyEvent, null);
     }
 
     public FlutterKeyEvent(
-        @NonNull KeyEvent androidKeyEvent, @Nullable Character complexCharacter, long eventId) {
+        @NonNull KeyEvent androidKeyEvent, @Nullable Character complexCharacter) {
       this(
           androidKeyEvent.getDeviceId(),
           androidKeyEvent.getFlags(),
@@ -246,7 +259,7 @@ public class KeyEventChannel {
           androidKeyEvent.getMetaState(),
           androidKeyEvent.getSource(),
           androidKeyEvent.getRepeatCount(),
-          eventId);
+          computeEventId(androidKeyEvent));
     }
 
     public FlutterKeyEvent(

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -285,13 +285,22 @@ class InputConnectionAdaptor extends BaseInputConnection
     return clamped;
   }
 
+  // This function is called both when hardware key events occur and aren't
+  // handled by the framework, as well as when soft keyboard editing events
+  // occur, and need a chance to be handled by the framework.
   @Override
   public boolean sendKeyEvent(KeyEvent event) {
-    // Give the key processor a chance to process this event.  It will send it
-    // to the framework to be handled and return true. If the framework ends up
-    // not handling it, the processor will re-send the event, this time
-    // returning false so that it can be processed here.
-    if (keyProcessor != null && keyProcessor.onKeyEvent(event)) {
+    // This gives the key processor a chance to process this event if it came
+    // from a soft keyboard. It will send it to the framework to be handled and
+    // return true. If the framework ends up not handling it, the processor will
+    // re-send the event to this function. Only do this if the event is not the
+    // current event, since that indicates that the key processor sent it to us,
+    // and we only want to call the key processor for events that it doesn't
+    // already know about (i.e. when events arrive here from a soft keyboard and
+    // not a hardware keyboard), to avoid a loop.
+    if (keyProcessor != null
+        && !keyProcessor.isCurrentEvent(event)
+        && keyProcessor.onKeyEvent(event)) {
       return true;
     }
 

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -21,7 +21,6 @@ import android.text.format.DateFormat;
 import android.util.AttributeSet;
 import android.util.SparseArray;
 import android.view.DisplayCutout;
-import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.PointerIcon;
 import android.view.Surface;
@@ -266,12 +265,6 @@ public class FlutterView extends SurfaceView
   @NonNull
   public DartExecutor getDartExecutor() {
     return dartExecutor;
-  }
-
-  @Override
-  public boolean dispatchKeyEventPreIme(KeyEvent event) {
-    return (isAttached() && androidKeyProcessor.onKeyEvent(event))
-        || super.dispatchKeyEventPreIme(event);
   }
 
   public FlutterNativeView getFlutterNativeView() {

--- a/shell/platform/android/test/io/flutter/embedding/android/AndroidKeyProcessorTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/AndroidKeyProcessorTest.java
@@ -117,7 +117,7 @@ public class AndroidKeyProcessorTest {
             });
 
     // Fake a response from the framework.
-    handlerCaptor.getValue().onKeyEventNotHandled(eventCaptor.getValue().eventId);
+    handlerCaptor.getValue().onKeyEventNotHandled(eventCaptor.getValue().event);
     verify(fakeView, times(1)).dispatchKeyEvent(fakeKeyEvent);
     assertEquals(false, dispatchResult[0]);
     verify(fakeKeyEventChannel, times(0)).keyUp(any(KeyEventChannel.FlutterKeyEvent.class));
@@ -167,7 +167,7 @@ public class AndroidKeyProcessorTest {
             });
 
     // Fake a response from the framework.
-    handlerCaptor.getValue().onKeyEventNotHandled(eventCaptor.getValue().eventId);
+    handlerCaptor.getValue().onKeyEventNotHandled(eventCaptor.getValue().event);
     verify(fakeView, times(1)).dispatchKeyEvent(fakeKeyEvent);
     assertEquals(false, dispatchResult[0]);
     verify(fakeKeyEventChannel, times(0)).keyUp(any(KeyEventChannel.FlutterKeyEvent.class));

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyEventChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyEventChannelTest.java
@@ -62,7 +62,7 @@ public class KeyEventChannelTest {
 
     KeyEvent event = new FakeKeyEvent(KeyEvent.ACTION_DOWN, 65);
     KeyEventChannel.FlutterKeyEvent flutterKeyEvent =
-        new KeyEventChannel.FlutterKeyEvent(event, null, 10);
+        new KeyEventChannel.FlutterKeyEvent(event, null);
     keyEventChannel.keyDown(flutterKeyEvent);
     ArgumentCaptor<ByteBuffer> byteBufferArgumentCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
     ArgumentCaptor<BinaryMessenger.BinaryReply> replyArgumentCaptor =
@@ -78,7 +78,7 @@ public class KeyEventChannelTest {
     // Simulate a reply, and see that it is handled.
     sendReply(true, replyArgumentCaptor.getValue());
     assertTrue(handled[0]);
-    assertEquals(10, handledId[0]);
+    assertEquals(KeyEventChannel.FlutterKeyEvent.computeEventId(event), handledId[0]);
   }
 
   @Test
@@ -103,7 +103,7 @@ public class KeyEventChannelTest {
 
     KeyEvent event = new FakeKeyEvent(KeyEvent.ACTION_UP, 65);
     KeyEventChannel.FlutterKeyEvent flutterKeyEvent =
-        new KeyEventChannel.FlutterKeyEvent(event, null, 10);
+        new KeyEventChannel.FlutterKeyEvent(event, null);
     keyEventChannel.keyUp(flutterKeyEvent);
     ArgumentCaptor<ByteBuffer> byteBufferArgumentCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
     ArgumentCaptor<BinaryMessenger.BinaryReply> replyArgumentCaptor =
@@ -119,6 +119,6 @@ public class KeyEventChannelTest {
     // Simulate a reply, and see that it is handled.
     sendReply(true, replyArgumentCaptor.getValue());
     assertTrue(handled[0]);
-    assertEquals(10, handledId[0]);
+    assertEquals(KeyEventChannel.FlutterKeyEvent.computeEventId(event), handledId[0]);
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyEventChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/KeyEventChannelTest.java
@@ -45,17 +45,17 @@ public class KeyEventChannelTest {
     BinaryMessenger fakeMessenger = mock(BinaryMessenger.class);
     KeyEventChannel keyEventChannel = new KeyEventChannel(fakeMessenger);
     final boolean[] handled = {false};
-    final long[] handledId = {-1};
+    final KeyEvent[] handledKeyEvents = {null};
     keyEventChannel.setEventResponseHandler(
         new KeyEventChannel.EventResponseHandler() {
-          public void onKeyEventHandled(@NonNull long id) {
+          public void onKeyEventHandled(@NonNull KeyEvent event) {
             handled[0] = true;
-            handledId[0] = id;
+            handledKeyEvents[0] = event;
           }
 
-          public void onKeyEventNotHandled(@NonNull long id) {
+          public void onKeyEventNotHandled(@NonNull KeyEvent event) {
             handled[0] = false;
-            handledId[0] = id;
+            handledKeyEvents[0] = event;
           }
         });
     verify(fakeMessenger, times(0)).send(any(), any(), any());
@@ -78,7 +78,7 @@ public class KeyEventChannelTest {
     // Simulate a reply, and see that it is handled.
     sendReply(true, replyArgumentCaptor.getValue());
     assertTrue(handled[0]);
-    assertEquals(KeyEventChannel.FlutterKeyEvent.computeEventId(event), handledId[0]);
+    assertEquals(event, handledKeyEvents[0]);
   }
 
   @Test
@@ -86,17 +86,17 @@ public class KeyEventChannelTest {
     BinaryMessenger fakeMessenger = mock(BinaryMessenger.class);
     KeyEventChannel keyEventChannel = new KeyEventChannel(fakeMessenger);
     final boolean[] handled = {false};
-    final long[] handledId = {-1};
+    final KeyEvent[] handledKeyEvents = {null};
     keyEventChannel.setEventResponseHandler(
         new KeyEventChannel.EventResponseHandler() {
-          public void onKeyEventHandled(long id) {
+          public void onKeyEventHandled(@NonNull KeyEvent event) {
             handled[0] = true;
-            handledId[0] = id;
+            handledKeyEvents[0] = event;
           }
 
-          public void onKeyEventNotHandled(long id) {
+          public void onKeyEventNotHandled(@NonNull KeyEvent event) {
             handled[0] = false;
-            handledId[0] = id;
+            handledKeyEvents[0] = event;
           }
         });
     verify(fakeMessenger, times(0)).send(any(), any(), any());
@@ -119,6 +119,6 @@ public class KeyEventChannelTest {
     // Simulate a reply, and see that it is handled.
     sendReply(true, replyArgumentCaptor.getValue());
     assertTrue(handled[0]);
-    assertEquals(KeyEventChannel.FlutterKeyEvent.computeEventId(event), handledId[0]);
+    assertEquals(event, handledKeyEvents[0]);
   }
 }


### PR DESCRIPTION
## Description

This fixes a problem in Android key event handling where, because I was only using a single bool to indicate that we were re-dispatching, there was a race condition when multiple keys were pending (sent to the framework, awaiting responses).

This fixes that by switching to a mechanism that uses a fingerprint calculated from the event information itself (a combination of event action (up/down), scan code, and event timestamp).

In doing this, I realized that because key events can come from either the dispatchEvent call, or through the `InputConnectionAdaptor`, I needed to handle both routes properly so that the events would all be handled, and all go through the same mechanism on the framework side.

## Related Issues

- https://github.com/flutter/flutter/issues/70908

## Tests

- Added tests to make sure that key events received through the `InputConnectionAdaptor` get sent to the `AndroidKeyProcessor`, but when the key processor send the events to the InputConnection, it doesn't get them back again.

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.