### PR TITLE
Ensure gen_snapshot for the target is built when needed

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -62,6 +62,11 @@ group("flutter") {
       public_deps += [
         "//flutter/flutter_frontend_server:frontend_server",
         "//third_party/dart:create_sdk",
+
+        # This must be listed explicitly for desktop cross-builds since
+        # //flutter/lib/snapshot:generate_snapshot_bin will only build
+        # gen_snapshot for the host and not the target.
+        "//third_party/dart/runtime/bin:gen_snapshot",
       ]
 
       if (full_dart_sdk) {

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -201,6 +201,7 @@ action("create_arm_gen_snapshot") {
   output_dir = "$root_out_dir/clang_x64"
   script = "//flutter/sky/tools/create_macos_gen_snapshots.py"
   visibility = [ ":*" ]
+  deps = [ "//third_party/dart/runtime/bin:gen_snapshot" ]
   args = [
     "--dst",
     rebase_path(output_dir),


### PR DESCRIPTION
This PR ensures that gen_snapshot is built to run on the target for a desktop cross-build and adds a missing build dependency for MacOS cross builds.