### PR TITLE
[embedder] Refactor GL texture resolution

### DIFF
--- a/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/shell/platform/embedder/embedder_external_texture_gl.h
@@ -7,6 +7,7 @@
 
 #include "flutter/common/graphics/texture.h"
 #include "flutter/fml/macros.h"
+#include "flutter/shell/platform/embedder/embedder.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkSize.h"
 
@@ -14,10 +15,8 @@ namespace flutter {
 
 class EmbedderExternalTextureGL : public flutter::Texture {
  public:
-  using ExternalTextureCallback =
-      std::function<sk_sp<SkImage>(int64_t texture_identifier,
-                                   GrDirectContext*,
-                                   const SkISize&)>;
+  using ExternalTextureCallback = std::function<
+      std::unique_ptr<FlutterOpenGLTexture>(int64_t, size_t, size_t)>;
 
   EmbedderExternalTextureGL(int64_t texture_identifier,
                             const ExternalTextureCallback& callback);
@@ -25,8 +24,12 @@ class EmbedderExternalTextureGL : public flutter::Texture {
   ~EmbedderExternalTextureGL();
 
  private:
-  ExternalTextureCallback external_texture_callback_;
+  const ExternalTextureCallback& external_texture_callback_;
   sk_sp<SkImage> last_image_;
+
+  sk_sp<SkImage> ResolveTexture(int64_t texture_id,
+                                GrDirectContext* context,
+                                const SkISize& size);
 
   // |flutter::Texture|
   void Paint(SkCanvas& canvas,


### PR DESCRIPTION
This moves the texture resolution out of embedder.cc and into embedder external_texture_gl.cc.