### PR TITLE
Load App.framework in macOS app

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -32,6 +32,9 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
     _dartBundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
                                               URLByAppendingPathComponent:@"App.framework"]];
   }
+  if (!_dartBundle.loaded) {
+    [_dartBundle load];
+  }
   _dartEntrypointArguments = [[NSProcessInfo processInfo] arguments];
   // Remove the first element as it's the binary name
   _dartEntrypointArguments = [_dartEntrypointArguments

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -32,7 +32,7 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
     _dartBundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
                                               URLByAppendingPathComponent:@"App.framework"]];
   }
-  if (!_dartBundle.loaded) {
+  if (!_dartBundle.isLoaded) {
     [_dartBundle load];
   }
   _dartEntrypointArguments = [[NSProcessInfo processInfo] arguments];


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/71764  stopped explicitly linking the App.framework into the macOS app, which means the bundle isn't loaded (no longer `LC_LOAD_DYLIB`).

In release, this is causing `native_library_->ResolveSymbol(symbol_name)` to return `nullptr`.
https://github.com/flutter/engine/blob/fff415d517d641a9e750d4a2c7e643262e130068/fml/mapping.cc#L111

There are too many places that expect the App.framework to be loaded in the process.  Just load the bundle to mimic the behavior pre-https://github.com/flutter/flutter/pull/71764.

## Related Issues

Follow up to https://github.com/flutter/engine/pull/22979
Fixes https://github.com/flutter/flutter/issues/72585

## Tests

Add a `flutter run --release` macOS test to the framework: https://github.com/flutter/flutter/issues/72743
Add a macos scenario app: https://github.com/flutter/flutter/issues/72744