### PR TITLE
Revert "Roll buildroot to 33f05b6c"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -100,7 +100,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '33f05b6cb73903c59a74d71a7dfdc1d9158b2f55',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e664d190b83ba911194a8a9517ae5f8bba3fcfaa',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Reverts flutter/engine#23986

From the prod builders:

```
FAILED: clang_x64/gen_snapshot 
../../buildtools/mac-x64/clang/bin/clang++ -isysroot /opt/s/w/ir/cache/osx_sdk/XCode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -mmacosx-version-min=10.11.0 -flto -rdynamic -arch x86_64 -nostdlib++ -stdlib=libc++ -Wl,-dead_strip -Wl,-search_paths_first -L. -Wl,-rpath,@loader_path/. -Wl,-rpath,@loader_path/../../.. -Wl,-pie  -Xlinker -rpath -Xlinker @executable_path/Frameworks -o clang_x64/gen_snapshot -Wl,-filelist,clang_x64/gen_snapshot.rsp  -ldl -lpthread -framework CoreFoundation -framework CoreServices
ld: reference to bitcode symbol '___gxx_personality_v0' which LTO has not compiled in '___gxx_personality_v0' for architecture x86_64
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
[3829/3842] SOLINK ./libflutter.so
ninja: build stopped: subcommand failed.
```