### PR TITLE
Adds a mechanism for announce events to be forwarded to a11y.

### DIFF
--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -111,6 +111,7 @@ template("runner_sources") {
       "//flutter/lib/ui",
       "//flutter/runtime",
       "//flutter/shell/common",
+      "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
     ]
     flutter_deps = [
       ":fuchsia_gpu_configuration",

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -431,6 +431,15 @@ fuchsia::accessibility::semantics::Node AccessibilityBridge::GetRootNodeUpdate(
   return root_fuchsia_node;
 }
 
+void AccessibilityBridge::RequestAnnounce(const std::string message) {
+  fuchsia::accessibility::semantics::SemanticEvent semantic_event;
+  fuchsia::accessibility::semantics::AnnounceEvent announce_event;
+  announce_event.set_message(message);
+  semantic_event.set_announce(std::move(announce_event));
+
+  tree_ptr_->SendSemanticEvent(std::move(semantic_event), []() {});
+}
+
 void AccessibilityBridge::UpdateScreenRects() {
   std::unordered_set<int32_t> visited_nodes;
   UpdateScreenRects(kRootNodeId, SkM44{}, &visited_nodes);

--- a/shell/platform/fuchsia/flutter/accessibility_bridge.h
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.h
@@ -85,6 +85,9 @@ class AccessibilityBridge
   void AddSemanticsNodeUpdate(const flutter::SemanticsNodeUpdates update,
                               float view_pixel_ratio);
 
+  // Requests a message announcement from the accessibility TTS system.
+  void RequestAnnounce(const std::string message);
+
   // Notifies the bridge of a 'hover move' touch exploration event.
   zx_status_t OnHoverMove(double x, double y);
 

--- a/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge_unittest.cc
@@ -103,6 +103,16 @@ TEST_F(AccessibilityBridgeTest, EnableDisable) {
   EXPECT_TRUE(accessibility_delegate_.enabled());
 }
 
+TEST_F(AccessibilityBridgeTest, RequestAnnounce) {
+  accessibility_bridge_->RequestAnnounce("message");
+  RunLoopUntilIdle();
+
+  auto& last_events = semantics_manager_.GetLastEvents();
+  ASSERT_EQ(last_events.size(), 1u);
+  ASSERT_TRUE(last_events[0].is_announce());
+  EXPECT_EQ(last_events[0].announce().message(), "message");
+}
+
 TEST_F(AccessibilityBridgeTest, UpdatesNodeRoles) {
   flutter::SemanticsNodeUpdates updates;
 

--- a/shell/platform/fuchsia/flutter/flutter_runner_fakes.h
+++ b/shell/platform/fuchsia/flutter/flutter_runner_fakes.h
@@ -90,6 +90,18 @@ class MockSemanticsManager
     commit_count_++;
   }
 
+  void SendSemanticEvent(
+      fuchsia::accessibility::semantics::SemanticEvent semantic_event,
+      SendSemanticEventCallback callback) override {
+    last_events_.emplace_back(std::move(semantic_event));
+    callback();
+  }
+
+  std::vector<fuchsia::accessibility::semantics::SemanticEvent>&
+  GetLastEvents() {
+    return last_events_;
+  }
+
  private:
   bool has_view_ref_ = false;
   fidl::BindingSet<SemanticsManager> bindings_;
@@ -102,6 +114,7 @@ class MockSemanticsManager
   bool delete_overflowed_;
   std::vector<uint32_t> last_deleted_node_ids_;
   int commit_count_;
+  std::vector<fuchsia::accessibility::semantics::SemanticEvent> last_events_;
 };
 
 }  // namespace flutter_runner_test


### PR DESCRIPTION
## Description

This change adds a mechanism enabling announce events to be forwarded to/handled by accessibility infra.

## Related Issues

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=67180&q=component%3AAccessibility&can=2

## Tests

I added the following tests:

Accessibility bridge UTs for propagation of announce event to a11y.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
