### PR TITLE
Windows: linker compatibility with AppContainer for winuwp target

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -245,8 +245,9 @@ if (enable_unittests) {
     sources = [ "tests/embedder_unittests_proctable.cc" ]
 
     defines = [ "FLUTTER_ENGINE_NO_PROTOTYPES" ]
-
-    libs = [ "psapi.lib" ]
+    if (is_win) {
+      libs = [ "psapi.lib" ]
+    }
 
     deps = [
       ":embedder",

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -246,6 +246,8 @@ if (enable_unittests) {
 
     defines = [ "FLUTTER_ENGINE_NO_PROTOTYPES" ]
 
+    libs = [ "psapi.lib" ]
+
     deps = [
       ":embedder",
       ":embedder_gpu_configuration",

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -170,7 +170,7 @@ executable("flutter_windows_unittests") {
   testonly = true
 
   if (target_os == "winuwp") {
-    libs = [ "windowsapp.lib" ]
+    libs = [ "windowsapp.lib", "user32.lib" ]
   }
 
   # Common Windows test sources.

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -170,7 +170,10 @@ executable("flutter_windows_unittests") {
   testonly = true
 
   if (target_os == "winuwp") {
-    libs = [ "windowsapp.lib", "user32.lib" ]
+    libs = [
+      "windowsapp.lib",
+      "user32.lib",
+    ]
   }
 
   # Common Windows test sources.

--- a/shell/platform/windows/key_event_handler.cc
+++ b/shell/platform/windows/key_event_handler.cc
@@ -122,7 +122,9 @@ KeyEventHandler::KeyEventHandler(flutter::BinaryMessenger* messenger,
               kChannelName,
               &flutter::JsonMessageCodec::GetInstance())),
       send_input_(send_input) {
+#ifndef WINUWP
   assert(send_input != nullptr);
+#endif
 }
 
 KeyEventHandler::~KeyEventHandler() = default;
@@ -190,6 +192,7 @@ void KeyEventHandler::HandleResponse(bool handled,
       std::cerr << "Unable to find event " << id << " in pending events queue.";
       return;
     }
+#ifndef WINUWP
     INPUT input_event;
     input_event.type = INPUT_KEYBOARD;
     input_event.ki = *key_event;
@@ -199,6 +202,7 @@ void KeyEventHandler::HandleResponse(bool handled,
                    "with scancode "
                 << scancode << " (character " << character << ")" << std::endl;
     }
+#endif
   }
 }
 
@@ -225,6 +229,10 @@ bool KeyEventHandler::KeyboardHook(FlutterWindowsView* view,
   event.AddMember(kKeyMapKey, kWindowsKeyMap, allocator);
 #ifndef WINUWP
   event.AddMember(kModifiersKey, GetModsForKeyState(), allocator);
+#else
+  // TODO: Implement modifiers in UWP codepath
+  // TODO: https://github.com/flutter/flutter/issues/70202
+  event.AddMember(kModifiersKey, 0, allocator);
 #endif
 
   switch (action) {

--- a/shell/platform/windows/key_event_handler.cc
+++ b/shell/platform/windows/key_event_handler.cc
@@ -122,6 +122,9 @@ KeyEventHandler::KeyEventHandler(flutter::BinaryMessenger* messenger,
               kChannelName,
               &flutter::JsonMessageCodec::GetInstance())),
       send_input_(send_input) {
+// As described in the header, UWP doesn't support the SendInput API hence we
+// only need to assert that the delegate is null in the non-UWP case since it is
+// expected to be null in the UWP case.
 #ifndef WINUWP
   assert(send_input != nullptr);
 #endif
@@ -192,6 +195,14 @@ void KeyEventHandler::HandleResponse(bool handled,
       std::cerr << "Unable to find event " << id << " in pending events queue.";
       return;
     }
+
+// As described in the header, the user32 SendInput function is not supported in
+// UWP appcontainer and there is no WinRT equivalent hence we pass null for
+// SendInputDelegate param.  Since this handler is one of last resort, it is
+// only applicable for platformview scenarios where the host view can handle
+// input events in the event the Flutter view does not choose to handle them.
+// Since platformview is currently not support for desktop, there is no
+// functional gap caused by this currently.
 #ifndef WINUWP
     INPUT input_event;
     input_event.type = INPUT_KEYBOARD;

--- a/shell/platform/windows/key_event_handler.h
+++ b/shell/platform/windows/key_event_handler.h
@@ -27,8 +27,13 @@ class KeyEventHandler : public KeyboardHookHandler {
   using SendInputDelegate =
       std::function<UINT(UINT cInputs, LPINPUT pInputs, int cbSize)>;
 
+#ifdef WINUWP
+  explicit KeyEventHandler(flutter::BinaryMessenger* messenger,
+                           SendInputDelegate delegate = nullptr);
+#else
   explicit KeyEventHandler(flutter::BinaryMessenger* messenger,
                            SendInputDelegate delegate = SendInput);
+#endif
 
   virtual ~KeyEventHandler();
 

--- a/shell/platform/windows/key_event_handler.h
+++ b/shell/platform/windows/key_event_handler.h
@@ -27,6 +27,12 @@ class KeyEventHandler : public KeyboardHookHandler {
   using SendInputDelegate =
       std::function<UINT(UINT cInputs, LPINPUT pInputs, int cbSize)>;
 
+// the user32 SendInput function is not supported in UWP appcontainer and there
+// is no WinRT equivalent hence we pass null for SendInputDelegate param.  Since
+// this handler is one of last resort, it is only applicable for platformview
+// scenarios where the host view can handle input events in the event the
+// Flutter view does not choose to handle them. Since platformview is currently
+// not support for desktop, there is no functional gap caused by this currently.
 #ifdef WINUWP
   explicit KeyEventHandler(flutter::BinaryMessenger* messenger,
                            SendInputDelegate delegate = nullptr);

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -14,6 +14,8 @@ executable("testing") {
 
   sources = [ "tester_main.cc" ]
 
+  libs = [ "psapi.lib", "user32.lib", "FontSub.lib", "shlwapi.lib"]
+
   deps = [
     "//flutter/assets",
     "//flutter/common",

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -13,8 +13,14 @@ executable("testing") {
   ]
 
   sources = [ "tester_main.cc" ]
-
-  libs = [ "psapi.lib", "user32.lib", "FontSub.lib", "shlwapi.lib"]
+  if (is_win) {
+    libs = [
+      "psapi.lib",
+      "user32.lib",
+      "FontSub.lib",
+      "shlwapi.lib",
+    ]
+  }
 
   deps = [
     "//flutter/assets",

--- a/tools/gn
+++ b/tools/gn
@@ -105,6 +105,8 @@ def to_gn_args(args):
     gn_args['skia_use_fontconfig'] = args.enable_fontconfig
     gn_args['flutter_use_fontconfig'] = args.enable_fontconfig
     gn_args['flutter_enable_skshaper'] = args.enable_skshaper
+    if args.target_os == 'winuwp':
+      gn_args['skia_enable_winuwp'] = True
     if args.enable_skshaper:
       gn_args['skia_use_icu'] = True
       gn_args['skia_enable_icu_ubrk_safeclone'] = True


### PR DESCRIPTION
This PR is the final engine patch required for the Flutter Engine `--winuwp` target to build and link correctly for the UWP/AppContainer environment.  Whist this PR stands alone, the linker configuration will not be completely compatible until the following related changes also land:

- [Add UWP support (I4ed9e440) · Gerrit Code Review (googlesource.com)](https://skia-review.googlesource.com/c/skia/+/345219)
- [Add support for building in Flutter Windows UWP configuration (Idf5a4cbb) · Gerrit Code Review (googlesource.com)](https://chromium-review.googlesource.com/c/angle/angle/+/2620580) 
- https://github.com/flutter/buildroot/pull/438

Related issue:
https://github.com/flutter/flutter/issues/70196
https://github.com/flutter/flutter/issues/14967

Must land before:
https://github.com/flutter/buildroot/pull/438

Related:


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
