### PR TITLE
[macos] Support smooth resizing for Metal

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.mm
@@ -78,14 +78,19 @@
 }
 
 - (void)resizeSynchronizerFlush:(nonnull FlutterResizeSynchronizer*)synchronizer {
-  // TODO (kaushikiska): Support smooth resizing on Metal.
+  // no-op when using Metal rendering backend.
 }
 
 - (void)resizeSynchronizerCommit:(nonnull FlutterResizeSynchronizer*)synchronizer {
+  [CATransaction begin];
+  [CATransaction setDisableActions:YES];
+
   id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
   [commandBuffer commit];
   [commandBuffer waitUntilScheduled];
   [_surfaceManager swapBuffers];
+
+  [CATransaction commit];
 }
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -27,6 +27,7 @@
   self = [super initWithFrame:NSZeroRect];
   if (self) {
     [self setWantsLayer:YES];
+    [self setLayerContentsRedrawPolicy:NSViewLayerContentsRedrawDuringViewResize];
     _reshapeListener = reshapeListener;
     _resizableBackingStoreProvider = [[FlutterMetalResizableBackingStoreProvider alloc]
         initWithDevice:device
@@ -44,7 +45,14 @@
 }
 
 - (CALayer*)makeBackingLayer {
-  return [CAMetalLayer layer];
+  CAMetalLayer* metalLayer = [CAMetalLayer layer];
+  // This is set to true to synchronize the presentation of the layer and its contents with Core
+  // Animation. When presenting the texture see `[FlutterMetalResizableBackingStoreProvider
+  // resizeSynchronizerCommit:]` we start a CATransaction and wait for the command buffer to be
+  // scheduled. This ensures that the resizing process is smooth.
+  metalLayer.presentsWithTransaction = YES;
+  metalLayer.autoresizingMask = kCALayerHeightSizable | kCALayerWidthSizable;
+  return metalLayer;
 }
 #endif
 


### PR DESCRIPTION
Coordinate command buffer submission with Core Animation
scheduling to ensure smooth resizing.

Fixes: https://github.com/flutter/flutter/issues/74056