### PR TITLE
Update FlutterPlatformViewsTests

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -102,13 +102,13 @@ FLUTTER_ASSERT_ARC
                                        message:encodedSetInitialRouteMethod]);
 }
 
-- (void)testPlatformViewsControllerRenderingMetalBackend {
-  FlutterEngine* engine = [[FlutterEngine alloc] init];
-  [engine run];
-  flutter::IOSRenderingAPI renderingApi = [engine platformViewsRenderingAPI];
-
-  XCTAssertEqual(renderingApi, flutter::IOSRenderingAPI::kMetal);
-}
+//- (void)testPlatformViewsControllerRenderingMetalBackend {
+//  FlutterEngine* engine = [[FlutterEngine alloc] init];
+//  [engine run];
+//  flutter::IOSRenderingAPI renderingApi = [engine platformViewsRenderingAPI];
+//
+//  XCTAssertEqual(renderingApi, flutter::IOSRenderingAPI::kMetal);
+//}
 
 - (void)testPlatformViewsControllerRenderingSoftware {
   auto settings = FLTDefaultSettingsForBundle();

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -102,13 +102,13 @@ FLUTTER_ASSERT_ARC
                                        message:encodedSetInitialRouteMethod]);
 }
 
-//- (void)testPlatformViewsControllerRenderingMetalBackend {
-//  FlutterEngine* engine = [[FlutterEngine alloc] init];
-//  [engine run];
-//  flutter::IOSRenderingAPI renderingApi = [engine platformViewsRenderingAPI];
-//
-//  XCTAssertEqual(renderingApi, flutter::IOSRenderingAPI::kMetal);
-//}
+- (void)testPlatformViewsControllerRenderingMetalBackend {
+  FlutterEngine* engine = [[FlutterEngine alloc] init];
+  [engine run];
+  flutter::IOSRenderingAPI renderingApi = [engine platformViewsRenderingAPI];
+
+  XCTAssertEqual(renderingApi, flutter::IOSRenderingAPI::kMetal);
+}
 
 - (void)testPlatformViewsControllerRenderingSoftware {
   auto settings = FLTDefaultSettingsForBundle();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -684,62 +684,70 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   id mockFlutterViewContoller = OCMClassMock([UIViewController class]);
   {
     // ***** Sequence 1, finishing touch event with touchEnded ***** //
-    id event = OCMClassMock([UIEvent class]);
     flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller);
 
     NSSet* touches1 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesBegan:touches1 withEvent:event];
-    OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event]);
+    id event1 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesBegan:touches1 withEvent:event1];
+    OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event1]);
 
     flutterPlatformViewsController->SetFlutterViewController(nil);
 
     // Allow the touch events to finish
     NSSet* touches2 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesMoved:touches2 withEvent:event];
-    OCMVerify([mockFlutterViewContoller touchesMoved:touches2 withEvent:event]);
+    id event2 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesMoved:touches2 withEvent:event2];
+    OCMVerify([mockFlutterViewContoller touchesMoved:touches2 withEvent:event2]);
 
     NSSet* touches3 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesEnded:touches3 withEvent:event];
-    OCMVerify([mockFlutterViewContoller touchesEnded:touches3 withEvent:event]);
+    id event3 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesEnded:touches3 withEvent:event3];
+    OCMVerify([mockFlutterViewContoller touchesEnded:touches3 withEvent:event3]);
 
     // Now the 2nd touch sequence should not be allowed.
     NSSet* touches4 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesBegan:touches4 withEvent:event];
-    OCMReject([mockFlutterViewContoller touchesBegan:touches4 withEvent:event]);
+    id event4 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesBegan:touches4 withEvent:event4];
+    OCMReject([mockFlutterViewContoller touchesBegan:touches4 withEvent:event4]);
 
     NSSet* touches5 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesEnded:touches5 withEvent:event];
-    OCMReject([mockFlutterViewContoller touchesEnded:touches5 withEvent:event]);
+    id event5 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesEnded:touches5 withEvent:event5];
+    OCMReject([mockFlutterViewContoller touchesEnded:touches5 withEvent:event5]);
   }
 
   {
     // ***** Sequence 2, finishing touch event with touchCancelled ***** //
-    id event = OCMClassMock([UIEvent class]);
     flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller);
 
     NSSet* touches1 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesBegan:touches1 withEvent:event];
-    OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event]);
+    id event1 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesBegan:touches1 withEvent:event1];
+    OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event1]);
 
     flutterPlatformViewsController->SetFlutterViewController(nil);
 
     // Allow the touch events to finish
     NSSet* touches2 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesMoved:touches2 withEvent:event];
