### PR TITLE
[canvaskit] cache and reuse platform view overlays

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -30,14 +30,16 @@ class HtmlViewEmbedder {
   /// The root view in the stack of mutator elements for the view id.
   final Map<int?, html.Element?> _rootViews = <int?, html.Element?>{};
 
-  /// The overlay for the view id.
-  final Map<int, Overlay> _overlays = <int, Overlay>{};
+  /// Surfaces used to draw on top of platform views, keyed by platform view ID.
+  ///
+  /// These surfaces are cached in the [OverlayCache] and reused.
+  final Map<int, Surface> _overlays = <int, Surface>{};
 
   /// The views that need to be recomposited into the scene on the next frame.
   final Set<int> _viewsToRecomposite = <int>{};
 
   /// The views that need to be disposed of on the next frame.
-  final Set<int?> _viewsToDispose = <int?>{};
+  final Set<int> _viewsToDispose = <int>{};
 
   /// The list of view ids that should be composited, in order.
   List<int> _compositionOrder = <int>[];
@@ -115,14 +117,15 @@ class HtmlViewEmbedder {
 
   void _dispose(
       MethodCall methodCall, ui.PlatformMessageResponseCallback callback) {
-    int? viewId = methodCall.arguments;
+    final int? viewId = methodCall.arguments;
     const MethodCodec codec = StandardMethodCodec();
-    if (!_views.containsKey(viewId)) {
+    if (viewId == null || !_views.containsKey(viewId)) {
       callback(codec.encodeErrorEnvelope(
         code: 'unknown_view',
         message: 'trying to dispose an unknown view',
         details: 'view id: $viewId',
       ));
+      return;
     }
     _viewsToDispose.add(viewId);
     callback(codec.encodeSuccessEnvelope(null));
@@ -339,9 +342,9 @@ class HtmlViewEmbedder {
 
     for (int i = 0; i < _compositionOrder.length; i++) {
       int viewId = _compositionOrder[i];
-      ensureOverlayInitialized(viewId);
+      _ensureOverlayInitialized(viewId);
       final SurfaceFrame frame =
-          _overlays[viewId]!.surface.acquireFrame(_frameSize);
+          _overlays[viewId]!.acquireFrame(_frameSize);
       final CkCanvas canvas = frame.skiaCanvas;
       canvas.drawPicture(
         _pictureRecorders[viewId]!.endRecording(),
@@ -353,12 +356,22 @@ class HtmlViewEmbedder {
       _compositionOrder.clear();
       return;
     }
+
+    final Set<int> unusedViews = Set<int>.from(_activeCompositionOrder);
     _activeCompositionOrder.clear();
 
     for (int i = 0; i < _compositionOrder.length; i++) {
       int viewId = _compositionOrder[i];
+
+      assert(
+        _views.containsKey(viewId),
+        'Cannot render platform view $viewId. '
+        'It has not been created, or it has been deleted.',
+      );
+
+      unusedViews.remove(viewId);
       html.Element platformViewRoot = _rootViews[viewId]!;
-      html.Element overlay = _overlays[viewId]!.surface.htmlElement!;
+      html.Element overlay = _overlays[viewId]!.htmlElement;
       platformViewRoot.remove();
       skiaSceneHost!.append(platformViewRoot);
       overlay.remove();
@@ -366,6 +379,10 @@ class HtmlViewEmbedder {
       _activeCompositionOrder.add(viewId);
     }
     _compositionOrder.clear();
+
+    for (final int unusedViewId in unusedViews) {
+      _releaseOverlay(unusedViewId);
+    }
   }
 
   void disposeViews() {
@@ -373,18 +390,12 @@ class HtmlViewEmbedder {
       return;
     }
 
-    for (int? viewId in _viewsToDispose) {
+    for (final int viewId in _viewsToDispose) {
       final html.Element rootView = _rootViews[viewId]!;
       rootView.remove();
       _views.remove(viewId);
       _rootViews.remove(viewId);
-      if (_overlays[viewId] != null) {
-        final Overlay overlay = _overlays[viewId]!;
-        overlay.surface.htmlElement?.remove();
-        overlay.surface.htmlElement = null;
-        overlay.skSurface?.dispose();
-      }
-      _overlays.remove(viewId);
+      _releaseOverlay(viewId);
       _currentCompositionParams.remove(viewId);
       _clipCount.remove(viewId);
       _viewsToRecomposite.remove(viewId);
@@ -392,14 +403,80 @@ class HtmlViewEmbedder {
     _viewsToDispose.clear();
   }
 
-  void ensureOverlayInitialized(int viewId) {
-    Overlay? overlay = _overlays[viewId];
+  void _releaseOverlay(int viewId) {
+    if (_overlays[viewId] != null) {
+      OverlayCache.instance.releaseOverlay(_overlays[viewId]!);
+      _overlays.remove(viewId);
+    }
+  }
+
+  void _ensureOverlayInitialized(int viewId) {
+    // If there's an active overlay for the view ID, continue using it.
+    Surface? overlay = _overlays[viewId];
     if (overlay != null) {
       return;
     }
-    Surface surface = Surface(this);
-    CkSurface? skSurface = surface.acquireRenderSurface(_frameSize);
-    _overlays[viewId] = Overlay(surface, skSurface);
+
+    // Try reusing a cached overlay created for another platform view.
+    overlay = OverlayCache.instance.reserveOverlay();
+
+    // If nothing to reuse, create a new overlay.
+    if (overlay == null) {
+      overlay = Surface(this);
+    }
+
+    _overlays[viewId] = overlay;
+  }
+}
+
+/// Caches surfaces used to overlay platform views.
+class OverlayCache {
+  static const int kDefaultCacheSize = 5;
+
+  /// The cache singleton.
+  static final OverlayCache instance = OverlayCache(kDefaultCacheSize);
+
+  OverlayCache(this.maximumSize);
+
+  /// The cache will not grow beyond this size.
+  final int maximumSize;
+
+  /// Cached surfaces, available for reuse.
+  final List<Surface> _cache = <Surface>[];
+
+  /// Returns the list of cached surfaces.
+  ///
+  /// Useful in tests.
+  List<Surface> get debugCachedSurfaces => _cache;
+
+  /// Reserves an overlay from the cache, if available.
+  ///
+  /// Returns null if the cache is empty.
+  Surface? reserveOverlay() {
+    if (_cache.isEmpty) {
+      return null;
+    }
+    return _cache.removeLast();
+  }
+
+  /// Returns an overlay back to the cache.
+  ///
+  /// If the cache is full, the overlay is deleted.
+  void releaseOverlay(Surface overlay) {
+    overlay.htmlElement.remove();
+    if (_cache.length < maximumSize) {
+      _cache.add(overlay);
+    } else {
+      overlay.dispose();
+    }
+  }
+
+  int get debugLength => _cache.length;
+
+  void debugClear() {
+    for (final Surface overlay in _cache) {
+      overlay.dispose();
+    }
   }
 }
 
@@ -546,12 +623,4 @@ class MutatorsStack extends Iterable<Mutator> {
 
   @override
   Iterator<Mutator> get iterator => _mutators.reversed.iterator;
-}
-
-/// Represents a surface overlaying a platform view.
-class Overlay {
-  final Surface surface;
-  final CkSurface? skSurface;
-
-  Overlay(this.surface, this.skSurface);
 }

--- a/lib/web_ui/test/canvaskit/common.dart
+++ b/lib/web_ui/test/canvaskit/common.dart
@@ -38,6 +38,7 @@ void setUpCanvasKitTest() {
   tearDown(() {
     testCollector.cleanUpAfterTest();
     debugResetBrowserSupportsFinalizationRegistry();
+    OverlayCache.instance.debugClear();
   });
 
   tearDownAll(() {

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 // @dart = 2.12
+import 'dart:html' as html;
+
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
@@ -20,19 +22,19 @@ void testMain() {
 
     test('Surface allocates canvases efficiently', () {
       final Surface surface = Surface(HtmlViewEmbedder());
-      final CkSurface original = surface.acquireRenderSurface(ui.Size(9, 19));
+      final CkSurface original = surface.acquireFrame(ui.Size(9, 19)).skiaSurface;
 
       // Expect exact requested dimensions.
       expect(original.width(), 9);
       expect(original.height(), 19);
 
       // Shrinking reuses the existing surface straight-up.
-      final CkSurface shrunk = surface.acquireRenderSurface(ui.Size(5, 15));
+      final CkSurface shrunk = surface.acquireFrame(ui.Size(5, 15)).skiaSurface;
       expect(shrunk, same(original));
 
       // The first increase will allocate a new surface, but will overallocate
       // by 40% to accommodate future increases.
-      final CkSurface firstIncrease = surface.acquireRenderSurface(ui.Size(10, 20));
+      final CkSurface firstIncrease = surface.acquireFrame(ui.Size(10, 20)).skiaSurface;
       expect(firstIncrease, isNot(same(original)));
 
       // Expect overallocated dimensions
@@ -40,11 +42,11 @@ void testMain() {
       expect(firstIncrease.height(), 28);
 
       // Subsequent increases within 40% reuse the old surface.
-      final CkSurface secondIncrease = surface.acquireRenderSurface(ui.Size(11, 22));
+      final CkSurface secondIncrease = surface.acquireFrame(ui.Size(11, 22)).skiaSurface;
       expect(secondIncrease, same(firstIncrease));
 
       // Increases beyond the 40% limit will cause a new allocation.
-      final CkSurface huge = surface.acquireRenderSurface(ui.Size(20, 40));
+      final CkSurface huge = surface.acquireFrame(ui.Size(20, 40)).skiaSurface;
       expect(huge, isNot(same(firstIncrease)));
 
       // Also over-allocated
@@ -52,8 +54,39 @@ void testMain() {
       expect(huge.height(), 56);
 
       // Shrink again. Reuse the last allocated surface.
-      final CkSurface shrunk2 = surface.acquireRenderSurface(ui.Size(5, 15));
+      final CkSurface shrunk2 = surface.acquireFrame(ui.Size(5, 15)).skiaSurface;
       expect(shrunk2, same(huge));
     });
+
+    test(
+      'Surface creates new context when WebGL context is lost',
+      () async {
+        final Surface surface = Surface(HtmlViewEmbedder());
+        expect(surface.debugForceNewContext, isTrue);
+        final CkSurface before = surface.acquireFrame(ui.Size(9, 19)).skiaSurface;
+        expect(surface.debugForceNewContext, isFalse);
+
+        // Pump a timer to flush any microtasks.
+        await Future<void>.delayed(Duration.zero);
+        final CkSurface afterAcquireFrame = surface.acquireFrame(ui.Size(9, 19)).skiaSurface;
+        // Existing context is reused.
+        expect(afterAcquireFrame, same(before));
+
+        // Emulate WebGL context loss.
+        final html.CanvasElement canvas = surface.htmlElement.children.single as html.CanvasElement;
+        final dynamic ctx = canvas.getContext('webgl2');
+        final dynamic loseContextExtension = ctx.getExtension('WEBGL_lose_context');
+        loseContextExtension.loseContext();
+
+        // Pump a timer to allow the "lose context" event to propagate.
+        await Future<void>.delayed(Duration.zero);
+        expect(surface.debugForceNewContext, isTrue);
+        final CkSurface afterContextLost = surface.acquireFrame(ui.Size(9, 19)).skiaSurface;
+        // A new cotext is created.
+        expect(afterContextLost, isNot(same(before)));
+      },
+      // Firefox doesn't have the WEBGL_lose_context extension.
+      skip: isFirefox || isIosSafari,
+    );
   }, skip: isIosSafari);
 }


### PR DESCRIPTION
## Description

Cache and reuse overlays created for previous platform views. This made the overlays more susceptible to the "WebGL: CONTEXT_LOST_WEBGL: loseContext: context lost" problem, so this change also includes recovery code for lost GL context.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/50721 (again, https://github.com/flutter/engine/pull/22966 didn't fix all situations)

## Tests

New tests in `surface_test.dart` and `embedded_views_test.dart`.