### PR TITLE
Update to sampling versions

### DIFF
--- a/flow/instrumentation.cc
+++ b/flow/instrumentation.cc
@@ -225,8 +225,7 @@ void Stopwatch::Visualize(SkCanvas* canvas, const SkRect& rect) const {
   prev_drawn_sample_index_ = current_sample_;
 
   // Draw the cached surface onto the output canvas.
-  paint.reset();
-  visualize_cache_surface_->draw(canvas, rect.x(), rect.y(), &paint);
+  visualize_cache_surface_->draw(canvas, rect.x(), rect.y());
 }
 
 CounterValues::CounterValues() : current_sample_(kMaxSamples - 1) {

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -75,7 +75,8 @@ TEST_F(ImageFilterLayerTest, SimpleFilter) {
   const SkPath child_path = SkPath().addRect(child_bounds);
   const SkPaint child_paint = SkPaint(SkColors::kYellow);
   auto layer_filter = SkImageFilters::MatrixTransform(
-      SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+      SkMatrix(),
+      SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear), nullptr);
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer = std::make_shared<ImageFilterLayer>(layer_filter);
   layer->Add(mock_layer);
@@ -109,7 +110,8 @@ TEST_F(ImageFilterLayerTest, SimpleFilterBounds) {
   const SkPaint child_paint = SkPaint(SkColors::kYellow);
   const SkMatrix filter_transform = SkMatrix::Scale(2.0, 2.0);
   auto layer_filter = SkImageFilters::MatrixTransform(
-      filter_transform, SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+      filter_transform,
+      SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear), nullptr);
   auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
   auto layer = std::make_shared<ImageFilterLayer>(layer_filter);
   layer->Add(mock_layer);
@@ -144,7 +146,8 @@ TEST_F(ImageFilterLayerTest, MultipleChildren) {
   const SkPaint child_paint1 = SkPaint(SkColors::kYellow);
   const SkPaint child_paint2 = SkPaint(SkColors::kCyan);
   auto layer_filter = SkImageFilters::MatrixTransform(
-      SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+      SkMatrix(),
+      SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear), nullptr);
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
   auto layer = std::make_shared<ImageFilterLayer>(layer_filter);
@@ -189,9 +192,11 @@ TEST_F(ImageFilterLayerTest, Nested) {
   const SkPaint child_paint1 = SkPaint(SkColors::kYellow);
   const SkPaint child_paint2 = SkPaint(SkColors::kCyan);
   auto layer_filter1 = SkImageFilters::MatrixTransform(
-      SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+      SkMatrix(),
+      SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear), nullptr);
   auto layer_filter2 = SkImageFilters::MatrixTransform(
-      SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+      SkMatrix(),
+      SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear), nullptr);
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
   auto layer1 = std::make_shared<ImageFilterLayer>(layer_filter1);
@@ -242,7 +247,8 @@ TEST_F(ImageFilterLayerTest, Nested) {
 
 TEST_F(ImageFilterLayerTest, Readback) {
   auto layer_filter = SkImageFilters::MatrixTransform(
-      SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+      SkMatrix(),
+      SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear), nullptr);
   auto initial_transform = SkMatrix();
 
   // ImageFilterLayer does not read from surface
@@ -262,7 +268,8 @@ TEST_F(ImageFilterLayerTest, Readback) {
 
 TEST_F(ImageFilterLayerTest, ChildIsCached) {
   auto layer_filter = SkImageFilters::MatrixTransform(
-      SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+      SkMatrix(),
+      SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear), nullptr);
   auto initial_transform = SkMatrix::Translate(50.0, 25.5);
   auto other_transform = SkMatrix::Scale(1.0, 2.0);
   const SkPath child_path = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
@@ -291,7 +298,8 @@ TEST_F(ImageFilterLayerTest, ChildIsCached) {
 
 TEST_F(ImageFilterLayerTest, ChildrenNotCached) {
   auto layer_filter = SkImageFilters::MatrixTransform(
-      SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+      SkMatrix(),
+      SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear), nullptr);
   auto initial_transform = SkMatrix::Translate(50.0, 25.5);
   auto other_transform = SkMatrix::Scale(1.0, 2.0);
   const SkPath child_path1 = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -60,9 +60,10 @@ void ImageFilter::initBlur(double sigma_x,
 
 void ImageFilter::initMatrix(const tonic::Float64List& matrix4,
                              int filterQuality) {
-  filter_ = SkImageFilters::MatrixTransform(
-      ToSkMatrix(matrix4), static_cast<SkFilterQuality>(filterQuality),
-      nullptr);
+  auto sampling = SkSamplingOptions(static_cast<SkFilterQuality>(filterQuality),
+                                    SkSamplingOptions::kMedium_asMipmapLinear);
+  filter_ =
+      SkImageFilters::MatrixTransform(ToSkMatrix(matrix4), sampling, nullptr);
 }
 
 void ImageFilter::initColorFilter(ColorFilter* colorFilter) {


### PR DESCRIPTION
Pass sampling options to MatrixTransform imagefilter.
Pass sampling options (or nothing) to surface.draw

All part of deprecation of SkFilterQuality