### PR TITLE
Fix vulkan surface leaks.

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.h
@@ -146,7 +146,8 @@ class VulkanSurface final : public SurfaceProducerSurface {
 
   bool AllocateDeviceMemory(fuchsia::sysmem::AllocatorSyncPtr& sysmem_allocator,
                             sk_sp<GrDirectContext> context,
-                            const SkISize& size);
+                            const SkISize& size,
+                            uint32_t buffer_id);
 
   bool CreateVulkanImage(vulkan::VulkanProvider& vulkan_provider,
                          const SkISize& size,
@@ -174,9 +175,9 @@ class VulkanSurface final : public SurfaceProducerSurface {
   VkMemoryAllocateInfo vk_memory_info_;
   vulkan::VulkanHandle<VkFence> command_buffer_fence_;
   sk_sp<SkSurface> sk_surface_;
-  const uint32_t buffer_id_;
+  uint32_t buffer_id_ = 0;
   uint32_t image_id_ = 0;
-  VkBufferCollectionFUCHSIA collection_;
+  vulkan::VulkanHandle<VkBufferCollectionFUCHSIA> collection_;
   zx::event acquire_event_;
   vulkan::VulkanHandle<VkSemaphore> acquire_semaphore_;
   std::unique_ptr<vulkan::VulkanCommandBuffer> command_buffer_;

--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -138,6 +138,7 @@ bool VulkanProcTable::SetupDeviceProcAddresses(
 #endif  // OS_ANDROID
 #if OS_FUCHSIA
   ACQUIRE_PROC(CreateBufferCollectionFUCHSIA, handle);
+  ACQUIRE_PROC(DestroyBufferCollectionFUCHSIA, handle);
   ACQUIRE_PROC(GetMemoryZirconHandleFUCHSIA, handle);
   ACQUIRE_PROC(ImportSemaphoreZirconHandleFUCHSIA, handle);
   ACQUIRE_PROC(SetBufferCollectionConstraintsFUCHSIA, handle);

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -116,6 +116,7 @@ class VulkanProcTable : public fml::RefCountedThreadSafe<VulkanProcTable> {
 #endif  // OS_ANDROID
 #if OS_FUCHSIA
   DEFINE_PROC(CreateBufferCollectionFUCHSIA);
+  DEFINE_PROC(DestroyBufferCollectionFUCHSIA);
   DEFINE_PROC(GetMemoryZirconHandleFUCHSIA);
   DEFINE_PROC(ImportSemaphoreZirconHandleFUCHSIA);
   DEFINE_PROC(SetBufferCollectionConstraintsFUCHSIA);


### PR DESCRIPTION
This fixes 3 memory leaks:

1. Destroys local vulkan buffer collections.
2. Releases image2 resource in Scenic.
3. Deregister buffer collections from Scenic session.