### PR TITLE
[felt] report failures after running all shards

### DIFF
--- a/lib/web_ui/dev/felt.dart
+++ b/lib/web_ui/dev/felt.dart
@@ -38,7 +38,7 @@ void main(List<String> args) async {
   try {
     final bool result = (await runner.run(args)) as bool;
     if (result == false) {
-      print('Sub-command returned false: `${args.join(' ')}`');
+      print('Sub-command failed: `${args.join(' ')}`');
       exitCode = 1;
     }
   } on UsageException catch (e) {

--- a/lib/web_ui/dev/watcher.dart
+++ b/lib/web_ui/dev/watcher.dart
@@ -34,11 +34,14 @@ class Pipeline {
 
   Future<dynamic> _currentStepFuture;
 
-  PipelineStatus status = PipelineStatus.idle;
+  PipelineStatus get status => _status;
+  PipelineStatus _status = PipelineStatus.idle;
 
   /// Starts executing tasks of the pipeline.
+  ///
+  /// Returns a future that resolves after all steps have been performed.
   Future<void> start() async {
-    status = PipelineStatus.started;
+    _status = PipelineStatus.started;
     try {
       for (PipelineStep step in steps) {
         if (status != PipelineStatus.started) {
@@ -47,9 +50,9 @@ class Pipeline {
         _currentStepFuture = step();
         await _currentStepFuture;
       }
-      status = PipelineStatus.done;
+      _status = PipelineStatus.done;
     } catch (error, stackTrace) {
-      status = PipelineStatus.error;
+      _status = PipelineStatus.error;
       print('Error in the pipeline: $error');
       print(stackTrace);
     } finally {
@@ -61,9 +64,9 @@ class Pipeline {
   ///
   /// If a task is already being executed, it won't be interrupted.
   Future<void> stop() {
-    status = PipelineStatus.stopping;
+    _status = PipelineStatus.stopping;
     return (_currentStepFuture ?? Future<void>.value(null)).then((_) {
-      status = PipelineStatus.stopped;
+      _status = PipelineStatus.stopped;
     });
   }
 }


### PR DESCRIPTION
Report failures after running all shards.

Currently we stop the test process as soon as we encounter the first failure. This makes the process of updating goldens from LUCI results unnecessarily complicated as LUCI will only show a subset of updated screenshots, and if the failing test is a unit-test, it won't show any screenshots at all. After this change, we will run all tests and report the failure afterwards. This way we'll see all the needed screenshot updates.