### PR TITLE
add ffi_allocation_patch.dart to libraries.yaml 2

### DIFF
--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -9750,9 +9750,11 @@ FILE: ../../../third_party/dart/samples_2/ffi/sqlite/lib/src/ffi/arena.dart
 FILE: ../../../third_party/dart/samples_2/ffi/sqlite/lib/src/ffi/dylib_utils.dart
 FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/rti.dart
 FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/shared/recipe_syntax.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart
 FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart
 FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart
 FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart
 FILE: ../../../third_party/dart/sdk/lib/ffi/annotations.dart
 FILE: ../../../third_party/dart/sdk/lib/ffi/dynamic_library.dart
 FILE: ../../../third_party/dart/sdk/lib/ffi/ffi.dart

--- a/lib/snapshot/libraries.json
+++ b/lib/snapshot/libraries.json
@@ -82,9 +82,11 @@
       "ffi": {
         "uri": "../../../third_party/dart/sdk/lib/ffi/ffi.dart",
         "patches": [
+          "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart",
+          "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart",
           "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart",
           "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+          "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"
         ]
       },
       "wasm": {

--- a/lib/snapshot/libraries.yaml
+++ b/lib/snapshot/libraries.yaml
@@ -87,9 +87,11 @@ flutter:
     ffi:
       uri: "../../../third_party/dart/sdk/lib/ffi/ffi.dart"
       patches:
+        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart"
         - "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart"
         - "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_struct_patch.dart"
 
     wasm:
       uri: "../../../third_party/dart/sdk/lib/wasm/wasm.dart"


### PR DESCRIPTION
After https://github.com/flutter/engine/pull/23808 and https://github.com/flutter/engine/pull/23000 ffi patch files were still not included in the Flutter build.

This patch is tested locally with a Flutter app (on Android) using the extension method in [ffi_allocation_patch](https://github.com/dart-lang/sdk/blob/0f371f2dba0dac9179c042cc46ce7ec6b1b90ab2/sdk/lib/_internal/vm/lib/ffi_allocation_patch.dart#L15-L18) and changes the result from

```
When the exception was thrown, this was the stack:
#0      NoSuchMethodError._throwNew (dart:core-patch/errors_patch.dart:212:5)
#1      AllocatorAlloc.call (dart:ffi/allocation.dart)
...
```

to a succeeding run.

If the branch cut is done after this is merged, this requires a cherry pick for `AllocatorAlloc.call` to work in the next Flutter release.