### PR TITLE
allow verbose_gc

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -68,6 +68,7 @@ static const std::string gAllowedDartFlags[] = {
     "--write-service-info",
     "--null_assertions",
     "--strict_null_safety_checks",
+    "--verbose_gc",
 };
 // clang-format on
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/72396

Only allows in non-release mode. If we have someone that really wants to debug GC behavior in release mode we could consider allowing it there, but that seems strange.

No test because this is a simple allow list change, and we can't really depend on the output or behavior of the GC in Dart.

This allows for:

```
flutter run --dart-define=--verbose_gc
```

to work and output more details about Dart GC activity.