### PR TITLE
[flutter_releases] Flutter Stable Engine 1.22.5 Cherrypicks

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -465,6 +465,17 @@ deps = {
      'dep_type': 'cipd',
    },
 
+  'src/third_party/android_tools/sdk/licenses': {
+     'packages': [
+       {
+        'package': 'flutter_internal/android/sdk/licenses',
+        'version': 'latest',
+       }
+     ],
+    'condition': 'download_android_deps',
+    'dep_type': 'cipd',
+  },
+
   'src/third_party/android_embedding_dependencies': {
      'packages': [
        {


### PR DESCRIPTION
Cherrypick https://github.com/flutter/engine/commit/8d93ea0d06e9968b9a1ea189f27cb84fa41e0b69 to fix the "Linux Android AOT Engine" pre-submit test.