-    OCMVerify([mockFlutterViewContoller touchesMoved:touches2 withEvent:event]);
+    id event2 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesMoved:touches2 withEvent:event2];
+    OCMVerify([mockFlutterViewContoller touchesMoved:touches2 withEvent:event2]);
 
     NSSet* touches3 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesCancelled:touches3 withEvent:event];
-    OCMVerify([mockFlutterViewContoller touchesCancelled:touches3 withEvent:event]);
+    id event3 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesCancelled:touches3 withEvent:event3];
+    OCMVerify([mockFlutterViewContoller touchesCancelled:touches3 withEvent:event3]);
 
     // Now the 2nd touch sequence should not be allowed.
     NSSet* touches4 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesBegan:touches4 withEvent:event];
-    OCMReject([mockFlutterViewContoller touchesBegan:touches4 withEvent:event]);
+    id event4 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesBegan:touches4 withEvent:event4];
+    OCMReject([mockFlutterViewContoller touchesBegan:touches4 withEvent:event4]);
 
     NSSet* touches5 = [[[NSSet alloc] init] autorelease];
-    [forwardGectureRecognizer touchesEnded:touches5 withEvent:event];
-    OCMReject([mockFlutterViewContoller touchesEnded:touches5 withEvent:event]);
+    id event5 = OCMClassMock([UIEvent class]);
+    [forwardGectureRecognizer touchesEnded:touches5 withEvent:event5];
+    OCMReject([mockFlutterViewContoller touchesEnded:touches5 withEvent:event5]);
   }
 
   flutterPlatformViewsController->Reset();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -621,15 +621,15 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   }
 
   // Before setting flutter view controller, events are not dispatched.
-  NSSet* touches1 = OCMClassMock([NSSet class]);
-  UIEvent* event1 = OCMClassMock([UIEvent class]);
-  UIViewController* mockFlutterViewContoller = OCMClassMock([UIViewController class]);
+  NSSet* touches1 = [[[NSSet alloc] init] autorelease];
+  id event1 = OCMClassMock([UIEvent class]);
+  id mockFlutterViewContoller = OCMClassMock([UIViewController class]);
   [forwardGectureRecognizer touchesBegan:touches1 withEvent:event1];
   OCMReject([mockFlutterViewContoller touchesBegan:touches1 withEvent:event1]);
 
   // Set flutter view controller allows events to be dispatched.
-  NSSet* touches2 = OCMClassMock([NSSet class]);
-  UIEvent* event2 = OCMClassMock([UIEvent class]);
+  NSSet* touches2 = [[[NSSet alloc] init] autorelease];
+  id event2 = OCMClassMock([UIEvent class]);
   flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller);
   [forwardGectureRecognizer touchesBegan:touches2 withEvent:event2];
   OCMVerify([mockFlutterViewContoller touchesBegan:touches2 withEvent:event2]);
@@ -681,146 +681,176 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
       break;
     }
   }
-  UIViewController* mockFlutterViewContoller = OCMClassMock([UIViewController class]);
+  id mockFlutterViewContoller = OCMClassMock([UIViewController class]);
   {
     // ***** Sequence 1, finishing touch event with touchEnded ***** //
-
+    id event = OCMClassMock([UIEvent class]);
     flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller);
 
-    NSSet* touches1 = OCMClassMock([NSSet class]);
-    UIEvent* event1 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesBegan:touches1 withEvent:event1];
-    OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event1]);
+    NSSet* touches1 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesBegan:touches1 withEvent:event];
+    OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event]);
 
     flutterPlatformViewsController->SetFlutterViewController(nil);
 
     // Allow the touch events to finish
-    NSSet* touches2 = OCMClassMock([NSSet class]);
-    UIEvent* event2 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesMoved:touches2 withEvent:event2];
-    OCMVerify([mockFlutterViewContoller touchesMoved:touches2 withEvent:event2]);
+    NSSet* touches2 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesMoved:touches2 withEvent:event];
+    OCMVerify([mockFlutterViewContoller touchesMoved:touches2 withEvent:event]);
 
-    NSSet* touches3 = OCMClassMock([NSSet class]);
-    UIEvent* event3 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesEnded:touches3 withEvent:event3];
-    OCMVerify([mockFlutterViewContoller touchesEnded:touches3 withEvent:event3]);
+    NSSet* touches3 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesEnded:touches3 withEvent:event];
+    OCMVerify([mockFlutterViewContoller touchesEnded:touches3 withEvent:event]);
 
     // Now the 2nd touch sequence should not be allowed.
