### PR TITLE
During image decoding, avoid using smart pointers for DartWrappables that cross thread-boundaries.

### DIFF
--- a/lib/ui/painting/image_decoder.h
+++ b/lib/ui/painting/image_decoder.h
@@ -61,7 +61,7 @@ class ImageDecoder {
   FML_DISALLOW_COPY_AND_ASSIGN(ImageDecoder);
 };
 
-sk_sp<SkImage> ImageFromCompressedData(fml::RefPtr<ImageDescriptor> descriptor,
+sk_sp<SkImage> ImageFromCompressedData(ImageDescriptor* descriptor,
                                        uint32_t target_width,
                                        uint32_t target_height,
                                        const fml::tracing::TraceFlow& flow);

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -556,10 +556,10 @@ TEST(ImageDecoderTest, VerifySimpleDecoding) {
   auto descriptor =
       fml::MakeRefCounted<ImageDescriptor>(std::move(data), std::move(codec));
 
-  ASSERT_EQ(
-      ImageFromCompressedData(descriptor, 6, 2, fml::tracing::TraceFlow(""))
-          ->dimensions(),
-      SkISize::Make(6, 2));
+  ASSERT_EQ(ImageFromCompressedData(descriptor.get(), 6, 2,
+                                    fml::tracing::TraceFlow(""))
+                ->dimensions(),
+            SkISize::Make(6, 2));
 }
 
 TEST(ImageDecoderTest, VerifySubpixelDecodingPreservesExifOrientation) {
@@ -574,8 +574,8 @@ TEST(ImageDecoderTest, VerifySubpixelDecodingPreservesExifOrientation) {
   ASSERT_EQ(SkISize::Make(600, 200), image->dimensions());
 
   auto decode = [descriptor](uint32_t target_width, uint32_t target_height) {
-    return ImageFromCompressedData(descriptor, target_width, target_height,
-                                   fml::tracing::TraceFlow(""));
+    return ImageFromCompressedData(descriptor.get(), target_width,
+                                   target_height, fml::tracing::TraceFlow(""));
   };
 
   auto expected_data = OpenFixtureAsSkData("Horizontal.png");


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/19843, a regression was introduced
where an image descriptor object that has a Dart peer could be collected on a
concurrent task runner thread. Collection of such object needs to enter isolate
scope which might still be active on the UI thread. [A comment in the original
commit explicitly mentions][1] this and attempts to achieve the collection of the
Dart wrappable on the UI task runner. However, the author missed that the object
was present in the captures of a copyable closure. These captures may be
released on any of the participating threads. To avoid the the indeterminism of
the smart pointer being dropped on the concurrent task runner thread, this patch
resorts to manually reference counting the descriptor.

Fixes https://github.com/flutter/flutter/issues/72144

[1]: https://github.com/flutter/engine/pull/19843/files#diff-a3034d4a06133381b6b636d841ec98cb7cfce640f316dda9e71eda4d9e7872f6R227