### PR TITLE
fuchsia: Fix incorrect scale

### DIFF
--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -125,7 +125,7 @@ void SceneUpdateContext::Reset(const SkISize& frame_size,
 
   // Adjust scene scaling to match the device pixel ratio.
   const float inv_dpr = 1.0f / device_pixel_ratio;
-  metrics_node_.SetScale(inv_dpr, inv_dpr, 1.0f);
+  layer_tree_node_.SetScale(inv_dpr, inv_dpr, 1.0f);
 
   // Set up the input interceptor at the top of the scene, if applicable.
   if (input_interceptor_node_.has_value()) {


### PR DESCRIPTION
## Description

https://github.com/flutter/engine/pull/22687 unfortunately introduced a regression where the device pixel ratio was effectively ignored on Fuchsia because we applied it to the wrong Scenic node.  This PR rectifies that.

## Related Issues

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=61466

## Tests

I added the following tests:

Added an integration test case that verifies the device pixel ratio stays in sync with Scenic metrics events,
