### PR TITLE
Unblock FlutterResizeSynchronizer on engine shutdown

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -489,6 +489,10 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
     return;
   }
 
+  if (_viewController && _viewController.flutterView) {
+    [_viewController.flutterView shutdown];
+  }
+
   FlutterEngineResult result = _embedderAPI.Deinitialize(_engine);
   if (result != kSuccess) {
     NSLog(@"Could not de-initialize the Flutter engine: error %d", result);

--- a/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizeSynchronizer.h
@@ -75,4 +75,9 @@
  */
 - (void)requestCommit;
 
+/**
+ * Called when shutting down. Unblocks everything and prevents any further synchronization.
+ */
+- (void)shutdown;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -56,4 +56,10 @@
  */
 - (nonnull FlutterRenderBackingStore*)backingStoreForSize:(CGSize)size;
 
+/**
+ * Must be called when shutting down. Unblocks raster thread and prevents any further
+ * synchronization.
+ */
+- (void)shutdown;
+
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -124,4 +124,8 @@
   [_reshapeListener viewDidReshape:self];
 }
 
+- (void)shutdown {
+  [_resizeSynchronizer shutdown];
+}
+
 @end


### PR DESCRIPTION
Otherwise shutdown may deadlock if raster thread waits until swap is complete.

https://github.com/flutter/flutter/issues/75566

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
