### PR TITLE
Read loading unit mapping from AndroidManifest instead of strings

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -207,7 +207,6 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
     sessionIdToState = new SparseArray<>();
     nameToSessionId = new HashMap<>();
 
-
     loadingUnitIdToModuleNames = new HashMap<>();
     // Parse the metadata string. An example encoded string is:
     //
@@ -215,12 +214,13 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
     //
     // Where loading unit 2 is included in both module1 and module2, loading
     // unit 3 is included in module3, and loading unit 4 is included in module1.
+    String mappingKey = DeferredComponentManager.class.getName() + ".loadingUnitMapping";
     String rawMappingString = getApplicationInfo().metaData
-        .getString("flutterDeferredComponentsLoadingUnitMapping", null);
+        .getString(mappingKey, null);
     if (rawMappingString == null) {
       Log.e(
           TAG,
-          "No loading unit to dynamic feature module name found. Ensure 'flutterDeferredComponentsLoadingUnitMapping' is defined in the base module's AndroidManifest.");
+          "No loading unit to dynamic feature module name found. Ensure '" + mappingKey + "' is defined in the base module's AndroidManifest.");
     } else {
       for (String entry : rawMappingString.split(",")) {
         String[] splitEntry = entry.split(":");

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -55,7 +55,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
   private @NonNull SparseArray<String> sessionIdToState;
   private @NonNull Map<String, Integer> nameToSessionId;
 
-  protected @NonNull Map<Integer, String> loadingUnitIdToModuleNames;
+  protected @NonNull SparseArray<String> loadingUnitIdToModuleNames;
 
   private FeatureInstallStateUpdatedListener listener;
 
@@ -207,7 +207,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
     sessionIdToState = new SparseArray<>();
     nameToSessionId = new HashMap<>();
 
-    loadingUnitIdToModuleNames = new HashMap<>();
+    loadingUnitIdToModuleNames = new SparseArray<>();
     // Parse the metadata string. An example encoded string is:
     //
     //    "2:module2,3:module3,4:module1"

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -207,7 +207,14 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
     sessionIdToState = new SparseArray<>();
     nameToSessionId = new HashMap<>();
 
+
     loadingUnitIdToModuleNames = new HashMap<>();
+    // Parse the metadata string. An example encoded string is:
+    //
+    //    "2:module1:module2,3:module3,4:module1"
+    //
+    // Where loading unit 2 is included in both module1 and module2, loading
+    // unit 3 is included in module3, and loading unit 4 is included in module1.
     String rawMappingString = getApplicationInfo().metaData
         .getString("flutterDeferredComponentsLoadingUnitMapping", null);
     if (rawMappingString == null) {

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -448,7 +448,9 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
     List<String> modulesToUninstall = new ArrayList<>();
     modulesToUninstall.add(resolvedModuleName);
     splitInstallManager.deferredUninstall(modulesToUninstall);
-    sessionIdToState.delete(nameToSessionId.get(resolvedModuleName));
+    if (nameToSessionId.get(resolvedModuleName) != null) {
+      sessionIdToState.delete(nameToSessionId.get(resolvedModuleName));
+    }
     return true;
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -55,7 +55,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
   private @NonNull SparseArray<String> sessionIdToState;
   private @NonNull Map<String, Integer> nameToSessionId;
 
-  protected @NonNull Map<Integer, List<String>> loadingUnitIdToModuleNames;
+  protected @NonNull Map<Integer, String> loadingUnitIdToModuleNames;
 
   private FeatureInstallStateUpdatedListener listener;
 
@@ -210,25 +210,22 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
     loadingUnitIdToModuleNames = new HashMap<>();
     // Parse the metadata string. An example encoded string is:
     //
-    //    "2:module1:module2,3:module3,4:module1"
+    //    "2:module2,3:module3,4:module1"
     //
-    // Where loading unit 2 is included in both module1 and module2, loading
-    // unit 3 is included in module3, and loading unit 4 is included in module1.
+    // Where loading unit 2 is included in module2, loading unit 3 is
+    // included in module3, and loading unit 4 is included in module1.
     String mappingKey = DeferredComponentManager.class.getName() + ".loadingUnitMapping";
-    String rawMappingString = getApplicationInfo().metaData
-        .getString(mappingKey, null);
+    String rawMappingString = getApplicationInfo().metaData.getString(mappingKey, null);
     if (rawMappingString == null) {
       Log.e(
           TAG,
-          "No loading unit to dynamic feature module name found. Ensure '" + mappingKey + "' is defined in the base module's AndroidManifest.");
+          "No loading unit to dynamic feature module name found. Ensure '"
+              + mappingKey
+              + "' is defined in the base module's AndroidManifest.");
     } else {
       for (String entry : rawMappingString.split(",")) {
         String[] splitEntry = entry.split(":");
-        List<String> moduleNames = new ArrayList<>();
-        for (int i = 1; i < splitEntry.length; i++) {
-          moduleNames.add(splitEntry[i]);
-        }
-        loadingUnitIdToModuleNames.put(Integer.parseInt(splitEntry[0]), moduleNames);
+        loadingUnitIdToModuleNames.put(Integer.parseInt(splitEntry[0]), splitEntry[1]);
       }
     }
   }
@@ -264,7 +261,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
 
   public void installDeferredComponent(int loadingUnitId, String moduleName) {
     String resolvedModuleName =
-        moduleName != null ? moduleName : loadingUnitIdToModuleNames.get(loadingUnitId).get(0);
+        moduleName != null ? moduleName : loadingUnitIdToModuleNames.get(loadingUnitId);
     if (resolvedModuleName == null) {
       Log.e(
           TAG,
@@ -327,7 +324,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
 
   public String getDeferredComponentInstallState(int loadingUnitId, String moduleName) {
     String resolvedModuleName =
-        moduleName != null ? moduleName : loadingUnitIdToModuleNames.get(loadingUnitId).get(0);
+        moduleName != null ? moduleName : loadingUnitIdToModuleNames.get(loadingUnitId);
     if (resolvedModuleName == null) {
       Log.e(
           TAG,
@@ -430,7 +427,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
 
   public boolean uninstallDeferredComponent(int loadingUnitId, String moduleName) {
     String resolvedModuleName =
-        moduleName != null ? moduleName : loadingUnitIdToModuleNames.get(loadingUnitId).get(0);
+        moduleName != null ? moduleName : loadingUnitIdToModuleNames.get(loadingUnitId);
     if (resolvedModuleName == null) {
       Log.e(
           TAG,

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -55,7 +55,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
   private @NonNull SparseArray<String> sessionIdToState;
   private @NonNull Map<String, Integer> nameToSessionId;
 
-  private @NonNull Map<Integer, List<String>> loadingUnitIdToModuleNames;
+  protected @NonNull Map<Integer, List<String>> loadingUnitIdToModuleNames;
 
   private FeatureInstallStateUpdatedListener listener;
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -230,7 +230,7 @@ public class PlayStoreDeferredComponentManagerTest {
   }
 
   @Test
-  public void invalidSearchPathsAreIgnored() throws NameNotFoundException {
+  public void loadingUnitMappingFindsMatch() throws NameNotFoundException {
     TestPlayStoreDeferredComponentManager playStoreManager =
         new TestPlayStoreDeferredComponentManager(spyContext, jni);
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -23,6 +23,7 @@ import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.ApplicationInfoLoader;
 import java.io.File;
+import java.util.HashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -70,6 +71,9 @@ public class PlayStoreDeferredComponentManagerTest {
   private class TestPlayStoreDeferredComponentManager extends PlayStoreDeferredComponentManager {
     public TestPlayStoreDeferredComponentManager(Context context, FlutterJNI jni) {
       super(context, jni);
+      loadingUnitIdToModuleNames = new HashMap<>();
+      loadingUnitIdToModuleNames.put(5, "FakeModuleName5");
+      loadingUnitIdToModuleNames.put(2, "FakeModuleName2");
     }
 
     @Override
@@ -222,5 +226,15 @@ public class PlayStoreDeferredComponentManagerTest {
     TestPlayStoreDeferredComponentManager playStoreManager =
         new TestPlayStoreDeferredComponentManager(spyContext, jni);
     assertEquals(playStoreManager.getDeferredComponentInstallState(-1, "invalidName"), "unknown");
+  }
+
+  @Test
+  public void invalidSearchPathsAreIgnored() throws NameNotFoundException {
+    TestPlayStoreDeferredComponentManager playStoreManager =
+        new TestPlayStoreDeferredComponentManager(spyContext, jni);
+
+    assertTrue(playStoreManager.uninstallDeferredComponent(5, null));
+    assertTrue(playStoreManager.uninstallDeferredComponent(2, null));
+    assertFalse(playStoreManager.uninstallDeferredComponent(3, null));
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -5,6 +5,7 @@
 package io.flutter.embedding.engine.deferredcomponents;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -231,6 +231,8 @@ public class PlayStoreDeferredComponentManagerTest {
 
   @Test
   public void loadingUnitMappingFindsMatch() throws NameNotFoundException {
+    TestFlutterJNI jni = new TestFlutterJNI();
+    Context spyContext = spy(RuntimeEnvironment.application);
     TestPlayStoreDeferredComponentManager playStoreManager =
         new TestPlayStoreDeferredComponentManager(spyContext, jni);
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -20,11 +20,11 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
 import android.os.Bundle;
+import android.util.SparseArray;
 import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.loader.ApplicationInfoLoader;
 import java.io.File;
-import java.util.HashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -72,7 +72,7 @@ public class PlayStoreDeferredComponentManagerTest {
   private class TestPlayStoreDeferredComponentManager extends PlayStoreDeferredComponentManager {
     public TestPlayStoreDeferredComponentManager(Context context, FlutterJNI jni) {
       super(context, jni);
-      loadingUnitIdToModuleNames = new HashMap<>();
+      loadingUnitIdToModuleNames = new SparseArray<>();
       loadingUnitIdToModuleNames.put(5, "FakeModuleName5");
       loadingUnitIdToModuleNames.put(2, "FakeModuleName2");
     }


### PR DESCRIPTION
This PR replaces the string resource based encoding of the loading unit id -> module name mapping. Instead, we now store the mapping in AndroidManifest.xml of a deferred components enabled app's base module.

This helps separate string resources from app configuration.

https://github.com/flutter/flutter/pull/63773 implements the storing of the data inside of the manifest file.