### PR TITLE
Remove workarounds now that type promotion accounts for local boolean variables.

### DIFF
--- a/lib/web_ui/lib/src/engine/html/surface.dart
+++ b/lib/web_ui/lib/src/engine/html/surface.dart
@@ -1092,17 +1092,7 @@ abstract class PersistedContainerSurface extends PersistedSurface {
       for (int indexInOld = 0; indexInOld < oldChildCount; indexInOld += 1) {
         final PersistedSurface? oldChild = oldChildren[indexInOld];
         final bool childAlreadyClaimed = oldChild == null;
-        // After https://github.com/dart-lang/language/issues/1274 is
-        // implemented, `oldChild` will be promoted to non-nullable on the RHS
-        // of the `||`, so we won't need to null check it (and it will cause a
-        // build failure to try to do so).  Until then, we need to null check it
-        // in such a way that won't cause a build failure once the feature is
-        // implemented.  We can do that by casting to `dynamic`, and then
-        // relying on the call to `canUpdateAsMatch` implicitly downcasting to
-        // PersistentSurface.
-        // TODO(paulberry): remove this workaround once the feature is
-        // implemented.
-        if (childAlreadyClaimed || !newChild.canUpdateAsMatch(oldChild as dynamic)) {
+        if (childAlreadyClaimed || !newChild.canUpdateAsMatch(oldChild)) {
           continue;
         }
         allMatches.add(_PersistedSurfaceMatch(

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -875,16 +875,6 @@ class SemanticsObject {
         effectiveTransformIsIdentity = effectiveTransform.isIdentity();
       }
     } else if (!hasIdentityTransform) {
-      // After https://github.com/dart-lang/language/issues/1274 is implemented,
-      // `transform` will be promoted to non-nullable so we won't need to null
-      // check it (and it will cause a build failure to try to do so).  Until
-      // then, we need to null check it in such a way that won't cause a build
-      // failure once the feature is implemented.  We can do that using an
-      // explicit "if" test.
-      // TODO(paulberry): remove this check once the feature is implemented.
-      if (transform == null) { // ignore: unnecessary_null_comparison
-        throw 'impossible';
-      }
       effectiveTransform = Matrix4.fromFloat32List(transform);
       effectiveTransformIsIdentity = false;
     }


### PR DESCRIPTION
This change removes workarounds that were introduced prior to landing
Dart language feature
https://github.com/dart-lang/language/issues/1274, which allows type
promotion in null safe code to account for local boolean variables.
The workarounds ensured that the code would analyze the same
regardless of whether the feature was enabled, allowing for a smoother
transition.  Now that the feature has fully landed, the workarounds
aren't needed anymore.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
