### PR TITLE
Fix ImageReader may leak images when onDraw() not called

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -23,8 +23,6 @@ import androidx.annotation.VisibleForTesting;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.RenderSurface;
 import java.nio.ByteBuffer;
-import java.util.LinkedList;
-import java.util.Queue;
 
 /**
  * Paints a Flutter UI provided by an {@link android.media.ImageReader} onto a {@link
@@ -41,7 +39,6 @@ import java.util.Queue;
 @TargetApi(19)
 public class FlutterImageView extends View implements RenderSurface {
   @NonNull private ImageReader imageReader;
-  @Nullable private Queue<Image> imageQueue;
   @Nullable private Image currentImage;
   @Nullable private Bitmap currentBitmap;
   @Nullable private FlutterRenderer flutterRenderer;
@@ -56,13 +53,6 @@ public class FlutterImageView extends View implements RenderSurface {
 
   /** The kind of surface. */
   private SurfaceKind kind;
-
-  /**
-   * The number of images acquired from the current {@link android.media.ImageReader} that are
-   * waiting to be painted. This counter is decreased after calling {@link
-   * android.media.Image#close()}.
-   */
-  private int pendingImages = 0;
 
   /** Whether the view is attached to the Flutter render. */
   private boolean isAttachedToFlutterRenderer = false;
@@ -89,7 +79,6 @@ public class FlutterImageView extends View implements RenderSurface {
     super(context, null);
     this.imageReader = imageReader;
     this.kind = kind;
-    this.imageQueue = new LinkedList<>();
     init();
   }
 
@@ -155,22 +144,14 @@ public class FlutterImageView extends View implements RenderSurface {
       return;
     }
     setAlpha(0.0f);
-    // Drop the lastest image as it shouldn't render this image if this view is
+    // Drop the latest image as it shouldn't render this image if this view is
     // attached to the renderer again.
     acquireLatestImage();
     // Clear drawings.
     currentBitmap = null;
 
-    // Close the images in the queue and clear the queue.
-    for (final Image image : imageQueue) {
-      image.close();
-    }
-    imageQueue.clear();
     // Close and clear the current image if any.
-    if (currentImage != null) {
-      currentImage.close();
-      currentImage = null;
-    }
+    closeCurrentImage();
     invalidate();
     isAttachedToFlutterRenderer = false;
   }
