### PR TITLE
unhide uitextinput when focused

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -38,6 +38,7 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
 - (void)showAutocorrectionPromptRectForStart:(NSUInteger)start
                                          end:(NSUInteger)end
                                   withClient:(int)client;
+- (void)waitForFirstFrame:(NSTimeInterval)timeout callback:(void (^)(BOOL didTimeout))callback;
 @end
 
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTDELEGATE_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -38,7 +38,6 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
 - (void)showAutocorrectionPromptRectForStart:(NSUInteger)start
                                          end:(NSUInteger)end
                                   withClient:(int)client;
-- (void)waitForFirstFrame:(NSTimeInterval)timeout callback:(void (^)(BOOL didTimeout))callback;
 @end
 
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTDELEGATE_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -71,7 +71,8 @@ FLUTTER_DARWIN_EXPORT
 @property(nonatomic, copy) UITextContentType textContentType API_AVAILABLE(ios(10.0));
 
 @property(nonatomic, assign) id<FlutterTextInputDelegate> textInputDelegate;
-@property(class, nonatomic, weak, assign) UIAccessibilityElement* backingTextInputAccessibilityObject;
+@property(class, nonatomic, weak, assign)
+    UIAccessibilityElement* backingTextInputAccessibilityObject;
 
 @end
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTPLUGIN_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -71,8 +71,7 @@ FLUTTER_DARWIN_EXPORT
 @property(nonatomic, copy) UITextContentType textContentType API_AVAILABLE(ios(10.0));
 
 @property(nonatomic, assign) id<FlutterTextInputDelegate> textInputDelegate;
-@property(class, nonatomic, weak, assign)
-    UIAccessibilityElement* backingTextInputAccessibilityObject;
+@property(nonatomic, assign) UIAccessibilityElement* backingTextInputAccessibilityObject;
 
 @end
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTPLUGIN_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -71,6 +71,7 @@ FLUTTER_DARWIN_EXPORT
 @property(nonatomic, copy) UITextContentType textContentType API_AVAILABLE(ios(10.0));
 
 @property(nonatomic, assign) id<FlutterTextInputDelegate> textInputDelegate;
+@property(class, nonatomic, weak, assign) UIAccessibilityElement* backingTextInputAccessibilityObject;
 
 @end
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTPLUGIN_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -541,11 +541,11 @@ static UIAccessibilityElement* _backingTextInputAccessibilityObject;
   [super dealloc];
 }
 
-+(UIAccessibilityElement*)backingTextInputAccessibilityObject {
++ (UIAccessibilityElement*)backingTextInputAccessibilityObject {
   return _backingTextInputAccessibilityObject;
 }
 
-+(void)setBackingTextInputAccessibilityObject:(UIAccessibilityElement*)element {
++ (void)setBackingTextInputAccessibilityObject:(UIAccessibilityElement*)element {
   _backingTextInputAccessibilityObject = element;
 }
 
@@ -1127,16 +1127,16 @@ static UIAccessibilityElement* _backingTextInputAccessibilityObject;
     // For most of the cases, this flutter text input view should never
     // receive the focus. If we do receive the focus, we make the best effort
     // to send the focus back to the real text field.
-    __strong UIAccessibilityElement* textInput = FlutterTextInputView.backingTextInputAccessibilityObject;
+    __strong UIAccessibilityElement* textInput =
+        FlutterTextInputView.backingTextInputAccessibilityObject;
     FML_DCHECK(textInput);
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, textInput);
   }
 }
 
-- (BOOL)isAccessibilityElement{
+- (BOOL)isAccessibilityElement {
   return _accessibilityEnabled;
 }
-
 
 @end
 
@@ -1266,14 +1266,14 @@ static UIAccessibilityElement* _backingTextInputAccessibilityObject;
   // the newly attached active view while performing accessibility update.
   // This results in accessibility focus stuck at the FlutterTextInputView.
   [NSTimer scheduledTimerWithTimeInterval:_kUITextInputAccessibilityEnablingDelaySeconds
-                                 target:self
-                               selector:@selector(enableActiveViewAccessibility:)
-                               userInfo:nil
-                                repeats:NO];
+                                   target:self
+                                 selector:@selector(enableActiveViewAccessibility:)
+                                 userInfo:nil
+                                  repeats:NO];
   [_activeView becomeFirstResponder];
 }
 
