### PR TITLE
share font collections between spawn engines

### DIFF
--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -560,7 +560,7 @@ class RuntimeController : public PlatformConfigurationClient {
   void RequestDartDeferredLibrary(intptr_t loading_unit_id) override;
   const fml::WeakPtr<IOManager>& GetIOManager() const { return io_manager_; }
 
-  DartVM* GetDartVM() const { return vm_; }
+  virtual DartVM* GetDartVM() const { return vm_; }
 
   const fml::RefPtr<const DartSnapshot>& GetIsolateSnapshot() const {
     return isolate_snapshot_;

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -256,6 +256,7 @@ if (enable_unittests) {
       "//flutter/common/graphics",
       "//flutter/shell/profiling:profiling_unittests",
       "//flutter/shell/version",
+      "//flutter/testing:fixture_test",
       "//third_party/googletest:gmock",
     ]
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -297,6 +297,7 @@ class Engine final : public RuntimeDelegate,
          Settings settings,
          std::unique_ptr<Animator> animator,
          fml::WeakPtr<IOManager> io_manager,
+         const std::shared_ptr<FontCollection>& font_collection,
          std::unique_ptr<RuntimeController> runtime_controller);
 
   //----------------------------------------------------------------------------
@@ -888,7 +889,7 @@ class Engine final : public RuntimeDelegate,
   std::shared_ptr<AssetManager> asset_manager_;
   bool activity_running_;
   bool have_surface_;
-  FontCollection font_collection_;
+  std::shared_ptr<FontCollection> font_collection_;
   ImageDecoder image_decoder_;
   TaskRunners task_runners_;
   size_t hint_freed_bytes_since_last_idle_ = 0;

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -8,6 +8,7 @@
 
 #include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/shell/common/thread_host.h"
+#include "flutter/testing/fixture_test.h"
 #include "flutter/testing/testing.h"
 #include "gmock/gmock.h"
 #include "rapidjson/document.h"
@@ -96,7 +97,7 @@ fml::RefPtr<PlatformMessage> MakePlatformMessage(
   return message;
 }
 
-class EngineTest : public ::testing::Test {
+class EngineTest : public testing::FixtureTest {
  public:
   EngineTest()
       : thread_host_("EngineTest",
@@ -121,7 +122,7 @@ class EngineTest : public ::testing::Test {
 
  protected:
   void SetUp() override {
-    settings_.leak_vm = false;
+    settings_ = CreateSettingsForFixture();
     dispatcher_maker_ = [](PointerDataDispatcher::Delegate&) {
       return nullptr;
     };


### PR DESCRIPTION
## Description

Implemented sharing font collections between spawned engines.

## Related Issues

fixes https://github.com/flutter/flutter/issues/72024

## Tests

I added the following tests:

EngineTest unit tests.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
