### PR TITLE
Started sharing skia contexts on the io thread

### DIFF
--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -452,6 +452,8 @@ class Shell final : public PlatformView::Delegate,
   // How many frames have been timed since last report.
   size_t UnreportedFramesCount() const;
 
+  sk_sp<GrDirectContext> shared_resource_context_;
+
   Shell(DartVMRef vm,
         TaskRunners task_runners,
         Settings settings,

--- a/shell/common/shell_io_manager.h
+++ b/shell/common/shell_io_manager.h
@@ -55,6 +55,10 @@ class ShellIOManager final : public IOManager {
   // |IOManager|
   std::shared_ptr<fml::SyncSwitch> GetIsGpuDisabledSyncSwitch() override;
 
+  sk_sp<GrDirectContext> GetSharedResourceContext() const {
+    return resource_context_;
+  };
+
  private:
   // Resource context management.
   sk_sp<GrDirectContext> resource_context_;


### PR DESCRIPTION
## Description

This is half of the work of sharing skia contexts between lightweight engines.  We also have to share the skia contexts associated with the surfaces, this is just for the io thread.

## Related Issues

https://github.com/flutter/flutter/issues/72021

## Tests

I added the following tests:

added assert to ShellTest.Spawn

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
