### PR TITLE
update browser history switching

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -77,7 +77,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   }) async {
     // Prevent any further customization of URL strategy.
     _isUrlStrategySet = true;
-
+    _usingRouter = false;
     await _browserHistory?.tearDown();
     if (useSingle) {
       _browserHistory = SingleEntryBrowserHistory(urlStrategy: strategy);
@@ -114,6 +114,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
             'This can happen if you use non-router versions of MaterialApp/'
             'CupertinoApp/WidgetsApp together with the router versions of them.'
           );
+          return false;
         }
         return true;
       case 'routeInformationUpdated':

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -104,9 +104,17 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
 
     switch (decoded.method) {
       case 'routeUpdated':
-        assert(!_usingRouter);
-        await _useSingleEntryBrowserHistory();
-        browserHistory.setRouteName(arguments['routeName']);
+        if (!_usingRouter) {
+          await _useSingleEntryBrowserHistory();
+          browserHistory.setRouteName(arguments['routeName']);
+        } else {
+          assert(
+            false,
+            'Receives old navigator update in a router application. '
+            'This can happen if you use non-router versions of MaterialApp/'
+            'CupertinoApp/WidgetsApp together with the router versions of them.'
+          );
+        }
         return true;
       case 'routeInformationUpdated':
         await _useMultiEntryBrowserHistory();

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -116,7 +116,7 @@ void testMain() {
     ).catchError((Object e) {
       caughtAssertion = e as AssertionError;
     });
-    
+
     expect(
       caughtAssertion.message,
       'Receives old navigator update in a router application. This can '

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
+import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
@@ -67,6 +68,64 @@ void testMain() {
     // After a navigation platform message, [window.defaultRouteName] should
     // reset to "/".
     expect(window.defaultRouteName, '/');
+  });
+
+  test('should throw when using nav1 and nav2 together',
+      () async {
+    await window.debugInitializeHistory(TestUrlStrategy.fromEntry(
+      TestHistoryEntry('initial state', null, '/initial'),
+    ), useSingle: false);
+    // Receive nav1 update first.
+    Completer<void> callback = Completer<void>();
+    window.sendPlatformMessage(
+      'flutter/navigation',
+      JSONMethodCodec().encodeMethodCall(MethodCall(
+        'routeUpdated',
+        <String, dynamic>{'routeName': '/bar'},
+      )),
+      (_) { callback.complete(); },
+    );
+    await callback.future;
+    expect(window.browserHistory is SingleEntryBrowserHistory, true);
+    expect(window.browserHistory.urlStrategy.getPath(), '/bar');
+
+    // We can still receive nav2 update.
+    callback = Completer<void>();
+    window.sendPlatformMessage(
+      'flutter/navigation',
+      JSONMethodCodec().encodeMethodCall(MethodCall(
+        'routeInformationUpdated',
+        <String, dynamic>{
+          'location': '/baz',
+          'state': null,
+        },
+      )),
+      (_) { callback.complete(); },
+    );
+    await callback.future;
+    expect(window.browserHistory is MultiEntriesBrowserHistory, true);
+    expect(window.browserHistory.urlStrategy.getPath(), '/baz');
+
+    // Throws assertion error if it receives nav1 update after nav2 update.
+    AssertionError caughtAssertion;
+    await window.handleNavigationMessage(
+      JSONMethodCodec().encodeMethodCall(MethodCall(
+        'routeUpdated',
+        <String, dynamic>{'routeName': '/foo'},
+      ))
+    ).catchError((Object e) {
+      caughtAssertion = e as AssertionError;
+    });
+    
+    expect(
+      caughtAssertion.message,
+      'Receives old navigator update in a router application. This can '
+      'happen if you use non-router versions of '
+      'MaterialApp/CupertinoApp/WidgetsApp together with the router versions of them.'
+    );
+    // The history does not change.
+    expect(window.browserHistory is MultiEntriesBrowserHistory, true);
+    expect(window.browserHistory.urlStrategy.getPath(), '/baz');
   });
 
   test('can disable location strategy', () async {


### PR DESCRIPTION
## Description

Previously we throw assertion if the browser receives nav2 updates after it has received nav1 updates, and browser will remain nav1 through out its life time. This means the browser favor nav1 over nav2. This PR updates it so that it will only throw if it receives nav1 update after it has received nav2 update.

In case where users nested a MaterialApp.router inside a MaterialApp, the app will throw assertion error for nav1 update in debug mode, and drop nav1 update silently in release mode. 

## Related Issues

https://github.com/flutter/flutter/issues/72093

## Tests

I added the following tests:

see files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [ ] I signed the [CLA].
- [ ] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [ ] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [ ] I updated/added relevant documentation.
- [ ] All existing and new tests are passing.
- [ ] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [ ] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
