### PR TITLE
Implement handling of framework-handled key events

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -131,8 +131,7 @@ class Keyboard {
         if (data == null) {
           return;
         }
-        final String response = utf8.decode(data.buffer.asUint8List());
-        final Map<String, dynamic> jsonResponse = json.decode(response);
+        final Map<String, dynamic> jsonResponse = _messageCodec.decodeMessage(data);
         if (jsonResponse['handled'] as bool) {
           // If the framework handled it, then don't propagate it any further.
           event.preventDefault();

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -80,11 +80,6 @@ class Keyboard {
     }
 
     final html.KeyboardEvent keyboardEvent = event;
-
-    if (_shouldPreventDefault(event)) {
-      event.preventDefault();
-    }
-
     final String timerKey = keyboardEvent.code!;
 
     // Don't handle synthesizing a keyup event for modifier keys
@@ -132,16 +127,18 @@ class Keyboard {
     };
 
     EnginePlatformDispatcher.instance.invokeOnPlatformMessage('flutter/keyevent',
-        _messageCodec.encodeMessage(eventData), _noopCallback);
-  }
-
-  bool _shouldPreventDefault(html.KeyboardEvent event) {
-    switch (event.key) {
-      case 'Tab':
-        return true;
-      default:
-        return false;
-    }
+      _messageCodec.encodeMessage(eventData), (ByteData? data) {
+        if (data == null) {
+          return;
+        }
+        final String response = utf8.decode(data.buffer.asUint8List());
+        final Map<String, dynamic> jsonResponse = json.decode(response);
+        if (jsonResponse['handled'] as bool) {
+          // If the framework handled it, then don't propagate it any further.
+          event.preventDefault();
+        }
+      },
+    );
   }
 
   void _synthesizeKeyup(html.KeyboardEvent event) {

--- a/lib/web_ui/test/keyboard_test.dart
+++ b/lib/web_ui/test/keyboard_test.dart
@@ -6,7 +6,6 @@
 import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
-import 'dart:convert' hide Codec;
 
 import 'package:quiver/testing/async.dart';
 import 'package:test/bootstrap/browser.dart';
@@ -16,14 +15,6 @@ import 'package:ui/ui.dart' as ui;
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
-}
-
-ByteData _toByteData(List<int> bytes) {
-  final ByteData byteData = ByteData(bytes.length);
-  for (int i = 0; i < bytes.length; i++) {
-    byteData.setUint8(i, bytes[i]);
-  }
-  return byteData;
 }
 
 void testMain() {
@@ -236,21 +227,13 @@ void testMain() {
     });
 
     test('prevents default when key is handled by the framework', () {
-      ByteData _toByteData(List<int> bytes) {
-        final ByteData byteData = ByteData(bytes.length);
-        for (int i = 0; i < bytes.length; i++) {
-          byteData.setUint8(i, bytes[i]);
-        }
-        return byteData;
-      }
-
       Keyboard.initialize();
 
       int count = 0;
       ui.window.onPlatformMessage = (String channel, ByteData data,
           ui.PlatformMessageResponseCallback callback) {
         count += 1;
-        ByteData response = _toByteData(utf8.encode(json.encode(<String, dynamic>{'handled': true})));
+        ByteData response = const JSONMessageCodec().encodeMessage(<String, dynamic>{'handled': true});
         callback(response);
       };
 
@@ -273,7 +256,7 @@ void testMain() {
       ui.window.onPlatformMessage = (String channel, ByteData data,
           ui.PlatformMessageResponseCallback callback) {
         count += 1;
-        ByteData response = _toByteData(utf8.encode(json.encode(<String, dynamic>{'handled': false})));
+        ByteData response = const JSONMessageCodec().encodeMessage(<String, dynamic>{'handled': false});
         callback(response);
       };
 
@@ -320,7 +303,7 @@ void testMain() {
       ui.window.onPlatformMessage = (String channel, ByteData data,
           ui.PlatformMessageResponseCallback callback) {
         count += 1;
-        ByteData response = _toByteData(utf8.encode(json.encode(<String, dynamic>{'handled': true})));
+        ByteData response = const JSONMessageCodec().encodeMessage(<String, dynamic>{'handled': true});
         callback(response);
       };
 


### PR DESCRIPTION
## Description

This implements the "Delayed event delivery" that I've implemented for the other platforms.

Because they require synchronous responses, other platforms need to re-dispatch events that weren't handled by the framework once it responds, but the web just needs to call `preventDefault` on the events that the framework handles, since it all happens in the same thread anyhow.

## Related Issues

- flutter/flutter#47156

## Tests

- Added tests to check that events handled by the framework have `preventDefault` called on them (and vice versa).

## Breaking Change

- [X] No, no existing tests failed, so this is *not* a breaking change.