### PR TITLE
Use non-deprecated SkImageFilter factory functions

### DIFF
--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -74,7 +74,7 @@ TEST_F(ImageFilterLayerTest, SimpleFilter) {
   const SkRect child_bounds = SkRect::MakeLTRB(5.0f, 6.0f, 20.5f, 21.5f);
   const SkPath child_path = SkPath().addRect(child_bounds);
   const SkPaint child_paint = SkPaint(SkColors::kYellow);
-  auto layer_filter = SkImageFilter::MakeMatrixFilter(
+  auto layer_filter = SkImageFilters::MatrixTransform(
       SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer = std::make_shared<ImageFilterLayer>(layer_filter);
@@ -108,7 +108,7 @@ TEST_F(ImageFilterLayerTest, SimpleFilterBounds) {
   const SkPath child_path = SkPath().addRect(child_bounds);
   const SkPaint child_paint = SkPaint(SkColors::kYellow);
   const SkMatrix filter_transform = SkMatrix::Scale(2.0, 2.0);
-  auto layer_filter = SkImageFilter::MakeMatrixFilter(
+  auto layer_filter = SkImageFilters::MatrixTransform(
       filter_transform, SkFilterQuality::kMedium_SkFilterQuality, nullptr);
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer = std::make_shared<ImageFilterLayer>(layer_filter);
@@ -143,7 +143,7 @@ TEST_F(ImageFilterLayerTest, MultipleChildren) {
       SkPath().addRect(child_bounds.makeOffset(3.0f, 0.0f));
   const SkPaint child_paint1 = SkPaint(SkColors::kYellow);
   const SkPaint child_paint2 = SkPaint(SkColors::kCyan);
-  auto layer_filter = SkImageFilter::MakeMatrixFilter(
+  auto layer_filter = SkImageFilters::MatrixTransform(
       SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
@@ -188,9 +188,9 @@ TEST_F(ImageFilterLayerTest, Nested) {
       SkPath().addRect(child_bounds.makeOffset(3.0f, 0.0f));
   const SkPaint child_paint1 = SkPaint(SkColors::kYellow);
   const SkPaint child_paint2 = SkPaint(SkColors::kCyan);
-  auto layer_filter1 = SkImageFilter::MakeMatrixFilter(
+  auto layer_filter1 = SkImageFilters::MatrixTransform(
       SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
-  auto layer_filter2 = SkImageFilter::MakeMatrixFilter(
+  auto layer_filter2 = SkImageFilters::MatrixTransform(
       SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
@@ -241,7 +241,7 @@ TEST_F(ImageFilterLayerTest, Nested) {
 }
 
 TEST_F(ImageFilterLayerTest, Readback) {
-  auto layer_filter = SkImageFilter::MakeMatrixFilter(
+  auto layer_filter = SkImageFilters::MatrixTransform(
       SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
   auto initial_transform = SkMatrix();
 
@@ -261,7 +261,7 @@ TEST_F(ImageFilterLayerTest, Readback) {
 }
 
 TEST_F(ImageFilterLayerTest, ChildIsCached) {
-  auto layer_filter = SkImageFilter::MakeMatrixFilter(
+  auto layer_filter = SkImageFilters::MatrixTransform(
       SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
   auto initial_transform = SkMatrix::Translate(50.0, 25.5);
   auto other_transform = SkMatrix::Scale(1.0, 2.0);
@@ -290,7 +290,7 @@ TEST_F(ImageFilterLayerTest, ChildIsCached) {
 }
 
 TEST_F(ImageFilterLayerTest, ChildrenNotCached) {
-  auto layer_filter = SkImageFilter::MakeMatrixFilter(
+  auto layer_filter = SkImageFilters::MatrixTransform(
       SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
   auto initial_transform = SkMatrix::Translate(50.0, 25.5);
   auto other_transform = SkMatrix::Scale(1.0, 2.0);

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -8,7 +8,7 @@
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/fml/macros.h"
 #include "flutter/testing/mock_canvas.h"
-#include "third_party/skia/include/core/SkImageFilter.h"
+#include "third_party/skia/include/effects/SkImageFilters.h"
 
 namespace flutter {
 namespace testing {

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -5,10 +5,7 @@
 #include "flutter/lib/ui/painting/image_filter.h"
 
 #include "flutter/lib/ui/painting/matrix.h"
-#include "third_party/skia/include/effects/SkBlurImageFilter.h"
 #include "third_party/skia/include/effects/SkImageFilters.h"
-#include "third_party/skia/include/effects/SkImageSource.h"
-#include "third_party/skia/include/effects/SkPictureImageFilter.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"
 #include "third_party/tonic/dart_binding_macros.h"
@@ -48,11 +45,11 @@ ImageFilter::ImageFilter() {}
 ImageFilter::~ImageFilter() {}
 
 void ImageFilter::initImage(CanvasImage* image) {
-  filter_ = SkImageSource::Make(image->image());
+  filter_ = SkImageFilters::Image(image->image());
 }
 
 void ImageFilter::initPicture(Picture* picture) {
-  filter_ = SkPictureImageFilter::Make(picture->picture());
+  filter_ = SkImageFilters::Picture(picture->picture());
 }
 
 void ImageFilter::initBlur(double sigma_x,
@@ -63,7 +60,7 @@ void ImageFilter::initBlur(double sigma_x,
 
 void ImageFilter::initMatrix(const tonic::Float64List& matrix4,
                              int filterQuality) {
-  filter_ = SkImageFilter::MakeMatrixFilter(
+  filter_ = SkImageFilters::MatrixTransform(
       ToSkMatrix(matrix4), static_cast<SkFilterQuality>(filterQuality),
       nullptr);
 }


### PR DESCRIPTION
## Description

Updates SkPictureImageFilter::Make -> SkImageFilters::Picture and SkImageSource::Make -> SkImageFilters::Image.  Also deletes unused image filter related headers and fixes unit tests that were making SkImageFilters directly.

Will address https://bugs.chromium.org/p/skia/issues/detail?id=9310 given that other image filter factories in image_filter.cc have already been updated to use SkImageFilters.h

## Related Issues

https://github.com/flutter/flutter/issues/40602 (will be fixed after this)
https://bugs.chromium.org/p/skia/issues/detail?id=9310 (this PR fixes the Flutter-side changes necessary to close the Skia issue).

## Tests

No behavioral changes, so no new tests needed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
