### PR TITLE
[web] Switch web-render option default to auto

### DIFF
--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -619,6 +619,8 @@ class TestCommand extends Command<bool> with ArgUtils {
       '--enable-experiment=non-nullable',
       '--no-sound-null-safety',
       if (input.forCanvasKit) '-DFLUTTER_WEB_USE_SKIA=true',
+      if (!input.forCanvasKit) '-DFLUTTER_WEB_AUTO_DETECT=false',
+      if (!input.forCanvasKit) '-DFLUTTER_WEB_USE_SKIA=false',
       '-O2',
       '-o',
       targetFileName, // target path.

--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -31,7 +31,7 @@ bool _detectRenderer() {
 /// Using flutter tools option "--web-render=auto" would set the value to true.
 /// Otherwise, it would be false.
 const bool _autoDetect =
-    bool.fromEnvironment('FLUTTER_WEB_AUTO_DETECT', defaultValue: false);
+    bool.fromEnvironment('FLUTTER_WEB_AUTO_DETECT', defaultValue: true);
 
 /// Enable the Skia-based rendering backend.
 ///


### PR DESCRIPTION
## Description

Switches web-render to default to auto detect. On desktop flutter web will start using canvas kit by default, on mobile html will be used to render. Users can still override by -web-renderer=html or canvaskit.

See public doc https://docs.google.com/document/d/1aY0iU16wf_sdT7nwfpjgT-IatHNfF3slTiYHKmxcIog/edit

After this change if you encounter issues please see https://flutter.dev/docs/development/tools/web-renderers to switch to html (prior default) or canvaskit modes explicitely.

## Related Issues

https://github.com/flutter/flutter/issues/72377

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
