### PR TITLE
[Prototype] [Do NOT Merge] Binary Metal Archive Prototype for iOS/Mac.

### DIFF
--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -49,6 +49,8 @@ source_set("gpu_surface_vulkan") {
 
 source_set("gpu_surface_metal") {
   sources = [
+    "gpu_binary_archive_metal.h",
+    "gpu_binary_archive_metal.mm",
     "gpu_surface_metal.h",
     "gpu_surface_metal.mm",
     "gpu_surface_metal_delegate.cc",

--- a/shell/gpu/gpu_binary_archive_metal.h
+++ b/shell/gpu/gpu_binary_archive_metal.h
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <Metal/Metal.h>
+
+#include <mutex>
+#include <string>
+
+#include "flutter/fml/macros.h"
+#include "flutter/fml/platform/darwin/scoped_nsobject.h"
+#include "third_party/skia/include/gpu/mtl/GrMtlTypes.h"
+
+#define FLUTTER_METAL_BINARY_ARCHIVE_AVAILABLE SK_API_AVAILABLE(macos(11.0), ios(14.0))
+
+namespace flutter {
+
+//------------------------------------------------------------------------------
+/// @brief      A archive of pipeline state objects that can be serialized to disk.
+///
+///             Pipeline state objects will be collected as the application is running and will be
+///             serialized to disk when the application is backgrounded.
+///
+///             Binary caches are serialized to a file in the caches directory with the following
+///             format: flutter_engine_<flutter engine version>_<skia_version>_<engine instance
+///             ID>.metallib.
+///
+///             Binary cache contents are specific to a particular GPU family and are not portable.
+///
+///             Limitations:
+///             1: The archive will only be read the next time the application launched
+///                and not when it is foregrounded.
+///             2: Only the pipeline state objects for the first instance of the Flutter engine will
+///                be archived and reused. This is because there is no way to provide an array of
+///                binary archives to Skia when setting up the GrContext.
+///
+class FLUTTER_METAL_BINARY_ARCHIVE_AVAILABLE GPUBinaryArchiveMetal {
+ public:
+  GPUBinaryArchiveMetal(id<MTLDevice> device);
+
+  ~GPUBinaryArchiveMetal();
+
+  sk_cf_obj<GrMTLHandle> GetBinaryArchiveHandle() const;
+
+ private:
+  const size_t archive_index_;
+  const std::string metallib_archive_path_;
+  fml::scoped_nsprotocol<id<MTLBinaryArchive>> binary_archive_;
+  std::mutex serialization_mutex_;
+  fml::scoped_nsprotocol<id<NSObject>> notification_observer_;
+
+  bool InitializeArchive(id<MTLDevice> device);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Serializes the binary archive to disk. This can only be done
+  ///             once. Once serialized, adding more pipeline state objects to
+  ///             the binary archive at the given URL is undefined behavior.
+  ///
+  /// @return     If the binary archive was written to disk successfully.
+  ///
+  bool SerializeArchiveToDisk();
+
+  FML_DISALLOW_COPY_AND_ASSIGN(GPUBinaryArchiveMetal);
+};
+
+}  // namespace flutter

--- a/shell/gpu/gpu_binary_archive_metal.mm
+++ b/shell/gpu/gpu_binary_archive_metal.mm
@@ -1,0 +1,145 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/gpu/gpu_binary_archive_metal.h"
+
+#include <UIKit/UIKit.h>
+
+#include <atomic>
+#include <sstream>
+
+#include "flutter/fml/closure.h"
+#include "flutter/fml/file.h"
+#include "flutter/fml/paths.h"
+#include "flutter/shell/version/version.h"
+
+namespace flutter {
+
+static std::atomic_size_t sBinaryArchiveIndex = 0;
+
+static std::string BinaryArchiveURLForIndex(size_t index) {
+  auto items = [[NSFileManager defaultManager] URLsForDirectory:NSCachesDirectory
+                                                      inDomains:NSUserDomainMask];
+  if (items.count == 0) {
+    return {};
+  }
+
+  std::stringstream stream;
+  stream << "flutter_engine_" << GetFlutterEngineVersion() << "_" << GetSkiaVersion() << "_"
+         << index << ".metallib";
+  return fml::paths::JoinPaths({items[0].fileSystemRepresentation, stream.str()});
+}
+static std::string TemporaryBinaryArchiveURL(const std::string& binary_archive_url) {
+  std::stringstream stream;
+  stream << binary_archive_url << ".temp";
+  return stream.str();
+}
+
+GPUBinaryArchiveMetal::GPUBinaryArchiveMetal(id<MTLDevice> device)
+    : archive_index_(sBinaryArchiveIndex++),
+      metallib_archive_path_(BinaryArchiveURLForIndex(archive_index_)) {
+  InitializeArchive(device);
+
+  // This object is created and collected on the platform thread with construction initiated by the
+  // platform view. We need to look for opportunities to serialize the archive to disk at a time
+  // when Flutter is not rendering frames. For this purpose, the did enter background notification
+  // seems like a fine time as rendering frames here will terminate the process anyway.
+  //
+  // TODO: Verify if the owner of this object is collected on the platform thread or if its one of
+  // the rendering surface owned objects which are collected on the raster thread. If this is
+  // collected on the raster thread, the capture of `this` will be unsafe.
+  notification_observer_.reset([[[NSNotificationCenter defaultCenter]
+      addObserverForName:UIApplicationDidEnterBackgroundNotification
+                  object:nil  // no receiver matching
+                   queue:nil  // posting thread
+              usingBlock:^(NSNotification* notification) {
+                // TODO: This must be synchronized with collection of `this`.
+                this->SerializeArchiveToDisk();
+              }] retain]);
+}
+
+GPUBinaryArchiveMetal::~GPUBinaryArchiveMetal() {
+  [[NSNotificationCenter defaultCenter] removeObserver:notification_observer_.get()];
+  notification_observer_.reset();
+}
+
+bool GPUBinaryArchiveMetal::InitializeArchive(id<MTLDevice> device) {
+  if (metallib_archive_path_.empty()) {
+    return false;
+  }
+  auto descriptor =
+      fml::scoped_nsobject<MTLBinaryArchiveDescriptor>([[MTLBinaryArchiveDescriptor alloc] init]);
+  descriptor.get().url = fml::IsFile(metallib_archive_path_)
+                             ? [NSURL fileURLWithPath:@(metallib_archive_path_.c_str())]
+                             : nil;
+
+  NSError* error = nil;
+  binary_archive_.reset([device newBinaryArchiveWithDescriptor:descriptor.get() error:&error]);
+  if (error != nil) {
+    binary_archive_.reset();
+    FML_LOG(ERROR) << "Could not create Metal Binary archive for engine run at index "
+                   << archive_index_ << ". No pipeline state objects will be cached. Error: "
+                   << error.localizedDescription.UTF8String;
+    return false;
+  }
+
+  binary_archive_.get().label = @"Flutter Binary Archive";
+
+  return true;
+}
+
+bool GPUBinaryArchiveMetal::SerializeArchiveToDisk() {
+  if (binary_archive_ == nullptr) {
+    // No binary archive to cache.
+    return false;
+  }
+  std::scoped_lock serialization_lock(serialization_mutex_);
+  // Clear the old archive and store the new one.
+
+  // If the MTLBinaryArchive operated on a descriptor only, then it would be safe to directly unlink
+  // the old descriptor here. However, we gave the full path to the archive in the constructor of
+  // the descriptor. So the implementation could attempt to open the file descriptor again between
+  // this point and the subsequent call to serialize. To be absolutely safe, write to a temporary
+  // file and swap.
+
+  auto temp_archive_string = TemporaryBinaryArchiveURL(metallib_archive_path_);
+  if (temp_archive_string.empty()) {
+    return false;
+  }
+
+  auto temp_archive_url = [NSURL fileURLWithPath:@(temp_archive_string.c_str())];
+  NSError* error = nil;
+  if (![binary_archive_.get() serializeToURL:temp_archive_url error:&error]) {
+    FML_LOG(ERROR) << "Could not serialize Metal binary archive at index " << archive_index_
+                   << ". Error: " << error.localizedDescription.UTF8String;
+    return false;
+  }
+
+  // We are about to rename, flush pending writes to the the temporary archive.
+  {
+    // TODO: Is this necessary? Per the WriteAtomically implementation, one would think so, but we
+    // don't own the descriptor on which write are being performed. Not sure this is safe.
+#if 0
+    if (::fsync(temp_archive_string.c_str()) != 0) {
+      FML_LOG(ERROR) << "Could not fsync temporary Metal binary archive at index " << archive_index_
+                     << ". Error: " << strerror(errno);
+      return false;
+    }
+#endif
+  }
+
+  if (::rename(temp_archive_string.c_str(), metallib_archive_path_.c_str()) != 0) {
+    FML_LOG(ERROR) << "Could not finish writing the Metal binary archive at index "
+                   << archive_index_ << ". Error: " << strerror(errno);
+    return false;
+  }
+
+  return true;
+}
+
+sk_cf_obj<GrMTLHandle> GPUBinaryArchiveMetal::GetBinaryArchiveHandle() const {
+  return sk_cf_obj<GrMTLHandle>{[binary_archive_ retain]};
+}
+
+}  // namespace flutter


### PR DESCRIPTION
This patch wires up Metal Binary Archives for Mac and iOS. Metal Binary Archives
are used to cache pipeline state objects generated at runtime on the device and
serialize them to disk when rendering is paused. In this prototype, the binary
archives are serialized to disk when the application moves into the background.
On the next launch of the application, the serialized representation of the
archives is used for the creation of new pipeline state objects.

Per the [details in the linked issue][1], I do not recommend we land this patch.
This PR is just meant to be a record of the prototyping work done to evaluate
Metal Binary Archives for Flutter.

[1]: https://github.com/flutter/flutter/issues/60267#issuecomment-762786388

## Observations

Once patched in, the following observations can be made while running a Flutter application.

* After first launch, the application caches directory should contain a `.metallib` file with the following format. `flutter_engine_<engine_version>_<skia_version>_<index>.metallib`. This was done so any changes to the Flutter engine or the Skia version would not run the risk of using invalid cached contents. The file ([example](https://github.com/flutter/engine/files/5865817/flutter_engine_08daa2c8962687253fbcbd812d08d70c34c86721_069e484cc3b9518f115312c065a6f9c843b0839a_0.metallib.zip)) seems to be a Mach-O binary. This is consistent with Apple's recommendation that the `lipo` tool be used to combine archives harvested from devices of different GPU families.
* This file will get updated every time the application is backgrounded and will get reused when the application is launched.
* To prevent any issues with threading (I could find no mention in the docs about the thread safety aspects of any of the APIs) only raster thread operations will using this archive.
* One open question not answered in my linked comment was how much these archives would help for jank during subsequent application launches (as seeding the archive for first launch is a no-go). I tried to find determine this by making sure the cache was seeded and launching the application again. My hope was to see a reduction in the `GrMtlPipelineStateBuilder::finalize` trace in Observatory. This [did not materialize (trace is from a warmed up archive)](https://github.com/flutter/engine/files/5865862/warmed_cached_pipeline_state_extra_skia_traces.json.zip). This seems to be because the primary cause of jank in pipeline state setup is the construction of the Metal shader library (SKSL -> MSL -> MTLLibrary (AIR?)) and not the pipeline state object construction. An annotated version of one of the traces is as follows:
![Screen Shot 2021-01-25 at 2 24 51 AM](https://user-images.githubusercontent.com/44085/105694897-5058fc80-5eb6-11eb-8440-5b6f973abe0a.png)