### PR TITLE
Fix FlutterPlatformViewSemanticsContainer retain cycle with SemanticsObject

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -571,14 +571,41 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)dealloc {
+  [_semanticsObject release];
+  _semanticsObject = nil;
   [_platformView release];
   _platformView = nil;
   [super dealloc];
 }
 
-- (NSArray*)accessibilityElements {
-  return @[ _semanticsObject, _platformView ];
+#pragma mark - UIAccessibilityContainer overrides
+
+- (NSInteger)accessibilityElementCount {
+  // This container should only contain 2 elements:
+  // 1. The semantic object that represents this container.
+  // 2. The platform view object.
+  return 2;
 }
+
+- (nullable id)accessibilityElementAtIndex:(NSInteger)index {
+  FML_DCHECK(index < 2);
+  if (index == 0) {
+    return _semanticsObject;
+  } else {
+    return _platformView;
+  }
+}
+
+- (NSInteger)indexOfAccessibilityElement:(id)element {
+  FML_DCHECK(element == _semanticsObject || element == _platformView);
+  if (element == _semanticsObject) {
+    return 0;
+  } else {
+    return 1;
+  }
+}
+
+#pragma mark - UIAccessibilityElement overrides
 
 - (CGRect)accessibilityFrame {
   return _semanticsObject.accessibilityFrame;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -571,8 +571,6 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)dealloc {
-  [_semanticsObject release];
-  _semanticsObject = nil;
   [_platformView release];
   _platformView = nil;
   [super dealloc];

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -222,8 +222,8 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
       new flutter::MockAccessibilityBridge());
   fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
   SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
-  object.platformViewSemanticsContainer = [[FlutterPlatformViewSemanticsContainer alloc]
-    initWithSemanticsObject:object];
+  object.platformViewSemanticsContainer =
+      [[FlutterPlatformViewSemanticsContainer alloc] initWithSemanticsObject:object];
   __weak SemanticsObject* weakObject = object;
   object = nil;
   XCTAssertNil(weakObject);

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -217,4 +217,16 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   XCTAssertTrue(bridge->observations[0].action == flutter::SemanticsAction::kShowOnScreen);
 }
 
+- (void)testSemanticsObjectAndPlatformViewSemanticsContainerDontHaveRetainCycle {
+  fml::WeakPtrFactory<flutter::MockAccessibilityBridge> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
+  SemanticsObject* object = [[SemanticsObject alloc] initWithBridge:bridge uid:1];
+  object.platformViewSemanticsContainer = [[FlutterPlatformViewSemanticsContainer alloc]
+    initWithSemanticsObject:object];
+  __weak SemanticsObject* weakObject = object;
+  object = nil;
+  XCTAssertNil(weakObject);
+}
+
 @end


### PR DESCRIPTION
The `FlutterPlatformViewSemanticsContainer` created a strong reference back to the `SemanticsObject` when constructing an NSArray in the `accessibilityElements` method. To avoid the retain cycle, simply replace the `accessibilityElements` with the `AccessibilityContainer` protocol methods.

Fixes https://github.com/flutter/flutter/issues/73716

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
