### PR TITLE
[Android Text Input] Remove Samsung restart input workaround

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -9,7 +9,6 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
-import android.provider.Settings;
 import android.text.Editable;
 import android.text.InputType;
 import android.util.SparseArray;
@@ -22,7 +21,6 @@ import android.view.autofill.AutofillValue;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
-import android.view.inputmethod.InputMethodSubtype;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -49,7 +47,6 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
   @Nullable private InputConnection lastInputConnection;
   @NonNull private PlatformViewsController platformViewsController;
   @Nullable private Rect lastClientRect;
-  private final boolean restartAlwaysRequired;
   private ImeSyncDeferringInsetsCallback imeSyncCallback;
   private AndroidKeyProcessor keyProcessor;
 
@@ -161,7 +158,6 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
 
     this.platformViewsController = platformViewsController;
     this.platformViewsController.attachTextInputPlugin(this);
-    restartAlwaysRequired = isRestartAlwaysRequired();
   }
 
   @NonNull
@@ -422,9 +418,9 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
     mLastKnownFrameworkTextEditingState = state;
     mEditable.setEditingState(state);
 
-    // Restart if there is a pending restart or the device requires a force restart
-    // (see isRestartAlwaysRequired). Restarting will also update the selection.
-    if (restartAlwaysRequired || mRestartInputPending) {
+    // Restart if there is a pending restart. Restarting will also update the
+    // selection.
+    if (mRestartInputPending) {
       mImm.restartInput(view);
       mRestartInputPending = false;
     }
@@ -472,32 +468,6 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
             (int) (minMax[2] * density),
             (int) Math.ceil(minMax[1] * density),
             (int) Math.ceil(minMax[3] * density));
-  }
-
-  // Samsung's Korean keyboard has a bug where it always attempts to combine characters based on
-  // its internal state, ignoring if and when the cursor is moved programmatically. The same bug
-  // also causes non-korean keyboards to occasionally duplicate text when tapping in the middle
-  // of existing text to edit it.
-  //
-  // Fully restarting the IMM works around this because it flushes the keyboard's internal state
-  // and stops it from trying to incorrectly combine characters. However this also has some
-  // negative performance implications, so we don't want to apply this workaround in every case.
-  @SuppressLint("NewApi") // New API guard is inline, the linter can't see it.
-  @SuppressWarnings("deprecation")
-  private boolean isRestartAlwaysRequired() {
-    InputMethodSubtype subtype = mImm.getCurrentInputMethodSubtype();
-    // Impacted devices all shipped with Android Lollipop or newer.
-    if (subtype == null
-        || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
-        || !Build.MANUFACTURER.equals("samsung")) {
-      return false;
-    }
-    String keyboardName =
-        Settings.Secure.getString(
-            mView.getContext().getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
-    // The Samsung keyboard is called "com.sec.android.inputmethod/.SamsungKeypad" but look
-    // for "Samsung" just in case Samsung changes the name of the keyboard.
-    return keyboardName.contains("Samsung");
   }
 
   @VisibleForTesting

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -339,13 +339,15 @@ public class TextInputPluginTest {
     assertTrue(textInputPlugin.getEditable().toString().equals("Shibuyawoo"));
   }
 
-  // See https://github.com/flutter/flutter/issues/29341 and
-  // https://github.com/flutter/flutter/issues/31512
-  // All modern Samsung keybords are affected including non-korean languages and thus
-  // need the restart.
+  // Regression test for https://github.com/flutter/flutter/issues/73433.
+  // See also: https://github.com/flutter/flutter/issues/29341 and
+  // https://github.com/flutter/flutter/issues/31512.
+  // All modern Samsung keybords were affected including non-korean languages
+  // and thus needed the restart. The restart workaround seems to have caused
+  // #73433 and it's no longer needed.
   @Test
-  public void setTextInputEditingState_alwaysRestartsOnAffectedDevices2() {
-    // Initialize a TextInputPlugin that needs to be always restarted.
+  public void setTextInputEditingState_DontForceRestartOnPreviouslyAffectedSamsungDevices() {
+    // Initialize a TextInputPlugin with a Samsung keypad.
     ShadowBuild.setManufacturer("samsung");
     InputMethodSubtype inputMethodSubtype =
         new InputMethodSubtype(0, 0, /*locale=*/ "en", "", "", false, false);
@@ -382,8 +384,8 @@ public class TextInputPluginTest {
     textInputPlugin.setTextInputEditingState(
         testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
 
-    // Verify that we've restarted the input.
-    assertEquals(2, testImm.getRestartCount(testView));
+    // Verify that we've NOT restarted the input.
+    assertEquals(1, testImm.getRestartCount(testView));
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/73433, where holding the backspace on a Samsung keyboard only deletes 1 character at a time. To delete more characters you'd have to press the backspace key again.

The Samsung "always-restart-input" workaround doesn't seem to be needed anymore (tested on a Galaxy Tab A SMT510, the [duplication bug](https://github.com/flutter/flutter/issues/31512) didn't happen with this patch applied).

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
