### PR TITLE
Fix ios voiceover (for safari >13.4)

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
@@ -256,8 +256,9 @@ class MobileSemanticsEnabler extends SemanticsEnabler {
   @override
   bool tryEnableSemantics(html.Event event) {
     if (_schedulePlaceholderRemoval) {
-      final bool removeNow =
-          (browserEngine != BrowserEngine.webkit || event.type == 'touchend');
+      final bool removeNow = (browserEngine != BrowserEngine.webkit ||
+          event.type == 'touchend' ||
+          event.type == 'pointerup');
       if (removeNow) {
         _semanticsPlaceholder!.remove();
         _semanticsPlaceholder = null;
@@ -288,6 +289,7 @@ class MobileSemanticsEnabler extends SemanticsEnabler {
       'touchstart',
       'touchend',
       'pointerdown',
+      'pointermove',
       'pointerup',
     };
 
@@ -338,6 +340,11 @@ class MobileSemanticsEnabler extends SemanticsEnabler {
           final html.TouchEvent touch = event as html.TouchEvent;
           activationPoint = touch.changedTouches!.first.client;
           break;
+        case 'pointerdown':
+        case 'pointerup':
+          final html.PointerEvent touch = event as html.PointerEvent;
+          activationPoint = new html.Point(touch.client.x, touch.client.y);
+          break;
         default:
           // The event is not relevant, forward to framework as normal.
           return true;
@@ -346,9 +353,11 @@ class MobileSemanticsEnabler extends SemanticsEnabler {
       final html.Rectangle<num> activatingElementRect =
           domRenderer.glassPaneElement!.getBoundingClientRect();
       final double midX = (activatingElementRect.left +
-          (activatingElementRect.right - activatingElementRect.left) / 2).toDouble();
+              (activatingElementRect.right - activatingElementRect.left) / 2)
+          .toDouble();
       final double midY = (activatingElementRect.top +
-          (activatingElementRect.bottom - activatingElementRect.top) / 2).toDouble();
+              (activatingElementRect.bottom - activatingElementRect.top) / 2)
+          .toDouble();
       final double deltaX = activationPoint.x.toDouble() - midX;
       final double deltaY = activationPoint.y.toDouble() - midY;
       final double deltaSquared = deltaX * deltaX + deltaY * deltaY;

--- a/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
@@ -256,9 +256,11 @@ class MobileSemanticsEnabler extends SemanticsEnabler {
   @override
   bool tryEnableSemantics(html.Event event) {
     if (_schedulePlaceholderRemoval) {
+      // The event type can also be click for VoiceOver.
       final bool removeNow = (browserEngine != BrowserEngine.webkit ||
           event.type == 'touchend' ||
-          event.type == 'pointerup');
+          event.type == 'pointerup' ||
+          event.type == 'click');
       if (removeNow) {
         _semanticsPlaceholder!.remove();
         _semanticsPlaceholder = null;

--- a/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
@@ -280,10 +280,15 @@ class MobileSemanticsEnabler extends SemanticsEnabler {
       return true;
     }
 
+    // ios-safari browsers which starts sending `pointer` events instead of
+    // `touch` events. (Tested with 12.1 which uses touch events vs 13.5
+    // which uses pointer events.)
     const Set<String> kInterestingEventTypes = <String>{
       'click',
       'touchstart',
       'touchend',
+      'pointerdown',
+      'pointerup',
     };
 
     if (!kInterestingEventTypes.contains(event.type)) {

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -155,19 +155,18 @@ void testMain() {
     test('Not relevant events should be forwarded to the framework', () async {
       html.Event event;
       if (_defaultSupportDetector.hasPointerEvents) {
-         event = html.PointerEvent('pointerdown');
-      } else if(_defaultSupportDetector.hasTouchEvents) {
-         event = html.TouchEvent('touchcancel');
+        event = html.PointerEvent('pointerdown');
+      } else if (_defaultSupportDetector.hasTouchEvents) {
+        event = html.TouchEvent('touchcancel');
       } else {
-         event = html.MouseEvent('mousemove');
+        event = html.MouseEvent('mousemove');
       }
 
       bool shouldForwardToFramework =
           mobileSemanticsEnabler.tryEnableSemantics(event);
 
       expect(shouldForwardToFramework, true);
-    },
-        skip: browserEngine == BrowserEngine.edge);
+    });
 
     test('Pointer down is relevant event', () async {
       expect(mobileSemanticsEnabler.semanticsActivationAttempts, isZero);
@@ -176,8 +175,9 @@ void testMain() {
       mobileSemanticsEnabler.tryEnableSemantics(event);
 
       expect(mobileSemanticsEnabler.semanticsActivationAttempts, isNonZero);
-    },
-        skip: browserEngine == BrowserEngine.edge ||
-              browserEngine == BrowserEngine.firefox);
-  });
+    });
+  },  // Run the `MobileSemanticsEnabler` only on mobile browsers.
+      skip: operatingSystem == OperatingSystem.linux ||
+          operatingSystem == OperatingSystem.macOs ||
+          operatingSystem == OperatingSystem.windows);
 }

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -155,7 +155,7 @@ void testMain() {
     test('Not relevant events should be forwarded to the framework', () async {
       html.Event event;
       if (_defaultSupportDetector.hasPointerEvents) {
-        event = html.PointerEvent('pointerdown');
+        event = html.PointerEvent('pointermove');
       } else if (_defaultSupportDetector.hasTouchEvents) {
         event = html.TouchEvent('touchcancel');
       } else {
@@ -166,15 +166,6 @@ void testMain() {
           mobileSemanticsEnabler.tryEnableSemantics(event);
 
       expect(shouldForwardToFramework, true);
-    });
-
-    test('Pointer down is relevant event', () async {
-      expect(mobileSemanticsEnabler.semanticsActivationAttempts, isZero);
-
-      final html.Event event = html.PointerEvent('pointerdown');
-      mobileSemanticsEnabler.tryEnableSemantics(event);
-
-      expect(mobileSemanticsEnabler.semanticsActivationAttempts, isNonZero);
     });
   },  // Run the `MobileSemanticsEnabler` only on mobile browsers.
       skip: operatingSystem == OperatingSystem.linux ||

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -9,6 +9,8 @@ import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 
+const PointerSupportDetector _defaultSupportDetector = PointerSupportDetector();
+
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
@@ -151,15 +153,31 @@ void testMain() {
         skip: browserEngine == BrowserEngine.webkit);
 
     test('Not relevant events should be forwarded to the framework', () async {
-      final html.Event event = html.TouchEvent('touchcancel');
+      html.Event event;
+      if (_defaultSupportDetector.hasPointerEvents) {
+         event = html.PointerEvent('pointerdown');
+      } else if(_defaultSupportDetector.hasTouchEvents) {
+         event = html.TouchEvent('touchcancel');
+      } else {
+         event = html.MouseEvent('mousemove');
+      }
+
       bool shouldForwardToFramework =
           mobileSemanticsEnabler.tryEnableSemantics(event);
 
       expect(shouldForwardToFramework, true);
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
-        skip: browserEngine != BrowserEngine.blink);
+        skip: browserEngine == BrowserEngine.edge);
+
+    test('Pointer down is relevant event', () async {
+      expect(mobileSemanticsEnabler.semanticsActivationAttempts, isZero);
+
+      final html.Event event = html.PointerEvent('pointerdown');
+      mobileSemanticsEnabler.tryEnableSemantics(event);
+
+      expect(mobileSemanticsEnabler.semanticsActivationAttempts, isNonZero);
+    },
+        skip: browserEngine == BrowserEngine.edge ||
+              browserEngine == BrowserEngine.firefox);
   });
 }


### PR DESCRIPTION
## Description

We weren't able to enable a11y for some versions of safari since for mobile we were only checking `touch` events. This PR adds `pointer` events to the list.

## Related Issues

Fixes: https://github.com/flutter/flutter/issues/71605

## Tests

Added unit tests to semantics_helper_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