--(void)enableActiveViewAccessibility:(NSTimer*)time {
+- (void)enableActiveViewAccessibility:(NSTimer*)time {
   if (_activeView.isFirstResponder) {
     _activeView.accessibilityEnabled = YES;
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1170,7 +1170,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 @property(nonatomic, readonly)
     NSMutableDictionary<NSString*, FlutterTextInputView*>* autofillContext;
 @property(nonatomic, assign) FlutterTextInputView* activeView;
-@property(nonatomic, retain) FlutterTextInputViewAccessibilityHider* inputHider;
+@property(nonatomic, strong) FlutterTextInputViewAccessibilityHider* inputHider;
 @end
 
 @implementation FlutterTextInputPlugin {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1173,9 +1173,9 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 @property(nonatomic, retain) FlutterTextInputViewAccessibilityHider* inputHider;
 @end
 
-@implementation FlutterTextInputPlugin
-
-NSTimer* _enableFlutterTextInputViewAccessibilityTimer;
+@implementation FlutterTextInputPlugin {
+  NSTimer* _enableFlutterTextInputViewAccessibilityTimer;
+}
 
 @synthesize textInputDelegate = _textInputDelegate;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1134,8 +1134,8 @@ static UIAccessibilityElement* _backingTextInputAccessibilityObject;
   }
 }
 
-- (BOOL)isAccessibilityElement {
-  return _accessibilityEnabled;
+- (BOOL)accessibilityElementsHidden {
+  return !_accessibilityEnabled;
 }
 
 @end
@@ -1144,6 +1144,17 @@ static UIAccessibilityElement* _backingTextInputAccessibilityObject;
  * Hides `FlutterTextInputView` from iOS accessibility system so it
  * does not show up twice, once where it is in the `UIView` hierarchy,
  * and a second time as part of the `SemanticsObject` hierarchy.
+ *
+ * This prevents the `FlutterTextInputView` from receiving the focus
+ * due to swipping gesture.
+ *
+ * There are other cases the `FlutterTextInputView` may receive
+ * focus. One example is during screen changes, the accessibility
+ * tree will undergo a dramatic structural update. The Voiceover may
+ * decide to focus the `FlutterTextInputView` that is not involved
+ * in the structural update instead. If that happens, the
+ * `FlutterTextInputView` will make a best effort to direct the
+ * focus back to the `SemanticsObject`.
  */
 @interface FlutterTextInputViewAccessibilityHider : UIView {
 }
@@ -1154,15 +1165,6 @@ static UIAccessibilityElement* _backingTextInputAccessibilityObject;
 }
 
 - (BOOL)accessibilityElementsHidden {
-  // We are hiding this accessibility element.
-  // There are 2 accessible elements involved in text entry in 2 different parts of the view
-  // hierarchy. This `FlutterTextInputView` is injected at the top of key window. We use this as a
-  // `UITextInput` protocol to bridge text edit events between Flutter and iOS.
-  //
-  // We also create ur own custom `UIAccessibilityElements` tree with our `SemanticsObject` to
-  // mimic the semantics tree from Flutter. We want the text field to be represented as a
-  // `TextInputSemanticsObject` in that `SemanticsObject` tree rather than in this
-  // `FlutterTextInputView` bridge which doesn't appear above a text field from the Flutter side.
   return YES;
 }
 
@@ -1260,7 +1262,7 @@ static UIAccessibilityElement* _backingTextInputAccessibilityObject;
   // Adds a delay to prevent the text view from receiving accessibility
   // focus in case it is activated during semantics updates.
   //
-  // One comment case is when the app navigating to a page with an auto
+  // One common case is when the app navigates to a page with an auto
   // focused text field. The text field will activate the FlutterTextInputView
   // with a semantics update sent to the engine. The voiceover will focus
   // the newly attached active view while performing accessibility update.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1204,6 +1204,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 - (void)removeEnableFlutterTextInputViewAccessibilityTimer {
   if (_enableFlutterTextInputViewAccessibilityTimer) {
     [_enableFlutterTextInputViewAccessibilityTimer invalidate];
+    [_enableFlutterTextInputViewAccessibilityTimer release];
     _enableFlutterTextInputViewAccessibilityTimer = nil;
   }
 }
@@ -1270,11 +1271,11 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   // This results in accessibility focus stuck at the FlutterTextInputView.
   if (!_enableFlutterTextInputViewAccessibilityTimer) {
     _enableFlutterTextInputViewAccessibilityTimer =
-        [NSTimer scheduledTimerWithTimeInterval:kUITextInputAccessibilityEnablingDelaySeconds
-                                         target:self
-                                       selector:@selector(enableActiveViewAccessibility:)
-                                       userInfo:nil
-                                        repeats:NO];
+        [[NSTimer scheduledTimerWithTimeInterval:kUITextInputAccessibilityEnablingDelaySeconds
+                                          target:self
+                                        selector:@selector(enableActiveViewAccessibility:)
+                                        userInfo:nil
+                                         repeats:NO] retain];
   }
   [_activeView becomeFirstResponder];
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1284,7 +1284,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   if (_activeView.isFirstResponder) {
     _activeView.accessibilityEnabled = YES;
   }
-  _enableFlutterTextInputViewAccessibilityTimer = nil;
+  [self removeEnableFlutterTextInputViewAccessibilityTimer];
 }
 
 - (void)hideTextInput {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -424,6 +424,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 @property(nonatomic, readonly) CATransform3D editableTransform;
 @property(nonatomic, assign) CGRect markedRect;
 @property(nonatomic) BOOL isVisibleToAutofill;
+@property(nonatomic) BOOL hidden;
 
 - (void)setEditableTransform:(NSArray*)matrix;
 @end
@@ -1116,7 +1117,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   // mimic the semantics tree from Flutter. We want the text field to be represented as a
   // `TextInputSemanticsObject` in that `SemanticsObject` tree rather than in this
   // `FlutterTextInputView` bridge which doesn't appear above a text field from the Flutter side.
-  return YES;
+  return _hidden;
 }
 
 @end
