### PR TITLE
Temporarily reduce e2e test matrix to stop flaky web engine builds

### DIFF
--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -632,9 +632,26 @@ const Map<String, List<String>> blockedTestsListsMapForModes =
     'treeshaking_integration.dart',
     'text_editing_integration.dart',
     'url_strategy_integration.dart',
+
+    // The following tests are blocked to reduce the load on the build bot.
+    // The bot currently frequently exceeds the timeout limit.
+    'image_loading_integration.dart',
+    'platform_messages_integration.dart',
+    'profile_diagnostics_integration.dart',
+    'scroll_wheel_integration.dart',
   ],
   'profile': [],
-  'release': [],
+  'release': [
+    // The following tests are blocked to reduce the load on the build bot.
+    // The bot currently frequently exceeds the timeout limit.
+    'image_loading_integration.dart',
+    'platform_messages_integration.dart',
+    'profile_diagnostics_integration.dart',
+    'scroll_wheel_integration.dart',
+    'text_editing_integration.dart',
+    'treeshaking_integration.dart',
+    'url_strategy_integration.dart',
+  ],
 };
 
 /// Tests blocked for one of the rendering backends.

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -633,6 +633,7 @@ const Map<String, List<String>> blockedTestsListsMapForModes =
     'text_editing_integration.dart',
     'url_strategy_integration.dart',
 
+    // TODO(yjbanov): https://github.com/flutter/flutter/issues/71583
     // The following tests are blocked to reduce the load on the build bot.
     // The bot currently frequently exceeds the timeout limit.
     'image_loading_integration.dart',
@@ -642,6 +643,7 @@ const Map<String, List<String>> blockedTestsListsMapForModes =
   ],
   'profile': [],
   'release': [
+    // TODO(yjbanov): https://github.com/flutter/flutter/issues/71583
     // The following tests are blocked to reduce the load on the build bot.
     // The bot currently frequently exceeds the timeout limit.
     'image_loading_integration.dart',


### PR DESCRIPTION
## Description

Temporarily reduce e2e test matrix to stop flaky web engine builds.

This should be reverted when we have shards available for LUCI web builds.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/71576