### PR TITLE
[web] fixing text editing for autofill with semantics

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -927,6 +927,7 @@ class SemanticsObject {
           ..height = '${rect.height}px';
       }
     } else {
+      // This condition creates a issue in scrolling.
       if (isDesktop) {
         element.style
           ..removeProperty('transform-origin')

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -927,7 +927,7 @@ class SemanticsObject {
           ..height = '${rect.height}px';
       }
     } else {
-      // This condition creates a issue in scrolling.
+      // TODO: https://github.com/flutter/flutter/issues/73347
       if (isDesktop) {
         element.style
           ..removeProperty('transform-origin')

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -384,7 +384,7 @@ void testMain() {
 
     test('autofill form lifecycle works', () async {
       editingElement = SemanticsTextEditingStrategy(
-          new SemanticsObject(5, null), testTextEditing, testInputElement);
+          SemanticsObject(5, null), testTextEditing, testInputElement);
       // Create a configuration with an AutofillGroup of four text fields.
       final Map<String, dynamic> flutterMultiAutofillElementConfig =
           createFlutterConfig('text',
@@ -445,14 +445,14 @@ void testMain() {
       final HtmlElement span = SpanElement();
       expect(
         () => SemanticsTextEditingStrategy(
-            new SemanticsObject(5, null), HybridTextEditing(), span),
+            SemanticsObject(5, null), HybridTextEditing(), span),
         throwsAssertionError,
       );
     });
 
     test('Do not re-acquire focus', () {
       editingElement = SemanticsTextEditingStrategy(
-          new SemanticsObject(5, null), HybridTextEditing(), testInputElement);
+          SemanticsObject(5, null), HybridTextEditing(), testInputElement);
 
       expect(document.activeElement, document.body);
 
@@ -475,7 +475,7 @@ void testMain() {
 
     test('Does not dispose and recreate dom elements in persistent mode', () {
       editingElement = SemanticsTextEditingStrategy(
-          new SemanticsObject(5, null), HybridTextEditing(), testInputElement);
+          SemanticsObject(5, null), HybridTextEditing(), testInputElement);
 
       // The DOM element should've been eagerly created.
       expect(testInputElement, isNotNull);
@@ -521,7 +521,7 @@ void testMain() {
 
     test('Refocuses when setting editing state', () {
       editingElement = SemanticsTextEditingStrategy(
-          new SemanticsObject(5, null), HybridTextEditing(), testInputElement);
+          SemanticsObject(5, null), HybridTextEditing(), testInputElement);
 
       document.body.append(testInputElement);
       editingElement.enable(
@@ -541,7 +541,7 @@ void testMain() {
     test('Works in multi-line mode', () {
       final TextAreaElement textarea = TextAreaElement();
       editingElement = SemanticsTextEditingStrategy(
-          new SemanticsObject(5, null), HybridTextEditing(), textarea);
+          SemanticsObject(5, null), HybridTextEditing(), textarea);
 
       expect(editingElement.domElement, textarea);
       expect(document.activeElement, document.body);

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -365,6 +365,13 @@ void testMain() {
     InputElement testInputElement;
     HybridTextEditing testTextEditing;
 
+    final PlatformMessagesSpy spy = PlatformMessagesSpy();
+
+    /// Emulates sending of a message by the framework to the engine.
+    void sendFrameworkMessage(dynamic message) {
+      textEditing.channel.handleTextInput(message, (ByteData data) {});
+    }
+
     setUp(() {
       testInputElement = InputElement();
       testTextEditing = HybridTextEditing();
@@ -375,18 +382,77 @@ void testMain() {
       testInputElement = null;
     });
 
+    test('autofill form lifecycle works', () async {
+      editingElement = SemanticsTextEditingStrategy(
+          new SemanticsObject(5, null), testTextEditing, testInputElement);
+      // Create a configuration with an AutofillGroup of four text fields.
+      final Map<String, dynamic> flutterMultiAutofillElementConfig =
+          createFlutterConfig('text',
+              autofillHint: 'username',
+              autofillHintsForFields: [
+            'username',
+            'email',
+            'name',
+            'telephoneNumber'
+          ]);
+      final MethodCall setClient = MethodCall('TextInput.setClient',
+          <dynamic>[123, flutterMultiAutofillElementConfig]);
+      sendFrameworkMessage(codec.encodeMethodCall(setClient));
+
+      const MethodCall setEditingState1 =
+          MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': 'abcd',
+        'selectionBase': 2,
+        'selectionExtent': 3,
+      });
+      sendFrameworkMessage(codec.encodeMethodCall(setEditingState1));
+
+      const MethodCall show = MethodCall('TextInput.show');
+      sendFrameworkMessage(codec.encodeMethodCall(show));
+
+      // The transform is changed. For example after a validation error, red
+      // line appeared under the input field.
+      final MethodCall setSizeAndTransform =
+          configureSetSizeAndTransformMethodCall(150, 50,
+              Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
+
+      // Form is added to DOM.
+      expect(document.getElementsByTagName('form'), isNotEmpty);
+
+      const MethodCall clearClient = MethodCall('TextInput.clearClient');
+      sendFrameworkMessage(codec.encodeMethodCall(clearClient));
+
+      // Confirm that [HybridTextEditing] didn't send any messages.
+      expect(spy.messages, isEmpty);
+      // Form stays on the DOM until autofill context is finalized.
+      expect(document.getElementsByTagName('form'), isNotEmpty);
+      expect(formsOnTheDom, hasLength(1));
+
+      const MethodCall finishAutofillContext =
+          MethodCall('TextInput.finishAutofillContext', false);
+      sendFrameworkMessage(codec.encodeMethodCall(finishAutofillContext));
+
+      // Form element is removed from DOM.
+      expect(document.getElementsByTagName('form'), hasLength(0));
+      expect(formsOnTheDom, hasLength(0));
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+        skip: browserEngine == BrowserEngine.edge);
+
     test('Does not accept dom elements of a wrong type', () {
       // A regular <span> shouldn't be accepted.
       final HtmlElement span = SpanElement();
       expect(
-        () => SemanticsTextEditingStrategy(HybridTextEditing(), span),
+        () => SemanticsTextEditingStrategy(
+            new SemanticsObject(5, null), HybridTextEditing(), span),
         throwsAssertionError,
       );
     });
 
     test('Do not re-acquire focus', () {
-      editingElement =
-          SemanticsTextEditingStrategy(HybridTextEditing(), testInputElement);
+      editingElement = SemanticsTextEditingStrategy(
+          new SemanticsObject(5, null), HybridTextEditing(), testInputElement);
 
       expect(document.activeElement, document.body);
 
@@ -408,8 +474,8 @@ void testMain() {
         skip: browserEngine == BrowserEngine.edge);
 
     test('Does not dispose and recreate dom elements in persistent mode', () {
-      editingElement =
-          SemanticsTextEditingStrategy(HybridTextEditing(), testInputElement);
+      editingElement = SemanticsTextEditingStrategy(
+          new SemanticsObject(5, null), HybridTextEditing(), testInputElement);
 
       // The DOM element should've been eagerly created.
       expect(testInputElement, isNotNull);
@@ -454,8 +520,8 @@ void testMain() {
         skip: browserEngine == BrowserEngine.edge);
 
     test('Refocuses when setting editing state', () {
-      editingElement =
-          SemanticsTextEditingStrategy(HybridTextEditing(), testInputElement);
+      editingElement = SemanticsTextEditingStrategy(
+          new SemanticsObject(5, null), HybridTextEditing(), testInputElement);
 
       document.body.append(testInputElement);
       editingElement.enable(
@@ -474,8 +540,8 @@ void testMain() {
 
     test('Works in multi-line mode', () {
       final TextAreaElement textarea = TextAreaElement();
-      editingElement =
-          SemanticsTextEditingStrategy(HybridTextEditing(), textarea);
+      editingElement = SemanticsTextEditingStrategy(
+          new SemanticsObject(5, null), HybridTextEditing(), textarea);
 
       expect(editingElement.domElement, textarea);
       expect(document.activeElement, document.body);
@@ -731,8 +797,8 @@ void testMain() {
           operatingSystem == OperatingSystem.iOs) {
         expect(spy.messages, hasLength(1));
         expect(spy.messages[0].channel, 'flutter/textinput');
-        expect(spy.messages[0].methodName,
-            'TextInputClient.onConnectionClosed');
+        expect(
+            spy.messages[0].methodName, 'TextInputClient.onConnectionClosed');
         await Future<void>.delayed(Duration.zero);
         // DOM element loses the focus.
         expect(document.activeElement, document.body);
@@ -787,10 +853,8 @@ void testMain() {
       // Input element is removed from DOM.
       expect(document.getElementsByTagName('input'), hasLength(0));
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: (browserEngine == BrowserEngine.webkit ||
-            browserEngine == BrowserEngine.edge));
+        skip: browserEngine == BrowserEngine.edge);
 
     test('finishAutofillContext removes form from DOM', () async {
       // Create a configuration with an AutofillGroup of four text fields.
@@ -818,6 +882,13 @@ void testMain() {
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
 
+      // The transform is changed. For example after a validation error, red
+      // line appeared under the input field.
+      final MethodCall setSizeAndTransform =
+          configureSetSizeAndTransformMethodCall(150, 50,
+              Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
+
       // Form is added to DOM.
       expect(document.getElementsByTagName('form'), isNotEmpty);
 
@@ -838,10 +909,8 @@ void testMain() {
       expect(document.getElementsByTagName('form'), hasLength(0));
       expect(formsOnTheDom, hasLength(0));
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: (browserEngine == BrowserEngine.webkit ||
-            browserEngine == BrowserEngine.edge));
+        skip: browserEngine == BrowserEngine.edge);
 
     test('finishAutofillContext with save submits forms', () async {
       // Create a configuration with an AutofillGroup of four text fields.
@@ -869,6 +938,13 @@ void testMain() {
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
 
+      // The transform is changed. For example after a validation error, red
+      // line appeared under the input field.
+      final MethodCall setSizeAndTransform =
+          configureSetSizeAndTransformMethodCall(150, 50,
+              Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
+
       // Form is added to DOM.
       expect(document.getElementsByTagName('form'), isNotEmpty);
       FormElement formElement = document.getElementsByTagName('form')[0];
@@ -886,10 +962,8 @@ void testMain() {
       // `submit` action is called on form.
       await expectLater(await submittedForm.future, true);
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: (browserEngine == BrowserEngine.webkit ||
-            browserEngine == BrowserEngine.edge));
+        skip: browserEngine == BrowserEngine.edge);
 
     test('forms submits for focused input', () async {
       // Create a configuration with an AutofillGroup of four text fields.
@@ -917,6 +991,13 @@ void testMain() {
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
 
+      // The transform is changed. For example after a validation error, red
+      // line appeared under the input field.
+      final MethodCall setSizeAndTransform =
+          configureSetSizeAndTransformMethodCall(150, 50,
+              Matrix4.translationValues(10.0, 20.0, 30.0).storage.toList());
+      sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
+
       // Form is added to DOM.
       expect(document.getElementsByTagName('form'), isNotEmpty);
       FormElement formElement = document.getElementsByTagName('form')[0];
@@ -940,10 +1021,8 @@ void testMain() {
       expect(document.getElementsByTagName('form'), hasLength(0));
       expect(formsOnTheDom, hasLength(0));
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
-        skip: (browserEngine == BrowserEngine.webkit ||
-            browserEngine == BrowserEngine.edge));
+        skip: browserEngine == BrowserEngine.edge);
 
     test('setClient, setEditingState, show, setClient', () {
       final MethodCall setClient = MethodCall(


### PR DESCRIPTION
## Description

Fixes the issues around autofill+semantics.

## Related Issues

https://github.com/flutter/flutter/issues/60402
https://github.com/flutter/flutter/issues/60404

## Tests

I added unit tests to text_editing_test.dart. I also unskip autofill related webkit tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
