### PR TITLE
Fix Android IO and Worker threads priority issue

### DIFF
--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -122,6 +122,11 @@ AndroidShellHolder::AndroidShellHolder(
       FML_LOG(ERROR) << "Failed to set UI task runner priority";
     }
   });
+  task_runners.GetIOTaskRunner()->PostTask([]() {
+    if (::setpriority(PRIO_PROCESS, gettid(), 1) != 0) {
+      FML_LOG(ERROR) << "Failed to set IO task runner priority";
+    }
+  });
 
   shell_ =
       Shell::Create(task_runners,              // task runners
@@ -130,6 +135,14 @@ AndroidShellHolder::AndroidShellHolder(
                     on_create_platform_view,   // platform view create callback
                     on_create_rasterizer       // rasterizer create callback
       );
+
+  if (shell_) {
+    shell_->GetDartVM()->GetConcurrentMessageLoop()->PostTaskToAllWorkers([]() {
+      if (::setpriority(PRIO_PROCESS, gettid(), 1) != 0) {
+        FML_LOG(ERROR) << "Failed to set Workers task runner priority";
+      }
+    });
+  }
 
   platform_view_ = weak_platform_view;
   FML_DCHECK(platform_view_);


### PR DESCRIPTION
Manually set IO and Worker threads priority to THREAD_PRIORITY_LESS_FAVORABLE(1).

1. From Android 8+, the priority of main thread (aka Flutter's platform thread) has been raised from THREAD_PRIORITY_DEFAULT(0) to THREAD_PRIORITY_VIDEO(-10) by system;
2. The UI/Raster/IO and Worker threads are created by platform thread and inherit its priority;
3. Flutter raised priority of UI and Raster threads to -1 and -5, but leave IO and Worker threads untouched;
4. The current result is IO and Worker threads have extreme high priority (-10), much higher than UI and Raster thread;
5. The image decoding and mipmap generation on IO and Worker threads are very time consuming and usually block the UI and Raster threads when App loading bunch of images, especially on low end devices;

So manually set IO and Worker threads to an appropriate background priority such as THREAD_PRIORITY_LESS_FAVORABLE(1) will be a good move, it will work nicely on both Android 8+ and lower version.

*List which issues are fixed by this PR. You must list at least one issue.*

The background threads -  IO and Worker threads, have much higher priority than UI and Raster thread, and easy to make them blocked and cause jank.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

No

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
