### PR TITLE
fix concurrent threads cannot set thread name on Android issue

### DIFF
--- a/fml/concurrent_message_loop.cc
+++ b/fml/concurrent_message_loop.cc
@@ -22,7 +22,7 @@ ConcurrentMessageLoop::ConcurrentMessageLoop(size_t worker_count)
   for (size_t i = 0; i < worker_count_; ++i) {
     workers_.emplace_back([i, this]() {
       fml::Thread::SetCurrentThreadName(
-          std::string{"io.flutter.worker." + std::to_string(i + 1)});
+          std::string{"io.worker." + std::to_string(i + 1)});
       WorkerMain();
     });
   }


### PR DESCRIPTION
For [the source code of  pthread_setname_np](https://cs.android.com/android/platform/superproject/+/master:bionic/libc/bionic/pthread_setname_np.cpp;l=90), the thread name should less than 16, but concurrent thread worker name `std::string{"io.flutter.worker." + std::to_string(i + 1)}` is more than 16, so the thread name cannot set successfully, and in gdb, it show the main thread name.
So just make the concurrent thread worker name shorter:)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
