### PR TITLE
Roll clang further, fix buggy test

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -502,7 +502,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/${{platform}}',
-        'version': 'git_revision:25abd1994ed209c1bf4139946a42e36a42143a85'
+        'version': 'git_revision:7d48eff8ba172216fca3649a3c452de4c7c16c00' 
       }
     ],
     'condition': 'host_os == "mac" or host_os == "linux"',

--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -14,19 +14,22 @@ ImageFilterLayer::ImageFilterLayer(sk_sp<SkImageFilter> filter)
 void ImageFilterLayer::Preroll(PrerollContext* context,
                                const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "ImageFilterLayer::Preroll");
-
   Layer::AutoPrerollSaveLayerState save =
       Layer::AutoPrerollSaveLayerState::Create(context);
 
   SkRect child_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_bounds);
-  if (filter_) {
-    const SkIRect filter_input_bounds = child_bounds.roundOut();
-    SkIRect filter_output_bounds =
-        filter_->filterBounds(filter_input_bounds, SkMatrix::I(),
-                              SkImageFilter::kForward_MapDirection);
-    child_bounds = SkRect::Make(filter_output_bounds);
+
+  if (!filter_) {
+    set_paint_bounds(child_bounds);
+    return;
   }
+
+  const SkIRect filter_input_bounds = child_bounds.roundOut();
+  SkIRect filter_output_bounds = filter_->filterBounds(
+      filter_input_bounds, SkMatrix::I(), SkImageFilter::kForward_MapDirection);
+  child_bounds = SkRect::Make(filter_output_bounds);
+
   set_paint_bounds(child_bounds);
 
   transformed_filter_ = nullptr;


### PR DESCRIPTION
Rolls us to the latest integration Clang toolchain from Fuchsia. Still 12.0.0.

It's really not clear to me why this test didn't segfault before - it seems like it's pretty obviously dereferencing a null pointer.

This is a slight change in behavior though: previously, an image filter layer with a nullptr image filter could end up in the rastercache, whereas no it will not. I think that is more desirable, but hoping @flar can help determine that.