### PR TITLE
Add split AOT loading unit failure/error code path

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -350,17 +350,17 @@ bool DartIsolate::LoadLoadingUnit(
       loading_unit_id, dart_snapshot->GetDataMapping(),
       dart_snapshot->GetInstructionsMapping());
   if (tonic::LogIfError(result)) {
-    LoadLoadingUnitFailure(loading_unit_id, Dart_GetError(result),
-                           /*transient*/ true);
+    LoadLoadingUnitError(loading_unit_id, Dart_GetError(result),
+                         /*transient*/ true);
     return false;
   }
   loading_unit_snapshots_.insert(dart_snapshot);
   return true;
 }
 
-void DartIsolate::LoadLoadingUnitFailure(intptr_t loading_unit_id,
-                                         const std::string error_message,
-                                         bool transient) {
+void DartIsolate::LoadLoadingUnitError(intptr_t loading_unit_id,
+                                       const std::string error_message,
+                                       bool transient) {
   tonic::DartState::Scope scope(this);
   Dart_Handle result = Dart_DeferredLoadCompleteError(
       loading_unit_id, error_message.c_str(), transient);

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -390,9 +390,9 @@ class DartIsolate : public UIDartState {
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions);
 
-  void LoadLoadingUnitFailure(intptr_t loading_unit_id,
-                              const std::string error_message,
-                              bool transient);
+  void LoadLoadingUnitError(intptr_t loading_unit_id,
+                            const std::string error_message,
+                            bool transient);
 
  private:
   friend class IsolateConfiguration;

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -424,6 +424,13 @@ void RuntimeController::LoadDartDeferredLibrary(
                                         std::move(snapshot_instructions));
 }
 
+void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                  const std::string error_message,
+                                  bool transient) {
+  root_isolate_.lock()->LoadLoadingUnitError(loading_unit_id, error_message,
+                                             transient);
+}
+
 void RuntimeController::RequestDartDeferredLibrary(intptr_t loading_unit_id) {
   return client_.RequestDartDeferredLibrary(loading_unit_id);
 }

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -424,9 +424,10 @@ void RuntimeController::LoadDartDeferredLibrary(
                                         std::move(snapshot_instructions));
 }
 
-void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
-                                  const std::string error_message,
-                                  bool transient) {
+void RuntimeController::LoadDartDeferredLibraryError(
+    intptr_t loading_unit_id,
+    const std::string error_message,
+    bool transient) {
   root_isolate_.lock()->LoadLoadingUnitError(loading_unit_id, error_message,
                                              transient);
 }

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -510,6 +510,28 @@ class RuntimeController : public PlatformConfigurationClient {
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions);
 
+  //--------------------------------------------------------------------------
+  /// @brief      Indicates to the dart VM that the request to load a deferred
+  ///             library with the specified loading unit id has failed.
+  ///
+  ///             The dart future returned by the initiating loadLibrary() call
+  ///             will complete with an error.
+  ///
+  /// @param[in]  loading_unit_id  The unique id of the deferred library's
+  ///                              loading unit, as passed in by
+  ///                              RequestDartDeferredLibrary.
+  ///
+  /// @param[in]  error_message    The error message that will appear in the
+  ///                              dart Future.
+  ///
+  /// @param[in]  transient        A transient error is a failure due to
+  ///                              temporary conditions such as no network.
+  ///                              Transient errors allow the dart VM to
+  ///                              re-request the same deferred library and
+  ///                              and loading_unit_id again. Non-transient
+  ///                              errors are permanent and attempts to
+  ///                              re-request the library will instantly
+  ///                              complete with an error.
   void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                     const std::string error_message,
                                     bool transient);

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -532,9 +532,9 @@ class RuntimeController : public PlatformConfigurationClient {
   ///                              errors are permanent and attempts to
   ///                              re-request the library will instantly
   ///                              complete with an error.
-  void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
-                                    const std::string error_message,
-                                    bool transient);
+  virtual void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                            const std::string error_message,
+                                            bool transient);
 
   // |PlatformConfigurationClient|
   void RequestDartDeferredLibrary(intptr_t loading_unit_id) override;

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -510,6 +510,10 @@ class RuntimeController : public PlatformConfigurationClient {
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions);
 
