### PR TITLE
Add API to force redraw of flutter view

### DIFF
--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -64,6 +64,9 @@ FlutterDesktopViewRef FlutterDesktopViewControllerGetView(
   return reinterpret_cast<FlutterDesktopViewRef>(1);
 }
 
+void FlutterDesktopViewControllerForceRedraw(
+    FlutterDesktopViewControllerRef controller) {}
+
 bool FlutterDesktopViewControllerHandleTopLevelWindowProc(
     FlutterDesktopViewControllerRef controller,
     HWND hwnd,

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -76,6 +76,11 @@ FlutterDesktopViewRef FlutterDesktopViewControllerGetView(
   return HandleForView(controller->view.get());
 }
 
+void FlutterDesktopViewControllerForceRedraw(
+    FlutterDesktopViewControllerRef controller) {
+    controller->view->ForceRedraw();
+}
+
 FlutterDesktopEngineRef FlutterDesktopEngineCreate(
     const FlutterDesktopEngineProperties& engine_properties) {
   flutter::FlutterProjectBundle project(engine_properties);

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -78,7 +78,7 @@ FlutterDesktopViewRef FlutterDesktopViewControllerGetView(
 
 void FlutterDesktopViewControllerForceRedraw(
     FlutterDesktopViewControllerRef controller) {
-    controller->view->ForceRedraw();
+  controller->view->ForceRedraw();
 }
 
 FlutterDesktopEngineRef FlutterDesktopEngineCreate(

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -95,6 +95,16 @@ uint32_t FlutterWindowsView::GetFrameBufferId(size_t width, size_t height) {
   return kWindowFrameBufferID;
 }
 
+void FlutterWindowsView::ForceRedraw() {
+  if (resize_status_ == ResizeState::kDone) {
+    // Request new frame
+    // TODO(knopp): Replace with more specific call once there is API for it
+    // https://github.com/flutter/flutter/issues/69716
+    SendWindowMetrics(resize_target_width_, resize_target_height_,
+                      binding_handler_->GetDpiScale());
+  }
+}
+
 void FlutterWindowsView::OnWindowSizeChanged(size_t width, size_t height) {
   // Called on the platform thread.
   std::unique_lock<std::mutex> lock(resize_mutex_);

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -64,6 +64,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   // Returns the engine backing this view.
   FlutterWindowsEngine* GetEngine();
 
+  // Tells the engine to generate a new frame
+  void ForceRedraw();
+
   // Callbacks for clearing context, settings context and swapping buffers,
   // these are typically called on an engine-controlled (non-platform) thread.
   bool ClearContext();

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -107,6 +107,10 @@ FLUTTER_EXPORT FlutterDesktopEngineRef FlutterDesktopViewControllerGetEngine(
 FLUTTER_EXPORT FlutterDesktopViewRef
 FlutterDesktopViewControllerGetView(FlutterDesktopViewControllerRef controller);
 
+// Requests new frame from engine and repaints the view
+FLUTTER_EXPORT void FlutterDesktopViewControllerForceRedraw(
+    FlutterDesktopViewControllerRef controller);
+
 #ifndef WINUWP
 // Allows the Flutter engine and any interested plugins an opportunity to
 // handle the given message.


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/75319

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
