### PR TITLE
Allow the root layout to be overriden.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -358,7 +358,7 @@ public class FlutterFragmentActivity extends FragmentActivity
    */
   @NonNull
   private View createFragmentContainer() {
-    FrameLayout container = new FrameLayout(this);
+    FrameLayout container = provideRootLayout(this);
     container.setId(FRAGMENT_CONTAINER_ID);
     container.setLayoutParams(
         new ViewGroup.LayoutParams(
@@ -740,5 +740,11 @@ public class FlutterFragmentActivity extends FragmentActivity
    */
   private boolean isDebuggable() {
     return (getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
+  }
+
+  /** Returns a {@link FrameLayout} that is used as the content view of this activity. */
+  @NonNull
+  protected FrameLayout provideRootLayout(Context context) {
+    return new FrameLayout(context);
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -12,6 +12,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
@@ -127,6 +129,24 @@ public class FlutterFragmentActivityTest {
     assertFalse(spyFlutterActivity.shouldHandleDeeplinking());
   }
 
+  @Test
+  public void itAllowsRootLayoutOverride() {
+    FlutterFragmentActivityWithRootLayout activity =
+        Robolectric.buildActivity(FlutterFragmentActivityWithRootLayout.class).get();
+
+    activity.onCreate(null);
+    ViewGroup contentView = (ViewGroup) activity.findViewById(android.R.id.content);
+    boolean foundCustomView = false;
+    for (int i = 0; i < contentView.getChildCount(); i++) {
+      foundCustomView =
+          contentView.getChildAt(i) instanceof FlutterFragmentActivityWithRootLayout.CustomLayout;
+      if (foundCustomView) {
+        break;
+      }
+    }
+    assertTrue(foundCustomView);
+  }
+
   static class FlutterFragmentActivityWithProvidedEngine extends FlutterFragmentActivity {
     @Override
     protected FlutterFragment createFlutterFragment() {
@@ -168,6 +188,20 @@ public class FlutterFragmentActivityTest {
     @Override
     protected boolean shouldHandleDeeplinking() {
       return false;
+    }
+  }
+
+  private static class FlutterFragmentActivityWithRootLayout
+      extends FlutterFragmentActivityWithProvidedEngine {
+    public static class CustomLayout extends FrameLayout {
+      public CustomLayout(Context context) {
+        super(context);
+      }
+    }
+
+    @Override
+    protected FrameLayout provideRootLayout(Context context) {
+      return new CustomLayout(context);
     }
   }
 


### PR DESCRIPTION
- Allow FlutterFragmentActivity subclasses to provide its own Layout.

## Description

This exposes a protected method in FlutterFragmentActivity to allow subclasses to provide a FrameLayout as parent of the Flutter view.

## Related Issues



## Tests

I added the following tests:
FlutterFragmentActivityTest.itAllowsRootLayoutOverride

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
