### PR TITLE
Revert "Roll buildroot and benchmark"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -102,7 +102,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '084f0d394f5b8fab6ddc2edb4837e20209a726a0',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '4985b584a430ea3fda9433dccafa5047531e0974',
 
    # Fuchsia compatibility
    #
@@ -111,7 +111,7 @@ deps = {
    # and not have to specific specific hashes.
 
   'src/third_party/benchmark':
-   Var('github_git') + '/google/benchmark' + '@' + 'bf585a2789e30585b4e3ce6baf11ef2750b54677',
+   Var('fuchsia_git') + '/third_party/benchmark' + '@' + 'a779ffce872b4c811beef482e18bd0b63626aa42',
 
   'src/third_party/googletest':
    Var('fuchsia_git') + '/third_party/googletest' + '@' + '3fef9015bfe7617d57806cd7c73a653b28559fae',

--- a/benchmarking/benchmarking.h
+++ b/benchmarking/benchmarking.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_BENCHMARKING_BENCHMARKING_H_
 #define FLUTTER_BENCHMARKING_BENCHMARKING_H_
 
-#include "benchmark/benchmark.h"
+#include "benchmark/benchmark_api.h"
 
 namespace benchmarking {
 

--- a/third_party/txt/benchmarks/paint_record_benchmarks.cc
+++ b/third_party/txt/benchmarks/paint_record_benchmarks.cc
@@ -17,7 +17,7 @@
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
-#include "third_party/benchmark/include/benchmark/benchmark.h"
+#include "third_party/benchmark/include/benchmark/benchmark_api.h"
 #include "txt/paint_record.h"
 #include "txt/text_style.h"
 

--- a/third_party/txt/benchmarks/paragraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/paragraph_benchmarks.cc
@@ -22,7 +22,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
 #include "minikin/LayoutUtils.h"
-#include "third_party/benchmark/include/benchmark/benchmark.h"
+#include "third_party/benchmark/include/benchmark/benchmark_api.h"
 #include "third_party/icu/source/common/unicode/unistr.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkCanvas.h"

--- a/third_party/txt/benchmarks/paragraph_builder_benchmarks.cc
+++ b/third_party/txt/benchmarks/paragraph_builder_benchmarks.cc
@@ -16,7 +16,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
-#include "third_party/benchmark/include/benchmark/benchmark.h"
+#include "third_party/benchmark/include/benchmark/benchmark_api.h"
 #include "third_party/icu/source/common/unicode/unistr.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "txt/font_collection.h"

--- a/third_party/txt/benchmarks/skparagraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/skparagraph_benchmarks.cc
@@ -19,7 +19,7 @@
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
-#include "third_party/benchmark/include/benchmark/benchmark.h"
+#include "third_party/benchmark/include/benchmark/benchmark_api.h"
 #include "third_party/icu/source/common/unicode/unistr.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkCanvas.h"

--- a/third_party/txt/benchmarks/styled_runs_benchmarks.cc
+++ b/third_party/txt/benchmarks/styled_runs_benchmarks.cc
@@ -17,7 +17,7 @@
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
-#include "third_party/benchmark/include/benchmark/benchmark.h"
+#include "third_party/benchmark/include/benchmark/benchmark_api.h"
 #include "txt/styled_runs.h"
 #include "txt/text_style.h"
 

--- a/third_party/txt/benchmarks/txt_run_all_benchmarks.cc
+++ b/third_party/txt/benchmarks/txt_run_all_benchmarks.cc
@@ -18,7 +18,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/testing/testing.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
-#include "third_party/benchmark/include/benchmark/benchmark.h"
+#include "third_party/benchmark/include/benchmark/benchmark_api.h"
 
 // We will use a custom main to allow custom font directories for consistency.
 int main(int argc, char** argv) {


### PR DESCRIPTION
Reverts flutter/engine#22804

metrics_center needs an update

```
+ dart bin/parse_and_send.dart ../../../out/host_release/txt_benchmarks.json
run_name: BM_PaintRecordInit (String) is not a number
Unhandled exception:
type 'String' is not a subtype of type 'num'
#0      _parseAnItem (package:metrics_center/google_benchmark.dart:47:9)
#1      GoogleBenchmarkParser.parse (package:metrics_center/google_benchmark.dart:28:7)
#2      _parse (file:///b/s/w/ir/cache/builder/src/flutter/testing/benchmark/bin/parse_and_send.dart:28:35)
<asynchronous suspension>
#3      main (file:///b/s/w/ir/cache/builder/src/flutter/testing/benchmark/bin/parse_and_send.dart:61:55)
#4      _startIsolate.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:309:32)
#5      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:184:12)
```