### PR TITLE
[canvaskit] push methods return layers with correct class names

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -117,10 +117,10 @@ abstract class ContainerLayer extends Layer {
   }
 }
 
-class BackdropFilterLayer extends ContainerLayer {
+class BackdropFilterEngineLayer extends ContainerLayer implements ui.BackdropFilterEngineLayer {
   final ui.ImageFilter _filter;
 
-  BackdropFilterLayer(this._filter);
+  BackdropFilterEngineLayer(this._filter);
 
   @override
   void paint(PaintContext context) {
@@ -131,12 +131,12 @@ class BackdropFilterLayer extends ContainerLayer {
 }
 
 /// A layer that clips its child layers by a given [Path].
-class ClipPathLayer extends ContainerLayer {
+class ClipPathEngineLayer extends ContainerLayer implements ui.ClipPathEngineLayer {
   /// The path used to clip child layers.
   final CkPath _clipPath;
   final ui.Clip _clipBehavior;
 
-  ClipPathLayer(this._clipPath, this._clipBehavior)
+  ClipPathEngineLayer(this._clipPath, this._clipBehavior)
       : assert(_clipBehavior != ui.Clip.none);
 
   @override
@@ -170,12 +170,12 @@ class ClipPathLayer extends ContainerLayer {
 }
 
 /// A layer that clips its child layers by a given [Rect].
-class ClipRectLayer extends ContainerLayer {
+class ClipRectEngineLayer extends ContainerLayer implements ui.ClipRectEngineLayer {
   /// The rectangle used to clip child layers.
   final ui.Rect _clipRect;
   final ui.Clip _clipBehavior;
 
-  ClipRectLayer(this._clipRect, this._clipBehavior)
+  ClipRectEngineLayer(this._clipRect, this._clipBehavior)
       : assert(_clipBehavior != ui.Clip.none);
 
   @override
@@ -210,12 +210,12 @@ class ClipRectLayer extends ContainerLayer {
 }
 
 /// A layer that clips its child layers by a given [RRect].
-class ClipRRectLayer extends ContainerLayer {
+class ClipRRectEngineLayer extends ContainerLayer implements ui.ClipRRectEngineLayer {
   /// The rounded rectangle used to clip child layers.
   final ui.RRect _clipRRect;
   final ui.Clip? _clipBehavior;
 
-  ClipRRectLayer(this._clipRRect, this._clipBehavior)
+  ClipRRectEngineLayer(this._clipRRect, this._clipBehavior)
       : assert(_clipBehavior != ui.Clip.none);
 
   @override
@@ -247,11 +247,11 @@ class ClipRRectLayer extends ContainerLayer {
 }
 
 /// A layer that paints its children with the given opacity.
-class OpacityLayer extends ContainerLayer implements ui.OpacityEngineLayer {
+class OpacityEngineLayer extends ContainerLayer implements ui.OpacityEngineLayer {
   final int _alpha;
   final ui.Offset _offset;
 
-  OpacityLayer(this._alpha, this._offset);
+  OpacityEngineLayer(this._alpha, this._offset);
 
   @override
   void preroll(PrerollContext context, Matrix4 matrix) {
@@ -287,12 +287,11 @@ class OpacityLayer extends ContainerLayer implements ui.OpacityEngineLayer {
 }
 
 /// A layer that transforms its child layers by the given transform matrix.
-class TransformLayer extends ContainerLayer
-    implements ui.OffsetEngineLayer, ui.TransformEngineLayer {
+class TransformEngineLayer extends ContainerLayer implements ui.TransformEngineLayer {
   /// The matrix with which to transform the child layers.
   final Matrix4 _transform;
 
-  TransformLayer(this._transform);
+  TransformEngineLayer(this._transform);
 
   @override
   void preroll(PrerollContext context, Matrix4 matrix) {
@@ -314,9 +313,18 @@ class TransformLayer extends ContainerLayer
   }
 }
 
+/// Translates its children along x and y coordinates.
+///
+/// This is a thin wrapper over [TransformEngineLayer] just so the framework
+/// gets the "OffsetEngineLayer" when calling `runtimeType.toString()`. This is
+/// better for debugging.
+class OffsetEngineLayer extends TransformEngineLayer implements ui.OffsetEngineLayer {
+  OffsetEngineLayer(double dx, double dy) : super(Matrix4.translationValues(dx, dy, 0.0));
+}
+
 /// A layer that applies an [ui.ImageFilter] to its children.
-class ImageFilterLayer extends ContainerLayer implements ui.OpacityEngineLayer {
-  ImageFilterLayer(this._filter);
+class ImageFilterEngineLayer extends ContainerLayer implements ui.ImageFilterEngineLayer {
+  ImageFilterEngineLayer(this._filter);
 
   final ui.ImageFilter _filter;
 
@@ -328,6 +336,13 @@ class ImageFilterLayer extends ContainerLayer implements ui.OpacityEngineLayer {
     paintContext.internalNodesCanvas.saveLayer(paintBounds, paint);
     paintChildren(paintContext);
     paintContext.internalNodesCanvas.restore();
+  }
+}
+
+class ShaderMaskEngineLayer extends ContainerLayer implements ui.ShaderMaskEngineLayer {
+  @override
+  void paint(PaintContext paintContext) {
+    // TODO(yjbanov): this needs to be implemented
   }
 }
 
@@ -369,7 +384,7 @@ class PictureLayer extends Layer {
 ///
 /// The shape clips its children to a given [Path], and casts a shadow based
 /// on the given elevation.
-class PhysicalShapeLayer extends ContainerLayer
+class PhysicalShapeEngineLayer extends ContainerLayer
     implements ui.PhysicalShapeEngineLayer {
   final double _elevation;
   final ui.Color _color;
@@ -377,7 +392,7 @@ class PhysicalShapeLayer extends ContainerLayer
   final CkPath _path;
   final ui.Clip _clipBehavior;
 
-  PhysicalShapeLayer(
+  PhysicalShapeEngineLayer(
     this._elevation,
     this._color,
     this._shadowColor,
@@ -445,8 +460,8 @@ class PhysicalShapeLayer extends ContainerLayer
 }
 
 /// A layer which contains a [ui.ColorFilter].
-class ColorFilterLayer extends ContainerLayer {
-  ColorFilterLayer(this.filter);
+class ColorFilterEngineLayer extends ContainerLayer implements ui.ColorFilterEngineLayer {
+  ColorFilterEngineLayer(this.filter);
 
   final ui.ColorFilter filter;
 

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -99,88 +99,77 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   }
 
   @override
-  ui.BackdropFilterEngineLayer? pushBackdropFilter(
+  BackdropFilterEngineLayer? pushBackdropFilter(
     ui.ImageFilter filter, {
     ui.EngineLayer? oldLayer,
   }) {
-    pushLayer(BackdropFilterLayer(filter));
-    return null;
+    return pushLayer<BackdropFilterEngineLayer>(BackdropFilterEngineLayer(filter));
   }
 
   @override
-  ui.ClipPathEngineLayer? pushClipPath(
+  ClipPathEngineLayer? pushClipPath(
     ui.Path path, {
     ui.Clip clipBehavior = ui.Clip.antiAlias,
     ui.EngineLayer? oldLayer,
   }) {
-    pushLayer(ClipPathLayer(path as CkPath, clipBehavior));
-    return null;
+    return pushLayer<ClipPathEngineLayer>(ClipPathEngineLayer(path as CkPath, clipBehavior));
   }
 
   @override
-  ui.ClipRRectEngineLayer? pushClipRRect(
+  ClipRRectEngineLayer? pushClipRRect(
     ui.RRect rrect, {
     ui.Clip? clipBehavior,
     ui.EngineLayer? oldLayer,
   }) {
-    pushLayer(ClipRRectLayer(rrect, clipBehavior));
-    return null;
+    return pushLayer<ClipRRectEngineLayer>(ClipRRectEngineLayer(rrect, clipBehavior));
   }
 
   @override
-  ui.ClipRectEngineLayer? pushClipRect(
+  ClipRectEngineLayer? pushClipRect(
     ui.Rect rect, {
     ui.Clip clipBehavior = ui.Clip.antiAlias,
     ui.EngineLayer? oldLayer,
   }) {
-    pushLayer(ClipRectLayer(rect, clipBehavior));
-    return null;
+    return pushLayer<ClipRectEngineLayer>(ClipRectEngineLayer(rect, clipBehavior));
   }
 
   @override
-  ui.ColorFilterEngineLayer? pushColorFilter(
+  ColorFilterEngineLayer? pushColorFilter(
     ui.ColorFilter filter, {
     ui.ColorFilterEngineLayer? oldLayer,
   }) {
     assert(filter != null); // ignore: unnecessary_null_comparison
-    pushLayer(ColorFilterLayer(filter));
-    return null;
+    return pushLayer<ColorFilterEngineLayer>(ColorFilterEngineLayer(filter));
   }
 
-  ui.ImageFilterEngineLayer? pushImageFilter(
+  ImageFilterEngineLayer? pushImageFilter(
     ui.ImageFilter filter, {
     ui.ImageFilterEngineLayer? oldLayer,
   }) {
     assert(filter != null); // ignore: unnecessary_null_comparison
-    pushLayer(ImageFilterLayer(filter));
-    return null;
+    return pushLayer<ImageFilterEngineLayer>(ImageFilterEngineLayer(filter));
   }
 
   @override
-  ui.OffsetEngineLayer pushOffset(
+  OffsetEngineLayer pushOffset(
     double dx,
     double dy, {
     ui.EngineLayer? oldLayer,
   }) {
-    final Matrix4 matrix = Matrix4.translationValues(dx, dy, 0.0);
-    final TransformLayer layer = TransformLayer(matrix);
-    pushLayer(layer);
-    return layer;
+    return pushLayer<OffsetEngineLayer>(OffsetEngineLayer(dx, dy));
   }
 
   @override
-  ui.OpacityEngineLayer pushOpacity(
+  OpacityEngineLayer pushOpacity(
     int alpha, {
     ui.EngineLayer? oldLayer,
     ui.Offset offset = ui.Offset.zero,
   }) {
-    final OpacityLayer layer = OpacityLayer(alpha, offset);
-    pushLayer(layer);
-    return layer;
+    return pushLayer<OpacityEngineLayer>(OpacityEngineLayer(alpha, offset));
   }
 
   @override
-  ui.PhysicalShapeEngineLayer pushPhysicalShape({
+  PhysicalShapeEngineLayer pushPhysicalShape({
     required ui.Path path,
     required double elevation,
     required ui.Color color,
@@ -188,19 +177,17 @@ class LayerSceneBuilder implements ui.SceneBuilder {
     ui.Clip clipBehavior = ui.Clip.none,
     ui.EngineLayer? oldLayer,
   }) {
-    final PhysicalShapeLayer layer = PhysicalShapeLayer(
+    return pushLayer<PhysicalShapeEngineLayer>(PhysicalShapeEngineLayer(
       elevation,
       color,
       shadowColor,
       path as CkPath,
       clipBehavior,
-    );
-    pushLayer(layer);
-    return layer;
+    ));
   }
 
   @override
-  ui.ShaderMaskEngineLayer pushShaderMask(
+  ShaderMaskEngineLayer pushShaderMask(
     ui.Shader shader,
     ui.Rect maskRect,
     ui.BlendMode blendMode, {
@@ -210,13 +197,12 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   }
 
   @override
-  ui.TransformEngineLayer? pushTransform(
+  TransformEngineLayer? pushTransform(
     Float64List matrix4, {
     ui.EngineLayer? oldLayer,
   }) {
     final Matrix4 matrix = Matrix4.fromFloat32List(toMatrix32(matrix4));
-    pushLayer(TransformLayer(matrix));
-    return null;
+    return pushLayer<TransformEngineLayer>(TransformEngineLayer(matrix));
   }
 
   @override
@@ -234,18 +220,19 @@ class LayerSceneBuilder implements ui.SceneBuilder {
     // TODO: implement setRasterizerTracingThreshold
   }
 
-  void pushLayer(ContainerLayer layer) {
+  T pushLayer<T extends ContainerLayer>(T layer) {
     if (rootLayer == null) {
       rootLayer = currentLayer = layer;
-      return;
+      return layer;
     }
 
     if (currentLayer == null) {
-      return;
+      return layer;
     }
 
     currentLayer!.add(layer);
     currentLayer = layer;
+    return layer;
   }
 
   @override

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -107,7 +107,7 @@ void testMain() {
             canvas.drawShadow(shape, ui.Color(0xFFFF0000), elevation, true);
             canvas.drawPath(shape, shapePaint);
 
-            final PhysicalShapeLayer psl = PhysicalShapeLayer(
+            final PhysicalShapeEngineLayer psl = PhysicalShapeEngineLayer(
               elevation,
               const ui.Color(0xFF000000),
               const ui.Color(0xFF000000),
@@ -149,12 +149,12 @@ void testMain() {
         (rectSize + padding) * 3 + padding,
         (rectSize + padding) * 2 + padding,
       );
-      late List<PhysicalShapeLayer> physicalShapeLayers;
+      late List<PhysicalShapeEngineLayer> physicalShapeLayers;
 
       LayerTree buildTestScene({ required bool paintShadowBounds }) {
-        final Iterator<PhysicalShapeLayer>? shadowBounds = paintShadowBounds
+        final Iterator<PhysicalShapeEngineLayer>? shadowBounds = paintShadowBounds
           ? physicalShapeLayers.iterator : null;
-        physicalShapeLayers = <PhysicalShapeLayer>[];
+        physicalShapeLayers = <PhysicalShapeEngineLayer>[];
 
         final LayerSceneBuilder builder = LayerSceneBuilder();
         builder.pushOffset(padding + halfSize, padding + halfSize);
@@ -177,7 +177,7 @@ void testMain() {
               elevation: 6,
               color: const ui.Color(0xFF009900),
               shadowColor: const ui.Color(0xFF000000),
-            ) as PhysicalShapeLayer);
+            ));
             if (shadowBounds != null) {
               shadowBounds.moveNext();
               final ui.Rect bounds = shadowBounds.current.paintBounds;

--- a/lib/web_ui/test/canvaskit/layer_test.dart
+++ b/lib/web_ui/test/canvaskit/layer_test.dart
@@ -44,10 +44,10 @@ void testMain() {
       sb.addPicture(ui.Offset.zero, picture);
       final LayerTree layerTree = sb.build().layerTree;
       dispatcher.rasterizer!.draw(layerTree);
-      final ClipRectLayer clipRect = layerTree.rootLayer as ClipRectLayer;
+      final ClipRectEngineLayer clipRect = layerTree.rootLayer as ClipRectEngineLayer;
       expect(clipRect.paintBounds, ui.Rect.fromLTRB(15, 15, 30, 30));
 
-      final TransformLayer transform = clipRect.debugLayers.single as TransformLayer;
+      final TransformEngineLayer transform = clipRect.debugLayers.single as TransformEngineLayer;
       expect(transform.paintBounds, ui.Rect.fromLTRB(0, 0, 30, 30));
     });
     // TODO: https://github.com/flutter/flutter/issues/60040

--- a/lib/web_ui/test/golden_tests/engine/backdrop_filter_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/backdrop_filter_golden_test.dart
@@ -8,7 +8,7 @@ import 'dart:html' as html;
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/ui.dart';
-import 'package:ui/src/engine.dart';
+import 'package:ui/src/engine.dart' hide ClipRectEngineLayer, BackdropFilterEngineLayer;
 
 import 'package:web_engine_tester/golden_tester.dart';
 

--- a/lib/web_ui/test/golden_tests/engine/color_filter_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/color_filter_golden_test.dart
@@ -9,7 +9,7 @@ import 'dart:js_util' as js_util;
 import 'package:test/bootstrap/browser.dart'; // ignore: import_of_legacy_library_into_null_safe
 import 'package:test/test.dart'; // ignore: import_of_legacy_library_into_null_safe
 import 'package:ui/ui.dart';
-import 'package:ui/src/engine.dart';
+import 'package:ui/src/engine.dart' hide PhysicalShapeEngineLayer;
 
 import 'package:web_engine_tester/golden_tester.dart'; // ignore: import_of_legacy_library_into_null_safe
 


### PR DESCRIPTION
## Description

Make all `LayerSceneBuilder.push*` methods return an `EngineLayer` with class name matching the mobile version. This fixes all framework unit-tests under `test/foundation`.

## Related Issues

Progress towards https://github.com/flutter/flutter/issues/71604

## Tests

No tests. This is largely a noop change functionality-wise.