### PR TITLE
[web] Fix exception when using a keyboard

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -194,10 +194,15 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// Engine code should use this method instead of the callback directly.
   /// Otherwise zones won't work properly.
   void invokeOnKeyData(ui.KeyData data, _KeyDataResponseCallback callback) {
-    invoke(
-      () { callback(onKeyData == null ? false : onKeyData!(data)); },
-      _onKeyDataZone,
-    );
+    final ui.KeyDataCallback? onKeyData = _onKeyData;
+    if (onKeyData != null) {
+      invoke(
+        () => callback(onKeyData(data)),
+        _onKeyDataZone,
+      );
+    } else {
+      callback(false);
+    }
   }
 
   /// A callback that is invoked to report the [FrameTiming] of recently


### PR DESCRIPTION
When the framework doesn't set a listener on key data, we shouldn't try to invoke it with a null zone.

This exception started happening after https://github.com/flutter/engine/pull/23466. There's no need to cherry-pick this PR unless https://github.com/flutter/engine/pull/23466 is cherry-picked.

Fixes https://github.com/flutter/flutter/issues/75076