### PR TITLE
Create wrapper for IOSurface

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1056,6 +1056,8 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterExter
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterExternalTextureGL.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProvider.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -54,6 +54,8 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterExternalTextureGL.mm",
     "framework/Source/FlutterFrameBufferProvider.h",
     "framework/Source/FlutterFrameBufferProvider.mm",
+    "framework/Source/FlutterIOSurfaceHolder.h",
+    "framework/Source/FlutterIOSurfaceHolder.mm",
     "framework/Source/FlutterMouseCursorPlugin.h",
     "framework/Source/FlutterMouseCursorPlugin.mm",
     "framework/Source/FlutterResizeSynchronizer.h",

--- a/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.h
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+
+/**
+ * FlutterIOSurfaceHolder maintains an IOSurface
+ * and provides an interface to bind the IOSurface to a texture.
+ */
+@interface FlutterIOSurfaceHolder : NSObject
+
+/**
+ * Bind the IOSurface to the provided texture and fbo.
+ */
+- (void)bindSurfaceToTexture:(GLuint)texture fbo:(GLuint)fbo size:(CGSize)size;
+
+/**
+ * Releases the current IOSurface if one exists
+ * and creates a new IOSurface with the specified size.
+ */
+- (void)recreateIOSurfaceWithSize:(CGSize)size;
+
+/**
+ * Returns a reference to the underlying IOSurface.
+ */
+- (const IOSurfaceRef&)ioSurface;
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.mm
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterIOSurfaceHolder.h"
+
+#include <OpenGL/gl.h>
+
+@interface FlutterIOSurfaceHolder () {
+  IOSurfaceRef _ioSurface;
+}
+@end
+
+@implementation FlutterIOSurfaceHolder
+
+- (void)bindSurfaceToTexture:(GLuint)texture fbo:(GLuint)fbo size:(CGSize)size {
+  [self recreateIOSurfaceWithSize:size];
+
+  glBindTexture(GL_TEXTURE_RECTANGLE_ARB, texture);
+
+  CGLTexImageIOSurface2D(CGLGetCurrentContext(), GL_TEXTURE_RECTANGLE_ARB, GL_RGBA, int(size.width),
+                         int(size.height), GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, _ioSurface,
+                         0 /* plane */);
+  glBindTexture(GL_TEXTURE_RECTANGLE_ARB, 0);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_RECTANGLE_ARB, texture,
+                         0);
+
+  NSAssert(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE,
+           @"Framebuffer status check failed");
+}
+
+- (void)recreateIOSurfaceWithSize:(CGSize)size {
+  if (_ioSurface) {
+    CFRelease(_ioSurface);
+  }
+
+  unsigned pixelFormat = 'BGRA';
+  unsigned bytesPerElement = 4;
+
+  size_t bytesPerRow = IOSurfaceAlignProperty(kIOSurfaceBytesPerRow, size.width * bytesPerElement);
+  size_t totalBytes = IOSurfaceAlignProperty(kIOSurfaceAllocSize, size.height * bytesPerRow);
+  NSDictionary* options = @{
+    (id)kIOSurfaceWidth : @(size.width),
+    (id)kIOSurfaceHeight : @(size.height),
+    (id)kIOSurfacePixelFormat : @(pixelFormat),
+    (id)kIOSurfaceBytesPerElement : @(bytesPerElement),
+    (id)kIOSurfaceBytesPerRow : @(bytesPerRow),
+    (id)kIOSurfaceAllocSize : @(totalBytes),
+  };
+
+  _ioSurface = IOSurfaceCreate((CFDictionaryRef)options);
+}
+
+- (const IOSurfaceRef&)ioSurface {
+  return _ioSurface;
+}
+
+- (void)dealloc {
+  if (_ioSurface) {
+    CFRelease(_ioSurface);
+  }
+}
+
+@end


### PR DESCRIPTION
Tentatively named IOSurfaceWrapper.

Create a wrapper for IOSurface to handle creation and binding IOSurfaces to textures / framebuffers.

Decouple IOSurface logic from FlutterSurfaceManager.

Depends on #22656