### PR TITLE
[web] Fix regression in paragraph foreground style

### DIFF
--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -1328,7 +1328,7 @@ class DomParagraphBuilder implements ui.ParagraphBuilder {
   /// paragraph. Plain text is more efficient to lay out and measure than rich
   /// text.
   EngineParagraph? _tryBuildPlainText() {
-    ui.Color color = _defaultTextColor;
+    ui.Color? color;
     ui.TextDecoration? decoration;
     ui.Color? decorationColor;
     ui.TextDecorationStyle? decorationStyle;
@@ -1416,6 +1416,10 @@ class DomParagraphBuilder implements ui.ParagraphBuilder {
       i++;
     }
 
+    if (color == null && foreground == null) {
+      color = _defaultTextColor;
+    }
+
     final EngineTextStyle cumulativeStyle = EngineTextStyle(
       color: color,
       decoration: decoration,
@@ -1443,7 +1447,7 @@ class DomParagraphBuilder implements ui.ParagraphBuilder {
       paint = foreground;
     } else {
       paint = ui.Paint();
-      paint.color = color;
+      paint.color = color!;
     }
 
     if (i >= _ops.length) {

--- a/lib/web_ui/test/paragraph_builder_test.dart
+++ b/lib/web_ui/test/paragraph_builder_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.12
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -28,10 +28,20 @@ void testMain() {
     expect(paragraph.height, isNonZero);
   });
 
-  test('PushStyle should not segfault after build()', () {
+  test('pushStyle should not segfault after build()', () {
     final ParagraphBuilder paragraphBuilder =
         ParagraphBuilder(ParagraphStyle());
     paragraphBuilder.build();
     paragraphBuilder.pushStyle(TextStyle());
+  });
+
+  test('the presence of foreground style should not throw', () {
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
+    builder.pushStyle(TextStyle(
+      foreground: Paint()..color = const Color(0xFFABCDEF),
+    ));
+    builder.addText('hi');
+
+    expect(() => builder.build(), returnsNormally);
   });
 }


### PR DESCRIPTION
## Description

Setting both `color` and `foreground` styles isn't allowed. A regression caused `color` to always be set to a default value, which made an assertion throw when it shouldn't.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/72076