### PR TITLE
Freiling warmup memory

### DIFF
--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -154,13 +154,7 @@ CompositorContext::CompositorContext(
     std::shared_ptr<flutter::SceneUpdateContext> scene_update_context)
     : session_connection_(session_connection),
       surface_producer_(surface_producer),
-      scene_update_context_(scene_update_context) {
-  SkISize size = SkISize::Make(1024, 600);
-  skp_warmup_surface_ = surface_producer_.ProduceOffscreenSurface(size);
-  if (!skp_warmup_surface_) {
-    FML_LOG(ERROR) << "SkSurface::MakeRenderTarget returned null";
-  }
-}
+      scene_update_context_(scene_update_context) {}
 
 CompositorContext::~CompositorContext() = default;
 
@@ -177,11 +171,6 @@ CompositorContext::AcquireFrame(
       *this, gr_context, canvas, view_embedder, root_surface_transformation,
       instrumentation_enabled, surface_supports_readback, raster_thread_merger,
       session_connection_, surface_producer_, scene_update_context_);
-}
-
-void CompositorContext::WarmupSkp(const sk_sp<SkPicture> picture) {
-  skp_warmup_surface_->getCanvas()->drawPicture(picture);
-  surface_producer_.gr_context()->flush();
 }
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -27,13 +27,11 @@ class CompositorContext final : public flutter::CompositorContext {
       std::shared_ptr<flutter::SceneUpdateContext> scene_update_context);
 
   ~CompositorContext() override;
-  void WarmupSkp(sk_sp<SkPicture> picture);
 
  private:
   SessionConnection& session_connection_;
   VulkanSurfaceProducer& surface_producer_;
   std::shared_ptr<flutter::SceneUpdateContext> scene_update_context_;
-  sk_sp<SkSurface> skp_warmup_surface_;
 
   // |flutter::CompositorContext|
   std::unique_ptr<ScopedFrame> AcquireFrame(

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -256,6 +256,16 @@ Engine::Engine(Delegate& delegate,
       FML_DCHECK(surface_producer_);
       FML_DCHECK(legacy_external_view_embedder_);
 
+      if (product_config.enable_shader_warmup()) {
+        FML_DCHECK(surface_producer_);
+        WarmupSkps(shell.GetDartVM()
+                       ->GetConcurrentMessageLoop()
+                       ->GetTaskRunner()
+                       .get(),
+                   shell.GetTaskRunners().GetRasterTaskRunner().get(),
+                   surface_producer_.value());
+      }
+
       auto compositor_context =
           std::make_unique<flutter_runner::CompositorContext>(
               session_connection_.value(), surface_producer_.value(),

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -704,7 +704,7 @@ void Engine::WarmupSkps(fml::BasicTaskRunner* concurrent_task_runner,
           [skp_warmup_surface, picture, &surface_producer] {
             TRACE_DURATION("flutter", "WarmupSkp");
             skp_warmup_surface->getCanvas()->drawPicture(picture);
-            surface_producer.gr_context()->flush();
+            surface_producer.gr_context()->flushAndSubmit();
           });
       i++;
     }

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -271,9 +271,9 @@ void VulkanSurfaceProducer::SubmitSurface(
   surface_pool_->SubmitSurface(std::move(surface));
 }
 
-sk_sp<SkSurface> VulkanSurfaceProducer::ProduceOffscreenSurface(
-    const SkISize& size) {
-  return surface_pool_->CreateSurface(size)->GetSkiaSurface();
+std::unique_ptr<SurfaceProducerSurface>
+VulkanSurfaceProducer::ProduceOffscreenSurface(const SkISize& size) {
+  return surface_pool_->CreateSurface(size);
 }
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
@@ -35,7 +35,8 @@ class VulkanSurfaceProducer final : public SurfaceProducer,
   std::unique_ptr<SurfaceProducerSurface> ProduceSurface(
       const SkISize& size) override;
 
-  sk_sp<SkSurface> ProduceOffscreenSurface(const SkISize& size);
+  std::unique_ptr<SurfaceProducerSurface> ProduceOffscreenSurface(
+      const SkISize& size);
 
   // |SurfaceProducer|
   void SubmitSurface(std::unique_ptr<SurfaceProducerSurface> surface) override;


### PR DESCRIPTION
## Description

This PR contains fixes for a number of issues that came up around shader warmup
-  Correctly handling the Embedder API ifdefs
-  Decouple Shader warmup from embedder API so they can be enabled independently
- Reduce in flight memory usage to avoid OOM'ing the device
- Fix a resource lifetime issue uncovered by the fix for the OOM

## Tests

These issues are not within the scope of unit tests and need to be covered by an E2E integration test that runs on fuchsia infrastructure for the following reasons:

- Embedder API not present in unit test harness
- Memory pressure during testing is lower due to using beefier hardware and not running as much stuff
- resource lifetime issue is covered by existing unittests now that the OOM fix is in