### PR TITLE
fix OpenGL crash in GrOpsTask::onExecute when application enter background on iOS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -24,6 +24,7 @@ vars = {
   'fuchsia_git': 'https://fuchsia.googlesource.com',
   'github_git': 'https://github.com',
   'skia_git': 'https://skia.googlesource.com',
+  'liguisheng_skia_git': 'https://github.com/liguisheng/skia.git',
   # OCMock is for testing only so there is no google clone
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
   'skia_revision': 'd64a3193cd493e6ecabffd5061962f94c4e8cd54',
@@ -357,7 +358,8 @@ deps = {
    Var('dart_git') + '/root_certificates.git' + '@' + Var('dart_root_certificates_rev'),
 
   'src/third_party/skia':
-   Var('skia_git') + '/skia.git' + '@' +  Var('skia_revision'),
+   #Var('skia_git') + '/skia.git' + '@' +  Var('skia_revision'),
+   Var('liguisheng_skia_git') + '@' + '99cac3c3ace05969d7bcf62578de274cca071df9',
 
   'src/third_party/ocmock':
    Var('ocmock_git') + '@' +  Var('ocmock_tag'),

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -851,10 +851,12 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 #pragma mark - Notifications
 
 - (void)applicationBecameActive:(NSNotification*)notification {
+  setGpuRenderDisabled(false);
   [self setIsGpuDisabled:NO];
 }
 
 - (void)applicationWillResignActive:(NSNotification*)notification {
+  setGpuRenderDisabled(true);
   [self setIsGpuDisabled:YES];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -697,6 +697,7 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 
 - (void)applicationBecameActive:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationBecameActive");
+  setGpuRenderDisabled(false);
   if (_viewportMetrics.physical_width)
     [self surfaceUpdated:YES];
   [self goToApplicationLifecycle:@"AppLifecycleState.resumed"];
@@ -704,6 +705,7 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 
 - (void)applicationWillResignActive:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationWillResignActive");
+  setGpuRenderDisabled(true);
   [self surfaceUpdated:NO];
   [self goToApplicationLifecycle:@"AppLifecycleState.inactive"];
 }


### PR DESCRIPTION
Related issue：https://github.com/flutter/flutter/issues/72261

I add a flag to disable gpu render task when application enter background on iOS；
disable GPU render in applicationWillResignActive, and restore in applicationBecameActive.