### PR TITLE
[web] update browser changing docs

### DIFF
--- a/lib/web_ui/dev/README.md
+++ b/lib/web_ui/dev/README.md
@@ -155,11 +155,9 @@ Since the engine code and infra recipes do not live in the same repository there
 
 1. Dowload the binaries for the new browser/driver for each operaing system (macOS, linux, windows).
 2. Create CIPD packages for these packages. (More documentation is available for Googlers. go/cipd-flutter-web)
-3. Add the new browser version to the recipe. Do not remove the old one. This recipe will apply to all PRs as soon as it is merged. However, not all PRs will have the up to date code for a while.
-4. Update the version in this repo. Do this by changing the related fields in `browser_lock.yaml` file.
-5. After a few days don't forget to remove the old version from the LUCI recipe.
+3. Update the version in this repo. Do this by changing the related fields in `browser_lock.yaml` file.
 
-Note that for LUCI builders, both unit and integration tests are using the same browser.
+Note that for LUCI builders, for Chrome both unit and integration tests are using the same browser. (For Firefox [issue](https://github.com/flutter/flutter/issues/71617)
 
 Some useful links:
 


### PR DESCRIPTION
Updating the documentation for updating the browser version. This process is simplified after I added the util methods for downloading dependencies: https://flutter.googlesource.com/recipes/+/refs/heads/master/recipe_modules/web_util/api.py

