### PR TITLE
[web] Draw shadows for text in rich paragraphs

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 7529e9018b11c79334b99d1e7343fcd500c77b08
+revision: 56a0296bba9bd614b4e16173f7ec7cfc2b2b284d

--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -833,7 +833,19 @@ class BitmapCanvas extends EngineCanvas {
   ///
   /// The text is drawn starting at coordinates ([x], [y]). It uses the current
   /// font set by the most recent call to [setCssFont].
-  void fillText(String text, double x, double y) {
+  void fillText(String text, double x, double y, {List<ui.Shadow>? shadows}) {
+    if (shadows != null) {
+      _canvasPool.context.save();
+      for (final ui.Shadow shadow in shadows) {
+        _canvasPool.context.shadowColor = colorToCssString(shadow.color)!;
+        _canvasPool.context.shadowBlur = shadow.blurRadius;
+        _canvasPool.context.shadowOffsetX = shadow.offset.dx;
+        _canvasPool.context.shadowOffsetY = shadow.offset.dy;
+
+        _canvasPool.context.fillText(text, x, y);
+      }
+      _canvasPool.context.restore();
+    }
     _canvasPool.context.fillText(text, x, y);
   }
 

--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -834,19 +834,20 @@ class BitmapCanvas extends EngineCanvas {
   /// The text is drawn starting at coordinates ([x], [y]). It uses the current
   /// font set by the most recent call to [setCssFont].
   void fillText(String text, double x, double y, {List<ui.Shadow>? shadows}) {
+    final html.CanvasRenderingContext2D ctx = _canvasPool.context;
     if (shadows != null) {
-      _canvasPool.context.save();
+      ctx.save();
       for (final ui.Shadow shadow in shadows) {
-        _canvasPool.context.shadowColor = colorToCssString(shadow.color)!;
-        _canvasPool.context.shadowBlur = shadow.blurRadius;
-        _canvasPool.context.shadowOffsetX = shadow.offset.dx;
-        _canvasPool.context.shadowOffsetY = shadow.offset.dy;
+        ctx.shadowColor = colorToCssString(shadow.color)!;
+        ctx.shadowBlur = shadow.blurRadius;
+        ctx.shadowOffsetX = shadow.offset.dx;
+        ctx.shadowOffsetY = shadow.offset.dy;
 
-        _canvasPool.context.fillText(text, x, y);
+        ctx.fillText(text, x, y);
       }
-      _canvasPool.context.restore();
+      ctx.restore();
     }
-    _canvasPool.context.fillText(text, x, y);
+    ctx.fillText(text, x, y);
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/text/paint_service.dart
+++ b/lib/web_ui/lib/src/engine/text/paint_service.dart
@@ -52,7 +52,7 @@ class TextPaintService {
             box.start.index,
             box.end.indexWithoutTrailingNewlines,
           );
-      canvas.fillText(text, x, y);
+      canvas.fillText(text, x, y, shadows: span.style._shadows);
 
       // Paint the ellipsis using the same span styles.
       final String? ellipsis = line.ellipsis;

--- a/lib/web_ui/test/golden_tests/engine/canvas_paragraph/general_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_paragraph/general_test.dart
@@ -17,25 +17,6 @@ typedef CanvasTest = FutureOr<void> Function(EngineCanvas canvas);
 
 const Rect bounds = Rect.fromLTWH(0, 0, 800, 600);
 
-const Color white = Color(0xFFFFFFFF);
-const Color black = Color(0xFF000000);
-const Color red = Color(0xFFFF0000);
-const Color green = Color(0xFF00FF00);
-const Color blue = Color(0xFF0000FF);
-
-ParagraphConstraints constrain(double width) {
-  return ParagraphConstraints(width: width);
-}
-
-CanvasParagraph rich(
-  EngineParagraphStyle style,
-  void Function(CanvasParagraphBuilder) callback,
-) {
-  final CanvasParagraphBuilder builder = CanvasParagraphBuilder(style);
-  callback(builder);
-  return builder.build();
-}
-
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }

--- a/lib/web_ui/test/golden_tests/engine/canvas_paragraph/helper.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_paragraph/helper.dart
@@ -9,6 +9,26 @@ import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 import 'package:web_engine_tester/golden_tester.dart';
 
+const Color white = Color(0xFFFFFFFF);
+const Color black = Color(0xFF000000);
+const Color red = Color(0xFFFF0000);
+const Color green = Color(0xFF00FF00);
+const Color blue = Color(0xFF0000FF);
+const Color yellow = Color(0xFFFFEB3B);
+
+ParagraphConstraints constrain(double width) {
+  return ParagraphConstraints(width: width);
+}
+
+CanvasParagraph rich(
+  EngineParagraphStyle style,
+  void Function(CanvasParagraphBuilder) callback,
+) {
+  final CanvasParagraphBuilder builder = CanvasParagraphBuilder(style);
+  callback(builder);
+  return builder.build();
+}
+
 Future<void> takeScreenshot(
   EngineCanvas canvas,
   Rect region,

--- a/lib/web_ui/test/golden_tests/engine/canvas_paragraph/overflow_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_paragraph/overflow_test.dart
@@ -17,25 +17,6 @@ typedef CanvasTest = FutureOr<void> Function(EngineCanvas canvas);
 
 const Rect bounds = Rect.fromLTWH(0, 0, 800, 600);
 
-const Color white = Color(0xFFFFFFFF);
-const Color black = Color(0xFF000000);
-const Color red = Color(0xFFFF0000);
-const Color green = Color(0xFF00FF00);
-const Color blue = Color(0xFF0000FF);
-
-ParagraphConstraints constrain(double width) {
-  return ParagraphConstraints(width: width);
-}
-
-CanvasParagraph rich(
-  EngineParagraphStyle style,
-  void Function(CanvasParagraphBuilder) callback,
-) {
-  final CanvasParagraphBuilder builder = CanvasParagraphBuilder(style);
-  callback(builder);
-  return builder.build();
-}
-
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }

--- a/lib/web_ui/test/golden_tests/engine/canvas_paragraph/placeholders_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_paragraph/placeholders_test.dart
@@ -17,25 +17,6 @@ typedef CanvasTest = FutureOr<void> Function(EngineCanvas canvas);
 
 const Rect bounds = Rect.fromLTWH(0, 0, 800, 600);
 
-const Color white = Color(0xFFFFFFFF);
-const Color black = Color(0xFF000000);
-const Color red = Color(0xFFFF0000);
-const Color green = Color(0xFF00FF00);
-const Color blue = Color(0xFF0000FF);
-
-ParagraphConstraints constrain(double width) {
-  return ParagraphConstraints(width: width);
-}
-
-CanvasParagraph rich(
-  EngineParagraphStyle style,
-  void Function(CanvasParagraphBuilder) callback,
-) {
-  final CanvasParagraphBuilder builder = CanvasParagraphBuilder(style);
-  callback(builder);
-  return builder.build();
-}
-
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }

--- a/lib/web_ui/test/golden_tests/engine/canvas_paragraph/shadows_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_paragraph/shadows_test.dart
@@ -1,0 +1,55 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.6
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+import 'package:ui/ui.dart' hide window;
+import 'package:ui/src/engine.dart';
+
+import '../scuba.dart';
+import 'helper.dart';
+
+const Rect bounds = Rect.fromLTWH(0, 0, 800, 600);
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() async {
+  setUpStableTestFonts();
+
+  test('paints multiple shadows', () {
+    final canvas = BitmapCanvas(bounds, RenderStrategy());
+
+    final CanvasParagraph paragraph = rich(
+      ParagraphStyle(fontFamily: 'Roboto'),
+      (builder) {
+        builder.pushStyle(EngineTextStyle.only(
+          fontSize: 32.0,
+          color: blue,
+          shadows: [
+            Shadow(color: red, blurRadius:2.0, offset: Offset(4.0, 2.0)),
+            Shadow(color: green, blurRadius: 3.0),
+          ],
+        ));
+        builder.addText('Lorem ');
+        builder.pushStyle(EngineTextStyle.only(
+          color: green,
+          background: Paint()..color = yellow,
+          shadows: [
+            Shadow(color: black, blurRadius: 10.0),
+          ],
+        ));
+        builder.addText('ipsum');
+        builder.pop();
+        builder.addText('dolor.');
+      },
+    )..layout(constrain(double.infinity));
+    canvas.drawParagraph(paragraph, Offset.zero);
+
+    return takeScreenshot(canvas, bounds, 'canvas_paragraph_shadows');
+  });
+}


### PR DESCRIPTION
## Description

Draw the list of shadows before drawing the text itself.

Screenshots PR: https://github.com/flutter/goldens/pull/138

## Tests

Added screenshot tests in `test/golden_tests/engine/canvas_paragraph/shadows_test.dart`