-    NSSet* touches4 = OCMClassMock([NSSet class]);
-    UIEvent* event4 = OCMClassMock([UIEvent class]);
-    mockFlutterViewContoller = OCMClassMock([UIViewController class]);
-    [forwardGectureRecognizer touchesBegan:touches4 withEvent:event4];
-    OCMReject([mockFlutterViewContoller touchesBegan:touches4 withEvent:event4]);
+    NSSet* touches4 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesBegan:touches4 withEvent:event];
+    OCMReject([mockFlutterViewContoller touchesBegan:touches4 withEvent:event]);
 
-    NSSet* touches5 = OCMClassMock([NSSet class]);
-    UIEvent* event5 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesEnded:touches5 withEvent:event5];
-    OCMReject([mockFlutterViewContoller touchesEnded:touches5 withEvent:event5]);
+    NSSet* touches5 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesEnded:touches5 withEvent:event];
+    OCMReject([mockFlutterViewContoller touchesEnded:touches5 withEvent:event]);
   }
 
   {
     // ***** Sequence 2, finishing touch event with touchCancelled ***** //
+    id event = OCMClassMock([UIEvent class]);
     flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller);
 
-    NSSet* touches1 = OCMClassMock([NSSet class]);
-    UIEvent* event1 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesBegan:touches1 withEvent:event1];
-    OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event1]);
+    NSSet* touches1 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesBegan:touches1 withEvent:event];
+    OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event]);
 
     flutterPlatformViewsController->SetFlutterViewController(nil);
 
     // Allow the touch events to finish
-    NSSet* touches2 = OCMClassMock([NSSet class]);
-    UIEvent* event2 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesMoved:touches2 withEvent:event2];
-    OCMVerify([mockFlutterViewContoller touchesMoved:touches2 withEvent:event2]);
+    NSSet* touches2 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesMoved:touches2 withEvent:event];
+    OCMVerify([mockFlutterViewContoller touchesMoved:touches2 withEvent:event]);
 
-    NSSet* touches3 = OCMClassMock([NSSet class]);
-    UIEvent* event3 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesCancelled:touches3 withEvent:event3];
-    OCMVerify([mockFlutterViewContoller touchesCancelled:touches3 withEvent:event3]);
+    NSSet* touches3 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesCancelled:touches3 withEvent:event];
+    OCMVerify([mockFlutterViewContoller touchesCancelled:touches3 withEvent:event]);
 
     // Now the 2nd touch sequence should not be allowed.
-    NSSet* touches4 = OCMClassMock([NSSet class]);
-    UIEvent* event4 = OCMClassMock([UIEvent class]);
-    mockFlutterViewContoller = OCMClassMock([UIViewController class]);
-    [forwardGectureRecognizer touchesBegan:touches4 withEvent:event4];
-    OCMReject([mockFlutterViewContoller touchesBegan:touches4 withEvent:event4]);
+    NSSet* touches4 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesBegan:touches4 withEvent:event];
+    OCMReject([mockFlutterViewContoller touchesBegan:touches4 withEvent:event]);
 
-    NSSet* touches5 = OCMClassMock([NSSet class]);
-    UIEvent* event5 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesEnded:touches5 withEvent:event5];
-    OCMReject([mockFlutterViewContoller touchesEnded:touches5 withEvent:event5]);
+    NSSet* touches5 = [[[NSSet alloc] init] autorelease];
+    [forwardGectureRecognizer touchesEnded:touches5 withEvent:event];
+    OCMReject([mockFlutterViewContoller touchesEnded:touches5 withEvent:event]);
   }
 
-  {
-    // ***** Sequence 3, multile touches in one sequence with setting flutter view controllers in
-    // between ***** //
-    flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller);
+  flutterPlatformViewsController->Reset();
+}
 
-    NSSet* touches1 = OCMClassMock([NSSet class]);
-    OCMStub([touches1 count]).andReturn(1);
-    UIEvent* event1 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesBegan:touches1 withEvent:event1];
-    OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event1]);
+- (void)
+    testSetFlutterViewControllerInTheMiddleOfTouchEventAllowsTheNewControllerToHandleSecondTouchSequence {
+  flutter::FlutterPlatformViewsTestMockPlatformViewDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("FlutterPlatformViewsTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto flutterPlatformViewsController = std::make_shared<flutter::FlutterPlatformViewsController>();
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*platform_views_controller=*/flutterPlatformViewsController,
+      /*task_runners=*/runners);
 
-    UIViewController* mockFlutterViewContoller2 = OCMClassMock([UIViewController class]);
-    flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller2);
+  FlutterPlatformViewsTestMockFlutterPlatformFactory* factory =
+      [[FlutterPlatformViewsTestMockFlutterPlatformFactory new] autorelease];
+  flutterPlatformViewsController->RegisterViewFactory(
+      factory, @"MockFlutterPlatformView",
+      FlutterPlatformViewGestureRecognizersBlockingPolicyEager);
+  FlutterResult result = ^(id result) {
+  };
+  flutterPlatformViewsController->OnMethodCall(
+      [FlutterMethodCall
+          methodCallWithMethodName:@"create"
+                         arguments:@{@"id" : @2, @"viewType" : @"MockFlutterPlatformView"}],
+      result);
 
