### PR TITLE
Revert "[web] Enable the new rich paragraph implementation"

### DIFF
--- a/lib/web_ui/lib/src/engine/web_experiments.dart
+++ b/lib/web_ui/lib/src/engine/web_experiments.dart
@@ -45,7 +45,7 @@ class WebExperiments {
 
   static const bool _defaultUseCanvasRichText = const bool.fromEnvironment(
     'FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_RICH_TEXT',
-    defaultValue: true,
+    defaultValue: false,
   );
 
   bool _useCanvasRichText = _defaultUseCanvasRichText;

--- a/lib/web_ui/test/engine/web_experiments_test.dart
+++ b/lib/web_ui/test/engine/web_experiments_test.dart
@@ -11,7 +11,7 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 
 const bool _defaultUseCanvasText = true;
-const bool _defaultUseCanvasRichText = true;
+const bool _defaultUseCanvasRichText = false;
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -547,8 +547,8 @@ void _testCullRectComputation() {
     'renders clipped text with high quality',
     () async {
       // To reproduce blurriness we need real clipping.
-      final DomParagraph paragraph =
-          (DomParagraphBuilder(ParagraphStyle(fontFamily: 'Roboto'))..addText('Am I blurry?')).build();
+      final Paragraph paragraph =
+          (ParagraphBuilder(ParagraphStyle(fontFamily: 'Roboto'))..addText('Am I blurry?')).build();
       paragraph.layout(const ParagraphConstraints(width: 1000));
 
       final Rect canvasSize = Rect.fromLTRB(


### PR DESCRIPTION
Reverts flutter/engine#23162

```
00:24 +15 -1: test/painting/text_painter_test.dart: TextPainter null text test [E]                                                                                                                     
  RangeError (index): Index out of range: no indices are valid: 0
  ../dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 236:49      throw_
  ../dart-sdk/lib/_internal/js_dev_runtime/private/js_array.dart 581:7                 _get]
  ../lib/_engine/engine/text/layout_service.dart 77:41                                 performLayout
  ../lib/_engine/engine/text/canvas_paragraph.dart 90:20                               layout
  ../packages/flutter/src/painting/placeholder_span.dart.js 1136:40                    layout
  text_painter_test.dart.js 1951:15                                                    <fn>
```