### PR TITLE
Prevent recycling of canvas multiple times

### DIFF
--- a/lib/web_ui/lib/src/engine/html/picture.dart
+++ b/lib/web_ui/lib/src/engine/html/picture.dart
@@ -314,6 +314,10 @@ class PersistedPicture extends PersistedLeafSurface {
       // painting. This removes all the setup work and scaffolding objects
       // that won't be useful for anything anyway.
       _recycleCanvas(oldCanvas);
+      if (oldSurface != null) {
+        // Make sure it doesn't get reused/recycled again.
+        oldSurface._canvas = null;
+      }
       if (rootElement != null) {
         domRenderer.clearDom(rootElement!);
       }

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -797,8 +797,7 @@ Picture _drawPicture() {
 
 Picture _drawEmptyPicture() {
   final EnginePictureRecorder recorder = PictureRecorder();
-  final RecordingCanvas canvas =
-      recorder.beginRecording(const Rect.fromLTRB(0, 0, 400, 400));
+  recorder.beginRecording(const Rect.fromLTRB(0, 0, 400, 400));
   return recorder.endRecording();
 }
 

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -588,6 +588,40 @@ void testMain() {
     expect(canvas2.width > unscaledWidth, true);
     expect(canvas2.height > unscaledHeight, true);
   });
+
+  test('Should recycle canvas once', () async {
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
+    final Picture picture1 = _drawPicture();
+    EngineLayer oldLayer = builder.pushClipRect(
+      const Rect.fromLTRB(10, 10, 300, 300),
+    );
+    builder.addPicture(Offset.zero, picture1);
+    builder.pop();
+    builder.build();
+
+    // Force update to scene which will utilize reuse code path.
+    final SurfaceSceneBuilder builder2 = SurfaceSceneBuilder();
+    EngineLayer oldLayer2 = builder2.pushClipRect(
+        const Rect.fromLTRB(5, 10, 300, 300),
+        oldLayer: oldLayer
+    );
+    builder2.addPicture(Offset.zero, _drawEmptyPicture());
+    builder2.pop();
+
+    html.HtmlElement contentAfterReuse = builder2.build().webOnlyRootElement;
+    expect(contentAfterReuse, isNotNull);
+
+    final SurfaceSceneBuilder builder3 = SurfaceSceneBuilder();
+    builder3.pushClipRect(
+        const Rect.fromLTRB(25, 10, 300, 300),
+        oldLayer: oldLayer2
+    );
+    builder3.addPicture(Offset.zero, _drawEmptyPicture());
+    builder3.pop();
+    // This build will crash if canvas gets recycled twice.
+    html.HtmlElement contentAfterReuse2 = builder3.build().webOnlyRootElement;
+    expect(contentAfterReuse2, isNotNull);
+  });
 }
 
 typedef TestLayerBuilder = EngineLayer Function(
@@ -758,6 +792,13 @@ Picture _drawPicture() {
       Paint()
         ..style = PaintingStyle.fill
         ..color = const Color.fromRGBO(0, 0, 255, 1));
+  return recorder.endRecording();
+}
+
+Picture _drawEmptyPicture() {
+  final EnginePictureRecorder recorder = PictureRecorder();
+  final RecordingCanvas canvas =
+      recorder.beginRecording(const Rect.fromLTRB(0, 0, 400, 400));
   return recorder.endRecording();
 }
 


### PR DESCRIPTION
## Description

This PR fixes recycling of canvas multiple times if pictures don't draw content or pictures scrolls out of view and we reuse bitmapcanvas.

## Related Issues

https://github.com/flutter/flutter/issues/72281

## Tests

Update SceneBuilder test.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
