### PR TITLE
Add missing header guard, namespace

### DIFF
--- a/shell/platform/common/text_range.h
+++ b/shell/platform/common/text_range.h
@@ -2,9 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#ifndef FLUTTER_SHELL_PLATFORM_COMMON_TEXT_RANGE_H_
+#define FLUTTER_SHELL_PLATFORM_COMMON_TEXT_RANGE_H_
+
 #include <algorithm>
 
 #include "flutter/fml/logging.h"
+
+namespace flutter {
 
 // A directional range of text.
 //
@@ -92,3 +97,7 @@ class TextRange {
   size_t base_;
   size_t extent_;
 };
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_COMMON_TEXT_RANGE_H_

--- a/shell/platform/linux/fl_text_input_plugin.cc
+++ b/shell/platform/linux/fl_text_input_plugin.cc
@@ -113,7 +113,7 @@ static void update_editing_state(FlTextInputPlugin* self) {
   fl_value_append_take(args, fl_value_new_int(priv->client_id));
   g_autoptr(FlValue) value = fl_value_new_map();
 
-  TextRange selection = priv->text_model->selection();
+  flutter::TextRange selection = priv->text_model->selection();
   fl_value_set_string_take(
       value, kTextKey,
       fl_value_new_string(priv->text_model->GetText().c_str()));
@@ -195,7 +195,8 @@ static void im_preedit_changed_cb(FlTextInputPlugin* self) {
                                     &cursor_offset);
   cursor_offset += priv->text_model->composing_range().base();
   priv->text_model->UpdateComposingText(buf);
-  priv->text_model->SetSelection(TextRange(cursor_offset, cursor_offset));
+  priv->text_model->SetSelection(
+      flutter::TextRange(cursor_offset, cursor_offset));
 
   update_editing_state(self);
 }
@@ -311,7 +312,8 @@ static FlMethodResponse* set_editing_state(FlTextInputPlugin* self,
   }
 
   priv->text_model->SetText(text);
-  priv->text_model->SetSelection(TextRange(selection_base, selection_extent));
+  priv->text_model->SetSelection(
+      flutter::TextRange(selection_base, selection_extent));
 
   int64_t composing_base =
       fl_value_get_int(fl_value_lookup_string(args, kComposingBaseKey));
@@ -323,7 +325,7 @@ static FlMethodResponse* set_editing_state(FlTextInputPlugin* self,
     size_t composing_start = std::min(composing_base, composing_extent);
     size_t cursor_offset = selection_base - composing_start;
     priv->text_model->SetComposingRange(
-        TextRange(composing_base, composing_extent), cursor_offset);
+        flutter::TextRange(composing_base, composing_extent), cursor_offset);
   }
 
   return FL_METHOD_RESPONSE(fl_method_success_response_new(nullptr));


### PR DESCRIPTION
TextRange was missing a namespace declaration and header guards.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
