### PR TITLE
Fix argument specifier and type for g_warning()

### DIFF
--- a/shell/platform/linux/fl_key_event_plugin.cc
+++ b/shell/platform/linux/fl_key_event_plugin.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/linux/fl_key_event_plugin.h"
 
 #include <gtk/gtk.h>
+#include <cinttypes>
 
 #include "flutter/shell/platform/linux/fl_text_input_plugin.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h"
@@ -172,10 +173,10 @@ static GdkEventKey* find_pending_event(FlKeyEventPlugin* self, uint64_t id) {
 static void remove_pending_event(FlKeyEventPlugin* self, uint64_t id) {
   if (self->pending_events->len == 0 ||
       FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, 0))->id != id) {
-    g_warning(
-        "Tried to remove pending event with id %ld, but the event was out of "
-        "order, or is unknown.",
-        id);
+    g_warning("Tried to remove pending event with id %" PRIu64
+              ", but the event was out of "
+              "order, or is unknown.",
+              id);
     return;
   }
   g_ptr_array_remove_index(self->pending_events, 0);
@@ -223,10 +224,10 @@ static void handle_response(GObject* object,
   if (handled_value != nullptr) {
     GdkEventKey* event = find_pending_event(self, data->id);
     if (event == nullptr) {
-      g_warning(
-          "Event response for event id %ld received, but event was received "
-          "out of order, or is unknown.",
-          data->id);
+      g_warning("Event response for event id %" PRIu64
+                " received, but event was received "
+                "out of order, or is unknown.",
+                data->id);
     } else {
       handled = fl_value_get_bool(handled_value);
       if (!handled) {


### PR DESCRIPTION
Fixes the following compilation errors:
 | ../../flutter/shell/platform/linux/fl_key_event_plugin.cc:178:9:
   error: format specifies type 'long' but the argument has type
   'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
 |         id);
 |         ^~

 | ../../flutter/shell/platform/linux/fl_key_event_plugin.cc:229:11:
   error: format specifies type 'long' but the argument has type
   'uint64_t' (aka 'unsigned long long') [-Werror,-Wformat]
 |           data->id);
 |           ^~~~~~~~

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>

## Description

*Replace this paragraph with a description of what this PR is doing. If you're
modifying existing behavior, describe the existing behavior, how this PR is
changing it, and what motivated the change.*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from our [issue
database]. Indicate, which of these issues are resolved or fixed by this PR.
There should be at least one issue listed here.*

## Tests

I added the following tests:

*Replace this with a list of the tests that you added as part of this PR. A
change in behaviour with no test covering it will likely get reverted
accidentally sooner or later. PRs must include tests for all
changed/updated/fixed behaviors. See [testing the engine] for instructions on
writing and running engine tests.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
