### PR TITLE
Add avoid_cache field to EmbedderRenderTarget to allow RenderTargets to avoid the cache

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -472,9 +472,11 @@ CreateEmbedderRenderTarget(const FlutterCompositor* compositor,
   auto c_create_callback = compositor->create_backing_store_callback;
   auto c_collect_callback = compositor->collect_backing_store_callback;
 
+  bool avoid_cache = false;
   {
     TRACE_EVENT0("flutter", "FlutterCompositorCreateBackingStore");
-    if (!c_create_callback(&config, &backing_store, compositor->user_data)) {
+    if (!c_create_callback(&config, &backing_store, compositor->user_data,
+                           &avoid_cache)) {
       FML_LOG(ERROR) << "Could not create the embedder backing store.";
       return nullptr;
     }
@@ -526,7 +528,8 @@ CreateEmbedderRenderTarget(const FlutterCompositor* compositor,
   }
 
   return std::make_unique<flutter::EmbedderRenderTarget>(
-      backing_store, std::move(render_surface), collect_callback.Release());
+      backing_store, std::move(render_surface), collect_callback.Release(),
+      avoid_cache);
 }
 
 static std::pair<std::unique_ptr<flutter::EmbedderExternalViewEmbedder>,

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -4,7 +4,6 @@
 
 #ifndef FLUTTER_EMBEDDER_H_
 #define FLUTTER_EMBEDDER_H_
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -905,7 +904,8 @@ typedef struct {
 typedef bool (*FlutterBackingStoreCreateCallback)(
     const FlutterBackingStoreConfig* config,
     FlutterBackingStore* backing_store_out,
-    void* user_data);
+    void* user_data,
+    bool* avoid_cache);
 
 typedef bool (*FlutterBackingStoreCollectCallback)(
     const FlutterBackingStore* renderer,

--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -263,8 +263,10 @@ void EmbedderExternalViewEmbedder::SubmitFrame(
   // Hold all rendered layers in the render target cache for one frame to
   // see if they may be reused next frame.
   for (auto& render_target : matched_render_targets) {
-    render_target_cache_.CacheRenderTarget(render_target.first,
-                                           std::move(render_target.second));
+    if (!render_target.second->GetAvoidCache()) {
+      render_target_cache_.CacheRenderTarget(render_target.first,
+                                             std::move(render_target.second));
+    }
   }
 
   frame->Submit();

--- a/shell/platform/embedder/embedder_render_target.cc
+++ b/shell/platform/embedder/embedder_render_target.cc
@@ -10,10 +10,12 @@ namespace flutter {
 
 EmbedderRenderTarget::EmbedderRenderTarget(FlutterBackingStore backing_store,
                                            sk_sp<SkSurface> render_surface,
-                                           fml::closure on_release)
+                                           fml::closure on_release,
+                                           bool avoid_cache)
     : backing_store_(backing_store),
       render_surface_(std::move(render_surface)),
-      on_release_(on_release) {
+      on_release_(on_release),
+      avoid_cache_(avoid_cache) {
   // TODO(38468): The optimization to elide backing store updates between frames
   // has not been implemented yet.
   backing_store_.did_update = true;
@@ -32,6 +34,10 @@ const FlutterBackingStore* EmbedderRenderTarget::GetBackingStore() const {
 
 sk_sp<SkSurface> EmbedderRenderTarget::GetRenderSurface() const {
   return render_surface_;
+}
+
+bool EmbedderRenderTarget::GetAvoidCache() {
+  return avoid_cache_;
 }
 
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_render_target.h
+++ b/shell/platform/embedder/embedder_render_target.h
@@ -36,7 +36,8 @@ class EmbedderRenderTarget {
   ///
   EmbedderRenderTarget(FlutterBackingStore backing_store,
                        sk_sp<SkSurface> render_surface,
-                       fml::closure on_release);
+                       fml::closure on_release,
+                       bool avoid_cache);
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys this instance of the render target and invokes the
@@ -65,10 +66,18 @@ class EmbedderRenderTarget {
   ///
   const FlutterBackingStore* GetBackingStore() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      The render target may want to avoid being cached.
+  ///
+  /// @return     A bool representing if the embedder render target should
+  ///             avoid the cache.
+  bool GetAvoidCache();
+
  private:
   FlutterBackingStore backing_store_;
   sk_sp<SkSurface> render_surface_;
   fml::closure on_release_;
+  bool avoid_cache_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderRenderTarget);
 };

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -257,10 +257,10 @@ void EmbedderConfigBuilder::SetCompositor() {
   compositor_.create_backing_store_callback =
       [](const FlutterBackingStoreConfig* config,  //
          FlutterBackingStore* backing_store_out,   //
-         void* user_data                           //
-      ) {
+         void* user_data,                          //
+         bool* avoid_cache) {
         return reinterpret_cast<EmbedderTestCompositor*>(user_data)
-            ->CreateBackingStore(config, backing_store_out);
+            ->CreateBackingStore(config, backing_store_out, avoid_cache);
       };
   compositor_.collect_backing_store_callback =
       [](const FlutterBackingStore* backing_store,  //

--- a/shell/platform/embedder/tests/embedder_test_compositor.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor.cc
@@ -29,11 +29,15 @@ static void InvokeAllCallbacks(const std::vector<fml::closure>& callbacks) {
 
 bool EmbedderTestCompositor::CreateBackingStore(
     const FlutterBackingStoreConfig* config,
-    FlutterBackingStore* backing_store_out) {
+    FlutterBackingStore* backing_store_out,
+    bool* avoid_cache) {
   bool success = backingstore_producer_->Create(config, backing_store_out);
   if (success) {
     backing_stores_created_++;
     InvokeAllCallbacks(on_create_render_target_callbacks_);
+  }
+  if (avoid_cache_callback_) {
+    avoid_cache_callback_(avoid_cache);
   }
   return success;
 }
@@ -102,6 +106,11 @@ void EmbedderTestCompositor::SetNextSceneCallback(
 void EmbedderTestCompositor::SetPlatformViewRendererCallback(
     const PlatformViewRendererCallback& callback) {
   platform_view_renderer_callback_ = callback;
+}
+
+void EmbedderTestCompositor::SetUpdateAvoidCacheCallback(
+    const UpdateAvoidCacheCallback& avoid_cache_callback) {
+  avoid_cache_callback_ = avoid_cache_callback;
 }
 
 size_t EmbedderTestCompositor::GetPendingBackingStoresCount() const {

--- a/shell/platform/embedder/tests/embedder_test_compositor.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor.h
@@ -24,6 +24,8 @@ class EmbedderTestCompositor {
   using PresentCallback =
       std::function<void(const FlutterLayer** layers, size_t layers_count)>;
 
+  using UpdateAvoidCacheCallback = std::function<void(bool* avoid_cache)>;
+
   EmbedderTestCompositor(SkISize surface_size, sk_sp<GrDirectContext> context);
 
   virtual ~EmbedderTestCompositor();
@@ -32,7 +34,8 @@ class EmbedderTestCompositor {
       std::unique_ptr<EmbedderTestBackingStoreProducer> backingstore_producer);
 
   bool CreateBackingStore(const FlutterBackingStoreConfig* config,
-                          FlutterBackingStore* backing_store_out);
+                          FlutterBackingStore* backing_store_out,
+                          bool* avoid_cache);
 
   bool CollectBackingStore(const FlutterBackingStore* backing_store);
 
@@ -52,6 +55,15 @@ class EmbedderTestCompositor {
 
   void SetPresentCallback(const PresentCallback& present_callback,
                           bool one_shot);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Allows tests to install a callback to update the
+  ///             avoid_cache_callback_ bool.
+  ///
+  /// @param[in]  avoid_cache_callback  The callback to update the
+  /// avoid_cache_callback_.
+  void SetUpdateAvoidCacheCallback(
+      const UpdateAvoidCacheCallback& avoid_cache_callback);
 
   using NextSceneCallback = std::function<void(sk_sp<SkImage> image)>;
   void SetNextSceneCallback(const NextSceneCallback& next_scene_callback);
@@ -85,6 +97,7 @@ class EmbedderTestCompositor {
   bool present_callback_is_one_shot_ = false;
   PresentCallback present_callback_;
   NextSceneCallback next_scene_callback_;
+  UpdateAvoidCacheCallback avoid_cache_callback_;
   sk_sp<SkImage> last_composition_;
   size_t backing_stores_created_ = 0;
   size_t backing_stores_collected_ = 0;


### PR DESCRIPTION
Follow up on https://github.com/flutter/engine/pull/22643

Approach described here https://github.com/flutter/engine/pull/22643#discussion_r529914441

Created avoid_cache field to EmbedderRenderTarget. 

CreateBackingStore takes a pointer to a bool which is modified to true if the backing store should not be cached.
