### PR TITLE
Windows: Improve window resizing

### DIFF
--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -245,15 +245,17 @@ double FlutterWindowWinUWP::GetPosY(
 void FlutterWindowWinUWP::OnBoundsChanged(
     winrt::Windows::UI::ViewManagement::ApplicationView const& app_view,
     winrt::Windows::Foundation::IInspectable const&) {
-#ifndef USECOREWINDOW
   if (binding_handler_delegate_) {
     auto bounds = GetBounds(current_display_info_, true);
 
     binding_handler_delegate_->OnWindowSizeChanged(
         static_cast<size_t>(bounds.width), static_cast<size_t>(bounds.height));
+#ifndef USECOREWINDOW
+
     render_target_.Size({bounds.width, bounds.height});
-  }
+
 #endif
+  }
 }
 
 void FlutterWindowWinUWP::OnKeyUp(


### PR DESCRIPTION
This PR improves window resizing on Windows in the following ways:

1. For all cases (win32, UWP CoreWindow, UWP Compositor), rather than destroying and creating a new render surface for each resize step, instead resize the buffers by calling eglPostSubBufferNV which internally calls `ResizeBuffers` on the underlying `SwapChain` which is preferable and far less expensive.
2. This change also fixes UWP resizing for both CoreWindow and Compositor modes.

https://github.com/flutter/flutter/issues/14967
https://github.com/flutter/flutter/issues/70198

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
