### PR TITLE
Correct button state on synthetic pointer events

### DIFF
--- a/lib/ui/window/pointer_data_packet_converter.cc
+++ b/lib/ui/window/pointer_data_packet_converter.cc
@@ -119,6 +119,7 @@ void PointerDataPacketConverter::ConvertPointerData(
           PointerData synthesized_add_event = pointer_data;
           synthesized_add_event.change = PointerData::Change::kAdd;
           synthesized_add_event.synthesized = 1;
+          synthesized_add_event.buttons = 0;
           state = EnsurePointerState(synthesized_add_event);
           converted_pointers.push_back(synthesized_add_event);
         } else {
@@ -126,6 +127,7 @@ void PointerDataPacketConverter::ConvertPointerData(
         }
 
         FML_DCHECK(!state.isDown);
+        state.buttons = pointer_data.buttons;
         if (LocationNeedsUpdate(pointer_data, state)) {
           UpdateDeltaAndState(pointer_data, state);
           converted_pointers.push_back(pointer_data);
@@ -140,6 +142,7 @@ void PointerDataPacketConverter::ConvertPointerData(
           PointerData synthesized_add_event = pointer_data;
           synthesized_add_event.change = PointerData::Change::kAdd;
           synthesized_add_event.synthesized = 1;
+          synthesized_add_event.buttons = 0;
           state = EnsurePointerState(synthesized_add_event);
           converted_pointers.push_back(synthesized_add_event);
         } else {
@@ -152,6 +155,7 @@ void PointerDataPacketConverter::ConvertPointerData(
           PointerData synthesized_hover_event = pointer_data;
           synthesized_hover_event.change = PointerData::Change::kHover;
           synthesized_hover_event.synthesized = 1;
+          synthesized_hover_event.buttons = 0;
 
           UpdateDeltaAndState(synthesized_hover_event, state);
           converted_pointers.push_back(synthesized_hover_event);
@@ -159,6 +163,7 @@ void PointerDataPacketConverter::ConvertPointerData(
 
         UpdatePointerIdentifier(pointer_data, state, true);
         state.isDown = true;
+        state.buttons = pointer_data.buttons;
         states_[pointer_data.device] = state;
         converted_pointers.push_back(pointer_data);
         break;
@@ -172,6 +177,7 @@ void PointerDataPacketConverter::ConvertPointerData(
 
         UpdatePointerIdentifier(pointer_data, state, false);
         UpdateDeltaAndState(pointer_data, state);
+        state.buttons = pointer_data.buttons;
         converted_pointers.push_back(pointer_data);
         break;
       }
@@ -188,6 +194,7 @@ void PointerDataPacketConverter::ConvertPointerData(
           // Synthesizes a move event if the location does not match.
           PointerData synthesized_move_event = pointer_data;
           synthesized_move_event.change = PointerData::Change::kMove;
+          synthesized_move_event.buttons = state.buttons;
           synthesized_move_event.synthesized = 1;
 
           UpdateDeltaAndState(synthesized_move_event, state);
@@ -195,6 +202,7 @@ void PointerDataPacketConverter::ConvertPointerData(
         }
 
         state.isDown = false;
+        state.buttons = pointer_data.buttons;
         states_[pointer_data.device] = state;
         converted_pointers.push_back(pointer_data);
         break;
@@ -218,6 +226,7 @@ void PointerDataPacketConverter::ConvertPointerData(
             PointerData synthesized_move_event = pointer_data;
             synthesized_move_event.signal_kind = PointerData::SignalKind::kNone;
             synthesized_move_event.change = PointerData::Change::kMove;
+            synthesized_move_event.buttons = state.buttons;
             synthesized_move_event.synthesized = 1;
 
             UpdateDeltaAndState(synthesized_move_event, state);
@@ -228,6 +237,7 @@ void PointerDataPacketConverter::ConvertPointerData(
             synthesized_hover_event.signal_kind =
                 PointerData::SignalKind::kNone;
             synthesized_hover_event.change = PointerData::Change::kHover;
+            synthesized_hover_event.buttons = 0;
             synthesized_hover_event.synthesized = 1;
 
             UpdateDeltaAndState(synthesized_hover_event, state);

--- a/lib/ui/window/pointer_data_packet_converter.h
+++ b/lib/ui/window/pointer_data_packet_converter.h
@@ -16,15 +16,23 @@
 namespace flutter {
 
 //------------------------------------------------------------------------------
-/// The current information about a pointer. This struct is used by
-/// PointerDataPacketConverter to fill in necesarry information for raw pointer
-/// packet sent from embedding.
+/// The current information about a pointer.
+///
+/// This struct is used by PointerDataPacketConverter to fill in necessary
+/// information for the raw pointer packet sent from embedding. This struct also
+/// stores the button state of the last pointer down, up, move, or hover event.
+/// When an embedder issues a pointer up or down event where the pointer's
+/// position has changed since the last move or hover event,
+/// PointerDataPacketConverter generates a synthetic move or hover to notify the
+/// framework. In these cases, these events must be issued with the button state
+/// prior to the pointer up or down.
 ///
 struct PointerState {
   int64_t pointer_identifier;
   bool isDown;
   double physical_x;
   double physical_y;
+  int64_t buttons;
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This corrects the button state emitted on synthetic pointer move and
hover events generated by the engine.

When an embedder notifies the engine of a pointer up or down event, and
the pointer's position has changed since the last move or hover event,
`PointerDataPacketConverter` generates a synthetic move or hover to
notify the framework of the change in position. In these cases, the
current event from the embedder contains the new button state *after*
the pointer up/down event, but the move/hover needs to be synthesized
such that it occurs *before* the pointer up/down, with the previous
button state.

This patch stores the button state after each pointer down, up, move, or
hover event such that it can be used by the next event if a synthetic
event must be issued.

The bug in the previous logic was revealed by the release of macOS 11
(Big Sur), which appears to issue move events between mouse down and
mouse up, which did not use to be the case.

## Related Issues

This fixes https://github.com/flutter/flutter/issues/64961, which is the
desktop-specific tracking bug for the more general Big Sur mouse click
umbrella issue https://github.com/flutter/flutter/issues/71190.

## Tests

I added the following tests:

* Test that synthesised move and hover events have the correct button state.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.

## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
