### PR TITLE
[web] Fix text cutoff when rendering paragraphs on DomCanvas

### DIFF
--- a/lib/web_ui/lib/src/engine/engine_canvas.dart
+++ b/lib/web_ui/lib/src/engine/engine_canvas.dart
@@ -254,9 +254,6 @@ html.Element _drawParagraphElement(
   assert(paragraph.isLaidOut);
 
   final html.HtmlElement paragraphElement = paragraph.toDomElement();
-  paragraphElement.style
-      ..height = '${paragraph.height}px'
-      ..width = '${paragraph.width}px';
 
   if (transform != null) {
     setElementTransform(

--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -96,6 +96,7 @@ class CanvasParagraph implements EngineParagraph {
 
     isLaidOut = true;
     _lastUsedConstraints = constraints;
+    _cachedDomElement = null;
   }
 
   // TODO(mdebbar): Returning true means we always require a bitmap canvas. Revisit
@@ -115,6 +116,7 @@ class CanvasParagraph implements EngineParagraph {
 
   @override
   html.HtmlElement toDomElement() {
+    assert(isLaidOut);
     final html.HtmlElement? domElement = _cachedDomElement;
     if (domElement == null) {
       return _cachedDomElement ??= _createDomElement();
@@ -123,19 +125,20 @@ class CanvasParagraph implements EngineParagraph {
   }
 
   html.HtmlElement _createDomElement() {
-    final html.HtmlElement element =
+    final html.HtmlElement rootElement =
         domRenderer.createElement('p') as html.HtmlElement;
 
     // 1. Set paragraph-level styles.
-    _applyParagraphStyleToElement(element: element, style: paragraphStyle);
-    final html.CssStyleDeclaration cssStyle = element.style;
+    _applyParagraphStyleToElement(element: rootElement, style: paragraphStyle);
+    final html.CssStyleDeclaration cssStyle = rootElement.style;
     cssStyle
       ..position = 'absolute'
-      ..whiteSpace = 'pre-wrap'
-      ..overflowWrap = 'break-word';
+      ..whiteSpace = 'pre';
 
     if (paragraphStyle._maxLines != null || paragraphStyle._ellipsis != null) {
-      cssStyle..overflowY = 'hidden';
+      cssStyle
+        ..overflowY = 'hidden'
+        ..height = '${height}px';
     }
 
     if (paragraphStyle._ellipsis != null &&
@@ -147,25 +150,46 @@ class CanvasParagraph implements EngineParagraph {
     }
 
     // 2. Append all spans to the paragraph.
-    for (final ParagraphSpan span in spans) {
-      if (span is FlatTextSpan) {
-        final html.HtmlElement spanElement =
-            domRenderer.createElement('span') as html.HtmlElement;
-        _applyTextStyleToElement(
-          element: spanElement,
-          style: span.style,
-          isSpan: true,
-        );
-        domRenderer.appendText(spanElement, span.textOf(this));
-        domRenderer.append(element, spanElement);
-      } else if (span is PlaceholderSpan) {
-        domRenderer.append(
-          element,
-          _createPlaceholderElement(placeholder: span),
-        );
+
+    ParagraphSpan? span;
+    late html.HtmlElement element;
+    final List<EngineLineMetrics> lines = computeLineMetrics();
+
+    for (int i = 0; i < lines.length; i++) {
+      // Insert a <BR> element before each line except the first line.
+      if (i > 0) {
+        domRenderer.append(element, domRenderer.createElement('br'));
+      }
+
+      for (final RangeBox box in lines[i].boxes!) {
+        if (box is SpanBox) {
+          if (box.span != span) {
+            span = box.span;
+            element = domRenderer.createElement('span') as html.HtmlElement;
+            _applyTextStyleToElement(
+              element: element,
+              style: box.span.style,
+              isSpan: true
+            );
+            domRenderer.append(rootElement, element);
+          }
+          domRenderer.appendText(element, box.toText());
+        } else if (box is PlaceholderBox) {
+          span = box.placeholder;
+          // If there's a line-end after this placeholder, we want the <BR> to
+          // be inserted in the root paragraph element.
+          element = rootElement;
+          domRenderer.append(
+            rootElement,
+            _createPlaceholderElement(placeholder: box.placeholder),
+          );
+        } else {
+          throw UnimplementedError('Unknown box type: ${box.runtimeType}');
+        }
       }
     }
-    return element;
+
+    return rootElement;
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -133,6 +133,8 @@ class CanvasParagraph implements EngineParagraph {
     final html.CssStyleDeclaration cssStyle = rootElement.style;
     cssStyle
       ..position = 'absolute'
+      // Prevent the browser from doing any line breaks in the paragraph. We want
+      // to insert our own <BR> breaks based on layout results.
       ..whiteSpace = 'pre';
 
     if (paragraphStyle._maxLines != null || paragraphStyle._ellipsis != null) {
@@ -144,8 +146,8 @@ class CanvasParagraph implements EngineParagraph {
     if (paragraphStyle._ellipsis != null &&
         (paragraphStyle._maxLines == null || paragraphStyle._maxLines == 1)) {
       cssStyle
+        ..width = '${width}px'
         ..overflowX = 'hidden'
-        ..whiteSpace = 'pre'
         ..textOverflow = 'ellipsis';
     }
 

--- a/lib/web_ui/lib/src/engine/text/layout_service.dart
+++ b/lib/web_ui/lib/src/engine/text/layout_service.dart
@@ -487,6 +487,13 @@ class SpanBox extends RangeBox {
     return startIndex < this.end.index && this.start.index < endIndex;
   }
 
+  /// Returns the substring of the paragraph that's represented by this box.
+  ///
+  /// Trailing newlines are omitted, if any.
+  String toText() {
+    return spanometer.paragraph.toPlainText().substring(start.index, end.indexWithoutTrailingNewlines);
+  }
+
   /// Returns a [ui.TextBox] representing this range box in the given [line].
   ///
   /// The coordinates of the resulting [ui.TextBox] are relative to the

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -480,6 +480,8 @@ class DomParagraph implements EngineParagraph {
 
     final html.CssStyleDeclaration paragraphStyle = paragraphElement.style;
     paragraphStyle
+      ..height = '${height}px'
+      ..width = '${width}px'
       ..position = 'absolute'
       ..whiteSpace = 'pre-wrap'
       ..overflowWrap = 'break-word'

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -547,8 +547,8 @@ void _testCullRectComputation() {
     'renders clipped text with high quality',
     () async {
       // To reproduce blurriness we need real clipping.
-      final Paragraph paragraph =
-          (ParagraphBuilder(ParagraphStyle(fontFamily: 'Roboto'))..addText('Am I blurry?')).build();
+      final DomParagraph paragraph =
+          (DomParagraphBuilder(ParagraphStyle(fontFamily: 'Roboto'))..addText('Am I blurry?')).build();
       paragraph.layout(const ParagraphConstraints(width: 1000));
 
       final Rect canvasSize = Rect.fromLTRB(

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -8,17 +8,20 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
-const String paragraphStyle =
-    'font-family: sans-serif; position: absolute; white-space: pre-wrap; overflow-wrap: break-word;';
 const String defaultColor = 'color: rgb(255, 0, 0);';
-const String defaultFontFamily = 'font-family: sans-serif;';
+const String defaultFontFamily =
+    'font-family: Ahem, -apple-system, BlinkMacSystemFont, sans-serif;';
 const String defaultFontSize = 'font-size: 14px;';
+const String paragraphStyle =
+    '$defaultFontFamily position: absolute; white-space: pre;';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
 
-void testMain() {
+void testMain() async {
+  await webOnlyInitializeTestDomRenderer();
+
   setUpAll(() {
     WebExperiments.ensureInitialized();
   });
@@ -32,6 +35,9 @@ void testMain() {
     final CanvasParagraph paragraph = builder.build();
     expect(paragraph.paragraphStyle, style);
     expect(paragraph.toPlainText(), 'Hello');
+    expect(paragraph.spans, hasLength(1));
+
+    paragraph.layout(ParagraphConstraints(width: double.infinity));
     expect(
       paragraph.toDomElement().outerHtml,
       '<p style="font-size: 13px; $paragraphStyle">'
@@ -40,7 +46,17 @@ void testMain() {
       '</span>'
       '</p>',
     );
-    expect(paragraph.spans, hasLength(1));
+
+    // Should break "Hello" into "Hel" and "lo".
+    paragraph.layout(ParagraphConstraints(width: 39.0));
+    expect(
+      paragraph.toDomElement().outerHtml,
+      '<p style="font-size: 13px; $paragraphStyle">'
+      '<span style="$defaultColor font-size: 13px; $defaultFontFamily">'
+      'Hel<br>lo'
+      '</span>'
+      '</p>',
+    );
 
     final ParagraphSpan span = paragraph.spans.single;
     expect(span, isA<FlatTextSpan>());
@@ -58,11 +74,13 @@ void testMain() {
     final CanvasParagraph paragraph = builder.build();
     expect(paragraph.paragraphStyle, style);
     expect(paragraph.toPlainText(), 'Hello');
+    expect(paragraph.spans, hasLength(1));
+
+    paragraph.layout(ParagraphConstraints(width: double.infinity));
     expect(
       paragraph.toDomElement().outerHtml,
       '<p style="$paragraphStyle"><span style="$defaultColor $defaultFontSize $defaultFontFamily">Hello</span></p>',
     );
-    expect(paragraph.spans, hasLength(1));
 
     final FlatTextSpan textSpan = paragraph.spans.single as FlatTextSpan;
     expect(textSpan.style, styleWithDefaults());
@@ -77,9 +95,11 @@ void testMain() {
     final CanvasParagraph paragraph = builder.build();
     expect(paragraph.paragraphStyle, style);
     expect(paragraph.toPlainText(), 'Hello');
+
+    paragraph.layout(ParagraphConstraints(width: double.infinity));
     expect(
       paragraph.toDomElement().outerHtml,
-      '<p style="$paragraphStyle overflow-y: hidden;">'
+      '<p style="$paragraphStyle overflow-y: hidden; height: 14px;">'
       '<span style="$defaultColor $defaultFontSize $defaultFontFamily">'
       'Hello'
       '</span>'
@@ -96,13 +116,11 @@ void testMain() {
     final CanvasParagraph paragraph = builder.build();
     expect(paragraph.paragraphStyle, style);
     expect(paragraph.toPlainText(), 'Hello');
-    final String expectedParagraphStyle = paragraphStyle.replaceFirst(
-      'white-space: pre-wrap',
-      'white-space: pre',
-    );
+
+    paragraph.layout(ParagraphConstraints(width: double.infinity));
     expect(
       paragraph.toDomElement().outerHtml,
-      '<p style="$expectedParagraphStyle overflow: hidden; text-overflow: ellipsis;">'
+      '<p style="$paragraphStyle overflow: hidden; height: 14px; text-overflow: ellipsis;">'
       '<span style="$defaultColor $defaultFontSize $defaultFontFamily">'
       'Hello'
       '</span>'
@@ -125,6 +143,9 @@ void testMain() {
 
     final CanvasParagraph paragraph = builder.build();
     expect(paragraph.toPlainText(), 'Hello');
+    expect(paragraph.spans, hasLength(1));
+
+    paragraph.layout(ParagraphConstraints(width: double.infinity));
     expect(
       paragraph.toDomElement().outerHtml,
       '<p style="line-height: 1.5; font-size: 13px; $paragraphStyle">'
@@ -133,7 +154,6 @@ void testMain() {
       '</span>'
       '</p>',
     );
-    expect(paragraph.spans, hasLength(1));
 
     final FlatTextSpan span = paragraph.spans.single as FlatTextSpan;
     expect(span.textOf(paragraph), 'Hello');
@@ -161,6 +181,9 @@ void testMain() {
 
     final CanvasParagraph paragraph = builder.build();
     expect(paragraph.toPlainText(), 'Hello world');
+    expect(paragraph.spans, hasLength(2));
+
+    paragraph.layout(ParagraphConstraints(width: double.infinity));
     expect(
       paragraph.toDomElement().outerHtml,
       '<p style="font-size: 13px; $paragraphStyle">'
@@ -172,7 +195,20 @@ void testMain() {
       '</span>'
       '</p>',
     );
-    expect(paragraph.spans, hasLength(2));
+
+    // Should break "Hello world" into "Hello" and " world".
+    paragraph.layout(ParagraphConstraints(width: 65.0));
+    expect(
+      paragraph.toDomElement().outerHtml,
+      '<p style="font-size: 13px; $paragraphStyle">'
+      '<span style="$defaultColor font-size: 13px; font-weight: bold; $defaultFontFamily">'
+      'Hello'
+      '</span>'
+      '<span style="$defaultColor font-size: 13px; font-style: italic; $defaultFontFamily">'
+      ' <br>world'
+      '</span>'
+      '</p>',
+    );
 
     final FlatTextSpan hello = paragraph.spans.first as FlatTextSpan;
     expect(hello.textOf(paragraph), 'Hello');
@@ -210,6 +246,9 @@ void testMain() {
 
     final CanvasParagraph paragraph = builder.build();
     expect(paragraph.toPlainText(), 'Hello world!');
+    expect(paragraph.spans, hasLength(3));
+
+    paragraph.layout(ParagraphConstraints(width: double.infinity));
     expect(
       paragraph.toDomElement().outerHtml,
       '<p style="font-size: 13px; $paragraphStyle">'
@@ -224,7 +263,6 @@ void testMain() {
       '</span>'
       '</p>',
     );
-    expect(paragraph.spans, hasLength(3));
 
     final FlatTextSpan hello = paragraph.spans[0] as FlatTextSpan;
     expect(hello.textOf(paragraph), 'Hello');
@@ -257,6 +295,48 @@ void testMain() {
         fontWeight: FontWeight.normal,
         fontStyle: FontStyle.italic,
       ),
+    );
+  });
+
+  test('Paragraph with new lines generates correct DOM', () {
+    final EngineParagraphStyle style = EngineParagraphStyle(fontSize: 13.0);
+    final CanvasParagraphBuilder builder = CanvasParagraphBuilder(style);
+
+    builder.addText('First\nSecond ');
+    builder.pushStyle(TextStyle(fontStyle: FontStyle.italic));
+    builder.addText('ThirdLongLine');
+
+    final CanvasParagraph paragraph = builder.build();
+    expect(paragraph.toPlainText(), 'First\nSecond ThirdLongLine');
+    expect(paragraph.spans, hasLength(2));
+
+    // There's a new line between "First" and "Second", but "Second" and
+    // "ThirdLongLine" remain together since constraints are infinite.
+    paragraph.layout(ParagraphConstraints(width: double.infinity));
+    expect(
+      paragraph.toDomElement().outerHtml,
+      '<p style="font-size: 13px; $paragraphStyle">'
+      '<span style="$defaultColor font-size: 13px; $defaultFontFamily">'
+      'First<br>Second '
+      '</span>'
+      '<span style="$defaultColor font-size: 13px; font-style: italic; $defaultFontFamily">'
+      'ThirdLongLine'
+      '</span>'
+      '</p>',
+    );
+
+    // Should break the paragraph into "First", "Second" and "ThirdLongLine".
+    paragraph.layout(ParagraphConstraints(width: 180.0));
+    expect(
+      paragraph.toDomElement().outerHtml,
+      '<p style="font-size: 13px; $paragraphStyle">'
+      '<span style="$defaultColor font-size: 13px; $defaultFontFamily">'
+      'First<br>Second <br>'
+      '</span>'
+      '<span style="$defaultColor font-size: 13px; font-style: italic; $defaultFontFamily">'
+      'ThirdLongLine'
+      '</span>'
+      '</p>',
     );
   });
 }

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -8,6 +8,9 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
+bool get isIosSafari => browserEngine == BrowserEngine.webkit &&
+          operatingSystem == OperatingSystem.iOs;
+
 String get defaultFontFamily {
   String fontFamily = canonicalizeFontFamily('Ahem')!;
   if (browserEngine == BrowserEngine.firefox) {
@@ -103,10 +106,15 @@ void testMain() async {
     expect(paragraph.paragraphStyle, style);
     expect(paragraph.toPlainText(), 'Hello');
 
+    double expectedHeight = 14.0;
+    if (isIosSafari) {
+      // On iOS Safari, the height measurement is one extra pixel.
+      expectedHeight++;
+    }
     paragraph.layout(ParagraphConstraints(width: double.infinity));
     expect(
       paragraph.toDomElement().outerHtml,
-      '<p style="$paragraphStyle overflow-y: hidden; height: 14px;">'
+      '<p style="$paragraphStyle overflow-y: hidden; height: ${expectedHeight}px;">'
       '<span style="$defaultColor $defaultFontSize $defaultFontFamily">'
       'Hello'
       '</span>'
@@ -124,10 +132,15 @@ void testMain() async {
     expect(paragraph.paragraphStyle, style);
     expect(paragraph.toPlainText(), 'Hello');
 
+    double expectedHeight = 14.0;
+    if (isIosSafari) {
+      // On iOS Safari, the height measurement is one extra pixel.
+      expectedHeight++;
+    }
     paragraph.layout(ParagraphConstraints(width: double.infinity));
     expect(
       paragraph.toDomElement().outerHtml,
-      '<p style="$paragraphStyle overflow: hidden; height: 14px; text-overflow: ellipsis;">'
+      '<p style="$paragraphStyle overflow: hidden; height: ${expectedHeight}px; text-overflow: ellipsis;">'
       '<span style="$defaultColor $defaultFontSize $defaultFontFamily">'
       'Hello'
       '</span>'

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -8,11 +8,18 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
 
+String get defaultFontFamily {
+  String fontFamily = canonicalizeFontFamily('Ahem')!;
+  if (browserEngine == BrowserEngine.firefox) {
+    fontFamily = fontFamily.replaceAll('"', '&quot;');
+  } else if (browserEngine == BrowserEngine.blink || browserEngine == BrowserEngine.webkit) {
+    fontFamily = fontFamily.replaceAll('"', '');
+  }
+  return 'font-family: $fontFamily;';
+}
 const String defaultColor = 'color: rgb(255, 0, 0);';
-const String defaultFontFamily =
-    'font-family: Ahem, -apple-system, BlinkMacSystemFont, sans-serif;';
 const String defaultFontSize = 'font-size: 14px;';
-const String paragraphStyle =
+final String paragraphStyle =
     '$defaultFontFamily position: absolute; white-space: pre;';
 
 void main() {
@@ -197,7 +204,7 @@ void testMain() async {
     );
 
     // Should break "Hello world" into "Hello" and " world".
-    paragraph.layout(ParagraphConstraints(width: 65.0));
+    paragraph.layout(ParagraphConstraints(width: 70.0));
     expect(
       paragraph.toDomElement().outerHtml,
       '<p style="font-size: 13px; $paragraphStyle">'


### PR DESCRIPTION
## Description

When using a DomCanvas (for whatever reason), paragraphs are rendered using DOM elements. But measurement is always done using canvas2d, which results in slightly different numbers than DOM (up to 1-2 pixels when zoom level != 1x).

This discrepancy in measurement causes some portions of text to disappear because the <p> may decide to take line breaks at a different position than we did based on canvas2d measurements.

In order to fix the issue, we prevent the <p> from deciding its own line breaks (`white-space: pre`) and instead, we insert `<BR>` (i.e. new line HTML element) at the positions that were determined as line breaks.

## Related Issues

Fixes https://github.com/flutter/flutter/issues/67327
Fixes https://github.com/flutter/flutter/issues/64904