### PR TITLE
Request quickReject results from correct drawing canvas

### DIFF
--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -195,7 +195,7 @@ class Layer {
     if (paint_bounds_.isEmpty()) {
       return false;
     }
-    return !context.internal_nodes_canvas->quickReject(paint_bounds_);
+    return !context.leaf_nodes_canvas->quickReject(paint_bounds_);
   }
 
   uint64_t unique_id() const { return unique_id_; }

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -158,6 +158,7 @@ std::unique_ptr<RasterCacheResult> RasterCache::RasterizeLayer(
         SkISize canvas_size = canvas->getBaseLayerSize();
         SkNWayCanvas internal_nodes_canvas(canvas_size.width(),
                                            canvas_size.height());
+        internal_nodes_canvas.setMatrix(canvas->getTotalMatrix());
         internal_nodes_canvas.addCanvas(canvas);
         Layer::PaintContext paintContext = {
             /* internal_nodes_canvas= */ static_cast<SkCanvas*>(

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -148,6 +148,8 @@ void MockCanvas::onClipRect(const SkRect& rect,
                             ClipEdgeStyle style) {
   draw_calls_.emplace_back(
       DrawCall{current_layer_, ClipRectData{rect, op, style}});
+  // quickReject() is handled by base class and needs accurate clip information
+  SkCanvas::onClipRect(rect, op, style);
 }
 
 void MockCanvas::onClipRRect(const SkRRect& rrect,
@@ -155,6 +157,8 @@ void MockCanvas::onClipRRect(const SkRRect& rrect,
                              ClipEdgeStyle style) {
   draw_calls_.emplace_back(
       DrawCall{current_layer_, ClipRRectData{rrect, op, style}});
+  // quickReject() is handled by base class and needs accurate clip information
+  SkCanvas::onClipRRect(rrect, op, style);
 }
 
 void MockCanvas::onClipPath(const SkPath& path,
@@ -162,6 +166,8 @@ void MockCanvas::onClipPath(const SkPath& path,
                             ClipEdgeStyle style) {
   draw_calls_.emplace_back(
       DrawCall{current_layer_, ClipPathData{path, op, style}});
+  // quickReject() is handled by base class and needs accurate clip information
+  SkCanvas::onClipPath(path, op, style);
 }
 
 bool MockCanvas::onDoSaveBehind(const SkRect*) {


### PR DESCRIPTION
The [recent PR](https://github.com/flutter/engine/pull/22336) to use Skia's mechanism for quick clip culling caused a problem during rasterization of cache entries in 2 ways:

- There are 2 canvases used while rendering engine Layer objects. An N-way multiplexer that sends calls to a number of canvases, and a leaf canvas that draws to the current destination. The culling method was being called on the multiplexer instead of the actual rendering canvas. This wouldn't normally be an issue since the properties that affect clip culling should be kept in sync, but...

- The setup for the caching code was not informing the N-way canvas of the transform being rendered under. The leaf canvas did have the right transform, but the N-way did not. Thus, queries about culling on the N-way canvas might make an incorrect assumption about the transform being used.

Either of the 2 code changes here could individually fix the problem, but I include both because I think it will be important to have the caching N-way canvas know accurate information about the rendering environment, and we should probably do the culling against the actual leaf rendering canvas because that is the canvas on which all rendering calls are executed.

This change fixes https://github.com/flutter/flutter/issues/70933