@@ -188,26 +169,20 @@ public class FlutterImageView extends View implements RenderSurface {
     if (!isAttachedToFlutterRenderer) {
       return false;
     }
-    // There's no guarantee that the image will be closed before the next call to
-    // `acquireLatestImage()`. For example, the device may not produce new frames if
-    // it's in sleep mode, so the calls to `invalidate()` will be queued up
+    // 1. `acquireLatestImage()` may return null if no new image is available.
+    // 2. There's no guarantee that `onDraw()` is called after `invalidate()`.
+    // For example, the device may not produce new frames if it's in sleep mode
+    // or some special Android devices so the calls to `invalidate()` queued up
     // until the device produces a new frame.
-    //
-    // While the engine will also stop producing frames, there is a race condition.
-    //
-    // To avoid exceptions, check if a new image can be acquired.
-    int imageOpenedCount = imageQueue.size();
-    if (currentImage != null) {
-      imageOpenedCount++;
+    // 3. While the engine will also stop producing frames, there is a race condition.
+    final Image newImage = imageReader.acquireLatestImage();
+    if (newImage != null) {
+      // Only close current image after acquiring valid new image
+      closeCurrentImage();
+      currentImage = newImage;
+      invalidate();
     }
-    if (imageOpenedCount < imageReader.getMaxImages()) {
-      final Image image = imageReader.acquireLatestImage();
-      if (image != null) {
-        imageQueue.add(image);
-      }
-    }
-    invalidate();
-    return !imageQueue.isEmpty();
+    return newImage != null;
   }
 
   /** Creates a new image reader with the provided size. */
@@ -218,29 +193,33 @@ public class FlutterImageView extends View implements RenderSurface {
     if (width == imageReader.getWidth() && height == imageReader.getHeight()) {
       return;
     }
-    imageQueue.clear();
-    currentImage = null;
+
+    // Close resources.
+    closeCurrentImage();
+
     // Close all the resources associated with the image reader,
     // including the images.
     imageReader.close();
     // Image readers cannot be resized once created.
     imageReader = createImageReader(width, height);
-    pendingImages = 0;
   }
 
   @Override
   protected void onDraw(Canvas canvas) {
     super.onDraw(canvas);
-
-    if (!imageQueue.isEmpty()) {
-      if (currentImage != null) {
-        currentImage.close();
-      }
-      currentImage = imageQueue.poll();
+    if (currentImage != null) {
       updateCurrentBitmap();
     }
     if (currentBitmap != null) {
       canvas.drawBitmap(currentBitmap, 0, 0, null);
+    }
+  }
+
+  private void closeCurrentImage() {
+    // Close and clear the current image if any.
+    if (currentImage != null) {
+      currentImage.close();
+      currentImage = null;
     }
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -659,35 +659,18 @@ public class FlutterViewTest {
   }
 
   @Test
-  public void flutterImageView_acquireLatestImageReturnsFalse() {
-    final ImageReader mockReader = mock(ImageReader.class);
-    when(mockReader.getMaxImages()).thenReturn(2);
-
-    final FlutterImageView imageView =
-        spy(
-            new FlutterImageView(
-                RuntimeEnvironment.application,
-                mockReader,
-                FlutterImageView.SurfaceKind.background));
-
-    assertFalse(imageView.acquireLatestImage());
-
-    final FlutterJNI jni = mock(FlutterJNI.class);
-    imageView.attachToRenderer(new FlutterRenderer(jni));
-
-    when(mockReader.acquireLatestImage()).thenReturn(null);
-    assertFalse(imageView.acquireLatestImage());
-  }
-
-  @Test
   @SuppressLint("WrongCall") /*View#onDraw*/
-  public void flutterImageView_acquiresMaxImagesAtMost() {
+  public void flutterImageView_acquiresImageClosesPreviousImageUnlessNoNewImage() {
     final ImageReader mockReader = mock(ImageReader.class);
     when(mockReader.getMaxImages()).thenReturn(3);
 
     final Image mockImage = mock(Image.class);
     when(mockImage.getPlanes()).thenReturn(new Plane[0]);
-    when(mockReader.acquireLatestImage()).thenReturn(mockImage);
+    // Mock no latest image on the second time
+    when(mockReader.acquireLatestImage())
+        .thenReturn(mockImage)
+        .thenReturn(null)
+        .thenReturn(mockImage);
 
     final FlutterImageView imageView =
         spy(
@@ -700,33 +683,27 @@ public class FlutterViewTest {
     imageView.attachToRenderer(new FlutterRenderer(jni));
     doNothing().when(imageView).invalidate();
 
-    assertTrue(imageView.acquireLatestImage()); // 1 image
-    assertTrue(imageView.acquireLatestImage()); // 2 images
-    assertTrue(imageView.acquireLatestImage()); // 3 images
-    assertTrue(imageView.acquireLatestImage()); // 3 images
-    verify(mockReader, times(3)).acquireLatestImage();
+    assertTrue(imageView.acquireLatestImage()); // No previous, acquire latest image
+    assertFalse(
+        imageView.acquireLatestImage()); // Mock no image when acquire, don't close, and assertFalse
+    assertTrue(imageView.acquireLatestImage()); // Acquire latest image and close previous
+    assertTrue(imageView.acquireLatestImage()); // Acquire latest image and close previous
+    assertTrue(imageView.acquireLatestImage()); // Acquire latest image and close previous
+    verify(mockImage, times(3)).close(); // Close 3 times
 
-    imageView.onDraw(mock(Canvas.class)); // 3 images
-    assertTrue(imageView.acquireLatestImage()); // 3 images
-    verify(mockReader, times(3)).acquireLatestImage();
+    imageView.onDraw(mock(Canvas.class)); // Draw latest image
 
-    imageView.onDraw(mock(Canvas.class)); // 2 images
-    assertTrue(imageView.acquireLatestImage()); // 3 images
-    verify(mockReader, times(4)).acquireLatestImage();
+    assertTrue(imageView.acquireLatestImage()); // acquire latest image and close previous
 
-    imageView.onDraw(mock(Canvas.class)); // 2 images
-    imageView.onDraw(mock(Canvas.class)); // 1 image
-    imageView.onDraw(mock(Canvas.class)); // 1 image
+    imageView.onDraw(mock(Canvas.class)); // Draw latest image
+    imageView.onDraw(mock(Canvas.class)); // Draw latest image
+    imageView.onDraw(mock(Canvas.class)); // Draw latest image
 
-    assertTrue(imageView.acquireLatestImage()); // 2 images
-    assertTrue(imageView.acquireLatestImage()); // 3 images
-    assertTrue(imageView.acquireLatestImage()); // 3 images
-    assertTrue(imageView.acquireLatestImage()); // 3 images
     verify(mockReader, times(6)).acquireLatestImage();
   }
 
   @Test
-  public void flutterImageView_detachFromRendererClosesAllImages() {
+  public void flutterImageView_detachFromRendererClosesPreviousImage() {
     final ImageReader mockReader = mock(ImageReader.class);
     when(mockReader.getMaxImages()).thenReturn(2);
 
@@ -746,54 +723,12 @@ public class FlutterViewTest {
     doNothing().when(imageView).invalidate();
     imageView.acquireLatestImage();
     imageView.acquireLatestImage();
+    verify(mockImage, times(1)).close();
+
     imageView.detachFromRenderer();
-
-    verify(mockImage, times(2)).close();
-  }
-
-  @Test
-  @SuppressLint("WrongCall") /*View#onDraw*/
-  public void flutterImageView_onDrawClosesAllImages() {
-    final ImageReader mockReader = mock(ImageReader.class);
-    when(mockReader.getMaxImages()).thenReturn(2);
-
-    final Image mockImage = mock(Image.class);
-    when(mockImage.getPlanes()).thenReturn(new Plane[0]);
-    when(mockReader.acquireLatestImage()).thenReturn(mockImage);
-
-    final FlutterImageView imageView =
-        spy(
-            new FlutterImageView(
-                RuntimeEnvironment.application,
-                mockReader,
-                FlutterImageView.SurfaceKind.background));
-
-    final FlutterJNI jni = mock(FlutterJNI.class);
-    imageView.attachToRenderer(new FlutterRenderer(jni));
-
-    doNothing().when(imageView).invalidate();
-    imageView.acquireLatestImage();
-    imageView.acquireLatestImage();
-
-    imageView.onDraw(mock(Canvas.class));
-    imageView.onDraw(mock(Canvas.class));
-
-    // 1 image is closed and 1 is active.
-    verify(mockImage, times(1)).close();
-    verify(mockReader, times(2)).acquireLatestImage();
-
-    // This call doesn't do anything because there isn't
-    // an image in the queue.
-    imageView.onDraw(mock(Canvas.class));
-    verify(mockImage, times(1)).close();
-
-    // Aquire another image and push it to the queue.
-    imageView.acquireLatestImage();
-    verify(mockReader, times(3)).acquireLatestImage();
-
-    // Then, the second image is closed.
-    imageView.onDraw(mock(Canvas.class));
-    verify(mockImage, times(2)).close();
+    // There's an acquireLatestImage() in detachFromRenderer(),
+    // so it will be 2 times called close() inside detachFromRenderer()
+    verify(mockImage, times(3)).close();
   }
 
   @Test


### PR DESCRIPTION
# Description

The onDraw() may not called after invalidate(), it makes some flash or flickering of flutter elements. This can be reproduced on some Android devices. (For example: HUAWEI P30 or HUAWEI Mate 30 PRO.)

And as the screen recording below:

https://user-images.githubusercontent.com/922837/107143669-4385df80-6971-11eb-897d-2a425eee84ee.mp4


I made a demo code in main.dart:

```
import 'dart:io';

import 'package:flutter/cupertino.dart';
import 'package:flutter/material.dart';
import 'package:webview_flutter/webview_flutter.dart';

void main() {
  runApp(MyApp());
}

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
        visualDensity: VisualDensity.adaptivePlatformDensity,
      ),
      home: MyHomePage(),
    );
  }
}

class MyHomePage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: Text('HomePage'),
      ),
      body: Column(
        children: [
          _button(context),
        ],
      ),
    );
  }
}

Widget _button(BuildContext context) {
  return RaisedButton(
    child: Text('WebView'),
    onPressed: () {
      Navigator.of(context).push(CupertinoPageRoute(
        builder: (context) {
          return WebViewPage();
        },
      ));
    },
  );
}

class WebViewPage extends StatefulWidget {
  @override
  State<StatefulWidget> createState() {
    return WebViewPageState();
  }
}

class WebViewPageState extends State<WebViewPage> {
  @override
  void initState() {
    super.initState();
    if (Platform.isAndroid) WebView.platform = SurfaceAndroidWebView();
  }

  @override
  Widget build(BuildContext context) {
    return Material(
      child: SafeArea(
        child: Stack(
          children: [
            WebView(
              initialUrl: 'https://github.com',
              javascriptMode: JavascriptMode.unrestricted,
            ),
            _button(context),
            // Positioned(
            //   child: _button(context),
            //   top: 20,
            //   left: 20,
            // ),
          ],
        ),
      ),
    );
  }
}
```

and using webview_flutter 1.0.7 version in pubspec.yaml:
```
dependencies:
  flutter:
    sdk: flutter
  webview_flutter: 1.0.7
```

And also there's a log: "unable to acquire a buffer item, very likely client tried to acquire more than maximages buffers".

![image](https://user-images.githubusercontent.com/922837/107143583-cce8e200-6970-11eb-9b97-1c16a574c99c.png)


The imageQueue in old implementation may leaves two or more items after acquireLatestImage() and occure the native level log:
"unable to acquire a buffer item, very likely client tried to acquire more than maximages buffers" in https://android.googlesource.com/platform/frameworks/base/+/master/media/jni/android_media_ImageReader.cpp#517


# ROOT CAUSE
**Because there's no guarantee that onDraw() must be called after invalidate() when device sleeping or on some special devices.**

Not all devices are reproduced. So we can add a modification to the flutter engine to simulate this problem on most Android phones.

`shell/platform/android/io/flutter/embedding/android/FlutterImageView.java`:

```diff

@@ -227,8 +222,17 @@ public class FlutterImageView extends View implements RenderSurface {
     pendingImages = 0;
   }
 
+  private int onDrawCounter = 0;
+
   @Override
   protected void onDraw(Canvas canvas) {
+    onDrawCounter++;
+    if (onDrawCounter > 10) {
+      onDrawCounter = 0;
+      Log.e("FlutterImageView", "mock onDraw() calling lost");
+      // mock onDraw() calling lost
+      return;
+    }
     super.onDraw(canvas);
 
     if (!imageQueue.isEmpty()) {
```

This can simulate the missing call of onDraw() once every 10 times. And the flashing or widgets can be observed as well as video above.

# Solution
So after all, I made this change and I also think ImageReader related logics can be simplified:
* The new code closes current image every time when `imageReader.acquireLatestImage()` returns a new image, and no need to record a queue and no need to check `imageReader.getMaxImages()`

It fixes:
flutter/flutter#63897
flutter/flutter#70290


# Test
The test code:
* Remove the test `flutterImageView_onDrawClosesAllImages()` with old logic.
* Merged `acquiresMaxImagesAtMost` and `acquireLatestImageReturnsFalse()` to the test `acquiresImageClosesPreviousImageUnlessNoNewImage`, it can cover `mockReader.acquireLatestImage()` returns null making the method returns false when no latest image, and the `onDraw()` missing cases.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
