### PR TITLE
Add flt-renderer and flt-build-mode debug attributes to <body>

### DIFF
--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -618,9 +618,13 @@ class TestCommand extends Command<bool> with ArgUtils {
       '--enable-asserts',
       '--enable-experiment=non-nullable',
       '--no-sound-null-safety',
-      if (input.forCanvasKit) '-DFLUTTER_WEB_USE_SKIA=true',
-      if (!input.forCanvasKit) '-DFLUTTER_WEB_AUTO_DETECT=false',
-      if (!input.forCanvasKit) '-DFLUTTER_WEB_USE_SKIA=false',
+
+      // We do not want to auto-select a renderer in tests. As of today, tests
+      // are designed to run in one specific mode. So instead, we specify the
+      // renderer explicitly.
+      '-DFLUTTER_WEB_AUTO_DETECT=false',
+      '-DFLUTTER_WEB_USE_SKIA=${input.forCanvasKit}',
+
       '-O2',
       '-o',
       targetFileName, // target path.

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -147,6 +147,17 @@ part 'engine/vector_math.dart';
 part 'engine/web_experiments.dart';
 part 'engine/window.dart';
 
+// The mode the app is running in.
+// Keep these in sync with the same constants on the framework-side under foundation/constants.dart.
+const bool kReleaseMode = bool.fromEnvironment('dart.vm.product', defaultValue: false);
+const bool kProfileMode = bool.fromEnvironment('dart.vm.profile', defaultValue: false);
+const bool kDebugMode = !kReleaseMode && !kProfileMode;
+String get buildMode => kReleaseMode
+  ? 'release'
+  : kProfileMode
+    ? 'profile'
+    : 'debug';
+
 /// A benchmark metric that includes frame-related computations prior to
 /// submitting layer and picture operations to the underlying renderer, such as
 /// HTML and CanvasKit. During this phase we compute transforms, clips, and

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -330,6 +330,14 @@ flt-glass-pane * {
     }
 
     final html.BodyElement bodyElement = html.document.body!;
+
+    setElementAttribute(
+      bodyElement,
+      'flt-renderer',
+      '${useCanvasKit ? 'canvaskit' : 'html'} (${_autoDetect ? 'auto-selected' : 'requested explicitly'})',
+    );
+    setElementAttribute(bodyElement, 'flt-build-mode', buildMode);
+
     setElementStyle(bodyElement, 'position', 'fixed');
     setElementStyle(bodyElement, 'top', '0');
     setElementStyle(bodyElement, 'right', '0');

--- a/lib/web_ui/test/canvaskit/initialization_test.dart
+++ b/lib/web_ui/test/canvaskit/initialization_test.dart
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.12
+import 'dart:html' as html;
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+import 'common.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('CanvasKit', () {
+    setUpCanvasKitTest();
+
+    test('populates flt-renderer and flt-build-mode', () {
+      DomRenderer();
+      expect(html.document.body!.attributes['flt-renderer'], 'canvaskit (requested explicitly)');
+      expect(html.document.body!.attributes['flt-build-mode'], 'debug');
+    });
+    // TODO: https://github.com/flutter/flutter/issues/60040
+  }, skip: isIosSafari);
+}

--- a/lib/web_ui/test/dom_renderer_test.dart
+++ b/lib/web_ui/test/dom_renderer_test.dart
@@ -14,6 +14,11 @@ void main() {
 }
 
 void testMain() {
+  test('populates flt-renderer and flt-build-mode', () {
+    DomRenderer();
+    expect(html.document.body.attributes['flt-renderer'], 'html (requested explicitly)');
+    expect(html.document.body.attributes['flt-build-mode'], 'debug');
+  });
   test('creating elements works', () {
     final DomRenderer renderer = DomRenderer();
     final html.Element element = renderer.createElement('div');


### PR DESCRIPTION
## Description

Add `flt-renderer` and `flt-build-mode` debug attributes to `<body>` for easier debugging.

## Tests

I added the following tests:

- Added a new test in `dom_renderer_test.dart`.
- Added `canvaskit/initialization_test.dart`.
