### PR TITLE
Add SDK constraint to android_lint package

### DIFF
--- a/tools/android_lint/pubspec.yaml
+++ b/tools/android_lint/pubspec.yaml
@@ -1,4 +1,8 @@
 name: android_lint
+
+environment:
+  sdk: ">=2.4.0 <3.0.0"
+
 dependencies:
   args: 1.5.0
   path: ^1.6.2

--- a/tools/android_lint/pubspec.yaml
+++ b/tools/android_lint/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_lint
 
 environment:
-  sdk: ">=2.4.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   args: 1.5.0


### PR DESCRIPTION
To unblock the Dart SDK roll.
