### PR TITLE
bump fuchsia toolchain to clang-12

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -100,7 +100,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '64bf32094b19bfecc2515aedb7e130f7ba15d297',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'c80bb183b30b3df12a3d8a6db235c0171c10d6a0',
 
    # Fuchsia compatibility
    #
@@ -534,16 +534,6 @@ deps = {
      'condition': 'host_os == "mac"',
      'dep_type': 'cipd',
    },
-   'src/fuchsia/toolchain/mac': {
-     'packages': [
-       {
-        'package': 'fuchsia/clang/mac-amd64',
-        'version': 'OzTZOKkICT0yD82Dbx0jvVn5hN5eOSi6ByVTDseE7i0C'
-       }
-     ],
-     'condition': 'host_os == "mac"',
-     'dep_type': 'cipd',
-   },
    'src/fuchsia/sdk/linux': {
      'packages': [
        {
@@ -554,16 +544,16 @@ deps = {
      'condition': 'host_os == "linux"',
      'dep_type': 'cipd',
    },
-   'src/fuchsia/toolchain/linux': {
+   'src/fuchsia/toolchain/{host_os}': {
      'packages': [
        {
-        'package': 'fuchsia/clang/linux-amd64',
-        'version': 'OT6p30bQQhyCzRSy7xPsSbZ88J3PWOnneenkMZ0j7kIC'
+         'package': 'fuchsia/third_party/clang/${{platform}}',
+         'version': 'git_revision:2c0536b76b35fa592ac7b4a0e4bb176eaf55af75'
        }
-     ],
-     'condition': 'host_os == "linux"',
-     'dep_type': 'cipd',
-   },
+      ],
+      'condition': 'host_os == "mac" or host_os == "linux"',
+      'dep_type': 'cipd',
+  },
 }
 
 hooks = [

--- a/tools/fuchsia/clang.gni
+++ b/tools/fuchsia/clang.gni
@@ -26,7 +26,10 @@ if (is_fuchsia) {
   assert(false, "OS not supported")
 }
 
-clang_manifest = rebase_path("$clang_base/${clang_target}.manifest")
+clang_manifest = rebase_path("$clang_base/runtime.json")
 clang_manifest_json = exec_script("//flutter/tools/fuchsia/parse_manifest.py",
-                                  [ "--input=${clang_manifest}" ],
+                                  [
+                                    "--input=${clang_manifest}",
+                                    "--clang-cpu=${clang_cpu}",
+                                  ],
                                   "json")

--- a/tools/fuchsia/fuchsia_libs.gni
+++ b/tools/fuchsia/fuchsia_libs.gni
@@ -48,17 +48,17 @@ common_libs = [
   {
     name = "libc++.so.2"
     path = rebase_path(
-            "$clang_base/${clang_manifest_json.md5_33bfe15b05ada4ed326fbc33adb39b95}")
+            "$clang_base/${clang_manifest_json.md5_19df03aecdc9eb27bc8b4038352f2b27}")
   },
   {
     name = "libc++abi.so.1"
     path = rebase_path(
-            "$clang_base/${clang_manifest_json.md5_916c01a85e3353f124776599819ecb1c}")
+            "$clang_base/${clang_manifest_json.md5_6aff1b5f218d4a9278d85d63d0695af8}")
   },
   {
     name = "libunwind.so.1"
     path = rebase_path(
-            "$clang_base/${clang_manifest_json.md5_beb70f40d525448b39ea87d9f5811e56}")
+            "$clang_base/${clang_manifest_json.md5_fb2bd871885ef42c2cf3138655f901ed}")
   },
 ]
 


### PR DESCRIPTION
## Description
Bumps fuchsia's toolchain to use clang 12. The new cipd bucket has a different manifest format so the parsing logic is updated as well.

## Related Issues
https://github.com/flutter/flutter/issues/63581