### PR TITLE
implemented GetMainContext() for opengl

### DIFF
--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -93,6 +93,7 @@ GPUSurfaceGL::GPUSurfaceGL(sk_sp<GrDirectContext> gr_context,
                            bool render_to_surface)
     : delegate_(delegate),
       context_(gr_context),
+      context_owner_(false),
       render_to_surface_(render_to_surface),
       weak_factory_(this) {
   auto context_switch = delegate_->GLContextMakeCurrent();

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -34,16 +34,13 @@ static const int kGrCacheMaxCount = 8192;
 // system channel.
 static const size_t kGrCacheMaxByteSize = 24 * (1 << 20);
 
-GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate,
-                           bool render_to_surface)
-    : delegate_(delegate),
-      render_to_surface_(render_to_surface),
-      weak_factory_(this) {
-  auto context_switch = delegate_->GLContextMakeCurrent();
+sk_sp<GrDirectContext> GPUSurfaceGL::MakeGLContext(
+    GPUSurfaceGLDelegate* delegate) {
+  auto context_switch = delegate->GLContextMakeCurrent();
   if (!context_switch->GetResult()) {
     FML_LOG(ERROR)
         << "Could not make the context current to setup the gr context.";
-    return;
+    return nullptr;
   }
 
   GrContextOptions options;
@@ -64,32 +61,31 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate,
   // TODO(goderbauer): remove option when skbug.com/7523 is fixed.
   // A similar work-around is also used in shell/common/io_manager.cc.
   options.fDisableGpuYUVConversion = true;
+  auto context = GrDirectContext::MakeGL(delegate->GetGLInterface(), options);
 
-  auto context = GrDirectContext::MakeGL(delegate_->GetGLInterface(), options);
-
-  if (context == nullptr) {
+  if (!context) {
     FML_LOG(ERROR) << "Failed to setup Skia Gr context.";
-    return;
+    return nullptr;
   }
 
-  context_ = std::move(context);
-
-  context_->setResourceCacheLimits(kGrCacheMaxCount, kGrCacheMaxByteSize);
-
-  context_owner_ = true;
-
-  valid_ = true;
+  context->setResourceCacheLimits(kGrCacheMaxCount, kGrCacheMaxByteSize);
 
   std::vector<PersistentCache::SkSLCache> caches =
       PersistentCache::GetCacheForProcess()->LoadSkSLs();
   int compiled_count = 0;
   for (const auto& cache : caches) {
-    compiled_count += context_->precompileShader(*cache.first, *cache.second);
+    compiled_count += context->precompileShader(*cache.first, *cache.second);
   }
   FML_LOG(INFO) << "Found " << caches.size() << " SkSL shaders; precompiled "
                 << compiled_count;
 
-  delegate_->GLContextClearCurrent();
+  return context;
+}
+
+GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate,
+                           bool render_to_surface)
+    : GPUSurfaceGL(MakeGLContext(delegate), delegate, render_to_surface) {
+  context_owner_ = true;
 }
 
 GPUSurfaceGL::GPUSurfaceGL(sk_sp<GrDirectContext> gr_context,
@@ -109,7 +105,6 @@ GPUSurfaceGL::GPUSurfaceGL(sk_sp<GrDirectContext> gr_context,
   delegate_->GLContextClearCurrent();
 
   valid_ = true;
-  context_owner_ = false;
 }
 
 GPUSurfaceGL::~GPUSurfaceGL() {

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -20,6 +20,8 @@ namespace flutter {
 
 class GPUSurfaceGL : public Surface {
  public:
+  static sk_sp<GrDirectContext> MakeGLContext(GPUSurfaceGLDelegate* delegate);
+
   GPUSurfaceGL(GPUSurfaceGLDelegate* delegate, bool render_to_surface);
 
   // Creates a new GL surface reusing an existing GrDirectContext.

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -55,13 +55,13 @@ class GPUSurfaceGL : public Surface {
   sk_sp<GrDirectContext> context_;
   sk_sp<SkSurface> onscreen_surface_;
   /// FBO backing the current `onscreen_surface_`.
-  uint32_t fbo_id_;
-  bool context_owner_;
+  uint32_t fbo_id_ = 0;
+  bool context_owner_ = false;
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an
   // external view embedder may want to render to the root surface. This is a
   // hack to make avoid allocating resources for the root surface when an
   // external view embedder is present.
-  const bool render_to_surface_;
+  const bool render_to_surface_ = true;
   bool valid_ = false;
   fml::TaskRunnerAffineWeakPtrFactory<GPUSurfaceGL> weak_factory_;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
@@ -33,10 +33,8 @@ FLUTTER_ASSERT_NOT_ARC
   std::shared_ptr<flutter::IOSContext> engine_context = [engine iosPlatformView]->GetIosContext();
   std::shared_ptr<flutter::IOSContext> spawn_context = [spawn iosPlatformView]->GetIosContext();
   XCTAssertEqual(engine_context, spawn_context);
-  // If this assert fails it means we may be using the software or OpenGL
-  // renderer when we were expecting Metal.  For software rendering, this is
-  // expected to be nullptr.  For OpenGL, implementing this is an outstanding
-  // change see https://github.com/flutter/flutter/issues/73744.
+  // If this assert fails it means we may be using the software.  For software rendering, this is
+  // expected to be nullptr.
   XCTAssertTrue(engine_context->GetMainContext() != nullptr);
   XCTAssertEqual(engine_context->GetMainContext(), spawn_context->GetMainContext());
   [engine release];

--- a/shell/platform/darwin/ios/ios_context_gl.h
+++ b/shell/platform/darwin/ios/ios_context_gl.h
@@ -25,15 +25,10 @@ class IOSContextGL final : public IOSContext {
 
   std::unique_ptr<IOSRenderTargetGL> CreateRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer);
 
- private:
-  fml::scoped_nsobject<EAGLContext> context_;
-  fml::scoped_nsobject<EAGLContext> resource_context_;
+  void SetMainContext(const sk_sp<GrDirectContext>& main_context);
 
   // |IOSContext|
   sk_sp<GrDirectContext> CreateResourceContext() override;
-
-  // |IOSContext|
-  sk_sp<GrDirectContext> GetMainContext() const override;
 
   // |IOSContext|
   std::unique_ptr<GLContextResult> MakeCurrent() override;
@@ -42,6 +37,14 @@ class IOSContextGL final : public IOSContext {
   std::unique_ptr<Texture> CreateExternalTexture(
       int64_t texture_id,
       fml::scoped_nsobject<NSObject<FlutterTexture>> texture) override;
+
+  // |IOSContext|
+  sk_sp<GrDirectContext> GetMainContext() const override;
+
+ private:
+  fml::scoped_nsobject<EAGLContext> context_;
+  fml::scoped_nsobject<EAGLContext> resource_context_;
+  sk_sp<GrDirectContext> main_context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSContextGL);
 };

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -38,8 +38,16 @@ void IOSSurfaceGL::UpdateStorageSizeIfNecessary() {
 std::unique_ptr<Surface> IOSSurfaceGL::CreateGPUSurface(GrDirectContext* gr_context) {
   if (gr_context) {
     return std::make_unique<GPUSurfaceGL>(sk_ref_sp(gr_context), this, true);
+  } else {
+    IOSContextGL* gl_context = CastToGLContext(GetContext());
+    sk_sp<GrDirectContext> context = gl_context->GetMainContext();
+    if (!context) {
+      context = GPUSurfaceGL::MakeGLContext(this);
+      gl_context->SetMainContext(context);
+    }
+
+    return std::make_unique<GPUSurfaceGL>(context, this, true);
   }
-  return std::make_unique<GPUSurfaceGL>(this, true);
 }
 
 // |GPUSurfaceGLDelegate|

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -40,10 +40,10 @@ void IOSSurfaceMetal::UpdateStorageSizeIfNecessary() {
 }
 
 // |IOSSurface|
-std::unique_ptr<Surface> IOSSurfaceMetal::CreateGPUSurface(GrDirectContext* /* unused */) {
-  auto metal_context = CastToMetalContext(GetContext());
-  return std::make_unique<GPUSurfaceMetal>(this,                            // layer
-                                           metal_context->GetMainContext()  // context
+std::unique_ptr<Surface> IOSSurfaceMetal::CreateGPUSurface(GrDirectContext* context) {
+  FML_DCHECK(context);
+  return std::make_unique<GPUSurfaceMetal>(this,               // layer
+                                           sk_ref_sp(context)  // context
   );
 }
 

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -148,7 +148,7 @@ std::unique_ptr<Surface> PlatformViewIOS::CreateRenderingSurface() {
                       "has no ViewController.";
     return nullptr;
   }
-  return ios_surface_->CreateGPUSurface();
+  return ios_surface_->CreateGPUSurface(ios_context_->GetMainContext().get());
 }
 
 // |PlatformView|

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -80,7 +80,6 @@ std::unique_ptr<Surface> EmbedderSurfaceGL::CreateGPUSurface() {
   const bool render_to_surface = !external_view_embedder_;
   return std::make_unique<GPUSurfaceGL>(this,  // GPU surface GL delegate
                                         render_to_surface  // render to surface
-
   );
 }
 


### PR DESCRIPTION
## Description

For Metal, the IOSContext owns the skia context, for OpenGL it was the GPUSurface that owned the context.  I've made the IOSContextGL behave like the IOSContextMetal which allowed us to percolate up a shared interface `GetMainContext()`.  This effectively solves the sharing GPU context problem for OpenGL as well.

## Related Issues

fixes https://github.com/flutter/flutter/issues/72021
https://github.com/flutter/engine/pull/23539

## Tests

I added the following tests:

No new functionality other than changing who has ownership of the skia context.  Existing tests should cover it.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [x] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
