### PR TITLE
Adds Roboto as a global font fallback in CanvasKit

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -28,7 +28,7 @@ class SkiaFontCollection {
   final Map<String, List<SkTypeface>> familyToTypefaceMap =
       <String, List<SkTypeface>>{};
 
-  final List<String> globalFontFallbacks = <String>[];
+  final List<String> globalFontFallbacks = <String>['Roboto'];
 
   final Map<String, int> _fontFallbackCounts = <String, int>{};
 
@@ -178,6 +178,7 @@ class SkiaFontCollection {
   void debugResetFallbackFonts() {
     _registeredFallbackFonts.clear();
     globalFontFallbacks.clear();
+    globalFontFallbacks.add('Roboto');
     _fontFallbackCounts.clear();
   }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -814,9 +814,7 @@ enum _ParagraphCommandType {
 List<String> _getEffectiveFontFamilies(String? fontFamily,
     [List<String>? fontFamilyFallback]) {
   List<String> fontFamilies = <String>[];
-  if (fontFamily == null) {
-    fontFamilies.add('Roboto');
-  } else {
+  if (fontFamily != null) {
     fontFamilies.add(fontFamily);
   }
   if (fontFamilyFallback != null &&

--- a/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
@@ -87,7 +87,7 @@ void testMain() {
 }
 ''';
 
-      expect(skiaFontCollection.globalFontFallbacks, isEmpty);
+      expect(skiaFontCollection.globalFontFallbacks, ['Roboto']);
 
       // Creating this paragraph should cause us to start to download the
       // fallback font.
@@ -127,7 +127,7 @@ void testMain() {
               'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic+UI'] =
           'invalid CSS... this should cause our parser to fail';
 
-      expect(skiaFontCollection.globalFontFallbacks, isEmpty);
+      expect(skiaFontCollection.globalFontFallbacks, ['Roboto']);
 
       // Creating this paragraph should cause us to start to download the
       // fallback font.
@@ -140,7 +140,7 @@ void testMain() {
       await Future<void>.delayed(Duration.zero);
 
       expect(notoDownloadQueue.isPending, isFalse);
-      expect(skiaFontCollection.globalFontFallbacks, isEmpty);
+      expect(skiaFontCollection.globalFontFallbacks, ['Roboto']);
     });
     // TODO: https://github.com/flutter/flutter/issues/60040
   }, skip: isIosSafari);

--- a/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
@@ -51,6 +51,10 @@ void testMain() {
       ui.window.onPlatformMessage = savedCallback;
     });
 
+    test('Roboto is always a fallback font', () {
+      expect(skiaFontCollection.globalFontFallbacks, contains('Roboto'));
+    });
+
     test('will download Noto Naskh Arabic if Arabic text is added', () async {
       final Completer<void> fontChangeCompleter = Completer<void>();
       // Intercept the system font change message.


### PR DESCRIPTION
Adds Roboto as a global font fallback when running in CanvasKit mode.

Fixes https://github.com/flutter/flutter/issues/74603

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
