### PR TITLE
[web] Add new line break type (prohibited)

### DIFF
--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -771,8 +771,6 @@ class LinesCalculator {
   /// This method should be called for every line break. As soon as it reaches
   /// the maximum number of lines required
   void update(LineBreakResult brk) {
-    final bool isHardBreak = brk.type == LineBreakType.mandatory ||
-        brk.type == LineBreakType.endOfText;
     final int chunkEnd = brk.index;
     final int chunkEndWithoutNewlines = brk.indexWithoutTrailingNewlines;
     final int chunkEndWithoutSpace = brk.indexWithoutTrailingSpaces;
@@ -855,7 +853,7 @@ class LinesCalculator {
       return;
     }
 
-    if (isHardBreak) {
+    if (brk.isHard) {
       _addLineBreak(brk);
     }
     _lastBreak = brk;
@@ -872,15 +870,13 @@ class LinesCalculator {
       lineWidth: lineWidth,
       maxWidth: _maxWidth,
     );
-    final bool isHardBreak = brk.type == LineBreakType.mandatory ||
-        brk.type == LineBreakType.endOfText;
 
     final EngineLineMetrics metrics = EngineLineMetrics.withText(
       _text!.substring(_lineStart, brk.indexWithoutTrailingNewlines),
       startIndex: _lineStart,
       endIndex: brk.index,
       endIndexWithoutNewlines: brk.indexWithoutTrailingNewlines,
-      hardBreak: isHardBreak,
+      hardBreak: brk.isHard,
       width: lineWidth,
       widthWithTrailingSpaces: lineWidthWithTrailingSpaces,
       left: alignOffset,
@@ -995,7 +991,7 @@ class MaxIntrinsicCalculator {
   /// intrinsic width calculated so far. When the whole text is consumed,
   /// [value] will contain the final maximum intrinsic width.
   void update(LineBreakResult brk) {
-    if (brk.type == LineBreakType.opportunity) {
+    if (!brk.isHard) {
       return;
     }
 

--- a/lib/web_ui/test/text/line_breaker_test.dart
+++ b/lib/web_ui/test/text/line_breaker_test.dart
@@ -252,6 +252,14 @@ void testMain() {
                   '"$text"\n'
                   '\nExpected line break at {$lastLineBreak - $i} but found line break at {$lastLineBreak - ${result.index}}.',
             );
+
+            // Since this is a line break, passing a `maxEnd` that's greater
+            // should return the same line break.
+            final LineBreakResult maxEndResult =
+                nextLineBreak(text, lastLineBreak, maxEnd: i + 1);
+            expect(maxEndResult.index, i);
+            expect(maxEndResult.type, isNot(LineBreakType.prohibited));
+
             lastLineBreak = i;
           } else {
             // This isn't a line break opportunity so the line break should be
@@ -264,6 +272,13 @@ void testMain() {
                   '"$text"\n'
                   '\nUnexpected line break found at {$lastLineBreak - $i}.',
             );
+
+            // Since this isn't a line break, passing it as a `maxEnd` should
+            // return `maxEnd` as a prohibited line break type.
+            final LineBreakResult maxEndResult =
+                nextLineBreak(text, lastLineBreak, maxEnd: i);
+            expect(maxEndResult.index, i);
+            expect(maxEndResult.type, LineBreakType.prohibited);
           }
         }
       }


### PR DESCRIPTION
## Description

Add the ability to pass a `maxEnd` argument to `nextLineBreak` so it can be used by rich text measurement in case the end of the current span occurs before the line break. This is so that the measurement algorithm stops at this point, measures whatever is left from the current span, and switches to the font/styles of the next span.

The type of the line break is `prohibited` because it's not a real line break, it's just a stopping point.