### PR TITLE
Let FlutterFragment not pop the whole activity by default when more fragments are in the activity

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -902,11 +902,7 @@ public class FlutterActivity extends Activity
   @Override
   public PlatformPlugin providePlatformPlugin(
       @Nullable Activity activity, @NonNull FlutterEngine flutterEngine) {
-    if (activity != null) {
-      return new PlatformPlugin(getActivity(), flutterEngine.getPlatformChannel());
-    } else {
-      return null;
-    }
+    return new PlatformPlugin(getActivity(), flutterEngine.getPlatformChannel(), this);
   }
 
   /**
@@ -1030,6 +1026,12 @@ public class FlutterActivity extends Activity
       return false;
     }
     return true;
+  }
+
+  @Override
+  public boolean popSystemNavigator() {
+    // Hook for subclass. No-op if returns false.
+    return false;
   }
 
   private boolean stillAttachedForEvent(String event) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -22,7 +22,6 @@ import androidx.annotation.VisibleForTesting;
 import androidx.lifecycle.Lifecycle;
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
-import io.flutter.app.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterShellArgs;
@@ -752,7 +751,10 @@ import java.util.Arrays;
    * FlutterActivityAndFragmentDelegate}.
    */
   /* package */ interface Host
-      extends SplashScreenProvider, FlutterEngineProvider, FlutterEngineConfigurator {
+      extends SplashScreenProvider,
+          FlutterEngineProvider,
+          FlutterEngineConfigurator,
+          PlatformPlugin.PlatformPluginDelegate {
     /** Returns the {@link Context} that backs the host {@link Activity} or {@code Fragment}. */
     @NonNull
     Context getContext();

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -432,7 +432,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
       this(FlutterFragment.class, engineId);
     }
 
-    protected CachedEngineFragmentBuilder(
+    public CachedEngineFragmentBuilder(
         @NonNull Class<? extends FlutterFragment> subclass, @NonNull String engineId) {
       this.fragmentClass = subclass;
       this.engineId = engineId;
@@ -984,7 +984,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
   public PlatformPlugin providePlatformPlugin(
       @Nullable Activity activity, @NonNull FlutterEngine flutterEngine) {
     if (activity != null) {
-      return new PlatformPlugin(getActivity(), flutterEngine.getPlatformChannel());
+      return new PlatformPlugin(getActivity(), flutterEngine.getPlatformChannel(), this);
     } else {
       return null;
     }
@@ -1108,6 +1108,12 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
       return false;
     }
     return true;
+  }
+
+  @Override
+  public boolean popSystemNavigator() {
+    // Hook for subclass. No-op if returns false.
+    return false;
   }
 
   private boolean stillAttachedForEvent(String event) {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -382,5 +382,10 @@ public class FlutterAndroidComponentTest {
 
     @Override
     public void detachFromFlutterEngine() {}
+
+    @Override
+    public boolean popSystemNavigator() {
+      return false;
+    }
   }
 }

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -187,6 +187,7 @@ public class PlatformPluginTest {
     verify(mockFragmentActivity, never()).finish();
     verify(mockPlatformPluginDelegate, times(1)).popSystemNavigator();
     verify(mockFragmentActivity, times(1)).getOnBackPressedDispatcher();
+    verify(onBackPressedDispatcher, times(1)).onBackPressed();
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -6,6 +6,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
@@ -18,9 +21,12 @@ import android.net.Uri;
 import android.os.Build;
 import android.view.View;
 import android.view.Window;
+import androidx.activity.OnBackPressedDispatcher;
+import androidx.fragment.app.FragmentActivity;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel.ClipboardContentFormat;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel.SystemChromeStyle;
+import io.flutter.plugin.platform.PlatformPlugin.PlatformPluginDelegate;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -132,5 +138,87 @@ public class PlatformPluginTest {
       assertEquals(0XFFC70039, fakeActivity.getWindow().getStatusBarColor());
       assertEquals(0XFF000000, fakeActivity.getWindow().getNavigationBarColor());
     }
+  }
+
+  @Test
+  public void popSystemNavigatorFlutterActivity() {
+    Activity mockActivity = mock(Activity.class);
+    PlatformChannel mockPlatformChannel = mock(PlatformChannel.class);
+    PlatformPluginDelegate mockPlatformPluginDelegate = mock(PlatformPluginDelegate.class);
+    when(mockPlatformPluginDelegate.popSystemNavigator()).thenReturn(false);
+    PlatformPlugin platformPlugin =
+        new PlatformPlugin(mockActivity, mockPlatformChannel, mockPlatformPluginDelegate);
+
+    platformPlugin.mPlatformMessageHandler.popSystemNavigator();
+
+    verify(mockPlatformPluginDelegate, times(1)).popSystemNavigator();
+    verify(mockActivity, times(1)).finish();
+  }
+
+  @Test
+  public void doesNotDoAnythingByDefaultIfPopSystemNavigatorOverridden() {
+    Activity mockActivity = mock(Activity.class);
+    PlatformChannel mockPlatformChannel = mock(PlatformChannel.class);
+    PlatformPluginDelegate mockPlatformPluginDelegate = mock(PlatformPluginDelegate.class);
+    when(mockPlatformPluginDelegate.popSystemNavigator()).thenReturn(true);
+    PlatformPlugin platformPlugin =
+        new PlatformPlugin(mockActivity, mockPlatformChannel, mockPlatformPluginDelegate);
+
+    platformPlugin.mPlatformMessageHandler.popSystemNavigator();
+
+    verify(mockPlatformPluginDelegate, times(1)).popSystemNavigator();
+    // No longer perform the default action when overridden.
+    verify(mockActivity, never()).finish();
+  }
+
+  @Test
+  public void popSystemNavigatorFlutterFragment() {
+    FragmentActivity mockFragmentActivity = mock(FragmentActivity.class);
+    OnBackPressedDispatcher onBackPressedDispatcher = mock(OnBackPressedDispatcher.class);
+    when(mockFragmentActivity.getOnBackPressedDispatcher()).thenReturn(onBackPressedDispatcher);
+    PlatformChannel mockPlatformChannel = mock(PlatformChannel.class);
+    PlatformPluginDelegate mockPlatformPluginDelegate = mock(PlatformPluginDelegate.class);
+    when(mockPlatformPluginDelegate.popSystemNavigator()).thenReturn(false);
+    PlatformPlugin platformPlugin =
+        new PlatformPlugin(mockFragmentActivity, mockPlatformChannel, mockPlatformPluginDelegate);
+
+    platformPlugin.mPlatformMessageHandler.popSystemNavigator();
+
+    verify(mockFragmentActivity, never()).finish();
+    verify(mockPlatformPluginDelegate, times(1)).popSystemNavigator();
+    verify(mockFragmentActivity, times(1)).getOnBackPressedDispatcher();
+  }
+
+  @Test
+  public void doesNotDoAnythingByDefaultIfFragmentPopSystemNavigatorOverridden() {
+    FragmentActivity mockFragmentActivity = mock(FragmentActivity.class);
+    OnBackPressedDispatcher onBackPressedDispatcher = mock(OnBackPressedDispatcher.class);
+    when(mockFragmentActivity.getOnBackPressedDispatcher()).thenReturn(onBackPressedDispatcher);
+    PlatformChannel mockPlatformChannel = mock(PlatformChannel.class);
+    PlatformPluginDelegate mockPlatformPluginDelegate = mock(PlatformPluginDelegate.class);
+    when(mockPlatformPluginDelegate.popSystemNavigator()).thenReturn(true);
+    PlatformPlugin platformPlugin =
+        new PlatformPlugin(mockFragmentActivity, mockPlatformChannel, mockPlatformPluginDelegate);
+
+    platformPlugin.mPlatformMessageHandler.popSystemNavigator();
+
+    verify(mockPlatformPluginDelegate, times(1)).popSystemNavigator();
+    // No longer perform the default action when overridden.
+    verify(mockFragmentActivity, never()).finish();
+    verify(mockFragmentActivity, never()).getOnBackPressedDispatcher();
+  }
+
+  @Test
+  public void setRequestedOrientationFlutterFragment() {
+    FragmentActivity mockFragmentActivity = mock(FragmentActivity.class);
+    PlatformChannel mockPlatformChannel = mock(PlatformChannel.class);
+    PlatformPluginDelegate mockPlatformPluginDelegate = mock(PlatformPluginDelegate.class);
+    when(mockPlatformPluginDelegate.popSystemNavigator()).thenReturn(false);
+    PlatformPlugin platformPlugin =
+        new PlatformPlugin(mockFragmentActivity, mockPlatformChannel, mockPlatformPluginDelegate);
+
+    platformPlugin.mPlatformMessageHandler.setPreferredOrientations(0);
+
+    verify(mockFragmentActivity, times(1)).setRequestedOrientation(0);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/69879

Addresses 4-6 of https://github.com/flutter/flutter/issues/67011#issuecomment-730665542. 

Custom implementations that does not want the default behavior, such as passing through the OnBackPressedDispatcher can override the popSystemNavigator method on FlutterFragment or FlutterActivity to have a custom behavior. 

cc @math1man 