### PR TITLE
Fix NPE when platform plugin delegate is null

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -310,7 +310,7 @@ public class PlatformPlugin {
   }
 
   private void popSystemNavigator() {
-    if (platformPluginDelegate.popSystemNavigator()) {
+    if (platformPluginDelegate != null && platformPluginDelegate.popSystemNavigator()) {
       // A custom behavior was executed by the delegate. Don't execute default behavior.
       return;
     }


### PR DESCRIPTION
Adds a null check before dereferencing in
PlatformPlugin.popSystemNavigator. platformPluginDelegate is allowed to
be null, as it is in the PlatformPlugin(Activity, PlatformChannel)
constructor.