### PR TITLE
Populates fuchsia a11y toggled state.

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -117,6 +117,14 @@ fuchsia::accessibility::semantics::States AccessibilityBridge::GetNodeStates(
     (*additional_size) += node.value.size();
   }
 
+  // Set toggled state.
+  if (node.HasFlag(flutter::SemanticsFlags::kHasToggledState)) {
+    states.set_toggled_state(
+        node.HasFlag(flutter::SemanticsFlags::kIsToggled)
+            ? fuchsia::accessibility::semantics::ToggledState::ON
+            : fuchsia::accessibility::semantics::ToggledState::OFF);
+  }
+
   return states;
 }
 
@@ -195,6 +203,9 @@ fuchsia::accessibility::semantics::Role AccessibilityBridge::GetNodeRole(
     }
   }
 
+  if (node.HasFlag(flutter::SemanticsFlags::kHasToggledState)) {
+    return fuchsia::accessibility::semantics::Role::TOGGLE_SWITCH;
+  }
   return fuchsia::accessibility::semantics::Role::UNKNOWN;
 }
 


### PR DESCRIPTION
This change ensures that flutter accessibility updates include toggled
state as appropriate.

## Description

This change adds support for toggle switches to the accessibility bridge.

## Related Issues

https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=67482

## Tests

I added the following tests:

UT for toggle role

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [contributor guide] and followed the process outlined there for submitting PRs.
- [X] I signed the [CLA].
- [X] I read and followed the [C++, Objective-C, Java style guides] for the engine.
- [X] I read the [tree hygiene] wiki page, which explains my responsibilities.
- [X] I updated/added relevant documentation.
- [X] All existing and new tests are passing.
- [X] I am willing to follow-up on review comments in a timely manner.


## Reviewer Checklist

- [ ] I have submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


## Breaking Change

Did any tests fail when you ran them? Please read [handling breaking changes].

- [X] No, no existing tests failed, so this is *not* a breaking change.
- [ ] Yes, this is a breaking change. *If not, delete the remainder of this section.*
   - [ ] I wrote a design doc: https://flutter.dev/go/template *Replace this with a link to your design doc's short link*
   - [ ] I got input from the developer relations team, specifically from: *Replace with the names of who gave advice*
   - [ ] I wrote a migration guide: https://flutter.dev/go/breaking-changes-template *Replace this with a link to a pull request that adds the migration guide to https://flutter.dev/docs/release/breaking-changes*

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[contributor guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[tree hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[handling breaking changes]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
