### PR TITLE
add ffi_allocation_patch.dart to libraries.yaml

### DIFF
--- a/shell/platform/fuchsia/dart_runner/kernel/libraries.json
+++ b/shell/platform/fuchsia/dart_runner/kernel/libraries.json
@@ -83,6 +83,7 @@
         "uri": "../../../../../../third_party/dart/sdk/lib/ffi/ffi.dart",
         "patches": [
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart",
+          "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"

--- a/shell/platform/fuchsia/dart_runner/kernel/libraries.yaml
+++ b/shell/platform/fuchsia/dart_runner/kernel/libraries.yaml
@@ -88,6 +88,7 @@ dart_runner:
       uri: "../../../../../../third_party/dart/sdk/lib/ffi/ffi.dart"
       patches:
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+        - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"

--- a/shell/platform/fuchsia/flutter/kernel/libraries.json
+++ b/shell/platform/fuchsia/flutter/kernel/libraries.json
@@ -83,6 +83,7 @@
         "uri": "../../../../../../third_party/dart/sdk/lib/ffi/ffi.dart",
         "patches": [
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart",
+          "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart",
           "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"

--- a/shell/platform/fuchsia/flutter/kernel/libraries.yaml
+++ b/shell/platform/fuchsia/flutter/kernel/libraries.yaml
@@ -88,6 +88,7 @@ flutter_runner:
       uri: "../../../../../../third_party/dart/sdk/lib/ffi/ffi.dart"
       patches:
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+        - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart"
         - "../../../../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"


### PR DESCRIPTION
Adding the missing patch file for ffi. This matches what is in https://github.com/dart-lang/sdk/blob/master/sdk/lib/libraries.yaml.

Prior art PR: https://github.com/flutter/engine/pull/23000