### PR TITLE
Started shutting down the sampler when it gets deleted

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1455,6 +1455,7 @@ FILE: ../../../flutter/shell/platform/windows/window_binding_handler_delegate.h
 FILE: ../../../flutter/shell/platform/windows/window_state.h
 FILE: ../../../flutter/shell/profiling/sampling_profiler.cc
 FILE: ../../../flutter/shell/profiling/sampling_profiler.h
+FILE: ../../../flutter/shell/profiling/sampling_profiler_unittest.h
 FILE: ../../../flutter/shell/version/version.cc
 FILE: ../../../flutter/shell/version/version.h
 FILE: ../../../flutter/sky/packages/flutter_services/lib/empty.dart

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1455,7 +1455,7 @@ FILE: ../../../flutter/shell/platform/windows/window_binding_handler_delegate.h
 FILE: ../../../flutter/shell/platform/windows/window_state.h
 FILE: ../../../flutter/shell/profiling/sampling_profiler.cc
 FILE: ../../../flutter/shell/profiling/sampling_profiler.h
-FILE: ../../../flutter/shell/profiling/sampling_profiler_unittest.h
+FILE: ../../../flutter/shell/profiling/sampling_profiler_unittest.cc
 FILE: ../../../flutter/shell/version/version.cc
 FILE: ../../../flutter/shell/version/version.h
 FILE: ../../../flutter/sky/packages/flutter_services/lib/empty.dart

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -254,6 +254,7 @@ if (enable_unittests) {
       ":shell_unittests_fixtures",
       "//flutter/assets",
       "//flutter/common/graphics",
+      "//flutter/shell/profiling:profiling_unittests",
       "//flutter/shell/version",
       "//third_party/googletest:gmock",
     ]

--- a/shell/profiling/BUILD.gn
+++ b/shell/profiling/BUILD.gn
@@ -17,3 +17,9 @@ source_set("profiling") {
 
   deps = _profiler_deps
 }
+
+source_set("profiling_unittests") {
+  testonly = true
+  sources = [ "sampling_profiler_unittest.cc" ]
+  deps = [ "//flutter/testing" ]
+}

--- a/shell/profiling/BUILD.gn
+++ b/shell/profiling/BUILD.gn
@@ -21,5 +21,8 @@ source_set("profiling") {
 source_set("profiling_unittests") {
   testonly = true
   sources = [ "sampling_profiler_unittest.cc" ]
-  deps = [ "//flutter/testing" ]
+  deps = [
+    ":profiling",
+    "//flutter/testing",
+  ]
 }

--- a/shell/profiling/sampling_profiler.h
+++ b/shell/profiling/sampling_profiler.h
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 
+#include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/fml/trace_event.h"
 
@@ -97,17 +98,23 @@ class SamplingProfiler {
                    Sampler sampler,
                    int num_samples_per_sec);
 
+  ~SamplingProfiler();
+
   /**
    * @brief Starts the SamplingProfiler by triggering `SampleRepeatedly`.
    *
    */
-  void Start() const;
+  void Start();
+
+  void Stop();
 
  private:
   const std::string thread_label_;
   const fml::RefPtr<fml::TaskRunner> profiler_task_runner_;
   const Sampler sampler_;
   const uint32_t num_samples_per_sec_;
+  bool is_running_ = false;
+  std::atomic<fml::AutoResetWaitableEvent*> shutdown_latch_ = nullptr;
 
   void SampleRepeatedly(fml::TimeDelta task_delay) const;
 

--- a/shell/profiling/sampling_profiler_unittest.cc
+++ b/shell/profiling/sampling_profiler_unittest.cc
@@ -57,7 +57,7 @@ TEST(SamplingProfilerTest, DeleteAfterStart) {
     profiler.Start();
   }
   int invoke_count_at_delete = invoke_count.load();
-  usleep(2 * 1000);  // nyquist
+  std::this_thread::sleep_for(std::chrono::milliseconds(2)); // nyquist
   ASSERT_EQ(invoke_count_at_delete, invoke_count.load());
 }
 

--- a/shell/profiling/sampling_profiler_unittest.cc
+++ b/shell/profiling/sampling_profiler_unittest.cc
@@ -57,7 +57,7 @@ TEST(SamplingProfilerTest, DeleteAfterStart) {
     profiler.Start();
   }
   int invoke_count_at_delete = invoke_count.load();
-  std::this_thread::sleep_for(std::chrono::milliseconds(2)); // nyquist
+  std::this_thread::sleep_for(std::chrono::milliseconds(2));  // nyquist
   ASSERT_EQ(invoke_count_at_delete, invoke_count.load());
 }
 

--- a/shell/profiling/sampling_profiler_unittest.cc
+++ b/shell/profiling/sampling_profiler_unittest.cc
@@ -1,0 +1,64 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/profiling/sampling_profiler.h"
+#include "flutter/fml/message_loop_impl.h"
+#include "flutter/fml/thread.h"
+#include "flutter/testing/testing.h"
+#include "gmock/gmock.h"
+
+using testing::_;
+using testing::Invoke;
+
+namespace fml {
+namespace {
+class MockTaskRunner : public fml::TaskRunner {
+ public:
+  inline static RefPtr<MockTaskRunner> Create() {
+    return AdoptRef(new MockTaskRunner());
+  }
+  MOCK_METHOD1(PostTask, void(const fml::closure& task));
+  MOCK_METHOD2(PostTaskForTime,
+               void(const fml::closure& task, fml::TimePoint target_time));
+  MOCK_METHOD2(PostDelayedTask,
+               void(const fml::closure& task, fml::TimeDelta delay));
+  MOCK_METHOD0(RunsTasksOnCurrentThread, bool());
+  MOCK_METHOD0(GetTaskQueueId, TaskQueueId());
+
+ private:
+  MockTaskRunner() : TaskRunner(fml::RefPtr<MessageLoopImpl>()) {}
+};
+}  // namespace
+}  // namespace fml
+
+namespace flutter {
+
+TEST(SamplingProfilerTest, DeleteAfterStart) {
+  auto thread =
+      std::make_unique<fml::Thread>(flutter::testing::GetCurrentTestName());
+  auto task_runner = fml::MockTaskRunner::Create();
+  std::atomic<int> invoke_count = 0;
+
+  // Ignore calls to PostTask since that would require mocking out calls to
+  // Dart.
+  EXPECT_CALL(*task_runner, PostDelayedTask(_, _))
+      .WillRepeatedly(
+          Invoke([&](const fml::closure& task, fml::TimeDelta delay) {
+            invoke_count.fetch_add(1);
+            thread->GetTaskRunner()->PostTask(task);
+          }));
+
+  {
+    auto profiler = SamplingProfiler(
+        "profiler",
+        /*profiler_task_runner=*/task_runner, [] { return ProfileSample(); },
+        /*num_samples_per_sec=*/1000);
+    profiler.Start();
+  }
+  int invoke_count_at_delete = invoke_count.load();
+  usleep(2 * 1000);  // nyquist
+  ASSERT_EQ(invoke_count_at_delete, invoke_count.load());
+}
+
+}  // namespace flutter


### PR DESCRIPTION
## Description

Previously we'd just let it continue running after it's been deleted.

## Related Issues

https://github.com/flutter/flutter/issues/72107

## Tests

I added the following tests:

Added test that makes sure that the sampler isn't issuing any tasks on the task runner after it has been deleted.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
