### PR TITLE
Generate XCFramework in recipe package script

### DIFF
--- a/sky/tools/create_xcframework.py
+++ b/sky/tools/create_xcframework.py
@@ -25,8 +25,11 @@ def main():
 
   args = parser.parse_args()
 
-  output_dir = os.path.abspath(args.location)
-  output_xcframework = os.path.join(output_dir, '%s.xcframework' % args.name)
+  create_xcframework(args.location, args.name, args.frameworks)
+
+def create_xcframework(location, name, frameworks):
+  output_dir = os.path.abspath(location)
+  output_xcframework = os.path.join(output_dir, '%s.xcframework' % name)
 
   if not os.path.exists(output_dir):
     os.makedirs(output_dir)
@@ -41,7 +44,7 @@ def main():
     '-quiet',
     '-create-xcframework']
 
-  for framework in args.frameworks:
+  for framework in frameworks:
     command.extend(['-framework', os.path.abspath(framework)])
 
   command.extend(['-output', output_xcframework])


### PR DESCRIPTION
## Description

Create Flutter.xcframework as part of the [recipe packaging script](https://flutter.googlesource.com/recipes/+/9879a9427530e0ae449079bca6e3f4fef1931b5e/recipes/engine.py#1053).

## Next steps
- Update the recipe to upload the generated `Flutter.xcframework` in that recipe to publish `Flutter.xcframework` as a downloadable engine artifact.
- Add it to the [codesigning script](https://github.com/christopherfujino/codesign.py/blob/f8940c3360f322f80203d4172521c2529fdf31da/codesign.py#L122).
- Update `flutter` tooling to use `Flutter.xcframework`.

## Related Issues

Local engine support part of https://github.com/flutter/flutter/issues/60109, which is a dependency to support macOS ARM simulators https://github.com/flutter/flutter/issues/64502

## Tests

The `create_xcframework.py` change is tested via the Scenario app, which embeds the `Flutter.xcframework` from the [`out` directory](https://github.com/flutter/engine/pull/22506) and won't compile if something goes wrong there.

The `create_xcframework.py` output is only used in the recipe, and tested there.  There are also many framework tests validating framework validation, bitcode, symbol stripping, etc, and this will be tested there when the tool adopts.

## Checklist
- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*