### PR TITLE
SkParagraph: enable the ICU breaker cache

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -107,6 +107,7 @@ def to_gn_args(args):
     gn_args['flutter_enable_skshaper'] = args.enable_skshaper
     if args.enable_skshaper:
       gn_args['skia_use_icu'] = True
+      gn_args['skia_enable_icu_ubrk_safeclone'] = True
       gn_args['flutter_always_use_skshaper'] = args.always_use_skshaper
     gn_args['is_official_build'] = True    # Disable Skia test utilities.
     gn_args['dart_component_kind'] = 'static_library' # Always link Dart in statically.


### PR DESCRIPTION
The breaker cache requires a Skia build flag because it uses an ICU
API that is not available in all Skia build environments.
