### PR TITLE
fix memory leaks in fml/message.cc

### DIFF
--- a/fml/message.cc
+++ b/fml/message.cc
@@ -21,6 +21,7 @@ Message::~Message() {
   }
 }
 
+
 static uint32_t NextPowerOfTwoSize(uint32_t x) {
   if (x == 0) {
     return 1;

--- a/fml/message.cc
+++ b/fml/message.cc
@@ -21,7 +21,6 @@ Message::~Message() {
   }
 }
 
-
 static uint32_t NextPowerOfTwoSize(uint32_t x) {
   if (x == 0) {
     return 1;

--- a/fml/message.cc
+++ b/fml/message.cc
@@ -12,9 +12,14 @@ size_t MessageSerializable::GetSerializableTag() const {
   return 0;
 };
 
-Message::Message() = default;
+Message::Message() : buffer_(nullptr) {}
 
-Message::~Message() = default;
+Message::~Message() {
+  if (buffer_) {
+    free(buffer_);
+    buffer_ = nullptr;
+  }
+}
 
 static uint32_t NextPowerOfTwoSize(uint32_t x) {
   if (x == 0) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12612898/103116139-4d44d380-46a0-11eb-9a56-35fef90941c0.png)

Memory alloced in Message::Resize by malloc/realloc, but without free it