@@ -1207,10 +1208,12 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 - (void)showTextInput {
   _activeView.textInputDelegate = _textInputDelegate;
   [self addToInputParentViewIfNeeded:_activeView];
+  _activeView.hidden = NO;
   [_activeView becomeFirstResponder];
 }
 
 - (void)hideTextInput {
+  _activeView.hidden = YES;
   [_activeView resignFirstResponder];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -449,6 +449,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
     _markedText = [[NSMutableString alloc] init];
     _selectedTextRange = [[FlutterTextRange alloc] initWithNSRange:NSMakeRange(0, 0)];
     _markedRect = kInvalidFirstRect;
+    _hidden = YES;
     _cachedFirstRect = kInvalidFirstRect;
     // Initialize with the zero matrix which is not
     // an affine transform.

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1198,7 +1198,6 @@ NSTimer* _enableFlutterTextInputViewAccessibilityTimer;
   [_reusableInputView release];
   [_inputHider release];
   [_autofillContext release];
-  [self removeEnableFlutterTextInputViewAccessibilityTimer];
   [super dealloc];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -71,6 +71,24 @@ FLUTTER_ASSERT_ARC
                              }];
 }
 
+- (void)setTextInputShow{
+  FlutterMethodCall* setClientCall =
+    [FlutterMethodCall methodCallWithMethodName:@"TextInput.show"
+                                      arguments:@[]];
+  [textInputPlugin handleMethodCall:setClientCall
+                             result:^(id _Nullable result){
+                             }];
+}
+
+- (void)setTextInputHide{
+  FlutterMethodCall* setClientCall =
+    [FlutterMethodCall methodCallWithMethodName:@"TextInput.hide"
+                                      arguments:@[]];
+  [textInputPlugin handleMethodCall:setClientCall
+                             result:^(id _Nullable result){
+                             }];
+}
+
 - (NSMutableDictionary*)mutableTemplateCopy {
   if (!_template) {
     _template = @{
@@ -741,6 +759,25 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(self.installedInputViews.count, 2);
 
   [self commitAutofillContextAndVerify];
+}
+
+#pragma mark - Accessibility - Tests
+
+- (void)testUITextInputAccessibilityNotHiddenWhenShowed {
+  // Send show text input method call.
+  [self setTextInputShow];
+  // Find all the FlutterTextInputViews we created.
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+  FlutterTextInputView* inputView = inputFields[0];
+
+  // The input view should not be hidden.
+  XCTAssertEqual(inputView.accessibilityElementsHidden, NO);
+
+  // Send hide text input method call.
+  [self setTextInputHide];
+
+  // The input view should be hidden.
+  XCTAssertEqual(inputView.accessibilityElementsHidden, YES);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -33,7 +33,7 @@ FLUTTER_ASSERT_ARC
     NSMutableDictionary<NSString*, FlutterTextInputView*>* autofillContext;
 
 - (void)collectGarbageInputViews;
-- (UIView*)textInputParentView;
+- (NSArray<UIView*>*)textInputViews;
 @end
 
 @interface FlutterTextInputPluginTest : XCTestCase
@@ -71,19 +71,17 @@ FLUTTER_ASSERT_ARC
                              }];
 }
 
