### PR TITLE
[web] sharding change is merged. re-enable tests

### DIFF
--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -643,10 +643,18 @@ const Map<String, List<String>> blockedTestsListsMapForModes =
 // TODO(nurhan): Remove the failing test after fixing.
 const Map<String, List<String>> blockedTestsListsMapForRenderBackends =
     <String, List<String>>{
-  'auto': [],
+  'auto': [
+    'image_loading_integration.dart',
+    'platform_messages_integration.dart',
+    'profile_diagnostics_integration.dart',
+    'scroll_wheel_integration.dart',
+    'text_editing_integration.dart',
+    'treeshaking_integration.dart',
+    'url_strategy_integration.dart',
+  ],
   'html': [],
   // This test failed on canvaskit on all three build modes.
   'canvaskit': [
-    'image_loading_integration',
+    'image_loading_integration.dart',
   ],
 };

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -249,10 +249,9 @@ class IntegrationTestsManager {
         buildModes = <String>{mode};
       }
     } else {
-      // TODO(nurhan): Enable `release` when recipe is sharded.
       buildModes = _browser == 'chrome'
-          ? {'debug', 'profile'}
-          : {'profile'};
+          ? {'debug', 'profile', 'release'}
+          : {'profile', 'release'};
     }
     return buildModes;
   }
@@ -632,28 +631,9 @@ const Map<String, List<String>> blockedTestsListsMapForModes =
     'treeshaking_integration.dart',
     'text_editing_integration.dart',
     'url_strategy_integration.dart',
-
-    // TODO(yjbanov): https://github.com/flutter/flutter/issues/71583
-    // The following tests are blocked to reduce the load on the build bot.
-    // The bot currently frequently exceeds the timeout limit.
-    'image_loading_integration.dart',
-    'platform_messages_integration.dart',
-    'profile_diagnostics_integration.dart',
-    'scroll_wheel_integration.dart',
   ],
   'profile': [],
-  'release': [
-    // TODO(yjbanov): https://github.com/flutter/flutter/issues/71583
-    // The following tests are blocked to reduce the load on the build bot.
-    // The bot currently frequently exceeds the timeout limit.
-    'image_loading_integration.dart',
-    'platform_messages_integration.dart',
-    'profile_diagnostics_integration.dart',
-    'scroll_wheel_integration.dart',
-    'text_editing_integration.dart',
-    'treeshaking_integration.dart',
-    'url_strategy_integration.dart',
-  ],
+  'release': [],
 };
 
 /// Tests blocked for one of the rendering backends.
@@ -663,24 +643,10 @@ const Map<String, List<String>> blockedTestsListsMapForModes =
 // TODO(nurhan): Remove the failing test after fixing.
 const Map<String, List<String>> blockedTestsListsMapForRenderBackends =
     <String, List<String>>{
-  'auto': [
-    'image_loading_integration.dart',
-    'platform_messages_integration.dart',
-    'profile_diagnostics_integration.dart',
-    'scroll_wheel_integration.dart',
-    'text_editing_integration.dart',
-    'treeshaking_integration.dart',
-    'url_strategy_integration.dart',
-  ],
+  'auto': [],
   'html': [],
   // This test failed on canvaskit on all three build modes.
   'canvaskit': [
-    'image_loading_integration.dart',
-    'platform_messages_integration.dart',
-    'profile_diagnostics_integration.dart',
-    'scroll_wheel_integration.dart',
-    'text_editing_integration.dart',
-    'treeshaking_integration.dart',
-    'url_strategy_integration.dart',
+    'image_loading_integration',
   ],
 };


### PR DESCRIPTION
Due to timeouts on the Linux Web Engine builder we closed many tests in the last week:

https://github.com/flutter/engine/pull/22846/files
https://github.com/flutter/engine/pull/22824

Since the recipe changes are merged to enable sharding for LWE (design: go/web-engine-recipe-drones)
https://flutter-review.googlesource.com/c/recipes/+/9120
https://flutter-review.googlesource.com/c/recipes/+/8980

We can re-enable these tests.
Fixes: https://github.com/flutter/flutter/issues/71583