### PR TITLE
iOS deeplink sends "path + query" instead of just path

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -158,11 +158,12 @@ static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
                        FML_LOG(ERROR)
                            << "Timeout waiting for the first frame when launching an URL.";
                      } else {
-                       NSString *pathAndQuery = @"";
+                       NSString* pathAndQuery = @"";
                        if ([url.path length] != 0) {
                          pathAndQuery = url.path;
                          if ([url.query length] != 0) {
-                           pathAndQuery = [NSString stringWithFormat:@"%@?%@", pathAndQuery, url.query];
+                           pathAndQuery =
+                               [NSString stringWithFormat:@"%@?%@", pathAndQuery, url.query];
                          }
                        }
                        [flutterViewController.engine.navigationChannel invokeMethod:@"pushRoute"

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -158,13 +158,9 @@ static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
                        FML_LOG(ERROR)
                            << "Timeout waiting for the first frame when launching an URL.";
                      } else {
-                       NSString* pathAndQuery = @"";
-                       if ([url.path length] != 0) {
-                         pathAndQuery = url.path;
-                         if ([url.query length] != 0) {
-                           pathAndQuery =
-                               [NSString stringWithFormat:@"%@?%@", pathAndQuery, url.query];
-                         }
+                       NSString* pathAndQuery = url.path;
+                       if ([url.query length] != 0) {
+                         pathAndQuery = [NSString stringWithFormat:@"%@?%@", pathAndQuery, url.query];
                        }
                        [flutterViewController.engine.navigationChannel invokeMethod:@"pushRoute"
                                                                           arguments:pathAndQuery];

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -158,8 +158,15 @@ static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
                        FML_LOG(ERROR)
                            << "Timeout waiting for the first frame when launching an URL.";
                      } else {
+                       NSString *pathAndQuery = @"";
+                       if ([url.path length] != 0) {
+                         pathAndQuery = url.path;
+                         if ([url.query length] != 0) {
+                           pathAndQuery = [NSString stringWithFormat:@"%@?%@", pathAndQuery, url.query];
+                         }
+                       }
                        [flutterViewController.engine.navigationChannel invokeMethod:@"pushRoute"
-                                                                          arguments:url.path];
+                                                                          arguments:pathAndQuery];
                      }
                    }];
       return YES;

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -160,7 +160,8 @@ static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
                      } else {
                        NSString* pathAndQuery = url.path;
                        if ([url.query length] != 0) {
-                         pathAndQuery = [NSString stringWithFormat:@"%@?%@", pathAndQuery, url.query];
+                         pathAndQuery = 
+                             [NSString stringWithFormat:@"%@?%@", pathAndQuery, url.query];
                        }
                        [flutterViewController.engine.navigationChannel invokeMethod:@"pushRoute"
                                                                           arguments:pathAndQuery];

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -160,7 +160,7 @@ static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
                      } else {
                        NSString* pathAndQuery = url.path;
                        if ([url.query length] != 0) {
-                         pathAndQuery = 
+                         pathAndQuery =
                              [NSString stringWithFormat:@"%@?%@", pathAndQuery, url.query];
                        }
                        [flutterViewController.engine.navigationChannel invokeMethod:@"pushRoute"

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -29,7 +29,7 @@ FLUTTER_ASSERT_ARC
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };
-  NSURL* url = [NSURL URLWithString:@"http://example.com"];
+  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
   NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
   BOOL result = [appDelegate application:[UIApplication sharedApplication]
                                  openURL:url
@@ -38,7 +38,7 @@ FLUTTER_ASSERT_ARC
                            return @{@"FlutterDeepLinkingEnabled" : @(YES)};
                          }];
   XCTAssertTrue(result);
-  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:url.path]);
+  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
 }
 
 @end


### PR DESCRIPTION
## Description

Currently, iOS platform only sends URL path obtained from deeplink . This PR sets route as path + query instead of just path.

The fix for Android is in #23561 

## Related Issues

Fixes flutter/flutter#73637

## Tests

I have updated the test files.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.
