### PR TITLE
Generate gen_snapshot_armv7 and gen_snapshot_arm64

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -197,6 +197,29 @@ bin_to_linkable("platform_strong_dill_linkable") {
   executable = false
 }
 
+action("create_arm_gen_snapshot") {
+  output_dir = "$root_out_dir/clang_x64"
+  script = "//flutter/sky/tools/create_macos_gen_snapshots.py"
+  visibility = [ ":*" ]
+  args = [
+    "--dst",
+    rebase_path(output_dir),
+  ]
+  if (target_cpu == "arm") {
+    args += [
+      "--armv7-out-dir",
+      rebase_path("$root_out_dir"),
+    ]
+    outputs = [ "$output_dir/gen_snapshot_armv7" ]
+  } else {
+    args += [
+      "--arm64-out-dir",
+      rebase_path("$root_out_dir"),
+    ]
+    outputs = [ "$output_dir/gen_snapshot_arm64" ]
+  }
+}
+
 source_set("snapshot") {
   deps = [
     ":isolate_snapshot_data_linkable",
@@ -205,6 +228,10 @@ source_set("snapshot") {
     ":vm_snapshot_data_linkable",
     ":vm_snapshot_instructions_linkable",
   ]
+  if (host_os == "macos" && (target_cpu == "arm" || target_cpu == "arm64")) {
+    deps += [ ":create_arm_gen_snapshot" ]
+  }
+
   sources = get_target_outputs(":isolate_snapshot_data_linkable") +
             get_target_outputs(":isolate_snapshot_instructions_linkable") +
             get_target_outputs(":vm_snapshot_data_linkable") +

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -324,6 +324,29 @@ shared_library("copy_and_verify_framework_module") {
   ]
 }
 
+action("create_arm_gen_snapshot") {
+  output_dir = "$root_out_dir/clang_x64"
+  script = "//flutter/sky/tools/create_macos_gen_snapshots.py"
+  visibility = [ ":*" ]
+  args = [
+    "--dst",
+    rebase_path(output_dir),
+  ]
+  if (target_cpu == "arm") {
+    args += [
+      "--armv7-out-dir",
+      rebase_path("$root_out_dir"),
+    ]
+    outputs = [ "$output_dir/gen_snapshot_armv7" ]
+  } else {
+    args += [
+      "--arm64-out-dir",
+      rebase_path("$root_out_dir"),
+    ]
+    outputs = [ "$output_dir/gen_snapshot_arm64" ]
+  }
+}
+
 group("universal_flutter_framework") {
   visibility = [ ":*" ]
   deps = [
@@ -335,6 +358,9 @@ group("universal_flutter_framework") {
     ":copy_framework_podspec",
     ":copy_license",
   ]
+  if (target_cpu == "arm" || target_cpu == "arm64") {
+    deps += [ ":create_arm_gen_snapshot" ]
+  }
 }
 
 action("flutter_framework") {

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -324,29 +324,6 @@ shared_library("copy_and_verify_framework_module") {
   ]
 }
 
-action("create_arm_gen_snapshot") {
-  output_dir = "$root_out_dir/clang_x64"
-  script = "//flutter/sky/tools/create_macos_gen_snapshots.py"
-  visibility = [ ":*" ]
-  args = [
-    "--dst",
-    rebase_path(output_dir),
-  ]
-  if (target_cpu == "arm") {
-    args += [
-      "--armv7-out-dir",
-      rebase_path("$root_out_dir"),
-    ]
-    outputs = [ "$output_dir/gen_snapshot_armv7" ]
-  } else {
-    args += [
-      "--arm64-out-dir",
-      rebase_path("$root_out_dir"),
-    ]
-    outputs = [ "$output_dir/gen_snapshot_arm64" ]
-  }
-}
-
 group("universal_flutter_framework") {
   visibility = [ ":*" ]
   deps = [
@@ -358,9 +335,6 @@ group("universal_flutter_framework") {
     ":copy_framework_podspec",
     ":copy_license",
   ]
-  if (target_cpu == "arm" || target_cpu == "arm64") {
-    deps += [ ":create_arm_gen_snapshot" ]
-  }
 }
 
 action("flutter_framework") {

--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -13,26 +13,27 @@ def main():
   parser = argparse.ArgumentParser(description='Copies architecture-dependent gen_snapshot binaries to output dir')
 
   parser.add_argument('--dst', type=str, required=True)
-  parser.add_argument('--arm64-out-dir', type=str, required=True)
-  parser.add_argument('--armv7-out-dir', type=str, required=True)
+  parser.add_argument('--arm64-out-dir', type=str)
+  parser.add_argument('--armv7-out-dir', type=str)
 
   args = parser.parse_args()
 
-  arm64_gen_snapshot = os.path.join(args.arm64_out_dir, 'clang_x64', 'gen_snapshot')
-  armv7_gen_snapshot = os.path.join(args.armv7_out_dir, 'clang_x64', 'gen_snapshot')
+  if args.arm64_out_dir:
+    generate_gen_snapshot(args.arm64_out_dir, os.path.join(args.dst, 'gen_snapshot_arm64'))
 
-  if not os.path.isfile(arm64_gen_snapshot):
-    print 'Cannot find x86_64 (arm64) gen_snapshot at', arm64_gen_snapshot
-    return 1
+  if args.armv7_out_dir:
+    generate_gen_snapshot(args.armv7_out_dir, os.path.join(args.dst, 'gen_snapshot_armv7'))
 
-  if not os.path.isfile(armv7_gen_snapshot):
-    print 'Cannot find i386 (armv7) gen_snapshot at', armv7_gen_snapshot
-    return 1
 
-  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', armv7_gen_snapshot,
-      '-o', os.path.join(args.dst, 'gen_snapshot_armv7')])
-  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', arm64_gen_snapshot,
-      '-o', os.path.join(args.dst, 'gen_snapshot_arm64')])
+def generate_gen_snapshot(directory, destination):
+  gen_snapshot_dir = os.path.join(directory, 'clang_x64', 'gen_snapshot')
+  if not os.path.isfile(gen_snapshot_dir):
+    print 'Cannot find gen_snapshot at', gen_snapshot_dir
+    sys.exit(1)
+
+  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', gen_snapshot_dir,
+      '-o', destination])
+
 
 if __name__ == '__main__':
   sys.exit(main())


### PR DESCRIPTION
## Description

Make local engine builds mimic artifacts by creating `gen_snapshot_armv7` and `gen_snapshot_arm64` for iOS as appropriate.

I put the logic in `shell/platform/darwin/ios/BUILD.gn` to mirror where it is in the [engine recipe](https://flutter.googlesource.com/recipes/+/refs/heads/master/recipes/engine.py#1089).  Let me know if there's a better spot for it.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/38933

Split was introduced in https://github.com/flutter/flutter/pull/37445 and https://github.com/flutter/engine/pull/10430