### PR TITLE
Use List.filled constructor instead of soon-to-be-deprecated List constructor.

### DIFF
--- a/testing/dart/encoding_test.dart
+++ b/testing/dart/encoding_test.dart
@@ -89,7 +89,8 @@ class Square4x4Image {
 
   static List<int> get bytes {
     const int bytesPerChannel = 4;
-    final List<int> result = List<int>(_kWidth * _kWidth * bytesPerChannel);
+    final List<int> result = List<int>.filled(
+        _kWidth * _kWidth * bytesPerChannel, 0);
 
     void fillWithColor(Color color, int min, int max) {
       for (int i = min; i < max; i++) {


### PR DESCRIPTION
This should unblock dart roll, which deprecates List constructor (https://dart-review.googlesource.com/c/sdk/+/173261)