### PR TITLE
[dart-runner] Avoid calling Destroy on nullptr

### DIFF
--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -440,7 +440,11 @@ bool DartComponentController::Main() {
 
 void DartComponentController::Kill() {
   if (Dart_CurrentIsolate()) {
-    tonic::DartMicrotaskQueue::GetForCurrentThread()->Destroy();
+    tonic::DartMicrotaskQueue* queue =
+        tonic::DartMicrotaskQueue::GetForCurrentThread();
+    if (queue) {
+      queue->Destroy();
+    }
 
     loop_->Quit();
 

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -83,7 +83,12 @@ void IsolateShutdownCallback(void* isolate_group_data, void* isolate_data) {
   auto dispatcher = async_get_default_dispatcher();
   auto loop = async_loop_from_dispatcher(dispatcher);
   if (loop) {
-    tonic::DartMicrotaskQueue::GetForCurrentThread()->Destroy();
+    tonic::DartMicrotaskQueue* queue =
+        tonic::DartMicrotaskQueue::GetForCurrentThread();
+    if (queue) {
+      queue->Destroy();
+    }
+
     async_loop_quit(loop);
   }
 


### PR DESCRIPTION
The runner was calling Destroy() on the microtask after the
internal queue had been set to null. this checks to make sure
that the queue is not null before trying to access it.

This was leading to a crash when bumping to clang-12 causing
the roll into fuchsia GI to fail.


## Related Issues

https://github.com/flutter/flutter/issues/73515
