### PR TITLE
[web] Fix tests in preparation for enabling new rich paragraph implementation

### DIFF
--- a/lib/web_ui/test/golden_tests/engine/scuba.dart
+++ b/lib/web_ui/test/golden_tests/engine/scuba.dart
@@ -101,9 +101,11 @@ void testEachCanvas(String description, CanvasTest body,
     try {
       TextMeasurementService.initialize(rulerCacheCapacity: 2);
       WebExperiments.instance.useCanvasText = false;
+      WebExperiments.instance.useCanvasRichText = false;
       return body(BitmapCanvas(bounds, RenderStrategy()));
     } finally {
       WebExperiments.instance.useCanvasText = null;
+      WebExperiments.instance.useCanvasRichText = null;
       TextMeasurementService.clearCache();
     }
   });
@@ -111,9 +113,11 @@ void testEachCanvas(String description, CanvasTest body,
     try {
       TextMeasurementService.initialize(rulerCacheCapacity: 2);
       WebExperiments.instance.useCanvasText = true;
+      WebExperiments.instance.useCanvasRichText = false;
       await body(BitmapCanvas(bounds, RenderStrategy()));
     } finally {
       WebExperiments.instance.useCanvasText = null;
+      WebExperiments.instance.useCanvasRichText = null;
       TextMeasurementService.clearCache();
     }
   });
@@ -121,9 +125,11 @@ void testEachCanvas(String description, CanvasTest body,
     try {
       TextMeasurementService.initialize(rulerCacheCapacity: 2);
       WebExperiments.instance.useCanvasText = false;
+      WebExperiments.instance.useCanvasRichText = false;
       return body(DomCanvas(domRenderer.createElement('flt-picture')));
     } finally {
       WebExperiments.instance.useCanvasText = null;
+      WebExperiments.instance.useCanvasRichText = null;
       TextMeasurementService.clearCache();
     }
   });

--- a/lib/web_ui/test/paragraph_test.dart
+++ b/lib/web_ui/test/paragraph_test.dart
@@ -14,9 +14,11 @@ void testEachMeasurement(String description, VoidCallback body, {bool skip}) {
     try {
       TextMeasurementService.initialize(rulerCacheCapacity: 2);
       WebExperiments.instance.useCanvasText = false;
+      WebExperiments.instance.useCanvasRichText = false;
       return body();
     } finally {
       WebExperiments.instance.useCanvasText = null;
+      WebExperiments.instance.useCanvasRichText = null;
       TextMeasurementService.clearCache();
     }
   }, skip: skip);
@@ -24,9 +26,11 @@ void testEachMeasurement(String description, VoidCallback body, {bool skip}) {
     try {
       TextMeasurementService.initialize(rulerCacheCapacity: 2);
       WebExperiments.instance.useCanvasText = true;
+      WebExperiments.instance.useCanvasRichText = false;
       return body();
     } finally {
       WebExperiments.instance.useCanvasText = null;
+      WebExperiments.instance.useCanvasRichText = null;
       TextMeasurementService.clearCache();
     }
   }, skip: skip);
