### PR TITLE
[canvaskit] fix Path.from

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/path.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/path.dart
@@ -13,7 +13,7 @@ class CkPath extends ManagedSkiaObject<SkPath> implements ui.Path {
 
   CkPath.from(CkPath other)
       : _fillType = other.fillType,
-        super(SkPath(other.skiaObject)) {
+        super(other.skiaObject.copy()) {
     skiaObject.setFillType(toSkFillType(_fillType));
   }
 

--- a/lib/web_ui/test/canvaskit/path_test.dart
+++ b/lib/web_ui/test/canvaskit/path_test.dart
@@ -157,6 +157,25 @@ void testMain() {
       expect(measure1.contourIndex, 1);
       expect(measure1.extractPath(0, 15).getBounds(), ui.Rect.fromLTRB(20, 20, 30, 25));
     });
+
+    test('Path.from', () {
+      final ui.Rect rect1 = ui.Rect.fromLTRB(0, 0, 10, 10);
+      final ui.Rect rect2 = ui.Rect.fromLTRB(10, 10, 20, 20);
+
+      final ui.Path original = ui.Path();
+      original.addRect(rect1);
+      expect(original, isA<CkPath>());
+      expect(original.getBounds(), rect1);
+
+      final ui.Path copy = ui.Path.from(original);
+      expect(copy, isA<CkPath>());
+      expect(copy.getBounds(), rect1);
+
+      // Test that when copy is mutated, the original is not affected
+      copy.addRect(rect2);
+      expect(original.getBounds(), rect1);
+      expect(copy.getBounds(), rect1.expandToInclude(rect2));
+    });
   },
       skip:
           isIosSafari); // TODO: https://github.com/flutter/flutter/issues/60040


### PR DESCRIPTION
Fix `Path.from` for CanvasKit.

Fixes https://github.com/flutter/flutter/issues/75473
