### PR TITLE
Fix recursive access to SkImage in image resurrector

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -179,11 +179,13 @@ class CkImage implements ui.Image, StackTraceDebugger {
         colorType: canvasKit.ColorType.RGBA_8888,
         colorSpace: SkColorSpaceSRGB,
       );
+      final int originalWidth = skImage.width();
+      final int originalHeight = skImage.height();
       box = SkiaObjectBox<CkImage, SkImage>.resurrectable(this, skImage, () {
         return canvasKit.MakeImage(
           originalBytes.buffer.asUint8List(),
-          width,
-          height,
+          originalWidth,
+          originalHeight,
           canvasKit.AlphaType.Premul,
           canvasKit.ColorType.RGBA_8888,
           SkColorSpaceSRGB,

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -113,6 +113,26 @@ void testMain() {
       testCollector.collectNow();
     });
 
+    // Regression test for https://github.com/flutter/flutter/issues/72469
+    test('CkImage can be resurrected', () {
+      browserSupportsFinalizationRegistry = false;
+      final SkImage skImage =
+          canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)
+              .getCurrentFrame();
+      final CkImage image = CkImage(skImage);
+      expect(image.box.rawSkiaObject, isNotNull);
+
+      // Pretend that the image is temporarily deleted.
+      image.box.delete();
+      image.box.didDelete();
+      expect(image.box.rawSkiaObject, isNull);
+
+      // Attempting to access the skia object here would previously throw
+      // "Stack Overflow" in Safari.
+      expect(image.box.skiaObject, isNotNull);
+      testCollector.collectNow();
+    });
+
     test('skiaInstantiateWebImageCodec loads an image from the network',
         () async {
       httpRequestFactory = () {


### PR DESCRIPTION
## Description

Fix recursive access to `SkImage` in image resurrector. The object is not available in the middle of resurrection.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/72469

## Tests

Added a new test in `canvaskit/image_test.dart`.
