### PR TITLE
Switch to new virtuals on SkCanvas

### DIFF
--- a/shell/common/canvas_spy.cc
+++ b/shell/common/canvas_spy.cc
@@ -125,6 +125,7 @@ void DidDrawCanvas::onDrawPath(const SkPath& path, const SkPaint& paint) {
   MarkDrawIfNonTransparentPaint(paint);
 }
 
+#ifdef SK_SUPPORT_LEGACY_ONDRAWIMAGERECT
 void DidDrawCanvas::onDrawImage(const SkImage* image,
                                 SkScalar left,
                                 SkScalar top,
@@ -140,17 +141,47 @@ void DidDrawCanvas::onDrawImageRect(const SkImage* image,
   did_draw_ = true;
 }
 
-void DidDrawCanvas::onDrawImageNine(const SkImage* image,
-                                    const SkIRect& center,
-                                    const SkRect& dst,
-                                    const SkPaint* paint) {
-  did_draw_ = true;
-}
-
 void DidDrawCanvas::onDrawImageLattice(const SkImage* image,
                                        const Lattice& lattice,
                                        const SkRect& dst,
                                        const SkPaint* paint) {
+  did_draw_ = true;
+}
+
+void DidDrawCanvas::onDrawAtlas(const SkImage* image,
+                                const SkRSXform xform[],
+                                const SkRect tex[],
+                                const SkColor colors[],
+                                int count,
+                                SkBlendMode bmode,
+                                const SkRect* cull,
+                                const SkPaint* paint) {
+  did_draw_ = true;
+}
+#endif
+
+void DidDrawCanvas::onDrawImage2(const SkImage* image,
+                                 SkScalar left,
+                                 SkScalar top,
+                                 const SkSamplingOptions&,
+                                 const SkPaint* paint) {
+  did_draw_ = true;
+}
+
+void DidDrawCanvas::onDrawImageRect2(const SkImage* image,
+                                     const SkRect& src,
+                                     const SkRect& dst,
+                                     const SkSamplingOptions&,
+                                     const SkPaint* paint,
+                                     SrcRectConstraint constraint) {
+  did_draw_ = true;
+}
+
+void DidDrawCanvas::onDrawImageLattice2(const SkImage* image,
+                                        const Lattice& lattice,
+                                        const SkRect& dst,
+                                        SkFilterMode,
+                                        const SkPaint* paint) {
   did_draw_ = true;
 }
 
@@ -186,14 +217,15 @@ void DidDrawCanvas::onDrawPatch(const SkPoint cubics[12],
   MarkDrawIfNonTransparentPaint(paint);
 }
 
-void DidDrawCanvas::onDrawAtlas(const SkImage* image,
-                                const SkRSXform xform[],
-                                const SkRect tex[],
-                                const SkColor colors[],
-                                int count,
-                                SkBlendMode bmode,
-                                const SkRect* cull,
-                                const SkPaint* paint) {
+void DidDrawCanvas::onDrawAtlas2(const SkImage* image,
+                                 const SkRSXform xform[],
+                                 const SkRect tex[],
+                                 const SkColor colors[],
+                                 int count,
+                                 SkBlendMode bmode,
+                                 const SkSamplingOptions&,
+                                 const SkRect* cull,
+                                 const SkPaint* paint) {
   did_draw_ = true;
 }
 

--- a/shell/common/canvas_spy.h
+++ b/shell/common/canvas_spy.h
@@ -127,11 +127,12 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawPath(const SkPath&, const SkPaint&) override;
 
+#ifdef SK_SUPPORT_LEGACY_ONDRAWIMAGERECT
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawImage(const SkImage*,
                    SkScalar left,
                    SkScalar top,
-                   const SkPaint*) override;
+                    const SkPaint*) override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawImageRect(const SkImage*,
@@ -147,17 +148,6 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
                           const SkPaint*) override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
-  void onDrawImageNine(const SkImage*,
-                       const SkIRect& center,
-                       const SkRect& dst,
-                       const SkPaint*) override;
-
-  // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
-  void onDrawVerticesObject(const SkVertices*,
-                            SkBlendMode,
-                            const SkPaint&) override;
-
-  // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawAtlas(const SkImage*,
                    const SkRSXform[],
                    const SkRect[],
@@ -166,6 +156,45 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
                    SkBlendMode,
                    const SkRect*,
                    const SkPaint*) override;
+#endif
+
+  // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
+  void onDrawImage2(const SkImage*,
+                    SkScalar left,
+                    SkScalar top,
+                    const SkSamplingOptions&,
+                    const SkPaint*) override;
+
+  // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
+  void onDrawImageRect2(const SkImage*,
+                        const SkRect& src,
+                        const SkRect& dst,
+                        const SkSamplingOptions&,
+                        const SkPaint*,
+                        SrcRectConstraint) override;
+
+  // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
+  void onDrawImageLattice2(const SkImage*,
+                           const Lattice&,
+                           const SkRect&,
+                           SkFilterMode,
+                           const SkPaint*) override;
+
+  // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
+  void onDrawVerticesObject(const SkVertices*,
+                            SkBlendMode,
+                            const SkPaint&) override;
+
+  // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
+  void onDrawAtlas2(const SkImage*,
+                    const SkRSXform[],
+                    const SkRect[],
+                    const SkColor[],
+                    int,
+                    SkBlendMode,
+                    const SkSamplingOptions&,
+                    const SkRect*,
+                    const SkPaint*) override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawShadowRec(const SkPath&, const SkDrawShadowRec&) override;

