### PR TITLE
Always build with fontconfig on Linux.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -94,6 +94,12 @@ def to_gn_args(args):
 
     gn_args['enable_bitcode'] = args.bitcode
 
+    use_fontconfig = args.target_os == 'linux'
+    if args.target_os is not None:
+        use_fontconfig = args.target_os == 'linux'
+    else:
+        use_fontconfig = sys.platform.startswith('linux')
+
     # Skia GN args.
     gn_args['skia_enable_flutter_defines'] = True # Enable Flutter API guards in Skia.
     gn_args['skia_use_dng_sdk'] = False    # RAW image handling.
@@ -102,8 +108,8 @@ def to_gn_args(args):
     gn_args['skia_use_x11'] = False        # Never add the X11 dependency (only takes effect on Linux).
     gn_args['skia_use_wuffs'] = True
     gn_args['skia_use_expat'] = args.target_os == 'android'
-    gn_args['skia_use_fontconfig'] = args.enable_fontconfig
-    gn_args['flutter_use_fontconfig'] = args.enable_fontconfig
+    gn_args['skia_use_fontconfig'] = use_fontconfig
+    gn_args['flutter_use_fontconfig'] = use_fontconfig
     gn_args['flutter_enable_skshaper'] = args.enable_skshaper
     if args.enable_skshaper:
       gn_args['skia_use_icu'] = True
@@ -388,7 +394,6 @@ def parse_args(args):
   parser.add_argument('--macos-enable-metal', action='store_true', default=False)
   parser.add_argument('--enable-vulkan', action='store_true', default=False)
 
-  parser.add_argument('--enable-fontconfig', action='store_true', default=False)
   parser.add_argument('--enable-vulkan-validation-layers', action='store_true', default=False)
 
   parser.add_argument('--enable-skshaper', action='store_true', default=True)


### PR DESCRIPTION
## Description

Always build with fontconfig on Linux.

We depend on GTK, which depends on fontconfig (required via pango and optionally
required in GTK if compiled with X11 support) and this makes font fallback
working.

## Related Issues

https://github.com/flutter/flutter/issues/30700

## Tests

No tests added.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [x] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [x] I updated/added relevant documentation.
- [x] All existing and new tests are passing.
- [x] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [x] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
