### PR TITLE
[web] Convert Ctrl+mousewheel to pointerdata

### DIFF
--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -302,16 +302,15 @@ mixin _WheelEventListenerMixin on _BaseAdapter {
     if (_debugLogPointerEvents) {
       print(event.type);
     }
+    _callback(_convertWheelEventToPointerData(event));
     if (event.getModifierState('Control') &&
         operatingSystem != OperatingSystem.macOs &&
         operatingSystem != OperatingSystem.iOs) {
       // Ignore Control+wheel events since the default handler
       // will change browser zoom level instead of scrolling.
-      // The exception is MacOs where Control+wheel will still scroll and zoom
-      // is not implemented.
+      // The exception is MacOs where Control+wheel will still scroll and zoom.
       return;
     }
-    _callback(_convertWheelEventToPointerData(event));
     // Prevent default so mouse wheel event doesn't get converted to
     // a scroll event that semantic nodes would process.
     //


### PR DESCRIPTION
## Description

Since operating systems other than MacOS use Ctrl+mousewheel to browser zoom, we dont want to preventDefault on the event in most cases (this was addressed in  https://github.com/flutter/engine/pull/22285).

However there are applications that want to take over the browser zoom default and handle these using flutter shortcuts. This PR changes callback to be executed regardless of preventDefault.

Apps in this rare category will still have to manually preventDefault using:
<script>
    document.addEventListener("wheel", (e) => (e.ctrlKey || e.shiftKey)
      && e.preventDefault(), { passive: false });
</script>

## Related Issues

https://github.com/flutter/flutter/issues/73617

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*
