### PR TITLE
Android deeplink sends "path + query" instead of just path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,10 @@
 .*.sw?
 .DS_Store
 .ccls-cache
-.cipd/
 .classpath
 .clangd/
 .cproject
 .dart_tool
-.gclient
-.gclient_entries
 .gdb_history
 .checkstyle
 .gdbinit

--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,13 @@
 .*.sw?
 .DS_Store
 .ccls-cache
+.cipd/
 .classpath
 .clangd/
 .cproject
 .dart_tool
+.gclient
+.gclient_entries
 .gdb_history
 .checkstyle
 .gdbinit

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -398,12 +398,10 @@ import java.util.Arrays;
   private String maybeGetInitialRouteFromIntent(Intent intent) {
     if (host.shouldHandleDeeplinking()) {
       Uri data = intent.getData();
-      String pathAndQuery;
       if (data != null && !data.getPath().isEmpty()) {
-        pathAndQuery = data.getPath();
+        String pathAndQuery = data.getPath();
         if (!data.getQuery().isEmpty()) {
-          pathAndQuery += "?";
-          pathAndQuery += data.getQuery();
+          pathAndQuery += "?" + data.getQuery();
         }
         return pathAndQuery;
       }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -398,8 +398,14 @@ import java.util.Arrays;
   private String maybeGetInitialRouteFromIntent(Intent intent) {
     if (host.shouldHandleDeeplinking()) {
       Uri data = intent.getData();
+      String pathAndQuery;
       if (data != null && !data.getPath().isEmpty()) {
-        return data.getPath();
+        pathAndQuery = data.getPath();
+        if (!data.getQuery().isEmpty()) {
+          pathAndQuery += "?";
+          pathAndQuery += data.getQuery();
+        }
+        return pathAndQuery;
       }
     }
     return null;

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -433,7 +433,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void
       itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinking() {
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
-    intent.setData(Uri.parse("http://myApp/custom/route"));
+    intent.setData(Uri.parse("http://myApp/custom/route/?query=test"));
 
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
@@ -452,7 +452,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onStart();
 
     // Verify that the navigation channel was given the initial route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(1)).setInitialRoute("/custom/route");
+    verify(mockFlutterEngine.getNavigationChannel(), times(1)).setInitialRoute("/custom/route/?query=test");
   }
 
   @Test
@@ -491,12 +491,12 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onAttach(RuntimeEnvironment.application);
 
     Intent mockIntent = mock(Intent.class);
-    when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route"));
+    when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route/?query=test"));
     // Emulate the host and call the method that we expect to be forwarded.
     delegate.onNewIntent(mockIntent);
 
     // Verify that the navigation channel was given the push route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(1)).pushRoute("/custom/route");
+    verify(mockFlutterEngine.getNavigationChannel(), times(1)).pushRoute("/custom/route/?query=test");
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -452,7 +452,8 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onStart();
 
     // Verify that the navigation channel was given the initial route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(1)).setInitialRoute("/custom/route/?query=test");
+    verify(mockFlutterEngine.getNavigationChannel(), times(1))
+        .setInitialRoute("/custom/route/?query=test");
   }
 
   @Test
@@ -496,7 +497,8 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onNewIntent(mockIntent);
 
     // Verify that the navigation channel was given the push route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(1)).pushRoute("/custom/route?query=test");
+    verify(mockFlutterEngine.getNavigationChannel(), times(1))
+        .pushRoute("/custom/route?query=test");
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -433,7 +433,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void
       itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinking() {
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
-    intent.setData(Uri.parse("http://myApp/custom/route/?query=test"));
+    intent.setData(Uri.parse("http://myApp/custom/route?query=test"));
 
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
@@ -453,7 +453,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // Verify that the navigation channel was given the initial route message.
     verify(mockFlutterEngine.getNavigationChannel(), times(1))
-        .setInitialRoute("/custom/route/?query=test");
+        .setInitialRoute("/custom/route?query=test");
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -491,12 +491,12 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onAttach(RuntimeEnvironment.application);
 
     Intent mockIntent = mock(Intent.class);
-    when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route/?query=test"));
+    when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route?query=test"));
     // Emulate the host and call the method that we expect to be forwarded.
     delegate.onNewIntent(mockIntent);
 
     // Verify that the navigation channel was given the push route message.
-    verify(mockFlutterEngine.getNavigationChannel(), times(1)).pushRoute("/custom/route/?query=test");
+    verify(mockFlutterEngine.getNavigationChannel(), times(1)).pushRoute("/custom/route?query=test");
   }
 
   @Test


### PR DESCRIPTION
## Description
Currently, android platform only sends URL path obtained from deeplink . This PR sets route as `path + query` instead of just path. 

The fix for iOS is in #23562  

## Related Issues

Fixes flutter/flutter#73637

## Tests

I have updated the test files.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
