### PR TITLE
Hides symbols exported by statically linked libcxxabi

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1420,6 +1420,7 @@ FILE: ../../../flutter/shell/platform/linux/fl_value_test.cc
 FILE: ../../../flutter/shell/platform/linux/fl_view.cc
 FILE: ../../../flutter/shell/platform/linux/fl_view_accessible.cc
 FILE: ../../../flutter/shell/platform/linux/fl_view_accessible.h
+FILE: ../../../flutter/shell/platform/linux/flutter_linux_gtk.map
 FILE: ../../../flutter/shell/platform/linux/public/flutter_linux/fl_basic_message_channel.h
 FILE: ../../../flutter/shell/platform/linux/public/flutter_linux/fl_binary_codec.h
 FILE: ../../../flutter/shell/platform/linux/public/flutter_linux/fl_binary_messenger.h

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -217,6 +217,12 @@ shared_library("flutter_linux_gtk") {
   deps = [ ":flutter_linux" ]
 
   public_configs = [ "//flutter:config" ]
+
+  version_script =
+      rebase_path("//flutter/shell/platform/linux/flutter_linux_gtk.map",
+                  root_build_dir)
+
+  ldflags = [ "-Wl,--version-script=$version_script" ]
 }
 
 copy("publish_headers_linux") {

--- a/shell/platform/linux/flutter_linux_gtk.map
+++ b/shell/platform/linux/flutter_linux_gtk.map
@@ -1,0 +1,12 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+{
+  global:
+    fl*; # Flutter functions
+    k*;  # Dart
+
+  local:
+    *;
+};


### PR DESCRIPTION
This time we cannot throw and catch C++ exceptions in plugin platform code. Because Flutter statically links libcxx and libcxxabi which exposes symbols like `__cxa_decrement_exception_refcount`, which will introduce two versions of cxxabi functions, throwing libcxx exceptions, and catching them by libstdc++ method.
To fix this problem, this PR adds a version script to hide these symbols, which is tested and worked correctly.

This pull request fixes issue https://github.com/flutter/flutter/issues/66575 and https://github.com/flutter/flutter/issues/74599.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
