### PR TITLE
Fix double free in settings plugin tests

### DIFF
--- a/shell/platform/linux/fl_engine_test.cc
+++ b/shell/platform/linux/fl_engine_test.cc
@@ -170,18 +170,18 @@ TEST(FlEngineTest, SettingsPlugin) {
         EXPECT_NE(settings, nullptr);
         EXPECT_EQ(error, nullptr);
 
-        g_autoptr(FlValue) text_scale_factor =
+        FlValue* text_scale_factor =
             fl_value_lookup_string(settings, "textScaleFactor");
         EXPECT_NE(text_scale_factor, nullptr);
         EXPECT_EQ(fl_value_get_type(text_scale_factor), FL_VALUE_TYPE_FLOAT);
 
-        g_autoptr(FlValue) always_use_24hr_format =
+        FlValue* always_use_24hr_format =
             fl_value_lookup_string(settings, "alwaysUse24HourFormat");
         EXPECT_NE(always_use_24hr_format, nullptr);
         EXPECT_EQ(fl_value_get_type(always_use_24hr_format),
                   FL_VALUE_TYPE_BOOL);
 
-        g_autoptr(FlValue) platform_brightness =
+        FlValue* platform_brightness =
             fl_value_lookup_string(settings, "platformBrightness");
         EXPECT_NE(platform_brightness, nullptr);
         EXPECT_EQ(fl_value_get_type(platform_brightness), FL_VALUE_TYPE_STRING);

--- a/shell/platform/linux/fl_engine_test.cc
+++ b/shell/platform/linux/fl_engine_test.cc
@@ -169,7 +169,6 @@ TEST(FlEngineTest, SettingsPlugin) {
             FL_MESSAGE_CODEC(codec), data, &error);
         EXPECT_NE(settings, nullptr);
         EXPECT_EQ(error, nullptr);
-        g_printerr("%s\n", fl_value_to_string(settings));
 
         g_autoptr(FlValue) text_scale_factor =
             fl_value_lookup_string(settings, "textScaleFactor");

--- a/shell/platform/linux/fl_engine_test.cc
+++ b/shell/platform/linux/fl_engine_test.cc
@@ -147,9 +147,6 @@ TEST(FlEngineTest, PlatformMessageResponse) {
 
 // Checks settings plugin sends settings on startup.
 TEST(FlEngineTest, SettingsPlugin) {
-  GTEST_SKIP()
-      << "disabled: see https://github.com/flutter/flutter/issues/73517";
-
   g_autoptr(FlEngine) engine = make_mock_engine();
   FlutterEngineProcTable* embedder_api = fl_engine_get_embedder_api(engine);
 


### PR DESCRIPTION
## Description

Fix double free in settings plugin tests which have been disabled due to timing out on LUCI (https://github.com/flutter/flutter/issues/73517).

## Related Issues

https://github.com/flutter/flutter/issues/73517

## Tests

Fixes existing tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
