### PR TITLE
Use syslog for logging on Fuchsia

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -187,6 +187,7 @@ source_set("fml") {
       "$fuchsia_sdk_root/pkg:async-cpp",
       "$fuchsia_sdk_root/pkg:async-loop-cpp",
       "$fuchsia_sdk_root/pkg:async-loop-default",
+      "$fuchsia_sdk_root/pkg:syslog",
       "$fuchsia_sdk_root/pkg:trace",
       "$fuchsia_sdk_root/pkg:trace-engine",
       "$fuchsia_sdk_root/pkg:zx",

--- a/fml/log_settings.cc
+++ b/fml/log_settings.cc
@@ -10,7 +10,12 @@
 #include <cstring>
 #include <iostream>
 
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
+
+#if defined(OS_FUCHSIA)
+#include <lib/syslog/global.h>
+#endif
 
 namespace fml {
 namespace state {
@@ -24,6 +29,10 @@ void SetLogSettings(const LogSettings& settings) {
   // Validate the new settings as we set them.
   state::g_log_settings.min_log_level =
       std::min(LOG_FATAL, settings.min_log_level);
+#if defined(OS_FUCHSIA)
+  // Syslog should accept all logs, since filtering by severity is done by fml.
+  FX_LOG_SET_SEVERITY(ALL);
+#endif
 }
 
 LogSettings GetLogSettings() {

--- a/fml/logging_unittests.cc
+++ b/fml/logging_unittests.cc
@@ -2,8 +2,19 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/fml/build_config.h"
+#include "flutter/fml/log_settings.h"
 #include "flutter/fml/logging.h"
 #include "gtest/gtest.h"
+
+#if defined(OS_FUCHSIA)
+#include <lib/syslog/global.h>
+#include <lib/syslog/logger.h>
+#include <lib/syslog/wire_format.h>
+#include <lib/zx/socket.h>
+
+#include "gmock/gmock.h"
+#endif
 
 namespace fml {
 namespace testing {
@@ -27,6 +38,97 @@ TEST(LoggingTest, UnreachableKillProcessWithMacro) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   ASSERT_DEATH({ FML_UNREACHABLE(); }, "");
 }
+
+#if defined(OS_FUCHSIA)
+
+struct LogPacket {
+  fx_log_metadata_t metadata;
+  std::vector<std::string> tags;
+  std::string message;
+};
+
+class LoggingSocketTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    zx::socket local;
+    ASSERT_EQ(ZX_OK, zx::socket::create(ZX_SOCKET_DATAGRAM, &local, &socket_));
+
+    fx_logger_config_t config = {.min_severity = FX_LOG_INFO,
+                                 .console_fd = -1,
+                                 .log_service_channel = local.release(),
+                                 .tags = nullptr,
+                                 .num_tags = 0};
+
+    fx_log_reconfigure(&config);
+  }
+
+  LogPacket ReadPacket() {
+    LogPacket result;
+    fx_log_packet_t packet;
+    zx_status_t res = socket_.read(0, &packet, sizeof(packet), nullptr);
+    EXPECT_EQ(ZX_OK, res);
+    result.metadata = packet.metadata;
+    int pos = 0;
+    while (packet.data[pos]) {
+      int tag_len = packet.data[pos++];
+      result.tags.emplace_back(packet.data + pos, tag_len);
+      pos += tag_len;
+    }
+    result.message.append(packet.data + pos + 1);
+    return result;
+  }
+
+  void ReadPacketAndCompare(fx_log_severity_t severity,
+                            const std::string& message,
+                            const std::vector<std::string>& tags = {}) {
+    LogPacket packet = ReadPacket();
+    EXPECT_EQ(severity, packet.metadata.severity);
+    EXPECT_THAT(packet.message, ::testing::EndsWith(message));
+    EXPECT_EQ(tags, packet.tags);
+  }
+
+  void CheckSocketEmpty() {
+    zx_info_socket_t info = {};
+    zx_status_t status =
+        socket_.get_info(ZX_INFO_SOCKET, &info, sizeof(info), nullptr, nullptr);
+    ASSERT_EQ(ZX_OK, status);
+    EXPECT_EQ(0u, info.rx_buf_available);
+  }
+
+  zx::socket socket_;
+};
+
+TEST_F(LoggingSocketTest, UseSyslogOnFuchsia) {
+  const char* msg1 = "test message";
+  const char* msg2 = "hello";
+  const char* msg3 = "logging";
+  const char* msg4 = "Another message";
+  const char* msg5 = "Foo";
+
+  fml::SetLogSettings({.min_log_level = -1});
+
+  FML_LOG(INFO) << msg1;
+  ReadPacketAndCompare(FX_LOG_INFO, msg1);
+  CheckSocketEmpty();
+
+  FML_LOG(WARNING) << msg2;
+  ReadPacketAndCompare(FX_LOG_WARNING, msg2);
+  CheckSocketEmpty();
+
+  FML_LOG(ERROR) << msg3;
+  ReadPacketAndCompare(FX_LOG_ERROR, msg3);
+  CheckSocketEmpty();
+
+  FML_VLOG(1) << msg4;
+  ReadPacketAndCompare(fx_log_severity_from_verbosity(1), msg4);
+  CheckSocketEmpty();
+
+  // VLOG(2) is not enabled so the log gets dropped.
+  FML_VLOG(2) << msg5;
+  CheckSocketEmpty();
+}
+
+#endif
 
 }  // namespace testing
 }  // namespace fml


### PR DESCRIPTION
## Description

Make fml logging use syslog on Fuchsia. This allows logs to be attributed to flutter and not pollute kernel logs.

## Related Issues

Fixes https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=49770

## Tests

Added tests to fml/logging_unittests.cc

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
