### PR TITLE
[web] For Firefox focusing on the DOM element after blur propagates

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1262,10 +1262,20 @@ class FirefoxTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
     // Refocus on the domElement after blur, so that user can keep editing the
     // text field.
     _subscriptions.add(domElement.onBlur.listen((_) {
-      domElement.focus();
+      _postponeFocus();
     }));
 
     preventDefaultForMouseEvents();
+  }
+
+  void _postponeFocus() {
+    // Firefox does not focus on the editing element if we call the focus
+    // inside the blur event, therefore we postpone the focus.
+    // Calling focus inside a Timer for `0` milliseconds guarantee that it is
+    // called after blur event propagation is completed.
+    Timer(const Duration(milliseconds: 0), () {
+      domElement.focus();
+    });
   }
 
   @override

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -741,17 +741,15 @@ void testMain() {
         expect(spy.messages[0].channel, 'flutter/textinput');
         expect(spy.messages[0].methodName,
             'TextInputClient.onConnectionClosed');
+        await Future<void>.delayed(Duration.zero);
         // DOM element loses the focus.
-        Timer.run(expectAsync0(() {
-          expect(document.activeElement, document.body);
-        }));
+        expect(document.activeElement, document.body);
       } else {
         // No connection close message sent.
         expect(spy.messages, hasLength(0));
+        await Future<void>.delayed(Duration.zero);
         // DOM element still keeps the focus.
-        Timer.run(expectAsync0(() {
-          expect(document.activeElement, textEditing.editingElement.domElement);
-        }));
+        expect(document.activeElement, textEditing.editingElement.domElement);
       }
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -706,7 +706,10 @@ void testMain() {
       expect(spy.messages, isEmpty);
     });
 
-    test('do not close connection on blur', () async {
+    test('focus and connection with blur', () async {
+      // In all the desktop browsers we are keeping the connection
+      // open, keep the text editing element focused if it receives a blur
+      // event.
       final MethodCall setClient = MethodCall(
           'TextInput.setClient', <dynamic>[123, flutterSinglelineConfig]);
       sendFrameworkMessage(codec.encodeMethodCall(setClient));
@@ -731,19 +734,28 @@ void testMain() {
       // DOM element is blurred.
       textEditing.editingElement.domElement.blur();
 
-      expect(spy.messages, hasLength(0));
-
-      // DOM element still has focus.
-      // Even though this passes on manual tests it does not work on
-      // Firefox automated unit tests.
-      if (browserEngine != BrowserEngine.firefox) {
-        expect(document.activeElement, textEditing.editingElement.domElement);
+      // For ios-safari the connection is closed.
+      if (browserEngine == BrowserEngine.webkit &&
+          operatingSystem == OperatingSystem.iOs) {
+        expect(spy.messages, hasLength(1));
+        expect(spy.messages[0].channel, 'flutter/textinput');
+        expect(spy.messages[0].methodName,
+            'TextInputClient.onConnectionClosed');
+        // DOM element loses the focus.
+        Timer.run(expectAsync0(() {
+          expect(document.activeElement, document.body);
+        }));
+      } else {
+        // No connection close message sent.
+        expect(spy.messages, hasLength(0));
+        // DOM element still keeps the focus.
+        Timer.run(expectAsync0(() {
+          expect(document.activeElement, textEditing.editingElement.domElement);
+        }));
       }
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: (browserEngine == BrowserEngine.webkit ||
-            browserEngine == BrowserEngine.edge));
+        skip: (browserEngine == BrowserEngine.edge));
 
     test('finishAutofillContext closes connection no autofill element',
         () async {


### PR DESCRIPTION
## Description

Changing the focus time on Firefox. Instead of focusing on an element during the "onblur" event, we are adding a timer to schedule the focus right after the blur.

(Note: I also tried to schedule a microtask but it didn't worked)

## Related Issues

Fixes: https://github.com/flutter/flutter/issues/69680
Relates: https://github.com/flutter/flutter/issues/68005 (Username also gets filled after this change, but not at the same time with the password do I still left this issue open)

## Tests

This PR also modifies the unit tests related to this case. Also removes the skip for webkit (which enables the blur tests for safari desktop and safari ios).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
