### PR TITLE
fix infinite loop in findMinimumFontsForCodeunits

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
@@ -18,7 +18,7 @@ class IntervalTree<T> {
   /// have a range which contains the point.
   factory IntervalTree.createFromRanges(Map<T, List<CodeunitRange>> rangesMap) {
     // Get a list of all the ranges ordered by start index.
-    List<IntervalTreeNode<T>> intervals = <IntervalTreeNode<T>>[];
+    final List<IntervalTreeNode<T>> intervals = <IntervalTreeNode<T>>[];
     rangesMap.forEach((T key, List<CodeunitRange> rangeList) {
       for (CodeunitRange range in rangeList) {
         intervals.add(IntervalTreeNode<T>(key, range.start, range.end));
@@ -92,6 +92,16 @@ class IntervalTreeNode<T> {
   IntervalTreeNode<T>? right;
 
   IntervalTreeNode(this.value, this.low, this.high) : computedHigh = high;
+
+  Iterable<T> enumerateAllElements() sync* {
+    if (left != null) {
+      yield* left!.enumerateAllElements();
+    }
+    yield value;
+    if (right != null) {
+      yield* right!.enumerateAllElements();
+    }
+  }
 
   bool contains(int x) {
     return low <= x && x <= high;

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -714,7 +714,7 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
           missingCodeUnits.add(codeUnits[i]);
         }
       }
-      _findFontsForMissingCodeunits(missingCodeUnits);
+      findFontsForMissingCodeunits(missingCodeUnits);
     }
   }
 


### PR DESCRIPTION
Reset the `maxCodeunitsCovered` and `bestFonts` variables inside the `while` loop. Otherwise they leak previous `for` loop's state to subsequent loops.

Fixes https://github.com/flutter/flutter/issues/75836