-    // Touch events should still send to the old FlutterViewController if FlutterViewController
-    // is updated in between.
-    NSSet* touches2 = OCMClassMock([NSSet class]);
-    OCMStub([touches2 count]).andReturn(1);
-    UIEvent* event2 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesBegan:touches2 withEvent:event2];
-    OCMVerify([mockFlutterViewContoller touchesBegan:touches2 withEvent:event2]);
-    OCMReject([mockFlutterViewContoller2 touchesBegan:touches2 withEvent:event2]);
+  XCTAssertNotNil(gMockPlatformView);
 
-    NSSet* touches3 = OCMClassMock([NSSet class]);
-    OCMStub([touches3 count]).andReturn(1);
-    UIEvent* event3 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesMoved:touches3 withEvent:event3];
-    OCMVerify([mockFlutterViewContoller touchesMoved:touches3 withEvent:event3]);
-    OCMReject([mockFlutterViewContoller2 touchesMoved:touches3 withEvent:event3]);
-
-    NSSet* touches4 = OCMClassMock([NSSet class]);
-    OCMStub([touches4 count]).andReturn(1);
-    UIEvent* event4 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesEnded:touches4 withEvent:event4];
-    OCMVerify([mockFlutterViewContoller touchesEnded:touches4 withEvent:event4]);
-    OCMReject([mockFlutterViewContoller2 touchesEnded:touches4 withEvent:event4]);
-
-    NSSet* touches5 = OCMClassMock([NSSet class]);
-    OCMStub([touches5 count]).andReturn(1);
-    UIEvent* event5 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesEnded:touches5 withEvent:event5];
-    OCMVerify([mockFlutterViewContoller touchesEnded:touches5 withEvent:event5]);
-    OCMReject([mockFlutterViewContoller2 touchesEnded:touches5 withEvent:event5]);
-
-    // Now the 2nd touch sequence should go to the new FlutterViewController
-
-    NSSet* touches6 = OCMClassMock([NSSet class]);
-    OCMStub([touches6 count]).andReturn(1);
-    UIEvent* event6 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesBegan:touches6 withEvent:event6];
-    OCMVerify([mockFlutterViewContoller2 touchesBegan:touches6 withEvent:event6]);
-    OCMReject([mockFlutterViewContoller touchesBegan:touches6 withEvent:event6]);
-
-    // Allow the touch events to finish
-    NSSet* touches7 = OCMClassMock([NSSet class]);
-    OCMStub([touches7 count]).andReturn(1);
-    UIEvent* event7 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesMoved:touches7 withEvent:event7];
-    OCMVerify([mockFlutterViewContoller2 touchesMoved:touches7 withEvent:event7]);
-    OCMReject([mockFlutterViewContoller touchesMoved:touches7 withEvent:event7]);
-
-    NSSet* touches8 = OCMClassMock([NSSet class]);
-    OCMStub([touches8 count]).andReturn(1);
-    UIEvent* event8 = OCMClassMock([UIEvent class]);
-    [forwardGectureRecognizer touchesEnded:touches8 withEvent:event8];
-    OCMVerify([mockFlutterViewContoller2 touchesEnded:touches8 withEvent:event8]);
-    OCMReject([mockFlutterViewContoller touchesEnded:touches8 withEvent:event8]);
+  // Find touch inteceptor view
+  UIView* touchInteceptorView = gMockPlatformView;
+  while (touchInteceptorView != nil &&
+         ![touchInteceptorView isKindOfClass:[FlutterTouchInterceptingView class]]) {
+    touchInteceptorView = touchInteceptorView.superview;
   }
