### PR TITLE
Windows textures: Add placeholder flutter_texture_registrar.h

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -922,6 +922,7 @@ FILE: ../../../flutter/shell/platform/common/cpp/path_utils_unittests.cc
 FILE: ../../../flutter/shell/platform/common/cpp/public/flutter_export.h
 FILE: ../../../flutter/shell/platform/common/cpp/public/flutter_messenger.h
 FILE: ../../../flutter/shell/platform/common/cpp/public/flutter_plugin_registrar.h
+FILE: ../../../flutter/shell/platform/common/cpp/public/flutter_texture_registrar.h
 FILE: ../../../flutter/shell/platform/common/cpp/text_input_model.cc
 FILE: ../../../flutter/shell/platform/common/cpp/text_input_model.h
 FILE: ../../../flutter/shell/platform/common/cpp/text_input_model_unittests.cc

--- a/shell/platform/common/cpp/BUILD.gn
+++ b/shell/platform/common/cpp/BUILD.gn
@@ -13,6 +13,7 @@ _public_headers = [
   "public/flutter_export.h",
   "public/flutter_messenger.h",
   "public/flutter_plugin_registrar.h",
+  "public/flutter_texture_registrar.h",
 ]
 
 # Any files that are built by clients (client_wrapper code, library headers for

--- a/shell/platform/common/cpp/public/flutter_texture_registrar.h
+++ b/shell/platform/common/cpp/public/flutter_texture_registrar.h
@@ -1,0 +1,3 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.


### PR DESCRIPTION
## Description

As discussed with @stuartmorgan (https://github.com/flutter/engine/pull/19405#issuecomment-758770197), this PR adds an empty `flutter_texture_registrar.h` as a prerequisite for landing https://github.com/flutter/flutter/pull/61098

## Related Issues

- https://github.com/flutter/engine/pull/19405
- https://github.com/flutter/flutter/pull/61098
