### PR TITLE
fix video(texture) with opacity can not play issue

### DIFF
--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -43,6 +43,7 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
   // always be false.
   FML_DCHECK(!context->has_platform_view);
   bool child_has_platform_view = false;
+  bool child_has_texture_layer = false;
   for (auto& layer : layers_) {
     // Reset context->has_platform_view to false so that layers aren't treated
     // as if they have a platform view based on one being previously found in a
@@ -58,9 +59,12 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
 
     child_has_platform_view =
         child_has_platform_view || context->has_platform_view;
+    child_has_texture_layer =
+        child_has_texture_layer || context->has_texture_layer;
   }
 
   context->has_platform_view = child_has_platform_view;
+  context->has_texture_layer = child_has_texture_layer;
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   if (child_layer_exists_below_) {
@@ -90,7 +94,8 @@ void ContainerLayer::PaintChildren(PaintContext& context) const {
 void ContainerLayer::TryToPrepareRasterCache(PrerollContext* context,
                                              Layer* layer,
                                              const SkMatrix& matrix) {
-  if (!context->has_platform_view && context->raster_cache &&
+  if (!context->has_platform_view && !context->has_texture_layer &&
+      context->raster_cache &&
       SkRect::Intersects(context->cull_rect, layer->paint_bounds())) {
     context->raster_cache->Prepare(context, layer, matrix);
   }

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -64,6 +64,9 @@ struct PrerollContext {
   // Informs whether a layer needs to be system composited.
   bool child_scene_layer_exists_below = false;
 #endif
+  // These allow us to track properties like elevation, opacity, and the
+  // prescence of a texture layer during Preroll.
+  bool has_texture_layer = false;
 };
 
 // Represents a single composited layer. Created on the UI thread but then

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -28,6 +28,7 @@ void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));
+  context->has_texture_layer = true;
 }
 
 void TextureLayer::Paint(PaintContext& context) const {


### PR DESCRIPTION
If video is child of Opacity widget, it cannot play, for it generate layer cache. So ConainerLayer should not generate layer cache if has texture layer, just like PlatformViewLayer.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
