### PR TITLE
Revert "Roll buildroot to 92a8d2eb7aad592068f808e39b8330fd2bce25e3, Clang to 12.0.0"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -100,7 +100,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '92a8d2eb7aad592068f808e39b8330fd2bce25e3',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '9d2c731ba05432878cc5187329c66b70983d914b',
 
    # Fuchsia compatibility
    #
@@ -502,7 +502,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/${{platform}}',
-        'version': 'git_revision:25abd1994ed209c1bf4139946a42e36a42143a85'
+        'version': 'git_revision:7e9747b50bcb1be28d4a3236571e8050835497a6'
       }
     ],
     'condition': 'host_os == "mac" or host_os == "linux"',

--- a/tools/gn
+++ b/tools/gn
@@ -327,10 +327,6 @@ def to_gn_args(args):
 
     gn_args['dart_version_git_info'] = not args.no_dart_version_git_info
 
-    # Overrides whether Boring SSL is compiled with system as. Only meaningful
-    # on Android.
-    gn_args['bssl_use_clang_integrated_as'] = True
-
     return gn_args
 
 def parse_args(args):


### PR DESCRIPTION
Reverts flutter/engine#23698

Xcode clang that we use on CI doesn't knwo about -Wno-psabi.