### PR TITLE
[web] Fix typo and add `sampler3DRect` in ShaderBuilder reserved words

### DIFF
--- a/lib/web_ui/lib/src/engine/html/shaders/shader_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader_builder.dart
@@ -382,7 +382,7 @@ const List<String> _kReservedWords = [
   'image2DArrayShadow', 'image2DShadow', 'image3D', 'imageBuffer',
   'imageCube', 'inline', 'input', 'interface', 'long',
   'namespace', 'noinline', 'output', 'packed', 'partition', 'public',
-  'row_majo', 'short', 'sizeof', 'static', 'superp', 'template', 'this',
+  'row_major', 'sampler3DRect', 'short', 'sizeof', 'static', 'superp', 'template', 'this',
   'typedef', 'uimage1D', 'uimage1DArray', 'uimage2D', 'uimage2DArray',
   'uimage3D', 'uimageBuffer', 'uimageCube', 'union', 'unsigned',
   'using', 'volatile',


### PR DESCRIPTION
`row_majo` should be `row_major`
`sampler3DRect` is also listed in GLSLangSpec.4.10 as `keywords reserved for future use`