### PR TITLE
Load FlutterLoader when creating FlutterEngineGroup

### DIFF
--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/SpawnedEngineActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/SpawnedEngineActivity.java
@@ -14,7 +14,7 @@ public class SpawnedEngineActivity extends TestActivity {
 
   @Override
   public FlutterEngine provideFlutterEngine(@NonNull Context context) {
-    FlutterEngineGroup engineGroup = new FlutterEngineGroup();
+    FlutterEngineGroup engineGroup = new FlutterEngineGroup(context);
     engineGroup.createAndRunDefaultEngine(context);
 
     FlutterEngine secondEngine = engineGroup.createAndRunDefaultEngine(context);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/74767. Make the FlutterEngineGroup initialize the FlutterLoader. This is the same pattern as the FlutterEngine itself.  

It's a breaking change though since I need to let the FlutterEngineGroup have a context too.