### PR TITLE
Link SkShaper/SkParagraph into the engine by default

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -14,8 +14,11 @@ declare_args() {
   # The runtime mode ("debug", "profile", "release", or "jit_release")
   flutter_runtime_mode = "debug"
 
-  # Whether to use the Skia text shaper module
+  # Whether to link the Skia text shaper module into the engine
   flutter_enable_skshaper = false
+
+  # Whether to use the Skia text shaper module for all text rendering
+  flutter_always_use_skshaper = false
 
   # Whether to use the legacy embedder when building for Fuchsia.
   flutter_enable_legacy_fuchsia_embedder = true

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -135,6 +135,9 @@ source_set("ui") {
   if (flutter_enable_skshaper) {
     defines += [ "FLUTTER_ENABLE_SKSHAPER" ]
   }
+  if (flutter_always_use_skshaper) {
+    defines += [ "FLUTTER_ALWAYS_USE_SKSHAPER" ]
+  }
   if (is_win) {
     # Required for M_PI and others.
     defines += [ "_USE_MATH_DEFINES" ]

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -301,10 +301,15 @@ ParagraphBuilder::ParagraphBuilder(
   ParagraphBuilderFactory factory = txt::ParagraphBuilder::CreateTxtBuilder;
 
 #if FLUTTER_ENABLE_SKSHAPER
-  if (UIDartState::Current()->enable_skparagraph()) {
+#if FLUTTER_ALWAYS_USE_SKSHAPER
+  bool enable_skparagraph = true;
+#else
+  bool enable_skparagraph = UIDartState::Current()->enable_skparagraph();
+#endif
+  if (enable_skparagraph) {
     factory = txt::ParagraphBuilder::CreateSkiaBuilder;
   }
-#endif
+#endif  // FLUTTER_ENABLE_SKSHAPER
 
   m_paragraphBuilder = factory(style, font_collection.GetFontCollection());
 }

--- a/tools/gn
+++ b/tools/gn
@@ -107,6 +107,7 @@ def to_gn_args(args):
     gn_args['flutter_enable_skshaper'] = args.enable_skshaper
     if args.enable_skshaper:
       gn_args['skia_use_icu'] = True
+      gn_args['flutter_always_use_skshaper'] = args.always_use_skshaper
     gn_args['is_official_build'] = True    # Disable Skia test utilities.
     gn_args['dart_component_kind'] = 'static_library' # Always link Dart in statically.
     gn_args['is_debug'] = args.unoptimized
@@ -388,8 +389,11 @@ def parse_args(args):
   parser.add_argument('--enable-vulkan', action='store_true', default=False)
 
   parser.add_argument('--enable-fontconfig', action='store_true', default=False)
-  parser.add_argument('--enable-skshaper', action='store_true', default=False)
   parser.add_argument('--enable-vulkan-validation-layers', action='store_true', default=False)
+
+  parser.add_argument('--enable-skshaper', action='store_true', default=True)
+  parser.add_argument('--no-enable-skshaper', dest='enable_skshaper', action='store_false')
+  parser.add_argument('--always-use-skshaper', action='store_true', default=False)
 
   parser.add_argument('--embedder-for-target', dest='embedder_for_target', action='store_true', default=False)
 


### PR DESCRIPTION
Also add flags for excluding SkShaper and for using SkShaper as the
text renderer in all cases (by default SkShaper is only active if
the app sets a runtime flag)
