### PR TITLE
Ensures that hit testing only resturns focusable nodes. (#23931) #24385

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.h
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.h
@@ -110,6 +110,7 @@ class AccessibilityBridge
   struct SemanticsNode {
     int32_t id;
     int32_t flags;
+    bool is_focusable;
     SkRect rect;
     SkRect screen_rect;
     SkM44 transform;
@@ -196,6 +197,9 @@ class AccessibilityBridge
   //
   // Assumes that SemanticsNode::screen_rect is up to date.
   std::optional<int32_t> GetHitNode(int32_t node_id, float x, float y);
+
+  // Returns whether the node is considered focusable.
+  bool IsFocusable(const flutter::SemanticsNode& node) const;
 
   // Converts a fuchsia::accessibility::semantics::Action to a
   // flutter::SemanticsAction.


### PR DESCRIPTION
Cherry-picking #23931 to address http://fxbug.dev/68331