### PR TITLE
[web] Fix text selection from right to left

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -373,7 +373,11 @@ class AutofillInfo {
 /// The current text and selection state of a text field.
 @visibleForTesting
 class EditingState {
-  EditingState({this.text, this.baseOffset = 0, this.extentOffset = 0});
+  EditingState({this.text, int? baseOffset, int? extentOffset}) :
+    // Don't allow negative numbers. Pick the smallest selection index for base.
+    baseOffset = math.max(0, math.min(baseOffset ?? 0, extentOffset ?? 0)),
+    // Don't allow negative numbers. Pick the greatest selection index for extent.
+    extentOffset = math.max(0, math.max(baseOffset ?? 0, extentOffset ?? 0));
 
   /// Creates an [EditingState] instance using values from an editing state Map
   /// coming from Flutter.
@@ -401,9 +405,10 @@ class EditingState {
     final String? text = flutterEditingState['text'];
 
     return EditingState(
-        text: text,
-        baseOffset: math.max(0, selectionBase),
-        extentOffset: math.max(0, selectionExtent));
+      text: text,
+      baseOffset: selectionBase,
+      extentOffset: selectionExtent,
+    );
   }
 
   /// Creates an [EditingState] instance using values from the editing element

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2095,6 +2095,24 @@ void testMain() {
       );
     });
 
+    test('Fix flipped base and extent offsets', () {
+      expect(
+        EditingState(baseOffset: 10, extentOffset: 4),
+        EditingState(baseOffset: 4, extentOffset: 10),
+      );
+
+      expect(
+        EditingState.fromFrameworkMessage(<String, dynamic>{
+          'selectionBase': 10,
+          'selectionExtent': 4,
+        }),
+        EditingState.fromFrameworkMessage(<String, dynamic>{
+          'selectionBase': 4,
+          'selectionExtent': 10,
+        }),
+      );
+    });
+
     test('Configure input element from the editing state', () {
       final InputElement input = document.getElementsByTagName('input')[0];
       _editingState =


### PR DESCRIPTION
When the user uses a mouse to select text dragging from right to left, the selection keeps flickering, and copying doesn't work. (dragging from left to right works fine).

This was introduced in https://github.com/flutter/flutter/pull/71756. The framework started allowing reverse base/extent offsets for selection. That throws off the `<input>`/`<textarea>` DOM element.

Fixes https://github.com/flutter/flutter/issues/74504