### PR TITLE
Add engine tests for Linux shell

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1313,6 +1313,7 @@ FILE: ../../../flutter/shell/platform/linux/fl_dart_project_private.h
 FILE: ../../../flutter/shell/platform/linux/fl_dart_project_test.cc
 FILE: ../../../flutter/shell/platform/linux/fl_engine.cc
 FILE: ../../../flutter/shell/platform/linux/fl_engine_private.h
+FILE: ../../../flutter/shell/platform/linux/fl_engine_test.cc
 FILE: ../../../flutter/shell/platform/linux/fl_event_channel.cc
 FILE: ../../../flutter/shell/platform/linux/fl_event_channel_test.cc
 FILE: ../../../flutter/shell/platform/linux/fl_json_message_codec.cc

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -161,6 +161,7 @@ executable("flutter_linux_unittests") {
     "fl_binary_codec_test.cc",
     "fl_binary_messenger_test.cc",
     "fl_dart_project_test.cc",
+    "fl_engine_test.cc",
     "fl_event_channel_test.cc",
     "fl_json_message_codec_test.cc",
     "fl_json_method_codec_test.cc",

--- a/shell/platform/linux/fl_engine_test.cc
+++ b/shell/platform/linux/fl_engine_test.cc
@@ -1,0 +1,139 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Included first as it collides with the X11 headers.
+#include "gtest/gtest.h"
+
+#include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
+#include "flutter/shell/platform/linux/fl_engine_private.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
+#include "flutter/shell/platform/linux/testing/fl_test.h"
+
+// Checks sending window metrics events works.
+TEST(FlEngineTest, WindowMetrics) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
+
+  bool called = false;
+  embedder_api->SendWindowMetricsEvent = MOCK_ENGINE_PROC(
+      SendWindowMetricsEvent,
+      ([&called](auto engine, const FlutterWindowMetricsEvent* event) {
+        called = true;
+        EXPECT_EQ(event->width, static_cast<size_t>(3840));
+        EXPECT_EQ(event->height, static_cast<size_t>(2160));
+        EXPECT_EQ(event->pixel_ratio, 2.0);
+
+        return kSuccess;
+      }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+  fl_engine_send_window_metrics_event(engine, 3840, 2160, 2.0);
+
+  EXPECT_TRUE(called);
+}
+
+// Checks sending mouse pointer events works.
+TEST(FlEngineTest, MousePointer) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
+
+  bool called = false;
+  embedder_api->SendPointerEvent = MOCK_ENGINE_PROC(
+      SendPointerEvent,
+      ([&called](auto engine, const FlutterPointerEvent* events,
+                 size_t events_count) {
+        called = true;
+        EXPECT_EQ(events_count, static_cast<size_t>(1));
+        EXPECT_EQ(events[0].phase, kDown);
+        EXPECT_EQ(events[0].timestamp, static_cast<size_t>(1234567890));
+        EXPECT_EQ(events[0].x, 800);
+        EXPECT_EQ(events[0].y, 600);
+        EXPECT_EQ(events[0].device, static_cast<int32_t>(0));
+        EXPECT_EQ(events[0].signal_kind, kFlutterPointerSignalKindScroll);
+        EXPECT_EQ(events[0].scroll_delta_x, 1.2);
+        EXPECT_EQ(events[0].scroll_delta_y, -3.4);
+        EXPECT_EQ(events[0].device_kind, kFlutterPointerDeviceKindMouse);
+        EXPECT_EQ(events[0].buttons, kFlutterPointerButtonMouseSecondary);
+
+        return kSuccess;
+      }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+  fl_engine_send_mouse_pointer_event(engine, kDown, 1234567890, 800, 600, 1.2,
+                                     -3.4, kFlutterPointerButtonMouseSecondary);
+
+  EXPECT_TRUE(called);
+}
+
+// Checks sending platform messages works.
+TEST(FlEngineTest, PlatformMessage) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
+
+  bool called = false;
+  embedder_api->SendPlatformMessage = MOCK_ENGINE_PROC(
+      SendPlatformMessage,
+      ([&called](auto engine, const FlutterPlatformMessage* message) {
+        called = true;
+
+        EXPECT_STREQ(message->channel, "test");
+        EXPECT_EQ(message->message_size, static_cast<size_t>(4));
+        EXPECT_EQ(message->message[0], 't');
+        EXPECT_EQ(message->message[1], 'e');
+        EXPECT_EQ(message->message[2], 's');
+        EXPECT_EQ(message->message[3], 't');
+
+        return kSuccess;
+      }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+  g_autoptr(GBytes) message = g_bytes_new_static("test", 4);
+  fl_engine_send_platform_message(engine, "test", message, nullptr, nullptr,
+                                  nullptr);
+
+  EXPECT_TRUE(called);
+}
+
+// Checks sending platform message responses works.
+TEST(FlEngineTest, PlatformMessageResponse) {
+  g_autoptr(FlEngine) engine = make_mock_engine();
+  FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
+
+  bool called = false;
+  embedder_api->SendPlatformMessageResponse = MOCK_ENGINE_PROC(
+      SendPlatformMessageResponse,
+      ([&called](auto engine,
+                 const FlutterPlatformMessageResponseHandle* handle,
+                 const uint8_t* data, size_t data_length) {
+        called = true;
+
+        EXPECT_EQ(
+            handle,
+            reinterpret_cast<const FlutterPlatformMessageResponseHandle*>(42));
+        EXPECT_EQ(data_length, static_cast<size_t>(4));
+        EXPECT_EQ(data[0], 't');
+        EXPECT_EQ(data[1], 'e');
+        EXPECT_EQ(data[2], 's');
+        EXPECT_EQ(data[3], 't');
+
+        return kSuccess;
+      }));
+
+  g_autoptr(GError) error = nullptr;
+  EXPECT_TRUE(fl_engine_start(engine, &error));
+  EXPECT_EQ(error, nullptr);
+  g_autoptr(GBytes) response = g_bytes_new_static("test", 4);
+  EXPECT_TRUE(fl_engine_send_platform_message_response(
+      engine, reinterpret_cast<const FlutterPlatformMessageResponseHandle*>(42),
+      response, &error));
+  EXPECT_EQ(error, nullptr);
+
+  EXPECT_TRUE(called);
+}


### PR DESCRIPTION
## Description

Add engine tests for Linux shell

## Related Issues

None.

## Tests

This PR is adding tests that are now possible due to the `FlutterEngineProcTable` addition.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
