### PR TITLE
[web] Add --watch flag to 'felt test'

### DIFF
--- a/lib/web_ui/dev/README.md
+++ b/lib/web_ui/dev/README.md
@@ -7,7 +7,7 @@
 `felt` supports multiple commands as follows:
 
 1. **`felt check-licenses`**: Checks that all Dart and JS source code files contain the correct license headers.
-2. **`felt test`**: Runs all or some tests depending on the passed arguments.
+2. **`felt test`**: Runs all or some tests depending on the passed arguments. It supports a watch mode for convenience.
 3. **`felt build`**: Builds the engine locally so it can be used by Flutter apps. It also supports a watch mode for more convenience.
 
 You could also run `felt help` or `felt help <command>` to get more information about the available commands and arguments.
@@ -41,6 +41,18 @@ To run all tests on Chrome. This will run both integration tests and the unit te
 
 ```
 felt test
+```
+
+To run a specific test:
+
+```
+felt test test/engine/util_test.dart
+```
+
+To enable watch mode so that the test re-runs on every change:
+
+```
+felt test --watch test/engine/util_test.dart
 ```
 
 To run unit tests only:

--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -6,12 +6,11 @@
 import 'dart:async';
 
 import 'package:args/command_runner.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
-import 'package:watcher/watcher.dart';
 
 import 'environment.dart';
 import 'utils.dart';
