### PR TITLE
Roll Clang Linux from 1Wa1KIWqF... to 6BYbqFtrH...

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -100,7 +100,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '7565131390a39d9d6c460545d7992d76a0faa262',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '91dc41b99ddce8b5c4e82bb58453c51ede3e0134',
 
    # Fuchsia compatibility
    #
@@ -515,7 +515,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/linux-amd64',
-        'version': '1Wa1KIWqFodI7MyWcK3V1py3mdLwYYWY2KOaeyIR-roC'
+        'version': '6BYbqFtrHE9UvQ1kBdTLr3JsLf86E3tng1Ualm6bzWIC'
       }
     ],
     'condition': 'host_os == "linux"',

--- a/DEPS
+++ b/DEPS
@@ -100,7 +100,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '91dc41b99ddce8b5c4e82bb58453c51ede3e0134',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'de693a102213ea70b45fc4d31866d45a18d5e23e',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
This also brings in the buildroot change to exclude out of line symbols.
