### PR TITLE
Removes deprecated WLAN API dependency.

### DIFF
--- a/shell/platform/fuchsia/dart_runner/vmservice/meta/vmservice.cmx
+++ b/shell/platform/fuchsia/dart_runner/vmservice/meta/vmservice.cmx
@@ -13,8 +13,7 @@
       "fuchsia.sys.Environment",
       "fuchsia.ui.input.ImeService",
       "fuchsia.ui.policy.Presenter",
-      "fuchsia.ui.scenic.Scenic",
-      "fuchsia.wlan.service.Wlan"
+      "fuchsia.ui.scenic.Scenic"
     ]
   }
 }


### PR DESCRIPTION
fuchsia.wlan.service is headed for deprecation.  The runner
lists the service as a dependency though it is not actually
used.  This change removes the deprecated service from the
runner's sandbox.