### PR TITLE
Fix "Buffer not large enough for pixels" by adding buffer.rewind()

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -22,6 +22,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.RenderSurface;
+import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -266,7 +267,9 @@ public class FlutterImageView extends View implements RenderSurface {
             Bitmap.createBitmap(
                 desiredWidth, desiredHeight, android.graphics.Bitmap.Config.ARGB_8888);
       }
-      currentBitmap.copyPixelsFromBuffer(imagePlane.getBuffer());
+      ByteBuffer buffer = imagePlane.getBuffer();
+      buffer.rewind();
+      currentBitmap.copyPixelsFromBuffer(buffer);
     }
   }
 


### PR DESCRIPTION
The buffer.rewind() is a need.


Same problem here: 
https://stackoverflow.com/questions/22167192/runtimeexception-buffer-not-large-enough-for-pixels

Log:

D/BufferQueueProducer(30178): [ImageReader-1080x1920f1m3-30178-0](this:0xc8031000,id:0,api:1,p:30178,c:30178) queueBuffer: fps=0.03 dur=35021.86 max=35021.86 min=35021.86
D/BufferQueueProducer(30178): [ImageReader-1080x1920f1m3-30178-1](this:0xb90fb000,id:1,api:1,p:30178,c:30178) queueBuffer: fps=0.03 dur=35020.07 max=35020.07 min=35020.07
W/FlutterImageView(30178): io.flutter.embedding.android.FlutterImageView{5be722a V.ED..... ......ID 0,0-1080,1920}acquireLatestImage(): android.media.ImageReader$SurfaceImage@18a67e1
W/FlutterImageView(30178): io.flutter.embedding.android.FlutterImageView{103b791 V.ED..... ......ID 24,0-1080,1665}acquireLatestImage(): android.media.ImageReader$SurfaceImage@c9af906
I/SurfaceView(30178): Punch a hole(dispatchDraw), this = io.flutter.embedding.android.FlutterSurfaceView{fc60ec1 V.E...... ........ 0,0-1080,1920}
W/FlutterImageView(30178): io.flutter.embedding.android.FlutterImageView{5be722a V.ED..... ......I. 0,0-1080,1920} onDraw()
W/FlutterImageView(30178): io.flutter.embedding.android.FlutterImageView{103b791 V.ED..... ......I. 24,0-1080,1665} onDraw()
I/SurfaceView(30178): Punch a hole(dispatchDraw), this = io.flutter.embedding.android.FlutterSurfaceView{fc60ec1 V.E...... ........ 0,0-1080,1920}
W/FlutterImageView(30178): io.flutter.embedding.android.FlutterImageView{5be722a V.ED..... ......I. 0,0-1080,1920} onDraw()
W/System.err(30178): java.lang.RuntimeException: Buffer not large enough for pixels
W/System.err(30178): 	at android.graphics.Bitmap.copyPixelsFromBuffer(Bitmap.java:567)
W/System.err(30178): 	at io.flutter.embedding.android.FlutterImageView.updateCurrentBitmap(FlutterImageView.java:269)
W/System.err(30178): 	at io.flutter.embedding.android.FlutterImageView.onDraw(FlutterImageView.java:231)
W/System.err(30178): 	at android.view.View.draw(View.java:17424)
W/System.err(30178): 	at android.view.View.draw(View.java:17322)
W/System.err(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
W/System.err(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
W/System.err(30178): 	at android.view.View.draw(View.java:17317)
W/System.err(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
W/System.err(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
W/System.err(30178): 	at android.view.View.draw(View.java:17317)
W/System.err(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
W/System.err(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
W/System.err(30178): 	at android.view.View.draw(View.java:17317)
W/System.err(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
W/System.err(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
W/System.err(30178): 	at android.view.View.draw(View.java:17317)
W/System.err(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
W/System.err(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
W/System.err(30178): 	at android.view.View.draw(View.java:17436)
W/System.err(30178): 	at com.android.internal.policy.DecorView.draw(DecorView.java:772)
W/System.err(30178): 	at android.app.Activity$TintBarInject.getAutomaticColor(Activity.java:7857)
W/System.err(30178): 	at android.app.Activity$TintBarInject.getAutomaticColor(Activity.java:7883)
W/System.err(30178): 	at android.app.Activity$TintBarInject.onDrawDecorViewInner(Activity.java:7785)
W/System.err(30178): 	at android.app.Activity$TintBarInject.-wrap1(Activity.java)
W/System.err(30178): 	at android.app.Activity$TintBarInject$2.run(Activity.java:7834)
W/System.err(30178): 	at android.os.Handler.handleCallback(Handler.java:836)
W/System.err(30178): 	at android.os.Handler.dispatchMessage(Handler.java:103)
W/System.err(30178): 	at android.os.Looper.loop(Looper.java:203)
W/System.err(30178): 	at android.app.ActivityThread.main(ActivityThread.java:6436)
W/System.err(30178): 	at java.lang.reflect.Method.invoke(Native Method)
W/System.err(30178): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1113)
W/System.err(30178): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:974)
I/SurfaceView(30178): Punch a hole(dispatchDraw), this = io.flutter.embedding.android.FlutterSurfaceView{fc60ec1 V.E...... ........ 0,0-1080,1920}
W/FlutterImageView(30178): io.flutter.embedding.android.FlutterImageView{5be722a V.ED..... ......I. 0,0-1080,1920} onDraw()
W/System.err(30178): java.lang.RuntimeException: Buffer not large enough for pixels
W/System.err(30178): 	at android.graphics.Bitmap.copyPixelsFromBuffer(Bitmap.java:567)
W/System.err(30178): 	at io.flutter.embedding.android.FlutterImageView.updateCurrentBitmap(FlutterImageView.java:269)
W/System.err(30178): 	at io.flutter.embedding.android.FlutterImageView.onDraw(FlutterImageView.java:231)
W/System.err(30178): 	at android.view.View.draw(View.java:17424)
W/System.err(30178): 	at android.view.View.draw(View.java:17322)
W/System.err(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
W/System.err(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
W/System.err(30178): 	at android.view.View.draw(View.java:17317)
W/System.err(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
W/System.err(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
W/System.err(30178): 	at android.view.View.draw(View.java:17317)
W/System.err(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
W/System.err(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
W/System.err(30178): 	at android.view.View.draw(View.java:17317)
W/System.err(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
W/System.err(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
W/System.err(30178): 	at android.view.View.draw(View.java:17436)
W/System.err(30178): 	at android.app.Activity$TintBarInject.getAutomaticColor(Activity.java:7857)
W/System.err(30178): 	at android.app.Activity$TintBarInject.getAutomaticColor(Activity.java:7876)
W/System.err(30178): 	at android.app.Activity$TintBarInject.onDrawDecorViewInner(Activity.java:7785)
W/System.err(30178): 	at android.app.Activity$TintBarInject.-wrap1(Activity.java)
W/System.err(30178): 	at android.app.Activity$TintBarInject$2.run(Activity.java:7834)
W/System.err(30178): 	at android.os.Handler.handleCallback(Handler.java:836)
W/System.err(30178): 	at android.os.Handler.dispatchMessage(Handler.java:103)
W/System.err(30178): 	at android.os.Looper.loop(Looper.java:203)
W/System.err(30178): 	at android.app.ActivityThread.main(ActivityThread.java:6436)
W/System.err(30178): 	at java.lang.reflect.Method.invoke(Native Method)
W/System.err(30178): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1113)
W/System.err(30178): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:974)
W/FlutterImageView(30178): io.flutter.embedding.android.FlutterImageView{5be722a V.ED..... ........ 0,0-1080,1920} onDraw()
D/AndroidRuntime(30178): Shutting down VM
D/memory  (30178): currentRate 25.459999
I/flutter (30178): sceneName Framework_Animation(), fps: 39.09285714285714, uiAvgTime: 64.17952380952381, gpuAvgTime: 23.848095238095237
I/flutter (30178): sceneName Framework_Scroll(/information_container.dart:32:21), fps: 55.0, uiAvgTime: 55.0, gpuAvgTime: 6.69
I/flutter (30178): sceneName Framework_Route(/route_util.dart:159:16), fps: 7.703333333333333, uiAvgTime: 181.51666666666665, gpuAvgTime: 16.226666666666667
E/AndroidRuntime(30178): FATAL EXCEPTION: main
E/AndroidRuntime(30178): Process: com.prek.android.npy.parent, PID: 30178
E/AndroidRuntime(30178): java.lang.RuntimeException: Buffer not large enough for pixels
E/AndroidRuntime(30178): 	at android.graphics.Bitmap.copyPixelsFromBuffer(Bitmap.java:567)
E/AndroidRuntime(30178): 	at io.flutter.embedding.android.FlutterImageView.updateCurrentBitmap(FlutterImageView.java:269)
E/AndroidRuntime(30178): 	at io.flutter.embedding.android.FlutterImageView.onDraw(FlutterImageView.java:231)
E/AndroidRuntime(30178): 	at android.view.View.draw(View.java:17424)
E/AndroidRuntime(30178): 	at android.view.View.updateDisplayListIfDirty(View.java:16363)
E/AndroidRuntime(30178): 	at android.view.View.draw(View.java:17174)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
E/AndroidRuntime(30178): 	at android.view.View.updateDisplayListIfDirty(View.java:16355)
E/AndroidRuntime(30178): 	at android.view.View.draw(View.java:17174)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
E/AndroidRuntime(30178): 	at android.view.View.updateDisplayListIfDirty(View.java:16355)
E/AndroidRuntime(30178): 	at android.view.View.draw(View.java:17174)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
E/AndroidRuntime(30178): 	at android.view.View.updateDisplayListIfDirty(View.java:16355)
E/AndroidRuntime(30178): 	at android.view.View.draw(View.java:17174)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
E/AndroidRuntime(30178): 	at android.view.View.updateDisplayListIfDirty(View.java:16355)
E/AndroidRuntime(30178): 	at android.view.View.draw(View.java:17174)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.drawChild(ViewGroup.java:3890)
E/AndroidRuntime(30178): 	at android.view.ViewGroup.dispatchDraw(ViewGroup.java:3676)
E/AndroidRuntime(30178): 	at android.view.View.draw(View.java:17436)
E/AndroidRuntime(30178): 	at com.android.internal.policy.DecorView.draw(DecorView.java:772)
E/AndroidRuntime(30178): 	at android.view.View.updateDisplayListIfDirty(View.java:16363)
E/AndroidRuntime(30178): 	at android.view.ThreadedRenderer.updateViewTreeDisplayList(ThreadedRenderer.java:661)
E/AndroidRuntime(30178): 	at android.view.ThreadedRenderer.updateRootDisplayList(ThreadedRenderer.java:667)
E/AndroidRuntime(30178): 	at android.view.ThreadedRenderer.draw(ThreadedRenderer.java:775)
E/AndroidRuntime(30178): 	at android.view.ViewRootImpl.draw(ViewRootImpl.java:3214)
E/AndroidRuntime(30178): 	at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:3007)
E/AndroidRuntime(30178): 	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2592)
E/AndroidRuntime(30178): 	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1481)
E/AndroidRuntime(30178): 	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7071)
E/AndroidRuntime(30178): 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:907)
E/AndroidRuntime(30178): 	at android.view.Choreographer.doCallbacks(Choreographer.java:709)
E/AndroidRuntime(30178): 	at android.view.Choreographer.doFrame(Choreographer.java:644)
E/AndroidRuntime(30178): 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:893)
E/AndroidRuntime(30178): 	at android.os.Handler.handleCallback(Handler.java:836)
E/AndroidRuntime(30178): 	at android.os.Handler.dispatchMessage(Handler.java:103)
E/AndroidRuntime(30178): 	at android.os.Looper.loop(Looper.java:203)
E/AndroidRuntime(30178): 	at android.app.ActivityThread.main(ActivityThread.java:6436)
E/AndroidRuntime(30178): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(30178): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1113)
E/AndroidRuntime(30178): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:974)
