### PR TITLE
No longer redraw window every frame to reduce CPU consumption

### DIFF
--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -426,10 +426,6 @@ static void fl_view_draw_forall(GtkWidget* widget, gpointer user_data) {
 // Implements GtkWidget::draw.
 static gboolean fl_view_draw(GtkWidget* widget, cairo_t* cr) {
   FlView* self = FL_VIEW(widget);
-  // The engine doesn't support exposure events, so instead, force redraw by
-  // sending a window metrics event of the same geometry. Since the geometry
-  // didn't change, only a frame will be scheduled.
-  fl_view_geometry_changed(self);
 
   struct _DrawData data = {
       .parent_window = gtk_widget_get_window(GTK_WIDGET(self)),
@@ -744,5 +740,5 @@ void fl_view_end_frame(FlView* view) {
   g_list_free(view->children_list);
   view->children_list = view->pending_children_list;
   view->pending_children_list = nullptr;
-  gtk_widget_queue_resize(GTK_WIDGET(view));
+  gtk_widget_queue_draw(GTK_WIDGET(view));
 }


### PR DESCRIPTION
This PR will stop engine from request redrawing every vsync frame.

To fix the issue that engine will not handle exposure events, originally shell always schedules new frame every 16ms. But  after refacotor GTK will take the responsibility.
After this patch, Flutter will do redraw if necessary.

Actually no issue and test here. I have no idea to test changes in a simple way.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A

@robert-ancell @wmww 
