### PR TITLE
Revert "Load iOS dart bundle by URL fallback"

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -44,11 +44,6 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
     bundle = [NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]];
   }
   if (bundle == nil) {
-    // The bundle isn't loaded and can't be found by bundle ID. Find it by path.
-    bundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
-                                         URLByAppendingPathComponent:@"App.framework"]];
-  }
-  if (bundle == nil) {
     bundle = mainBundle;
   }
 
@@ -244,16 +239,11 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
     bundle = [NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]];
   }
   if (bundle == nil) {
-    // The bundle isn't loaded and can't be found by bundle ID. Find it by path.
-    bundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
-                                         URLByAppendingPathComponent:@"App.framework"]];
+    bundle = [NSBundle mainBundle];
   }
   NSString* flutterAssetsName = [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
-  if (bundle == nil) {
-    bundle = [NSBundle mainBundle];
+  if (flutterAssetsName == nil) {
     flutterAssetsName = @"Frameworks/App.framework/flutter_assets";
-  } else if (flutterAssetsName == nil) {
-    flutterAssetsName = @"flutter_assets";
   }
   return flutterAssetsName;
 }


### PR DESCRIPTION
Reverts flutter/engine#22997

This is causing 
`-[FlutterDartProject flutterAssetsName:]` to return `flutter_assets` instead of `Frameworks/App.framework/flutter_assets`, which is then passed into `[[NSBundle mainBundle] pathForResource:asset ofType:nil];` which returns `nil`.

https://github.com/flutter/plugins/blob/0b158bd73e9924a4c57c9b3cea0e450ba5533ce0/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m#L63-L66
crashes:
```
2020-12-14 10:28:34.735911-0800 Flutter Gallery[5463:1857812] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSURL initFileURLWithPath:]: nil string parameter'
```