### PR TITLE
[web] Apply font-family and other styles to the paragraph element

### DIFF
--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -132,12 +132,16 @@ class CanvasParagraph implements EngineParagraph {
     cssStyle
       ..position = 'absolute'
       ..whiteSpace = 'pre-wrap'
-      ..overflowWrap = 'break-word'
-      ..overflow = 'hidden';
+      ..overflowWrap = 'break-word';
+
+    if (paragraphStyle._maxLines != null || paragraphStyle._ellipsis != null) {
+      cssStyle..overflowY = 'hidden';
+    }
 
     if (paragraphStyle._ellipsis != null &&
         (paragraphStyle._maxLines == null || paragraphStyle._maxLines == 1)) {
       cssStyle
+        ..overflowX = 'hidden'
         ..whiteSpace = 'pre'
         ..textOverflow = 'ellipsis';
     }

--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -127,13 +127,9 @@ class CanvasParagraph implements EngineParagraph {
         domRenderer.createElement('p') as html.HtmlElement;
 
     // 1. Set paragraph-level styles.
+    _applyParagraphStyleToElement(element: element, style: paragraphStyle);
     final html.CssStyleDeclaration cssStyle = element.style;
-    final ui.TextDirection direction =
-        paragraphStyle._textDirection ?? ui.TextDirection.ltr;
-    final ui.TextAlign align = paragraphStyle._textAlign ?? ui.TextAlign.start;
     cssStyle
-      ..direction = _textDirectionToCss(direction)
-      ..textAlign = textAlignToCssValue(align, direction)
       ..position = 'absolute'
       ..whiteSpace = 'pre-wrap'
       ..overflowWrap = 'break-word'

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -200,6 +200,7 @@ class FontManager {
       // loaded. They were measured using fallback font, so we should clear the
       // cache.
       TextMeasurementService.clearCache();
+      Spanometer.clearRulersCache();
     }, onError: (dynamic exception) {
       // Failures here will throw an html.DomException which confusingly
       // does not implement Exception or Error. Rethrow an Exception so it can

--- a/lib/web_ui/lib/src/engine/text/layout_service.dart
+++ b/lib/web_ui/lib/src/engine/text/layout_service.dart
@@ -1072,6 +1072,18 @@ class Spanometer {
   static Map<TextHeightStyle, TextHeightRuler> _rulers =
       <TextHeightStyle, TextHeightRuler>{};
 
+  @visibleForTesting
+  static Map<TextHeightStyle, TextHeightRuler> get rulers => _rulers;
+
+  /// Clears the cache of rulers that are used for measuring text height and
+  /// baseline metrics.
+  static void clearRulersCache() {
+    _rulers.forEach((TextHeightStyle style, TextHeightRuler ruler) {
+      ruler.dispose();
+    });
+    _rulers.clear();
+  }
+
   String _cssFontString = '';
 
   double? get letterSpacing => currentSpan.style._letterSpacing;

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -414,6 +414,11 @@ class TextHeightRuler {
   /// The height for this ruler's [textHeightStyle].
   late final double height = _dimensions.height;
 
+  /// Disposes of this ruler and detaches it from the DOM tree.
+  void dispose() {
+    _host.remove();
+  }
+
   html.HtmlElement _createHost() {
     final html.DivElement host = html.DivElement();
     host.style
@@ -928,7 +933,7 @@ class ParagraphRuler {
     _singleLineHost.remove();
     _minIntrinsicHost.remove();
     _constrainedHost.remove();
-    _textHeightRuler._host.remove();
+    _textHeightRuler.dispose();
     assert(() {
       _debugIsDisposed = true;
       return true;

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
-const String paragraphStyle = 'style="position: absolute; white-space: pre-wrap; overflow-wrap: break-word; overflow: hidden;"';
+const String paragraphStyle = 'font-family: sans-serif; position: absolute; white-space: pre-wrap; overflow-wrap: break-word; overflow: hidden;';
 const String defaultColor = 'color: rgb(255, 0, 0);';
 const String defaultFontFamily = 'font-family: sans-serif;';
 const String defaultFontSize = 'font-size: 14px;';
@@ -33,7 +33,11 @@ void testMain() {
     expect(paragraph.toPlainText(), 'Hello');
     expect(
       paragraph.toDomElement().outerHtml,
-      '<p $paragraphStyle><span style="$defaultColor font-size: 13px; $defaultFontFamily">Hello</span></p>',
+      '<p style="font-size: 13px; $paragraphStyle">'
+      '<span style="$defaultColor font-size: 13px; $defaultFontFamily">'
+      'Hello'
+      '</span>'
+      '</p>',
     );
     expect(paragraph.spans, hasLength(1));
 
@@ -55,7 +59,7 @@ void testMain() {
     expect(paragraph.toPlainText(), 'Hello');
     expect(
       paragraph.toDomElement().outerHtml,
-      '<p $paragraphStyle><span style="$defaultColor $defaultFontSize $defaultFontFamily">Hello</span></p>',
+      '<p style="$paragraphStyle"><span style="$defaultColor $defaultFontSize $defaultFontFamily">Hello</span></p>',
     );
     expect(paragraph.spans, hasLength(1));
 
@@ -80,7 +84,7 @@ void testMain() {
     expect(paragraph.toPlainText(), 'Hello');
     expect(
       paragraph.toDomElement().outerHtml,
-      '<p $paragraphStyle>'
+      '<p style="line-height: 1.5; font-size: 13px; $paragraphStyle">'
       '<span style="$defaultColor line-height: 1.5; font-size: 9px; font-weight: bold; font-style: italic; $defaultFontFamily letter-spacing: 2px;">'
       'Hello'
       '</span>'
@@ -116,7 +120,7 @@ void testMain() {
     expect(paragraph.toPlainText(), 'Hello world');
     expect(
       paragraph.toDomElement().outerHtml,
-      '<p $paragraphStyle>'
+      '<p style="font-size: 13px; $paragraphStyle">'
       '<span style="$defaultColor font-size: 13px; font-weight: bold; $defaultFontFamily">'
       'Hello'
       '</span>'
@@ -165,7 +169,7 @@ void testMain() {
     expect(paragraph.toPlainText(), 'Hello world!');
     expect(
       paragraph.toDomElement().outerHtml,
-      '<p $paragraphStyle>'
+      '<p style="font-size: 13px; $paragraphStyle">'
       '<span style="$defaultColor line-height: 2; font-size: 13px; font-weight: bold; $defaultFontFamily">'
       'Hello'
       '</span>'

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -8,7 +8,8 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
-const String paragraphStyle = 'font-family: sans-serif; position: absolute; white-space: pre-wrap; overflow-wrap: break-word; overflow: hidden;';
+const String paragraphStyle =
+    'font-family: sans-serif; position: absolute; white-space: pre-wrap; overflow-wrap: break-word;';
 const String defaultColor = 'color: rgb(255, 0, 0);';
 const String defaultFontFamily = 'font-family: sans-serif;';
 const String defaultFontSize = 'font-size: 14px;';
@@ -65,6 +66,48 @@ void testMain() {
 
     final FlatTextSpan textSpan = paragraph.spans.single as FlatTextSpan;
     expect(textSpan.style, styleWithDefaults());
+  });
+
+  test('Sets correct styles for max-lines', () {
+    final EngineParagraphStyle style = EngineParagraphStyle(maxLines: 2);
+    final CanvasParagraphBuilder builder = CanvasParagraphBuilder(style);
+
+    builder.addText('Hello');
+
+    final CanvasParagraph paragraph = builder.build();
+    expect(paragraph.paragraphStyle, style);
+    expect(paragraph.toPlainText(), 'Hello');
+    expect(
+      paragraph.toDomElement().outerHtml,
+      '<p style="$paragraphStyle overflow-y: hidden;">'
+      '<span style="$defaultColor $defaultFontSize $defaultFontFamily">'
+      'Hello'
+      '</span>'
+      '</p>',
+    );
+  });
+
+  test('Sets correct styles for ellipsis', () {
+    final EngineParagraphStyle style = EngineParagraphStyle(ellipsis: '...');
+    final CanvasParagraphBuilder builder = CanvasParagraphBuilder(style);
+
+    builder.addText('Hello');
+
+    final CanvasParagraph paragraph = builder.build();
+    expect(paragraph.paragraphStyle, style);
+    expect(paragraph.toPlainText(), 'Hello');
+    final String expectedParagraphStyle = paragraphStyle.replaceFirst(
+      'white-space: pre-wrap',
+      'white-space: pre',
+    );
+    expect(
+      paragraph.toDomElement().outerHtml,
+      '<p style="$expectedParagraphStyle overflow: hidden; text-overflow: ellipsis;">'
+      '<span style="$defaultColor $defaultFontSize $defaultFontFamily">'
+      'Hello'
+      '</span>'
+      '</p>',
+    );
   });
 
   test('Builds a single-span paragraph with complex styles', () {

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -54,14 +54,20 @@ void testMain() async {
 
     test('loading font should clear measurement caches', () async {
       final ui.ParagraphStyle style = ui.ParagraphStyle();
-      final DomParagraphBuilder builder = DomParagraphBuilder(style);
       final ui.ParagraphConstraints constraints =
           ui.ParagraphConstraints(width: 30.0);
-      builder.addText('test');
-      final DomParagraph paragraph = builder.build();
+
+      final DomParagraphBuilder domBuilder = DomParagraphBuilder(style);
+      domBuilder.addText('test');
       // Triggers the measuring and verifies the result has been cached.
-      paragraph.layout(constraints);
+      domBuilder.build().layout(constraints);
       expect(TextMeasurementService.rulerManager.rulers.length, 1);
+
+      final CanvasParagraphBuilder canvasBuilder = CanvasParagraphBuilder(style);
+      canvasBuilder.addText('test');
+      // Triggers the measuring and verifies the ruler cache has been populated.
+      canvasBuilder.build().layout(constraints);
+      expect(Spanometer.rulers.length, 1);
 
       // Now, loads a new font using loadFontFromList. This should clear the
       // cache
@@ -74,6 +80,7 @@ void testMain() async {
       // Verifies the font is loaded, and the cache is cleaned.
       expect(_containsFontFamily('Blehm'), true);
       expect(TextMeasurementService.rulerManager.rulers.length, 0);
+      expect(Spanometer.rulers.length, 0);
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/56702
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50770


### PR DESCRIPTION
## Description

1. Apply `font-family` and other styles to the root paragraph element. For some reason, even if all the span have the correct font-family, the browser won't render the paragraph correctly unless the root element also has a `font-family`. This issue seems to only affect the Ahem font in tests for now.

2. Clear the font cache when new fonts are loaded. This causes issues occasionally when font loading is delayed or takes longer than expected.