### PR TITLE
[canvaskit] improve image error handling and messaging

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -8,32 +8,80 @@ part of engine;
 /// Instantiates a [ui.Codec] backed by an `SkAnimatedImage` from Skia.
 ui.Codec skiaInstantiateImageCodec(Uint8List list,
     [int? width, int? height, int? format, int? rowBytes]) {
-  return CkAnimatedImage.decodeFromBytes(list);
+  return CkAnimatedImage.decodeFromBytes(list, 'encoded image bytes');
+}
+
+/// Thrown when the web engine fails to decode an image, either due to a
+/// network issue, corrupted image contents, or missing codec.
+class ImageCodecException implements Exception {
+  ImageCodecException(this._message);
+
+  final String _message;
+
+  @override
+  String toString() => 'ImageCodecException: $_message';
+}
+
+const String _kNetworkImageMessage = 'Failed to load network image.';
+
+typedef HttpRequestFactory = html.HttpRequest Function();
+HttpRequestFactory httpRequestFactory = () => html.HttpRequest();
+void debugRestoreHttpRequestFactory() {
+  httpRequestFactory = () => html.HttpRequest();
 }
 
 /// Instantiates a [ui.Codec] backed by an `SkAnimatedImage` from Skia after
 /// requesting from URI.
 Future<ui.Codec> skiaInstantiateWebImageCodec(
-    String uri, WebOnlyImageCodecChunkCallback? chunkCallback) {
+    String url, WebOnlyImageCodecChunkCallback? chunkCallback) {
   Completer<ui.Codec> completer = Completer<ui.Codec>();
-  //TODO: Switch to using MakeImageFromCanvasImageSource when animated images are supported.
-  html.HttpRequest.request(uri, responseType: "arraybuffer",
-      onProgress: (html.ProgressEvent event) {
-    if (event.lengthComputable) {
-      chunkCallback?.call(event.loaded!, event.total!);
-    }
-  }).then((html.HttpRequest response) {
-    if (response.status != 200) {
-      completer.completeError(Exception(
-          'Network image request failed with status: ${response.status}'));
-    }
-    final Uint8List list =
-        new Uint8List.view((response.response as ByteBuffer));
-    final CkAnimatedImage codec = CkAnimatedImage.decodeFromBytes(list);
-    completer.complete(codec);
-  }, onError: (dynamic error) {
-    completer.completeError(error);
+
+  final html.HttpRequest request = httpRequestFactory();
+  request.open('GET', url, async: true);
+  request.responseType = 'arraybuffer';
+  if (chunkCallback != null) {
+    request.onProgress.listen((html.ProgressEvent event) {
+      chunkCallback.call(event.loaded!, event.total!);
+    });
+  }
+
+  request.onError.listen((html.ProgressEvent event) {
+    completer.completeError(ImageCodecException(
+      '$_kNetworkImageMessage\n'
+      'Image URL: $url\n'
+      'Trying to load an image from another domain? Find answers at:\n'
+      'https://flutter.dev/docs/development/platform-integration/web-images'
+    ));
   });
+
+  request.onLoad.listen((html.ProgressEvent event) {
+    final int status = request.status!;
+    final bool accepted = status >= 200 && status < 300;
+    final bool fileUri = status == 0; // file:// URIs have status of 0.
+    final bool notModified = status == 304;
+    final bool unknownRedirect = status > 307 && status < 400;
+    final bool success = accepted || fileUri || notModified || unknownRedirect;
+
+    if (!success) {
+      completer.completeError(ImageCodecException(
+        '$_kNetworkImageMessage\n'
+        'Image URL: $url\n'
+        'Server response code: $status'),
+      );
+      return;
+    }
+
+    try {
+      final Uint8List list =
+          new Uint8List.view((request.response as ByteBuffer));
+      final CkAnimatedImage codec = CkAnimatedImage.decodeFromBytes(list, url);
+      completer.complete(codec);
+    } catch (error, stackTrace) {
+      completer.completeError(error, stackTrace);
+    }
+  });
+
+  request.send();
   return completer.future;
 }
 
@@ -42,15 +90,19 @@ Future<ui.Codec> skiaInstantiateWebImageCodec(
 /// Wraps `SkAnimatedImage`.
 class CkAnimatedImage extends ManagedSkiaObject<SkAnimatedImage> implements ui.Codec {
   /// Decodes an image from a list of encoded bytes.
-  CkAnimatedImage.decodeFromBytes(this._bytes);
+  CkAnimatedImage.decodeFromBytes(this._bytes, this.src);
 
+  final String src;
   final Uint8List _bytes;
 
   @override
   SkAnimatedImage createDefault() {
     final SkAnimatedImage? animatedImage = canvasKit.MakeAnimatedImageFromEncoded(_bytes);
     if (animatedImage == null) {
-      throw Exception('Failed to decode image');
+      throw ImageCodecException(
+        'Failed to decode image data.\n'
+        'Image source: $src',
+      );
     }
     return animatedImage;
   }


### PR DESCRIPTION
## Description

- Change the implementation of `skiaInstantiateWebImageCodec` to use the lower-level XHR API that can distinguish between HTTP errors and non-HTTP error (e.g. CORS).
- Make all image-related errors `ImageCodecException`.
- Use custom error messages for HTTP errors, non-HTTP XHR errors, and codec errors. In particular, when encountering a non-HTTP XHR error, direct the user to the page that elaborates on CORS and other nuances of image loading on the web (this is the best we can do as the browser does not report whether an error is CORS or something else).

This PR should land after https://github.com/flutter/website/pull/5061 because it refers to the web page that's being added in that PR.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/71619.

## Tests

Added new tests in `canvaskit/image_test.dart`.
