### PR TITLE
Trigger redraw on WM_SHOWWINDOW event

### DIFF
--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -119,6 +119,14 @@ void FlutterWindowsView::OnWindowSizeChanged(size_t width, size_t height) {
   }
 }
 
+void FlutterWindowsView::OnShow() {
+  if (resize_status_ == ResizeState::kDone) {
+    // Request new frame
+    SendWindowMetrics(resize_target_width_, resize_target_height_,
+                      binding_handler_->GetDpiScale());
+  }
+}
+
 void FlutterWindowsView::OnPointerMove(double x, double y) {
   SendPointerMove(x, y);
 }

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -81,6 +81,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   void OnWindowSizeChanged(size_t width, size_t height) override;
 
   // |WindowBindingHandlerDelegate|
+  void OnShow() override;
+
+  // |WindowBindingHandlerDelegate|
   void OnPointerMove(double x, double y) override;
 
   // |WindowBindingHandlerDelegate|

--- a/shell/platform/windows/testing/mock_win32_window.h
+++ b/shell/platform/windows/testing/mock_win32_window.h
@@ -33,6 +33,7 @@ class MockWin32Window : public Win32Window {
 
   MOCK_METHOD1(OnDpiScale, void(unsigned int));
   MOCK_METHOD2(OnResize, void(unsigned int, unsigned int));
+  MOCK_METHOD0(OnShow, void());
   MOCK_METHOD2(OnPointerMove, void(double, double));
   MOCK_METHOD3(OnPointerDown, void(double, double, UINT));
   MOCK_METHOD3(OnPointerUp, void(double, double, UINT));

--- a/shell/platform/windows/win32_flutter_window.cc
+++ b/shell/platform/windows/win32_flutter_window.cc
@@ -130,6 +130,12 @@ void Win32FlutterWindow::OnResize(unsigned int width, unsigned int height) {
   }
 }
 
+void Win32FlutterWindow::OnShow() {
+  if (binding_handler_delegate_ != nullptr) {
+    binding_handler_delegate_->OnShow();
+  }
+}
+
 void Win32FlutterWindow::OnPointerMove(double x, double y) {
   binding_handler_delegate_->OnPointerMove(x, y);
 }

--- a/shell/platform/windows/win32_flutter_window.h
+++ b/shell/platform/windows/win32_flutter_window.h
@@ -37,6 +37,9 @@ class Win32FlutterWindow : public Win32Window, public WindowBindingHandler {
   void OnResize(unsigned int width, unsigned int height) override;
 
   // |Win32Window|
+  void OnShow() override;
+
+  // |Win32Window|
   void OnPointerMove(double x, double y) override;
 
   // |Win32Window|

--- a/shell/platform/windows/win32_flutter_window_unittests.cc
+++ b/shell/platform/windows/win32_flutter_window_unittests.cc
@@ -134,6 +134,7 @@ class MockWin32FlutterWindow : public Win32FlutterWindow {
 
   MOCK_METHOD1(OnDpiScale, void(unsigned int));
   MOCK_METHOD2(OnResize, void(unsigned int, unsigned int));
+  MOCK_METHOD0(OnShow, void());
   MOCK_METHOD2(OnPointerMove, void(double, double));
   MOCK_METHOD3(OnPointerDown, void(double, double, UINT));
   MOCK_METHOD3(OnPointerUp, void(double, double, UINT));

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -200,6 +200,11 @@ Win32Window::HandleMessage(UINT const message,
       current_height_ = height;
       HandleResize(width, height);
       break;
+    case WM_SHOWWINDOW:
+      if (wparam) {
+        OnShow();
+      }
+      break;
     case WM_MOUSEMOVE:
       TrackMouseLeaveEvent(window_handle_);
 

--- a/shell/platform/windows/win32_window.h
+++ b/shell/platform/windows/win32_window.h
@@ -73,6 +73,9 @@ class Win32Window {
   // Called when a resize occurs.
   virtual void OnResize(UINT width, UINT height) = 0;
 
+  // Called when window goes from hidden to shown
+  virtual void OnShow() = 0;
+
   // Called when the pointer moves within the
   // window bounds.
   virtual void OnPointerMove(double x, double y) = 0;

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -18,7 +18,7 @@ class WindowBindingHandlerDelegate {
   virtual void OnWindowSizeChanged(size_t width, size_t height) = 0;
 
   // Notifies delegate that the window going from hidden to visible
-  virtual void OnShow();
+  virtual void OnShow() = 0;
 
   // Notifies delegate that backing window mouse has moved.
   // Typically called by currently configured WindowBindingHandler

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -17,6 +17,9 @@ class WindowBindingHandlerDelegate {
   // called on the platform thread.
   virtual void OnWindowSizeChanged(size_t width, size_t height) = 0;
 
+  // Notifies delegate that the window going from hidden to visible
+  virtual void OnShow();
+
   // Notifies delegate that backing window mouse has moved.
   // Typically called by currently configured WindowBindingHandler
   virtual void OnPointerMove(double x, double y) = 0;


### PR DESCRIPTION
Add ability to trigger redraw by embedding app sending WM_SHOWWINDOW with wParam TRUE 

https://github.com/flutter/flutter/issues/75319

I'm not entirely sure repurposing WM_SHOWWINDOW is the best approach here, it could be a custom message as well.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
