### PR TITLE
Avoid clipboard permissions prompt

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -114,10 +114,9 @@ public class PlatformPlugin {
 
         @Override
         public boolean clipboardHasStrings() {
-          CharSequence data =
-              PlatformPlugin.this.getClipboardData(
-                  PlatformChannel.ClipboardContentFormat.PLAIN_TEXT);
-          return data != null && data.length() > 0;
+          ClipboardManager clipboard =
+              (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+          return clipboard.hasPrimaryClip();
         }
       };
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -116,7 +116,7 @@ public class PlatformPlugin {
         public boolean clipboardHasStrings() {
           ClipboardManager clipboard =
               (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
-          return clipboard.hasPrimaryClip();
+          return clipboard.hasText();
         }
       };
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -114,9 +114,7 @@ public class PlatformPlugin {
 
         @Override
         public boolean clipboardHasStrings() {
-          ClipboardManager clipboard =
-              (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
-          return clipboard.hasText();
+          return PlatformPlugin.this.clipboardHasText();
         }
       };
 
@@ -319,6 +317,12 @@ public class PlatformPlugin {
     } else {
       activity.finish();
     }
+  }
+
+  private boolean clipboardHasText() {
+    ClipboardManager clipboard =
+        (ClipboardManager) activity.getSystemService(Context.CLIPBOARD_SERVICE);
+    return clipboard.hasText();
   }
 
   private CharSequence getClipboardData(PlatformChannel.ClipboardContentFormat format) {

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -117,16 +117,18 @@ public class PlatformPluginTest {
 
     clip = ClipData.newPlainText("", "");
     clipboardManager.setPrimaryClip(clip);
-    assertTrue(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
+    assertFalse(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
 
-    clip = ClipData.newPlainText("label", null);
+    clip = ClipData.newPlainText("", null);
     clipboardManager.setPrimaryClip(clip);
-    // TODO(justinmc): This fails.
+    clipboardManager.clearPrimaryClip();
+    assertFalse(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
+
+    clipboardManager.setPrimaryClip(null);
+    clipboardManager.clearPrimaryClip();
     assertFalse(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
 
     clipboardManager.clearPrimaryClip();
-    // TODO(justinmc): This fails too. Also, directly running
-    // clipboardManager.hasPrimaryClip() here returns true too!
     assertFalse(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
   }
 

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -27,6 +27,7 @@ import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel.ClipboardContentFormat;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel.SystemChromeStyle;
 import io.flutter.plugin.platform.PlatformPlugin.PlatformPluginDelegate;
+import io.flutter.Log;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -116,6 +117,16 @@ public class PlatformPluginTest {
 
     clip = ClipData.newPlainText("", "");
     clipboardManager.setPrimaryClip(clip);
+    assertTrue(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
+
+    clip = ClipData.newPlainText("label", null);
+    clipboardManager.setPrimaryClip(clip);
+    // TODO(justinmc): This fails.
+    assertFalse(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
+
+    clipboardManager.clearPrimaryClip();
+    // TODO(justinmc): This fails too. Also, directly running
+    // clipboardManager.hasPrimaryClip() here returns true too!
     assertFalse(platformPlugin.mPlatformMessageHandler.clipboardHasStrings());
   }
 

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -27,7 +27,6 @@ import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel.ClipboardContentFormat;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel.SystemChromeStyle;
 import io.flutter.plugin.platform.PlatformPlugin.PlatformPluginDelegate;
-import io.flutter.Log;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
Currently, some Xiaomi devices show a permissions prompt when the clipboard is accessed.  This is similar to iOS14, where we added the `hasStrings` method to not trigger this prompt (see https://github.com/flutter/flutter/issues/60145).  This uses native Android's [hasText](https://developer.android.com/reference/android/content/ClipboardManager#hasText()) method to do the same sort of workaround in Android's hasStrings.

For https://github.com/flutter/flutter/issues/74139, but probably needs a small framework change too.