### PR TITLE
WIP: Add TextInput.setEditableSizeAndTransform handler

### DIFF
--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -16,6 +16,7 @@ static constexpr char kClearClientMethod[] = "TextInput.clearClient";
 static constexpr char kSetClientMethod[] = "TextInput.setClient";
 static constexpr char kShowMethod[] = "TextInput.show";
 static constexpr char kHideMethod[] = "TextInput.hide";
+static constexpr char kSetMarkedTextRect[] = "TextInput.setMarkedTextRect";
 
 static constexpr char kMultilineInputType[] = "TextInputType.multiline";
 
@@ -34,6 +35,10 @@ static constexpr char kSelectionBaseKey[] = "selectionBase";
 static constexpr char kSelectionExtentKey[] = "selectionExtent";
 static constexpr char kSelectionIsDirectionalKey[] = "selectionIsDirectional";
 static constexpr char kTextKey[] = "text";
+static constexpr char kXKey[] = "x";
+static constexpr char kYKey[] = "y";
+static constexpr char kWidthKey[] = "width";
+static constexpr char kHeightKey[] = "height";
 
 static constexpr char kChannelName[] = "flutter/textinput";
 
@@ -171,6 +176,27 @@ void TextInputPlugin::HandleMethodCall(
     }
     active_model_->SetText(text->value.GetString());
     active_model_->SetSelection(TextRange(base, extent));
+  } else if (method.compare(kSetMarkedTextRect) == 0) {
+    if (!method_call.arguments() || method_call.arguments()->IsNull()) {
+      result->Error(kBadArgumentError, "Method invoked without args");
+      return;
+    }
+    const rapidjson::Document& args = *method_call.arguments();
+    auto x = args.FindMember(kXKey);
+    auto y = args.FindMember(kYKey);
+    auto width = args.FindMember(kWidthKey);
+    auto height = args.FindMember(kHeightKey);
+    if (x == args.MemberEnd() || x->value.IsNull() ||
+        y == args.MemberEnd() || y->value.IsNull() ||
+        width == args.MemberEnd() || width->value.IsNull() ||
+        height == args.MemberEnd() || height->value.IsNull()) {
+      result->Error(kInternalConsistencyError, "Composing rect values invalid.");
+      return;
+    }
+    compose_rect_.x = x->value.GetDouble();
+    compose_rect_.y = y->value.GetDouble();
+    compose_rect_.width = width->value.GetDouble();
+    compose_rect_.height = height->value.GetDouble();
   } else {
     result->NotImplemented();
     return;

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -91,6 +91,10 @@ class TextInputPlugin : public KeyboardHookHandler {
   // range. This value is updated via `TextInput.setMarkedTextRect` messages
   // over the text input channel.
   Rect compose_rect_;
+
+  // A 4x4 matrix that maps from `EditableText` local coordinates to the
+  // coordinate system of `PipelineOwner.rootNode`.
+  double editabletext_transform_[4][4];
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -19,6 +19,21 @@ namespace flutter {
 
 class FlutterWindowsView;
 
+// A rectangle with a position and extent.
+//
+// Used to store the current composing rectangle when using multi-step (IME)
+// text input.
+struct Rect {
+  Rect() = default;
+  Rect(const Rect& rect) = default;
+  Rect& operator=(const Rect& other) = default;
+
+  double x;
+  double y;
+  double width;
+  double height;
+};
+
 // Implements a text input plugin.
 //
 // Specifically handles window events within windows.
@@ -50,6 +65,10 @@ class TextInputPlugin : public KeyboardHookHandler {
       const flutter::MethodCall<rapidjson::Document>& method_call,
       std::unique_ptr<flutter::MethodResult<rapidjson::Document>> result);
 
+  void SetMarkedTextRect(
+      const flutter::MethodCall<rapidjson::Document>& method_call,
+      std::unique_ptr<flutter::MethodResult<rapidjson::Document>> result);
+
   // The MethodChannel used for communication with the Flutter engine.
   std::unique_ptr<flutter::MethodChannel<rapidjson::Document>> channel_;
 
@@ -66,6 +85,12 @@ class TextInputPlugin : public KeyboardHookHandler {
   // An action requested by the user on the input client. See available options:
   // https://api.flutter.dev/flutter/services/TextInputAction-class.html
   std::string input_action_;
+
+  // The smallest rect, in local coordinates, of the text in the composing
+  // range, or of the caret in the case where there is no current composing
+  // range. This value is updated via `TextInput.setMarkedTextRect` messages
+  // over the text input channel.
+  Rect compose_rect_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
When inputting text, the framework computes a transform from local
coordinates to the coordinate system of PipelineOwner.rootNode and
updates the embedder via the TextInput.setEditableSizeAndTransform
message over the channel.

We add a handler for this method which stores this transform in an array
on TextInputPlugin.

In a previous patch, a similar handler was be added for the
TextInput.setMarkedTextRect message. When compose rect is needed in
window coordinates, the rect can be multipled by this 4x4 transform
matrix, so the result may be read by the view/window class and the
IME candidates window position updated.

Note: This PR is currently stacked on top of https://github.com/flutter/engine/pull/23789.

## Issues

This is one in a series of patches addressing flutter/flutter#65574: Full IME support for Windows.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
