### PR TITLE
Make pending event handling more lenient to allow out of order responses

### DIFF
--- a/shell/platform/linux/fl_key_event_plugin.cc
+++ b/shell/platform/linux/fl_key_event_plugin.cc
@@ -162,23 +162,30 @@ static uint64_t get_event_id(GdkEventKey* event) {
 // Finds an event in the event queue that was sent to the framework by its ID.
 static GdkEventKey* find_pending_event(FlKeyEventPlugin* self, uint64_t id) {
   for (guint i = 0; i <= self->pending_events->len; ++i) {
-    if (FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))->id == id) {
-      return FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, 0))->event;
+    if (FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))->id ==
+        id) {
+      return FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, 0))
+          ->event;
     }
   }
-  g_warning("Tried to find pending event with id %ld, but the event was not found.", id);
+  g_warning(
+      "Tried to find pending event with id %ld, but the event was not found.",
+      id);
   return nullptr;
 }
 
 // Removes an event from the pending event queue.
 static void remove_pending_event(FlKeyEventPlugin* self, uint64_t id) {
   for (guint i = 0; i <= self->pending_events->len; ++i) {
-    if (FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))->id == id) {
+    if (FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))->id ==
+        id) {
       g_ptr_array_remove_index(self->pending_events, i);
       return;
     }
   }
-  g_warning("Tried to remove pending event with id %ld, but the event was not found.", id);
+  g_warning(
+      "Tried to remove pending event with id %ld, but the event was not found.",
+      id);
 }
 
 // Adds an GdkEventKey to the pending event queue, with a unique ID, and the

--- a/shell/platform/linux/fl_key_event_plugin.cc
+++ b/shell/platform/linux/fl_key_event_plugin.cc
@@ -161,25 +161,24 @@ static uint64_t get_event_id(GdkEventKey* event) {
 
 // Finds an event in the event queue that was sent to the framework by its ID.
 static GdkEventKey* find_pending_event(FlKeyEventPlugin* self, uint64_t id) {
-  if (self->pending_events->len == 0 ||
-      FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, 0))->id != id) {
-    return nullptr;
+  for (guint i = 0; i <= self->pending_events->len; ++i) {
+    if (FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))->id == id) {
+      return FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, 0))->event;
+    }
   }
-
-  return FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, 0))->event;
+  g_warning("Tried to find pending event with id %ld, but the event was not found.", id);
+  return nullptr;
 }
 
 // Removes an event from the pending event queue.
 static void remove_pending_event(FlKeyEventPlugin* self, uint64_t id) {
-  if (self->pending_events->len == 0 ||
-      FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, 0))->id != id) {
-    g_warning("Tried to remove pending event with id %" PRIu64
-              ", but the event was out of "
-              "order, or is unknown.",
-              id);
-    return;
+  for (guint i = 0; i <= self->pending_events->len; ++i) {
+    if (FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))->id == id) {
+      g_ptr_array_remove_index(self->pending_events, i);
+      return;
+    }
   }
-  g_ptr_array_remove_index(self->pending_events, 0);
+  g_warning("Tried to remove pending event with id %ld, but the event was not found.", id);
 }
 
 // Adds an GdkEventKey to the pending event queue, with a unique ID, and the

--- a/shell/platform/linux/testing/mock_engine.cc
+++ b/shell/platform/linux/testing/mock_engine.cc
@@ -323,6 +323,26 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
         engine, message->channel, message->response_handle,
         static_cast<const uint8_t*>(g_bytes_get_data(response, nullptr)),
         g_bytes_get_size(response));
+  } else if (strcmp(message->channel, "test/key-event-delayed") == 0) {
+    static std::unique_ptr<const FlutterPlatformMessageResponseHandle>
+        delayed_response_handle = nullptr;
+    g_autoptr(FlJsonMessageCodec) codec = fl_json_message_codec_new();
+    g_autoptr(FlValue) handledValue = fl_value_new_map();
+    fl_value_set_string_take(handledValue, "handled", fl_value_new_bool(true));
+    g_autoptr(GBytes) response = fl_message_codec_encode_message(
+        FL_MESSAGE_CODEC(codec), handledValue, nullptr);
+    if (delayed_response_handle == nullptr) {
+      delayed_response_handle.reset(message->response_handle);
+    } else {
+      send_response(
+          engine, message->channel, message->response_handle,
+          static_cast<const uint8_t*>(g_bytes_get_data(response, nullptr)),
+          g_bytes_get_size(response));
+      send_response(
+          engine, message->channel, delayed_response_handle.release(),
+          static_cast<const uint8_t*>(g_bytes_get_data(response, nullptr)),
+          g_bytes_get_size(response));
+    }
   }
 
   return kSuccess;


### PR DESCRIPTION
## Description

This PR makes the Linux key handling code a little more lenient when it comes to the order in which it receives responses to key events from the framework. I had assumed that there wasn't a case where responses could get out of order, but it seems that it is possible, given that you can mash on the keyboard and eventually get one out of order.

This changes the code so that instead of just looking at the first entry in the pending event deque, it searches the deque starting at the beginning to find the event, and remove it.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/73406

## Tests

- I am not sure how to test this yet, working on that (which is why this is still draft)