+  void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                    const std::string error_message,
+                                    bool transient);
+
   // |PlatformConfigurationClient|
   void RequestDartDeferredLibrary(intptr_t loading_unit_id) override;
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -520,6 +520,9 @@ void Engine::LoadDartDeferredLibrary(
     runtime_controller_->LoadDartDeferredLibrary(
         loading_unit_id, std::move(snapshot_data),
         std::move(snapshot_instructions));
+  } else {
+    LoadDartDeferredLibraryError(loading_unit_id, "No running root isolate.",
+                                 true);
   }
 }
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -523,4 +523,13 @@ void Engine::LoadDartDeferredLibrary(
   }
 }
 
+void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                  const std::string error_message,
+                                  bool transient) {
+  if (runtime_controller_->IsRootIsolateRunning()) {
+    runtime_controller_->LoadDartDeferredLibraryError(loading_unit_id,
+                                                      error_message, transient);
+  }
+}
+
 }  // namespace flutter

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -523,9 +523,9 @@ void Engine::LoadDartDeferredLibrary(
   }
 }
 
-void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
-                                  const std::string error_message,
-                                  bool transient) {
+void Engine::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                          const std::string error_message,
+                                          bool transient) {
   if (runtime_controller_->IsRootIsolateRunning()) {
     runtime_controller_->LoadDartDeferredLibraryError(loading_unit_id,
                                                       error_message, transient);

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -825,6 +825,28 @@ class Engine final : public RuntimeDelegate,
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions);
 
+  //--------------------------------------------------------------------------
+  /// @brief      Indicates to the dart VM that the request to load a deferred
+  ///             library with the specified loading unit id has failed.
+  ///
+  ///             The dart future returned by the initiating loadLibrary() call
+  ///             will complete with an error.
+  ///
+  /// @param[in]  loading_unit_id  The unique id of the deferred library's
+  ///                              loading unit, as passed in by
+  ///                              RequestDartDeferredLibrary.
+  ///
+  /// @param[in]  error_message    The error message that will appear in the
+  ///                              dart Future.
+  ///
+  /// @param[in]  transient        A transient error is a failure due to
+  ///                              temporary conditions such as no network.
+  ///                              Transient errors allow the dart VM to
+  ///                              re-request the same deferred library and
+  ///                              and loading_unit_id again. Non-transient
+  ///                              errors are permanent and attempts to
+  ///                              re-request the library will instantly
+  ///                              complete with an error.
   void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                     const std::string error_message,
                                     bool transient);

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -825,6 +825,10 @@ class Engine final : public RuntimeDelegate,
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions);
 
