### PR TITLE
Allow Tile mode for blur filter and add new decal TileMode

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3218,11 +3218,20 @@ class _GaussianBlurImageFilter implements ImageFilter {
   @override
   _ImageFilter _toNativeImageFilter() => nativeFilter;
 
-  @override
-  String get _shortDescription => 'blur($sigmaX, $sigmaY, $tileMode)';
+  String get _modeString {
+    switch(tileMode) {
+      case TileMode.clamp: return 'clamp';
+      case TileMode.mirror: return 'mirror';
+      case TileMode.repeated: return 'repeated';
+      case TileMode.decal: return 'decal';
+    }
+  }
 
   @override
-  String toString() => 'ImageFilter.blur($sigmaX, $sigmaY, $tileMode)';
+  String get _shortDescription => 'blur($sigmaX, $sigmaY, $_modeString)';
+
+  @override
+  String toString() => 'ImageFilter.blur($sigmaX, $sigmaY, $_modeString)';
 
   @override
   bool operator ==(Object other) {

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -55,7 +55,8 @@ void ImageFilter::initPicture(Picture* picture) {
   filter_ = SkPictureImageFilter::Make(picture->picture());
 }
 
-void ImageFilter::initBlur(double sigma_x, double sigma_y,
+void ImageFilter::initBlur(double sigma_x,
+                           double sigma_y,
                            SkTileMode tile_mode) {
   filter_ = SkImageFilters::Blur(sigma_x, sigma_y, tile_mode, nullptr, nullptr);
 }

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -55,9 +55,9 @@ void ImageFilter::initPicture(Picture* picture) {
   filter_ = SkPictureImageFilter::Make(picture->picture());
 }
 
-void ImageFilter::initBlur(double sigma_x, double sigma_y) {
-  filter_ = SkBlurImageFilter::Make(sigma_x, sigma_y, nullptr, nullptr,
-                                    SkBlurImageFilter::kClamp_TileMode);
+void ImageFilter::initBlur(double sigma_x, double sigma_y,
+                           SkTileMode tile_mode) {
+  filter_ = SkImageFilters::Blur(sigma_x, sigma_y, tile_mode, nullptr, nullptr);
 }
 
 void ImageFilter::initMatrix(const tonic::Float64List& matrix4,

--- a/lib/ui/painting/image_filter.h
+++ b/lib/ui/painting/image_filter.h
@@ -24,7 +24,7 @@ class ImageFilter : public RefCountedDartWrappable<ImageFilter> {
 
   void initImage(CanvasImage* image);
   void initPicture(Picture*);
-  void initBlur(double sigma_x, double sigma_y);
+  void initBlur(double sigma_x, double sigma_y, SkTileMode tile_mode);
   void initMatrix(const tonic::Float64List& matrix4, int filter_quality);
   void initColorFilter(ColorFilter* colorFilter);
   void initComposeFilter(ImageFilter* outer, ImageFilter* inner);

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -642,6 +642,7 @@ class SkTileModeEnum {
   external SkTileMode get Clamp;
   external SkTileMode get Repeat;
   external SkTileMode get Mirror;
+  external SkTileMode get Decal;
 }
 
 @JS()
@@ -653,6 +654,7 @@ final List<SkTileMode> _skTileModes = <SkTileMode>[
   canvasKit.TileMode.Clamp,
   canvasKit.TileMode.Repeat,
   canvasKit.TileMode.Mirror,
+  canvasKit.TileMode.Decal,
 ];
 
 SkTileMode toSkTileMode(ui.TileMode mode) {

--- a/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
@@ -20,7 +20,7 @@ abstract class _CkManagedSkImageFilterConvertible<T extends Object> implements u
 ///
 /// Currently only supports `blur`.
 abstract class CkImageFilter extends ManagedSkiaObject<SkImageFilter> implements _CkManagedSkImageFilterConvertible<SkImageFilter> {
-  factory CkImageFilter.blur({ required double sigmaX, required double sigmaY }) = _CkBlurImageFilter;
+  factory CkImageFilter.blur({ required double sigmaX, required double sigmaY, required ui.TileMode tileMode }) = _CkBlurImageFilter;
   factory CkImageFilter.color({ required CkColorFilter colorFilter }) = _CkColorFilterImageFilter;
 
   CkImageFilter._();
@@ -66,17 +66,27 @@ class _CkColorFilterImageFilter extends CkImageFilter {
 }
 
 class _CkBlurImageFilter extends CkImageFilter {
-  _CkBlurImageFilter({ required this.sigmaX, required this.sigmaY }) : super._();
+  _CkBlurImageFilter({ required this.sigmaX, required this.sigmaY, required this.tileMode }) : super._();
 
   final double sigmaX;
   final double sigmaY;
+  final ui.TileMode tileMode;
+
+  String get _modeString {
+    switch (tileMode) {
+      case ui.TileMode.clamp: return 'clamp';
+      case ui.TileMode.mirror: return 'mirror';
+      case ui.TileMode.repeated: return 'repeated';
+      case ui.TileMode.decal: return 'decal';
+    }
+  }
 
   @override
   SkImageFilter _initSkiaObject() {
     return canvasKit.ImageFilter.MakeBlur(
       sigmaX,
       sigmaY,
-      canvasKit.TileMode.Clamp,
+      toSkTileMode(tileMode),
       null,
     );
   }
@@ -87,15 +97,16 @@ class _CkBlurImageFilter extends CkImageFilter {
       return false;
     return other is _CkBlurImageFilter
         && other.sigmaX == sigmaX
-        && other.sigmaY == sigmaY;
+        && other.sigmaY == sigmaY
+        && other.tileMode == tileMode;
   }
 
   @override
-  int get hashCode => ui.hashValues(sigmaX, sigmaY);
+  int get hashCode => ui.hashValues(sigmaX, sigmaY, tileMode);
 
   @override
   String toString() {
-    return 'ImageFilter.blur($sigmaX, $sigmaY)';
+    return 'ImageFilter.blur($sigmaX, $sigmaY, $_modeString)';
   }
 }
 

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -394,9 +394,9 @@ enum FilterQuality {
 }
 
 class ImageFilter {
-  factory ImageFilter.blur({double sigmaX = 0.0, double sigmaY = 0.0}) {
+  factory ImageFilter.blur({double sigmaX = 0.0, double sigmaY = 0.0, TileMode tileMode = TileMode.clamp}) {
     if (engine.useCanvasKit) {
-      return engine.CkImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY);
+      return engine.CkImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY, tileMode: tileMode);
     }
     return engine.EngineImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY);
   }

--- a/lib/web_ui/lib/src/ui/tile_mode.dart
+++ b/lib/web_ui/lib/src/ui/tile_mode.dart
@@ -10,4 +10,5 @@ enum TileMode {
   clamp,
   repeated,
   mirror,
+  decal,
 }

--- a/lib/web_ui/test/canvaskit/filter_test.dart
+++ b/lib/web_ui/test/canvaskit/filter_test.dart
@@ -40,8 +40,9 @@ void testMain() {
 
   List<CkImageFilter> createImageFilters() {
     return <CkImageFilter>[
-      CkImageFilter.blur(sigmaX: 5, sigmaY: 6),
-      CkImageFilter.blur(sigmaX: 6, sigmaY: 5),
+      CkImageFilter.blur(sigmaX: 5, sigmaY: 6, tileMode: ui.TileMode.clamp),
+      CkImageFilter.blur(sigmaX: 6, sigmaY: 5, tileMode: ui.TileMode.clamp),
+      CkImageFilter.blur(sigmaX: 6, sigmaY: 5, tileMode: ui.TileMode.decal),
       for (final CkColorFilter colorFilter in createColorFilters()) CkImageFilter.color(colorFilter: colorFilter),
     ];
   }
@@ -50,7 +51,7 @@ void testMain() {
     setUpCanvasKitTest();
 
     test('can be constructed', () {
-      final CkImageFilter imageFilter = CkImageFilter.blur(sigmaX: 5, sigmaY: 10);
+      final CkImageFilter imageFilter = CkImageFilter.blur(sigmaX: 5, sigmaY: 10, tileMode: ui.TileMode.clamp);
       expect(imageFilter, isA<CkImageFilter>());
       expect(imageFilter.createDefault(), isNotNull);
       expect(imageFilter.resurrect(), isNotNull);
@@ -80,12 +81,12 @@ void testMain() {
 
     test('reuses the Skia filter', () {
       final CkPaint paint = CkPaint();
-      paint.imageFilter = CkImageFilter.blur(sigmaX: 5, sigmaY: 10);
+      paint.imageFilter = CkImageFilter.blur(sigmaX: 5, sigmaY: 10, tileMode: ui.TileMode.clamp);
 
       final ManagedSkiaObject managedFilter = paint.imageFilter as ManagedSkiaObject;
       final Object skiaFilter = managedFilter?.skiaObject;
 
-      paint.imageFilter = CkImageFilter.blur(sigmaX: 5, sigmaY: 10);
+      paint.imageFilter = CkImageFilter.blur(sigmaX: 5, sigmaY: 10, tileMode: ui.TileMode.clamp);
       expect((paint.imageFilter as ManagedSkiaObject).skiaObject, same(skiaFilter));
     });
 

--- a/testing/dart/image_filter_test.dart
+++ b/testing/dart/image_filter_test.dart
@@ -72,8 +72,8 @@ void main() {
     return bytes.buffer.asUint32List();
   }
 
-  ImageFilter makeBlur(double sigmaX, double sigmaY) =>
-    ImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY);
+  ImageFilter makeBlur(double sigmaX, double sigmaY, [TileMode tileMode = TileMode.clamp]) =>
+    ImageFilter.blur(sigmaX: sigmaX, sigmaY: sigmaY, tileMode: tileMode);
 
   ImageFilter makeScale(double scX, double scY,
                         [double trX = 0.0, double trY = 0.0,
@@ -105,6 +105,7 @@ void main() {
   List<ImageFilter> makeList() {
     return <ImageFilter>[
       makeBlur(10.0, 10.0),
+      makeBlur(10.0, 10.0, TileMode.decal),
       makeBlur(10.0, 20.0),
       makeBlur(20.0, 20.0),
       makeScale(10.0, 10.0),
@@ -272,14 +273,14 @@ void main() {
 
   test('Composite ImageFilter toString', () {
     expect(
-      ImageFilter.compose(outer: makeBlur(20.0, 20.0), inner: makeBlur(10.0, 10.0)).toString(),
-      contains('blur(10.0, 10.0) -> blur(20.0, 20.0)'),
+      ImageFilter.compose(outer: makeBlur(20.0, 20.0, TileMode.decal), inner: makeBlur(10.0, 10.0)).toString(),
+      contains('blur(10.0, 10.0, clamp) -> blur(20.0, 20.0, decal)'),
     );
 
     // Produces a flat list of filters
     expect(
       ImageFilter.compose(
-        outer: ImageFilter.compose(outer: makeBlur(30.0, 30.0), inner: makeBlur(20.0, 20.0)),
+        outer: ImageFilter.compose(outer: makeBlur(30.0, 30.0, TileMode.mirror), inner: makeBlur(20.0, 20.0, TileMode.repeated)),
         inner: ImageFilter.compose(
           outer: const ColorFilter.mode(null, null),
           inner: makeScale(10.0, 10.0),
@@ -288,8 +289,8 @@ void main() {
       contains(
         'matrix([10.0, 0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, -0.0, -0.0, 0.0, 1.0], FilterQuality.low) -> '
         'ColorFilter.mode(null, null) -> '
-        'blur(20.0, 20.0) -> '
-        'blur(30.0, 30.0)'
+        'blur(20.0, 20.0, repeated) -> '
+        'blur(30.0, 30.0, mirror)'
       ),
     );
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/71871

Currently Skia supports a "decal" tile mode which defines "out of bounds" values of a gradient or image as transparency. Skia supports this in both Gradients and Blur filters, but we don't have the value in our TileMode enum. This PR adds that new value.

We also have no parameter on `ImageFilter.blur()` that allows the developer to specify a tile mode. The implementation currently defaults to `clamp` which is appropriate for opaque images, but it causes frustrating rendering anomalies for other uses (see https://github.com/flutter/flutter/issues/57180). This PR adds a new `TileMode` parameter to `ImageFilter.blur` to enable developers to control this aspect of the blur operation. The default value is `clamp` for backwards compatibility.

I've updated the tests to include the new values and implemented this on web, with a few caveats:

- Flutter web on HTML/CSS only supports a single radius and decal mode so the implementation of blur on this platform used to be "always wrong" and now it is "wrong unless a developer asks for decal mode and uses the same sigma for X and Y". Improvement, but this platform will likely never support all of the capabilities of the Flutter blur filter.

- Flutter with CanvasKit supports all of the new decal modes for Gradients, and it should support all of the modes for blur filters, but for some reason the values supplied in the `MakeBlur()` constructor don't seem to have any effect. Is there a missing link in getting that value to the underlying implementation that I missed?

Finally, I took the name `decal` from the Skia enum. Is that a good name for Flutter developers?