### PR TITLE
fix crash in FontCollection::init() when FontFamily is empty

### DIFF
--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -53,16 +53,15 @@ std::string GetFontLocale(uint32_t langListId) {
 
 std::shared_ptr<minikin::FontCollection> FontCollection::Create(
     const std::vector<std::shared_ptr<FontFamily>>& typefaces) {
-  std::shared_ptr<minikin::FontCollection> font_collection(new minikin::FontCollection());
+  std::shared_ptr<minikin::FontCollection> font_collection(
+      new minikin::FontCollection());
   if (!font_collection || !font_collection->init(typefaces)) {
     return nullptr;
   }
   return font_collection;
 }
 
-FontCollection::FontCollection()
-    : mMaxChar(0) {
-}
+FontCollection::FontCollection() : mMaxChar(0) {}
 
 bool FontCollection::init(
     const std::vector<std::shared_ptr<FontFamily>>& typefaces) {

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -91,13 +91,15 @@ bool FontCollection::init(
     mSupportedAxes.insert(supportedAxes.begin(), supportedAxes.end());
   }
   nTypefaces = mFamilies.size();
-  if (nTypefaces == 0 || nTypefaces > 254) {
-    if (nTypefaces == 0)
-      ALOGE("Font collection must have at least one valid typeface.");
-    else
-      ALOGE("Font collection may only have up to 254 font families.");
+  if (nTypefaces == 0) {
+    ALOGE("Font collection must have at least one valid typeface.");
     return false;
   }
+  if (nTypefaces > 254) {
+    ALOGE("Font collection may only have up to 254 font families.");
+    return false;
+  }
+
   size_t nPages = (mMaxChar + kPageMask) >> kLogCharsPerPage;
   // TODO: Use variation selector map for mRanges construction.
   // A font can have a glyph for a base code point and variation selector pair
@@ -572,11 +574,7 @@ std::shared_ptr<FontCollection> FontCollection::createCollectionWithVariation(
     }
   }
 
-  auto font_collection = minikin::FontCollection::Create(std::move(families));
-  if (!font_collection) {
-    return nullptr;
-  }
-  return font_collection;
+  return minikin::FontCollection::Create(std::move(families));
 }
 
 uint32_t FontCollection::getId() const {

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -51,12 +51,21 @@ std::string GetFontLocale(uint32_t langListId) {
   return langs.size() ? langs[0].getString() : "";
 }
 
+std::shared_ptr<minikin::FontCollection> FontCollection::Create(
+    const std::vector<std::shared_ptr<FontFamily>>& typefaces) {
+  std::shared_ptr<minikin::FontCollection> font_collection(new minikin::FontCollection());
+  if (!font_collection || !font_collection->init(typefaces)) {
+    return nullptr;
+  }
+  return font_collection;
+}
+
 FontCollection::FontCollection()
     : mMaxChar(0) {
 }
 
 bool FontCollection::init(
-    const vector<std::shared_ptr<FontFamily>>& typefaces) {
+    const std::vector<std::shared_ptr<FontFamily>>& typefaces) {
   std::scoped_lock _l(gMinikinLock);
   mId = sNextId++;
   vector<uint32_t> lastChar;
@@ -563,9 +572,8 @@ std::shared_ptr<FontCollection> FontCollection::createCollectionWithVariation(
     }
   }
 
-  auto font_collection = std::make_shared<FontCollection>();
-  if (!font_collection || !font_collection->init(std::move(families))) {
-    if (font_collection) font_collection.reset();
+  auto font_collection = minikin::FontCollection::Create(std::move(families));
+  if (!font_collection) {
     return nullptr;
   }
   return font_collection;

--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -98,7 +98,6 @@ bool FontCollection::init(
     ALOGE("Font collection may only have up to 254 font families.");
     return false;
   }
-
   size_t nPages = (mMaxChar + kPageMask) >> kLogCharsPerPage;
   // TODO: Use variation selector map for mRanges construction.
   // A font can have a glyph for a base code point and variation selector pair
@@ -573,7 +572,7 @@ std::shared_ptr<FontCollection> FontCollection::createCollectionWithVariation(
     }
   }
 
-  return minikin::FontCollection::Create(std::move(families));
+  return FontCollection::Create(std::move(families));
 }
 
 uint32_t FontCollection::getId() const {

--- a/third_party/txt/src/minikin/FontCollection.h
+++ b/third_party/txt/src/minikin/FontCollection.h
@@ -28,8 +28,12 @@
 namespace minikin {
 
 class FontCollection {
- public:
+ private:
   explicit FontCollection();
+
+ public:
+  static std::shared_ptr<minikin::FontCollection> Create(
+    const std::vector<std::shared_ptr<FontFamily>>& typefaces);
 
   // libtxt extension: an interface for looking up fallback fonts for characters
   // that do not match this collection's font families.
@@ -76,9 +80,6 @@ class FontCollection {
     mFallbackFontProvider = std::move(ffp);
   }
 
-  // Initialize the FontCollection.
-  bool init(const std::vector<std::shared_ptr<FontFamily>>& typefaces);
-
  private:
   static const int kLogCharsPerPage = 8;
   static const int kPageMask = (1 << kLogCharsPerPage) - 1;
@@ -93,6 +94,9 @@ class FontCollection {
     uint16_t start;
     uint16_t end;
   };
+
+  // Initialize the FontCollection.
+  bool init(const std::vector<std::shared_ptr<FontFamily>>& typefaces);
 
   const std::shared_ptr<FontFamily>& getFamilyForChar(uint32_t ch,
                                                       uint32_t vs,

--- a/third_party/txt/src/minikin/FontCollection.h
+++ b/third_party/txt/src/minikin/FontCollection.h
@@ -33,7 +33,7 @@ class FontCollection {
 
  public:
   static std::shared_ptr<minikin::FontCollection> Create(
-    const std::vector<std::shared_ptr<FontFamily>>& typefaces);
+      const std::vector<std::shared_ptr<FontFamily>>& typefaces);
 
   // libtxt extension: an interface for looking up fallback fonts for characters
   // that do not match this collection's font families.

--- a/third_party/txt/src/minikin/FontCollection.h
+++ b/third_party/txt/src/minikin/FontCollection.h
@@ -29,9 +29,7 @@ namespace minikin {
 
 class FontCollection {
  public:
-  explicit FontCollection(
-      const std::vector<std::shared_ptr<FontFamily>>& typefaces);
-  explicit FontCollection(std::shared_ptr<FontFamily>&& typeface);
+  explicit FontCollection();
 
   // libtxt extension: an interface for looking up fallback fonts for characters
   // that do not match this collection's font families.
@@ -78,6 +76,9 @@ class FontCollection {
     mFallbackFontProvider = std::move(ffp);
   }
 
+  // Initialize the FontCollection.
+  bool init(const std::vector<std::shared_ptr<FontFamily>>& typefaces);
+
  private:
   static const int kLogCharsPerPage = 8;
   static const int kPageMask = (1 << kLogCharsPerPage) - 1;
@@ -92,9 +93,6 @@ class FontCollection {
     uint16_t start;
     uint16_t end;
   };
-
-  // Initialize the FontCollection.
-  void init(const std::vector<std::shared_ptr<FontFamily>>& typefaces);
 
   const std::shared_ptr<FontFamily>& getFamilyForChar(uint32_t ch,
                                                       uint32_t vs,

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -206,8 +206,8 @@ FontCollection::GetMinikinFontCollectionForFamilies(
     }
   }
   // Create the minikin font collection.
-  auto font_collection = std::make_shared<minikin::FontCollection>();
-  if (!font_collection || !font_collection->init(std::move(minikin_families))) {
+  auto font_collection = minikin::FontCollection::Create(std::move(minikin_families));
+  if (!font_collection) {
     font_collections_cache_[family_key] = nullptr;
     return nullptr;
   }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -206,7 +206,8 @@ FontCollection::GetMinikinFontCollectionForFamilies(
     }
   }
   // Create the minikin font collection.
-  auto font_collection = minikin::FontCollection::Create(std::move(minikin_families));
+  auto font_collection =
+      minikin::FontCollection::Create(std::move(minikin_families));
   if (!font_collection) {
     font_collections_cache_[family_key] = nullptr;
     return nullptr;

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -206,8 +206,11 @@ FontCollection::GetMinikinFontCollectionForFamilies(
     }
   }
   // Create the minikin font collection.
-  auto font_collection =
-      std::make_shared<minikin::FontCollection>(std::move(minikin_families));
+  auto font_collection = std::make_shared<minikin::FontCollection>();
+  if (!font_collection || !font_collection->init(std::move(minikin_families))) {
+    font_collections_cache_[family_key] = nullptr;
+    return nullptr;
+  }
   if (enable_font_fallback_) {
     font_collection->set_fallback_font_provider(
         std::make_unique<TxtFallbackFontProvider>(shared_from_this()));

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -808,11 +808,6 @@ void ParagraphTxt::Layout(double width) {
       std::shared_ptr<minikin::FontCollection> minikin_font_collection =
           GetMinikinFontCollectionForStyle(run.style());
       if (minikin_font_collection == nullptr) {
-        FML_LOG(INFO) << "Could not find font collection for families \""
-                      << (run.style().font_families.empty()
-                              ? ""
-                              : run.style().font_families[0])
-                      << "\".";
         return;
       }
 

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -807,6 +807,14 @@ void ParagraphTxt::Layout(double width) {
 
       std::shared_ptr<minikin::FontCollection> minikin_font_collection =
           GetMinikinFontCollectionForStyle(run.style());
+      if (minikin_font_collection == nullptr) {
+        FML_LOG(INFO) << "Could not find font collection for families \""
+                      << (run.style().font_families.empty()
+                              ? ""
+                              : run.style().font_families[0])
+                      << "\".";
+        return;
+      }
 
       // Lay out this run.
       uint16_t* text_ptr = text_.data();

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -807,7 +807,7 @@ void ParagraphTxt::Layout(double width) {
 
       std::shared_ptr<minikin::FontCollection> minikin_font_collection =
           GetMinikinFontCollectionForStyle(run.style());
-      if (minikin_font_collection == nullptr) {
+      if (!minikin_font_collection) {
         return;
       }
 


### PR DESCRIPTION
Fixes：[flutter#72062] (flutter/flutter#72062)