### PR TITLE
[web] Do not reset 'cursor' in PersistedPlatformView.

### DIFF
--- a/lib/web_ui/dev/README.md
+++ b/lib/web_ui/dev/README.md
@@ -165,3 +165,17 @@ Some useful links:
 2. Browser and driver CIPD [packages](https://chrome-infra-packages.appspot.com/p/flutter_internal) (Note: Access rights are restricted for these packages.)
 3. LUCI web [recipe](https://flutter.googlesource.com/recipes/+/refs/heads/master/recipes/web_engine.py)
 4. More general reading on CIPD packages [link](https://chromium.googlesource.com/chromium/src.git/+/master/docs/cipd.md#What-is-CIPD)
+
+## Troubleshooting
+
+### Can't load Kernel binary: Invalid kernel binary format version.
+
+Some times `.dart_tool` cache invalidation fails, and you'll end up with a cached version of `felt` that is not compatible with the Dart SDK that you're using.
+
+In that case, any invocation to `felt` will fail with:
+
+`Can't load Kernel binary: Invalid kernel binary format version.`
+
+The solution is to delete the cached `felt.snapshot` files within `engine/src/flutter/lib/web_ui`:
+
+**`rm .dart_tool/felt.snapshot*`**

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -44,6 +44,7 @@ class PersistedPlatformView extends PersistedLeafSurface {
     _styleReset.innerHtml = '''
       :host {
         all: initial;
+        cursor: inherit;
       }''';
     _shadowRoot.append(_styleReset);
     final html.Element? platformView =

--- a/lib/web_ui/test/engine/surface/platform_view_test.dart
+++ b/lib/web_ui/test/engine/surface/platform_view_test.dart
@@ -67,6 +67,18 @@ void testMain() {
         expect(view.canUpdateAsMatch(anyView), isFalse);
       });
     });
+
+    group('createElement', () {
+      test('adds reset to stylesheet', () {
+        final element = view.createElement();
+        _assertShadowRootStylesheetContains(element, 'all: initial;');
+      });
+
+      test('creates element transparent to "cursor" property', () {
+        final element = view.createElement();
+        _assertShadowRootStylesheetContains(element, 'cursor: inherit;');
+      });
+    });
   });
 }
 
@@ -85,4 +97,15 @@ Future<void> _createPlatformView(int id, String viewType) {
     (dynamic _) => completer.complete(),
   );
   return completer.future;
+}
+
+void _assertShadowRootStylesheetContains(html.Element element, String rule) {
+  final shadow = element.shadowRoot;
+
+  expect(shadow, isNotNull);
+
+  final html.StyleElement style = shadow.children.first;
+
+  expect(style, isNotNull);
+  expect(style.innerHtml, contains(rule));
 }


### PR DESCRIPTION
## Description

This change adds `cursor: inherit;` to the reset stylesheet of the PersistedPlatformView, so it doesn't override the `cursor` property set by the `flt-glass-pane` (unless the developer wants to, of course).

(It also documents a fix for when the `felt` tool gets too stale and it stops working, which AFAIK has no issue associated with it)

Live demo: https://dit-mouse-boundary.web.app (the second button on top of the video should display a `cursor: pointer`, and when clicked, work as expected. The first button illustrates a separate flutter issue.)

## Related Issues

* https://github.com/flutter/flutter/issues/72037

## Tests

I added the following tests: 

* `createElement` test group to `lib/web_ui/test/engine/surface/platform_view_test.dart`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
<details>

<summary><tt>$ felt test --unit-tests-only</tt></summary>

