### PR TITLE
Fix JNI void vs object method call - Deferred Components

### DIFF
--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -1539,9 +1539,8 @@ bool PlatformViewAndroidJNIImpl::RequestDartDeferredLibrary(
     return true;
   }
 
-  env->CallObjectMethod(java_object.obj(),
-                        g_request_dart_deferred_library_method,
-                        loading_unit_id);
+  env->CallVoidMethod(java_object.obj(), g_request_dart_deferred_library_method,
+                      loading_unit_id);
 
   FML_CHECK(CheckException(env));
   return true;


### PR DESCRIPTION
Incorrect call of `CallObjectMethod` causes crash in g3. Fix by changing to correct `CallVoidMethod`.
