### PR TITLE
Fix use of uninitialized memory in animator

### DIFF
--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -108,7 +108,7 @@ class Animator final {
   bool frame_scheduled_;
   int notify_idle_task_id_;
   bool dimension_change_pending_;
-  SkISize last_layer_tree_size_ = { 0, 0 };
+  SkISize last_layer_tree_size_ = {0, 0};
   std::deque<uint64_t> trace_flow_ids_;
 
   fml::WeakPtrFactory<Animator> weak_factory_;

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -108,7 +108,7 @@ class Animator final {
   bool frame_scheduled_;
   int notify_idle_task_id_;
   bool dimension_change_pending_;
-  SkISize last_layer_tree_size_;
+  SkISize last_layer_tree_size_ = { 0, 0 };
   std::deque<uint64_t> trace_flow_ids_;
 
   fml::WeakPtrFactory<Animator> weak_factory_;


### PR DESCRIPTION
Discovered via MSAN build of embedder_unittests