### PR TITLE
add ffi_struct_patch.dart to libraries.yaml

### DIFF
--- a/shell/platform/fuchsia/dart_runner/kernel/libraries.json
+++ b/shell/platform/fuchsia/dart_runner/kernel/libraries.json
@@ -82,9 +82,10 @@
       "ffi": {
         "uri": "../../../../../../third_party/dart/sdk/lib/ffi/ffi.dart",
         "patches": [
+          "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart",
-          "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+          "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"
         ]
       },
       "wasm": {

--- a/shell/platform/fuchsia/dart_runner/kernel/libraries.yaml
+++ b/shell/platform/fuchsia/dart_runner/kernel/libraries.yaml
@@ -87,9 +87,10 @@ dart_runner:
     ffi:
       uri: "../../../../../../third_party/dart/sdk/lib/ffi/ffi.dart"
       patches:
+        - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart"
-        - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+        - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"
 
     wasm:
       uri: "../../../../../../third_party/dart/sdk/lib/wasm/wasm.dart"

--- a/shell/platform/fuchsia/flutter/kernel/libraries.json
+++ b/shell/platform/fuchsia/flutter/kernel/libraries.json
@@ -82,9 +82,10 @@
       "ffi": {
         "uri": "../../../../../../third_party/dart/sdk/lib/ffi/ffi.dart",
         "patches": [
+          "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart",
-          "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+          "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"
         ]
       },
       "wasm": {

--- a/shell/platform/fuchsia/flutter/kernel/libraries.yaml
+++ b/shell/platform/fuchsia/flutter/kernel/libraries.yaml
@@ -87,9 +87,10 @@ flutter_runner:
     ffi:
       uri: "../../../../../../third_party/dart/sdk/lib/ffi/ffi.dart"
       patches:
+        - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart"
-        - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+        - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"
 
     wasm:
       uri: "../../../../../../third_party/dart/sdk/lib/wasm/wasm.dart"


### PR DESCRIPTION
## Description
Adding the missing patch file for ffi. This matches what is in https://github.com/dart-lang/sdk/blob/master/sdk/lib/libraries.yaml.

