### PR TITLE
[ui-input] First N events "chatty" logging (#74368)

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -249,8 +249,9 @@ Engine::Engine(Delegate& delegate,
            external_view_embedder = GetExternalViewEmbedder(),
            vsync_offset = product_config.get_vsync_offset(),
            vsync_handle = vsync_event_.get(),
-           keyboard_listener_request = std::move(keyboard_listener_request)](
-              flutter::Shell& shell) mutable {
+           keyboard_listener_request = std::move(keyboard_listener_request),
+           chatty_max =
+               product_config.get_chatty_max()](flutter::Shell& shell) mutable {
             return std::make_unique<flutter_runner::PlatformView>(
                 shell,                   // delegate
                 debug_label,             // debug label
@@ -271,7 +272,7 @@ Engine::Engine(Delegate& delegate,
                 std::move(on_create_surface_callback),
                 external_view_embedder,   // external view embedder
                 std::move(vsync_offset),  // vsync offset
-                vsync_handle);
+                vsync_handle, chatty_max);
           });
 
   // Setup the callback that will instantiate the rasterizer.

--- a/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
+++ b/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
@@ -50,6 +50,11 @@ FlutterRunnerProductConfiguration::FlutterRunnerProductConfiguration(
       use_legacy_renderer_ = val.GetBool();
   }
 #endif
+  if (document.HasMember("chatty_max")) {
+    auto& val = document["chatty_max"];
+    if (val.IsUint())
+      chatty_max_ = val.GetUint();
+  }
 }
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h
+++ b/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h
@@ -21,6 +21,7 @@ class FlutterRunnerProductConfiguration {
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   bool use_legacy_renderer() { return use_legacy_renderer_; }
 #endif
+  uint32_t get_chatty_max() { return chatty_max_; }
 
  private:
   fml::TimeDelta vsync_offset_ = fml::TimeDelta::Zero();
@@ -30,6 +31,7 @@ class FlutterRunnerProductConfiguration {
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   bool use_legacy_renderer_ = true;
 #endif
+  uint32_t chatty_max_ = 0;
 };
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -70,7 +70,8 @@ class PlatformView final : public flutter::PlatformView,
                OnCreateSurface on_create_surface_callback,
                std::shared_ptr<flutter::ExternalViewEmbedder> view_embedder,
                fml::TimeDelta vsync_offset,
-               zx_handle_t vsync_event_handle);
+               zx_handle_t vsync_event_handle,
+               uint32_t chatty_max);
 
   ~PlatformView();
 
@@ -161,6 +162,8 @@ class PlatformView final : public flutter::PlatformView,
   void HandleFlutterPlatformViewsChannelPlatformMessage(
       fml::RefPtr<flutter::PlatformMessage> message);
 
+  void ChattyLog(const fuchsia::ui::input::InputEvent& event) const;
+
   const std::string debug_label_;
   // TODO(MI4-2490): remove once ViewRefControl is passed to Scenic and kept
   // alive there
@@ -219,6 +222,8 @@ class PlatformView final : public flutter::PlatformView,
 
   // The keyboard translation for fuchsia.ui.input3.KeyEvent.
   Keyboard keyboard_;
+
+  const uint32_t chatty_max_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformView);
 };

--- a/shell/platform/fuchsia/flutter/tests/flutter_runner_product_configuration_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/flutter_runner_product_configuration_unittests.cc
@@ -110,4 +110,22 @@ TEST_F(FlutterRunnerProductConfigurationTest, MissingInterceptAllInput) {
             product_config.get_intercept_all_input());
 }
 
+TEST_F(FlutterRunnerProductConfigurationTest, ValidChattyMax) {
+  const std::string json_string = "{ \"chatty_max\" : 5 } ";
+  const uint32_t expected_chatty_max = 5;
+
+  FlutterRunnerProductConfiguration product_config =
+      FlutterRunnerProductConfiguration(json_string);
+  EXPECT_EQ(product_config.get_chatty_max(), expected_chatty_max);
+}
+
+TEST_F(FlutterRunnerProductConfigurationTest, MissingChattyMax) {
+  const std::string json_string = "{ \"chatty_max\" :  } ";
+  const uint32_t expected_chatty_max = 0;
+
+  FlutterRunnerProductConfiguration product_config =
+      FlutterRunnerProductConfiguration(json_string);
+  EXPECT_EQ(product_config.get_chatty_max(), expected_chatty_max);
+}
+
 }  // namespace flutter_runner_test


### PR DESCRIPTION
This patch introduces "chatty" logging that records the first N input
events that come into the fuchsia embedder.

The default value of N is 0, but product configurations may adjust it
with the "chatty_max" variable.

Log messages to look out for:

Embedder[74/1000000]: fuchsia.ui.input.InputEvent.PointerEvent:
time=559653174000, device_id=2, pointer_id=0, type=TOUCH, phase=UP,
x=397.612, y=403.328, trace_id=73, buttons=0

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