+  void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                    const std::string error_message,
+                                    bool transient);
+
  private:
   Engine::Delegate& delegate_;
   const Settings settings_;

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -65,6 +65,8 @@ class MockRuntimeController : public RuntimeController {
       : RuntimeController(client, p_task_runners) {}
   MOCK_METHOD0(IsRootIsolateRunning, bool());
   MOCK_METHOD1(DispatchPlatformMessage, bool(fml::RefPtr<PlatformMessage>));
+  MOCK_METHOD3(LoadDartDeferredLibraryError,
+               void(intptr_t, const std::string, bool));
 };
 
 fml::RefPtr<PlatformMessage> MakePlatformMessage(
@@ -234,6 +236,34 @@ TEST_F(EngineTest, DispatchPlatformMessageInitialRouteIgnored) {
         MakePlatformMessage("flutter/navigation", values, response);
     engine->DispatchPlatformMessage(message);
     EXPECT_EQ(engine->InitialRoute(), "");
+  });
+}
+
+TEST_F(EngineTest, PassesLoadDartDeferredLibraryErrorToRuntime) {
+  PostUITaskSync([this] {
+    intptr_t error_id = 123;
+    const std::string error_message = "error message";
+    MockRuntimeDelegate client;
+    auto mock_runtime_controller =
+        std::make_unique<MockRuntimeController>(client, task_runners_);
+    EXPECT_CALL(*mock_runtime_controller, IsRootIsolateRunning())
+        .WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*mock_runtime_controller, DispatchPlatformMessage(::testing::_))
+        .WillRepeatedly(::testing::Return(true));
+    EXPECT_CALL(*mock_runtime_controller,
+                LoadDartDeferredLibraryError(error_id, error_message, true))
+        .Times(1);
+    auto engine = std::make_unique<Engine>(
+        /*delegate=*/delegate_,
+        /*dispatcher_maker=*/dispatcher_maker_,
+        /*image_decoder_task_runner=*/image_decoder_task_runner_,
+        /*task_runners=*/task_runners_,
+        /*settings=*/settings_,
+        /*animator=*/std::move(animator_),
+        /*io_manager=*/io_manager_,
+        /*runtime_controller=*/std::move(mock_runtime_controller));
+
+    engine->LoadDartDeferredLibraryError(error_id, error_message, true);
   });
 }
 

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -248,8 +248,6 @@ TEST_F(EngineTest, PassesLoadDartDeferredLibraryErrorToRuntime) {
         std::make_unique<MockRuntimeController>(client, task_runners_);
     EXPECT_CALL(*mock_runtime_controller, IsRootIsolateRunning())
         .WillRepeatedly(::testing::Return(true));
-    EXPECT_CALL(*mock_runtime_controller, DispatchPlatformMessage(::testing::_))
-        .WillRepeatedly(::testing::Return(true));
     EXPECT_CALL(*mock_runtime_controller,
                 LoadDartDeferredLibraryError(error_id, error_message, true))
         .Times(1);

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -166,6 +166,10 @@ void PlatformView::LoadDartDeferredLibrary(
     std::unique_ptr<const fml::Mapping> snapshot_data,
     std::unique_ptr<const fml::Mapping> snapshot_instructions) {}
 
+void PlatformView::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                                const std::string error_message,
+                                                bool transient) {}
+
 void PlatformView::UpdateAssetManager(
     std::shared_ptr<AssetManager> asset_manager) {}
 

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -247,6 +247,28 @@ class PlatformView {
         std::unique_ptr<const fml::Mapping> snapshot_data,
         std::unique_ptr<const fml::Mapping> snapshot_instructions) = 0;
 
+    //--------------------------------------------------------------------------
+    /// @brief      Indicates to the dart VM that the request to load a deferred
+    ///             library with the specified loading unit id has failed.
+    ///
+    ///             The dart future returned by the initiating loadLibrary()
+    ///             call will complete with an error.
+    ///
+    /// @param[in]  loading_unit_id  The unique id of the deferred library's
+    ///                              loading unit, as passed in by
+    ///                              RequestDartDeferredLibrary.
+    ///
+    /// @param[in]  error_message    The error message that will appear in the
+    ///                              dart Future.
+    ///
+    /// @param[in]  transient        A transient error is a failure due to
+    ///                              temporary conditions such as no network.
+    ///                              Transient errors allow the dart VM to
+    ///                              re-request the same deferred library and
+    ///                              and loading_unit_id again. Non-transient
+    ///                              errors are permanent and attempts to
+    ///                              re-request the library will instantly
+    ///                              complete with an error.
     virtual void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                               const std::string error_message,
                                               bool transient) = 0;
@@ -671,6 +693,29 @@ class PlatformView {
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions);
 
+  //--------------------------------------------------------------------------
+  /// @brief      Indicates to the dart VM that the request to load a deferred
+  ///             library with the specified loading unit id has failed.
+  ///
+  ///             The dart future returned by the initiating loadLibrary() call
+  ///             will complete with an error.
+  ///
+  /// @param[in]  loading_unit_id  The unique id of the deferred library's
+  ///                              loading unit, as passed in by
+  ///                              RequestDartDeferredLibrary.
+  ///
+  /// @param[in]  error_message    The error message that will appear in the
+  ///                              dart Future.
+  ///
+  /// @param[in]  transient        A transient error is a failure due to
+  ///                              temporary conditions such as no network.
+  ///                              Transient errors allow the dart VM to
+  ///                              re-request the same deferred library and
+  ///                              and loading_unit_id again. Non-transient
+  ///                              errors are permanent and attempts to
+  ///                              re-request the library will instantly
+  ///                              complete with an error.
+  ///
   virtual void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                             const std::string error_message,
                                             bool transient);

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -247,6 +247,10 @@ class PlatformView {
         std::unique_ptr<const fml::Mapping> snapshot_data,
         std::unique_ptr<const fml::Mapping> snapshot_instructions) = 0;
 