@@ -192,6 +196,7 @@ void testMain() async {
     // [Paragraph.getPositionForOffset] for multi-line text doesn't work well
     // with dom-based measurement.
     WebExperiments.instance.useCanvasText = true;
+    WebExperiments.instance.useCanvasRichText = false;
     TextMeasurementService.initialize(rulerCacheCapacity: 2);
 
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
@@ -288,10 +293,12 @@ void testMain() async {
 
     TextMeasurementService.clearCache();
     WebExperiments.instance.useCanvasText = null;
+    WebExperiments.instance.useCanvasRichText = null;
   });
 
   test('getPositionForOffset multi-line centered', () {
     WebExperiments.instance.useCanvasText = true;
+    WebExperiments.instance.useCanvasRichText = false;
     TextMeasurementService.initialize(rulerCacheCapacity: 2);
 
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
@@ -395,6 +402,7 @@ void testMain() async {
 
     TextMeasurementService.clearCache();
     WebExperiments.instance.useCanvasText = null;
+    WebExperiments.instance.useCanvasRichText = null;
   });
 
   test('getWordBoundary', () {
@@ -885,6 +893,7 @@ void testMain() async {
   test('longestLine', () {
     // [Paragraph.longestLine] is only supported by canvas-based measurement.
     WebExperiments.instance.useCanvasText = true;
+    WebExperiments.instance.useCanvasRichText = false;
     TextMeasurementService.initialize(rulerCacheCapacity: 2);
 
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
@@ -900,6 +909,7 @@ void testMain() async {
 
     TextMeasurementService.clearCache();
     WebExperiments.instance.useCanvasText = null;
+    WebExperiments.instance.useCanvasRichText = null;
   });
 
   testEachMeasurement('getLineBoundary (single-line)', () {
@@ -927,6 +937,7 @@ void testMain() async {
     // [Paragraph.getLineBoundary] for multi-line paragraphs is only supported
     // by canvas-based measurement.
     WebExperiments.instance.useCanvasText = true;
+    WebExperiments.instance.useCanvasRichText = false;
     TextMeasurementService.initialize(rulerCacheCapacity: 2);
 
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
@@ -970,6 +981,7 @@ void testMain() async {
 
     TextMeasurementService.clearCache();
     WebExperiments.instance.useCanvasText = null;
+    WebExperiments.instance.useCanvasRichText = null;
   });
 
   testEachMeasurement('width should be a whole integer', () {

--- a/lib/web_ui/test/text/measurement_test.dart
+++ b/lib/web_ui/test/text/measurement_test.dart
@@ -20,9 +20,9 @@ const ui.ParagraphConstraints constraints = ui.ParagraphConstraints(width: 50);
 const ui.ParagraphConstraints infiniteConstraints =
     ui.ParagraphConstraints(width: double.infinity);
 
-ui.Paragraph build(ui.ParagraphStyle style, String text,
+DomParagraph build(ui.ParagraphStyle style, String text,
     {ui.TextStyle textStyle}) {
-  final ui.ParagraphBuilder builder = ui.ParagraphBuilder(style);
+  final DomParagraphBuilder builder = DomParagraphBuilder(style);
   if (textStyle != null) {
     builder.pushStyle(textStyle);
   }
@@ -40,12 +40,26 @@ void testMeasurements(String description, MeasurementTestBody body, {
 }) {
   test(
     '$description (dom)',
-    () => body(TextMeasurementService.domInstance),
+    () {
+      try {
+        WebExperiments.instance.useCanvasRichText = false;
+        return body(TextMeasurementService.domInstance);
+      } finally {
+        WebExperiments.instance.useCanvasRichText = null;
+      }
+    },
     skip: skipDom,
   );
   test(
     '$description (canvas)',
-    () => body(TextMeasurementService.canvasInstance),
+    () {
+      try {
+        WebExperiments.instance.useCanvasRichText = false;
+        return body(TextMeasurementService.canvasInstance);
+      } finally {
+        WebExperiments.instance.useCanvasRichText = null;
+      }
+    },
     skip: skipCanvas,
   );
 }
@@ -532,14 +546,9 @@ void testMain()  async {
       const ui.ParagraphConstraints constraints =
           ui.ParagraphConstraints(width: 100);
 
-      final ui.ParagraphBuilder normalBuilder = ui.ParagraphBuilder(ahemStyle);
-      normalBuilder.addText('a b c');
-      final ui.Paragraph normalText = normalBuilder.build();
-
-      final ui.ParagraphBuilder spacedBuilder = ui.ParagraphBuilder(ahemStyle);
-      spacedBuilder.pushStyle(ui.TextStyle(wordSpacing: 1.5));
-      spacedBuilder.addText('a b c');
-      final ui.Paragraph spacedText = spacedBuilder.build();
+      final DomParagraph normalText = build(ahemStyle, 'a b c');
+      final DomParagraph spacedText =
+          build(ahemStyle, 'a b c', textStyle: ui.TextStyle(wordSpacing: 1.5));
 
       // Word spacing is only supported via DOM measurement.
       final TextMeasurementService instance =


### PR DESCRIPTION
## Description

These tests fail when the new rich paragraph implementation is enabled because the tests are expecting to run on the old implementation. This PR makes sure the tests run with rich paragraphs disabled.

I'm doing this in a separate PR from (https://github.com/flutter/engine/pull/23162) because this doesn't need to be reverted in case something blows up with the new rich implementation.