### PR TITLE
Started asserting that metal gpu contexts are shared

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
@@ -30,8 +30,17 @@ FLUTTER_ASSERT_NOT_ARC
   XCTAssertNotNil(spawn);
   XCTAssertTrue([engine iosPlatformView] != nullptr);
   XCTAssertTrue([spawn iosPlatformView] != nullptr);
-  XCTAssertEqual([engine iosPlatformView]->GetIosContext(),
-                 [spawn iosPlatformView]->GetIosContext());
+  std::shared_ptr<flutter::IOSContext> engine_context = [engine iosPlatformView]->GetIosContext();
+  std::shared_ptr<flutter::IOSContext> spawn_context = [spawn iosPlatformView]->GetIosContext();
+  XCTAssertEqual(engine_context, spawn_context);
+  // If this assert fails it means we may be using the software or OpenGL
+  // renderer when we were expecting Metal.  For software rendering, this is
+  // expected to be nullptr.  For OpenGL, implementing this is an outstanding
+  // change see b/tbd.
+  XCTAssertTrue(engine_context->GetMainContext() != nullptr);
+  XCTAssertEqual(engine_context->GetMainContext(), spawn_context->GetMainContext());
+  [engine release];
+  [spawn release];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
@@ -36,7 +36,7 @@ FLUTTER_ASSERT_NOT_ARC
   // If this assert fails it means we may be using the software or OpenGL
   // renderer when we were expecting Metal.  For software rendering, this is
   // expected to be nullptr.  For OpenGL, implementing this is an outstanding
-  // change see b/tbd.
+  // change see https://github.com/flutter/flutter/issues/73744.
   XCTAssertTrue(engine_context->GetMainContext() != nullptr);
   XCTAssertEqual(engine_context->GetMainContext(), spawn_context->GetMainContext());
   [engine release];

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -106,6 +106,14 @@ class IOSContext {
       int64_t texture_id,
       fml::scoped_nsobject<NSObject<FlutterTexture>> texture) = 0;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Accessor for the Skia context associated with IOSSurfaces.
+  ///
+  /// @attention  The software context doesn't have a Skia context, so this
+  ///             value will be nullptr.
+  ///
+  virtual sk_sp<GrDirectContext> GetMainContext() const = 0;
+
  protected:
   IOSContext();
 

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -107,10 +107,13 @@ class IOSContext {
       fml::scoped_nsobject<NSObject<FlutterTexture>> texture) = 0;
 
   //----------------------------------------------------------------------------
-  /// @brief      Accessor for the Skia context associated with IOSSurfaces.
-  ///
+  /// @brief      Accessor for the Skia context associated with IOSSurfaces and
+  ///             the raster thread.
+  /// @returns    `nullptr` on failure.
   /// @attention  The software context doesn't have a Skia context, so this
   ///             value will be nullptr.
+  /// @see        For contexts which are used for offscreen work like loading
+  ///             textures see IOSContext::CreateResourceContext.
   ///
   virtual sk_sp<GrDirectContext> GetMainContext() const = 0;
 

