### PR TITLE
Fix indexing error in Linux key event handling

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1344,6 +1344,7 @@ FILE: ../../../flutter/shell/platform/linux/fl_json_method_codec.cc
 FILE: ../../../flutter/shell/platform/linux/fl_json_method_codec_test.cc
 FILE: ../../../flutter/shell/platform/linux/fl_key_event_plugin.cc
 FILE: ../../../flutter/shell/platform/linux/fl_key_event_plugin.h
+FILE: ../../../flutter/shell/platform/linux/fl_key_event_plugin_private.h
 FILE: ../../../flutter/shell/platform/linux/fl_key_event_plugin_test.cc
 FILE: ../../../flutter/shell/platform/linux/fl_message_codec.cc
 FILE: ../../../flutter/shell/platform/linux/fl_message_codec_test.cc

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -74,6 +74,7 @@ source_set("flutter_linux_sources") {
              "fl_binary_messenger_private.h",
              "fl_dart_project_private.h",
              "fl_engine_private.h",
+             "fl_key_event_plugin_private.h",
              "fl_method_call_private.h",
              "fl_method_channel_private.h",
              "fl_method_codec_private.h",

--- a/shell/platform/linux/fl_key_event_plugin.cc
+++ b/shell/platform/linux/fl_key_event_plugin.cc
@@ -164,7 +164,7 @@ static GdkEventKey* find_pending_event(FlKeyEventPlugin* self, uint64_t id) {
   for (guint i = 0; i <= self->pending_events->len; ++i) {
     if (FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))->id ==
         id) {
-      return FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, 0))
+      return FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))
           ->event;
     }
   }

--- a/shell/platform/linux/fl_key_event_plugin.cc
+++ b/shell/platform/linux/fl_key_event_plugin.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/linux/fl_key_event_plugin.h"
+#include "flutter/shell/platform/linux/fl_key_event_plugin_private.h"
 
 #include <gtk/gtk.h>
 #include <cinttypes>
@@ -149,7 +150,7 @@ FlKeyEventResponseData* fl_key_event_response_data_new(FlKeyEventPlugin* plugin,
 
 // Calculates a unique ID for a given GdkEventKey object to use for
 // identification of responses from the framework.
-static uint64_t get_event_id(GdkEventKey* event) {
+uint64_t fl_key_event_plugin_get_event_id(GdkEventKey* event) {
   // Combine the event timestamp, the type of event, and the hardware keycode
   // (scan code) of the event to come up with a unique id for this event that
   // can be derived solely from the event data itself, so that we can identify
@@ -160,23 +161,21 @@ static uint64_t get_event_id(GdkEventKey* event) {
 }
 
 // Finds an event in the event queue that was sent to the framework by its ID.
-static GdkEventKey* find_pending_event(FlKeyEventPlugin* self, uint64_t id) {
-  for (guint i = 0; i <= self->pending_events->len; ++i) {
+GdkEventKey* fl_key_event_plugin_find_pending_event(FlKeyEventPlugin* self,
+                                                    uint64_t id) {
+  for (guint i = 0; i < self->pending_events->len; ++i) {
     if (FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))->id ==
         id) {
       return FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))
           ->event;
     }
   }
-  g_warning(
-      "Tried to find pending event with id %ld, but the event was not found.",
-      id);
   return nullptr;
 }
 
 // Removes an event from the pending event queue.
 static void remove_pending_event(FlKeyEventPlugin* self, uint64_t id) {
-  for (guint i = 0; i <= self->pending_events->len; ++i) {
+  for (guint i = 0; i < self->pending_events->len; ++i) {
     if (FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, i))->id ==
         id) {
       g_ptr_array_remove_index(self->pending_events, i);
@@ -228,11 +227,10 @@ static void handle_response(GObject* object,
   g_autoptr(FlValue) handled_value = fl_value_lookup_string(message, "handled");
   bool handled = FALSE;
   if (handled_value != nullptr) {
-    GdkEventKey* event = find_pending_event(self, data->id);
+    GdkEventKey* event = fl_key_event_plugin_find_pending_event(self, data->id);
     if (event == nullptr) {
       g_warning("Event response for event id %" PRIu64
-                " received, but event was received "
-                "out of order, or is unknown.",
+                " received, but pending event was not found.",
                 data->id);
     } else {
       handled = fl_value_get_bool(handled_value);
@@ -328,12 +326,12 @@ bool fl_key_event_plugin_send_key_event(FlKeyEventPlugin* self,
   // unique ID, since they are part of the event structure that we can look up
   // when we receive a random event that may or may not have been
   // tracked/produced by this code.
-  uint64_t id = get_event_id(event);
+  uint64_t id = fl_key_event_plugin_get_event_id(event);
   if (self->pending_events->len != 0 &&
-      FL_KEY_EVENT_PAIR(g_ptr_array_index(self->pending_events, 0))->id == id) {
-    // If the event is at the head of the queue of pending events we've seen,
-    // and has the same id, then we know that this is a re-dispatched event, and
-    // we shouldn't respond to it, but we should remove it from tracking.
+      fl_key_event_plugin_find_pending_event(self, id) != nullptr) {
+    // If the event is in the queue of pending events we've seen, then we know
+    // that this is a re-dispatched event, and we shouldn't respond to it, but
+    // we should remove it from tracking.
     remove_pending_event(self, id);
     return FALSE;
   }

--- a/shell/platform/linux/fl_key_event_plugin.h
+++ b/shell/platform/linux/fl_key_event_plugin.h
@@ -39,7 +39,7 @@ G_DECLARE_FINAL_TYPE(FlKeyEventPlugin,
  **/
 typedef void (*FlKeyEventPluginCallback)(GObject* source_object,
                                          FlValue* message,
-                                         bool handled,
+                                         gboolean handled,
                                          gpointer user_data);
 
 /**

--- a/shell/platform/linux/fl_key_event_plugin_private.h
+++ b/shell/platform/linux/fl_key_event_plugin_private.h
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_KEY_EVENT_PLUGIN_PRIVATE_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_FL_KEY_EVENT_PLUGIN_PRIVATE_H_
+
+#include "flutter/shell/platform/linux/fl_key_event_plugin.h"
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+/**
+ * fl_key_event_plugin_get_event_id:
+ * @event: a GDK key event (GdkEventKey).
+ *
+ * Calculates an internal key ID for a given event. Used to look up pending
+ * events using fl_key_event_plugin_find_pending_event.
+ *
+ * Returns: a 64-bit ID representing this GDK key event.
+ */
+uint64_t fl_key_event_plugin_get_event_id(GdkEventKey* event);
+
+/**
+ * fl_key_event_plugin_get_event_id:
+ * @id: a 64-bit id representing  a GDK key event (GdkEventKey). Calculated
+ * using #fl_key_event_plugin_get_event_id.
+ *
+ * Looks up an event that is waiting for a response from the framework.
+ *
+ * Returns: the GDK key event requested, or nullptr if the event doesn't exist
+ * in the queue.
+ */
+GdkEventKey* fl_key_event_plugin_find_pending_event(FlKeyEventPlugin* self,
+                                                    uint64_t id);
+
+G_END_DECLS
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_KEY_EVENT_PLUGIN_PRIVATE_H_


### PR DESCRIPTION
## Description

Fixes an indexing error in the linux key handling code. Thanks @stuartmorgan!

I also found another error when checking to see if an event is re-dispatched, and some off-by-one errors in the search. Not sure what I was smoking that day, but hopefully these are all the issues.

## Tests

- I added some tests to make sure that the events are added when dispatched, and that they are all removed when they have been handled.  I had to create a private header and make some of the APIs visible to the test to do that.