### PR TITLE
Fixes hot restart correctly reset the browser history

### DIFF
--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -203,7 +203,6 @@ void initializeEngine() {
   // This extension does not need to clean-up Dart statics. Those are cleaned
   // up by the compiler.
   developer.registerExtension('ext.flutter.disassemble', (_, __) {
-    window.resetHistory();
     for (ui.VoidCallback listener in _hotRestartListeners) {
       listener();
     }

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -203,6 +203,7 @@ void initializeEngine() {
   // This extension does not need to clean-up Dart statics. Those are cleaned
   // up by the compiler.
   developer.registerExtension('ext.flutter.disassemble', (_, __) {
+    window.resetHistory();
     for (ui.VoidCallback listener in _hotRestartListeners) {
       listener();
     }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -86,12 +86,11 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     }
   }
 
-  @visibleForTesting
-  Future<void> debugResetHistory() async {
+  Future<void> resetHistory() async {
     await _browserHistory?.tearDown();
     _browserHistory = null;
-
     // Reset the globals too.
+    _usingRouter = false;
     _isUrlStrategySet = false;
     _customUrlStrategy = null;
   }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -32,6 +32,9 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
       _browserHistory =
           MultiEntriesBrowserHistory(urlStrategy: _customUrlStrategy);
     }
+    registerHotRestartListener(() {
+      window.resetHistory();
+    });
   }
 
   final Object _windowId;

--- a/lib/web_ui/test/engine/history_test.dart
+++ b/lib/web_ui/test/engine/history_test.dart
@@ -48,7 +48,7 @@ void testMain() {
 
     tearDown(() async {
       spy.tearDown();
-      await window.debugResetHistory();
+      await window.resetHistory();
     });
 
     test('basic setup works', () async {
@@ -262,7 +262,7 @@ void testMain() {
 
     tearDown(() async {
       spy.tearDown();
-      await window.debugResetHistory();
+      await window.resetHistory();
     });
 
     test('basic setup works', () async {

--- a/lib/web_ui/test/engine/navigation_test.dart
+++ b/lib/web_ui/test/engine/navigation_test.dart
@@ -28,7 +28,7 @@ void testMain() {
 
   tearDown(() async {
     _strategy = null;
-    await engine.window.debugResetHistory();
+    await engine.window.resetHistory();
   });
 
   test('Tracks pushed, replaced and popped routes', () async {

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -33,7 +33,7 @@ void testMain() {
   });
 
   tearDown(() async {
-    await window.debugResetHistory();
+    await window.resetHistory();
     window = null;
   });
 


### PR DESCRIPTION
web engine hot restart does not tear down the browser history. When the app restarted, it confused itself with the existing browser history, thus causes error in https://github.com/flutter/flutter/issues/73793.

fixes https://github.com/flutter/flutter/issues/73793

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
