### PR TITLE
[embedder] Compositor can specify that no backing stores be cached

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -542,6 +542,8 @@ InferExternalViewEmbedderFromArgs(const FlutterCompositor* compositor) {
       SAFE_ACCESS(compositor, collect_backing_store_callback, nullptr);
   auto c_present_callback =
       SAFE_ACCESS(compositor, present_layers_callback, nullptr);
+  bool avoid_backing_store_cache =
+      SAFE_ACCESS(compositor, avoid_backing_store_cache, false);
 
   // Make sure the required callbacks are present
   if (!c_create_callback || !c_collect_callback || !c_present_callback) {
@@ -568,7 +570,8 @@ InferExternalViewEmbedderFromArgs(const FlutterCompositor* compositor) {
       };
 
   return {std::make_unique<flutter::EmbedderExternalViewEmbedder>(
-              create_render_target_callback, present_callback),
+              avoid_backing_store_cache, create_render_target_callback,
+              present_callback),
           false};
 }
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -937,6 +937,8 @@ typedef struct {
   /// Callback invoked by the engine to composite the contents of each layer
   /// onto the screen.
   FlutterLayersPresentCallback present_layers_callback;
+  /// Avoid caching backing stores provided by this compositor.
+  bool avoid_backing_store_cache;
 } FlutterCompositor;
 
 typedef struct {

--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -13,9 +13,11 @@
 namespace flutter {
 
 EmbedderExternalViewEmbedder::EmbedderExternalViewEmbedder(
+    bool avoid_backing_store_cache,
     const CreateRenderTargetCallback& create_render_target_callback,
     const PresentCallback& present_callback)
-    : create_render_target_callback_(create_render_target_callback),
+    : avoid_backing_store_cache_(avoid_backing_store_cache),
+      create_render_target_callback_(create_render_target_callback),
       present_callback_(present_callback) {
   FML_DCHECK(create_render_target_callback_);
   FML_DCHECK(present_callback_);
@@ -263,8 +265,10 @@ void EmbedderExternalViewEmbedder::SubmitFrame(
   // Hold all rendered layers in the render target cache for one frame to
   // see if they may be reused next frame.
   for (auto& render_target : matched_render_targets) {
-    render_target_cache_.CacheRenderTarget(render_target.first,
-                                           std::move(render_target.second));
+    if (!avoid_backing_store_cache_) {
+      render_target_cache_.CacheRenderTarget(render_target.first,
+                                             std::move(render_target.second));
+    }
   }
 
   frame->Submit();

--- a/shell/platform/embedder/embedder_external_view_embedder.h
+++ b/shell/platform/embedder/embedder_external_view_embedder.h
@@ -40,6 +40,11 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
   /// @brief      Creates an external view embedder used by the generic embedder
   ///             API.
   ///
+  /// @param[in] avoid_backing_store_cache If set, create_render_target callback
+  ///                                      will beinvoked every frame for every
+  ///                                      engine composited layer. The result
+  ///                                      will not cached.
+  ///
   /// @param[in]  create_render_target_callback
   ///                                     The render target callback used to
   ///                                     request the render target for a layer.
@@ -49,6 +54,7 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
   ///                                     embedder for presentation.
   ///
   EmbedderExternalViewEmbedder(
+      bool avoid_backing_store_cache,
       const CreateRenderTargetCallback& create_render_target_callback,
       const PresentCallback& present_callback);
 
@@ -100,6 +106,7 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
   SkCanvas* GetRootCanvas() override;
 
  private:
+  const bool avoid_backing_store_cache_;
   const CreateRenderTargetCallback create_render_target_callback_;
   const PresentCallback present_callback_;
   SurfaceTransformationCallback surface_transformation_callback_;

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -249,7 +249,7 @@ void EmbedderConfigBuilder::SetPlatformMessageCallback(
   context_.SetPlatformMessageCallback(callback);
 }
 
-void EmbedderConfigBuilder::SetCompositor() {
+void EmbedderConfigBuilder::SetCompositor(bool avoid_backing_store_cache) {
   context_.SetupCompositor();
   auto& compositor = context_.GetCompositor();
   compositor_.struct_size = sizeof(compositor_);
@@ -279,6 +279,7 @@ void EmbedderConfigBuilder::SetCompositor() {
 
     );
   };
+  compositor_.avoid_backing_store_cache = avoid_backing_store_cache;
   project_args_.compositor = &compositor_;
 }
 

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -85,7 +85,7 @@ class EmbedderConfigBuilder {
   void SetPlatformMessageCallback(
       const std::function<void(const FlutterPlatformMessage*)>& callback);
 
-  void SetCompositor();
+  void SetCompositor(bool avoid_backing_store_cache = false);
 
   FlutterCompositor& GetCompositor();
 


### PR DESCRIPTION
This supersedes:

1. https://github.com/flutter/engine/pull/22742
2. https://github.com/flutter/engine/pull/22643