### PR TITLE
Share Android surface GrDirectContext

### DIFF
--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -12,7 +12,7 @@ GPUSurfaceVulkan::GPUSurfaceVulkan(
     GPUSurfaceVulkanDelegate* delegate,
     std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,
     bool render_to_surface)
-    : GPUSurfaceVulkan(nullptr /* GrDirectContext */,
+    : GPUSurfaceVulkan(/*context=*/ nullptr,
                        delegate,
                        std::move(native_surface),
                        render_to_surface) {}

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -12,7 +12,7 @@ GPUSurfaceVulkan::GPUSurfaceVulkan(
     GPUSurfaceVulkanDelegate* delegate,
     std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,
     bool render_to_surface)
-    : GPUSurfaceVulkan(/*context=*/ nullptr,
+    : GPUSurfaceVulkan(/*context=*/nullptr,
                        delegate,
                        std::move(native_surface),
                        render_to_surface) {}

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -12,7 +12,7 @@ GPUSurfaceVulkan::GPUSurfaceVulkan(
     GPUSurfaceVulkanDelegate* delegate,
     std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,
     bool render_to_surface)
-    : GPUSurfaceVulkan(nullptr,
+    : GPUSurfaceVulkan(nullptr /* GrDirectContext */,
                        delegate,
                        std::move(native_surface),
                        render_to_surface) {}

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -12,7 +12,20 @@ GPUSurfaceVulkan::GPUSurfaceVulkan(
     GPUSurfaceVulkanDelegate* delegate,
     std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,
     bool render_to_surface)
-    : window_(delegate->vk(), std::move(native_surface), render_to_surface),
+    : GPUSurfaceVulkan(nullptr,
+                       delegate,
+                       std::move(native_surface),
+                       render_to_surface) {}
+
+GPUSurfaceVulkan::GPUSurfaceVulkan(
+    const sk_sp<GrDirectContext>& context,
+    GPUSurfaceVulkanDelegate* delegate,
+    std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,
+    bool render_to_surface)
+    : window_(context,
+              delegate->vk(),
+              std::move(native_surface),
+              render_to_surface),
       render_to_surface_(render_to_surface),
       weak_factory_(this) {}
 

--- a/shell/gpu/gpu_surface_vulkan.h
+++ b/shell/gpu/gpu_surface_vulkan.h
@@ -19,10 +19,18 @@ namespace flutter {
 
 class GPUSurfaceVulkan : public Surface {
  public:
+  //------------------------------------------------------------------------------
+  /// @brief      Create a GPUSurfaceVulkan which implicitly creates its own
+  ///             GrDirectContext for Skia.
+  ///
   GPUSurfaceVulkan(GPUSurfaceVulkanDelegate* delegate,
                    std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,
                    bool render_to_surface);
 
+  //------------------------------------------------------------------------------
+  /// @brief      Create a GPUSurfaceVulkan while letting it reuse an existing
+  ///             GrDirectContext.
+  ///
   GPUSurfaceVulkan(const sk_sp<GrDirectContext>& context,
                    GPUSurfaceVulkanDelegate* delegate,
                    std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,

--- a/shell/gpu/gpu_surface_vulkan.h
+++ b/shell/gpu/gpu_surface_vulkan.h
@@ -13,12 +13,18 @@
 #include "flutter/shell/gpu/gpu_surface_vulkan_delegate.h"
 #include "flutter/vulkan/vulkan_native_surface.h"
 #include "flutter/vulkan/vulkan_window.h"
+#include "include/core/SkRefCnt.h"
 
 namespace flutter {
 
 class GPUSurfaceVulkan : public Surface {
  public:
   GPUSurfaceVulkan(GPUSurfaceVulkanDelegate* delegate,
+                   std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,
+                   bool render_to_surface);
+
+  GPUSurfaceVulkan(const sk_sp<GrDirectContext>& context,
+                   GPUSurfaceVulkanDelegate* delegate,
                    std::unique_ptr<vulkan::VulkanNativeSurface> native_surface,
                    bool render_to_surface);
 

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -20,14 +20,14 @@ constexpr char kEmulatorRendererPrefix[] =
 }  // anonymous namespace
 
 AndroidSurfaceGL::AndroidSurfaceGL(
-    const AndroidContext& android_context,
+    const std::shared_ptr<AndroidContext>& android_context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
-    : android_context_(static_cast<const AndroidContextGL&>(android_context)),
+    : AndroidSurface(android_context),
       native_window_(nullptr),
       onscreen_surface_(nullptr),
       offscreen_surface_(nullptr) {
   // Acquire the offscreen surface.
-  offscreen_surface_ = android_context_.CreateOffscreenSurface();
+  offscreen_surface_ = GLContextPtr()->CreateOffscreenSurface();
   if (!offscreen_surface_->IsValid()) {
     offscreen_surface_ = nullptr;
   }
@@ -39,20 +39,27 @@ void AndroidSurfaceGL::TeardownOnScreenContext() {
   // When the onscreen surface is destroyed, the context and the surface
   // instance should be deleted. Issue:
   // https://github.com/flutter/flutter/issues/64414
-  android_context_.ClearCurrent();
+  GLContextPtr()->ClearCurrent();
   onscreen_surface_ = nullptr;
 }
 
 bool AndroidSurfaceGL::IsValid() const {
-  return offscreen_surface_ && android_context_.IsValid();
+  return offscreen_surface_ && GLContextPtr()->IsValid();
 }
 
 std::unique_ptr<Surface> AndroidSurfaceGL::CreateGPUSurface(
     GrDirectContext* gr_context) {
   if (gr_context) {
     return std::make_unique<GPUSurfaceGL>(sk_ref_sp(gr_context), this, true);
+  } else {
+    sk_sp<GrDirectContext> main_skia_context =
+        GLContextPtr()->GetMainSkiaContext();
+    if (!main_skia_context) {
+      main_skia_context = GPUSurfaceGL::MakeGLContext(this);
+      GLContextPtr()->SetMainSkiaContext(main_skia_context);
+    }
+    return std::make_unique<GPUSurfaceGL>(main_skia_context, this, true);
   }
-  return std::make_unique<GPUSurfaceGL>(this, true);
 }
 
 bool AndroidSurfaceGL::OnScreenSurfaceResize(const SkISize& size) {
@@ -64,12 +71,12 @@ bool AndroidSurfaceGL::OnScreenSurfaceResize(const SkISize& size) {
     return true;
   }
 
-  android_context_.ClearCurrent();
+  GLContextPtr()->ClearCurrent();
 
   // Ensure the destructor is called since it destroys the `EGLSurface` before
   // creating a new onscreen surface.
   onscreen_surface_ = nullptr;
-  onscreen_surface_ = android_context_.CreateOnscreenSurface(native_window_);
+  onscreen_surface_ = GLContextPtr()->CreateOnscreenSurface(native_window_);
   if (!onscreen_surface_->IsValid()) {
     FML_LOG(ERROR) << "Unable to create EGL window surface on resize.";
     return false;
@@ -85,7 +92,7 @@ bool AndroidSurfaceGL::ResourceContextMakeCurrent() {
 
 bool AndroidSurfaceGL::ResourceContextClearCurrent() {
   FML_DCHECK(IsValid());
-  return android_context_.ClearCurrent();
+  return GLContextPtr()->ClearCurrent();
 }
 
 bool AndroidSurfaceGL::SetNativeWindow(
@@ -97,7 +104,7 @@ bool AndroidSurfaceGL::SetNativeWindow(
   // creating a new onscreen surface.
   onscreen_surface_ = nullptr;
   // Create the onscreen surface.
-  onscreen_surface_ = android_context_.CreateOnscreenSurface(window);
+  onscreen_surface_ = GLContextPtr()->CreateOnscreenSurface(window);
   if (!onscreen_surface_->IsValid()) {
     return false;
   }
@@ -114,7 +121,7 @@ std::unique_ptr<GLContextResult> AndroidSurfaceGL::GLContextMakeCurrent() {
 
 bool AndroidSurfaceGL::GLContextClearCurrent() {
   FML_DCHECK(IsValid());
-  return android_context_.ClearCurrent();
+  return GLContextPtr()->ClearCurrent();
 }
 
 bool AndroidSurfaceGL::GLContextPresent(uint32_t fbo_id) {
@@ -143,7 +150,7 @@ sk_sp<const GrGLInterface> AndroidSurfaceGL::GetGLInterface() const {
       reinterpret_cast<const char*>(glGetString(GL_RENDERER));
   if (gl_renderer && strncmp(gl_renderer, kEmulatorRendererPrefix,
                              strlen(kEmulatorRendererPrefix)) == 0) {
-    EGLContext new_context = android_context_.CreateNewContext();
+    EGLContext new_context = GLContextPtr()->CreateNewContext();
     if (new_context != EGL_NO_CONTEXT) {
       EGLContext old_context = eglGetCurrentContext();
       EGLDisplay display = eglGetCurrentDisplay();
@@ -160,6 +167,10 @@ sk_sp<const GrGLInterface> AndroidSurfaceGL::GetGLInterface() const {
   }
 
   return GPUSurfaceGLDelegate::GetGLInterface();
+}
+
+AndroidContextGL* AndroidSurfaceGL::GLContextPtr() const {
+  return reinterpret_cast<AndroidContextGL*>(android_context_.get());
 }
 
 }  // namespace flutter

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -68,6 +68,10 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   std::unique_ptr<AndroidEGLSurface> onscreen_surface_;
   std::unique_ptr<AndroidEGLSurface> offscreen_surface_;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Takes the super class AndroidSurface's AndroidContext and
+  ///             return a raw pointer to an AndroidContextGL.
+  ///
   AndroidContextGL* GLContextPtr() const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidSurfaceGL);

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -21,7 +21,7 @@ namespace flutter {
 class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
                                public AndroidSurface {
  public:
-  AndroidSurfaceGL(const AndroidContext& android_context,
+  AndroidSurfaceGL(const std::shared_ptr<AndroidContext>& android_context,
                    std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
 
   ~AndroidSurfaceGL() override;
@@ -64,11 +64,11 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   sk_sp<const GrGLInterface> GetGLInterface() const override;
 
  private:
-  const AndroidContextGL& android_context_;
-
   fml::RefPtr<AndroidNativeWindow> native_window_;
   std::unique_ptr<AndroidEGLSurface> onscreen_surface_;
   std::unique_ptr<AndroidEGLSurface> offscreen_surface_;
+
+  AndroidContextGL* GLContextPtr() const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidSurfaceGL);
 };

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -38,8 +38,9 @@ bool GetSkColorType(int32_t buffer_format,
 }  // anonymous namespace
 
 AndroidSurfaceSoftware::AndroidSurfaceSoftware(
-    const AndroidContext& android_context,
-    std::shared_ptr<PlatformViewAndroidJNI> jni_facade) {
+    const std::shared_ptr<AndroidContext>& android_context,
+    std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
+    : AndroidSurface(android_context) {
   GetSkColorType(WINDOW_FORMAT_RGBA_8888, &target_color_type_,
                  &target_alpha_type_);
 }
@@ -60,6 +61,8 @@ bool AndroidSurfaceSoftware::ResourceContextClearCurrent() {
 }
 
 std::unique_ptr<Surface> AndroidSurfaceSoftware::CreateGPUSurface(
+    // The software AndroidSurface neither uses any passed in Skia context
+    // nor does it interact with the AndroidContext's raster Skia context.
     GrDirectContext* gr_context) {
   if (!IsValid()) {
     return nullptr;

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -17,7 +17,7 @@ namespace flutter {
 class AndroidSurfaceSoftware final : public AndroidSurface,
                                      public GPUSurfaceSoftwareDelegate {
  public:
-  AndroidSurfaceSoftware(const AndroidContext& android_context,
+  AndroidSurfaceSoftware(const std::shared_ptr<AndroidContext>& android_context,
                          std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
 
   ~AndroidSurfaceSoftware() override;

--- a/shell/platform/android/android_surface_vulkan.cc
+++ b/shell/platform/android/android_surface_vulkan.cc
@@ -4,11 +4,13 @@
 
 #include "flutter/shell/platform/android/android_surface_vulkan.h"
 
+#include <memory>
 #include <utility>
 
 #include "flutter/fml/logging.h"
 #include "flutter/shell/gpu/gpu_surface_vulkan.h"
 #include "flutter/vulkan/vulkan_native_surface_android.h"
+#include "include/core/SkRefCnt.h"
 
 namespace flutter {
 
@@ -30,8 +32,6 @@ void AndroidSurfaceVulkan::TeardownOnScreenContext() {
 
 std::unique_ptr<Surface> AndroidSurfaceVulkan::CreateGPUSurface(
     GrDirectContext* gr_context) {
-  // TODO(https://github.com/flutter/flutter/issues/73597): consume this
-  // Skia context or create a new one for AndroidContext.
   if (!IsValid()) {
     return nullptr;
   }
@@ -48,8 +48,22 @@ std::unique_ptr<Surface> AndroidSurfaceVulkan::CreateGPUSurface(
     return nullptr;
   }
 
-  auto gpu_surface = std::make_unique<GPUSurfaceVulkan>(
-      this, std::move(vulkan_surface_android), true);
+  sk_sp<GrDirectContext> provided_gr_context;
+  if (gr_context) {
+    provided_gr_context = sk_ref_sp(gr_context);
+  } else if (android_context_->GetMainSkiaContext()) {
+    provided_gr_context = android_context_->GetMainSkiaContext();
+  }
+
+  std::unique_ptr<GPUSurfaceVulkan> gpu_surface;
+  if (provided_gr_context) {
+    gpu_surface = std::make_unique<GPUSurfaceVulkan>(
+        provided_gr_context, this, std::move(vulkan_surface_android), true);
+  } else {
+    gpu_surface = std::make_unique<GPUSurfaceVulkan>(
+        this, std::move(vulkan_surface_android), true);
+    android_context_->SetMainSkiaContext(sk_ref_sp(gpu_surface->GetContext()));
+  }
 
   if (!gpu_surface->IsValid()) {
     return nullptr;

--- a/shell/platform/android/android_surface_vulkan.cc
+++ b/shell/platform/android/android_surface_vulkan.cc
@@ -13,9 +13,10 @@
 namespace flutter {
 
 AndroidSurfaceVulkan::AndroidSurfaceVulkan(
-    const AndroidContext& android_context,
+    const std::shared_ptr<AndroidContext>& android_context,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
-    : proc_table_(fml::MakeRefCounted<vulkan::VulkanProcTable>()) {}
+    : AndroidSurface(android_context),
+      proc_table_(fml::MakeRefCounted<vulkan::VulkanProcTable>()) {}
 
 AndroidSurfaceVulkan::~AndroidSurfaceVulkan() = default;
 
@@ -29,6 +30,8 @@ void AndroidSurfaceVulkan::TeardownOnScreenContext() {
 
 std::unique_ptr<Surface> AndroidSurfaceVulkan::CreateGPUSurface(
     GrDirectContext* gr_context) {
+  // TODO(https://github.com/flutter/flutter/issues/73597): consume this
+  // Skia context or create a new one for AndroidContext.
   if (!IsValid()) {
     return nullptr;
   }

--- a/shell/platform/android/android_surface_vulkan.h
+++ b/shell/platform/android/android_surface_vulkan.h
@@ -20,7 +20,7 @@ namespace flutter {
 class AndroidSurfaceVulkan : public AndroidSurface,
                              public GPUSurfaceVulkanDelegate {
  public:
-  AndroidSurfaceVulkan(const AndroidContext& android_context,
+  AndroidSurfaceVulkan(const std::shared_ptr<AndroidContext>& android_context,
                        std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
 
   ~AndroidSurfaceVulkan() override;

--- a/shell/platform/android/context/BUILD.gn
+++ b/shell/platform/android/context/BUILD.gn
@@ -12,5 +12,8 @@ source_set("context") {
 
   public_configs = [ "//flutter:config" ]
 
-  deps = [ "//flutter/fml" ]
+  deps = [
+    "//flutter/fml",
+    "//third_party/skia",
+  ]
 }

--- a/shell/platform/android/context/android_context.cc
+++ b/shell/platform/android/context/android_context.cc
@@ -9,7 +9,11 @@ namespace flutter {
 AndroidContext::AndroidContext(AndroidRenderingAPI rendering_api)
     : rendering_api_(rendering_api) {}
 
-AndroidContext::~AndroidContext() = default;
+AndroidContext::~AndroidContext() {
+  if (main_context_) {
+    main_context_->releaseResourcesAndAbandonContext();
+  }
+};
 
 AndroidRenderingAPI AndroidContext::RenderingApi() const {
   return rendering_api_;
@@ -17,6 +21,15 @@ AndroidRenderingAPI AndroidContext::RenderingApi() const {
 
 bool AndroidContext::IsValid() const {
   return true;
+}
+
+void AndroidContext::SetMainSkiaContext(
+    const sk_sp<GrDirectContext>& main_context) {
+  main_context_ = main_context;
+}
+
+sk_sp<GrDirectContext> AndroidContext::GetMainSkiaContext() const {
+  return main_context_;
 }
 
 }  // namespace flutter

--- a/shell/platform/android/context/android_context.h
+++ b/shell/platform/android/context/android_context.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_CONTEXT_H_
 
 #include "flutter/fml/macros.h"
+#include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
 
@@ -28,8 +29,36 @@ class AndroidContext {
 
   virtual bool IsValid() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Setter for the Skia context to be used by subsequent
+  ///             AndroidSurfaces.
+  /// @details    This is useful to reduce memory consumption when creating
+  ///             multiple AndroidSurfaces for the same AndroidContext.
+  ///
+  ///             The first AndroidSurface should set this for the
+  ///             AndroidContext if the AndroidContext does not yet have a
+  ///             Skia context to share via GetMainSkiaContext.
+  ///
+  void SetMainSkiaContext(const sk_sp<GrDirectContext>& main_context);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Accessor for the Skia context associated with AndroidSurfaces
+  ///             and the raster thread.
+  /// @details    This context is created lazily by the AndroidSurface based
+  ///             on their respective rendering backend and set on this
+  ///             AndroidContext to share via SetMainSkiaContext.
+  /// @returns    `nullptr` when no Skia context has been set yet by its
+  ///             AndroidSurface via SetMainSkiaContext.
+  /// @attention  The software context doesn't have a Skia context, so this
+  ///             value will be nullptr.
+  ///
+  sk_sp<GrDirectContext> GetMainSkiaContext() const;
+
  private:
   const AndroidRenderingAPI rendering_api_;
+
+  // This is the Skia context used for on-screen rendering.
+  sk_sp<GrDirectContext> main_context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidContext);
 };

--- a/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
+++ b/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
@@ -129,12 +129,12 @@ TEST(SurfacePool, GetLayer__Recycle) {
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
-  auto layer_1 = pool->GetLayer(gr_context_1.get(), &android_context, jni_mock,
+  auto layer_1 = pool->GetLayer(gr_context_1.get(), *android_context, jni_mock,
                                 surface_factory);
 
   pool->RecycleLayers();
 
-  auto layer_2 = pool->GetLayer(gr_context_2.get(), &android_context, jni_mock,
+  auto layer_2 = pool->GetLayer(gr_context_2.get(), *android_context, jni_mock,
                                 surface_factory);
 
   ASSERT_NE(nullptr, layer_1);

--- a/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
+++ b/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <memory>
 #include "flutter/shell/platform/android/external_view_embedder/surface_pool.h"
 
 #include "flutter/fml/make_copyable.h"
@@ -39,7 +40,8 @@ TEST(SurfacePool, GetLayer__AllocateOneLayer) {
   auto pool = std::make_unique<SurfacePool>();
 
   auto gr_context = GrDirectContext::MakeMock(nullptr);
-  auto android_context = AndroidContext(AndroidRenderingAPI::kSoftware);
+  auto android_context =
+      std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
   auto jni_mock = std::make_shared<JNIMock>();
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
@@ -48,15 +50,16 @@ TEST(SurfacePool, GetLayer__AllocateOneLayer) {
           ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
               0, window))));
 
-  auto surface_factory =
-      std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
-        auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
+  auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
+      [&android_context, gr_context, window]() {
+        auto android_surface_mock =
+            std::make_unique<AndroidSurfaceMock>(android_context);
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
         EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
-  auto layer = pool->GetLayer(gr_context.get(), android_context, jni_mock,
+  auto layer = pool->GetLayer(gr_context.get(), *android_context, jni_mock,
                               surface_factory);
 
   ASSERT_NE(nullptr, layer);
@@ -68,7 +71,8 @@ TEST(SurfacePool, GetUnusedLayers) {
   auto pool = std::make_unique<SurfacePool>();
 
   auto gr_context = GrDirectContext::MakeMock(nullptr);
-  auto android_context = AndroidContext(AndroidRenderingAPI::kSoftware);
+  auto android_context =
+      std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
   auto jni_mock = std::make_shared<JNIMock>();
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
@@ -77,15 +81,16 @@ TEST(SurfacePool, GetUnusedLayers) {
           ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
               0, window))));
 
-  auto surface_factory =
-      std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
-        auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
+  auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
+      [&android_context, gr_context, window]() {
+        auto android_surface_mock =
+            std::make_unique<AndroidSurfaceMock>(android_context);
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
         EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
-  auto layer = pool->GetLayer(gr_context.get(), android_context, jni_mock,
+  auto layer = pool->GetLayer(gr_context.get(), *android_context, jni_mock,
                               surface_factory);
   ASSERT_EQ(0UL, pool->GetUnusedLayers().size());
 
@@ -106,12 +111,14 @@ TEST(SurfacePool, GetLayer__Recycle) {
           ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
               0, window))));
 
-  auto android_context = AndroidContext(AndroidRenderingAPI::kSoftware);
+  auto android_context =
+      std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
   auto gr_context_2 = GrDirectContext::MakeMock(nullptr);
   auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
-      [gr_context_1, gr_context_2, window]() {
-        auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
+      [&android_context, gr_context_1, gr_context_2, window]() {
+        auto android_surface_mock =
+            std::make_unique<AndroidSurfaceMock>(android_context);
         // Allocate two GPU surfaces for each gr context.
         EXPECT_CALL(*android_surface_mock,
                     CreateGPUSurface(gr_context_1.get()));
@@ -122,12 +129,12 @@ TEST(SurfacePool, GetLayer__Recycle) {
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
-  auto layer_1 = pool->GetLayer(gr_context_1.get(), android_context, jni_mock,
+  auto layer_1 = pool->GetLayer(gr_context_1.get(), &android_context, jni_mock,
                                 surface_factory);
 
   pool->RecycleLayers();
 
-  auto layer_2 = pool->GetLayer(gr_context_2.get(), android_context, jni_mock,
+  auto layer_2 = pool->GetLayer(gr_context_2.get(), &android_context, jni_mock,
                                 surface_factory);
 
   ASSERT_NE(nullptr, layer_1);
@@ -142,7 +149,8 @@ TEST(SurfacePool, GetLayer__AllocateTwoLayers) {
   auto pool = std::make_unique<SurfacePool>();
 
   auto gr_context = GrDirectContext::MakeMock(nullptr);
-  auto android_context = AndroidContext(AndroidRenderingAPI::kSoftware);
+  auto android_context =
+      std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
   auto jni_mock = std::make_shared<JNIMock>();
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
@@ -155,17 +163,18 @@ TEST(SurfacePool, GetLayer__AllocateTwoLayers) {
           ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
               1, window))));
 
-  auto surface_factory =
-      std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
-        auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
+  auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
+      [&android_context, gr_context, window]() {
+        auto android_surface_mock =
+            std::make_unique<AndroidSurfaceMock>(android_context);
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
         EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
-  auto layer_1 = pool->GetLayer(gr_context.get(), android_context, jni_mock,
+  auto layer_1 = pool->GetLayer(gr_context.get(), *android_context, jni_mock,
                                 surface_factory);
-  auto layer_2 = pool->GetLayer(gr_context.get(), android_context, jni_mock,
+  auto layer_2 = pool->GetLayer(gr_context.get(), *android_context, jni_mock,
                                 surface_factory);
   ASSERT_NE(nullptr, layer_1);
   ASSERT_NE(nullptr, layer_2);
@@ -182,7 +191,8 @@ TEST(SurfacePool, DestroyLayers) {
   pool->DestroyLayers(jni_mock);
 
   auto gr_context = GrDirectContext::MakeMock(nullptr);
-  auto android_context = AndroidContext(AndroidRenderingAPI::kSoftware);
+  auto android_context =
+      std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
   EXPECT_CALL(*jni_mock, FlutterViewCreateOverlaySurface())
@@ -191,15 +201,16 @@ TEST(SurfacePool, DestroyLayers) {
           ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
               0, window))));
 
-  auto surface_factory =
-      std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
-        auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
+  auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
+      [&android_context, gr_context, window]() {
+        auto android_surface_mock =
+            std::make_unique<AndroidSurfaceMock>(android_context);
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
         EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
         return android_surface_mock;
       });
-  pool->GetLayer(gr_context.get(), android_context, jni_mock, surface_factory);
+  pool->GetLayer(gr_context.get(), *android_context, jni_mock, surface_factory);
 
   EXPECT_CALL(*jni_mock, FlutterViewDestroyOverlaySurfaces());
   pool->DestroyLayers(jni_mock);
@@ -213,13 +224,15 @@ TEST(SurfacePool, DestroyLayers__frameSizeChanged) {
   auto jni_mock = std::make_shared<JNIMock>();
 
   auto gr_context = GrDirectContext::MakeMock(nullptr);
-  auto android_context = AndroidContext(AndroidRenderingAPI::kSoftware);
+  auto android_context =
+      std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
 
   auto window = fml::MakeRefCounted<AndroidNativeWindow>(nullptr);
 
-  auto surface_factory =
-      std::make_shared<TestAndroidSurfaceFactory>([gr_context, window]() {
-        auto android_surface_mock = std::make_unique<AndroidSurfaceMock>();
+  auto surface_factory = std::make_shared<TestAndroidSurfaceFactory>(
+      [&android_context, gr_context, window]() {
+        auto android_surface_mock =
+            std::make_unique<AndroidSurfaceMock>(android_context);
         EXPECT_CALL(*android_surface_mock, CreateGPUSurface(gr_context.get()));
         EXPECT_CALL(*android_surface_mock, SetNativeWindow(window));
         EXPECT_CALL(*android_surface_mock, IsValid()).WillOnce(Return(true));
@@ -233,7 +246,7 @@ TEST(SurfacePool, DestroyLayers__frameSizeChanged) {
           ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
               0, window))));
 
-  pool->GetLayer(gr_context.get(), android_context, jni_mock, surface_factory);
+  pool->GetLayer(gr_context.get(), *android_context, jni_mock, surface_factory);
 
   pool->SetFrameSize(SkISize::Make(20, 20));
   EXPECT_CALL(*jni_mock, FlutterViewDestroyOverlaySurfaces()).Times(1);
@@ -242,7 +255,7 @@ TEST(SurfacePool, DestroyLayers__frameSizeChanged) {
       .WillOnce(Return(
           ByMove(std::make_unique<PlatformViewAndroidJNI::OverlayMetadata>(
               1, window))));
-  pool->GetLayer(gr_context.get(), android_context, jni_mock, surface_factory);
+  pool->GetLayer(gr_context.get(), *android_context, jni_mock, surface_factory);
 
   ASSERT_TRUE(pool->GetUnusedLayers().empty());
 }

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -25,7 +25,7 @@ namespace flutter {
 
 class AndroidSurfaceFactoryImpl : public AndroidSurfaceFactory {
  public:
-  AndroidSurfaceFactoryImpl(const AndroidContext& context,
+  AndroidSurfaceFactoryImpl(const std::shared_ptr<AndroidContext>& context,
                             std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
 
   ~AndroidSurfaceFactoryImpl() override;
@@ -33,7 +33,7 @@ class AndroidSurfaceFactoryImpl : public AndroidSurfaceFactory {
   std::unique_ptr<AndroidSurface> CreateSurface() override;
 
  private:
-  const AndroidContext& android_context_;
+  const std::shared_ptr<AndroidContext>& android_context_;
   std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
 };
 
@@ -171,7 +171,7 @@ class PlatformViewAndroid final : public PlatformView {
   void RequestDartDeferredLibrary(intptr_t loading_unit_id) override;
 
   std::shared_ptr<AndroidSurfaceFactoryImpl> MakeSurfaceFactory(
-      const AndroidContext& android_context,
+      const std::shared_ptr<AndroidContext>& android_context,
       const PlatformViewAndroidJNI& jni_facade);
 
   std::unique_ptr<AndroidSurface> MakeSurface(

--- a/shell/platform/android/surface/android_surface.cc
+++ b/shell/platform/android/surface/android_surface.cc
@@ -3,11 +3,13 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/android/surface/android_surface.h"
+#include "flutter/fml/logging.h"
 
 namespace flutter {
 
 AndroidSurface::AndroidSurface(
     const std::shared_ptr<AndroidContext>& android_context) {
+  FML_DCHECK(android_context->IsValid());
   android_context_ = android_context;
 }
 

--- a/shell/platform/android/surface/android_surface.cc
+++ b/shell/platform/android/surface/android_surface.cc
@@ -6,6 +6,11 @@
 
 namespace flutter {
 
+AndroidSurface::AndroidSurface(
+    const std::shared_ptr<AndroidContext>& android_context) {
+  android_context_ = android_context;
+}
+
 AndroidSurface::~AndroidSurface() = default;
 
 }  // namespace flutter

--- a/shell/platform/android/surface/android_surface.h
+++ b/shell/platform/android/surface/android_surface.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_SURFACE_H_
 #define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_SURFACE_H_
 
+#include <memory>
 #include "flutter/flow/embedded_views.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
@@ -35,6 +36,11 @@ class AndroidSurface {
   virtual bool ResourceContextClearCurrent() = 0;
 
   virtual bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) = 0;
+
+ protected:
+  explicit AndroidSurface(
+      const std::shared_ptr<AndroidContext>& android_context);
+  std::shared_ptr<AndroidContext> android_context_;
 };
 
 class AndroidSurfaceFactory {

--- a/shell/platform/android/surface/android_surface_mock.cc
+++ b/shell/platform/android/surface/android_surface_mock.cc
@@ -6,6 +6,10 @@
 
 namespace flutter {
 
+AndroidSurfaceMock::AndroidSurfaceMock(
+    const std::shared_ptr<AndroidContext>& android_context)
+    : AndroidSurface(android_context);
+
 std::unique_ptr<GLContextResult> AndroidSurfaceMock::GLContextMakeCurrent() {
   return std::make_unique<GLContextDefaultResult>(/*static_result=*/true);
 }

--- a/shell/platform/android/surface/android_surface_mock.cc
+++ b/shell/platform/android/surface/android_surface_mock.cc
@@ -8,7 +8,7 @@ namespace flutter {
 
 AndroidSurfaceMock::AndroidSurfaceMock(
     const std::shared_ptr<AndroidContext>& android_context)
-    : AndroidSurface(android_context);
+    : AndroidSurface(android_context) {}
 
 std::unique_ptr<GLContextResult> AndroidSurfaceMock::GLContextMakeCurrent() {
   return std::make_unique<GLContextDefaultResult>(/*static_result=*/true);

--- a/shell/platform/android/surface/android_surface_mock.h
+++ b/shell/platform/android/surface/android_surface_mock.h
@@ -18,6 +18,9 @@ namespace flutter {
 class AndroidSurfaceMock final : public GPUSurfaceGLDelegate,
                                  public AndroidSurface {
  public:
+  explicit AndroidSurfaceMock(
+      const std::shared_ptr<AndroidContext>& android_context);
+
   MOCK_METHOD(bool, IsValid, (), (const, override));
 
   MOCK_METHOD(void, TeardownOnScreenContext, (), (override));

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -21,7 +21,7 @@ namespace vulkan {
 VulkanWindow::VulkanWindow(fml::RefPtr<VulkanProcTable> proc_table,
                            std::unique_ptr<VulkanNativeSurface> native_surface,
                            bool render_to_surface)
-    : VulkanWindow(nullptr,
+    : VulkanWindow(nullptr /* GrDirectContext */,
                    proc_table,
                    std::move(native_surface),
                    render_to_surface) {}

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -21,7 +21,7 @@ namespace vulkan {
 VulkanWindow::VulkanWindow(fml::RefPtr<VulkanProcTable> proc_table,
                            std::unique_ptr<VulkanNativeSurface> native_surface,
                            bool render_to_surface)
-    : VulkanWindow(nullptr /* GrDirectContext */,
+    : VulkanWindow(/*context/*/ nullptr,
                    proc_table,
                    std::move(native_surface),
                    render_to_surface) {}

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -21,7 +21,16 @@ namespace vulkan {
 VulkanWindow::VulkanWindow(fml::RefPtr<VulkanProcTable> proc_table,
                            std::unique_ptr<VulkanNativeSurface> native_surface,
                            bool render_to_surface)
-    : valid_(false), vk(std::move(proc_table)) {
+    : VulkanWindow(nullptr,
+                   proc_table,
+                   std::move(native_surface),
+                   render_to_surface);
+
+VulkanWindow::VulkanWindow(const sk_sp<GrDirectContext>& context,
+                           fml::RefPtr<VulkanProcTable> proc_table,
+                           std::unique_ptr<VulkanNativeSurface> native_surface,
+                           bool render_to_surface)
+    : valid_(false), vk(std::move(proc_table)), skia_gr_context_(context) {
   if (!vk || !vk->HasAcquiredMandatoryProcAddresses()) {
     FML_DLOG(INFO) << "Proc table has not acquired mandatory proc addresses.";
     return;
@@ -78,7 +87,7 @@ VulkanWindow::VulkanWindow(fml::RefPtr<VulkanProcTable> proc_table,
 
   // Create the Skia GrDirectContext.
 
-  if (!CreateSkiaGrContext()) {
+  if (!skia_gr_context_ && !CreateSkiaGrContext()) {
     FML_DLOG(INFO) << "Could not create Skia context.";
     return;
   }

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -24,7 +24,7 @@ VulkanWindow::VulkanWindow(fml::RefPtr<VulkanProcTable> proc_table,
     : VulkanWindow(nullptr,
                    proc_table,
                    std::move(native_surface),
-                   render_to_surface);
+                   render_to_surface) {}
 
 VulkanWindow::VulkanWindow(const sk_sp<GrDirectContext>& context,
                            fml::RefPtr<VulkanProcTable> proc_table,

--- a/vulkan/vulkan_window.h
+++ b/vulkan/vulkan_window.h
@@ -31,10 +31,18 @@ class VulkanBackbuffer;
 
 class VulkanWindow {
  public:
+  //------------------------------------------------------------------------------
+  /// @brief      Construct a VulkanWindow. Let it implicitly create a
+  ///             GrDirectContext.
+  ///
   VulkanWindow(fml::RefPtr<VulkanProcTable> proc_table,
                std::unique_ptr<VulkanNativeSurface> native_surface,
                bool render_to_surface);
 
+  //------------------------------------------------------------------------------
+  /// @brief      Construct a VulkanWindow. Let reuse an existing
+  ///             GrDirectContext built by another VulkanWindow.
+  ///
   VulkanWindow(const sk_sp<GrDirectContext>& context,
                fml::RefPtr<VulkanProcTable> proc_table,
                std::unique_ptr<VulkanNativeSurface> native_surface,

--- a/vulkan/vulkan_window.h
+++ b/vulkan/vulkan_window.h
@@ -35,6 +35,11 @@ class VulkanWindow {
                std::unique_ptr<VulkanNativeSurface> native_surface,
                bool render_to_surface);
 
+  VulkanWindow(const sk_sp<GrDirectContext>& context,
+               fml::RefPtr<VulkanProcTable> proc_table,
+               std::unique_ptr<VulkanNativeSurface> native_surface,
+               bool render_to_surface);
+
   ~VulkanWindow();
 
   bool IsValid() const;


### PR DESCRIPTION
Does half of https://github.com/flutter/flutter/issues/73597. 
The Android side of https://github.com/flutter/engine/pull/23634. 

- Make the AndroidContext store (but not create) GrDirectContext.
- Give all AndroidSurfaces' CreateGPUSurface the AndroidContext's stored GrDirectContext if there is one.
- Move AndroidSurfaceGL's reference storage of the AndroidContext up to the super AndroidSurface as a shared_ptr (since it now modifies it).
- Let AndroidSurfaceGL lazy create the first GrDirectContext and save it in the AndroidContext. 
- Let AndroidSurfaceVulkan->GpuSurfaceVulkan->VulkanWindow have a constructor injectable GrDirectContext too. 
- Let AndroidSurfaceVulkan also lazy create the first GrDirectContext by building the GpuSurfaceVulkan, then pull it out to save another copy in the AndroidContext.

Manual tested and via the new Scenario App spawn test so far. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
