### PR TITLE
Remove dead code for 3x3 matrices

### DIFF
--- a/shell/common/canvas_spy.cc
+++ b/shell/common/canvas_spy.cc
@@ -51,11 +51,6 @@ bool DidDrawCanvas::onDoSaveBehind(const SkRect* bounds) {
 
 void DidDrawCanvas::willRestore() {}
 
-#ifdef SK_SUPPORT_LEGACY_CANVASMATRIX33
-void DidDrawCanvas::didConcat(const SkMatrix& matrix) {}
-void DidDrawCanvas::didSetMatrix(const SkMatrix& matrix) {}
-#endif
-
 void DidDrawCanvas::didConcat44(const SkM44&) {}
 
 void DidDrawCanvas::didScale(SkScalar, SkScalar) {}

--- a/shell/common/canvas_spy.h
+++ b/shell/common/canvas_spy.h
@@ -70,10 +70,6 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
   void willRestore() override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
-#ifdef SK_SUPPORT_LEGACY_CANVASMATRIX33
-  void didConcat(const SkMatrix&) override;
-  void didSetMatrix(const SkMatrix&) override;
-#endif
   void didConcat44(const SkM44&) override;
   void didScale(SkScalar, SkScalar) override;
   void didTranslate(SkScalar, SkScalar) override;

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -56,15 +56,6 @@ void MockCanvas::willRestore() {
   current_layer_--;  // Must go here; func params order of eval is undefined
 }
 
-#ifdef SK_SUPPORT_LEGACY_CANVASMATRIX33
-void MockCanvas::didConcat(const SkMatrix& matrix) {
-  this->didConcat44(SkM44(matrix));
-}
-void MockCanvas::didSetMatrix(const SkMatrix& matrix) {
-  this->didSetM44(SkM44(matrix));
-}
-#endif
-
 void MockCanvas::didConcat44(const SkM44& matrix) {
   draw_calls_.emplace_back(DrawCall{current_layer_, ConcatMatrixData{matrix}});
 }

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -144,10 +144,6 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
   SaveLayerStrategy getSaveLayerStrategy(const SaveLayerRec& rec) override;
   void willRestore() override;
   void didRestore() override {}
-#ifdef SK_SUPPORT_LEGACY_CANVASMATRIX33
-  void didConcat(const SkMatrix& matrix) override;
-  void didSetMatrix(const SkMatrix& matrix) override;
-#endif
   void didConcat44(const SkM44&) override;
   void didSetM44(const SkM44&) override;
   void didScale(SkScalar x, SkScalar y) override;


### PR DESCRIPTION
Remove conditional code for supporting 3x3 matrices. This code is now dead (skia no longer supports it).