### PR TITLE
Load iOS dart bundle by URL fallback

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -44,6 +44,11 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
     bundle = [NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]];
   }
   if (bundle == nil) {
+    // The bundle isn't loaded and can't be found by bundle ID. Find it by path.
+    bundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
+                                         URLByAppendingPathComponent:@"App.framework"]];
+  }
+  if (bundle == nil) {
     bundle = mainBundle;
   }
 
@@ -239,11 +244,16 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
     bundle = [NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]];
   }
   if (bundle == nil) {
-    bundle = [NSBundle mainBundle];
+    // The bundle isn't loaded and can't be found by bundle ID. Find it by path.
+    bundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
+                                         URLByAppendingPathComponent:@"App.framework"]];
   }
   NSString* flutterAssetsName = [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
-  if (flutterAssetsName == nil) {
+  if (bundle == nil) {
+    bundle = [NSBundle mainBundle];
     flutterAssetsName = @"Frameworks/App.framework/flutter_assets";
+  } else if (flutterAssetsName == nil) {
+    flutterAssetsName = @"flutter_assets";
   }
   return flutterAssetsName;
 }


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/51453 stopped explicitly linking the App.framework into the iOS app, which means `[NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]]` returns null because the bundle isn't loaded (no longer `LC_LOAD_DYLIB`)

This is awkwardly worked around by loading the asset path `Frameworks/App.framework/flutter_assets` from the main bundle https://github.com/flutter/engine/pull/7518.
https://github.com/flutter/engine/blob/d6627c6a7d8e3407d85249270122556c22053736/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm#L244-L247

Instead, fallback to detecting the dart bundle by path to `Frameworks/App.framework`.

## Related Issues

iOS version of https://github.com/flutter/engine/pull/22979.

## Tests

I'm not sure how to explicitly test this, but any devicelab run tests will blow up if the assets aren't found.