```
Running the unit tests only
Compiled 11,203,988 characters Dart to 1,719,196 characters JavaScript in 13.3 seconds
Dart file test/golden_tests/golden_success_smoke_test.dart compiled to JavaScript: test/golden_tests/golden_success_smoke_test.dart.browser_test.dart.js
Compiled 11,203,801 characters Dart to 1,268,617 characters JavaScript in 13.8 seconds
Dart file test/golden_tests/golden_failure_smoke_test.dart compiled to JavaScript: test/golden_tests/golden_failure_smoke_test.dart.browser_test.dart.js
Compiled 11,204,679 characters Dart to 1,623,250 characters JavaScript in 14.4 seconds
Dart file test/dom_renderer_test.dart compiled to JavaScript: test/dom_renderer_test.dart.browser_test.dart.js
Compiled 11,205,170 characters Dart to 1,702,125 characters JavaScript in 15.1 seconds
Dart file test/golden_tests/engine/canvas_stroke_joins_golden_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_stroke_joins_golden_test.dart.browser_test.dart.js
Compiled 11,213,544 characters Dart to 1,959,302 characters JavaScript in 15.7 seconds
Dart file test/golden_tests/engine/text_overflow_golden_test.dart compiled to JavaScript: test/golden_tests/engine/text_overflow_golden_test.dart.browser_test.dart.js
Compiled 11,209,259 characters Dart to 1,779,056 characters JavaScript in 17.4 seconds
Dart file test/golden_tests/engine/path_to_svg_golden_test.dart compiled to JavaScript: test/golden_tests/engine/path_to_svg_golden_test.dart.browser_test.dart.js
Compiled 11,219,815 characters Dart to 2,002,550 characters JavaScript in 18.2 seconds
Dart file test/golden_tests/engine/gradient_golden_test.dart compiled to JavaScript: test/golden_tests/engine/gradient_golden_test.dart.browser_test.dart.js
Compiled 11,241,923 characters Dart to 2,291,750 characters JavaScript in 19.8 seconds
Dart file test/golden_tests/engine/canvas_draw_image_golden_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_draw_image_golden_test.dart.browser_test.dart.js
Compiled 11,209,102 characters Dart to 1,978,887 characters JavaScript in 16.6 seconds
Dart file test/golden_tests/engine/radial_gradient_golden_test.dart compiled to JavaScript: test/golden_tests/engine/radial_gradient_golden_test.dart.browser_test.dart.js
Compiled 11,213,567 characters Dart to 2,035,340 characters JavaScript in 15.7 seconds
Dart file test/golden_tests/engine/shadow_golden_test.dart compiled to JavaScript: test/golden_tests/engine/shadow_golden_test.dart.browser_test.dart.js
Compiled 11,204,461 characters Dart to 1,698,562 characters JavaScript in 16.4 seconds
Dart file test/golden_tests/engine/picture_golden_test.dart compiled to JavaScript: test/golden_tests/engine/picture_golden_test.dart.browser_test.dart.js
Compiled 11,205,208 characters Dart to 1,708,232 characters JavaScript in 15.9 seconds
Dart file test/golden_tests/engine/canvas_winding_rule_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_winding_rule_test.dart.browser_test.dart.js
Compiled 11,207,027 characters Dart to 2,009,298 characters JavaScript in 17.2 seconds
Dart file test/golden_tests/engine/canvas_draw_picture_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_draw_picture_test.dart.browser_test.dart.js
Compiled 11,206,775 characters Dart to 1,971,255 characters JavaScript in 16.0 seconds
Dart file test/golden_tests/engine/canvas_reuse_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_reuse_test.dart.browser_test.dart.js
Compiled 11,207,064 characters Dart to 1,727,190 characters JavaScript in 14.7 seconds
Dart file test/golden_tests/engine/canvas_arc_golden_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_arc_golden_test.dart.browser_test.dart.js
Compiled 11,208,949 characters Dart to 2,064,198 characters JavaScript in 17.6 seconds
Dart file test/golden_tests/engine/color_filter_golden_test.dart compiled to JavaScript: test/golden_tests/engine/color_filter_golden_test.dart.browser_test.dart.js
Compiled 11,209,230 characters Dart to 1,875,073 characters JavaScript in 15.8 seconds
Dart file test/golden_tests/engine/draw_vertices_golden_test.dart compiled to JavaScript: test/golden_tests/engine/draw_vertices_golden_test.dart.browser_test.dart.js
Compiled 11,207,160 characters Dart to 1,958,964 characters JavaScript in 16.5 seconds
Dart file test/golden_tests/engine/canvas_clip_path_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_clip_path_test.dart.browser_test.dart.js
Compiled 11,205,912 characters Dart to 1,953,510 characters JavaScript in 15.6 seconds
Dart file test/golden_tests/engine/canvas_draw_color_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_draw_color_test.dart.browser_test.dart.js
Compiled 11,208,396 characters Dart to 1,947,504 characters JavaScript in 17.8 seconds
Dart file test/golden_tests/engine/backdrop_filter_golden_test.dart compiled to JavaScript: test/golden_tests/engine/backdrop_filter_golden_test.dart.browser_test.dart.js
Compiled 11,216,780 characters Dart to 2,161,540 characters JavaScript in 16.7 seconds
Dart file test/golden_tests/engine/canvas_golden_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_golden_test.dart.browser_test.dart.js
Compiled 11,214,345 characters Dart to 2,111,802 characters JavaScript in 15.3 seconds
Dart file test/golden_tests/engine/multiline_text_clipping_golden_test.dart compiled to JavaScript: test/golden_tests/engine/multiline_text_clipping_golden_test.dart.browser_test.dart.js
Compiled 11,206,222 characters Dart to 1,623,796 characters JavaScript in 16.0 seconds
Dart file test/golden_tests/engine/canvas_rrect_golden_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_rrect_golden_test.dart.browser_test.dart.js
Compiled 11,940,797 characters Dart to 2,357,544 characters JavaScript in 18.1 seconds
Dart file test/golden_tests/engine/recording_canvas_golden_test.dart compiled to JavaScript: test/golden_tests/engine/recording_canvas_golden_test.dart.browser_test.dart.js
Compiled 11,205,086 characters Dart to 1,607,552 characters JavaScript in 14.6 seconds
Dart file test/golden_tests/engine/canvas_stroke_rects_golden_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_stroke_rects_golden_test.dart.browser_test.dart.js
Compiled 11,206,147 characters Dart to 1,756,064 characters JavaScript in 16.4 seconds
Dart file test/golden_tests/engine/conic_golden_test.dart compiled to JavaScript: test/golden_tests/engine/conic_golden_test.dart.browser_test.dart.js
Compiled 11,204,882 characters Dart to 1,603,784 characters JavaScript in 15.0 seconds
Dart file test/golden_tests/engine/canvas_rect_golden_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_rect_golden_test.dart.browser_test.dart.js
Compiled 11,204,784 characters Dart to 1,383,455 characters JavaScript in 12.1 seconds
Dart file test/golden_tests/engine/canvas_draw_points_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_draw_points_test.dart.browser_test.dart.js
Compiled 11,206,090 characters Dart to 1,738,423 characters JavaScript in 15.4 seconds
Dart file test/golden_tests/engine/clip_op_golden_test.dart compiled to JavaScript: test/golden_tests/engine/clip_op_golden_test.dart.browser_test.dart.js
Compiled 11,208,039 characters Dart to 1,863,680 characters JavaScript in 15.0 seconds
Dart file test/golden_tests/engine/canvas_blend_golden_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_blend_golden_test.dart.browser_test.dart.js
Compiled 11,936,294 characters Dart to 2,266,916 characters JavaScript in 19.1 seconds
Dart file test/golden_tests/engine/compositing_golden_test.dart compiled to JavaScript: test/golden_tests/engine/compositing_golden_test.dart.browser_test.dart.js
Compiled 11,920,822 characters Dart to 2,033,854 characters JavaScript in 18.8 seconds
Dart file test/golden_tests/engine/path_metrics_test.dart compiled to JavaScript: test/golden_tests/engine/path_metrics_test.dart.browser_test.dart.js
Compiled 11,205,365 characters Dart to 1,676,191 characters JavaScript in 14.5 seconds
Dart file test/golden_tests/engine/canvas_lines_golden_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_lines_golden_test.dart.browser_test.dart.js
Compiled 11,209,348 characters Dart to 1,962,126 characters JavaScript in 16.5 seconds
Dart file test/golden_tests/engine/canvas_mask_filter_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_mask_filter_test.dart.browser_test.dart.js
Compiled 11,217,422 characters Dart to 2,015,137 characters JavaScript in 16.7 seconds
Dart file test/golden_tests/engine/canvas_image_blend_mode_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_image_blend_mode_test.dart.browser_test.dart.js
Compiled 11,210,969 characters Dart to 1,968,093 characters JavaScript in 15.4 seconds
Dart file test/golden_tests/engine/path_transform_test.dart compiled to JavaScript: test/golden_tests/engine/path_transform_test.dart.browser_test.dart.js
Compiled 11,212,278 characters Dart to 1,986,389 characters JavaScript in 16.8 seconds
Dart file test/golden_tests/engine/text_placeholders_test.dart compiled to JavaScript: test/golden_tests/engine/text_placeholders_test.dart.browser_test.dart.js
Compiled 11,215,644 characters Dart to 1,988,479 characters JavaScript in 16.6 seconds
Dart file test/golden_tests/engine/text_style_golden_test.dart compiled to JavaScript: test/golden_tests/engine/text_style_golden_test.dart.browser_test.dart.js
Compiled 11,206,884 characters Dart to 1,949,490 characters JavaScript in 17.5 seconds
Dart file test/golden_tests/engine/canvas_context_test.dart compiled to JavaScript: test/golden_tests/engine/canvas_context_test.dart.browser_test.dart.js
Compiled 11,210,092 characters Dart to 1,951,673 characters JavaScript in 17.8 seconds
Dart file test/golden_tests/engine/linear_gradient_golden_test.dart compiled to JavaScript: test/golden_tests/engine/linear_gradient_golden_test.dart.browser_test.dart.js
Compiled 11,213,763 characters Dart to 1,294,260 characters JavaScript in 12.9 seconds
Dart file test/channel_buffers_test.dart compiled to JavaScript: test/channel_buffers_test.dart.browser_test.dart.js
Compiled 11,203,610 characters Dart to 1,231,402 characters JavaScript in 13.4 seconds
Dart file test/geometry_test.dart compiled to JavaScript: test/geometry_test.dart.browser_test.dart.js
Compiled 11,932,542 characters Dart to 1,603,723 characters JavaScript in 16.0 seconds
Dart file test/path_test.dart compiled to JavaScript: test/path_test.dart.browser_test.dart.js
Compiled 11,204,548 characters Dart to 1,225,175 characters JavaScript in 11.8 seconds
Dart file test/hash_codes_test.dart compiled to JavaScript: test/hash_codes_test.dart.browser_test.dart.js
Compiled 11,205,584 characters Dart to 1,238,826 characters JavaScript in 12.4 seconds
Dart file test/rrect_test.dart compiled to JavaScript: test/rrect_test.dart.browser_test.dart.js
Compiled 11,232,722 characters Dart to 2,009,492 characters JavaScript in 17.9 seconds
Dart file test/paragraph_test.dart compiled to JavaScript: test/paragraph_test.dart.browser_test.dart.js
Compiled 11,208,712 characters Dart to 1,843,624 characters JavaScript in 16.5 seconds
Dart file test/canvas_test.dart compiled to JavaScript: test/canvas_test.dart.browser_test.dart.js
Compiled 11,228,073 characters Dart to 1,251,552 characters JavaScript in 12.5 seconds
Dart file test/alarm_clock_test.dart compiled to JavaScript: test/alarm_clock_test.dart.browser_test.dart.js
Compiled 11,202,340 characters Dart to 1,431,924 characters JavaScript in 15.3 seconds
Dart file test/gradient_test.dart compiled to JavaScript: test/gradient_test.dart.browser_test.dart.js
Compiled 11,202,974 characters Dart to 1,228,667 characters JavaScript in 14.2 seconds
Dart file test/locale_test.dart compiled to JavaScript: test/locale_test.dart.browser_test.dart.js
Compiled 11,201,907 characters Dart to 1,796,395 characters JavaScript in 16.3 seconds
Dart file test/title_test.dart compiled to JavaScript: test/title_test.dart.browser_test.dart.js
Compiled 11,201,398 characters Dart to 1,775,765 characters JavaScript in 16.0 seconds
Dart file test/paragraph_builder_test.dart compiled to JavaScript: test/paragraph_builder_test.dart.browser_test.dart.js
Compiled 11,205,995 characters Dart to 1,603,348 characters JavaScript in 14.6 seconds
Dart file test/engine/semantics/semantics_helper_test.dart compiled to JavaScript: test/engine/semantics/semantics_helper_test.dart.browser_test.dart.js
Compiled 11,202,229 characters Dart to 1,286,355 characters JavaScript in 13.7 seconds
Dart file test/engine/semantics/accessibility_test.dart compiled to JavaScript: test/engine/semantics/accessibility_test.dart.browser_test.dart.js
Compiled 12,029,059 characters Dart to 2,317,936 characters JavaScript in 19.6 seconds
Dart file test/engine/semantics/semantics_test.dart compiled to JavaScript: test/engine/semantics/semantics_test.dart.browser_test.dart.js
Compiled 11,203,017 characters Dart to 1,372,205 characters JavaScript in 14.2 seconds
Dart file test/engine/profiler_test.dart compiled to JavaScript: test/engine/profiler_test.dart.browser_test.dart.js
Compiled 11,216,049 characters Dart to 1,479,969 characters JavaScript in 13.3 seconds
Dart file test/engine/surface/path/path_winding_test.dart compiled to JavaScript: test/engine/surface/path/path_winding_test.dart.browser_test.dart.js
Compiled 11,942,126 characters Dart to 2,677,868 characters JavaScript in 20.8 seconds
Dart file test/engine/surface/scene_builder_test.dart compiled to JavaScript: test/engine/surface/scene_builder_test.dart.browser_test.dart.js
Compiled 11,203,617 characters Dart to 1,388,250 characters JavaScript in 14.4 seconds
Dart file test/engine/surface/path/path_iterator_test.dart compiled to JavaScript: test/engine/surface/path/path_iterator_test.dart.browser_test.dart.js
Compiled 11,204,612 characters Dart to 1,201,543 characters JavaScript in 12.6 seconds
Dart file test/engine/surface/shaders/normalized_gradient_test.dart compiled to JavaScript: test/engine/surface/shaders/normalized_gradient_test.dart.browser_test.dart.js
Compiled 11,215,185 characters Dart to 1,784,947 characters JavaScript in 15.8 seconds
Dart file test/engine/surface/surface_test.dart compiled to JavaScript: test/engine/surface/surface_test.dart.browser_test.dart.js
Compiled 11,208,427 characters Dart to 1,638,871 characters JavaScript in 17.1 seconds
Dart file test/engine/surface/shaders/shader_builder_test.dart compiled to JavaScript: test/engine/surface/shaders/shader_builder_test.dart.browser_test.dart.js
Compiled 11,202,413 characters Dart to 1,729,017 characters JavaScript in 15.3 seconds
Dart file test/engine/surface/frame_timings_test.dart compiled to JavaScript: test/engine/surface/frame_timings_test.dart.browser_test.dart.js
Compiled 11,215,588 characters Dart to 1,522,994 characters JavaScript in 14.8 seconds
Dart file test/engine/recording_canvas_test.dart compiled to JavaScript: test/engine/recording_canvas_test.dart.browser_test.dart.js
Compiled 11,914,675 characters Dart to 1,894,932 characters JavaScript in 19.9 seconds
Dart file test/engine/surface/platform_view_test.dart compiled to JavaScript: test/engine/surface/platform_view_test.dart.browser_test.dart.js
Compiled 11,203,239 characters Dart to 1,230,798 characters JavaScript in 12.2 seconds
Dart file test/engine/frame_reference_test.dart compiled to JavaScript: test/engine/frame_reference_test.dart.browser_test.dart.js
Compiled 11,202,125 characters Dart to 1,229,353 characters JavaScript in 11.4 seconds
Dart file test/engine/util_test.dart compiled to JavaScript: test/engine/util_test.dart.browser_test.dart.js
Compiled 11,203,318 characters Dart to 1,400,222 characters JavaScript in 14.3 seconds
Dart file test/engine/web_experiments_test.dart compiled to JavaScript: test/engine/web_experiments_test.dart.browser_test.dart.js
Compiled 11,225,339 characters Dart to 1,866,599 characters JavaScript in 16.4 seconds
Dart file test/engine/history_test.dart compiled to JavaScript: test/engine/history_test.dart.browser_test.dart.js
Compiled 11,204,287 characters Dart to 1,234,357 characters JavaScript in 12.6 seconds
Dart file test/engine/ulps_test.dart compiled to JavaScript: test/engine/ulps_test.dart.browser_test.dart.js
Compiled 11,205,144 characters Dart to 1,832,885 characters JavaScript in 16.6 seconds
Dart file test/engine/image/html_image_codec_test.dart compiled to JavaScript: test/engine/image/html_image_codec_test.dart.browser_test.dart.js
Compiled 11,920,329 characters Dart to 1,519,638 characters JavaScript in 14.9 seconds
Dart file test/engine/path_metrics_test.dart compiled to JavaScript: test/engine/path_metrics_test.dart.browser_test.dart.js
Compiled 11,291,372 characters Dart to 1,785,604 characters JavaScript in 15.0 seconds
Dart file test/engine/pointer_binding_test.dart compiled to JavaScript: test/engine/pointer_binding_test.dart.browser_test.dart.js
Compiled 11,203,538 characters Dart to 1,253,728 characters JavaScript in 13.1 seconds
Dart file test/engine/services/serialization_test.dart compiled to JavaScript: test/engine/services/serialization_test.dart.browser_test.dart.js
Compiled 11,201,546 characters Dart to 1,807,380 characters JavaScript in 15.7 seconds
Dart file test/engine/navigation_test.dart compiled to JavaScript: test/engine/navigation_test.dart.browser_test.dart.js
Compiled 11,201,884 characters Dart to 1,851,098 characters JavaScript in 16.5 seconds
Dart file test/engine/image_to_byte_data_test.dart compiled to JavaScript: test/engine/image_to_byte_data_test.dart.browser_test.dart.js
Compiled 11,210,337 characters Dart to 1,842,835 characters JavaScript in 17.5 seconds
Dart file test/engine/window_test.dart compiled to JavaScript: test/engine/window_test.dart.browser_test.dart.js
Compiled 11,930,638 characters Dart to 1,979,336 characters JavaScript in 17.8 seconds
Dart file test/text_test.dart compiled to JavaScript: test/text_test.dart.browser_test.dart.js
Compiled 11,206,240 characters Dart to 1,302,687 characters JavaScript in 12.5 seconds
Dart file test/text/canvas_paragraph_builder_test.dart compiled to JavaScript: test/text/canvas_paragraph_builder_test.dart.browser_test.dart.js
Compiled 11,205,498 characters Dart to 1,437,605 characters JavaScript in 15.6 seconds
Dart file test/color_test.dart compiled to JavaScript: test/color_test.dart.browser_test.dart.js
Compiled 11,206,455 characters Dart to 1,255,103 characters JavaScript in 13.2 seconds
Dart file test/text/word_breaker_test.dart compiled to JavaScript: test/text/word_breaker_test.dart.browser_test.dart.js
Compiled 11,230,246 characters Dart to 1,839,777 characters JavaScript in 16.0 seconds
Dart file test/text/layout_service_plain_test.dart compiled to JavaScript: test/text/layout_service_plain_test.dart.browser_test.dart.js
Compiled 11,207,913 characters Dart to 1,334,353 characters JavaScript in 13.3 seconds
Dart file test/text/font_collection_test.dart compiled to JavaScript: test/text/font_collection_test.dart.browser_test.dart.js
Compiled 11,205,069 characters Dart to 1,950,368 characters JavaScript in 17.0 seconds
Dart file test/text/font_loading_test.dart compiled to JavaScript: test/text/font_loading_test.dart.browser_test.dart.js
Compiled 12,313,075 characters Dart to 2,532,897 characters JavaScript in 13.6 seconds
Dart file test/text/line_breaker_test.dart compiled to JavaScript: test/text/line_breaker_test.dart.browser_test.dart.js
Compiled 11,247,237 characters Dart to 1,982,417 characters JavaScript in 17.7 seconds
Dart file test/text/measurement_test.dart compiled to JavaScript: test/text/measurement_test.dart.browser_test.dart.js
Compiled 11,203,143 characters Dart to 1,236,353 characters JavaScript in 12.3 seconds
Dart file test/rect_test.dart compiled to JavaScript: test/rect_test.dart.browser_test.dart.js
Compiled 11,239,233 characters Dart to 1,449,824 characters JavaScript in 13.5 seconds
Dart file test/keyboard_test.dart compiled to JavaScript: test/keyboard_test.dart.browser_test.dart.js
Compiled 11,207,004 characters Dart to 1,234,634 characters JavaScript in 11.0 seconds
Dart file test/lerp_test.dart compiled to JavaScript: test/lerp_test.dart.browser_test.dart.js
Compiled 11,251,567 characters Dart to 1,878,364 characters JavaScript in 12.7 seconds
Dart file test/clipboard_test.dart compiled to JavaScript: test/clipboard_test.dart.browser_test.dart.js
Compiled 11,995,986 characters Dart to 1,848,282 characters JavaScript in 12.8 seconds
Dart file test/text_editing_test.dart compiled to JavaScript: test/text_editing_test.dart.browser_test.dart.js
Compiled 11,940,217 characters Dart to 1,846,347 characters JavaScript in 10.6 seconds
Dart file test/window_test.dart compiled to JavaScript: test/window_test.dart.browser_test.dart.js
Compiled 11,208,378 characters Dart to 1,860,897 characters JavaScript in 14.8 seconds
Dart file test/canvaskit/layer_test.dart compiled to JavaScript: test/canvaskit/layer_test.dart.browser_test.dart.js
Compiled 11,208,045 characters Dart to 1,803,646 characters JavaScript in 14.8 seconds
Dart file test/canvaskit/vertices_test.dart compiled to JavaScript: test/canvaskit/vertices_test.dart.browser_test.dart.js
Compiled 11,212,360 characters Dart to 1,932,924 characters JavaScript in 15.6 seconds
Dart file test/canvaskit/path_test.dart compiled to JavaScript: test/canvaskit/path_test.dart.browser_test.dart.js
Compiled 11,210,205 characters Dart to 1,812,701 characters JavaScript in 15.5 seconds
Dart file test/canvaskit/shader_test.dart compiled to JavaScript: test/canvaskit/shader_test.dart.browser_test.dart.js
Compiled 11,242,019 characters Dart to 1,989,249 characters JavaScript in 15.7 seconds
Dart file test/canvaskit/canvaskit_api_test.dart compiled to JavaScript: test/canvaskit/canvaskit_api_test.dart.browser_test.dart.js
Compiled 11,209,662 characters Dart to 2,044,296 characters JavaScript in 15.8 seconds
Dart file test/canvaskit/embedded_views_test.dart compiled to JavaScript: test/canvaskit/embedded_views_test.dart.browser_test.dart.js
Compiled 11,974,890 characters Dart to 1,899,642 characters JavaScript in 16.1 seconds
Dart file test/canvaskit/skia_objects_cache_test.dart compiled to JavaScript: test/canvaskit/skia_objects_cache_test.dart.browser_test.dart.js
Compiled 11,209,754 characters Dart to 1,806,634 characters JavaScript in 16.4 seconds
Dart file test/canvaskit/filter_test.dart compiled to JavaScript: test/canvaskit/filter_test.dart.browser_test.dart.js
Compiled 11,220,574 characters Dart to 1,977,385 characters JavaScript in 9.53 seconds
Dart file test/canvaskit/canvas_golden_test.dart compiled to JavaScript: test/canvaskit/canvas_golden_test.dart.browser_test.dart.js
Compiled 11,208,660 characters Dart to 1,875,271 characters JavaScript in 8.70 seconds
Dart file test/canvaskit/frame_timings_test.dart compiled to JavaScript: test/canvaskit/frame_timings_test.dart.browser_test.dart.js
Compiled 11,923,451 characters Dart to 1,836,429 characters JavaScript in 9.09 seconds
Dart file test/canvaskit/image_test.dart compiled to JavaScript: test/canvaskit/image_test.dart.browser_test.dart.js
Compiled 11,208,032 characters Dart to 1,993,233 characters JavaScript in 9.24 seconds
Dart file test/canvaskit/scene_test.dart compiled to JavaScript: test/canvaskit/scene_test.dart.browser_test.dart.js
The build took 212 seconds.
00:00 +0: loading test/golden_tests/golden_failure_smoke_test.dart                                                   
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/eed57403-5606-4d23-99a1-f8f9d954b4bc
00:03 +0 -1: screenshot test reports failure [E]                                                                     
  Golden file smoke_test.png did not match the image generated by the test.
  (2.8891% of pixels were different. Maximum allowed rate is: 0.2800%).
  You can view the test report in your browser by opening:
  /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/smoke_test.report.html
  To update the golden file call matchGoldenFile('smoke_test.png', write: true).
  Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/smoke_test.expected.png
  Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/smoke_test.actual.png
  
  org-dartlang-sdk:///lib/_internal/js_runtime/lib/js_helper.dart 1130:37                                                            Object.wrapException
  org-dartlang-sdk:///lib/_internal/js_runtime/lib/js_helper.dart 1161:25                                                            Object.throwExpression
  /usr/local/google/.pub-cache/hosted/pub.dartlang.org/test_api-0.2.19-nullsafety.6/lib/src/frontend/expect.dart 155:31              Object.fail
  ../../../../web_sdk/web_engine_tester/lib/golden_tester.dart 86:3                                                                  <fn>
  org-dartlang-sdk:///lib/_internal/js_runtime/lib/async_patch.dart 316:19                                                           _wrapJsFunctionForAsync.closure.$protected
  org-dartlang-sdk:///lib/_internal/js_runtime/lib/async_patch.dart 341:23                                                           _wrapJsFunctionForAsync.<fn>
  /usr/local/google/.pub-cache/hosted/pub.dartlang.org/stack_trace-1.10.0-nullsafety.6/lib/src/stack_zone_specification.dart 138:25  StackZoneSpecification._registerBinaryCallback.<fn>.<fn>
  /usr/local/google/.pub-cache/hosted/pub.dartlang.org/stack_trace-1.10.0-nullsafety.6/lib/src/stack_zone_specification.dart 208:14  StackZoneSpecification._run
  /usr/local/google/.pub-cache/hosted/pub.dartlang.org/stack_trace-1.10.0-nullsafety.6/lib/src/stack_zone_specification.dart 138:14  StackZoneSpecification._registerBinaryCallback.<fn>
  org-dartlang-sdk:///lib/_internal/js_runtime/lib/async_patch.dart 292:19                                                           _awaitOnObject.<fn>
  ===== asynchronous gap ===========================
  org-dartlang-sdk:///lib/_internal/js_runtime/lib/js_helper.dart 2183:5                                                             Object.eval
  org-dartlang-sdk:///lib/async/zone.dart 1125:34                                                                                    _CustomZone.registerBinaryCallback
  org-dartlang-sdk:///lib/_internal/js_runtime/lib/async_patch.dart 340:23                                                           Object._wrapJsFunctionForAsync
  org-dartlang-sdk:///lib/async/zone.dart 1186:12                                                                                    StaticClosure._rootRun
  org-dartlang-sdk:///lib/async/zone.dart 1089:34                                                                                    _CustomZone.run
  ===== asynchronous gap ===========================
  org-dartlang-sdk:///lib/_internal/js_runtime/lib/js_helper.dart 2183:5                                                             Object.eval
  org-dartlang-sdk:///lib/async/zone.dart 1125:34                                                                                    _CustomZone.registerBinaryCallback
  org-dartlang-sdk:///lib/_internal/js_runtime/lib/async_patch.dart 340:23                                                           Object._wrapJsFunctionForAsync
  org-dartlang-sdk:///lib/async/zone.dart 1186:12                                                                                    StaticClosure._rootRun
  org-dartlang-sdk:///lib/async/zone.dart 1089:34                                                                                    _CustomZone.run
  
00:03 +0 -1: Some tests failed.                                                                                      
00:00 +0: loading test/dom_renderer_test.dart                                                                        
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/aa3d4b31-fa61-4c67-86ec-44e8b4a52b9f
00:04 +2: test/channel_buffers_test.dart: push drain zero                                                            
A message on the foo channel was discarded before it could be handled.
This happens when a plugin sends messages to the framework side before the framework has had an opportunity to register a listener. See the ChannelBuffers API documentation for details on how to configure the channel to expect more messages, or to expect messages to get discarded:
  https://api.flutter.dev/flutter/dart-ui/ChannelBuffers-class.html
00:04 +6: test/channel_buffers_test.dart: overflow                                                                   
A message on the foo channel was discarded before it could be handled.
This happens when a plugin sends messages to the framework side before the framework has had an opportunity to register a listener. See the ChannelBuffers API documentation for details on how to configure the channel to expect more messages, or to expect messages to get discarded:
  https://api.flutter.dev/flutter/dart-ui/ChannelBuffers-class.html
00:05 +12: test/channel_buffers_test.dart: overflow calls callback                                                   
A message on the foo channel was discarded before it could be handled.
This happens when a plugin sends messages to the framework side before the framework has had an opportunity to register a listener. See the ChannelBuffers API documentation for details on how to configure the channel to expect more messages, or to expect messages to get discarded:
  https://api.flutter.dev/flutter/dart-ui/ChannelBuffers-class.html
00:05 +18: test/channel_buffers_test.dart: ChannelBuffers.setListener                                                
A message on the a channel was discarded before it could be handled.
This happens when a plugin sends messages to the framework side before the framework has had an opportunity to register a listener. See the ChannelBuffers API documentation for details on how to configure the channel to expect more messages, or to expect messages to get discarded:
  https://api.flutter.dev/flutter/dart-ui/ChannelBuffers-class.html
00:05 +32: test/dom_renderer_test.dart: replaces viewport meta tags during style reset                               
WARNING: found an existing <meta name="viewport"> tag. Flutter Web uses its own viewport configuration for better compatibility with Flutter. This tag will be replaced.
00:11 +294: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "" - noop
00:11 +296: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "" - noop
Testing "be" - zero-to-many
00:11 +297: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "bcde" - insert in the middle
00:11 +300: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "abcde" - prepend
00:12 +301: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "abcdef" - append
00:12 +303: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "fbcdea" - swap at ends
Testing "fecdba" - swap in the middle
00:12 +305: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "fedcba" - swap adjacent in one move
Testing "fedcba" - non-empty noop
Testing "afedcb" - shift right by 1
Testing "fedcba" - shift left by 1
Testing "abcdef" - reverse
00:12 +307: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "efabcd" - shift right by 2
00:12 +309: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "abcdef" - shift left by 2
Testing "9abcde" - scroll right by 1
00:12 +310: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "789abc" - scroll right by 2
Testing "89abcd" - scroll left by 1
Testing "abcdef" - scroll left by 2
00:12 +314: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "zabcde" - scroll right by 1
Testing "xyzabc" - scroll right by 2
00:12 +315: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "yzabcd" - scroll left by 1
Testing "abcdef" - scroll left by 2
00:12 +317: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "bcdef" - remove as start
00:12 +318: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "bcde" - remove as end
00:12 +320: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "be" - remove in the middle
00:12 +321: test/engine/surface/scene_builder_test.dart: updates child lists efficiently                             
Testing "" - remove all
00:15 +519 ~3: test/text/font_loading_test.dart: loadFontFromList loading font should clear measurement caches       
A message on the flutter/system channel was discarded before it could be handled.
This happens when a plugin sends messages to the framework side before the framework has had an opportunity to register a listener. See the ChannelBuffers API documentation for details on how to configure the channel to expect more messages, or to expect messages to get discarded:
  https://api.flutter.dev/flutter/dart-ui/ChannelBuffers-class.html
00:18 +757 ~5: All tests passed!                                                                                     
00:00 +0: loading test/golden_tests/golden_success_smoke_test.dart                                                   
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/8c8cac9d-8e15-4e3c-84de-d7116936f23b
00:03 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/path_to_svg_golden_test.dart                                              
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/76bc3a8a-059a-4c83-86ba-a83803874f74
00:05 +3: loading test/golden_tests/engine/path_to_svg_golden_test.dart                                              
WARNING:
Golden file svg_arc_1.png did not match the image generated by the test.
(0.0098% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_1.report.html
To update the golden file call matchGoldenFile('svg_arc_1.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_1.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_1.actual.png

WARNING:
Golden file svg_arc_2.png did not match the image generated by the test.
(0.0254% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_2.report.html
To update the golden file call matchGoldenFile('svg_arc_2.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_2.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_2.actual.png

WARNING:
Golden file svg_arc_3.png did not match the image generated by the test.
(0.0612% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_3.report.html
To update the golden file call matchGoldenFile('svg_arc_3.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_3.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_3.actual.png

WARNING:
Golden file svg_arc_4.png did not match the image generated by the test.
(0.0117% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_4.report.html
To update the golden file call matchGoldenFile('svg_arc_4.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_4.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_4.actual.png

WARNING:
Golden file svg_arc_5.png did not match the image generated by the test.
(0.0606% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_5.report.html
To update the golden file call matchGoldenFile('svg_arc_5.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_5.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_5.actual.png

WARNING:
Golden file svg_arc_6.png did not match the image generated by the test.
(0.0117% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_6.report.html
To update the golden file call matchGoldenFile('svg_arc_6.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_6.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_6.actual.png

WARNING:
Golden file svg_arc_7.png did not match the image generated by the test.
(0.0152% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_7.report.html
To update the golden file call matchGoldenFile('svg_arc_7.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_7.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_7.actual.png

WARNING:
Golden file svg_arc_8.png did not match the image generated by the test.
(0.0338% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_8.report.html
To update the golden file call matchGoldenFile('svg_arc_8.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_8.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_arc_8.actual.png

00:11 +4: loading test/golden_tests/engine/path_to_svg_golden_test.dart                                              
WARNING:
Golden file svg_rect.png did not match the image generated by the test.
(0.5477% of pixels were different. Maximum allowed rate is: 1.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_rect.report.html
To update the golden file call matchGoldenFile('svg_rect.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_rect.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/svg_rect.actual.png

00:11 +6: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_draw_image_golden_test.dart                                        
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/4e1a0296-7e66-4b41-b5dd-a96766348344
00:08 +14: loading test/golden_tests/engine/canvas_draw_image_golden_test.dart                                       
WARNING:
Golden file draw_text_composite_order_below.png did not match the image generated by the test.
(0.6244% of pixels were different. Maximum allowed rate is: 1.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/draw_text_composite_order_below.report.html
To update the golden file call matchGoldenFile('draw_text_composite_order_below.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/draw_text_composite_order_below.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/draw_text_composite_order_below.actual.png

00:09 +17: loading test/golden_tests/engine/canvas_draw_image_golden_test.dart                                       
WARNING:
Golden file draw_3d_image.png did not match the image generated by the test.
(5.8375% of pixels were different. Maximum allowed rate is: 6.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/draw_3d_image.report.html
To update the golden file call matchGoldenFile('draw_3d_image.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/draw_3d_image.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/draw_3d_image.actual.png

00:09 +18: loading test/golden_tests/engine/canvas_draw_image_golden_test.dart                                       
WARNING:
Golden file draw_3d_image_clipped.png did not match the image generated by the test.
(3.7125% of pixels were different. Maximum allowed rate is: 5.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/draw_3d_image_clipped.report.html
To update the golden file call matchGoldenFile('draw_3d_image_clipped.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/draw_3d_image_clipped.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/draw_3d_image_clipped.actual.png

00:10 +23: All tests passed!                                                                                         
00:00 +0: loading test/golden_tests/engine/canvas_stroke_joins_golden_test.dart                                      
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/9623f720-bc49-477e-9a50-c52214268ba9
00:03 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/text_overflow_golden_test.dart                                            
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/5d03171e-e8bd-4780-af08-2b9279b7565e
00:09 +9: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/gradient_golden_test.dart                                                 
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/5efbf76e-89d5-4609-98a3-77b53a05fab9
00:05 +3: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/radial_gradient_golden_test.dart                                          
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/360cfcc5-719c-4c5e-b1ff-b80606bfb044
00:05 +5: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/picture_golden_test.dart                                                  
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/1e16aafb-1b70-4f78-b4e7-65916156a4f1
00:01 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/shadow_golden_test.dart                                                   
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/c3e14649-cd32-408e-8bd6-5a0abee82785
00:01 +2: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_winding_rule_test.dart                                             
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/1f27ef24-c8f2-46d4-a765-99b66b0e4e3d
00:03 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_draw_picture_test.dart                                             
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/ec464cb0-5702-4ce2-a47a-9904e16e3df7
00:03 +2: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/color_filter_golden_test.dart                                             
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/4221a0d8-a0c1-490d-9ad7-d978df1e8438
00:03 +0: loading test/golden_tests/engine/color_filter_golden_test.dart                                             
WARNING:
Golden file color_filter_blendMode_color.png did not match the image generated by the test.
(0.1716% of pixels were different. Maximum allowed rate is: 12.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/color_filter_blendMode_color.report.html
To update the golden file call matchGoldenFile('color_filter_blendMode_color.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/color_filter_blendMode_color.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/color_filter_blendMode_color.actual.png

00:03 +1: loading test/golden_tests/engine/color_filter_golden_test.dart                                             
WARNING:
Golden file color_filter_blendMode_overlay.png did not match the image generated by the test.
(11.7208% of pixels were different. Maximum allowed rate is: 12.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/color_filter_blendMode_overlay.report.html
To update the golden file call matchGoldenFile('color_filter_blendMode_overlay.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/color_filter_blendMode_overlay.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/color_filter_blendMode_overlay.actual.png

00:03 +2: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_reuse_test.dart                                                    
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/8ef9a6da-5a6b-4827-bcdf-f556052140f5
00:03 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_arc_golden_test.dart                                               
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/83c9bf36-34f7-4851-90a7-557c92b15a47
00:04 +3: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_clip_path_test.dart                                                
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/80334472-4caa-4ccb-950a-66165c4ff9da
00:03 +2: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/draw_vertices_golden_test.dart                                            
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/dde66aec-480e-40c2-a526-790a87d135c5
00:06 +7: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/backdrop_filter_golden_test.dart                                          
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/5d27e4ae-c2df-41e8-a588-7d4f3dc625ba
00:03 +2: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_draw_color_test.dart                                               
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/3769611c-0747-4585-9c0c-5ac7337d25d8
00:03 +0 ~2: All tests skipped.                                                                                      
00:00 +0: loading test/golden_tests/engine/canvas_golden_test.dart                                                   
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/2949f1e5-53ed-4fed-be38-f3870a8c423a
00:03 +1: loading test/golden_tests/engine/canvas_golden_test.dart                                                   
WARNING:
Golden file misaligned_canvas_test.png did not match the image generated by the test.
(0.1600% of pixels were different. Maximum allowed rate is: 1.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/misaligned_canvas_test.report.html
To update the golden file call matchGoldenFile('misaligned_canvas_test.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/misaligned_canvas_test.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/misaligned_canvas_test.actual.png

00:03 +2: loading test/golden_tests/engine/canvas_golden_test.dart                                                   
WARNING:
Golden file bitmap_canvas_fills_color_when_transformed.png did not match the image generated by the test.
(0.4080% of pixels were different. Maximum allowed rate is: 5.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/bitmap_canvas_fills_color_when_transformed.report.html
To update the golden file call matchGoldenFile('bitmap_canvas_fills_color_when_transformed.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/bitmap_canvas_fills_color_when_transformed.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/bitmap_canvas_fills_color_when_transformed.actual.png

00:03 +3: loading test/golden_tests/engine/canvas_golden_test.dart                                                   
WARNING:
Golden file bitmap_canvas_fills_paint_when_transformed.png did not match the image generated by the test.
(0.4080% of pixels were different. Maximum allowed rate is: 5.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/bitmap_canvas_fills_paint_when_transformed.report.html
To update the golden file call matchGoldenFile('bitmap_canvas_fills_paint_when_transformed.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/bitmap_canvas_fills_paint_when_transformed.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/bitmap_canvas_fills_paint_when_transformed.actual.png

00:03 +6: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/recording_canvas_golden_test.dart                                         
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/0a70d173-c468-4ccd-92fc-9a2c6bf5ac87
00:14 +32: loading test/golden_tests/engine/recording_canvas_golden_test.dart                                        
WARNING:
Golden file paint_spread_bounds.png did not match the image generated by the test.
(0.0053% of pixels were different. Maximum allowed rate is: 0.2000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/paint_spread_bounds.report.html
To update the golden file call matchGoldenFile('paint_spread_bounds.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/paint_spread_bounds.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/paint_spread_bounds.actual.png

00:14 +33: All tests passed!                                                                                         
00:00 +0: loading test/golden_tests/engine/canvas_rrect_golden_test.dart                                             
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/bad0d578-f9e6-4180-8683-ccd487bf9767
00:03 +3: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/multiline_text_clipping_golden_test.dart                                  
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/b4cbed38-9b92-40d1-ba92-9e937a001723
00:08 +15: All tests passed!                                                                                         
00:00 +0: loading test/golden_tests/engine/conic_golden_test.dart                                                    
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/59b40996-2ab6-4dfb-8c7d-6618768713cf
00:04 +3: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_stroke_rects_golden_test.dart                                      
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/dcccda37-e5f8-4926-9f80-87aa1371f6d6
00:03 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_rect_golden_test.dart                                              
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/838a6806-0b67-476c-ac38-b0b4a43f9958
00:03 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/compositing_golden_test.dart                                              
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/2f2d9d11-20a4-42ee-923c-ddab58f00da9
00:03 +5: Cull rect computation fills screen bounds                                                                  
  Skip: TODO(https://github.com/flutter/flutter/issues/40395)
  Needs ability to set iframe to 500,100 size. Current screen seems to be 500,500
00:03 +9 ~1: Cull rect computation offset overflows paint bounds                                                     
  Skip: TODO(https://github.com/flutter/flutter/issues/40395)
  Needs ability to set iframe to 500,100 size. Current screen seems to be 500,500
00:04 +15 ~2: loading test/golden_tests/engine/compositing_golden_test.dart                                          
WARNING:
Golden file compositing_3d_rotate1.png did not match the image generated by the test.
(0.0140% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/compositing_3d_rotate1.report.html
To update the golden file call matchGoldenFile('compositing_3d_rotate1.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/compositing_3d_rotate1.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/compositing_3d_rotate1.actual.png

00:04 +17 ~2: All tests passed!                                                                                      
00:00 +0: loading test/golden_tests/engine/clip_op_golden_test.dart                                                  
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/c59eccb3-19fd-4eab-8231-797063131c3b
00:03 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_blend_golden_test.dart                                             
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/1cc54af3-b444-46e9-97d9-2c41558291d4
00:03 +2: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/path_metrics_test.dart                                                    
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/8c8f263b-a9e4-4c52-a7e8-10d325dfef7a
00:03 +5: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_draw_points_test.dart                                              
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/e0aa736f-68f3-4918-bb68-27cefd512cdb
00:03 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_mask_filter_test.dart                                              
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/75e226ef-48dc-465e-9f9a-b6f23df7a85d
00:04 +7: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_lines_golden_test.dart                                             
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/14aea1ca-299d-4ad9-a81b-be63c84efa26
00:03 +1: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_image_blend_mode_test.dart                                         
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/2eb9152c-4be0-4ab0-b3c8-7d14942f6f7e
00:03 +0: loading test/golden_tests/engine/canvas_image_blend_mode_test.dart                                         
WARNING:
Golden file canvas_image_blend_group0.png did not match the image generated by the test.
(6.9512% of pixels were different. Maximum allowed rate is: 8.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group0.report.html
To update the golden file call matchGoldenFile('canvas_image_blend_group0.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group0.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group0.actual.png

00:04 +1: loading test/golden_tests/engine/canvas_image_blend_mode_test.dart                                         
WARNING:
Golden file canvas_image_blend_group1.png did not match the image generated by the test.
(5.0092% of pixels were different. Maximum allowed rate is: 8.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group1.report.html
To update the golden file call matchGoldenFile('canvas_image_blend_group1.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group1.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group1.actual.png

00:04 +2: loading test/golden_tests/engine/canvas_image_blend_mode_test.dart                                         
WARNING:
Golden file canvas_image_blend_group2.png did not match the image generated by the test.
(7.6680% of pixels were different. Maximum allowed rate is: 8.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group2.report.html
To update the golden file call matchGoldenFile('canvas_image_blend_group2.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group2.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group2.actual.png

00:05 +3: loading test/golden_tests/engine/canvas_image_blend_mode_test.dart                                         
WARNING:
Golden file canvas_image_blend_group3.png did not match the image generated by the test.
(3.3160% of pixels were different. Maximum allowed rate is: 8.0000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group3.report.html
To update the golden file call matchGoldenFile('canvas_image_blend_group3.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group3.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/canvas_image_blend_group3.actual.png

00:05 +5: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/path_transform_test.dart                                                  
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/9da98001-ae9b-458a-a885-1ccf84cb4605
00:05 +4: loading test/golden_tests/engine/path_transform_test.dart                                                  
WARNING:
Golden file path_transform_with_arc.png did not match the image generated by the test.
(1.3760% of pixels were different. Maximum allowed rate is: 1.4000%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/path_transform_with_arc.report.html
To update the golden file call matchGoldenFile('path_transform_with_arc.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/path_transform_with_arc.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/path_transform_with_arc.actual.png

00:05 +6: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/text_placeholders_test.dart                                               
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/5b87e74f-8414-417d-a429-8d50102d0667
00:03 +0: loading test/golden_tests/engine/text_placeholders_test.dart                                               
WARNING:
Golden file text_with_placeholders_BitmapCanvas.png did not match the image generated by the test.
(0.1767% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/text_with_placeholders_BitmapCanvas.report.html
To update the golden file call matchGoldenFile('text_with_placeholders_BitmapCanvas.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/text_with_placeholders_BitmapCanvas.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/text_with_placeholders_BitmapCanvas.actual.png

00:04 +1: loading test/golden_tests/engine/text_placeholders_test.dart                                               
WARNING:
Golden file text_with_placeholders_BitmapCanvas+canvas_measurement.png did not match the image generated by the test.
(0.1767% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/text_with_placeholders_BitmapCanvas+canvas_measurement.report.html
To update the golden file call matchGoldenFile('text_with_placeholders_BitmapCanvas+canvas_measurement.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/text_with_placeholders_BitmapCanvas+canvas_measurement.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/text_with_placeholders_BitmapCanvas+canvas_measurement.actual.png

00:04 +2: loading test/golden_tests/engine/text_placeholders_test.dart                                               
WARNING:
Golden file text_with_placeholders_DomCanvas.png did not match the image generated by the test.
(0.1767% of pixels were different. Maximum allowed rate is: 0.2800%).
You can view the test report in your browser by opening:
/usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/text_with_placeholders_DomCanvas.report.html
To update the golden file call matchGoldenFile('text_with_placeholders_DomCanvas.png', write: true).
Golden file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/text_with_placeholders_DomCanvas.expected.png
Actual file: /usr/local/google/home/dit/github/engine/src/flutter/lib/web_ui/.dart_tool/test_results/text_with_placeholders_DomCanvas.actual.png

00:06 +6: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/canvas_context_test.dart                                                  
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/75fcc9a1-3379-4ab6-9f81-51205ef23d1a
00:03 +2: All tests passed!                                                                                          
00:00 +0: loading test/golden_tests/engine/text_style_golden_test.dart                                               
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/85439334-46e2-4610-8c6f-956a0e22c8d1
00:14 +18: All tests passed!                                                                                         
00:00 +0: loading test/golden_tests/engine/linear_gradient_golden_test.dart                                          
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/dacb4ecc-7ab8-4bfe-8392-796ddab10963
00:05 +5: All tests passed!                                                                                          
00:00 +0: loading test/canvaskit/canvas_golden_test.dart                                                             
[CHROME STDERR]:
[CHROME STDERR]:DevTools listening on ws://127.0.0.1:12345/devtools/browser/25b45513-7625-4834-8344-e3e91ca57209
00:06 +2: All tests passed!
```

</details>

- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*



<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