+import 'watcher.dart';
 
 class BuildCommand extends Command<bool> with ArgUtils {
   BuildCommand() {
@@ -37,7 +36,7 @@ class BuildCommand extends Command<bool> with ArgUtils {
     final FilePath libPath = FilePath.fromWebUi('lib');
     final Pipeline buildPipeline = Pipeline(steps: <PipelineStep>[
       gn,
-      () => ninja(),
+      ninja,
     ]);
     await buildPipeline.start();
 
@@ -76,125 +75,4 @@ Future<void> ninja() {
     '-C',
     environment.hostDebugUnoptDir.path,
   ]);
-}
-
-enum PipelineStatus {
-  idle,
-  started,
-  stopping,
-  stopped,
-  error,
-  done,
-}
-
-typedef PipelineStep = Future<void> Function();
-
-class Pipeline {
-  Pipeline({@required this.steps});
-
-  final Iterable<PipelineStep> steps;
-
-  Future<dynamic> _currentStepFuture;
-
-  PipelineStatus status = PipelineStatus.idle;
-
-  Future<void> start() async {
-    status = PipelineStatus.started;
-    try {
-      for (PipelineStep step in steps) {
-        if (status != PipelineStatus.started) {
-          break;
-        }
-        _currentStepFuture = step();
-        await _currentStepFuture;
-      }
-      status = PipelineStatus.done;
-    } catch (error, stackTrace) {
-      status = PipelineStatus.error;
-      print('Error in the pipeline: $error');
-      print(stackTrace);
-    } finally {
-      _currentStepFuture = null;
-    }
-  }
-
-  Future<void> stop() {
-    status = PipelineStatus.stopping;
-    return (_currentStepFuture ?? Future<void>.value(null)).then((_) {
-      status = PipelineStatus.stopped;
-    });
-  }
-}
-
-typedef WatchEventPredicate = bool Function(WatchEvent event);
-
-class PipelineWatcher {
-  PipelineWatcher({
-    @required this.dir,
-    @required this.pipeline,
-    this.ignore,
-  }) : watcher = DirectoryWatcher(dir);
-
-  /// The path of the directory to watch for changes.
-  final String dir;
-
-  /// The pipeline to be executed when an event is fired by the watcher.
-  final Pipeline pipeline;
-
-  /// Used to watch a directory for any file system changes.
-  final DirectoryWatcher watcher;
-
-  /// A callback that determines whether to rerun the pipeline or not for a
-  /// given [WatchEvent] instance.
-  final WatchEventPredicate ignore;
-
-  void start() {
-    watcher.events.listen(_onEvent);
-  }
-
-  int _pipelineRunCount = 0;
-  Timer _scheduledPipeline;
-
-  void _onEvent(WatchEvent event) {
-    if (ignore != null && ignore(event)) {
-      return;
-    }
-
-    final String relativePath = path.relative(event.path, from: dir);
-    print('- [${event.type}] ${relativePath}');
-
-    _pipelineRunCount++;
-    _scheduledPipeline?.cancel();
-    _scheduledPipeline = Timer(const Duration(milliseconds: 100), () {
-      _scheduledPipeline = null;
-      _runPipeline();
-    });
-  }
-
-  void _runPipeline() {
-    int runCount;
-    switch (pipeline.status) {
-      case PipelineStatus.started:
-        pipeline.stop().then((_) {
-          runCount = _pipelineRunCount;
-          pipeline.start().then((_) => _pipelineDone(runCount));
-        });
-        break;
-
-      case PipelineStatus.stopping:
-        // We are already trying to stop the pipeline. No need to do anything.
-        break;
-
-      default:
-        runCount = _pipelineRunCount;
-        pipeline.start().then((_) => _pipelineDone(runCount));
-        break;
-    }
-  }
-
-  void _pipelineDone(int pipelineRunCount) {
-    if (pipelineRunCount == _pipelineRunCount) {
-      print('*** Done! ***');
-    }
-  }
 }

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -14,6 +14,16 @@ import 'package:path/path.dart' as path;
 import 'environment.dart';
 import 'exceptions.dart';
 
+/// Clears the terminal screen and places the cursor at the top left corner.
+///
+/// This works on Linux and Mac. On Windows, it's a no-op.
+void clearTerminalScreen() {
+  if (!io.Platform.isWindows) {
+    // See: https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_sequences
+    print("\x1B[2J\x1B[1;2H");
+  }
+}
+
 class FilePath {
   FilePath.fromCwd(String relativePath)
       : _absolutePath = path.absolute(relativePath);

--- a/lib/web_ui/dev/watcher.dart
+++ b/lib/web_ui/dev/watcher.dart
@@ -20,6 +20,13 @@ enum PipelineStatus {
 
 typedef PipelineStep = Future<void> Function();
 
+/// Represents a sequence of asynchronous tasks to be executed.
+///
+/// The pipeline can be executed by calling [start] and stopped by calling
+/// [stop].
+///
+/// When a pipeline is stopped, it switches to the [PipelineStatus.stopping]
+/// state and waits until the current task finishes.
 class Pipeline {
   Pipeline({@required this.steps});
 
@@ -29,6 +36,7 @@ class Pipeline {
 
   PipelineStatus status = PipelineStatus.idle;
 
+  /// Starts executing tasks of the pipeline.
   Future<void> start() async {
     status = PipelineStatus.started;
     try {
@@ -49,6 +57,9 @@ class Pipeline {
     }
   }
 
+  /// Stops executing any more tasks in the pipeline.
+  ///
+  /// If a task is already being executed, it won't be interrupted.
   Future<void> stop() {
     status = PipelineStatus.stopping;
     return (_currentStepFuture ?? Future<void>.value(null)).then((_) {
@@ -57,8 +68,14 @@ class Pipeline {
   }
 }
 
+/// Signature of functions to be called when a [WatchEvent] is received.
 typedef WatchEventPredicate = bool Function(WatchEvent event);
 
+/// Responsible for watching a directory [dir] and executing the given
+/// [pipeline] whenever a change occurs in the directory.
+///
+/// The [ignore] callback can be used to customize the watching behavior to
+/// ignore certain files.
 class PipelineWatcher {
   PipelineWatcher({
     @required this.dir,
@@ -79,6 +96,7 @@ class PipelineWatcher {
   /// given [WatchEvent] instance.
   final WatchEventPredicate ignore;
 
+  /// Activates the watcher.
   void start() {
     watcher.events.listen(_onEvent);
   }

--- a/lib/web_ui/dev/watcher.dart
+++ b/lib/web_ui/dev/watcher.dart
@@ -1,0 +1,131 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.6
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+import 'package:path/path.dart' as path;
+import 'package:watcher/watcher.dart';
+
+enum PipelineStatus {
+  idle,
+  started,
+  stopping,
+  stopped,
+  error,
+  done,
+}
+
+typedef PipelineStep = Future<void> Function();
+
+class Pipeline {
+  Pipeline({@required this.steps});
+
+  final Iterable<PipelineStep> steps;
+
+  Future<dynamic> _currentStepFuture;
+
+  PipelineStatus status = PipelineStatus.idle;
+
+  Future<void> start() async {
+    status = PipelineStatus.started;
+    try {
+      for (PipelineStep step in steps) {
+        if (status != PipelineStatus.started) {
+          break;
+        }
+        _currentStepFuture = step();
+        await _currentStepFuture;
+      }
+      status = PipelineStatus.done;
+    } catch (error, stackTrace) {
+      status = PipelineStatus.error;
+      print('Error in the pipeline: $error');
+      print(stackTrace);
+    } finally {
+      _currentStepFuture = null;
+    }
+  }
+
+  Future<void> stop() {
+    status = PipelineStatus.stopping;
+    return (_currentStepFuture ?? Future<void>.value(null)).then((_) {
+      status = PipelineStatus.stopped;
+    });
+  }
+}
+
+typedef WatchEventPredicate = bool Function(WatchEvent event);
+
+class PipelineWatcher {
+  PipelineWatcher({
+    @required this.dir,
+    @required this.pipeline,
+    this.ignore,
+  }) : watcher = DirectoryWatcher(dir);
+
+  /// The path of the directory to watch for changes.
+  final String dir;
+
+  /// The pipeline to be executed when an event is fired by the watcher.
+  final Pipeline pipeline;
+
+  /// Used to watch a directory for any file system changes.
+  final DirectoryWatcher watcher;
+
+  /// A callback that determines whether to rerun the pipeline or not for a
+  /// given [WatchEvent] instance.
+  final WatchEventPredicate ignore;
+
+  void start() {
+    watcher.events.listen(_onEvent);
+  }
+
+  int _pipelineRunCount = 0;
+  Timer _scheduledPipeline;
+
+  void _onEvent(WatchEvent event) {
+    if (ignore != null && ignore(event)) {
+      return;
+    }
+
+    final String relativePath = path.relative(event.path, from: dir);
+    print('- [${event.type}] ${relativePath}');
+
+    _pipelineRunCount++;
+    _scheduledPipeline?.cancel();
+    _scheduledPipeline = Timer(const Duration(milliseconds: 100), () {
+      _scheduledPipeline = null;
+      _runPipeline();
+    });
+  }
+
+  void _runPipeline() {
+    int runCount;
+    switch (pipeline.status) {
+      case PipelineStatus.started:
+        pipeline.stop().then((_) {
+          runCount = _pipelineRunCount;
+          pipeline.start().then((_) => _pipelineDone(runCount));
+        });
+        break;
+
+      case PipelineStatus.stopping:
+        // We are already trying to stop the pipeline. No need to do anything.
+        break;
+
+      default:
+        runCount = _pipelineRunCount;
+        pipeline.start().then((_) => _pipelineDone(runCount));
+        break;
+    }
+  }
+
+  void _pipelineDone(int pipelineRunCount) {
+    if (pipelineRunCount == _pipelineRunCount) {
+      print('*** Done! ***');
+    }
+  }
+}


### PR DESCRIPTION
Add ability to run tests in watch mode.

Known issues:
- Doesn't work on tests running in a simulator.
- Doesn't work with the `--debug` flag that launches a Chrome instance.

Fixes https://github.com/flutter/flutter/issues/44197