### PR TITLE
started sharing GPU contexts between spawned engines

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1743,6 +1743,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineG
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineGroupTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterHeadlessDartRunner.mm

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -181,6 +181,7 @@ source_set("ios_test_flutter_mrc") {
   ]
   sources = [
     "framework/Source/FlutterEnginePlatformViewTest.mm",
+    "framework/Source/FlutterEngineTest_mrc.mm",
     "framework/Source/FlutterPlatformPluginTest.mm",
     "framework/Source/FlutterPlatformViewsTest.mm",
     "framework/Source/accessibility_bridge_test.mm",

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -943,10 +943,14 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 
   fml::WeakPtr<flutter::PlatformView> platform_view = _shell->GetPlatformView();
   FML_DCHECK(platform_view);
+  // Static-cast safe since this class always creates PlatformViewIOS instances.
   flutter::PlatformViewIOS* ios_platform_view =
       static_cast<flutter::PlatformViewIOS*>(platform_view.get());
   std::shared_ptr<flutter::IOSContext> context = ios_platform_view->GetIosContext();
   FML_DCHECK(context);
+
+  // Lambda captures by pointers to ObjC objects are fine here because the
+  // create call is synchronous.
   flutter::Shell::CreateCallback<flutter::PlatformView> on_create_platform_view =
       [result, context](flutter::Shell& shell) {
         [result recreatePlatformViewController];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -941,11 +941,17 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   flutter::Settings settings = _shell->GetSettings();
   SetEntryPoint(&settings, entrypoint, libraryURI);
 
+  fml::WeakPtr<flutter::PlatformView> platform_view = _shell->GetPlatformView();
+  FML_DCHECK(platform_view);
+  flutter::PlatformViewIOS* ios_platform_view =
+      static_cast<flutter::PlatformViewIOS*>(platform_view.get());
+  std::shared_ptr<flutter::IOSContext> context = ios_platform_view->GetIosContext();
+  FML_DCHECK(context);
   flutter::Shell::CreateCallback<flutter::PlatformView> on_create_platform_view =
-      [result](flutter::Shell& shell) {
+      [result, context](flutter::Shell& shell) {
         [result recreatePlatformViewController];
         return std::make_unique<flutter::PlatformViewIOS>(
-            shell, result->_renderingApi, result->_platformViewsController, shell.GetTaskRunners());
+            shell, context, result->_platformViewsController, shell.GetTaskRunners());
       };
 
   flutter::Shell::CreateCallback<flutter::Rasterizer> on_create_rasterizer =

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Test.h"
+#import "flutter/shell/platform/darwin/ios/platform_view_ios.h"
+
+FLUTTER_ASSERT_NOT_ARC
+
+@interface FlutterEngineTest_mrc : XCTestCase
+@end
+
+@implementation FlutterEngineTest_mrc
+
+- (void)setUp {
+}
+
+- (void)tearDown {
+}
+
+- (void)testSpawnsShareGpuContext {
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"];
+  [engine run];
+  FlutterEngine* spawn = [engine spawnWithEntrypoint:nil libraryURI:nil];
+  XCTAssertNotNil(spawn);
+  XCTAssertTrue([engine iosPlatformView] != nullptr);
+  XCTAssertTrue([spawn iosPlatformView] != nullptr);
+  XCTAssertEqual([engine iosPlatformView]->GetIosContext(),
+                 [spawn iosPlatformView]->GetIosContext());
+}
+
+@end

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -93,6 +93,7 @@ class PlatformViewIOS final : public PlatformView {
   // |PlatformView|
   void SetSemanticsEnabled(bool enabled) override;
 
+  /** Acessor for the `IOSContext` associated with the platform view. */
   const std::shared_ptr<IOSContext>& GetIosContext() { return ios_context_; }
 
  private:

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -40,6 +40,11 @@ namespace flutter {
  */
 class PlatformViewIOS final : public PlatformView {
  public:
+  PlatformViewIOS(PlatformView::Delegate& delegate,
+                  const std::shared_ptr<IOSContext>& context,
+                  const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller,
+                  flutter::TaskRunners task_runners);
+
   explicit PlatformViewIOS(
       PlatformView::Delegate& delegate,
       IOSRenderingAPI rendering_api,
@@ -87,6 +92,8 @@ class PlatformViewIOS final : public PlatformView {
 
   // |PlatformView|
   void SetSemanticsEnabled(bool enabled) override;
+
+  const std::shared_ptr<IOSContext>& GetIosContext() { return ios_context_; }
 
  private:
   /// Smart pointer for use with objective-c observers.

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -47,13 +47,23 @@ void PlatformViewIOS::AccessibilityBridgePtr::reset(AccessibilityBridge* bridge)
 
 PlatformViewIOS::PlatformViewIOS(
     PlatformView::Delegate& delegate,
-    IOSRenderingAPI rendering_api,
+    const std::shared_ptr<IOSContext>& context,
     const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller,
     flutter::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)),
-      ios_context_(IOSContext::Create(rendering_api)),
+      ios_context_(context),
       platform_views_controller_(platform_views_controller),
       accessibility_bridge_([this](bool enabled) { PlatformView::SetSemanticsEnabled(enabled); }) {}
+
+PlatformViewIOS::PlatformViewIOS(
+    PlatformView::Delegate& delegate,
+    IOSRenderingAPI rendering_api,
+    const std::shared_ptr<FlutterPlatformViewsController>& platform_views_controller,
+    flutter::TaskRunners task_runners)
+    : PlatformViewIOS(delegate,
+                      IOSContext::Create(rendering_api),
+                      platform_views_controller,
+                      task_runners) {}
 
 PlatformViewIOS::~PlatformViewIOS() = default;
 


### PR DESCRIPTION
## Description

As shown in flutter.dev/go/multiple-engines, sharing graphics contexts between engines in a group opens up memory savings.  This is one more optimization that is happening as part of the multiple-flutters work.

## Related Issues

fixes https://github.com/flutter/flutter/issues/72022

## Tests

I added the following tests:

FlutterEngineTest unit tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
