### PR TITLE
Fix shell_unittests flakes related to external_view_embedder

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2101,6 +2101,8 @@ TEST_F(ShellTest, DiscardLayerTreeOnResize) {
   ASSERT_TRUE(raster_thread_merger_ref->IsMerged());
 
   end_frame_latch.Wait();
+  // 2 frames are submitted because `kResubmitFrame`, but only the 2nd frame should be
+  // submitted with `external_view_embedder`, hence the below check.
   ASSERT_EQ(1, external_view_embedder->GetSubmittedFrameCount());
   ASSERT_EQ(expected_size, external_view_embedder->GetLastSubmittedFrameSize());
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1040,11 +1040,12 @@ TEST_F(ShellTest,
 
   // `EndFrame` changed the post preroll result to `kSuccess`.
   end_frame_latch.Wait();
-  ASSERT_EQ(0, external_view_embedder->GetSubmittedFrameCount());
 
   // Let the resubmitted frame to run and `GetSubmittedFrameCount` should be
   // called.
   end_frame_latch.Wait();
+  // 2 frames are submitted because `kSkipAndRetryFrame`, but only the 2nd frame should be
+  // submitted with `external_view_embedder`, hence the below check.
   ASSERT_EQ(1, external_view_embedder->GetSubmittedFrameCount());
 
   PlatformViewNotifyDestroyed(shell.get());
@@ -1095,10 +1096,11 @@ TEST_F(ShellTest,
   // `external_view_embedder->GetSubmittedFrameCount()` is called.
   end_frame_latch.Wait();
   ASSERT_TRUE(raster_thread_merger_ref->IsMerged());
-  ASSERT_EQ(0, external_view_embedder->GetSubmittedFrameCount());
 
   // This is the resubmitted frame, which threads are also merged.
   end_frame_latch.Wait();
+  // 2 frames are submitted because `kResubmitFrame`, but only the 2nd frame should be
+  // submitted with `external_view_embedder`, hence the below check.
   ASSERT_EQ(1, external_view_embedder->GetSubmittedFrameCount());
 
   PlatformViewNotifyDestroyed(shell.get());
@@ -2096,11 +2098,7 @@ TEST_F(ShellTest, DiscardLayerTreeOnResize) {
                static_cast<double>(expected_size.height()));
 
   end_frame_latch.Wait();
-  // Even the threads are merged at the end of the frame,
-  // during the frame, the threads are not merged,
-  // So no `external_view_embedder->GetSubmittedFrameCount()` is called.
   ASSERT_TRUE(raster_thread_merger_ref->IsMerged());
-  ASSERT_EQ(0, external_view_embedder->GetSubmittedFrameCount());
 
   end_frame_latch.Wait();
   ASSERT_EQ(1, external_view_embedder->GetSubmittedFrameCount());

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1044,8 +1044,8 @@ TEST_F(ShellTest,
   // Let the resubmitted frame to run and `GetSubmittedFrameCount` should be
   // called.
   end_frame_latch.Wait();
-  // 2 frames are submitted because `kSkipAndRetryFrame`, but only the 2nd frame should be
-  // submitted with `external_view_embedder`, hence the below check.
+  // 2 frames are submitted because `kSkipAndRetryFrame`, but only the 2nd frame
+  // should be submitted with `external_view_embedder`, hence the below check.
   ASSERT_EQ(1, external_view_embedder->GetSubmittedFrameCount());
 
   PlatformViewNotifyDestroyed(shell.get());
@@ -1099,8 +1099,8 @@ TEST_F(ShellTest,
 
   // This is the resubmitted frame, which threads are also merged.
   end_frame_latch.Wait();
-  // 2 frames are submitted because `kResubmitFrame`, but only the 2nd frame should be
-  // submitted with `external_view_embedder`, hence the below check.
+  // 2 frames are submitted because `kResubmitFrame`, but only the 2nd frame
+  // should be submitted with `external_view_embedder`, hence the below check.
   ASSERT_EQ(1, external_view_embedder->GetSubmittedFrameCount());
 
   PlatformViewNotifyDestroyed(shell.get());
@@ -2101,8 +2101,8 @@ TEST_F(ShellTest, DiscardLayerTreeOnResize) {
   ASSERT_TRUE(raster_thread_merger_ref->IsMerged());
 
   end_frame_latch.Wait();
-  // 2 frames are submitted because `kResubmitFrame`, but only the 2nd frame should be
-  // submitted with `external_view_embedder`, hence the below check.
+  // 2 frames are submitted because `kResubmitFrame`, but only the 2nd frame
+  // should be submitted with `external_view_embedder`, hence the below check.
   ASSERT_EQ(1, external_view_embedder->GetSubmittedFrameCount());
   ASSERT_EQ(expected_size, external_view_embedder->GetLastSubmittedFrameSize());
 


### PR DESCRIPTION
## Description

The tests were still flaky, see: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8863001188407459360/+/steps/Host_Tests_for_host_profile/0/stdout?format=raw

Although I couldn't repro this locally or on a cloud linux box, there is clearly a race condition that might cause the same failure, due to the below reason.
There was an automatically resubmitted frame due to `kResubmitFrame`. And the failed check is not running on raster thread, so it could happen before or after the 2nd frame's SubmitFrame is called. Hence the flake.

The solution is to remove those similar checks, which is really unnecessary. Instead, we just need to make sure  there is only a single `external_view_embedder->GetSubmittedFrameCount()` during the 2 frames before and after resubmitting. 

## Related Issues

Fixes https://github.com/flutter/flutter/issues/66056

## Tests

I added the following tests:

Updated tests such as:
ShellTest::SkipAndSubmitFrame
ShellTest::ReSubmitFrame
ShellTest::DiscardLayerTreeOnResize

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
