### PR TITLE
Migrate to use the published metrics_center

### DIFF
--- a/testing/benchmark/bin/parse_and_send.dart
+++ b/testing/benchmark/bin/parse_and_send.dart
@@ -7,8 +7,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:git/git.dart';
-import 'package:metrics_center/flutter.dart';
-import 'package:metrics_center/google_benchmark.dart';
+import 'package:metrics_center/metrics_center.dart';
 
 Future<String> _getGitRevision() async {
   final GitDir gitDir = await GitDir.fromExisting('../../');

--- a/testing/benchmark/pubspec.yaml
+++ b/testing/benchmark/pubspec.yaml
@@ -3,7 +3,7 @@ name: flutter_engine_benchmark
 dependencies:
   git: any
 
-  metrics_center: ^0.0.4
+  metrics_center: 0.0.4
 
 dev_dependencies:
   test: any

--- a/testing/benchmark/pubspec.yaml
+++ b/testing/benchmark/pubspec.yaml
@@ -2,10 +2,8 @@ name: flutter_engine_benchmark
 
 dependencies:
   git: any
-  metrics_center:
-    # TODO(liyuqian): once metrics_center is properly reviewed, add it to
-    # flutter/packages, publish on pub.dev, and use the published package here.
-    git: https://github.com/liyuqian/metrics_center.git
+
+  metrics_center: ^0.0.4
 
 dev_dependencies:
   test: any


### PR DESCRIPTION
This change shouldn't affect anything except for the "Linux benchmarks" LUCI post-submit bot.

We'll closely monitor the LUCI bot to see if this works as intended. If so, we'll continue the migration in Cocoon (https://github.com/flutter/cocoon/pull/1062) to cut the dependency on the old Cocoon datastore and Tong's desktop.

Related issue: https://github.com/flutter/flutter/issues/73872