### PR TITLE
[web] Enable the new rich paragraph implementation

### DIFF
--- a/lib/web_ui/lib/src/engine/web_experiments.dart
+++ b/lib/web_ui/lib/src/engine/web_experiments.dart
@@ -45,7 +45,7 @@ class WebExperiments {
 
   static const bool _defaultUseCanvasRichText = const bool.fromEnvironment(
     'FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_RICH_TEXT',
-    defaultValue: false,
+    defaultValue: true,
   );
 
   bool _useCanvasRichText = _defaultUseCanvasRichText;

--- a/lib/web_ui/test/engine/web_experiments_test.dart
+++ b/lib/web_ui/test/engine/web_experiments_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 
 const bool _defaultUseCanvasText = true;
-const bool _defaultUseCanvasRichText = false;
+const bool _defaultUseCanvasRichText = true;
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -547,8 +547,8 @@ void _testCullRectComputation() {
     'renders clipped text with high quality',
     () async {
       // To reproduce blurriness we need real clipping.
-      final Paragraph paragraph =
-          (ParagraphBuilder(ParagraphStyle(fontFamily: 'Roboto'))..addText('Am I blurry?')).build();
+      final DomParagraph paragraph =
+          (DomParagraphBuilder(ParagraphStyle(fontFamily: 'Roboto'))..addText('Am I blurry?')).build();
       paragraph.layout(const ParagraphConstraints(width: 1000));
 
       final Rect canvasSize = Rect.fromLTRB(


### PR DESCRIPTION
## Description

This PR turns on the new rich text implementation by default.

It's still possible to opt-out by passing `false` to the flag:
```
flutter run -d chrome --release --dart-define=FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_RICH_TEXT=false
```

## Related Issues

Fixes https://github.com/flutter/flutter/issues/55587
Fixes https://github.com/flutter/flutter/issues/39226
Fixes https://github.com/flutter/flutter/issues/61992
Fixes https://github.com/flutter/flutter/issues/63638
Fixes https://github.com/flutter/flutter/issues/66089
Fixes https://github.com/flutter/flutter/issues/71176