### PR TITLE
Revert "Support Mice in iPadOS 13.4+"

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -48,8 +48,7 @@ extern NSNotificationName const FlutterSemanticsUpdateNotification;
  * FlutterViewController and other `UIViewController`s.
  */
 FLUTTER_EXPORT
-@interface FlutterViewController
-    : UIViewController <FlutterTextureRegistry, FlutterPluginRegistry, UIPointerInteractionDelegate>
+@interface FlutterViewController : UIViewController <FlutterTextureRegistry, FlutterPluginRegistry>
 
 /**
  * Initializes this FlutterViewController with the specified `FlutterEngine`.

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -12,15 +12,10 @@
 
 FLUTTER_ASSERT_ARC
 
-namespace flutter {
-class PointerDataPacket {};
-}
-
 @interface FlutterEngine ()
 - (BOOL)createShell:(NSString*)entrypoint
          libraryURI:(NSString*)libraryURI
        initialRoute:(NSString*)initialRoute;
-- (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
 @end
 
 @interface FlutterEngine (TestLowMemory)
@@ -69,7 +64,6 @@ typedef enum UIAccessibilityContrast : NSInteger {
 - (void)surfaceUpdated:(BOOL)appeared;
 - (void)performOrientationUpdate:(UIInterfaceOrientationMask)new_preferences;
 - (void)dispatchPresses:(NSSet<UIPress*>*)presses;
-- (void)scrollEvent:(UIPanGestureRecognizer*)recognizer;
 @end
 
 @implementation FlutterViewControllerTest
@@ -649,53 +643,6 @@ typedef enum UIAccessibilityContrast : NSInteger {
 
   // Clean up mocks
   [keyEventChannel stopMocking];
-}
-
-- (void)testPanGestureRecognizer API_AVAILABLE(ios(13.4)) {
-  if (@available(iOS 13.4, *)) {
-    // noop
-  } else {
-    return;
-  }
-
-  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:self.mockEngine
-                                                                    nibName:nil
-                                                                     bundle:nil];
-  XCTAssertNotNil(vc);
-  UIView* view = vc.view;
-  XCTAssertNotNil(view);
-  NSArray* gestureRecognizers = view.gestureRecognizers;
-  XCTAssertNotNil(gestureRecognizers);
-
-  BOOL found = NO;
-  for (id gesture in gestureRecognizers) {
-    if ([gesture isKindOfClass:[UIPanGestureRecognizer class]]) {
-      found = YES;
-      break;
-    }
-  }
-  XCTAssertTrue(found);
-}
-
-- (void)testMouseSupport API_AVAILABLE(ios(13.4)) {
-  if (@available(iOS 13.4, *)) {
-    // noop
-  } else {
-    return;
-  }
-
-  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:self.mockEngine
-                                                                    nibName:nil
-                                                                     bundle:nil];
-  XCTAssertNotNil(vc);
-
-  id mockPanGestureRecognizer = OCMClassMock([UIPanGestureRecognizer class]);
-  XCTAssertNotNil(mockPanGestureRecognizer);
-
-  [vc scrollEvent:mockPanGestureRecognizer];
-
-  [[[self.mockEngine verify] ignoringNonObjectArgs]
-      dispatchPointerDataPacket:std::make_unique<flutter::PointerDataPacket>()];
 }
 
 - (NSSet<UIPress*>*)fakeUiPressSetForPhase:(UIPressPhase)phase


### PR DESCRIPTION
Reverts flutter/engine#23362

Fixes https://github.com/flutter/flutter/issues/73764

Caused framework test failure:
```
stdout:                /Users/flutter/.cocoon/flutter/bin/cache/artifacts/engine/ios-release/Flutter.xcframework/ios-armv7_arm64/Flutter.framework/Headers/FlutterViewController.h:52:72: error: cannot find protocol declaration for 'UIPointerInteractionDelegate'
stdout:                    : UIViewController <FlutterTextureRegistry, FlutterPluginRegistry, UIPointerInteractionDelegate>
stdout:                                                                                       ^
stdout:                1 error generated.
stdout:                In file included from /Users/flutter/.cocoon/flutter/packages/integration_test/ios/Classes/IntegrationTestPlugin.m:5:
stdout:                /Users/flutter/.cocoon/flutter/packages/integration_test/ios/Classes/IntegrationTestPlugin.h:5:9: fatal error: could not build module 'Flutter'
stdout:                #import <Flutter/Flutter.h>
stdout:                 ~~~~~~~^
stdout:                2 errors generated.
```