### PR TITLE
[fuchsia] Add wrapper for zx_clock_get_monotonic.

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
@@ -189,6 +189,7 @@ class System extends NativeFieldWrapperClass2 {
   static MapResult vmoMap(Handle vmo) native 'System_VmoMap';
 
   // Time operations.
+  static int clockGetMonotonic() native 'System_ClockGetMonotonic';
   static int clockGet(int clockId) native 'System_ClockGet';
 
   // TODO(edcoyne): Remove this, it is required to safely do an API transition across repos.

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
@@ -459,6 +459,10 @@ Dart_Handle System::VmoMap(fml::RefPtr<Handle> vmo) {
   return ConstructDartObject(kMapResult, ToDart(ZX_OK), object);
 }
 
+uint64_t System::ClockGetMonotonic() {
+  return zx_clock_get_monotonic();
+}
+
 uint64_t System::ClockGet(uint32_t clock_id) {
   zx_time_t result = 0;
   zx_clock_get(clock_id, &result);

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
@@ -61,6 +61,8 @@ class System : public fml::RefCountedThreadSafe<System>,
 
   static Dart_Handle VmoMap(fml::RefPtr<Handle> vmo);
 
+  static uint64_t ClockGetMonotonic();
+
   static uint64_t ClockGet(uint32_t clock_id);
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);


### PR DESCRIPTION
Bug: https://github.com/flutter/flutter/issues/72321

## Description

This CL adds a new `clockGetMonotonic` function to `system.Zircon` as
the first step in moving off the now deprecated `zx_clock_get` syscall.

## Related Issues

https://github.com/flutter/flutter/issues/72321

## Tests

Tested manually by building a patched version of the engine for Fuchsia and deploying to a Fuchsia device. Verified build succeeds and that `zircon.System.clockGetMonotonic()` exhibits the same behavior as `zircon.System.clockGet(_zxClockMonotonic)`.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
