### PR TITLE
Propagate image decode errors to the future returned by Codec.getNextFrame

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1939,12 +1939,13 @@ class Codec extends NativeFieldWrapperClass2 {
     final Completer<FrameInfo> completer = Completer<FrameInfo>.sync();
     final String? error = _getNextFrame((_Image? image, int durationMilliseconds) {
       if (image == null) {
-        throw Exception('Codec failed to produce an image, possibly due to invalid image data.');
+        completer.completeError(Exception('Codec failed to produce an image, possibly due to invalid image data.'));
+      } else {
+        completer.complete(FrameInfo._(
+          image: Image._(image),
+          duration: Duration(milliseconds: durationMilliseconds),
+        ));
       }
-      completer.complete(FrameInfo._(
-        image: Image._(image),
-        duration: Duration(milliseconds: durationMilliseconds),
-      ));
     });
     if (error != null) {
       throw Exception(error);

--- a/testing/dart/codec_test.dart
+++ b/testing/dart/codec_test.dart
@@ -34,6 +34,18 @@ void main() {
     );
   });
 
+  test('getNextFrame fails with invalid data', () async {
+    Uint8List data = await _getSkiaResource('flutter_logo.jpg').readAsBytes();
+    data = Uint8List.view(data.buffer, 0, 4000);
+    final ui.Codec codec = await ui.instantiateImageCodec(data);
+    try {
+      await codec.getNextFrame();
+      fail('exception not thrown');
+    } catch(e) {
+      expect(e, exceptionWithMessage('Codec failed'));
+    }
+  });
+
   test('nextFrame', () async {
     final Uint8List data = await _getSkiaResource('test640x479.gif').readAsBytes();
     final ui.Codec codec = await ui.instantiateImageCodec(data);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/75560
