### PR TITLE
AssetResolver updating in AssetManager for Dynamic features

### DIFF
--- a/assets/asset_manager.cc
+++ b/assets/asset_manager.cc
@@ -32,15 +32,16 @@ void AssetManager::PushBack(std::unique_ptr<AssetResolver> resolver) {
 void AssetManager::UpdateResolverByType(
     std::unique_ptr<AssetResolver> updated_asset_resolver,
     AssetResolver::AssetResolverType type) {
+  if (updated_asset_resolver == nullptr) {
+    return;
+  }
   bool updated = false;
   std::deque<std::unique_ptr<AssetResolver>> new_resolvers;
   for (auto& old_resolver : resolvers_) {
     if (!updated && old_resolver->GetType() == type) {
-      if (updated_asset_resolver != nullptr) {
-        // Push the replacement updated resolver in place of the old_resolver.
-        new_resolvers.push_back(std::move(updated_asset_resolver));
-        updated = true;
-      }  // Drop the resolver if no replacement available.
+      // Push the replacement updated resolver in place of the old_resolver.
+      new_resolvers.push_back(std::move(updated_asset_resolver));
+      updated = true;
     } else {
       new_resolvers.push_back(std::move(old_resolver));
     }

--- a/assets/asset_manager.cc
+++ b/assets/asset_manager.cc
@@ -102,11 +102,6 @@ bool AssetManager::IsValidAfterAssetManagerChange() const {
 }
 
 // |AssetResolver|
-bool AssetManager::IsUpdatable() const {
-  return false;
-}
-
-// |AssetResolver|
 AssetResolver::AssetResolverType AssetManager::GetType() const {
   return AssetResolverType::kAssetManager;
 }

--- a/assets/asset_manager.cc
+++ b/assets/asset_manager.cc
@@ -29,24 +29,25 @@ void AssetManager::PushBack(std::unique_ptr<AssetResolver> resolver) {
   resolvers_.push_back(std::move(resolver));
 }
 
-void AssetManager::UpdateResolversByType(
-    std::vector<std::unique_ptr<AssetResolver>>& updated_asset_resolvers,
+void AssetManager::UpdateResolverByType(
+    std::unique_ptr<AssetResolver> updated_asset_resolver,
     AssetResolver::AssetResolverType type) {
-  size_t index = 0;
+  bool updated = false;
   std::deque<std::unique_ptr<AssetResolver>> new_resolvers;
   for (auto& old_resolver : resolvers_) {
-    if (old_resolver->GetType() == type) {
-      if (index < updated_asset_resolvers.size()) {
+    if (!updated && old_resolver->GetType() == type) {
+      if (updated_asset_resolver != nullptr) {
         // Push the replacement updated resolver in place of the old_resolver.
-        new_resolvers.push_back(std::move(updated_asset_resolvers[index++]));
+        new_resolvers.push_back(std::move(updated_asset_resolver));
+        updated = true;
       }  // Drop the resolver if no replacement available.
     } else {
       new_resolvers.push_back(std::move(old_resolver));
     }
   }
-  // Append all extra resolvers to the end.
-  while (index < updated_asset_resolvers.size()) {
-    new_resolvers.push_back(std::move(updated_asset_resolvers[index++]));
+  // Append resolver to the end if not used as a replacement.
+  if (!updated && updated_asset_resolver != nullptr) {
+    new_resolvers.push_back(std::move(updated_asset_resolver));
   }
   resolvers_.swap(new_resolvers);
 }

--- a/assets/asset_manager.cc
+++ b/assets/asset_manager.cc
@@ -79,4 +79,9 @@ bool AssetManager::IsValidAfterAssetManagerChange() const {
   return false;
 }
 
+// |AssetResolver|
+bool AssetManager::IsUpdatable() const {
+  return false;
+}
+
 }  // namespace flutter

--- a/assets/asset_manager.cc
+++ b/assets/asset_manager.cc
@@ -47,7 +47,7 @@ void AssetManager::UpdateResolverByType(
     }
   }
   // Append resolver to the end if not used as a replacement.
-  if (!updated && updated_asset_resolver != nullptr) {
+  if (!updated) {
     new_resolvers.push_back(std::move(updated_asset_resolver));
   }
   resolvers_.swap(new_resolvers);

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -75,8 +75,6 @@ class AssetManager final : public AssetResolver {
   std::vector<std::unique_ptr<fml::Mapping>> GetAsMappings(
       const std::string& asset_pattern) const override;
 
-  size_t Size() { return resolvers_.size(); }
-
  private:
   std::deque<std::unique_ptr<AssetResolver>> resolvers_;
 

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -30,7 +30,7 @@ class AssetManager final : public AssetResolver {
   ///             `updated_asset_resolver`. The matching AssetResolver is
   ///             removed and replaced with `updated_asset_resolvers`.
   ///
-  ///             AssetResolvers should be updated when the exisitng resolver
+  ///             AssetResolvers should be updated when the existing resolver
   ///             becomes obsolete and a newer one becomes available that
   ///             provides updated access to the same type of assets as the
   ///             existing one. This update process is meant to be performed

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -44,6 +44,8 @@ class AssetManager final : public AssetResolver {
   std::vector<std::unique_ptr<fml::Mapping>> GetAsMappings(
       const std::string& asset_pattern) const override;
 
+  size_t Size() { return resolvers_.size(); }
+
  private:
   std::deque<std::unique_ptr<AssetResolver>> resolvers_;
 

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -25,6 +25,10 @@ class AssetManager final : public AssetResolver {
 
   void PushBack(std::unique_ptr<AssetResolver> resolver);
 
+  void UpdateResolversByType(
+      std::vector<std::unique_ptr<AssetResolver>>& updated_asset_resolvers,
+      AssetResolver::AssetResolverType type);
+
   std::deque<std::unique_ptr<AssetResolver>> TakeResolvers();
 
   // |AssetResolver|
@@ -35,6 +39,9 @@ class AssetManager final : public AssetResolver {
 
   // |AssetResolver|
   bool IsUpdatable() const override;
+
+  // |AssetResolver|
+  AssetResolver::AssetResolverType GetType() const override;
 
   // |AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -36,8 +36,7 @@ class AssetManager final : public AssetResolver {
   ///             existing one. This update process is meant to be performed
   ///             at runtime.
   ///
-  ///             If a null resolver is provided, any existing matching
-  ///             resolvers will be removed without replacement. If no
+  ///             If a null resolver is provided, nothing will be done. If no
   ///             matching resolver is found, the provided resolver will be
   ///             added to the end of the AssetManager resolvers queue. The
   ///             replacement only occurs with the first matching resolver.

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -26,34 +26,32 @@ class AssetManager final : public AssetResolver {
   void PushBack(std::unique_ptr<AssetResolver> resolver);
 
   //--------------------------------------------------------------------------
-  /// @brief      Replaces asset resolvers handled by this AssetManager that are
-  ///             of the specified `type` with the resolvers provided in
-  ///             `updated_asset_resolvers`. Updatable AssetResolvers
-  ///             are removed and replaced with the next available resolver
-  ///             in `updated_asset_resolvers`.
+  /// @brief      Replaces an asset resolver of the specified `type` with
+  ///             `updated_asset_resolver`. The matching AssetResolver is
+  ///             removed and replaced with `updated_asset_resolvers`.
   ///
   ///             AssetResolvers should be updated when the exisitng resolver
   ///             becomes obsolete and a newer one becomes available that
   ///             provides updated access to the same type of assets as the
-  ///             existing one. This update process is meant to be performed at
-  ///             runtime.
+  ///             existing one. This update process is meant to be performed
+  ///             at runtime.
   ///
-  ///             If less resolvers are provided than existing resolvers of
-  ///             matching type, the the extra existing resolvers will
-  ///             be removed without replacement. If more resolvers are provided
-  ///             than existing matching resolvers, then the extra provided
-  ///             resolvers will be added to the end of the AssetManager
-  ///             resolvers queue.
+  ///             If a null resolver is provided, any existing matching
+  ///             resolvers will be removed without replacement. If no
+  ///             matching resolver is found, the provided resolver will be
+  ///             added to the end of the AssetManager resolvers queue. The
+  ///             replacement only occurs with the first matching resolver.
+  ///             Any additional matching resolvers are untouched.
   ///
-  /// @param[in]  asset_resolvers  The asset resolvers to replace updatable
-  ///                              existing resolvers with.
+  /// @param[in]  updated_asset_resolver  The asset resolver to replace the
+  ///             resolver of matching type with.
   ///
   /// @param[in]  type  The type of AssetResolver to update. Only resolvers of
-  ///                   the specified type will be replaced by an updated
+  ///                   the specified type will be replaced by the updated
   ///                   resolver.
   ///
-  void UpdateResolversByType(
-      std::vector<std::unique_ptr<AssetResolver>>& updated_asset_resolvers,
+  void UpdateResolverByType(
+      std::unique_ptr<AssetResolver> updated_asset_resolver,
       AssetResolver::AssetResolverType type);
 
   std::deque<std::unique_ptr<AssetResolver>> TakeResolvers();

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -25,6 +25,33 @@ class AssetManager final : public AssetResolver {
 
   void PushBack(std::unique_ptr<AssetResolver> resolver);
 
+  //--------------------------------------------------------------------------
+  /// @brief      Replaces asset resolvers handled by this AssetManager that are
+  ///             of the specified `type` with the resolvers provided in
+  ///             `updated_asset_resolvers`. Updatable AssetResolvers
+  ///             are removed and replaced with the next available resolver
+  ///             in `updated_asset_resolvers`.
+  ///
+  ///             AssetResolvers should be updated when the exisitng resolver
+  ///             becomes obsolete and a newer one becomes available that
+  ///             provides updated access to the same type of assets as the
+  ///             existing one. This update process is meant to be performed at
+  ///             runtime.
+  ///
+  ///             If less resolvers are provided than existing resolvers of
+  ///             matching type, the the extra existing resolvers will
+  ///             be removed without replacement. If more resolvers are provided
+  ///             than existing matching resolvers, then the extra provided
+  ///             resolvers will be added to the end of the AssetManager
+  ///             resolvers queue.
+  ///
+  /// @param[in]  asset_resolvers  The asset resolvers to replace updatable
+  ///                              existing resolvers with.
+  ///
+  /// @param[in]  type  The type of AssetResolver to update. Only resolvers of
+  ///                   the specified type will be replaced by an updated
+  ///                   resolver.
+  ///
   void UpdateResolversByType(
       std::vector<std::unique_ptr<AssetResolver>>& updated_asset_resolvers,
       AssetResolver::AssetResolverType type);
@@ -36,9 +63,6 @@ class AssetManager final : public AssetResolver {
 
   // |AssetResolver|
   bool IsValidAfterAssetManagerChange() const override;
-
-  // |AssetResolver|
-  bool IsUpdatable() const override;
 
   // |AssetResolver|
   AssetResolver::AssetResolverType GetType() const override;

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -34,6 +34,9 @@ class AssetManager final : public AssetResolver {
   bool IsValidAfterAssetManagerChange() const override;
 
   // |AssetResolver|
+  bool IsUpdatable() const override;
+
+  // |AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
 

--- a/assets/asset_resolver.h
+++ b/assets/asset_resolver.h
@@ -46,23 +46,11 @@ class AssetResolver {
   virtual bool IsValidAfterAssetManagerChange() const = 0;
 
   //----------------------------------------------------------------------------
-  /// @brief      Some asset resolvers may be replaced by an updated version
-  ///             during runtime. Resolvers marked `Updatable` are removed and
-  ///             invalidated when an update is processed and is replaced by a
-  ///             new resolver that provides the latest availablity state of
-  ///             assets. This usually adds access to new assets or removes
-  ///             access to old/invalid/deleted assets. For example, when
-  ///             downloading a dynamic feature, Android provides a new java
-  ///             asset manager that has access to the newly installed assets.
-  ///             This new manager should replace the existing java asset
-  ///             manager resolver. We call this replacement an update as the
-  ///             old resolver is obsolete and the new one should assume
-  ///             responsibility for providing access to android assets.
+  /// @brief      Gets the type of AssetResolver this is. Types are defined in
+  ///             AssetResolverType.
   ///
-  /// @return     Returns whether this resolver can be updated.
+  /// @return     Returns the AssetResolverType that this resolver is.
   ///
-  virtual bool IsUpdatable() const = 0;
-
   virtual AssetResolverType GetType() const = 0;
 
   [[nodiscard]] virtual std::unique_ptr<fml::Mapping> GetAsMapping(

--- a/assets/asset_resolver.h
+++ b/assets/asset_resolver.h
@@ -19,6 +19,12 @@ class AssetResolver {
 
   virtual ~AssetResolver() = default;
 
+  enum AssetResolverType {
+    kAssetManager,
+    kApkAssetProvider,
+    kDirectoryAssetBundle
+  };
+
   virtual bool IsValid() const = 0;
 
   //----------------------------------------------------------------------------
@@ -56,6 +62,8 @@ class AssetResolver {
   /// @return     Returns whether this resolver can be updated.
   ///
   virtual bool IsUpdatable() const = 0;
+
+  virtual AssetResolverType GetType() const = 0;
 
   [[nodiscard]] virtual std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const = 0;

--- a/assets/asset_resolver.h
+++ b/assets/asset_resolver.h
@@ -19,6 +19,9 @@ class AssetResolver {
 
   virtual ~AssetResolver() = default;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Identifies the type of AssetResolver an instance is.
+  ///
   enum AssetResolverType {
     kAssetManager,
     kApkAssetProvider,

--- a/assets/asset_resolver.h
+++ b/assets/asset_resolver.h
@@ -39,6 +39,21 @@ class AssetResolver {
   ///
   virtual bool IsValidAfterAssetManagerChange() const = 0;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Some asset resolvers may be replaced by an updated version
+  ///             during runtime. For example, when downloading a dynamic
+  ///             feature, Android provides a new java asset manager that has
+  ///             access to the newly installed assets. This new manager should
+  ///             replace the existing java asset manager resolver. We call
+  ///             this replacement an update as the old resolver is obsolete and
+  ///             the new one should assume responsibility for providing access
+  ///             to android assets. Updatable asset resolvers will be removed
+  ///             in favor of the replacement resolvers at runtime.
+  ///
+  /// @return     Returns whether this resolver should be updated.
+  ///
+  virtual bool IsUpdatable() const = 0;
+
   [[nodiscard]] virtual std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const = 0;
 

--- a/assets/asset_resolver.h
+++ b/assets/asset_resolver.h
@@ -41,16 +41,19 @@ class AssetResolver {
 
   //----------------------------------------------------------------------------
   /// @brief      Some asset resolvers may be replaced by an updated version
-  ///             during runtime. For example, when downloading a dynamic
-  ///             feature, Android provides a new java asset manager that has
-  ///             access to the newly installed assets. This new manager should
-  ///             replace the existing java asset manager resolver. We call
-  ///             this replacement an update as the old resolver is obsolete and
-  ///             the new one should assume responsibility for providing access
-  ///             to android assets. Updatable asset resolvers will be removed
-  ///             in favor of the replacement resolvers at runtime.
+  ///             during runtime. Resolvers marked `Updatable` are removed and
+  ///             invalidated when an update is processed and is replaced by a
+  ///             new resolver that provides the latest availablity state of
+  ///             assets. This usually adds access to new assets or removes
+  ///             access to old/invalid/deleted assets. For example, when
+  ///             downloading a dynamic feature, Android provides a new java
+  ///             asset manager that has access to the newly installed assets.
+  ///             This new manager should replace the existing java asset
+  ///             manager resolver. We call this replacement an update as the
+  ///             old resolver is obsolete and the new one should assume
+  ///             responsibility for providing access to android assets.
   ///
-  /// @return     Returns whether this resolver should be updated.
+  /// @return     Returns whether this resolver can be updated.
   ///
   virtual bool IsUpdatable() const = 0;
 

--- a/assets/directory_asset_bundle.cc
+++ b/assets/directory_asset_bundle.cc
@@ -37,11 +37,6 @@ bool DirectoryAssetBundle::IsValidAfterAssetManagerChange() const {
 }
 
 // |AssetResolver|
-bool DirectoryAssetBundle::IsUpdatable() const {
-  return false;
-}
-
-// |AssetResolver|
 AssetResolver::AssetResolverType DirectoryAssetBundle::GetType() const {
   return AssetResolver::AssetResolverType::kDirectoryAssetBundle;
 }

--- a/assets/directory_asset_bundle.cc
+++ b/assets/directory_asset_bundle.cc
@@ -42,6 +42,11 @@ bool DirectoryAssetBundle::IsUpdatable() const {
 }
 
 // |AssetResolver|
+AssetResolver::AssetResolverType DirectoryAssetBundle::GetType() const {
+  return AssetResolver::AssetResolverType::kDirectoryAssetBundle;
+}
+
+// |AssetResolver|
 std::unique_ptr<fml::Mapping> DirectoryAssetBundle::GetAsMapping(
     const std::string& asset_name) const {
   if (!is_valid_) {

--- a/assets/directory_asset_bundle.cc
+++ b/assets/directory_asset_bundle.cc
@@ -37,6 +37,11 @@ bool DirectoryAssetBundle::IsValidAfterAssetManagerChange() const {
 }
 
 // |AssetResolver|
+bool DirectoryAssetBundle::IsUpdatable() const {
+  return false;
+}
+
+// |AssetResolver|
 std::unique_ptr<fml::Mapping> DirectoryAssetBundle::GetAsMapping(
     const std::string& asset_name) const {
   if (!is_valid_) {

--- a/assets/directory_asset_bundle.h
+++ b/assets/directory_asset_bundle.h
@@ -34,6 +34,9 @@ class DirectoryAssetBundle : public AssetResolver {
   bool IsUpdatable() const override;
 
   // |AssetResolver|
+  AssetResolver::AssetResolverType GetType() const override;
+
+  // |AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
 

--- a/assets/directory_asset_bundle.h
+++ b/assets/directory_asset_bundle.h
@@ -31,9 +31,6 @@ class DirectoryAssetBundle : public AssetResolver {
   bool IsValidAfterAssetManagerChange() const override;
 
   // |AssetResolver|
-  bool IsUpdatable() const override;
-
-  // |AssetResolver|
   AssetResolver::AssetResolverType GetType() const override;
 
   // |AssetResolver|

--- a/assets/directory_asset_bundle.h
+++ b/assets/directory_asset_bundle.h
@@ -31,6 +31,9 @@ class DirectoryAssetBundle : public AssetResolver {
   bool IsValidAfterAssetManagerChange() const override;
 
   // |AssetResolver|
+  bool IsUpdatable() const override;
+
+  // |AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
 

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -170,10 +170,10 @@ void PlatformView::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                                 const std::string error_message,
                                                 bool transient) {}
 
-void PlatformView::UpdateAssetResolvers(
-    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+void PlatformView::UpdateAssetResolverByType(
+    std::unique_ptr<AssetResolver> updated_asset_resolver,
     AssetResolver::AssetResolverType type) {
-  delegate_.UpdateAssetResolvers(asset_resolvers, type);
+  delegate_.UpdateAssetResolverByType(std::move(updated_asset_resolver), type);
 }
 
 }  // namespace flutter

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -171,6 +171,6 @@ void PlatformView::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                                 bool transient) {}
 
 void PlatformView::UpdateAssetResolvers(
-    const std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {}
+    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {}
 
 }  // namespace flutter

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -171,8 +171,9 @@ void PlatformView::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                                 bool transient) {}
 
 void PlatformView::UpdateAssetResolvers(
-    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {
-  delegate_.UpdateAssetResolvers(asset_resolvers);
+    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+    AssetResolver::AssetResolverType type) {
+  delegate_.UpdateAssetResolvers(asset_resolvers, type);
 }
 
 }  // namespace flutter

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -170,7 +170,7 @@ void PlatformView::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                                 const std::string error_message,
                                                 bool transient) {}
 
-void PlatformView::UpdateAssetManager(
-    std::shared_ptr<AssetManager> asset_manager) {}
+void PlatformView::UpdateAssetResolvers(
+    const std::vector<std::shared_ptr<AssetResolver>>& asset_resolvers) {}
 
 }  // namespace flutter

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -171,6 +171,8 @@ void PlatformView::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                                 bool transient) {}
 
 void PlatformView::UpdateAssetResolvers(
-    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {}
+    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {
+  delegate_.UpdateAssetResolvers(asset_resolvers);
+}
 
 }  // namespace flutter

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -171,6 +171,6 @@ void PlatformView::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                                 bool transient) {}
 
 void PlatformView::UpdateAssetResolvers(
-    const std::vector<std::shared_ptr<AssetResolver>>& asset_resolvers) {}
+    const std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {}
 
 }  // namespace flutter

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -285,8 +285,7 @@ class PlatformView {
     ///             existing one. This update process is meant to be performed
     ///             at runtime.
     ///
-    ///             If a null resolver is provided, any existing matching
-    ///             resolvers will be removed without replacement. If no
+    ///             If a null resolver is provided, nothing will be done. If no
     ///             matching resolver is found, the provided resolver will be
     ///             added to the end of the AssetManager resolvers queue. The
     ///             replacement only occurs with the first matching resolver.
@@ -752,8 +751,7 @@ class PlatformView {
   ///             existing one. This update process is meant to be performed
   ///             at runtime.
   ///
-  ///             If a null resolver is provided, any existing matching
-  ///             resolvers will be removed without replacement. If no
+  ///             If a null resolver is provided, nothing will be done. If no
   ///             matching resolver is found, the provided resolver will be
   ///             added to the end of the AssetManager resolvers queue. The
   ///             replacement only occurs with the first matching resolver.

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -281,7 +281,7 @@ class PlatformView {
     /// @param[in]  asset_manager  The asset manager to use.
     ///
     virtual void UpdateAssetResolvers(
-        const std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) = 0;
+        std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) = 0;
   };
 
   //----------------------------------------------------------------------------
@@ -725,18 +725,26 @@ class PlatformView {
   ///             `AssetManager` that are marked as updatable
   ///             (`IsUpdateable()` returns true). Updatable AssetResolvers
   ///             are removed and replaced with the next available resolver
-  ///             in `asset_resolvers`. If less resolvers are provided than
-  ///             existing resolvers marked updatable, then the extra
-  ///             existing resolvers will be removed without replacement. If
-  ///             more resolvers are provided than existing resolvers marked
-  ///             updatable, then the extra provided resolvers will be added
-  ///             to the end of the resolver deque.
+  ///             in `asset_resolvers`.
+  ///
+  ///             AssetResolvers should be updated when the exisitng resolver
+  ///             becomes obsolete and a newer one becomes available that
+  ///             provides updated access to the same type of assets as the
+  ///             existing one. This update process is meant to be performed at
+  ///             runtime.
+  ///
+  ///             If less resolvers are provided than existing updatable
+  ///             resolvers, the the extra existing updatable resolvers will be
+  ///             removed without replacement. If more resolvers are provided
+  ///             than existing updatable resolvers, then the extra provided
+  ///             resolvers will be added to the end of the AssetManager
+  ///             resolvers list.
   ///
   /// @param[in]  asset_resolvers  The asset resolvers to replace updatable
   ///                              existing resolvers with.
   ///
   virtual void UpdateAssetResolvers(
-      const std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers);
+      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers);
 
  protected:
   PlatformView::Delegate& delegate_;

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -279,7 +279,7 @@ class PlatformView {
     ///             `updated_asset_resolver`. The matching AssetResolver is
     ///             removed and replaced with `updated_asset_resolvers`.
     ///
-    ///             AssetResolvers should be updated when the exisitng resolver
+    ///             AssetResolvers should be updated when the existing resolver
     ///             becomes obsolete and a newer one becomes available that
     ///             provides updated access to the same type of assets as the
     ///             existing one. This update process is meant to be performed
@@ -745,7 +745,7 @@ class PlatformView {
   ///             `updated_asset_resolver`. The matching AssetResolver is
   ///             removed and replaced with `updated_asset_resolvers`.
   ///
-  ///             AssetResolvers should be updated when the exisitng resolver
+  ///             AssetResolvers should be updated when the existing resolver
   ///             becomes obsolete and a newer one becomes available that
   ///             provides updated access to the same type of assets as the
   ///             existing one. This update process is meant to be performed

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -742,24 +742,24 @@ class PlatformView {
                                             bool transient);
 
   //--------------------------------------------------------------------------
-  /// @brief      Replaces asset resolvers in the current engine's
-  ///             `AssetManager` that are marked as updatable
-  ///             (`IsUpdateable()` returns true). Updatable AssetResolvers
-  ///             are removed and replaced with the next available resolver
-  ///             in `asset_resolvers`.
+  /// @brief      Replaces asset resolvers handled by the engine's
+  ///             AssetManager that are of the specified `type` with the
+  ///             resolvers provided in `updated_asset_resolvers`. Updatable
+  ///             AssetResolvers are removed and replaced with the next
+  ///             available resolver in `updated_asset_resolvers`.
   ///
   ///             AssetResolvers should be updated when the exisitng resolver
   ///             becomes obsolete and a newer one becomes available that
   ///             provides updated access to the same type of assets as the
-  ///             existing one. This update process is meant to be performed at
-  ///             runtime.
+  ///             existing one. This update process is meant to be performed
+  ///             at runtime.
   ///
-  ///             If less resolvers are provided than existing updatable
-  ///             resolvers, the the extra existing updatable resolvers will be
-  ///             removed without replacement. If more resolvers are provided
-  ///             than existing updatable resolvers, then the extra provided
-  ///             resolvers will be added to the end of the AssetManager
-  ///             resolvers list.
+  ///             If less resolvers are provided than existing resolvers of
+  ///             matching type, the the extra existing resolvers will
+  ///             be removed without replacement. If more resolvers are
+  ///             provided than existing matching resolvers, then the extra
+  ///             provided resolvers will be added to the end of the
+  ///             AssetManager resolvers queue.
   ///
   /// @param[in]  asset_resolvers  The asset resolvers to replace updatable
   ///                              existing resolvers with.

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -273,12 +273,32 @@ class PlatformView {
                                               const std::string error_message,
                                               bool transient) = 0;
 
-    // TODO(garyq): Implement a proper asset_resolver replacement instead of
-    // overwriting the entire asset manager.
     //--------------------------------------------------------------------------
-    /// @brief      Sets the asset manager of the engine to asset_manager
+    /// @brief      Replaces asset resolvers handled by the engine's
+    ///             AssetManager that are of the specified `type` with the
+    ///             resolvers provided in `updated_asset_resolvers`. Updatable
+    ///             AssetResolvers are removed and replaced with the next
+    ///             available resolver in `updated_asset_resolvers`.
     ///
-    /// @param[in]  asset_manager  The asset manager to use.
+    ///             AssetResolvers should be updated when the exisitng resolver
+    ///             becomes obsolete and a newer one becomes available that
+    ///             provides updated access to the same type of assets as the
+    ///             existing one. This update process is meant to be performed
+    ///             at runtime.
+    ///
+    ///             If less resolvers are provided than existing resolvers of
+    ///             matching type, the the extra existing resolvers will
+    ///             be removed without replacement. If more resolvers are
+    ///             provided than existing matching resolvers, then the extra
+    ///             provided resolvers will be added to the end of the
+    ///             AssetManager resolvers queue.
+    ///
+    /// @param[in]  asset_resolvers  The asset resolvers to replace updatable
+    ///                              existing resolvers with.
+    ///
+    /// @param[in]  type  The type of AssetResolver to update. Only resolvers of
+    ///                   the specified type will be replaced by an updated
+    ///                   resolver.
     ///
     virtual void UpdateAssetResolvers(
         std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
@@ -743,6 +763,10 @@ class PlatformView {
   ///
   /// @param[in]  asset_resolvers  The asset resolvers to replace updatable
   ///                              existing resolvers with.
+  ///
+  /// @param[in]  type  The type of AssetResolver to update. Only resolvers of
+  ///                   the specified type will be replaced by an updated
+  ///                   resolver.
   ///
   virtual void UpdateAssetResolvers(
       std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -281,7 +281,8 @@ class PlatformView {
     /// @param[in]  asset_manager  The asset manager to use.
     ///
     virtual void UpdateAssetResolvers(
-        std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) = 0;
+        std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+        AssetResolver::AssetResolverType type) = 0;
   };
 
   //----------------------------------------------------------------------------
@@ -744,7 +745,8 @@ class PlatformView {
   ///                              existing resolvers with.
   ///
   virtual void UpdateAssetResolvers(
-      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers);
+      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+      AssetResolver::AssetResolverType type);
 
  protected:
   PlatformView::Delegate& delegate_;

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -274,11 +274,10 @@ class PlatformView {
                                               bool transient) = 0;
 
     //--------------------------------------------------------------------------
-    /// @brief      Replaces asset resolvers handled by the engine's
-    ///             AssetManager that are of the specified `type` with the
-    ///             resolvers provided in `updated_asset_resolvers`. Updatable
-    ///             AssetResolvers are removed and replaced with the next
-    ///             available resolver in `updated_asset_resolvers`.
+    /// @brief      Replaces the asset resolver handled by the engine's
+    ///             AssetManager of the specified `type` with
+    ///             `updated_asset_resolver`. The matching AssetResolver is
+    ///             removed and replaced with `updated_asset_resolvers`.
     ///
     ///             AssetResolvers should be updated when the exisitng resolver
     ///             becomes obsolete and a newer one becomes available that
@@ -286,22 +285,22 @@ class PlatformView {
     ///             existing one. This update process is meant to be performed
     ///             at runtime.
     ///
-    ///             If less resolvers are provided than existing resolvers of
-    ///             matching type, the the extra existing resolvers will
-    ///             be removed without replacement. If more resolvers are
-    ///             provided than existing matching resolvers, then the extra
-    ///             provided resolvers will be added to the end of the
-    ///             AssetManager resolvers queue.
+    ///             If a null resolver is provided, any existing matching
+    ///             resolvers will be removed without replacement. If no
+    ///             matching resolver is found, the provided resolver will be
+    ///             added to the end of the AssetManager resolvers queue. The
+    ///             replacement only occurs with the first matching resolver.
+    ///             Any additional matching resolvers are untouched.
     ///
-    /// @param[in]  asset_resolvers  The asset resolvers to replace updatable
-    ///                              existing resolvers with.
+    /// @param[in]  updated_asset_resolver  The asset resolver to replace the
+    ///             resolver of matching type with.
     ///
     /// @param[in]  type  The type of AssetResolver to update. Only resolvers of
-    ///                   the specified type will be replaced by an updated
+    ///                   the specified type will be replaced by the updated
     ///                   resolver.
     ///
-    virtual void UpdateAssetResolvers(
-        std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+    virtual void UpdateAssetResolverByType(
+        std::unique_ptr<AssetResolver> updated_asset_resolver,
         AssetResolver::AssetResolverType type) = 0;
   };
 
@@ -742,11 +741,10 @@ class PlatformView {
                                             bool transient);
 
   //--------------------------------------------------------------------------
-  /// @brief      Replaces asset resolvers handled by the engine's
-  ///             AssetManager that are of the specified `type` with the
-  ///             resolvers provided in `updated_asset_resolvers`. Updatable
-  ///             AssetResolvers are removed and replaced with the next
-  ///             available resolver in `updated_asset_resolvers`.
+  /// @brief      Replaces the asset resolver handled by the engine's
+  ///             AssetManager of the specified `type` with
+  ///             `updated_asset_resolver`. The matching AssetResolver is
+  ///             removed and replaced with `updated_asset_resolvers`.
   ///
   ///             AssetResolvers should be updated when the exisitng resolver
   ///             becomes obsolete and a newer one becomes available that
@@ -754,22 +752,22 @@ class PlatformView {
   ///             existing one. This update process is meant to be performed
   ///             at runtime.
   ///
-  ///             If less resolvers are provided than existing resolvers of
-  ///             matching type, the the extra existing resolvers will
-  ///             be removed without replacement. If more resolvers are
-  ///             provided than existing matching resolvers, then the extra
-  ///             provided resolvers will be added to the end of the
-  ///             AssetManager resolvers queue.
+  ///             If a null resolver is provided, any existing matching
+  ///             resolvers will be removed without replacement. If no
+  ///             matching resolver is found, the provided resolver will be
+  ///             added to the end of the AssetManager resolvers queue. The
+  ///             replacement only occurs with the first matching resolver.
+  ///             Any additional matching resolvers are untouched.
   ///
-  /// @param[in]  asset_resolvers  The asset resolvers to replace updatable
-  ///                              existing resolvers with.
+  /// @param[in]  updated_asset_resolver  The asset resolver to replace the
+  ///             resolver of matching type with.
   ///
   /// @param[in]  type  The type of AssetResolver to update. Only resolvers of
-  ///                   the specified type will be replaced by an updated
+  ///                   the specified type will be replaced by the updated
   ///                   resolver.
   ///
-  virtual void UpdateAssetResolvers(
-      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+  virtual void UpdateAssetResolverByType(
+      std::unique_ptr<AssetResolver> updated_asset_resolver,
       AssetResolver::AssetResolverType type);
 
  protected:

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -280,8 +280,8 @@ class PlatformView {
     ///
     /// @param[in]  asset_manager  The asset manager to use.
     ///
-    virtual void UpdateAssetManager(
-        std::shared_ptr<AssetManager> asset_manager) = 0;
+    virtual void UpdateAssetResolvers(
+        const std::vector<std::shared_ptr<AssetResolver>>& asset_resolvers) = 0;
   };
 
   //----------------------------------------------------------------------------
@@ -727,7 +727,8 @@ class PlatformView {
   ///
   /// @param[in]  asset_manager  The asset manager to use.
   ///
-  virtual void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager);
+  virtual void UpdateAssetResolvers(
+      const std::vector<std::shared_ptr<AssetResolver>>& asset_resolvers);
 
  protected:
   PlatformView::Delegate& delegate_;

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -281,7 +281,7 @@ class PlatformView {
     /// @param[in]  asset_manager  The asset manager to use.
     ///
     virtual void UpdateAssetResolvers(
-        const std::vector<std::shared_ptr<AssetResolver>>& asset_resolvers) = 0;
+        const std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) = 0;
   };
 
   //----------------------------------------------------------------------------
@@ -720,15 +720,23 @@ class PlatformView {
                                             const std::string error_message,
                                             bool transient);
 
-  // TODO(garyq): Implement a proper asset_resolver replacement instead of
-  // overwriting the entire asset manager.
   //--------------------------------------------------------------------------
-  /// @brief      Sets the asset manager of the engine to asset_manager
+  /// @brief      Replaces asset resolvers in the current engine's
+  ///             `AssetManager` that are marked as updatable
+  ///             (`IsUpdateable()` returns true). Updatable AssetResolvers
+  ///             are removed and replaced with the next available resolver
+  ///             in `asset_resolvers`. If less resolvers are provided than
+  ///             existing resolvers marked updatable, then the extra
+  ///             existing resolvers will be removed without replacement. If
+  ///             more resolvers are provided than existing resolvers marked
+  ///             updatable, then the extra provided resolvers will be added
+  ///             to the end of the resolver deque.
   ///
-  /// @param[in]  asset_manager  The asset manager to use.
+  /// @param[in]  asset_resolvers  The asset resolvers to replace updatable
+  ///                              existing resolvers with.
   ///
   virtual void UpdateAssetResolvers(
-      const std::vector<std::shared_ptr<AssetResolver>>& asset_resolvers);
+      const std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers);
 
  protected:
   PlatformView::Delegate& delegate_;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1232,13 +1232,15 @@ void Shell::UpdateAssetResolvers(
     for (auto& old_resolver : old_asset_manager->TakeResolvers()) {
       if (old_resolver->IsUpdatable()) {
         if (index < asset_resolvers.size()) {
+          // Push the replacement updated resolver in place of the old_resolver.
           asset_manager->PushBack(std::move(asset_resolvers[index++]));
-        }
+        }  // Drop the resolver if no replacement available.
       } else {
         asset_manager->PushBack(std::move(old_resolver));
       }
     }
   }
+  // Append all extra resolvers to the end.
   while (index < asset_resolvers.size()) {
     asset_manager->PushBack(std::move(asset_resolvers[index++]));
   }

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1224,7 +1224,7 @@ void Shell::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
 }
 
 void Shell::UpdateAssetResolvers(
-    const std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {
+    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {
   size_t index = 0;
   auto asset_manager = std::make_shared<AssetManager>();
   auto old_asset_manager = engine_->GetAssetManager();

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1223,10 +1223,11 @@ void Shell::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                         transient);
 }
 
-void Shell::UpdateAssetResolvers(
-    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+void Shell::UpdateAssetResolverByType(
+    std::unique_ptr<AssetResolver> updated_asset_resolver,
     AssetResolver::AssetResolverType type) {
-  engine_->GetAssetManager()->UpdateResolversByType(asset_resolvers, type);
+  engine_->GetAssetManager()->UpdateResolverByType(
+      std::move(updated_asset_resolver), type);
 }
 
 // |Engine::Delegate|

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1224,27 +1224,9 @@ void Shell::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
 }
 
 void Shell::UpdateAssetResolvers(
-    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {
-  size_t index = 0;
-  auto asset_manager = std::make_shared<AssetManager>();
-  auto old_asset_manager = engine_->GetAssetManager();
-  if (old_asset_manager != nullptr) {
-    for (auto& old_resolver : old_asset_manager->TakeResolvers()) {
-      if (old_resolver->IsUpdatable()) {
-        if (index < asset_resolvers.size()) {
-          // Push the replacement updated resolver in place of the old_resolver.
-          asset_manager->PushBack(std::move(asset_resolvers[index++]));
-        }  // Drop the resolver if no replacement available.
-      } else {
-        asset_manager->PushBack(std::move(old_resolver));
-      }
-    }
-  }
-  // Append all extra resolvers to the end.
-  while (index < asset_resolvers.size()) {
-    asset_manager->PushBack(std::move(asset_resolvers[index++]));
-  }
-  engine_->UpdateAssetManager(std::move(asset_manager));
+    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+    AssetResolver::AssetResolverType type) {
+  engine_->GetAssetManager()->UpdateResolversByType(asset_resolvers, type);
 }
 
 // |Engine::Delegate|

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1223,8 +1223,9 @@ void Shell::LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                         transient);
 }
 
-void Shell::UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) {
-  engine_->UpdateAssetManager(std::move(asset_manager));
+void Shell::UpdateAssetResolvers(
+    const std::vector<std::shared_ptr<AssetResolver>>& asset_resolvers) {
+  // engine_->UpdateAssetManager(std::move(asset_manager));
 }
 
 // |Engine::Delegate|

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -536,7 +536,8 @@ class Shell final : public PlatformView::Delegate,
                                     bool transient) override;
 
   // |PlatformView::Delegate|
-  void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override;
+  void UpdateAssetResolvers(const std::vector<std::shared_ptr<AssetResolver>>&
+                                asset_resolvers) override;
 
   // |Animator::Delegate|
   void OnAnimatorBeginFrame(fml::TimePoint frame_target_time) override;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -536,8 +536,8 @@ class Shell final : public PlatformView::Delegate,
                                     bool transient) override;
 
   // |PlatformView::Delegate|
-  void UpdateAssetResolvers(const std::vector<std::unique_ptr<AssetResolver>>&
-                                asset_resolvers) override;
+  void UpdateAssetResolvers(
+      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) override;
 
   // |Animator::Delegate|
   void OnAnimatorBeginFrame(fml::TimePoint frame_target_time) override;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -536,8 +536,8 @@ class Shell final : public PlatformView::Delegate,
                                     bool transient) override;
 
   // |PlatformView::Delegate|
-  void UpdateAssetResolvers(
-      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+  void UpdateAssetResolverByType(
+      std::unique_ptr<AssetResolver> updated_asset_resolver,
       AssetResolver::AssetResolverType type) override;
 
   // |Animator::Delegate|

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -537,7 +537,8 @@ class Shell final : public PlatformView::Delegate,
 
   // |PlatformView::Delegate|
   void UpdateAssetResolvers(
-      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) override;
+      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+      AssetResolver::AssetResolverType type) override;
 
   // |Animator::Delegate|
   void OnAnimatorBeginFrame(fml::TimePoint frame_target_time) override;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -536,7 +536,7 @@ class Shell final : public PlatformView::Delegate,
                                     bool transient) override;
 
   // |PlatformView::Delegate|
-  void UpdateAssetResolvers(const std::vector<std::shared_ptr<AssetResolver>>&
+  void UpdateAssetResolvers(const std::vector<std::unique_ptr<AssetResolver>>&
                                 asset_resolvers) override;
 
   // |Animator::Delegate|

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -116,17 +116,19 @@ class MockPlatformView : public PlatformView {
 };
 }  // namespace
 
-class TestAssetResolver final : public AssetResolver {
+class TestAssetResolver : public AssetResolver {
  public:
-  TestAssetResolver(bool updatable) : updatable_(updatable) {}
-
-  // ~TestAssetResolver() {}
+  TestAssetResolver(bool updatable, int valid)
+      : updatable_(updatable), valid_(valid) {}
 
   bool IsValid() const override { return true; }
 
-  bool IsValidAfterAssetManagerChange() const override { return true; }
+  bool IsValidAfterAssetManagerChange() const override { return valid_; }
 
-  bool IsUpdatable() const override { return updatable_; }
+  bool IsUpdatable() const override {
+    FML_LOG(ERROR) << "Returning updatable_ " << updatable_;
+    return updatable_;
+  }
 
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override {
@@ -140,6 +142,7 @@ class TestAssetResolver final : public AssetResolver {
 
  private:
   bool updatable_;
+  int valid_;
 };
 
 static bool ValidateShell(Shell* shell) {
@@ -215,7 +218,53 @@ static void TestDartVmFlags(std::vector<const char*>& flags) {
     EXPECT_EQ(settings.dart_flags[i], flags[i]);
   }
 }
-TEST_F(ShellTest, UpdateAssetResolvers) {
+
+TEST_F(ShellTest, UpdateAssetResolversReplaces) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  Settings settings = CreateSettingsForFixture();
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::Platform);
+  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  auto shell = CreateShell(std::move(settings), task_runners);
+  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+  ASSERT_TRUE(ValidateShell(shell.get()));
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+  RunEngine(shell.get(), std::move(configuration));
+
+  auto platform_view =
+      std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
+
+  auto asset_manager = shell->GetEngine()->GetAssetManager();
+
+  auto old_resolver = std::make_unique<TestAssetResolver>(true, true);
+  ASSERT_TRUE(old_resolver->IsUpdatable());
+  ASSERT_TRUE(old_resolver->IsValid());
+  asset_manager->PushBack(std::move(old_resolver));
+
+  std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
+  auto updated_resolver = std::make_unique<TestAssetResolver>(true, false);
+  ASSERT_TRUE(updated_resolver->IsUpdatable());
+  ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
+  resolver_vector.push_back(std::move(updated_resolver));
+  platform_view->UpdateAssetResolvers(resolver_vector);
+
+  auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
+  ASSERT_EQ(resolvers.size(), 2ull);
+  ASSERT_FALSE(resolvers[0]->IsUpdatable());
+  ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
+
+  ASSERT_TRUE(resolvers[1]->IsUpdatable());
+  ASSERT_FALSE(resolvers[1]->IsValidAfterAssetManagerChange());
+
+  DestroyShell(std::move(shell), std::move(task_runners));
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest, UpdateAssetResolversAppends) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
@@ -235,10 +284,59 @@ TEST_F(ShellTest, UpdateAssetResolvers) {
       std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
 
   std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
-  resolver_vector.push_back(std::make_unique<TestAssetResolver>(true));
+  auto updated_resolver = std::make_unique<TestAssetResolver>(true, false);
+  ASSERT_TRUE(updated_resolver->IsUpdatable());
+  ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
+  resolver_vector.push_back(std::move(updated_resolver));
   platform_view->UpdateAssetResolvers(resolver_vector);
 
-  // DestroyShell(std::move(shell), std::move(task_runners));
+  auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
+  ASSERT_EQ(resolvers.size(), 2ull);
+  ASSERT_FALSE(resolvers[0]->IsUpdatable());
+  ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
+
+  ASSERT_TRUE(resolvers[1]->IsUpdatable());
+  ASSERT_FALSE(resolvers[1]->IsValidAfterAssetManagerChange());
+
+  DestroyShell(std::move(shell), std::move(task_runners));
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest, UpdateAssetResolversRemoves) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  Settings settings = CreateSettingsForFixture();
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::Platform);
+  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  auto shell = CreateShell(std::move(settings), task_runners);
+  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+  ASSERT_TRUE(ValidateShell(shell.get()));
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+  RunEngine(shell.get(), std::move(configuration));
+
+  auto platform_view =
+      std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
+
+  auto asset_manager = shell->GetEngine()->GetAssetManager();
+
+  auto old_resolver = std::make_unique<TestAssetResolver>(true, true);
+  ASSERT_TRUE(old_resolver->IsUpdatable());
+  ASSERT_TRUE(old_resolver->IsValid());
+  asset_manager->PushBack(std::move(old_resolver));
+
+  std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
+  platform_view->UpdateAssetResolvers(resolver_vector);
+
+  auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
+  ASSERT_EQ(resolvers.size(), 1ull);
+  ASSERT_FALSE(resolvers[0]->IsUpdatable());
+  ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
+
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2545,7 +2545,7 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeAppends) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
-TEST_F(ShellTest, UpdateAssetResolverByTypeRemoves) {
+TEST_F(ShellTest, UpdateAssetResolverByTypeNull) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
@@ -2574,8 +2574,9 @@ TEST_F(ShellTest, UpdateAssetResolverByTypeRemoves) {
       std::move(nullptr), AssetResolver::AssetResolverType::kApkAssetProvider);
 
   auto resolvers = asset_manager->TakeResolvers();
-  ASSERT_EQ(resolvers.size(), 1ull);
+  ASSERT_EQ(resolvers.size(), 2ull);
   ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
+  ASSERT_TRUE(resolvers[1]->IsValidAfterAssetManagerChange());
 
   DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -89,10 +89,9 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
                     const std::string error_message,
                     bool transient));
 
-  MOCK_METHOD2(
-      UpdateAssetResolvers,
-      void(std::vector<std::unique_ptr<AssetResolver>>& updated_asset_resolvers,
-           AssetResolver::AssetResolverType type));
+  MOCK_METHOD2(UpdateAssetResolverByType,
+               void(std::unique_ptr<AssetResolver> updated_asset_resolver,
+                    AssetResolver::AssetResolverType type));
 };
 
 class MockSurface : public Surface {
@@ -2467,7 +2466,7 @@ TEST_F(ShellTest, Spawn) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
-TEST_F(ShellTest, UpdateAssetResolversReplaces) {
+TEST_F(ShellTest, UpdateAssetResolverByTypeReplaces) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
@@ -2492,13 +2491,12 @@ TEST_F(ShellTest, UpdateAssetResolversReplaces) {
   ASSERT_TRUE(old_resolver->IsValid());
   asset_manager->PushBack(std::move(old_resolver));
 
-  std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
   auto updated_resolver = std::make_unique<TestAssetResolver>(
       false, AssetResolver::AssetResolverType::kApkAssetProvider);
   ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
-  resolver_vector.push_back(std::move(updated_resolver));
-  platform_view->UpdateAssetResolvers(
-      resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
+  platform_view->UpdateAssetResolverByType(
+      std::move(updated_resolver),
+      AssetResolver::AssetResolverType::kApkAssetProvider);
 
   auto resolvers = asset_manager->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 2ull);
@@ -2510,7 +2508,7 @@ TEST_F(ShellTest, UpdateAssetResolversReplaces) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
-TEST_F(ShellTest, UpdateAssetResolversAppends) {
+TEST_F(ShellTest, UpdateAssetResolverByTypeAppends) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
@@ -2530,13 +2528,12 @@ TEST_F(ShellTest, UpdateAssetResolversAppends) {
   auto platform_view =
       std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
 
-  std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
   auto updated_resolver = std::make_unique<TestAssetResolver>(
       false, AssetResolver::AssetResolverType::kApkAssetProvider);
   ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
-  resolver_vector.push_back(std::move(updated_resolver));
-  platform_view->UpdateAssetResolvers(
-      resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
+  platform_view->UpdateAssetResolverByType(
+      std::move(updated_resolver),
+      AssetResolver::AssetResolverType::kApkAssetProvider);
 
   auto resolvers = asset_manager->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 2ull);
@@ -2548,7 +2545,7 @@ TEST_F(ShellTest, UpdateAssetResolversAppends) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
-TEST_F(ShellTest, UpdateAssetResolversRemoves) {
+TEST_F(ShellTest, UpdateAssetResolverByTypeRemoves) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
@@ -2573,9 +2570,8 @@ TEST_F(ShellTest, UpdateAssetResolversRemoves) {
   ASSERT_TRUE(old_resolver->IsValid());
   asset_manager->PushBack(std::move(old_resolver));
 
-  std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
-  platform_view->UpdateAssetResolvers(
-      resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
+  platform_view->UpdateAssetResolverByType(
+      std::move(nullptr), AssetResolver::AssetResolverType::kApkAssetProvider);
 
   auto resolvers = asset_manager->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 1ull);
@@ -2585,7 +2581,7 @@ TEST_F(ShellTest, UpdateAssetResolversRemoves) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
-TEST_F(ShellTest, UpdateAssetResolversDoesNotReplaceMismatchType) {
+TEST_F(ShellTest, UpdateAssetResolverByTypeDoesNotReplaceMismatchType) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
   Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
@@ -2610,13 +2606,12 @@ TEST_F(ShellTest, UpdateAssetResolversDoesNotReplaceMismatchType) {
   ASSERT_TRUE(old_resolver->IsValid());
   asset_manager->PushBack(std::move(old_resolver));
 
-  std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
   auto updated_resolver = std::make_unique<TestAssetResolver>(
       false, AssetResolver::AssetResolverType::kApkAssetProvider);
   ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
-  resolver_vector.push_back(std::move(updated_resolver));
-  platform_view->UpdateAssetResolvers(
-      resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
+  platform_view->UpdateAssetResolverByType(
+      std::move(updated_resolver),
+      AssetResolver::AssetResolverType::kApkAssetProvider);
 
   auto resolvers = asset_manager->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 3ull);

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -128,8 +128,6 @@ class TestAssetResolver : public AssetResolver {
   // This is used to identify if replacement was made or not.
   bool IsValidAfterAssetManagerChange() const override { return valid_; }
 
-  bool IsUpdatable() const override { return true; }
-
   AssetResolver::AssetResolverType GetType() const override { return type_; }
 
   std::unique_ptr<fml::Mapping> GetAsMapping(
@@ -2492,14 +2490,12 @@ TEST_F(ShellTest, UpdateAssetResolversReplaces) {
 
   auto old_resolver = std::make_unique<TestAssetResolver>(
       true, AssetResolver::AssetResolverType::kApkAssetProvider);
-  ASSERT_TRUE(old_resolver->IsUpdatable());
   ASSERT_TRUE(old_resolver->IsValid());
   asset_manager->PushBack(std::move(old_resolver));
 
   std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
   auto updated_resolver = std::make_unique<TestAssetResolver>(
       false, AssetResolver::AssetResolverType::kApkAssetProvider);
-  ASSERT_TRUE(updated_resolver->IsUpdatable());
   ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
   resolver_vector.push_back(std::move(updated_resolver));
   platform_view->UpdateAssetResolvers(
@@ -2507,10 +2503,8 @@ TEST_F(ShellTest, UpdateAssetResolversReplaces) {
 
   auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 2ull);
-  ASSERT_FALSE(resolvers[0]->IsUpdatable());
   ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
 
-  ASSERT_TRUE(resolvers[1]->IsUpdatable());
   ASSERT_FALSE(resolvers[1]->IsValidAfterAssetManagerChange());
 
   DestroyShell(std::move(shell), std::move(task_runners));
@@ -2539,7 +2533,6 @@ TEST_F(ShellTest, UpdateAssetResolversAppends) {
   std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
   auto updated_resolver = std::make_unique<TestAssetResolver>(
       false, AssetResolver::AssetResolverType::kApkAssetProvider);
-  ASSERT_TRUE(updated_resolver->IsUpdatable());
   ASSERT_FALSE(updated_resolver->IsValidAfterAssetManagerChange());
   resolver_vector.push_back(std::move(updated_resolver));
   platform_view->UpdateAssetResolvers(
@@ -2547,10 +2540,8 @@ TEST_F(ShellTest, UpdateAssetResolversAppends) {
 
   auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 2ull);
-  ASSERT_FALSE(resolvers[0]->IsUpdatable());
   ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
 
-  ASSERT_TRUE(resolvers[1]->IsUpdatable());
   ASSERT_FALSE(resolvers[1]->IsValidAfterAssetManagerChange());
 
   DestroyShell(std::move(shell), std::move(task_runners));

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2481,12 +2481,11 @@ TEST_F(ShellTest, UpdateAssetResolversReplaces) {
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("emptyMain");
+  auto asset_manager = configuration.GetAssetManager();
   RunEngine(shell.get(), std::move(configuration));
 
   auto platform_view =
       std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
-
-  auto asset_manager = shell->GetEngine()->GetAssetManager();
 
   auto old_resolver = std::make_unique<TestAssetResolver>(
       true, AssetResolver::AssetResolverType::kApkAssetProvider);
@@ -2501,7 +2500,7 @@ TEST_F(ShellTest, UpdateAssetResolversReplaces) {
   platform_view->UpdateAssetResolvers(
       resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
 
-  auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
+  auto resolvers = asset_manager->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 2ull);
   ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
 
@@ -2525,6 +2524,7 @@ TEST_F(ShellTest, UpdateAssetResolversAppends) {
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("emptyMain");
+  auto asset_manager = configuration.GetAssetManager();
   RunEngine(shell.get(), std::move(configuration));
 
   auto platform_view =
@@ -2538,7 +2538,7 @@ TEST_F(ShellTest, UpdateAssetResolversAppends) {
   platform_view->UpdateAssetResolvers(
       resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
 
-  auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
+  auto resolvers = asset_manager->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 2ull);
   ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
 
@@ -2562,12 +2562,11 @@ TEST_F(ShellTest, UpdateAssetResolversRemoves) {
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("emptyMain");
+  auto asset_manager = configuration.GetAssetManager();
   RunEngine(shell.get(), std::move(configuration));
 
   auto platform_view =
       std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
-
-  auto asset_manager = shell->GetEngine()->GetAssetManager();
 
   auto old_resolver = std::make_unique<TestAssetResolver>(
       true, AssetResolver::AssetResolverType::kApkAssetProvider);
@@ -2578,7 +2577,7 @@ TEST_F(ShellTest, UpdateAssetResolversRemoves) {
   platform_view->UpdateAssetResolvers(
       resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
 
-  auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
+  auto resolvers = asset_manager->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 1ull);
   ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
 
@@ -2600,12 +2599,11 @@ TEST_F(ShellTest, UpdateAssetResolversDoesNotReplaceMismatchType) {
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
   configuration.SetEntrypoint("emptyMain");
+  auto asset_manager = configuration.GetAssetManager();
   RunEngine(shell.get(), std::move(configuration));
 
   auto platform_view =
       std::make_unique<PlatformView>(*shell.get(), std::move(task_runners));
-
-  auto asset_manager = shell->GetEngine()->GetAssetManager();
 
   auto old_resolver = std::make_unique<TestAssetResolver>(
       true, AssetResolver::AssetResolverType::kAssetManager);
@@ -2620,7 +2618,7 @@ TEST_F(ShellTest, UpdateAssetResolversDoesNotReplaceMismatchType) {
   platform_view->UpdateAssetResolvers(
       resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
 
-  auto resolvers = shell->GetEngine()->GetAssetManager()->TakeResolvers();
+  auto resolvers = asset_manager->TakeResolvers();
   ASSERT_EQ(resolvers.size(), 3ull);
   ASSERT_TRUE(resolvers[0]->IsValidAfterAssetManagerChange());
 

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -32,6 +32,9 @@ bool APKAssetProvider::IsValidAfterAssetManagerChange() const {
 }
 
 bool APKAssetProvider::IsUpdatable() const {
+  // APKAssetProvider is always updatable to allow dynamic features to
+  // runtime-update the Java AssetManager instance being used when a new dynamic
+  // feature is installed.
   return true;
 }
 

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -38,6 +38,11 @@ bool APKAssetProvider::IsUpdatable() const {
   return true;
 }
 
+// |AssetResolver|
+AssetResolver::AssetResolverType APKAssetProvider::GetType() const {
+  return AssetResolver::AssetResolverType::kAssetManager;
+}
+
 class APKAssetMapping : public fml::Mapping {
  public:
   APKAssetMapping(AAsset* asset) : asset_(asset) {}

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -31,16 +31,9 @@ bool APKAssetProvider::IsValidAfterAssetManagerChange() const {
   return true;
 }
 
-bool APKAssetProvider::IsUpdatable() const {
-  // APKAssetProvider is always updatable to allow dynamic features to
-  // runtime-update the Java AssetManager instance being used when a new dynamic
-  // feature is installed.
-  return true;
-}
-
 // |AssetResolver|
 AssetResolver::AssetResolverType APKAssetProvider::GetType() const {
-  return AssetResolver::AssetResolverType::kAssetManager;
+  return AssetResolver::AssetResolverType::kApkAssetProvider;
 }
 
 class APKAssetMapping : public fml::Mapping {

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -31,6 +31,10 @@ bool APKAssetProvider::IsValidAfterAssetManagerChange() const {
   return true;
 }
 
+bool APKAssetProvider::IsUpdatable() const {
+  return true;
+}
+
 class APKAssetMapping : public fml::Mapping {
  public:
   APKAssetMapping(AAsset* asset) : asset_(asset) {}

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -35,6 +35,9 @@ class APKAssetProvider final : public AssetResolver {
   // |flutter::AssetResolver|
   bool IsUpdatable() const override;
 
+  // |AssetResolver|
+  AssetResolver::AssetResolverType GetType() const override;
+
   // |flutter::AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -33,6 +33,9 @@ class APKAssetProvider final : public AssetResolver {
   bool IsValidAfterAssetManagerChange() const override;
 
   // |flutter::AssetResolver|
+  bool IsUpdatable() const override;
+
+  // |flutter::AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
 

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -32,9 +32,6 @@ class APKAssetProvider final : public AssetResolver {
   // |flutter::AssetResolver|
   bool IsValidAfterAssetManagerChange() const override;
 
-  // |flutter::AssetResolver|
-  bool IsUpdatable() const override;
-
   // |AssetResolver|
   AssetResolver::AssetResolverType GetType() const override;
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -1056,14 +1056,14 @@ public class FlutterJNI {
    *     value is `flutter_assets`.
    */
   @UiThread
-  public void updateAssetManager(
+  public void updateJavaAssetManager(
       @NonNull AssetManager assetManager, @NonNull String assetBundlePath) {
     ensureRunningOnMainThread();
     ensureAttachedToNative();
-    nativeUpdateAssetManager(nativePlatformViewId, assetManager, assetBundlePath);
+    nativeUpdateJavaAssetManager(nativePlatformViewId, assetManager, assetBundlePath);
   }
 
-  private native void nativeUpdateAssetManager(
+  private native void nativeUpdateJavaAssetManager(
       long nativePlatformViewId,
       @NonNull AssetManager assetManager,
       @NonNull String assetBundlePath);

--- a/shell/platform/android/io/flutter/embedding/engine/dynamicfeatures/PlayStoreDynamicFeatureManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dynamicfeatures/PlayStoreDynamicFeatureManager.java
@@ -317,7 +317,7 @@ public class PlayStoreDynamicFeatureManager implements DynamicFeatureManager {
       context = context.createPackageContext(context.getPackageName(), 0);
 
       AssetManager assetManager = context.getAssets();
-      flutterJNI.updateAssetManager(
+      flutterJNI.updateJavaAssetManager(
           assetManager,
           // TODO(garyq): Made the "flutter_assets" directory dynamic based off of DartEntryPoint.
           "flutter_assets");

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -363,9 +363,9 @@ void PlatformViewAndroid::LoadDartDeferredLibraryError(
 }
 
 // |PlatformView|
-void PlatformViewAndroid::UpdateAssetManager(
-    std::shared_ptr<AssetManager> asset_manager) {
-  delegate_.UpdateAssetManager(std::move(asset_manager));
+void PlatformViewAndroid::UpdateAssetResolvers(
+    const std::vector<std::shared_ptr<AssetResolver>>& asset_resolvers) {
+  delegate_.UpdateAssetResolvers(asset_resolvers);
 }
 
 void PlatformViewAndroid::InstallFirstFrameCallback() {

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -364,7 +364,7 @@ void PlatformViewAndroid::LoadDartDeferredLibraryError(
 
 // |PlatformView|
 void PlatformViewAndroid::UpdateAssetResolvers(
-    const std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {
+    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {
   delegate_.UpdateAssetResolvers(asset_resolvers);
 }
 

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -363,10 +363,10 @@ void PlatformViewAndroid::LoadDartDeferredLibraryError(
 }
 
 // |PlatformView|
-void PlatformViewAndroid::UpdateAssetResolvers(
-    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+void PlatformViewAndroid::UpdateAssetResolverByType(
+    std::unique_ptr<AssetResolver> updated_asset_resolver,
     AssetResolver::AssetResolverType type) {
-  delegate_.UpdateAssetResolvers(asset_resolvers, type);
+  delegate_.UpdateAssetResolverByType(std::move(updated_asset_resolver), type);
 }
 
 void PlatformViewAndroid::InstallFirstFrameCallback() {

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -364,7 +364,7 @@ void PlatformViewAndroid::LoadDartDeferredLibraryError(
 
 // |PlatformView|
 void PlatformViewAndroid::UpdateAssetResolvers(
-    const std::vector<std::shared_ptr<AssetResolver>>& asset_resolvers) {
+    const std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {
   delegate_.UpdateAssetResolvers(asset_resolvers);
 }
 

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -364,8 +364,9 @@ void PlatformViewAndroid::LoadDartDeferredLibraryError(
 
 // |PlatformView|
 void PlatformViewAndroid::UpdateAssetResolvers(
-    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) {
-  delegate_.UpdateAssetResolvers(asset_resolvers);
+    std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+    AssetResolver::AssetResolverType type) {
+  delegate_.UpdateAssetResolvers(asset_resolvers, type);
 }
 
 void PlatformViewAndroid::InstallFirstFrameCallback() {

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -104,8 +104,8 @@ class PlatformViewAndroid final : public PlatformView {
                                     bool transient) override;
 
   // |PlatformView|
-  void UpdateAssetResolvers(
-      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+  void UpdateAssetResolverByType(
+      std::unique_ptr<AssetResolver> updated_asset_resolver,
       AssetResolver::AssetResolverType type) override;
 
  private:

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -104,7 +104,8 @@ class PlatformViewAndroid final : public PlatformView {
                                     bool transient) override;
 
   // |PlatformView|
-  void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override;
+  void UpdateAssetResolvers(const std::vector<std::shared_ptr<AssetResolver>>&
+                                asset_resolvers) override;
 
  private:
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -104,8 +104,8 @@ class PlatformViewAndroid final : public PlatformView {
                                     bool transient) override;
 
   // |PlatformView|
-  void UpdateAssetResolvers(const std::vector<std::unique_ptr<AssetResolver>>&
-                                asset_resolvers) override;
+  void UpdateAssetResolvers(
+      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) override;
 
  private:
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -105,7 +105,8 @@ class PlatformViewAndroid final : public PlatformView {
 
   // |PlatformView|
   void UpdateAssetResolvers(
-      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers) override;
+      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+      AssetResolver::AssetResolverType type) override;
 
  private:
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -104,7 +104,7 @@ class PlatformViewAndroid final : public PlatformView {
                                     bool transient) override;
 
   // |PlatformView|
-  void UpdateAssetResolvers(const std::vector<std::shared_ptr<AssetResolver>>&
+  void UpdateAssetResolvers(const std::vector<std::unique_ptr<AssetResolver>>&
                                 asset_resolvers) override;
 
  private:

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -581,9 +581,6 @@ static void UpdateJavaAssetManager(JNIEnv* env,
       jAssetManager,                                         // asset manager
       fml::jni::JavaStringToString(env, jAssetBundlePath));  // apk asset dir
   std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
-  // auto resolver_vector =
-  //     std::make_unique<std::vector<std::unique_ptr<AssetResolver>>>();
-  // resolver_vector->push_back(std::move(asset_resolver));
   resolver_vector.push_back(std::move(asset_resolver));
 
   ANDROID_SHELL_HOLDER->GetPlatformView()->UpdateAssetResolvers(

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -584,7 +584,7 @@ static void UpdateJavaAssetManager(JNIEnv* env,
   resolver_vector.push_back(std::move(asset_resolver));
 
   ANDROID_SHELL_HOLDER->GetPlatformView()->UpdateAssetResolvers(
-      resolver_vector);
+      resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
 }
 
 bool RegisterApi(JNIEnv* env) {

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -580,11 +580,10 @@ static void UpdateJavaAssetManager(JNIEnv* env,
       env,                                                   // jni environment
       jAssetManager,                                         // asset manager
       fml::jni::JavaStringToString(env, jAssetBundlePath));  // apk asset dir
-  std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
-  resolver_vector.push_back(std::move(asset_resolver));
 
-  ANDROID_SHELL_HOLDER->GetPlatformView()->UpdateAssetResolvers(
-      resolver_vector, AssetResolver::AssetResolverType::kApkAssetProvider);
+  ANDROID_SHELL_HOLDER->GetPlatformView()->UpdateAssetResolverByType(
+      std::move(asset_resolver),
+      AssetResolver::AssetResolverType::kApkAssetProvider);
 }
 
 bool RegisterApi(JNIEnv* env) {

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -571,32 +571,23 @@ static void LoadDartDeferredLibrary(JNIEnv* env,
       std::move(instructions_mapping));
 }
 
-// TODO(garyq): persist additional asset resolvers by updating instead of
-// replacing with newly created asset_manager
 static void UpdateJavaAssetManager(JNIEnv* env,
                                    jobject obj,
                                    jlong shell_holder,
                                    jobject jAssetManager,
                                    jstring jAssetBundlePath) {
-  // auto asset_manager = std::make_shared<flutter::AssetManager>();
-  // asset_manager->PushBack(std::make_unique<flutter::APKAssetProvider>(
-  //     env,                                                  // jni
-  //     environment jAssetManager,                                        //
-  //     asset manager fml::jni::JavaStringToString(env, jAssetBundlePath))  //
-  //     apk asset dir
-  // );
-  // Create config to set persistent cache asset manager
-  // RunConfiguration config(nullptr, std::move(asset_manager));
   auto asset_resolver = std::make_unique<flutter::APKAssetProvider>(
       env,                                                   // jni environment
       jAssetManager,                                         // asset manager
       fml::jni::JavaStringToString(env, jAssetBundlePath));  // apk asset dir
-  std::unique_ptr<std::vector<std::shared_ptr<AssetResolver>>> resolver_vector =
-      std::make_unique<std::vector<std::shared_ptr<AssetResolver>>>();
-  resolver_vector->push_back(std::move(asset_resolver));
+  std::vector<std::unique_ptr<AssetResolver>> resolver_vector;
+  // auto resolver_vector =
+  //     std::make_unique<std::vector<std::unique_ptr<AssetResolver>>>();
+  // resolver_vector->push_back(std::move(asset_resolver));
+  resolver_vector.push_back(std::move(asset_resolver));
 
   ANDROID_SHELL_HOLDER->GetPlatformView()->UpdateAssetResolvers(
-      *resolver_vector);
+      resolver_vector);
 }
 
 bool RegisterApi(JNIEnv* env) {

--- a/shell/platform/android/test/io/flutter/embedding/engine/dynamicfeatures/PlayStoreDynamicFeatureManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/dynamicfeatures/PlayStoreDynamicFeatureManagerTest.java
@@ -44,7 +44,7 @@ public class PlayStoreDynamicFeatureManagerTest {
     }
 
     @Override
-    public void updateAssetManager(
+    public void updateJavaAssetManager(
         @NonNull AssetManager assetManager, @NonNull String assetBundlePath) {
       updateAssetManagerCalled++;
       this.loadingUnitId = loadingUnitId;

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -41,8 +41,8 @@ class MockDelegate : public PlatformView::Delegate {
   void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                     const std::string error_message,
                                     bool transient) override {}
-  void UpdateResolverByType(std::unique_ptr<AssetResolver> updated_asset_resolver,
-                            AssetResolver::AssetResolverType type) override {}
+  void UpdateAssetResolverByType(std::unique_ptr<AssetResolver> updated_asset_resolver,
+                                 AssetResolver::AssetResolverType type) override {}
 };
 
 }  // namespace

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -41,7 +41,8 @@ class MockDelegate : public PlatformView::Delegate {
   void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                     const std::string error_message,
                                     bool transient) override {}
-  void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override {}
+  void UpdateResolverByType(std::unique_ptr<AssetResolver> updated_asset_resolver,
+                            AssetResolver::AssetResolverType type) override {}
 };
 
 }  // namespace

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -111,7 +111,8 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                     const std::string error_message,
                                     bool transient) override {}
-  void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override {}
+  void UpdateAssetResolverByType(std::unique_ptr<flutter::AssetResolver> updated_asset_resolver,
+                                 flutter::AssetResolver::AssetResolverType type) override {}
 };
 
 }  // namespace

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -94,7 +94,8 @@ class MockDelegate : public PlatformView::Delegate {
   void LoadDartDeferredLibraryError(intptr_t loading_unit_id,
                                     const std::string error_message,
                                     bool transient) override {}
-  void UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager) override {}
+  void UpdateAssetResolverByType(std::unique_ptr<flutter::AssetResolver> updated_asset_resolver,
+                                 flutter::AssetResolver::AssetResolverType type) override {}
 };
 
 class MockIosDelegate : public AccessibilityBridge::IosDelegate {

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -115,8 +115,8 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
                                     bool transient) {}
   // |flutter::PlatformView::Delegate|
   void UpdateAssetResolverByType(
-      std::unique_ptr<AssetResolver> updated_asset_resolver,
-      AssetResolver::AssetResolverType type) {}
+      std::unique_ptr<flutter::AssetResolver> updated_asset_resolver,
+      flutter::AssetResolver::AssetResolverType type) {}
 
   flutter::Surface* surface() const { return surface_.get(); }
   flutter::PlatformMessage* message() const { return message_.get(); }

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -114,8 +114,9 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
                                     const std::string error_message,
                                     bool transient) {}
   // |flutter::PlatformView::Delegate|
-  void UpdateAssetManager(
-      std::shared_ptr<flutter::AssetManager> asset_manager) {}
+  void UpdateAssetResolvers(
+      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+      AssetResolver::AssetResolverType type) {}
 
   flutter::Surface* surface() const { return surface_.get(); }
   flutter::PlatformMessage* message() const { return message_.get(); }

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -114,8 +114,8 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
                                     const std::string error_message,
                                     bool transient) {}
   // |flutter::PlatformView::Delegate|
-  void UpdateAssetResolvers(
-      std::vector<std::unique_ptr<AssetResolver>>& asset_resolvers,
+  void UpdateAssetResolverByType(
+      std::unique_ptr<AssetResolver> updated_asset_resolver,
       AssetResolver::AssetResolverType type) {}
 
   flutter::Surface* surface() const { return surface_.get(); }


### PR DESCRIPTION
Loosely based off of https://github.com/flutter/engine/pull/21611

Adds `IsUpdatable` to AssetResolvers. Updatable resolvers may be replaced with newer versions with `UpdateAssetResolvers`.