### PR TITLE
Windows: Fix fml::GetFullHandlePath for WINUWP target

### DIFF
--- a/fml/unique_fd.cc
+++ b/fml/unique_fd.cc
@@ -13,6 +13,9 @@ namespace internal {
 
 namespace os_win {
 
+std::mutex UniqueFDTraits::file_map_mutex;
+std::map<HANDLE, DirCacheEntry> UniqueFDTraits::file_map;
+
 void UniqueFDTraits::Free_Handle(HANDLE fd) {
   CloseHandle(fd);
 }

--- a/fml/unique_fd.cc
+++ b/fml/unique_fd.cc
@@ -13,7 +13,7 @@ namespace internal {
 
 namespace os_win {
 
-void UniqueFDTraits::Free(HANDLE fd) {
+void UniqueFDTraits::Free_Handle(HANDLE fd) {
   CloseHandle(fd);
 }
 

--- a/fml/unique_fd.h
+++ b/fml/unique_fd.h
@@ -50,9 +50,7 @@ struct UniqueFDTraits {
   static void RemoveCacheEntry(HANDLE fd) {
     const std::lock_guard<std::mutex> lock(file_map_mutex);
 
-    if (file_map.count(fd) > 0) {
-      file_map.erase(fd);
-    }
+    file_map.erase(fd);
   }
 
   static void StoreCacheEntry(HANDLE fd, DirCacheEntry state) {
@@ -62,10 +60,10 @@ struct UniqueFDTraits {
 
   static std::optional<DirCacheEntry> GetCacheEntry(HANDLE fd) {
     const std::lock_guard<std::mutex> lock(file_map_mutex);
-    if (file_map.count(fd) > 0) {
-      return file_map[fd];
-    }
-    return {};
+    auto found = file_map.find(fd);
+    return found == file_map.end()
+               ? std::nullopt
+               : std::optional<DirCacheEntry>{found->second};
   }
 };
 

--- a/fml/unique_fd.h
+++ b/fml/unique_fd.h
@@ -10,6 +10,9 @@
 
 #if OS_WIN
 #include <windows.h>
+#include <map>
+#include <mutex>
+#include <optional>
 #else  // OS_WIN
 #include <dirent.h>
 #include <unistd.h>
@@ -22,10 +25,48 @@ namespace internal {
 
 namespace os_win {
 
+struct DirCacheEntry {
+  std::wstring filename;
+  FILE_ID_128 id;
+};
+
+// The order of these is important.  Must come before UniqueFDTraits struct
+// else linker error.  Embedding in struct also causes linker error.
+
 struct UniqueFDTraits {
+  inline static std::mutex file_map_mutex;
+  inline static std::map<HANDLE, DirCacheEntry> file_map;
+
   static HANDLE InvalidValue() { return INVALID_HANDLE_VALUE; }
   static bool IsValid(HANDLE value) { return value != InvalidValue(); }
-  static void Free(HANDLE fd);
+  static void Free_Handle(HANDLE fd);
+
+  static void Free(HANDLE fd) {
+    RemoveCacheEntry(fd);
+
+    UniqueFDTraits::Free_Handle(fd);
+  }
+
+  static void RemoveCacheEntry(HANDLE fd) {
+    const std::lock_guard<std::mutex> lock(file_map_mutex);
+
+    if (file_map.count(fd) > 0) {
+      file_map.erase(fd);
+    }
+  }
+
+  static void StoreCacheEntry(HANDLE fd, DirCacheEntry state) {
+    const std::lock_guard<std::mutex> lock(file_map_mutex);
+    file_map[fd] = state;
+  }
+
+  static std::optional<DirCacheEntry> GetCacheEntry(HANDLE fd) {
+    const std::lock_guard<std::mutex> lock(file_map_mutex);
+    if (file_map.count(fd) > 0) {
+      return file_map[fd];
+    }
+    return {};
+  }
 };
 
 }  // namespace os_win

--- a/fml/unique_fd.h
+++ b/fml/unique_fd.h
@@ -34,8 +34,8 @@ struct DirCacheEntry {
 // else linker error.  Embedding in struct also causes linker error.
 
 struct UniqueFDTraits {
-  inline static std::mutex file_map_mutex;
-  inline static std::map<HANDLE, DirCacheEntry> file_map;
+  static std::mutex file_map_mutex;
+  static std::map<HANDLE, DirCacheEntry> file_map;
 
   static HANDLE InvalidValue() { return INVALID_HANDLE_VALUE; }
   static bool IsValid(HANDLE value) { return value != InvalidValue(); }


### PR DESCRIPTION
Although the documentation claims that GetFinalPathNameByHandle is supported for UWP apps, turns out it does not work correctly hence the need to workaround by maintaining a map of file handles to absolute paths in order to be able to satisfy GetFullHandlePath for the WINUWP target.

https://github.com/flutter/flutter/issues/14967
https://github.com/flutter/flutter/issues/70196

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on (**WINUWP test infra not yet functional**)
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
