### PR TITLE
use the profile build of CanvasKit in --profile mode

### DIFF
--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -468,7 +468,7 @@ flt-glass-pane * {
     if (useCanvasKit) {
       _canvasKitScript?.remove();
       _canvasKitScript = html.ScriptElement();
-      _canvasKitScript!.src = canvasKitBaseUrl + 'canvaskit.js';
+      _canvasKitScript!.src = canvasKitJavaScriptBindingsUrl;
 
       // TODO(hterkelsen): Rather than this monkey-patch hack, we should
       // build CanvasKit ourselves. See:


### PR DESCRIPTION
## Description

Use the profile build of CanvasKit in `--profile` mode. This PR must land _after_ https://github.com/flutter/engine/pull/23348.

## Tests

This is covered by existing integration tests and benchmarks.