### PR TITLE
Disable focused_text_field golden on Firefox

### DIFF
--- a/e2etests/web/regular_integration_tests/lib/common.dart
+++ b/e2etests/web/regular_integration_tests/lib/common.dart
@@ -1,0 +1,8 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html';
+
+/// Whether the current browser is Firefox.
+bool get isFirefox => window.navigator.userAgent.toLowerCase().contains('firefox');

--- a/e2etests/web/regular_integration_tests/test_driver/text_editing_integration.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/text_editing_integration.dart
@@ -7,10 +7,11 @@ import 'dart:js_util' as js_util;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:regular_integration_tests/text_editing_main.dart' as app;
 import 'package:flutter/material.dart';
-
 import 'package:integration_test/integration_test.dart';
+
+import 'package:regular_integration_tests/text_editing_main.dart' as app;
+import 'package:regular_integration_tests/common.dart';
 
 void main() {
   final IntegrationTestWidgetsFlutterBinding binding =
@@ -44,7 +45,13 @@ void main() {
     // DOM element's value also changes.
     expect(input.value, 'New Value');
 
-    await binding.takeScreenshot('focused_text_field');
+    // Firefox can't make up its mind about what the screenshot should
+    // look like between LUCI and local.
+    //
+    // https://github.com/flutter/flutter/issues/73382
+    if (!isFirefox) {
+      await binding.takeScreenshot('focused_text_field');
+    }
   });
 
   testWidgets('Input field with no initial value works',


### PR DESCRIPTION
## Description

I couldn't find a proper fix (e.g. updating the golden didn't help), so disabling the golden check on Firefox for now.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/73198.
Filed https://github.com/flutter/flutter/issues/73382 to follow-up.