+    virtual void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                              const std::string error_message,
+                                              bool transient) = 0;
+
     // TODO(garyq): Implement a proper asset_resolver replacement instead of
     // overwriting the entire asset manager.
     //--------------------------------------------------------------------------
@@ -666,6 +670,10 @@ class PlatformView {
       intptr_t loading_unit_id,
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions);
+
+  virtual void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                            const std::string error_message,
+                                            bool transient);
 
   // TODO(garyq): Implement a proper asset_resolver replacement instead of
   // overwriting the entire asset manager.

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1193,6 +1193,13 @@ void Shell::LoadDartDeferredLibrary(
                                    std::move(snapshot_instructions));
 }
 
+void Shell::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                         const std::string error_message,
+                                         bool transient) {
+  engine_->LoadDartDeferredLibraryError(loading_unit_id, error_message,
+                                        transient);
+}
+
 void Shell::UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) {
   engine_->UpdateAssetManager(std::move(asset_manager));
 }

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -513,6 +513,10 @@ class Shell final : public PlatformView::Delegate,
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions) override;
 
+  void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                    const std::string error_message,
+                                    bool transient) override;
+
   // |PlatformView::Delegate|
   void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override;
 

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -354,6 +354,13 @@ void PlatformViewAndroid::LoadDartDeferredLibrary(
 }
 
 // |PlatformView|
+void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                  const std::string error_message,
+                                  bool transient) {
+  delegate_.LoadDartDeferredLibrary(loading_unit_id, error_message, transient);
+}
+
+// |PlatformView|
 void PlatformViewAndroid::UpdateAssetManager(
     std::shared_ptr<AssetManager> asset_manager) {
   delegate_.UpdateAssetManager(std::move(asset_manager));

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -354,10 +354,12 @@ void PlatformViewAndroid::LoadDartDeferredLibrary(
 }
 
 // |PlatformView|
-void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
-                                  const std::string error_message,
-                                  bool transient) {
-  delegate_.LoadDartDeferredLibrary(loading_unit_id, error_message, transient);
+void PlatformViewAndroid::LoadDartDeferredLibraryError(
+    intptr_t loading_unit_id,
+    const std::string error_message,
+    bool transient) {
+  delegate_.LoadDartDeferredLibraryError(loading_unit_id, error_message,
+                                         transient);
 }
 
 // |PlatformView|

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -99,6 +99,10 @@ class PlatformViewAndroid final : public PlatformView {
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions) override;
 
+  void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                    const std::string error_message,
+                                    bool transient) override;
+
   // |PlatformView|
   void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -38,6 +38,9 @@ class MockDelegate : public PlatformView::Delegate {
                                std::unique_ptr<const fml::Mapping> snapshot_data,
                                std::unique_ptr<const fml::Mapping> snapshot_instructions) override {
   }
+  void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                    const std::string error_message,
+                                    bool transient) override {}
   void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override {}
 };
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -108,6 +108,9 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
                                std::unique_ptr<const fml::Mapping> snapshot_data,
                                std::unique_ptr<const fml::Mapping> snapshot_instructions) override {
   }
+  void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                    const std::string error_message,
+                                    bool transient) override {}
   void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override {}
 };
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -91,6 +91,9 @@ class MockDelegate : public PlatformView::Delegate {
                                std::unique_ptr<const fml::Mapping> snapshot_data,
                                std::unique_ptr<const fml::Mapping> snapshot_instructions) override {
   }
+  void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                    const std::string error_message,
+                                    bool transient) override {}
   void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override {}
 };
 

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -110,6 +110,10 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
       std::unique_ptr<const fml::Mapping> snapshot_data,
       std::unique_ptr<const fml::Mapping> snapshot_instructions) {}
   // |flutter::PlatformView::Delegate|
+  void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
+                                    const std::string error_message,
+                                    bool transient) {}
+  // |flutter::PlatformView::Delegate|
   void UpdateAssetManager(
       std::shared_ptr<flutter::AssetManager> asset_manager) {}
 


### PR DESCRIPTION
Adds LoadDartDeferredLibraryError. Failures during the loading process invoke it to complete the dart future with an error.