-- (void)setTextInputShow{
-  FlutterMethodCall* setClientCall =
-    [FlutterMethodCall methodCallWithMethodName:@"TextInput.show"
-                                      arguments:@[]];
+- (void)setTextInputShow {
+  FlutterMethodCall* setClientCall = [FlutterMethodCall methodCallWithMethodName:@"TextInput.show"
+                                                                       arguments:@[]];
   [textInputPlugin handleMethodCall:setClientCall
                              result:^(id _Nullable result){
                              }];
 }
 
-- (void)setTextInputHide{
-  FlutterMethodCall* setClientCall =
-    [FlutterMethodCall methodCallWithMethodName:@"TextInput.hide"
-                                      arguments:@[]];
+- (void)setTextInputHide {
+  FlutterMethodCall* setClientCall = [FlutterMethodCall methodCallWithMethodName:@"TextInput.hide"
+                                                                       arguments:@[]];
   [textInputPlugin handleMethodCall:setClientCall
                              result:^(id _Nullable result){
                              }];
@@ -106,7 +104,7 @@ FLUTTER_ASSERT_ARC
 }
 
 - (NSArray<FlutterTextInputView*>*)installedInputViews {
-  return [textInputPlugin.textInputParentView.subviews
+  return (NSArray<FlutterTextInputView*>*)[textInputPlugin.textInputViews
       filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"self isKindOfClass: %@",
                                                                    [FlutterTextInputView class]]];
 }
@@ -768,16 +766,17 @@ FLUTTER_ASSERT_ARC
   [self setTextInputShow];
   // Find all the FlutterTextInputViews we created.
   NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
-  FlutterTextInputView* inputView = inputFields[0];
 
   // The input view should not be hidden.
-  XCTAssertEqual(inputView.accessibilityElementsHidden, NO);
+  XCTAssertEqual([inputFields count], 1u);
 
   // Send hide text input method call.
   [self setTextInputHide];
 
+  inputFields = self.installedInputViews;
+
   // The input view should be hidden.
-  XCTAssertEqual(inputView.accessibilityElementsHidden, YES);
+  XCTAssertEqual([inputFields count], 0u);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -198,13 +198,14 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
 - (void)setSemanticsNode:(const flutter::SemanticsNode*)node {
   [super setSemanticsNode:node];
   _inactive_text_input.text = @(node->value.data());
+  FlutterTextInputView* textInput = (FlutterTextInputView*)[self bridge]->textInputView();
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsFocused)) {
+    textInput.backingTextInputAccessibilityObject = self;
     // The text input view must have a non-trivial size for the accessibility
     // system to send text editing events.
-    FlutterTextInputView.backingTextInputAccessibilityObject = self;
-    [self bridge]->textInputView().frame = CGRectMake(0.0, 0.0, 1.0, 1.0);
-  } else if (FlutterTextInputView.backingTextInputAccessibilityObject == self) {
-    FlutterTextInputView.backingTextInputAccessibilityObject = nil;
+    textInput.frame = CGRectMake(0.0, 0.0, 1.0, 1.0);
+  } else if (textInput.backingTextInputAccessibilityObject == self) {
+    textInput.backingTextInputAccessibilityObject = nil;
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -263,7 +263,7 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
   NSString* label = [super accessibilityLabel];
   if (label != nil)
     return label;
-  return _inactive_text_input.accessibilityLabel;
+  return [self textInputSurrogate].accessibilityLabel;
 }
 
 - (NSString*)accessibilityHint {
@@ -291,7 +291,7 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
   // a keyboard entry control, thus adding support for text editing features, such as
   // pinch to select text, and up/down fling to move cursor.
   UIAccessibilityTraits results = [super accessibilityTraits] |
-                                  _inactive_text_input.accessibilityTraits |
+                                  [self textInputSurrogate].accessibilityTraits |
                                   UIAccessibilityTraitKeyboardKey;
   // We remove an undocumented flag to get rid of a bug where single-tapping
   // a text input field incorrectly says "empty line".

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -201,7 +201,10 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsFocused)) {
     // The text input view must have a non-trivial size for the accessibility
     // system to send text editing events.
+    FlutterTextInputView.backingTextInputAccessibilityObject = self;
     [self bridge]->textInputView().frame = CGRectMake(0.0, 0.0, 1.0, 1.0);
+  } else if (FlutterTextInputView.backingTextInputAccessibilityObject == self) {
+    FlutterTextInputView.backingTextInputAccessibilityObject = nil;
   }
 }
 
@@ -260,7 +263,7 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
   NSString* label = [super accessibilityLabel];
   if (label != nil)
     return label;
-  return [self textInputSurrogate].accessibilityLabel;
+  return _inactive_text_input.accessibilityLabel;
 }
 
 - (NSString*)accessibilityHint {
@@ -288,7 +291,7 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
   // a keyboard entry control, thus adding support for text editing features, such as
   // pinch to select text, and up/down fling to move cursor.
   UIAccessibilityTraits results = [super accessibilityTraits] |
-                                  [self textInputSurrogate].accessibilityTraits |
+                                  _inactive_text_input.accessibilityTraits |
                                   UIAccessibilityTraitKeyboardKey;
   // We remove an undocumented flag to get rid of a bug where single-tapping
   // a text input field incorrectly says "empty line".


### PR DESCRIPTION
To make the UITextInput work properly, its accessibilityElementsHidden must return NO.

This pr makes sure to toggle it on or off when it is focused. However, I am not sure if there will be any side effect when doing this. Will write test once we confirm this is what we want to do.

Fixes https://github.com/flutter/flutter/issues/71885

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