--- a/shell/common/canvas_spy.h
+++ b/shell/common/canvas_spy.h
@@ -132,7 +132,7 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
   void onDrawImage(const SkImage*,
                    SkScalar left,
                    SkScalar top,
-                    const SkPaint*) override;
+                   const SkPaint*) override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawImageRect(const SkImage*,

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -230,32 +230,28 @@ void MockCanvas::onDrawRRect(const SkRRect&, const SkPaint&) {
   FML_DCHECK(false);
 }
 
-void MockCanvas::onDrawImage(const SkImage*,
-                             SkScalar,
-                             SkScalar,
-                             const SkPaint*) {
+void MockCanvas::onDrawImage2(const SkImage*,
+                              SkScalar,
+                              SkScalar,
+                              const SkSamplingOptions&,
+                              const SkPaint*) {
   FML_DCHECK(false);
 }
 
-void MockCanvas::onDrawImageRect(const SkImage*,
-                                 const SkRect*,
-                                 const SkRect&,
-                                 const SkPaint*,
-                                 SrcRectConstraint) {
+void MockCanvas::onDrawImageRect2(const SkImage*,
+                                  const SkRect&,
+                                  const SkRect&,
+                                  const SkSamplingOptions&,
+                                  const SkPaint*,
+                                  SrcRectConstraint) {
   FML_DCHECK(false);
 }
 
-void MockCanvas::onDrawImageNine(const SkImage*,
-                                 const SkIRect&,
-                                 const SkRect&,
-                                 const SkPaint*) {
-  FML_DCHECK(false);
-}
-
-void MockCanvas::onDrawImageLattice(const SkImage*,
-                                    const Lattice&,
-                                    const SkRect&,
-                                    const SkPaint*) {
+void MockCanvas::onDrawImageLattice2(const SkImage*,
+                                     const Lattice&,
+                                     const SkRect&,
+                                     SkFilterMode,
+                                     const SkPaint*) {
   FML_DCHECK(false);
 }
 
@@ -265,14 +261,15 @@ void MockCanvas::onDrawVerticesObject(const SkVertices*,
   FML_DCHECK(false);
 }
 
-void MockCanvas::onDrawAtlas(const SkImage*,
-                             const SkRSXform[],
-                             const SkRect[],
-                             const SkColor[],
-                             int,
-                             SkBlendMode,
-                             const SkRect*,
-                             const SkPaint*) {
+void MockCanvas::onDrawAtlas2(const SkImage*,
+                              const SkRSXform[],
+                              const SkRect[],
+                              const SkColor[],
+                              int,
+                              SkBlendMode,
+                              const SkSamplingOptions&,
+                              const SkRect*,
+                              const SkPaint*) {
   FML_DCHECK(false);
 }
 

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -198,34 +198,34 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
                  bool,
                  const SkPaint&) override;
   void onDrawRRect(const SkRRect&, const SkPaint&) override;
-  void onDrawImage(const SkImage* image,
-                   SkScalar x,
-                   SkScalar y,
-                   const SkPaint* paint) override;
-  void onDrawImageRect(const SkImage*,
-                       const SkRect*,
-                       const SkRect&,
-                       const SkPaint*,
-                       SrcRectConstraint) override;
-  void onDrawImageNine(const SkImage*,
-                       const SkIRect&,
-                       const SkRect&,
-                       const SkPaint*) override;
-  void onDrawImageLattice(const SkImage*,
-                          const Lattice&,
-                          const SkRect&,
-                          const SkPaint*) override;
+  void onDrawImage2(const SkImage* image,
+                    SkScalar x,
+                    SkScalar y,
+                    const SkSamplingOptions&,
+                    const SkPaint* paint) override;
+  void onDrawImageRect2(const SkImage*,
+                        const SkRect&,
+                        const SkRect&,
+                        const SkSamplingOptions&,
+                        const SkPaint*,
+                        SrcRectConstraint) override;
+  void onDrawImageLattice2(const SkImage*,
+                           const Lattice&,
+                           const SkRect&,
+                           SkFilterMode,
+                           const SkPaint*) override;
   void onDrawVerticesObject(const SkVertices*,
                             SkBlendMode,
                             const SkPaint&) override;
-  void onDrawAtlas(const SkImage*,
-                   const SkRSXform[],
-                   const SkRect[],
-                   const SkColor[],
-                   int,
-                   SkBlendMode,
-                   const SkRect*,
-                   const SkPaint*) override;
+  void onDrawAtlas2(const SkImage*,
+                    const SkRSXform[],
+                    const SkRect[],
+                    const SkColor[],
+                    int,
+                    SkBlendMode,
+                    const SkSamplingOptions&,
+                    const SkRect*,
+                    const SkPaint*) override;
   void onDrawEdgeAAQuad(const SkRect&,
                         const SkPoint[4],
                         QuadAAFlags,


### PR DESCRIPTION
SkCanvas has updated virtuals dealing with images and sampling. Switch over to those.

In the end, we should remove these overrides if possible.
https://bugs.chromium.org/p/skia/issues/detail?id=11126