### PR TITLE
Guard against Dart timeline API calls invoked during Dart_Cleanup

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -597,6 +597,8 @@ FILE: ../../../flutter/runtime/dart_vm.cc
 FILE: ../../../flutter/runtime/dart_vm.h
 FILE: ../../../flutter/runtime/dart_vm_data.cc
 FILE: ../../../flutter/runtime/dart_vm_data.h
+FILE: ../../../flutter/runtime/dart_vm_initializer.cc
+FILE: ../../../flutter/runtime/dart_vm_initializer.h
 FILE: ../../../flutter/runtime/dart_vm_lifecycle.cc
 FILE: ../../../flutter/runtime/dart_vm_lifecycle.h
 FILE: ../../../flutter/runtime/dart_vm_unittests.cc

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_FML_TRACE_EVENT_H_
 #define FLUTTER_FML_TRACE_EVENT_H_
 
+#include <functional>
+
 #include "flutter/fml/build_config.h"
 
 #if defined(OS_FUCHSIA)
@@ -144,6 +146,16 @@ using TraceArg = const char*;
 using TraceIDArg = int64_t;
 
 void TraceSetAllowlist(const std::vector<std::string>& allowlist);
+
+using TimelineEventHandler = std::function<void(const char*,
+                                                int64_t,
+                                                int64_t,
+                                                Dart_Timeline_Event_Type,
+                                                intptr_t,
+                                                const char**,
+                                                const char**)>;
+
+void TraceSetTimelineEventHandler(TimelineEventHandler handler);
 
 void TraceTimelineEvent(TraceArg category_group,
                         TraceArg name,

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -49,6 +49,8 @@ source_set("runtime") {
     "dart_vm.h",
     "dart_vm_data.cc",
     "dart_vm_data.h",
+    "dart_vm_initializer.cc",
+    "dart_vm_initializer.h",
     "dart_vm_lifecycle.cc",
     "dart_vm_lifecycle.h",
     "embedder_resources.cc",

--- a/runtime/dart_vm_initializer.cc
+++ b/runtime/dart_vm_initializer.cc
@@ -1,0 +1,71 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/runtime/dart_vm_initializer.h"
+
+#include <atomic>
+
+#include "flutter/fml/logging.h"
+#include "flutter/fml/synchronization/shared_mutex.h"
+#include "flutter/fml/trace_event.h"
+
+// Tracks whether Dart has been initialized and if it is safe to call Dart
+// APIs.
+static std::atomic<bool> gDartInitialized;
+
+void DartVMInitializer::Initialize(Dart_InitializeParams* params) {
+  FML_DCHECK(!gDartInitialized);
+
+  char* error = Dart_Initialize(params);
+  if (error) {
+    FML_LOG(FATAL) << "Error while initializing the Dart VM: " << error;
+    ::free(error);
+  } else {
+    gDartInitialized = true;
+  }
+
+  fml::tracing::TraceSetTimelineEventHandler(LogDartTimelineEvent);
+}
+
+void DartVMInitializer::Cleanup() {
+  FML_DCHECK(gDartInitialized);
+
+  // Dart_TimelineEvent is unsafe during a concurrent call to Dart_Cleanup
+  // because Dart_Cleanup will destroy the timeline recorder.  Clear the
+  // initialized flag so that future calls to LogDartTimelineEvent will not
+  // call Dart_TimelineEvent.
+  //
+  // Note that this is inherently racy.  If a thread sees that gDartInitialized
+  // is set and proceeds to call Dart_TimelineEvent shortly before another
+  // thread calls Dart_Cleanup, then the Dart_TimelineEvent call may crash
+  // if Dart_Cleanup deletes the timeline before Dart_TimelineEvent completes.
+  // In practice this is unlikely because Dart_Cleanup does significant other
+  // work before deleting the timeline.
+  //
+  // The engine can not safely guard Dart_Cleanup and LogDartTimelineEvent with
+  // a lock due to the risk of deadlocks.  Dart_Cleanup waits for various
+  // Dart-owned threads to shut down.  If one of those threads invokes an engine
+  // callback that calls LogDartTimelineEvent while the Dart_Cleanup thread owns
+  // the lock, then Dart_Cleanup would deadlock.
+  gDartInitialized = false;
+
+  char* error = Dart_Cleanup();
+  if (error) {
+    FML_LOG(FATAL) << "Error while cleaning up the Dart VM: " << error;
+    ::free(error);
+  }
+}
+
+void DartVMInitializer::LogDartTimelineEvent(const char* label,
+                                             int64_t timestamp0,
+                                             int64_t timestamp1_or_async_id,
+                                             Dart_Timeline_Event_Type type,
+                                             intptr_t argument_count,
+                                             const char** argument_names,
+                                             const char** argument_values) {
+  if (gDartInitialized) {
+    Dart_TimelineEvent(label, timestamp0, timestamp1_or_async_id, type,
+                       argument_count, argument_names, argument_values);
+  }
+}

--- a/runtime/dart_vm_initializer.h
+++ b/runtime/dart_vm_initializer.h
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_RUNTIME_DART_VM_INITIALIZER_H_
+#define FLUTTER_RUNTIME_DART_VM_INITIALIZER_H_
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "third_party/dart/runtime/include/dart_tools_api.h"
+
+class DartVMInitializer {
+ public:
+  static void Initialize(Dart_InitializeParams* params);
+  static void Cleanup();
+
+ private:
+  static void LogDartTimelineEvent(const char* label,
+                                   int64_t timestamp0,
+                                   int64_t timestamp1_or_async_id,
+                                   Dart_Timeline_Event_Type type,
+                                   intptr_t argument_count,
+                                   const char** argument_names,
+                                   const char** argument_values);
+};
+
+#endif  // FLUTTER_RUNTIME_DART_VM_INITIALIZER_H_

--- a/runtime/dart_vm_lifecycle.h
+++ b/runtime/dart_vm_lifecycle.h
@@ -11,6 +11,7 @@
 #include "flutter/lib/ui/isolate_name_server/isolate_name_server.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/runtime/service_protocol.h"
+#include "third_party/dart/runtime/include/dart_tools_api.h"
 
 namespace flutter {
 


### PR DESCRIPTION
The Dart timeline is not thread safe if an engine thread that is not
controlled by Dart calls Dart_TimelineEvent while another thread is
calling Dart_Cleanup.

Fixes https://github.com/flutter/flutter/issues/74134
