### PR TITLE
Add --strict_null_safety_checks to the Dart flag allowlist

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -67,6 +67,7 @@ static const std::string gAllowedDartFlags[] = {
     "--trace-reload-verbose",
     "--write-service-info",
     "--null_assertions",
+    "--strict_null_safety_checks",
 };
 // clang-format on
 


### PR DESCRIPTION
Users would like this flag to help catch issues during migration.