### PR TITLE
[web] Fix more tests that are specific to DomParagraph

### DIFF
--- a/lib/web_ui/lib/src/engine/text/layout_service.dart
+++ b/lib/web_ui/lib/src/engine/text/layout_service.dart
@@ -181,6 +181,7 @@ class TextLayoutService {
       height += line.height;
       if (alphabeticBaseline == -1.0) {
         alphabeticBaseline = line.baseline;
+        ideographicBaseline = alphabeticBaseline * _baselineRatioHack;
       }
       if (longestLine < line.width) {
         longestLine = line.width;

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -412,7 +412,7 @@ void testMain() {
       final bool useOffset = int.tryParse(char) == null;
       final EnginePictureRecorder recorder = PictureRecorder();
       final RecordingCanvas canvas = recorder.beginRecording(const Rect.fromLTRB(0, 0, 400, 400));
-      final Paragraph paragraph = (ParagraphBuilder(ParagraphStyle())..addText(char)).build();
+      final DomParagraph paragraph = (DomParagraphBuilder(ParagraphStyle())..addText(char)).build();
       paragraph.layout(ParagraphConstraints(width: 1000));
       canvas.drawParagraph(paragraph, Offset.zero);
       final EngineLayer newLayer = useOffset

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -54,11 +54,11 @@ void testMain() async {
 
     test('loading font should clear measurement caches', () async {
       final ui.ParagraphStyle style = ui.ParagraphStyle();
-      final ui.ParagraphBuilder builder = ui.ParagraphBuilder(style);
+      final DomParagraphBuilder builder = DomParagraphBuilder(style);
       final ui.ParagraphConstraints constraints =
           ui.ParagraphConstraints(width: 30.0);
       builder.addText('test');
-      final ui.Paragraph paragraph = builder.build();
+      final DomParagraph paragraph = builder.build();
       // Triggers the measuring and verifies the result has been cached.
       paragraph.layout(constraints);
       expect(TextMeasurementService.rulerManager.rulers.length, 1);

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -89,7 +89,7 @@ void testMain() async {
   });
 
   test('lay out unattached paragraph', () {
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    final DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'sans-serif',
       fontStyle: FontStyle.normal,
       fontWeight: FontWeight.normal,
@@ -155,7 +155,7 @@ void testMain() async {
   });
 
   test('$ParagraphBuilder detects plain text', () {
-    ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'sans-serif',
       fontStyle: FontStyle.normal,
       fontWeight: FontWeight.normal,
@@ -166,7 +166,7 @@ void testMain() async {
     expect(paragraph.plainText, isNotNull);
     expect(paragraph.geometricStyle.fontWeight, FontWeight.normal);
 
-    builder = ParagraphBuilder(ParagraphStyle(
+    builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'sans-serif',
       fontStyle: FontStyle.normal,
       fontWeight: FontWeight.normal,
@@ -180,7 +180,7 @@ void testMain() async {
   });
 
   test('$ParagraphBuilder detects rich text', () {
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    final DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'sans-serif',
       fontStyle: FontStyle.normal,
       fontWeight: FontWeight.normal,
@@ -195,7 +195,7 @@ void testMain() async {
   });
 
   test('$ParagraphBuilder treats empty text as plain', () {
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    final DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'sans-serif',
       fontStyle: FontStyle.normal,
       fontWeight: FontWeight.normal,
@@ -209,7 +209,7 @@ void testMain() async {
 
   // Regression test for https://github.com/flutter/flutter/issues/34931.
   test('hit test on styled text returns correct span offset', () {
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    final DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'sans-serif',
       fontStyle: FontStyle.normal,
       fontWeight: FontWeight.normal,
@@ -239,7 +239,7 @@ void testMain() async {
     const fontFamily = 'sans-serif';
     const fontSize = 20.0;
     final style = TextStyle(fontFamily: fontFamily, fontSize: fontSize);
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    final DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: fontFamily,
       fontSize: fontSize,
     ));
@@ -326,7 +326,7 @@ void testMain() async {
     'test te04 test050 '
     */
 
-    final Paragraph paragraph = builder.build();
+    final DomParagraph paragraph = builder.build();
     paragraph.layout(ParagraphConstraints(width: 800));
 
     // Reference the offsets with the output of `Display arrangement`.
@@ -358,7 +358,7 @@ void testMain() async {
   test(
       'should not set fontFamily to effectiveFontFamily for spans in rich text',
       () {
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    final DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'Roboto',
       fontStyle: FontStyle.normal,
       fontWeight: FontWeight.normal,
@@ -389,7 +389,7 @@ void testMain() async {
     // Set this to false so it doesn't default to 'Ahem' font.
     debugEmulateFlutterTesterEnvironment = false;
 
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    final DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'SomeFont',
       fontSize: 12.0,
     ));
@@ -411,7 +411,7 @@ void testMain() async {
     // Set this to false so it doesn't default to 'Ahem' font.
     debugEmulateFlutterTesterEnvironment = false;
 
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    final DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'serif',
       fontSize: 12.0,
     ));
@@ -428,7 +428,7 @@ void testMain() async {
     // Set this to false so it doesn't default to 'Ahem' font.
     debugEmulateFlutterTesterEnvironment = false;
 
-    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+    final DomParagraphBuilder builder = DomParagraphBuilder(ParagraphStyle(
       fontFamily: 'MyFont 2000',
       fontSize: 12.0,
     ));


### PR DESCRIPTION
## Description

Few more tests that I missed in https://github.com/flutter/engine/pull/23515. These tests are made specifically to test the `DomParagraph` implementation. By flipping the new rich implementation, these tests start receiving `CanvasParagraph` objects so they go wild.

Also, fix the `ideographicBaseline` calculation to make some tests happy.