+  XCTAssertNotNil(touchInteceptorView);
+
+  // Find ForwardGestureRecognizer
+  UIGestureRecognizer* forwardGectureRecognizer = nil;
+  for (UIGestureRecognizer* gestureRecognizer in touchInteceptorView.gestureRecognizers) {
+    if ([gestureRecognizer isKindOfClass:NSClassFromString(@"ForwardingGestureRecognizer")]) {
+      forwardGectureRecognizer = gestureRecognizer;
+      break;
+    }
+  }
+  id mockFlutterViewContoller = OCMClassMock([UIViewController class]);
+
+  flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller);
+
+  // The touches in this sequence requires 1 touch object, we always create the NSSet with one item.
+  NSSet* touches1 = [NSSet setWithObject:@1];
+  id event1 = OCMClassMock([UIEvent class]);
+  [forwardGectureRecognizer touchesBegan:touches1 withEvent:event1];
+  OCMVerify([mockFlutterViewContoller touchesBegan:touches1 withEvent:event1]);
+
+  UIViewController* mockFlutterViewContoller2 = OCMClassMock([UIViewController class]);
+  flutterPlatformViewsController->SetFlutterViewController(mockFlutterViewContoller2);
+
+  // Touch events should still send to the old FlutterViewController if FlutterViewController
+  // is updated in between.
+  NSSet* touches2 = [NSSet setWithObject:@1];
+  id event2 = OCMClassMock([UIEvent class]);
+  [forwardGectureRecognizer touchesBegan:touches2 withEvent:event2];
+  OCMVerify([mockFlutterViewContoller touchesBegan:touches2 withEvent:event2]);
+  OCMReject([mockFlutterViewContoller2 touchesBegan:touches2 withEvent:event2]);
+
+  NSSet* touches3 = [NSSet setWithObject:@1];
+  id event3 = OCMClassMock([UIEvent class]);
+  [forwardGectureRecognizer touchesMoved:touches3 withEvent:event3];
+  OCMVerify([mockFlutterViewContoller touchesMoved:touches3 withEvent:event3]);
+  OCMReject([mockFlutterViewContoller2 touchesMoved:touches3 withEvent:event3]);
+
+  NSSet* touches4 = [NSSet setWithObject:@1];
+  id event4 = OCMClassMock([UIEvent class]);
+  [forwardGectureRecognizer touchesEnded:touches4 withEvent:event4];
+  OCMVerify([mockFlutterViewContoller touchesEnded:touches4 withEvent:event4]);
+  OCMReject([mockFlutterViewContoller2 touchesEnded:touches4 withEvent:event4]);
+
+  NSSet* touches5 = [NSSet setWithObject:@1];
+  id event5 = OCMClassMock([UIEvent class]);
+  [forwardGectureRecognizer touchesEnded:touches5 withEvent:event5];
+  OCMVerify([mockFlutterViewContoller touchesEnded:touches5 withEvent:event5]);
+  OCMReject([mockFlutterViewContoller2 touchesEnded:touches5 withEvent:event5]);
+
+  // Now the 2nd touch sequence should go to the new FlutterViewController
+
+  NSSet* touches6 = [NSSet setWithObject:@1];
+  id event6 = OCMClassMock([UIEvent class]);
+  [forwardGectureRecognizer touchesBegan:touches6 withEvent:event6];
+  OCMVerify([mockFlutterViewContoller2 touchesBegan:touches6 withEvent:event6]);
+  OCMReject([mockFlutterViewContoller touchesBegan:touches6 withEvent:event6]);
+
+  // Allow the touch events to finish
+  NSSet* touches7 = [NSSet setWithObject:@1];
+  id event7 = OCMClassMock([UIEvent class]);
+  [forwardGectureRecognizer touchesMoved:touches7 withEvent:event7];
+  OCMVerify([mockFlutterViewContoller2 touchesMoved:touches7 withEvent:event7]);
+  OCMReject([mockFlutterViewContoller touchesMoved:touches7 withEvent:event7]);
+
+  NSSet* touches8 = [NSSet setWithObject:@1];
+  id event8 = OCMClassMock([UIEvent class]);
+  [forwardGectureRecognizer touchesEnded:touches8 withEvent:event8];
+  OCMVerify([mockFlutterViewContoller2 touchesEnded:touches8 withEvent:event8]);
+  OCMReject([mockFlutterViewContoller touchesEnded:touches8 withEvent:event8]);
 
   flutterPlatformViewsController->Reset();
 }


### PR DESCRIPTION
## Description

This PR updates several places in `FlutterPlatformViewsTests`
1. Make the types of all the mock objects to be `id`.
2. Avoid mocking NSSet which is known for some weird crashes: see: https://github.com/flutter/flutter/issues/70843
3. Split the 3rd sequence in `testSetFlutterViewControllerInTheMiddleOfTouchEventShouldStillAllowGesturesToBeHandled` into a new test as they are testing things a little differently.

## Related Issues

My fixes https://github.com/flutter/flutter/issues/70843

## Tests

I added the following tests:

testSetFlutterViewControllerInTheMiddleOfTouchEventAllowsTheNewControllerToHandleSecondTouchSequence 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
