### PR TITLE
Search multiple paths when loading deferred component .so files.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -1110,19 +1110,21 @@ public class FlutterJNI {
    * @param loadingUnitId The loadingUnitId is assigned during compile time by gen_snapshot and is
    *     automatically retrieved when loadLibrary() is called on a dart deferred library. This is
    *     used to identify which Dart deferred library the resolved correspond to.
-   * @param sharedLibraryName File name of the .so file to be loaded, or if the file is not already
-   *     in LD_LIBRARY_PATH, the full path to the file. The .so files in the lib/[abi] directory are
-   *     already in LD_LIBRARY_PATH and in this case you only need to pass the file name.
+   * @param searchPaths An array of paths in which to look for valid dart shared libraries. This
+   *     supports paths within zipped apks as long as the apks are not compressed using the
+   *     `path/to/apk.apk!path/inside/apk/lib.so` format. Paths will be tried first to last and ends
+   *     when a library is sucessfully found. When the found library is invalid, no additional paths
+   *     will be attempted.
    */
   @UiThread
-  public void loadDartDeferredLibrary(int loadingUnitId, @NonNull String sharedLibraryName) {
+  public void loadDartDeferredLibrary(int loadingUnitId, @NonNull String[] searchPaths) {
     ensureRunningOnMainThread();
     ensureAttachedToNative();
-    nativeLoadDartDeferredLibrary(nativeShellHolderId, loadingUnitId, sharedLibraryName);
+    nativeLoadDartDeferredLibrary(nativeShellHolderId, loadingUnitId, searchPaths);
   }
 
   private native void nativeLoadDartDeferredLibrary(
-      long nativeShellHolderId, int loadingUnitId, @NonNull String sharedLibraryName);
+      long nativeShellHolderId, int loadingUnitId, @NonNull String[] searchPaths);
 
   /**
    * Adds the specified AssetManager as an APKAssetResolver in the Flutter Engine's AssetManager.

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/DeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/DeferredComponentManager.java
@@ -22,11 +22,10 @@ import io.flutter.embedding.engine.systemchannels.DeferredComponentChannel;
  * This call retrieves a unique identifier called the loading unit id, which is assigned by
  * gen_snapshot during compilation. The loading unit id is passed down through the engine and
  * invokes installDeferredComponent. Once the feature module is downloaded, loadAssets and
- * loadDartLibrary should be invoked. loadDartLibrary should pass the file name of the shared
- * library .so file to FlutterJNI.loadDartDeferredLibrary for the engine to dlopen, or if the file
- * is not in LD_LIBRARY_PATH, it should find the shared library .so file and pass the full path.
- * loadAssets should typically ensure the new assets are available to the engine's asset manager by
- * passing an updated Android AssetManager to the engine via FlutterJNI.updateAssetManager.
+ * loadDartLibrary should be invoked. loadDartLibrary should find shared library .so files for the
+ * engine to open and pass the .so path to FlutterJNI.loadDartDeferredLibrary. loadAssets should
+ * typically ensure the new assets are available to the engine's asset manager by passing an updated
+ * Android AssetManager to the engine via FlutterJNI.updateAssetManager.
  *
  * <p>The loadAssets and loadDartLibrary methods are separated out because they may also be called
  * manually via platform channel messages. A full installDeferredComponent implementation should
@@ -183,10 +182,14 @@ public interface DeferredComponentManager {
    * Load the .so shared library file into the Dart VM.
    *
    * <p>When the download of a deferred component module completes, this method should be called to
-   * find the .so library file. The filenames, or path if it's not in LD_LIBRARY_PATH, should then
-   * be passed to FlutterJNI.loadDartDeferredLibrary to be dlopen-ed and loaded into the Dart VM.
-   * The .so files in the lib/[abi] directory are already in LD_LIBRARY_PATH and in this case you
-   * only need to pass the file name.
+   * find the path .so library file. The path(s) should then be passed to
+   * FlutterJNI.loadDartDeferredLibrary to be dlopen-ed and loaded into the Dart VM.
+   *
+   * <p>Specifically, APKs distributed by Android's app bundle format may vary by device and API
+   * number, so FlutterJNI's loadDartDeferredLibrary accepts a list of search paths with can include
+   * paths within APKs that have not been unpacked using the
+   * `path/to/apk.apk!path/inside/apk/lib.so` format. Each search path will be attempted in order
+   * until a shared library is found. This allows for the developer to avoid unpacking the apk zip.
    *
    * <p>Upon successful load of the Dart library, the Dart future from the originating loadLibary()
    * call completes and developers are able to use symbols and assets from the feature module.


### PR DESCRIPTION
Search multiple paths when loading deferred component .so files.

This is a partial revert of 7c19824c6d08bb8e3fc4217058178d42d451e26b

On some devices we still need to the original search paths approach
because dlopen with just the base file name doesn't work. We're
combining both approaches now, adding the base filename as the first
entry in the searchPaths.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
