### PR TITLE
Revert "Re-merge Switch web-render option default to auto. Add documentation"

### DIFF
--- a/lib/web_ui/dev/README.md
+++ b/lib/web_ui/dev/README.md
@@ -49,8 +49,6 @@ To run unit tests only:
 felt test --unit-tests-only
 ```
 
-Most of the unit tests are run using the html rendering backends. The unit tests under `test/cancaskit` directory use `canvaskit` backend.
-
 To run integration tests only. For now these tests are only available on Chrome Desktop browsers. These tests will fetch the flutter repository for using `flutter drive` and `flutter pub get` commands. The repository will be synced to the youngest commit older than the engine commit.
 
 ```
@@ -61,12 +59,6 @@ To skip cloning the flutter repository use the following flag. This flag can sav
 
 ```
 felt test --integration-tests-only --use-system-flutter
-```
-
-We can use different rendering backends for running the integrations tests. If one wants to use html backend use the following command. `web-renderer` flag accepts 3 different options: `html`, `canvaskit`, `auto`.
-
-```
-felt test --integration-tests-only --web-renderer=html
 ```
 
 To run tests on Firefox (this will work only on a Linux device):

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -619,8 +619,6 @@ class TestCommand extends Command<bool> with ArgUtils {
       '--enable-experiment=non-nullable',
       '--no-sound-null-safety',
       if (input.forCanvasKit) '-DFLUTTER_WEB_USE_SKIA=true',
-      if (!input.forCanvasKit) '-DFLUTTER_WEB_AUTO_DETECT=false',
-      if (!input.forCanvasKit) '-DFLUTTER_WEB_USE_SKIA=false',
       '-O2',
       '-o',
       targetFileName, // target path.

--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -31,7 +31,7 @@ bool _detectRenderer() {
 /// Using flutter tools option "--web-render=auto" would set the value to true.
 /// Otherwise, it would be false.
 const bool _autoDetect =
-    bool.fromEnvironment('FLUTTER_WEB_AUTO_DETECT', defaultValue: true);
+    bool.fromEnvironment('FLUTTER_WEB_AUTO_DETECT', defaultValue: false);
 
 /// Enable the Skia-based rendering backend.
 ///


### PR DESCRIPTION
Reverts flutter/engine#23187

Looks like these changes still blocks the engine roll, example: https://github.com/flutter/flutter/pull/72810

These two builders are failing (even after we started using '--dart-define=FLUTTER_WEB_USE_SKIA=false',)

https://ci.chromium.org/p/flutter/builders/try/Linux%20web_benchmarks_html/1718?
https://ci.chromium.org/p/flutter/builders/try/Linux%20web_tests/7676?

