### PR TITLE
Fix background crash when FlutterView going appear while app goes background

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -626,12 +626,10 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
   TRACE_EVENT0("flutter", "viewDidAppear");
   [self onUserSettingsChanged:nil];
   [self onAccessibilityStatusChanged:nil];
-  [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
-
-  [super viewDidAppear:animated];
-  if (UIApplication.sharedApplication.applicationState == UIApplicationStateBackground) {
-    [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.paused"];
+  if (UIApplication.sharedApplication.applicationState == UIApplicationStateActive) {
+    [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
   }
+  [super viewDidAppear:animated];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -629,6 +629,9 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
 
   [super viewDidAppear:animated];
+  if (UIApplication.sharedApplication.applicationState == UIApplicationStateBackground) {
+    [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.paused"];
+  }
 }
 
 - (void)viewWillDisappear:(BOOL)animated {


### PR DESCRIPTION


## Description

On some old iOS device, such as iPhone 6 or iPhone 6 Plus which runs on iOS 12.0+, when user choose a flutter view and that flutter view is going to present, and immediately user take a phone call or other stuff makes app goes to background, due to the currently wrongly LifeCycle, which is `AppLifecycleState.resumed`, Flutter Engine will continue to call on Metal Renderer to render new frames, that violates iOS's no background render policy and cause a crash.

With this PR, after view appeared, we recheck the Application state, if it's in background, we set the LifeCycle status right.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x ] I signed the [CLA].
- [x ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x ] I updated/added relevant documentation.
- [x ] All existing and new tests are passing.
- [x ] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
