### PR TITLE
[MacOS] Add support for creating and presenting platform views.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1096,6 +1096,9 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenG
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRendererTest.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.h

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1094,6 +1094,8 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouse
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRendererTest.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.h

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1094,6 +1094,7 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterMouse
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRenderer.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenGLRendererTest.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterRenderer.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.mm

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1097,6 +1097,7 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterOpenG
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -150,6 +150,9 @@ executable("flutter_desktop_darwin_unittests") {
   sources = [
     "framework/Source/FlutterEngineTest.mm",
     "framework/Source/FlutterGLCompositorUnittests.mm",
+    "framework/Source/FlutterPlatformViewControllerTest.mm",
+    "framework/Source/FlutterPlatformViewMock.h",
+    "framework/Source/FlutterPlatformViewMock.mm",
     "framework/Source/FlutterViewControllerTest.mm",
     "framework/Source/FlutterViewControllerTestUtils.h",
     "framework/Source/FlutterViewControllerTestUtils.mm",

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -77,6 +77,8 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterMouseCursorPlugin.mm",
     "framework/Source/FlutterOpenGLRenderer.h",
     "framework/Source/FlutterOpenGLRenderer.mm",
+    "framework/Source/FlutterPlatformViewController.mm",
+    "framework/Source/FlutterPlatformViewController_Internal.h",
     "framework/Source/FlutterPlatformViews.h",
     "framework/Source/FlutterRenderer.h",
     "framework/Source/FlutterResizableBackingStoreProvider.h",

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -77,6 +77,7 @@ source_set("flutter_framework_source") {
     "framework/Source/FlutterMouseCursorPlugin.mm",
     "framework/Source/FlutterOpenGLRenderer.h",
     "framework/Source/FlutterOpenGLRenderer.mm",
+    "framework/Source/FlutterPlatformViews.h",
     "framework/Source/FlutterRenderer.h",
     "framework/Source/FlutterResizableBackingStoreProvider.h",
     "framework/Source/FlutterResizableBackingStoreProvider.mm",

--- a/shell/platform/darwin/macos/framework/Source/FlutterGLCompositor.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterGLCompositor.h
@@ -75,6 +75,10 @@ class FlutterGLCompositor {
       FlutterBackingStoreData* flutter_backing_store_data,
       size_t layer_position);
 
+  // Add the Platform View's content to the FlutterView at depth
+  // layer_position.
+  void PresentPlatformView(const FlutterLayer* layer, size_t layer_position);
+
   // Set frame_started_ to true and reset all layer state.
   void StartFrame();
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterGLCompositor.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterGLCompositor.h
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/darwin/macos/framework/Source/FlutterBackingStoreData.h"
+#include "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController_Internal.h"
 #include "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"
 #include "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -51,6 +52,7 @@ class FlutterGLCompositor {
 
  private:
   const FlutterViewController* view_controller_;
+  const FlutterPlatformViewController* platform_view_controller_;
   const NSOpenGLContext* open_gl_context_;
   PresentCallback present_callback_;
 
@@ -75,9 +77,6 @@ class FlutterGLCompositor {
 
   // Set frame_started_ to true and reset all layer state.
   void StartFrame();
-
-  // Remove platform views that are specified for deletion.
-  void DisposePlatformViews();
 
   // Creates a CALayer and adds it to ca_layer_map_ and increments
   // ca_layer_count_; Returns the key value (size_t) for the layer in

--- a/shell/platform/darwin/macos/framework/Source/FlutterGLCompositor.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterGLCompositor.h
@@ -5,6 +5,7 @@
 #include <map>
 
 #include "flutter/fml/macros.h"
+#include "flutter/shell/platform/darwin/macos/framework/Source/FlutterBackingStoreData.h"
 #include "flutter/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.h"
 #include "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -67,8 +68,16 @@ class FlutterGLCompositor {
   // created for the frame.
   bool frame_started_ = false;
 
+  // Update the backing CALayer using the backing store's specifications.
+  void PresentBackingStoreContent(
+      FlutterBackingStoreData* flutter_backing_store_data,
+      size_t layer_position);
+
   // Set frame_started_ to true and reset all layer state.
   void StartFrame();
+
+  // Remove platform views that are specified for deletion.
+  void DisposePlatformViews();
 
   // Creates a CALayer and adds it to ca_layer_map_ and increments
   // ca_layer_count_; Returns the key value (size_t) for the layer in

--- a/shell/platform/darwin/macos/framework/Source/FlutterGLCompositorUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterGLCompositorUnittests.mm
@@ -5,6 +5,7 @@
 #import <Foundation/Foundation.h>
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterGLCompositor.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.h"
 #import "flutter/testing/testing.h"
 
@@ -12,9 +13,11 @@ namespace flutter::testing {
 
 TEST(FlutterGLCompositorTest, TestPresent) {
   id mockViewController = CreateMockViewController(nil);
+  FlutterPlatformViewController* platformViewController =
+      [[FlutterPlatformViewController alloc] init];
 
   std::unique_ptr<flutter::FlutterGLCompositor> macos_compositor =
-      std::make_unique<FlutterGLCompositor>(mockViewController, nullptr);
+      std::make_unique<FlutterGLCompositor>(mockViewController, platformViewController);
 
   bool flag = false;
   macos_compositor->SetPresentCallback([f = &flag]() {

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
@@ -10,8 +10,9 @@
 
 - (instancetype)init {
   self = [super init];
-
-  self->_platformViewFactories = [[NSMutableDictionary alloc] init];
+  if (self) {
+    _platformViewFactories = [[NSMutableDictionary alloc] init];
+  }
   return self;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController.mm
@@ -1,0 +1,92 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/logging.h"
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController_Internal.h"
+
+@implementation FlutterPlatformViewController
+
+- (instancetype)init {
+  self = [super init];
+
+  self->_platformViewFactories = [[NSMutableDictionary alloc] init];
+  return self;
+}
+
+- (void)onCreateWithViewId:(int64_t)viewId
+                  viewType:(nonnull NSString*)viewType
+                    result:(nonnull FlutterResult)result {
+  if (_platformViews.count(viewId) != 0) {
+    result([FlutterError errorWithCode:@"recreating_view"
+                               message:@"trying to create an already created view"
+                               details:[NSString stringWithFormat:@"view id: '%lld'", viewId]]);
+  }
+
+  NSObject<FlutterPlatformViewFactory>* factory = _platformViewFactories[viewType];
+  if (factory == nil) {
+    result([FlutterError
+        errorWithCode:@"unregistered_view_type"
+              message:@"trying to create a view with an unregistered type"
+              details:[NSString stringWithFormat:@"unregistered view type: '%@'", viewType]]);
+    return;
+  }
+
+  NSObject<FlutterPlatformView>* platform_view = [factory createWithFrame:CGRectZero
+                                                           viewIdentifier:viewId
+                                                                arguments:nil];
+
+  _platformViews[viewId] = [platform_view view];
+  result(nil);
+}
+
+- (void)onDisposeWithViewId:(int64_t)viewId result:(nonnull FlutterResult)result {
+  if (_platformViews.count(viewId) == 0) {
+    result([FlutterError errorWithCode:@"unknown_view"
+                               message:@"trying to dispose an unknown"
+                               details:[NSString stringWithFormat:@"view id: '%lld'", viewId]]);
+    return;
+  }
+
+  // The following disposePlatformViews call will dispose the views.
+  _platformViewsToDispose.insert(viewId);
+  result(nil);
+}
+
+- (void)registerViewFactory:(nonnull NSObject<FlutterPlatformViewFactory>*)factory
+                     withId:(nonnull NSString*)factoryId {
+  _platformViewFactories[factoryId] = factory;
+}
+
+- (void)handleMethodCall:(nonnull FlutterMethodCall*)call result:(nonnull FlutterResult)result {
+  if ([[call method] isEqualToString:@"create"]) {
+    NSMutableDictionary<NSString*, id>* args = [call arguments];
+    int64_t viewId = [args[@"id"] longValue];
+    NSString* viewType = [NSString stringWithUTF8String:([args[@"viewType"] UTF8String])];
+    [self onCreateWithViewId:viewId viewType:viewType result:result];
+  } else if ([[call method] isEqualToString:@"dispose"]) {
+    NSNumber* arg = [call arguments];
+    int64_t viewId = [arg longLongValue];
+    [self onDisposeWithViewId:viewId result:result];
+  } else {
+    result(FlutterMethodNotImplemented);
+  }
+}
+
+- (void)disposePlatformViews {
+  if (_platformViewsToDispose.empty()) {
+    return;
+  }
+
+  FML_DCHECK([[NSThread currentThread] isMainThread])
+      << "Must be on the main thread to handle disposing platform views";
+  for (int64_t viewId : _platformViewsToDispose) {
+    NSView* view = _platformViews[viewId];
+    [view removeFromSuperview];
+    _platformViews.erase(viewId);
+  }
+  _platformViewsToDispose.clear();
+}
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewControllerTest.mm
@@ -1,0 +1,128 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController_Internal.h"
+
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.h"
+
+#include "flutter/testing/testing.h"
+
+namespace flutter::testing {
+
+TEST(FlutterPlatformViewController, TestCreatePlatformViewNoMatchingViewType) {
+  // Use id so we can access handleMethodCall method.
+  id platformViewController = [[FlutterPlatformViewController alloc] init];
+
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"create"
+                                        arguments:@{
+                                          @"id" : @2,
+                                          @"viewType" : @"FlutterPlatformViewMock"
+                                        }];
+
+  __block bool errored = false;
+  FlutterResult result = ^(id result) {
+    if ([result isKindOfClass:[FlutterError class]]) {
+      errored = true;
+    }
+  };
+
+  [platformViewController handleMethodCall:methodCall result:result];
+
+  // We expect the call to error since no factories are registered.
+  EXPECT_TRUE(errored);
+}
+
+TEST(FlutterPlatformViewController, TestRegisterPlatformViewFactoryAndCreate) {
+  // Use id so we can access handleMethodCall method.
+  id platformViewController = [[FlutterPlatformViewController alloc] init];
+
+  FlutterPlatformViewMockFactory* factory = [FlutterPlatformViewMockFactory alloc];
+
+  [platformViewController registerViewFactory:factory withId:@"MockPlatformView"];
+
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"create"
+                                        arguments:@{
+                                          @"id" : @2,
+                                          @"viewType" : @"MockPlatformView"
+                                        }];
+
+  __block bool success = false;
+  FlutterResult result = ^(id result) {
+    // If a platform view is successfully created, the result is nil.
+    if (result == nil) {
+      success = true;
+    }
+  };
+  [platformViewController handleMethodCall:methodCall result:result];
+
+  EXPECT_TRUE(success);
+}
+
+TEST(FlutterPlatformViewController, TestCreateAndDispose) {
+  // Use id so we can access handleMethodCall method.
+  id platformViewController = [[FlutterPlatformViewController alloc] init];
+
+  FlutterPlatformViewMockFactory* factory = [FlutterPlatformViewMockFactory alloc];
+
+  [platformViewController registerViewFactory:factory withId:@"MockPlatformView"];
+
+  FlutterMethodCall* methodCallOnCreate =
+      [FlutterMethodCall methodCallWithMethodName:@"create"
+                                        arguments:@{
+                                          @"id" : @2,
+                                          @"viewType" : @"MockPlatformView"
+                                        }];
+
+  __block bool created = false;
+  FlutterResult resultOnCreate = ^(id result) {
+    // If a platform view is successfully created, the result is nil.
+    if (result == nil) {
+      created = true;
+    }
+  };
+
+  [platformViewController handleMethodCall:methodCallOnCreate result:resultOnCreate];
+
+  FlutterMethodCall* methodCallOnDispose =
+      [FlutterMethodCall methodCallWithMethodName:@"dispose"
+                                        arguments:[NSNumber numberWithLongLong:2]];
+
+  __block bool disposed = false;
+  FlutterResult resultOnDispose = ^(id result) {
+    // If a platform view is successfully created, the result is nil.
+    if (result == nil) {
+      disposed = true;
+    }
+  };
+
+  [platformViewController handleMethodCall:methodCallOnDispose result:resultOnDispose];
+
+  EXPECT_TRUE(created);
+  EXPECT_TRUE(disposed);
+}
+
+TEST(FlutterPlatformViewController, TestDisposeOnMissingViewId) {
+  // Use id so we can access handleMethodCall method.
+  id platformViewController = [[FlutterPlatformViewController alloc] init];
+
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:@"dispose"
+                                        arguments:[NSNumber numberWithLongLong:20]];
+
+  __block bool errored = false;
+  FlutterResult result = ^(id result) {
+    if ([result isKindOfClass:[FlutterError class]]) {
+      errored = true;
+    }
+  };
+
+  [platformViewController handleMethodCall:methodCall result:result];
+
+  EXPECT_TRUE(errored);
+}
+
+}  // flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewController_Internal.h
@@ -1,0 +1,58 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+#import "FlutterChannels.h"
+
+#include <map>
+#include <unordered_set>
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h"
+
+@interface FlutterPlatformViewController : NSViewController
+@end
+
+@interface FlutterPlatformViewController ()
+
+// NSDictionary maps strings to FlutterPlatformViewFactorys.
+@property(nonnull, nonatomic)
+    NSMutableDictionary<NSString*, NSObject<FlutterPlatformViewFactory>*>* platformViewFactories;
+
+// A map of platform view ids to views.
+@property(nonatomic) std::map<int, NSView*> platformViews;
+
+// View ids that are going to be disposed on the next present call.
+@property(nonatomic) std::unordered_set<int64_t> platformViewsToDispose;
+
+/**
+ * Creates a platform view of viewType with viewId.
+ * FlutterResult is updated to contain nil for success or to contain
+ * a FlutterError if there is an error.
+ */
+- (void)onCreateWithViewId:(int64_t)viewId
+                  viewType:(nonnull NSString*)viewType
+                    result:(nonnull FlutterResult)result;
+
+/**
+ * Disposes the platform view with id viewId.
+ * FlutterResult is updated to contain nil for success or a FlutterError if there is an error.
+ */
+- (void)onDisposeWithViewId:(int64_t)viewId result:(nonnull FlutterResult)result;
+
+/**
+ * Register a view factory by adding an entry into the platformViewFactories map with key factoryId
+ * and value factory.
+ */
+- (void)registerViewFactory:(nonnull NSObject<FlutterPlatformViewFactory>*)factory
+                     withId:(nonnull NSString*)factoryId;
+
+- (void)handleMethodCall:(nonnull FlutterMethodCall*)call result:(nonnull FlutterResult)result;
+
+/**
+ * Remove platform views who's ids are in the platformViewsToDispose set.
+ * Called before a new frame is presented.
+ */
+- (void)disposePlatformViews;
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.h
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Foundation/Foundation.h>
+#import <Foundation/NSObject.h>
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h"
+
+@interface FlutterPlatformViewMock : NSObject <FlutterPlatformView>
+@property(nonatomic, strong) NSView* view;
+@end
+
+@interface MockPlatformView : NSView
+@end
+
+@interface FlutterPlatformViewMockFactory : NSObject <FlutterPlatformViewFactory>
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.h
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import <Foundation/Foundation.h>
-#import <Foundation/NSObject.h>
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h"
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.mm
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Cocoa/Cocoa.h>
+#import <Foundation/Foundation.h>
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViewMock.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h"
+
+@implementation MockPlatformView
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  self = [super initWithFrame:frame];
+  return self;
+}
+
+@end
+
+@implementation FlutterPlatformViewMock
+
+- (instancetype)initWithFrame:(CGRect)frame arguments:(id _Nullable)args {
+  if (self = [super init]) {
+    _view = [[MockPlatformView alloc] initWithFrame:frame];
+  }
+  return self;
+}
+
+@end
+
+@implementation FlutterPlatformViewMockFactory
+- (NSObject<FlutterPlatformView>*)createWithFrame:(CGRect)frame
+                                   viewIdentifier:(int64_t)viewId
+                                        arguments:(id _Nullable)args {
+  return [[FlutterPlatformViewMock alloc] initWithFrame:frame arguments:args];
+}
+
+- (NSObject<FlutterMessageCodec>*)createArgsCodec {
+  return [FlutterStandardMessageCodec sharedInstance];
+}
+
+@end

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h
@@ -1,0 +1,62 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FLUTTERPLATFORMVIEWS_H_
+#define FLUTTER_FLUTTERPLATFORMVIEWS_H_
+
+#import <AppKit/AppKit.h>
+
+#import "FlutterCodecs.h"
+#import "FlutterMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Wraps a `NSView` for embedding in the Flutter hierarchy
+ */
+@protocol FlutterPlatformView <NSObject>
+/**
+ * Returns a reference to the `NSView` that is wrapped by this `FlutterPlatformView`.
+ *
+ * It is recommended to return a cached view instance in this method.
+ * Constructing and returning a new NSView instance in this method might cause undefined behavior.
+ *
+ * TODO(richardjcai): Prevent [FlutterPlatformView view] to be called multiple times
+ * in a single frame.
+ */
+- (NSView*)view;
+@end
+
+FLUTTER_EXPORT
+@protocol FlutterPlatformViewFactory <NSObject>
+/**
+ * Create a `FlutterPlatformView`.
+ *
+ * Implemented by MacOS code that expose a `FlutterPlatformView` for embedding in a Flutter app.
+ *
+ * The implementation of this method should create a new `FlutterPlatformView` and return it.
+ *
+ * @param frame The rectangle for the newly created `FlutterPlatformView` measured in points.
+ * @param viewId A unique identifier for this `FlutterPlatformView`.
+ * @param args Parameters for creating the `FlutterPlatformView` sent from the Dart side of the
+ * Flutter app. If `createArgsCodec` is not implemented, or if no creation arguments were sent from
+ * the Dart code, this will be null. Otherwise this will be the value sent from the Dart code as
+ * decoded by `createArgsCodec`.
+ */
+- (NSObject<FlutterPlatformView>*)createWithFrame:(CGRect)frame
+                                   viewIdentifier:(int64_t)viewId
+                                        arguments:(id _Nullable)args;
+
+/**
+ * Returns the `FlutterMessageCodec` for decoding the args parameter of `createWithFrame`.
+ *
+ * Only needs to be implemented if `createWithFrame` needs an arguments parameter.
+ */
+@optional
+- (NSObject<FlutterMessageCodec>*)createArgsCodec;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // FLUTTER_FLUTTERPLATFORMVIEWS_H_

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -213,9 +213,6 @@ struct KeyboardState {
 
   // A method channel for miscellaneous platform functionality.
   FlutterMethodChannel* _platformChannel;
-
-  // A method channel for platform view functionality.
-  FlutterMethodChannel* _platformViewsChannel;
 }
 
 @dynamic view;
@@ -231,7 +228,6 @@ static void CommonInit(FlutterViewController* controller) {
   }
   controller->_additionalKeyResponders = [[NSMutableOrderedSet alloc] init];
   controller->_mouseTrackingMode = FlutterMouseTrackingModeInKeyWindow;
-  controller->_factories = [[NSMutableDictionary alloc] init];
 }
 
 - (instancetype)initWithCoder:(NSCoder*)coder {
@@ -439,70 +435,10 @@ static void CommonInit(FlutterViewController* controller) {
       [FlutterMethodChannel methodChannelWithName:@"flutter/platform"
                                   binaryMessenger:_engine.binaryMessenger
                                             codec:[FlutterJSONMethodCodec sharedInstance]];
-
-  _platformViewsChannel =
-      [FlutterMethodChannel methodChannelWithName:@"flutter/platform_views"
-                                  binaryMessenger:_engine.binaryMessenger
-                                            codec:[FlutterStandardMethodCodec sharedInstance]];
-
   __weak FlutterViewController* weakSelf = self;
   [_platformChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
     [weakSelf handleMethodCall:call result:result];
   }];
-
-  [_platformViewsChannel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
-    [weakSelf handleMethodCall:call result:result];
-  }];
-}
-
-- (void)onCreate:(nonnull FlutterMethodCall*)call result:(nonnull FlutterResult)result {
-  NSMutableDictionary<NSString*, id>* args = [call arguments];
-  int64_t viewId = [args[@"id"] longValue];
-  NSString* viewType = [NSString stringWithUTF8String:([args[@"viewType"] UTF8String])];
-
-  if (_platformViews.count(viewId) != 0) {
-    result([FlutterError errorWithCode:@"recreating_view"
-                               message:@"trying to create an already created view"
-                               details:[NSString stringWithFormat:@"view id: '%lld'", viewId]]);
-  }
-
-  NSObject<FlutterPlatformViewFactory>* factory = _factories[viewType];
-  if (factory == nil) {
-    result([FlutterError errorWithCode:@"unregistered_view_type"
-                               message:@"trying to create a view with an unregistered type"
-                               details:[NSString stringWithFormat:@"unregistered view type: '%@'",
-                                                                  args[@"viewType"]]]);
-    return;
-  }
-
-  NSObject<FlutterPlatformView>* platform_view = [factory createWithFrame:CGRectZero
-                                                           viewIdentifier:viewId
-                                                                arguments:nil];
-
-  _platformViews[viewId] = [platform_view view];
-  result(nil);
-}
-
-- (void)onDispose:(nonnull FlutterMethodCall*)call result:(nonnull FlutterResult)result {
-  NSNumber* arg = [call arguments];
-  int64_t viewId = [arg longLongValue];
-  NSLog(@"onDispose ViewId: %lld", viewId);
-
-  if (_platformViews.count(viewId) == 0) {
-    result([FlutterError errorWithCode:@"unknown_view"
-                               message:@"trying to dispose an unknown"
-                               details:[NSString stringWithFormat:@"view id: '%lld'", viewId]]);
-    return;
-  }
-
-  // The following FlutterGLCompositor::Present call will dispose the views.
-  _platformViewsToDispose.insert(viewId);
-  result(nil);
-}
-
-- (void)registerViewFactory:(nonnull NSObject<FlutterPlatformViewFactory>*)factory
-                     withId:(nonnull NSString*)factoryId {
-  _factories[factoryId] = factory;
 }
 
 - (void)dispatchMouseEvent:(nonnull NSEvent*)event {
@@ -678,10 +614,6 @@ static void CommonInit(FlutterViewController* controller) {
     result(nil);
   } else if ([call.method isEqualToString:@"Clipboard.hasStrings"]) {
     result(@{@"value" : @([self clipboardHasStrings])});
-  } else if ([[call method] isEqualToString:@"create"]) {
-    [self onCreate:call result:result];
-  } else if ([[call method] isEqualToString:@"dispose"]) {
-    [self onDispose:call result:result];
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <map>
-#include <unordered_set>
-
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h"
@@ -15,26 +12,12 @@
 // The FlutterView for this view controller.
 @property(nonatomic, readonly, nullable) FlutterView* flutterView;
 
-// NSDictionary maps strings to FlutterPlatformViewFactorys.
-@property(nonnull, nonatomic)
-    NSMutableDictionary<NSString*, NSObject<FlutterPlatformViewFactory>*>* factories;
-
-// A map of platform view ids to views.
-@property(nonatomic) std::map<int, NSView*> platformViews;
-
-// View ids that are going to be disposed on the next present call.
-@property(nonatomic) std::unordered_set<int64_t> platformViewsToDispose;
-
 /**
  * This just returns the NSPasteboard so that it can be mocked in the tests.
  */
 @property(nonatomic, readonly, nonnull) NSPasteboard* pasteboard;
 
 /**
-<<<<<<< HEAD
- * Adds an intermediate responder for keyboard events. Key up and key down events are forwarded to
- * all added responders, and they either handle the keys or not.
-=======
  * Platform View Methods.
  */
 
@@ -64,10 +47,10 @@
 - (void)registerViewFactory:(nonnull NSObject<FlutterPlatformViewFactory>*)factory
                      withId:(nonnull NSString*)factoryId;
 
+
 /**
  * Adds a responder for keyboard events. Key up and key down events are forwarded to all added
  * responders.
->>>>>>> 182b97516 (Add MacOS platform view support to FlutterViewController)
  */
 - (void)addKeyResponder:(nonnull FlutterIntermediateKeyResponder*)responder;
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h
@@ -2,9 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
+#include <map>
+#include <unordered_set>
 
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterIntermediateKeyResponder.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformViews.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterView.h"
 
 @interface FlutterViewController ()
@@ -12,14 +15,59 @@
 // The FlutterView for this view controller.
 @property(nonatomic, readonly, nullable) FlutterView* flutterView;
 
+// NSDictionary maps strings to FlutterPlatformViewFactorys.
+@property(nonnull, nonatomic)
+    NSMutableDictionary<NSString*, NSObject<FlutterPlatformViewFactory>*>* factories;
+
+// A map of platform view ids to views.
+@property(nonatomic) std::map<int, NSView*> platformViews;
+
+// View ids that are going to be disposed on the next present call.
+@property(nonatomic) std::unordered_set<int64_t> platformViewsToDispose;
+
 /**
  * This just returns the NSPasteboard so that it can be mocked in the tests.
  */
 @property(nonatomic, readonly, nonnull) NSPasteboard* pasteboard;
 
 /**
+<<<<<<< HEAD
  * Adds an intermediate responder for keyboard events. Key up and key down events are forwarded to
  * all added responders, and they either handle the keys or not.
+=======
+ * Platform View Methods.
+ */
+
+/**
+ * Creates a platform view using the arguments from the provided call.
+ * The call's arguments should be castable to an NSMutableDictionary<NSString*, id>*
+ * and the dictionary should at least hold one key for "id" that maps to the view id and
+ * one key for "viewType" which maps to the view type (string) that was used to register
+ * the factory.
+ * FlutterResult is updated to contain nil for success or to contain
+ * a FlutterError if there is an error.
+ */
+- (void)onCreate:(nonnull FlutterMethodCall*)call result:(nonnull FlutterResult)result;
+
+/**
+ * Disposes a platform view using the arguments from the provided call.
+ * The call's arguments should be the Id (castable to NSNumber*) of the platform view
+ * that should be disposed.
+ * FlutterResult is updated to contain nil for success or a FlutterError if there is an error.
+ */
+- (void)onDispose:(nonnull FlutterMethodCall*)call result:(nonnull FlutterResult)result;
+
+/**
+ * Register a view factory by adding an entry into the factories_ map with key factoryId
+ * and value factory.
+ */
+- (void)registerViewFactory:(nonnull NSObject<FlutterPlatformViewFactory>*)factory
+                     withId:(nonnull NSString*)factoryId;
+
+/**
+ * Adds a responder for keyboard events. Key up and key down events are forwarded to all added
+ * responders.
+>>>>>>> 182b97516 (Add MacOS platform view support to FlutterViewController)
  */
 - (void)addKeyResponder:(nonnull FlutterIntermediateKeyResponder*)responder;
 


### PR DESCRIPTION
Add support for:
1. Registering view factories.
2. Creating / Disposing platform views.
3. Presenting platform views in FlutterGLCompositor

Will add follow up PR for static thread merging, there may be visual bugs since raster/ui threads are not merged.