### PR TITLE
fix crash in FontCollection::init() when FontFamily is empty

### DIFF
--- a/third_party/txt/src/minikin/FontCollection.h
+++ b/third_party/txt/src/minikin/FontCollection.h
@@ -29,9 +29,7 @@ namespace minikin {
 
 class FontCollection {
  public:
-  explicit FontCollection(
-      const std::vector<std::shared_ptr<FontFamily>>& typefaces);
-  explicit FontCollection(std::shared_ptr<FontFamily>&& typeface);
+  explicit FontCollection();
 
   // libtxt extension: an interface for looking up fallback fonts for characters
   // that do not match this collection's font families.
@@ -78,6 +76,9 @@ class FontCollection {
     mFallbackFontProvider = std::move(ffp);
   }
 
+  // Initialize the FontCollection.
+  bool init(const std::vector<std::shared_ptr<FontFamily>>& typefaces);
+
  private:
   static const int kLogCharsPerPage = 8;
   static const int kPageMask = (1 << kLogCharsPerPage) - 1;
@@ -92,9 +93,6 @@ class FontCollection {
     uint16_t start;
     uint16_t end;
   };
-
-  // Initialize the FontCollection.
-  void init(const std::vector<std::shared_ptr<FontFamily>>& typefaces);
 
   const std::shared_ptr<FontFamily>& getFamilyForChar(uint32_t ch,
                                                       uint32_t vs,

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -206,8 +206,11 @@ FontCollection::GetMinikinFontCollectionForFamilies(
     }
   }
   // Create the minikin font collection.
-  auto font_collection =
-      std::make_shared<minikin::FontCollection>(std::move(minikin_families));
+  auto font_collection = std::make_shared<minikin::FontCollection>();
+  if (!font_collection || !font_collection->init(std::move(minikin_families))) {
+    font_collections_cache_[family_key] = nullptr;
+    return nullptr;
+  }
   if (enable_font_fallback_) {
     font_collection->set_fallback_font_provider(
         std::make_unique<TxtFallbackFontProvider>(shared_from_this()));

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -807,6 +807,14 @@ void ParagraphTxt::Layout(double width) {
 
       std::shared_ptr<minikin::FontCollection> minikin_font_collection =
           GetMinikinFontCollectionForStyle(run.style());
+      if (minikin_font_collection == nullptr) {
+        FML_LOG(INFO) << "Could not find font collection for families \""
+                      << (run.style().font_families.empty()
+                              ? ""
+                              : run.style().font_families[0])
+                      << "\".";
+        return;
+      }
 
       // Lay out this run.
       uint16_t* text_ptr = text_.data();


### PR DESCRIPTION
Fixes：[flutter#72062] (https://github.com/flutter/flutter/issues/72062)
