### PR TITLE
WIP: Use custom device when creating EGL platform display

### DIFF
--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -108,6 +108,7 @@ source_set("flutter_windows_source") {
     ]
 
     libs = [
+      "d3d11.lib",
       "dwmapi.lib",
       "imm32.lib",
     ]

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -17,6 +17,8 @@
 
 #include "window_binding_handler.h"
 
+struct ID3D11Device;
+
 namespace flutter {
 
 // A manager for inializing ANGLE correctly and using it to create and
@@ -97,6 +99,12 @@ class AngleSurfaceManager {
 
   // Current render_surface that engine will draw into.
   EGLSurface render_surface_ = EGL_NO_SURFACE;
+
+#ifndef WINUWP
+  bool CreateDevice();
+  ID3D11Device* d3d11_device_ = nullptr;
+  EGLDeviceEXT egl_device_ = EGL_NO_DEVICE_EXT;
+#endif
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/53372

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
