### PR TITLE
libtxt: apply the justify offset to glyph positions instead of paint records

### DIFF
--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -909,8 +909,9 @@ void ParagraphTxt::Layout(double width) {
             blob_buffer.glyphs[blob_index] = layout.getGlyphId(glyph_index);
 
             size_t pos_index = blob_index * 2;
-            blob_buffer.pos[pos_index] =
-                layout.getX(glyph_index) + justify_x_offset_delta;
+            blob_buffer.pos[pos_index] = layout.getX(glyph_index) +
+                                         justify_x_offset +
+                                         justify_x_offset_delta;
             blob_buffer.pos[pos_index + 1] = layout.getY(glyph_index);
 
             if (glyph_index == cluster_start_glyph_index)
@@ -1028,10 +1029,11 @@ void ParagraphTxt::Layout(double width) {
         Range<double> record_x_pos(
             glyph_positions.front().x_pos.start - run_x_offset,
             glyph_positions.back().x_pos.end - run_x_offset);
-        paint_records.emplace_back(
-            run.style(), SkPoint::Make(run_x_offset + justify_x_offset, 0),
-            builder.make(), *metrics, line_number, record_x_pos.start,
-            record_x_pos.end, run.is_ghost(), run.placeholder_run());
+        paint_records.emplace_back(run.style(), SkPoint::Make(run_x_offset, 0),
+                                   builder.make(), *metrics, line_number,
+                                   record_x_pos.start, record_x_pos.end,
+                                   run.is_ghost(), run.placeholder_run());
+
         justify_x_offset += justify_x_offset_delta;
 
         line_glyph_positions.insert(line_glyph_positions.end(),

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -2461,6 +2461,55 @@ TEST_F(ParagraphTest, LINUX_ONLY(JustifyRTLNewLine)) {
   }
 }
 
+TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(JustifyPlaceholder)) {
+  const char* text1 = "A ";
+  auto icu_text1 = icu::UnicodeString::fromUTF8(text1);
+  std::u16string u16_text1(icu_text1.getBuffer(),
+                           icu_text1.getBuffer() + icu_text1.length());
+
+  txt::PlaceholderRun placeholder_run(60, 60, PlaceholderAlignment::kBaseline,
+                                      TextBaseline::kAlphabetic, 0);
+
+  const char* text2 = " B CCCCC";
+  auto icu_text2 = icu::UnicodeString::fromUTF8(text2);
+  std::u16string u16_text2(icu_text2.getBuffer(),
+                           icu_text2.getBuffer() + icu_text2.length());
+
+  txt::ParagraphStyle paragraph_style;
+  paragraph_style.text_align = TextAlign::justify;
+  txt::ParagraphBuilderTxt builder(paragraph_style, GetTestFontCollection());
+
+  txt::TextStyle text_style;
+  text_style.font_families = std::vector<std::string>(1, "Ahem");
+  text_style.font_size = 20;
+  text_style.decoration_color = SK_ColorBLACK;
+  builder.PushStyle(text_style);
+
+  builder.AddText(u16_text1);
+  builder.AddPlaceholder(placeholder_run);
+  builder.AddText(u16_text2);
+
+  builder.Pop();
+
+  auto paragraph = BuildParagraph(builder);
+  paragraph->Layout(200);
+
+  Paragraph::RectHeightStyle rect_height_style =
+      Paragraph::RectHeightStyle::kTight;
+  Paragraph::RectWidthStyle rect_width_style =
+      Paragraph::RectWidthStyle::kTight;
+
+  // Check location of placeholder at the center of the line.
+  std::vector<txt::Paragraph::TextBox> boxes =
+      paragraph->GetRectsForRange(2, 3, rect_height_style, rect_width_style);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 70);
+
+  // Check location of character B at the end of the line.
+  boxes =
+      paragraph->GetRectsForRange(4, 5, rect_height_style, rect_width_style);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 180);
+}
+
 TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(LeadingSpaceRTL)) {
   const char* text = " leading space";
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/50009
Fixes https://github.com/flutter/flutter/issues/66961
