### PR TITLE
[web] Prevent recycling canvas twice due to paint queue

### DIFF
--- a/lib/web_ui/lib/src/engine/html/picture.dart
+++ b/lib/web_ui/lib/src/engine/html/picture.dart
@@ -51,7 +51,11 @@ class _PaintRequest {
 List<_PaintRequest> _paintQueue = <_PaintRequest>[];
 
 void _recycleCanvas(EngineCanvas? canvas) {
-  assert(canvas == null || !_recycledCanvases.contains(canvas));
+  /// If a canvas is in the paint queue it maybe be recycled. To
+  /// prevent subsequence dispose recycling again check.
+  if (canvas != null && _recycledCanvases.contains(canvas)) {
+    return;
+  }
   if (canvas is BitmapCanvas) {
     canvas.setElementCache(null);
     if (canvas.isReusable()) {

--- a/lib/web_ui/lib/src/engine/html/picture.dart
+++ b/lib/web_ui/lib/src/engine/html/picture.dart
@@ -51,8 +51,8 @@ class _PaintRequest {
 List<_PaintRequest> _paintQueue = <_PaintRequest>[];
 
 void _recycleCanvas(EngineCanvas? canvas) {
-  /// If a canvas is in the paint queue it maybe be recycled. To
-  /// prevent subsequent dispose recycling again check.
+  // If a canvas is in the paint queue it maybe be recycled. To
+  // prevent subsequent dispose recycling again check.
   if (canvas != null && _recycledCanvases.contains(canvas)) {
     return;
   }

--- a/lib/web_ui/lib/src/engine/html/picture.dart
+++ b/lib/web_ui/lib/src/engine/html/picture.dart
@@ -52,7 +52,7 @@ List<_PaintRequest> _paintQueue = <_PaintRequest>[];
 
 void _recycleCanvas(EngineCanvas? canvas) {
   /// If a canvas is in the paint queue it maybe be recycled. To
-  /// prevent subsequence dispose recycling again check.
+  /// prevent subsequent dispose recycling again check.
   if (canvas != null && _recycledCanvases.contains(canvas)) {
     return;
   }


### PR DESCRIPTION
## Description

Changes recycleCanvas so it can be called multiple times. Race condition when scrolling quickly causes multiple instances to be placed in paint queue. The paint queue recycling before a dispose recycle is now allowed.

## Related Issues

https://github.com/flutter/flutter/issues/72171

## Tests

see https://github.com/flutter/flutter/issues/73051

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
