### PR TITLE
SDK constraints are now just generally required

### DIFF
--- a/flutter_frontend_server/pubspec.yaml
+++ b/flutter_frontend_server/pubspec.yaml
@@ -5,7 +5,6 @@ homepage: http://flutter.io
 author: Flutter Authors <flutter-dev@googlegroups.com>
 
 environment:
-  # The pub client defaults to an <2.0.0 sdk constraint which we need to explicitly overwrite.
   sdk: ">=2.2.2 <3.0.0"
 
 dependencies:


### PR DESCRIPTION
...so this comment is obsolete.

(Part of a wider audit of various `pubspec.yaml`s I'm doing.)