### PR TITLE
fuchsia: Shutdown Dart VM properly

### DIFF
--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -170,50 +170,6 @@ class Shell final : public PlatformView::Delegate,
       CreateCallback<Rasterizer> on_create_rasterizer);
 
   //----------------------------------------------------------------------------
-  /// @brief      Creates a shell instance using the provided settings. The
-  ///             callbacks to create the various shell subcomponents will be
-  ///             called on the appropriate threads before this method returns.
-  ///             Unlike the simpler variant of this factory method, this method
-  ///             allows for the specification of an isolate snapshot that
-  ///             cannot be adequately described in the settings. This call also
-  ///             requires the specification of a running VM instance.
-  ///
-  /// @param[in]  task_runners             The task runners
-  /// @param[in]  platform_data            The default data for setting up
-  ///                                      ui.Window that attached to this
-  ///                                      intance.
-  /// @param[in]  settings                 The settings
-  /// @param[in]  isolate_snapshot         A custom isolate snapshot. Takes
-  ///                                      precedence over any snapshots
-  ///                                      specified in the settings.
-  /// @param[in]  on_create_platform_view  The callback that must return a
-  ///                                      platform view. This will be called on
-  ///                                      the platform task runner before this
-  ///                                      method returns.
-  /// @param[in]  on_create_rasterizer     That callback that must provide a
-  ///                                      valid rasterizer. This will be called
-  ///                                      on the render task runner before this
-  ///                                      method returns.
-  /// @param[in]  vm                       A running VM instance.
-  ///
-  /// @return     A full initialized shell if the settings and callbacks are
-  ///             valid. The root isolate has been created but not yet launched.
-  ///             It may be launched by obtaining the engine weak pointer and
-  ///             posting a task onto the UI task runner with a valid run
-  ///             configuration to run the isolate. The embedder must always
-  ///             check the validity of the shell (using the IsSetup call)
-  ///             immediately after getting a pointer to it.
-  ///
-  static std::unique_ptr<Shell> Create(
-      TaskRunners task_runners,
-      const PlatformData platform_data,
-      Settings settings,
-      fml::RefPtr<const DartSnapshot> isolate_snapshot,
-      const CreateCallback<PlatformView>& on_create_platform_view,
-      const CreateCallback<Rasterizer>& on_create_rasterizer,
-      DartVMRef vm);
-
-  //----------------------------------------------------------------------------
   /// @brief      Destroys the shell. This is a synchronous operation and
   ///             synchronous barrier blocks are introduced on the various
   ///             threads to ensure shutdown of all shell sub-components before

--- a/shell/platform/fuchsia/flutter/component.h
+++ b/shell/platform/fuchsia/flutter/component.h
@@ -21,10 +21,10 @@
 #include <lib/vfs/cpp/pseudo_dir.h>
 #include <lib/zx/eventpair.h>
 
-#include "engine.h"
 #include "flutter/common/settings.h"
 #include "flutter/fml/macros.h"
 
+#include "engine.h"
 #include "flutter_runner_product_configuration.h"
 #include "thread.h"
 #include "unique_fdio_ns.h"
@@ -131,8 +131,6 @@ class Application final : public Engine::Delegate,
 
   // |flutter::Engine::Delegate|
   void OnEngineTerminate(const Engine* holder) override;
-
-  void AttemptVMLaunchWithCurrentSettings(const flutter::Settings& settings);
 
   FML_DISALLOW_COPY_AND_ASSIGN(Application);
 };

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -16,7 +16,7 @@
 #include <lib/ui/scenic/cpp/view_ref_pair.h>
 #include <lib/zx/event.h>
 
-#include "flow/embedded_views.h"
+#include "flutter/flow/embedded_views.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/common/shell.h"
@@ -52,7 +52,6 @@ class Engine final {
          std::shared_ptr<sys::ServiceDirectory> svc,
          std::shared_ptr<sys::ServiceDirectory> runner_services,
          flutter::Settings settings,
-         fml::RefPtr<const flutter::DartSnapshot> isolate_snapshot,
          fuchsia::ui::views::ViewToken view_token,
          scenic::ViewRefPair view_ref_pair,
          UniqueFDIONS fdio_ns,


### PR DESCRIPTION
## Description

Fuchsia's flutter_runner currently leaks the Dart VM, which means none of the internal Dart shutdown code runs.  It is bad for this code to not run and causes some crashes on shutdown.  Rectify this.

## Related Issues

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=64526
