### PR TITLE
fixes text area transitions both for mobile and desktop

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -582,6 +582,10 @@ class SemanticsObject {
       hasAction(ui.SemanticsAction.scrollDown) ||
       hasAction(ui.SemanticsAction.scrollUp);
 
+  bool get hasFocus => hasFlag(ui.SemanticsFlag.isFocused);
+  // bool get looseFocus => hasAction(ui.SemanticsAction.didLoseAccessibilityFocus);
+  // bool get gainFocus => hasAction(ui.SemanticsAction.didGainAccessibilityFocus);
+
   /// Whether this object represents a hotizontally scrollable area.
   bool get isHorizontalScrollContainer =>
       hasAction(ui.SemanticsAction.scrollLeft) ||
@@ -732,6 +736,9 @@ class SemanticsObject {
     // Apply updates to the DOM.
     _updateRoles();
     _updateChildrenInTraversalOrder();
+
+
+    // print('has focus: ${hasFocus}');
 
     // All properties that affect positioning and sizing are checked together
     // any one of them triggers position and size recomputation.

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -583,8 +583,6 @@ class SemanticsObject {
       hasAction(ui.SemanticsAction.scrollUp);
 
   bool get hasFocus => hasFlag(ui.SemanticsFlag.isFocused);
-  // bool get looseFocus => hasAction(ui.SemanticsAction.didLoseAccessibilityFocus);
-  // bool get gainFocus => hasAction(ui.SemanticsAction.didGainAccessibilityFocus);
 
   /// Whether this object represents a hotizontally scrollable area.
   bool get isHorizontalScrollContainer =>
@@ -736,9 +734,6 @@ class SemanticsObject {
     // Apply updates to the DOM.
     _updateRoles();
     _updateChildrenInTraversalOrder();
-
-
-    // print('has focus: ${hasFocus}');
 
     // All properties that affect positioning and sizing are checked together
     // any one of them triggers position and size recomputation.

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -198,7 +198,6 @@ class TextField extends RoleManager {
     num? lastTouchStartOffsetY;
 
     _textFieldElement.addEventListener('touchstart', (html.Event event) {
-      print('touch start');
       textEditing.useCustomEditableElement(textEditingElement);
       final html.TouchEvent touchEvent = event as html.TouchEvent;
       lastTouchStartOffsetX = touchEvent.changedTouches!.last.client.x;

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -98,8 +98,6 @@ class SemanticsTextEditingStrategy extends DefaultTextEditingStrategy {
   }
 }
 
-EditingState previousText = EditingState.empty();
-
 /// Manages semantics objects that represent editable text fields.
 ///
 /// This role is implemented via a content-editable HTML element. This role does
@@ -109,7 +107,6 @@ EditingState previousText = EditingState.empty();
 /// used to detect text box invocation. This is because Safari issues touch
 /// events even when Voiceover is enabled.
 class TextField extends RoleManager {
-  bool previouslyFocused = false;
   TextField(SemanticsObject semanticsObject)
       : super(Role.textField, semanticsObject) {
     final html.HtmlElement editableDomElement =
@@ -120,7 +117,6 @@ class TextField extends RoleManager {
       textEditing,
       editableDomElement,
     );
-    previouslyFocused = semanticsObject.hasFocus;
     _setupDomElement();
   }
 

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -193,10 +193,16 @@ class TextField extends RoleManager {
   /// events are present regardless of whether accessibility is enabled or not,
   /// this mode is always enabled.
   void _initializeForWebkit() {
+    // Safari for desktop is also initialized as the other browsers.
+    if (operatingSystem == OperatingSystem.macOs) {
+       _initializeForBlink();
+       return;
+    }
     num? lastTouchStartOffsetX;
     num? lastTouchStartOffsetY;
 
     _textFieldElement.addEventListener('touchstart', (html.Event event) {
+      print('touch start');
       textEditing.useCustomEditableElement(textEditingElement);
       final html.TouchEvent touchEvent = event as html.TouchEvent;
       lastTouchStartOffsetX = touchEvent.changedTouches!.last.client.x;

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -431,6 +431,12 @@ class EditingState {
     }
   }
 
+  /// Creates an [EditingState] with empty text and no selection.
+  factory EditingState.empty() {
+    return EditingState(text: '', baseOffset: 0, extentOffset: 0);
+  }
+
+
   /// The counterpart of [EditingState.fromFrameworkMessage]. It generates a Map that
   /// can be sent to Flutter.
   // TODO(mdebbar): Should we get `selectionAffinity` and other properties from flutter's editing state?

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -431,12 +431,6 @@ class EditingState {
     }
   }
 
-  /// Creates an [EditingState] with empty text and no selection.
-  factory EditingState.empty() {
-    return EditingState(text: '', baseOffset: 0, extentOffset: 0);
-  }
-
-
   /// The counterpart of [EditingState.fromFrameworkMessage]. It generates a Map that
   /// can be sent to Flutter.
   // TODO(mdebbar): Should we get `selectionAffinity` and other properties from flutter's editing state?

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -384,7 +384,7 @@ void testMain() {
       );
     });
 
-    test('Re-acquire focus', () {
+    test('Do not re-acquire focus', () {
       editingElement =
           SemanticsTextEditingStrategy(HybridTextEditing(), testInputElement);
 
@@ -398,17 +398,14 @@ void testMain() {
       );
       expect(document.activeElement, testInputElement);
 
-      // The input should refocus after blur.
+      // The input should not refocus after blur.
       editingElement.domElement.blur();
-      expect(document.activeElement, editingElement.domElement);
+      expect(document.activeElement, document.body);
 
       editingElement.disable();
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: (browserEngine == BrowserEngine.webkit ||
-            browserEngine == BrowserEngine.edge ||
-            browserEngine == BrowserEngine.firefox));
+        skip: browserEngine == BrowserEngine.edge);
 
     test('Does not dispose and recreate dom elements in persistent mode', () {
       editingElement =
@@ -443,17 +440,18 @@ void testMain() {
       // It doesn't remove the DOM element.
       expect(editingElement.domElement, testInputElement);
       expect(document.body.contains(editingElement.domElement), isTrue);
-      // The textArea does not lose focus.
-      // Even though this passes on manual tests it does not work on
-      // Firefox automated unit tests.
-      if (browserEngine != BrowserEngine.firefox) {
+      // Editing element is not enabled.
+      expect(editingElement.isEnabled, isFalse);
+      // For mobile browsers `blur` is called to close the onscreen keyboard.
+      if (operatingSystem == OperatingSystem.iOs &&
+          browserEngine == BrowserEngine.webkit) {
+        expect(document.activeElement, document.body);
+      } else {
         expect(document.activeElement, editingElement.domElement);
       }
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: (browserEngine == BrowserEngine.webkit ||
-            browserEngine == BrowserEngine.edge));
+        skip: browserEngine == BrowserEngine.edge);
 
     test('Refocuses when setting editing state', () {
       editingElement =
@@ -471,10 +469,8 @@ void testMain() {
 
       editingElement.disable();
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: (browserEngine == BrowserEngine.webkit ||
-            browserEngine == BrowserEngine.edge));
+        skip: browserEngine == BrowserEngine.edge);
 
     test('Works in multi-line mode', () {
       final TextAreaElement textarea = TextAreaElement();
@@ -504,21 +500,17 @@ void testMain() {
       expect(document.activeElement, textarea);
 
       textarea.blur();
-      // The textArea does not lose focus.
-      // Even though this passes on manual tests it does not work on
-      // Firefox automated unit tests.
-      if (browserEngine != BrowserEngine.firefox) {
-        expect(document.activeElement, textarea);
-      }
+      // The textArea loses focus.
+      expect(document.activeElement, document.body);
 
       editingElement.disable();
       // It doesn't remove the textarea from the DOM.
       expect(document.body.contains(editingElement.domElement), isTrue);
+      // Editing element is not enabled.
+      expect(editingElement.isEnabled, isFalse);
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: (browserEngine == BrowserEngine.webkit ||
-            browserEngine == BrowserEngine.edge));
+        skip: browserEngine == BrowserEngine.edge);
 
     test('Does not position or size its DOM element', () {
       editingElement.enable(


### PR DESCRIPTION
## Description

Currently there is an error for the transitions between text fields for both desktop and mobile browsers when semantics mode is enabled. This PR fixes those errors, also enables semantics text editing tests on firefox, safari desktop and ios-safari.

Note that there are different code path for different form factors and operating systems. Summary:
-> ios webkit is initialized with a touch start
-> all the other browsers including macOS webkit is initialized with focus
-> mobile browser call blur to close the onscreen keyboard when the text field is disabled. 

## Related Issues

Fixes: https://github.com/flutter/flutter/issues/72894

## Tests

Changed the tests in text_editing_test.dart

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
