### PR TITLE
Stopped mocking the a flutter engine to make sure we delete the FlutterViewController.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -101,15 +101,22 @@ typedef enum UIAccessibilityContrast : NSInteger {
 }
 
 - (void)testBinaryMessenger {
-  id engine = OCMClassMock([FlutterEngine class]);
-  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
-                                                                    nibName:nil
-                                                                     bundle:nil];
-  XCTAssertNotNil(vc);
-  id messenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
-  OCMStub([engine binaryMessenger]).andReturn(messenger);
-  XCTAssertEqual(vc.binaryMessenger, messenger);
-  OCMVerify([engine binaryMessenger]);
+  __weak FlutterViewController* weakVC;
+  @autoreleasepool {
+    id engine = OCMClassMock([FlutterEngine class]);
+    FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
+                                                                      nibName:nil
+                                                                       bundle:nil];
+    XCTAssertNotNil(vc);
+    weakVC = vc;
+    id messenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+    OCMStub([engine binaryMessenger]).andReturn(messenger);
+    XCTAssertEqual(vc.binaryMessenger, messenger);
+    OCMVerify([engine binaryMessenger]);
+    // This had to be added to make sure the view controller is deleted.
+    [engine stopMocking];
+  }
+  XCTAssertNil(weakVC);
 }
 
 #pragma mark - Platform Brightness


### PR DESCRIPTION
## Description

Somehow the mock engine is stopping the FlutterViewController from being dealloc'd.   Stop mocking clears it out.  I'm not sure if it's a sign of a deeper problem.

This leaked view controller would get notifications from other tests and crash.

## Related Issues

https://github.com/flutter/flutter/issues/72107

## Tests

I added the following tests:

It is a test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
