### PR TITLE
Stop using the List constructor.

### DIFF
--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -220,13 +220,13 @@ bool get isVerboseLoggingEnabled => GeneralTestsArgumentParser.instance.verbose;
 /// There might be proccesses started during the tests.
 ///
 /// Use this list to store those Processes, for cleaning up before shutdown.
-final List<io.Process> processesToCleanUp = List<io.Process>();
+final List<io.Process> processesToCleanUp = <io.Process>[];
 
 /// There might be temporary directories created during the tests.
 ///
 /// Use this list to store those directories and for deleteing them before
 /// shutdown.
-final List<io.Directory> temporaryDirectories = List<io.Directory>();
+final List<io.Directory> temporaryDirectories = <io.Directory>[];
 
 typedef AsyncCallback = Future<void> Function();
 
@@ -234,7 +234,7 @@ typedef AsyncCallback = Future<void> Function();
 ///
 /// Add these operations here to make sure that they will run before felt
 /// exit.
-final List<AsyncCallback> cleanupCallbacks = List<AsyncCallback>();
+final List<AsyncCallback> cleanupCallbacks = <AsyncCallback>[];
 
 /// Cleanup the remaning processes, close open browsers, delete temp files.
 void cleanup() async {

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -30,7 +30,7 @@ void testMain() {
     group('regular special characters', () {
       test('Register Asset with no special characters', () async {
         final String _testFontFamily = "Ahem";
-        final List<String> fontFamilyList = List<String>();
+        final List<String> fontFamilyList = <String>[];
 
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
@@ -48,7 +48,7 @@ void testMain() {
 
       test('Register Asset with white space in the family name', () async {
         final String _testFontFamily = "Ahem ahem ahem";
-        final List<String> fontFamilyList = List<String>();
+        final List<String> fontFamilyList = <String>[];
 
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
@@ -68,7 +68,7 @@ void testMain() {
 
       test('Register Asset with capital case letters', () async {
         final String _testFontFamily = "AhEm";
-        final List<String> fontFamilyList = List<String>();
+        final List<String> fontFamilyList = <String>[];
 
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
@@ -88,7 +88,7 @@ void testMain() {
     group('fonts with special characters', () {
       test('Register Asset twice with special character slash', () async {
         final String _testFontFamily = '/Ahem';
-        final List<String> fontFamilyList = List<String>();
+        final List<String> fontFamilyList = <String>[];
 
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
@@ -114,7 +114,7 @@ void testMain() {
 
       test('Register Asset twice with exclamation mark', () async {
         final String _testFontFamily = 'Ahem!!ahem';
-        final List<String> fontFamilyList = List<String>();
+        final List<String> fontFamilyList = <String>[];
 
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
@@ -140,7 +140,7 @@ void testMain() {
 
       test('Register Asset twice with comma', () async {
         final String _testFontFamily = 'Ahem ,ahem';
-        final List<String> fontFamilyList = List<String>();
+        final List<String> fontFamilyList = <String>[];
 
         fontManager.registerAsset(
             _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
@@ -167,7 +167,7 @@ void testMain() {
       test('Register Asset twice with a digit at the start of a token',
           () async {
         final String testFontFamily = 'Ahem 1998';
-        final List<String> fontFamilyList = List<String>();
+        final List<String> fontFamilyList = <String>[];
 
         fontManager.registerAsset(
             testFontFamily, 'url($_testFontUrl)', const <String, String>{});

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2163,7 +2163,7 @@ void checkInputEditingState(
 
 /// In case of an exception backup DOM element(s) can still stay on the DOM.
 void clearBackUpDomElementIfExists() {
-  List<Node> domElementsToRemove = List<Node>();
+  List<Node> domElementsToRemove = <Node>[];
   if (document.getElementsByTagName('input').length > 0) {
     domElementsToRemove..addAll(document.getElementsByTagName('input'));
   }


### PR DESCRIPTION
## Description

The `List` constructor will be deprecated in the Dart platform libraries.
It cannot be used in null safe code, and it's deprecated to give users a fair warning
to stop using it in legacy code.

See: https://dart-review.googlesource.com/c/sdk/+/173261

This removes uses of the `List` constructor which are detected by the Dart continuous build system.
It does not attempt to find further uses in other packages.

## Tests

Refactoring, should be covered by existing tests.

