### PR TITLE
Remove unnecessary buffer collection image constraints.

### DIFF
--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -141,6 +141,7 @@ bool VulkanProcTable::SetupDeviceProcAddresses(
   ACQUIRE_PROC(GetMemoryZirconHandleFUCHSIA, handle);
   ACQUIRE_PROC(ImportSemaphoreZirconHandleFUCHSIA, handle);
   ACQUIRE_PROC(SetBufferCollectionConstraintsFUCHSIA, handle);
+  ACQUIRE_PROC(GetBufferCollectionPropertiesFUCHSIA, handle);
 #endif  // OS_FUCHSIA
   device_ = {handle, nullptr};
   return true;

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -119,6 +119,7 @@ class VulkanProcTable : public fml::RefCountedThreadSafe<VulkanProcTable> {
   DEFINE_PROC(GetMemoryZirconHandleFUCHSIA);
   DEFINE_PROC(ImportSemaphoreZirconHandleFUCHSIA);
   DEFINE_PROC(SetBufferCollectionConstraintsFUCHSIA);
+  DEFINE_PROC(GetBufferCollectionPropertiesFUCHSIA);
 #endif  // OS_FUCHSIA
 
 #undef DEFINE_PROC


### PR DESCRIPTION
These constraints are not needed and result in usage of
images with linear layout. That's a significant
performance regression on most devices, and also not
guaranteed to work as color attachments.

Also, use GetBufferCollectionPropertiesFUCHSIA to improve
correctness of memory import.