--- a/shell/platform/darwin/ios/ios_context.h
+++ b/shell/platform/darwin/ios/ios_context.h
@@ -109,6 +109,9 @@ class IOSContext {
   //----------------------------------------------------------------------------
   /// @brief      Accessor for the Skia context associated with IOSSurfaces and
   ///             the raster thread.
+  /// @details    There can be any number of resource contexts but this is the
+  ///             one context that will be used by surfaces to draw to the
+  ///             screen from the raster thread.
   /// @returns    `nullptr` on failure.
   /// @attention  The software context doesn't have a Skia context, so this
   ///             value will be nullptr.

--- a/shell/platform/darwin/ios/ios_context_gl.h
+++ b/shell/platform/darwin/ios/ios_context_gl.h
@@ -33,6 +33,9 @@ class IOSContextGL final : public IOSContext {
   sk_sp<GrDirectContext> CreateResourceContext() override;
 
   // |IOSContext|
+  sk_sp<GrDirectContext> GetMainContext() const override;
+
+  // |IOSContext|
   std::unique_ptr<GLContextResult> MakeCurrent() override;
 
   // |IOSContext|

--- a/shell/platform/darwin/ios/ios_context_gl.mm
+++ b/shell/platform/darwin/ios/ios_context_gl.mm
@@ -45,7 +45,7 @@ sk_sp<GrDirectContext> IOSContextGL::CreateResourceContext() {
 
 // |IOSContext|
 sk_sp<GrDirectContext> IOSContextGL::GetMainContext() const {
-  /// TODO(b/tbd): Currently the GPUSurfaceGL creates the main context for
+  /// TODO(73744): Currently the GPUSurfaceGL creates the main context for
   /// OpenGL.  With Metal the IOSContextMetal creates the main context and is
   /// shared across surfaces.  We should refactor the OpenGL Context/Surfaces to
   /// behave like the Metal equivalents.  Until then engines in the same group

--- a/shell/platform/darwin/ios/ios_context_gl.mm
+++ b/shell/platform/darwin/ios/ios_context_gl.mm
@@ -44,6 +44,16 @@ sk_sp<GrDirectContext> IOSContextGL::CreateResourceContext() {
 }
 
 // |IOSContext|
+sk_sp<GrDirectContext> IOSContextGL::GetMainContext() const {
+  /// TODO(b/tbd): Currently the GPUSurfaceGL creates the main context for
+  /// OpenGL.  With Metal the IOSContextMetal creates the main context and is
+  /// shared across surfaces.  We should refactor the OpenGL Context/Surfaces to
+  /// behave like the Metal equivalents.  Until then engines in the same group
+  /// will have a heavier memory cost if they are using OpenGL.
+  return nullptr;
+}
+
+// |IOSContext|
 std::unique_ptr<GLContextResult> IOSContextGL::MakeCurrent() {
   return std::make_unique<GLContextSwitch>(
       std::make_unique<IOSSwitchableGLContext>(context_.get()));

--- a/shell/platform/darwin/ios/ios_context_metal.h
+++ b/shell/platform/darwin/ios/ios_context_metal.h
@@ -24,6 +24,7 @@ class IOSContextMetal final : public IOSContext {
 
   fml::scoped_nsobject<FlutterDarwinContextMetal> GetDarwinContext() const;
 
+  // |IOSContext|
   sk_sp<GrDirectContext> GetMainContext() const override;
 
   sk_sp<GrDirectContext> GetResourceContext() const;

--- a/shell/platform/darwin/ios/ios_context_metal.h
+++ b/shell/platform/darwin/ios/ios_context_metal.h
@@ -24,7 +24,7 @@ class IOSContextMetal final : public IOSContext {
 
   fml::scoped_nsobject<FlutterDarwinContextMetal> GetDarwinContext() const;
 
-  sk_sp<GrDirectContext> GetMainContext() const;
+  sk_sp<GrDirectContext> GetMainContext() const override;
 
   sk_sp<GrDirectContext> GetResourceContext() const;
 

--- a/shell/platform/darwin/ios/ios_context_software.h
+++ b/shell/platform/darwin/ios/ios_context_software.h
@@ -21,6 +21,9 @@ class IOSContextSoftware final : public IOSContext {
   sk_sp<GrDirectContext> CreateResourceContext() override;
 
   // |IOSContext|
+  sk_sp<GrDirectContext> GetMainContext() const override;
+
+  // |IOSContext|
   std::unique_ptr<GLContextResult> MakeCurrent() override;
 
   // |IOSContext|

--- a/shell/platform/darwin/ios/ios_context_software.mm
+++ b/shell/platform/darwin/ios/ios_context_software.mm
@@ -17,6 +17,11 @@ sk_sp<GrDirectContext> IOSContextSoftware::CreateResourceContext() {
 }
 
 // |IOSContext|
+sk_sp<GrDirectContext> IOSContextSoftware::GetMainContext() const {
+  return nullptr;
+}
+
+// |IOSContext|
 std::unique_ptr<GLContextResult> IOSContextSoftware::MakeCurrent() {
   // This only makes sense for context that need to be bound to a specific thread.
   return std::make_unique<GLContextDefaultResult>(false);


### PR DESCRIPTION
## Description

Also, added the ability for IOSContexts to store their skia contexts so we can make the OpenGL code work like the Metal code.

## Related Issues

https://github.com/flutter/flutter/issues/72021

## Tests

I added the following tests:

FlutterEngineTest_mrc test asserts changed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
