### PR TITLE
[web] Fix layout exception when text is null

### DIFF
--- a/lib/web_ui/lib/src/engine/text/layout_service.dart
+++ b/lib/web_ui/lib/src/engine/text/layout_service.dart
@@ -71,6 +71,10 @@ class TextLayoutService {
     didExceedMaxLines = false;
     lines.clear();
 
+    if (spanCount == 0) {
+      return;
+    }
+
     final Spanometer spanometer = Spanometer(paragraph, context);
 
     int spanIndex = 0;

--- a/lib/web_ui/test/text/layout_service_plain_test.dart
+++ b/lib/web_ui/test/text/layout_service_plain_test.dart
@@ -42,6 +42,16 @@ void main() {
 void testMain() async {
   await ui.webOnlyInitializeTestDomRenderer();
 
+  test('no text', () {
+    final CanvasParagraph paragraph = CanvasParagraphBuilder(ahemStyle).build();
+    paragraph.layout(constrain(double.infinity));
+
+    expect(paragraph.maxIntrinsicWidth, 0);
+    expect(paragraph.minIntrinsicWidth, 0);
+    expect(paragraph.height, 0);
+    expect(paragraph.computeLineMetrics(), isEmpty);
+  });
+
   test('preserves whitespace when measuring', () {
     CanvasParagraph paragraph;
 


### PR DESCRIPTION
## Description

Enabling the new rich paragraph implementation caused some framework tests to fail. These tests were creating paragraphs with no spans, which is an edge that wasn't being handled. This PR fixes it.

Engine auto-roll failure: https://ci.chromium.org/ui/p/flutter/builders/try/Linux%20web_tests/8457/overview

The framework tests that failed were in these files:

 - `test/painting/text_painter_test.dart`
 - `test/rendering/semantics_and_children_test.dart`