### PR TITLE
use the toolchain in //build for fuchsia

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -100,7 +100,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '7832e9ed954bd5b22d043ab49a67e93babd291e6',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e664d190b83ba911194a8a9517ae5f8bba3fcfaa',
 
    # Fuchsia compatibility
    #
@@ -547,16 +547,6 @@ deps = {
      'condition': 'host_os == "mac"',
      'dep_type': 'cipd',
    },
-   'src/fuchsia/toolchain/mac': {
-     'packages': [
-       {
-        'package': 'fuchsia/third_party/clang/mac-amd64',
-        'version': 'git_revision:2c0536b76b35fa592ac7b4a0e4bb176eaf55af75'
-       }
-     ],
-     'condition': 'host_os == "mac"',
-     'dep_type': 'cipd',
-   },
    'src/fuchsia/sdk/linux': {
      'packages': [
        {
@@ -567,16 +557,6 @@ deps = {
      'condition': 'host_os == "linux"',
      'dep_type': 'cipd',
    },
-   'src/fuchsia/toolchain/linux': {
-     'packages': [
-       {
-         'package': 'fuchsia/third_party/clang/linux-amd64',
-         'version': '8LaTdqf7wY_sjaptz0DIIKx9_Nxaoh3YgDEPgnfxzOEC'
-       }
-      ],
-      'condition': 'host_os == "linux"',
-      'dep_type': 'cipd',
-  },
 }
 
 hooks = [

--- a/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
@@ -21,7 +21,7 @@ template("generate_dart_profiler_symbols") {
 
     args = [
       "--nm",
-      rebase_path("//fuchsia/toolchain/$host_os/bin/llvm-nm"),
+      rebase_path("//buildtools/${host_os}-${host_cpu}/clang/bin/llvm-nm"),
       "--binary",
       rebase_path(invoker.library_path),
       "--output",

--- a/tools/fuchsia/clang.gni
+++ b/tools/fuchsia/clang.gni
@@ -5,7 +5,7 @@
 declare_args() {
   # The default clang toolchain provided by the prebuilt. This variable is
   # additionally consumed by the Go toolchain.
-  clang_base = rebase_path("//fuchsia/toolchain/$host_os/lib")
+  clang_base = rebase_path("//buildtools/${host_os}-${host_cpu}/clang/lib")
 }
 
 if (current_cpu == "arm64") {

--- a/tools/fuchsia/fuchsia_debug_symbols.gni
+++ b/tools/fuchsia/fuchsia_debug_symbols.gni
@@ -33,7 +33,7 @@ template("_copy_debug_symbols") {
       "--destination-base",
       rebase_path(_dest_base),
       "--read-elf",
-      rebase_path("//fuchsia/toolchain/$host_os/bin/llvm-readelf"),
+      rebase_path("//buildtools/${host_os}-${host_cpu}/clang/bin/llvm-readelf"),
     ]
 
     if (unstripped) {


### PR DESCRIPTION
Removes the extra fuchsia toolchain since we are already importing this into //buildtools.