### PR TITLE
Load macOS dart bundle by URL fallback

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -239,6 +239,10 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
     bundle = [NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]];
   }
   if (bundle == nil) {
+    bundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
+                                         URLByAppendingPathComponent:@"App.framework"]];
+  }
+  if (bundle == nil) {
     bundle = [NSBundle mainBundle];
   }
   NSString* flutterAssetsName = [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -239,10 +239,6 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
     bundle = [NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]];
   }
   if (bundle == nil) {
-    bundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
-                                         URLByAppendingPathComponent:@"App.framework"]];
-  }
-  if (bundle == nil) {
     bundle = [NSBundle mainBundle];
   }
   NSString* flutterAssetsName = [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -27,6 +27,10 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
   NSAssert(self, @"Super init cannot be nil");
 
   _dartBundle = bundle ?: [NSBundle bundleWithIdentifier:kAppBundleIdentifier];
+  if (_dartBundle == nil) {
+    _dartBundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
+                                              URLByAppendingPathComponent:@"App.framework"]];
+  }
   _dartEntrypointArguments = [[NSProcessInfo processInfo] arguments];
   // Remove the first element as it's the binary name
   _dartEntrypointArguments = [_dartEntrypointArguments

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -28,6 +28,7 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
 
   _dartBundle = bundle ?: [NSBundle bundleWithIdentifier:kAppBundleIdentifier];
   if (_dartBundle == nil) {
+    // The bundle isn't loaded and can't be found by bundle ID. Find it by path.
     _dartBundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
                                               URLByAppendingPathComponent:@"App.framework"]];
   }


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/71764 (reverted) will stop explicitly linking the App.framework into the macOS app, which means `[NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]]` returns null because the bundle isn't loaded (no longer `LC_LOAD_DYLIB`), and so the assets aren't found:
```
2020-12-08T14:22:03.476319: stdout: [ +341 ms] 2020-12-08 14:22:03.475 flutter_gallery[38930:24214860] Failed to find path for "flutter_assets"
2020-12-08T14:22:03.477822: stdout: [   +1 ms] 2020-12-08 14:22:03.475 flutter_gallery[38930:24214860] Failed to find path for "flutter_assets"
stdout: [        ] embedder.cc (764): 'FlutterEngineInitialize' returned 'kInvalidArguments'. The assets path in the Flutter project arguments was missing.
stdout: [        ] 2020-12-08 14:22:03.475 flutter_gallery[38930:24214860] Failed to initialize Flutter engine: error 2
2020-12-08T15:22:20.615880: Task execution finished
```

Instead, fallback macOS to detecting the dart bundle by path to `Contents/Frameworks/App.framework`.

## Related Issues

Unblock https://github.com/flutter/flutter/pull/71764.

## Tests

I'm not sure how to explicitly test this, but `hot_mode_dev_cycle_macos_target__benchmark` will pass on top of https://github.com/flutter/flutter/pull/71764 after this change.