### PR TITLE
[windows] Surface will not update when restoring

### DIFF
--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -20,10 +20,10 @@ static bool SurfaceWillUpdate(size_t cur_width,
                               size_t target_height) {
   // TODO (https://github.com/flutter/flutter/issues/65061) : Avoid special
   // handling for zero dimensions.
-  bool non_zero_dims = target_height > 0 && target_width > 0;
+  bool non_zero_target_dims = target_height > 0 && target_width > 0;
   bool not_same_size =
       (cur_height != target_height) || (cur_width != target_width);
-  return non_zero_dims && not_same_size;
+  return non_zero_target_dims && not_same_size;
 }
 
 FlutterWindowsView::FlutterWindowsView(
@@ -99,8 +99,11 @@ void FlutterWindowsView::OnWindowSizeChanged(size_t width, size_t height) {
   // Called on the platform thread.
   std::unique_lock<std::mutex> lock(resize_mutex_);
 
-  bool surface_will_update = SurfaceWillUpdate(
-      resize_target_width_, resize_target_height_, width, height);
+  EGLint surface_width, surface_height;
+  surface_manager_->GetSurfaceDimensions(&surface_width, &surface_height);
+
+  bool surface_will_update =
+      SurfaceWillUpdate(surface_width, surface_height, width, height);
   if (surface_will_update) {
     resize_status_ = ResizeState::kResizeStarted;
     resize_target_width_ = width;


### PR DESCRIPTION
Issue: https://github.com/flutter/flutter/issues/74797

Consider the following scenario:

1. Window is created.
  - resize_target_width_ and resize_target_height_ are zero.
  - onscreen_surface_ dims are window dims.
2. Window is immediately minimized.
  - resize target dims still zero.
  - onscreen_surface_ dims are window dims.
3. Window is then restored.
  - Surface will not be updated as the window dims are still
  onscreen_surface_ dims.
  - Hence we need to compare the target dims with surface dims rather
  than resize_target dims as they will continue to be zero.
