### PR TITLE
fix missing CJK and symbol glyphs, font precedence, fallback reset

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 2eb81061582dbe73939811d4471d6167b463f11c
+revision: ec80c8042759905a5215ab1cd87ad280e8ef3cd7

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1643,6 +1643,8 @@ class SkTypeface {}
 class SkFont {
   external SkFont(SkTypeface typeface);
   external Uint8List getGlyphIDs(String text);
+  external void getGlyphBounds(
+      List<int> glyphs, SkPaint? paint, Uint8List? output);
 }
 
 @JS()

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -5,48 +5,106 @@
 // @dart = 2.12
 part of engine;
 
-/// Whether or not "Noto Sans Symbols" and "Noto Color Emoji" fonts have been
-/// downloaded. We download these as fallbacks when no other font covers the
-/// given code units.
-bool _registeredSymbolsAndEmoji = false;
+/// Global static font fallback data.
+class FontFallbackData {
+  static FontFallbackData get instance => _instance;
+  static FontFallbackData _instance = FontFallbackData();
 
-final Set<int> codeUnitsWithNoKnownFont = <int>{};
+  /// Resets the fallback font data.
+  ///
+  /// After calling this method fallback fonts will be loaded from scratch.
+  ///
+  /// Used for tests.
+  static void debugReset() {
+    _instance = FontFallbackData();
+  }
 
-Future<void> findFontsForMissingCodeunits(List<int> codeunits) async {
-  _ensureNotoFontTreeCreated();
+  /// Whether or not "Noto Sans Symbols" and "Noto Color Emoji" fonts have been
+  /// downloaded. We download these as fallbacks when no other font covers the
+  /// given code units.
+  bool registeredSymbolsAndEmoji = false;
+
+  /// Code units that no known font has a glyph for.
+  final Set<int> codeUnitsWithNoKnownFont = <int>{};
+
+  /// Index of all font families by code unit range.
+  final IntervalTree<NotoFont> notoTree = createNotoFontTree();
+
+  static IntervalTree<NotoFont> createNotoFontTree() {
+    Map<NotoFont, List<CodeunitRange>> ranges =
+        <NotoFont, List<CodeunitRange>>{};
+
+    for (NotoFont font in _notoFonts) {
+      // TODO(yjbanov): instead of mutating the font tree during reset, it's
+      //                better to construct an immutable tree of resolved fonts
+      //                pointing back to the original NotoFont objects. Then
+      //                resetting the tree would be a matter of reconstructing
+      //                the new resolved tree.
+      font.reset();
+      for (CodeunitRange range in font.approximateUnicodeRanges) {
+        ranges.putIfAbsent(font, () => <CodeunitRange>[]).add(range);
+      }
+    }
+
+    return IntervalTree<NotoFont>.createFromRanges(ranges);
+  }
+
+
+  /// Fallback fonts which have been registered and loaded.
+  final List<_RegisteredFont> registeredFallbackFonts = <_RegisteredFont>[];
+
+  final List<String> globalFontFallbacks = <String>['Roboto'];
+
+  final Map<String, int> fontFallbackCounts = <String, int>{};
+
+  void registerFallbackFont(String family, Uint8List bytes) {
+    fontFallbackCounts.putIfAbsent(family, () => 0);
+    int fontFallbackTag = fontFallbackCounts[family]!;
+    fontFallbackCounts[family] = fontFallbackCounts[family]! + 1;
+    String countedFamily = '$family $fontFallbackTag';
+    registeredFallbackFonts.add(_RegisteredFont(bytes, countedFamily));
+    globalFontFallbacks.add(countedFamily);
+  }
+}
+
+Future<void> findFontsForMissingCodeunits(List<int> codeUnits) async {
+  final FontFallbackData data = FontFallbackData.instance;
 
   // If all of the code units are known to have no Noto Font which covers them,
   // then just give up. We have already logged a warning.
-  if (codeunits.every((u) => codeUnitsWithNoKnownFont.contains(u))) {
+  if (codeUnits.every((u) => data.codeUnitsWithNoKnownFont.contains(u))) {
     return;
   }
   Set<NotoFont> fonts = <NotoFont>{};
   Set<int> coveredCodeUnits = <int>{};
   Set<int> missingCodeUnits = <int>{};
-  for (int codeunit in codeunits) {
-    List<NotoFont> fontsForUnit = _notoTree!.intersections(codeunit);
+  for (int codeUnit in codeUnits) {
+    List<NotoFont> fontsForUnit = data.notoTree.intersections(codeUnit);
     fonts.addAll(fontsForUnit);
     if (fontsForUnit.isNotEmpty) {
-      coveredCodeUnits.add(codeunit);
+      coveredCodeUnits.add(codeUnit);
     } else {
-      missingCodeUnits.add(codeunit);
+      missingCodeUnits.add(codeUnit);
     }
   }
-
-  fonts = findMinimumFontsForCodeunits(coveredCodeUnits, fonts);
 
   for (NotoFont font in fonts) {
     await font.ensureResolved();
   }
 
+  // The call to `findMinimumFontsForCodeUnits` will remove all code units that
+  // were matched by `fonts` from `unmatchedCodeUnits`.
+  final Set<int> unmatchedCodeUnits = Set<int>.from(coveredCodeUnits);
+  fonts = findMinimumFontsForCodeUnits(unmatchedCodeUnits, fonts);
+
   Set<_ResolvedNotoSubset> resolvedFonts = <_ResolvedNotoSubset>{};
-  for (int codeunit in coveredCodeUnits) {
+  for (int codeUnit in coveredCodeUnits) {
     for (NotoFont font in fonts) {
       if (font.resolvedFont == null) {
         // We failed to resolve the font earlier.
         continue;
       }
-      resolvedFonts.addAll(font.resolvedFont!.tree.intersections(codeunit));
+      resolvedFonts.addAll(font.resolvedFont!.tree.intersections(codeUnit));
     }
   }
 
@@ -54,8 +112,12 @@ Future<void> findFontsForMissingCodeunits(List<int> codeunits) async {
     notoDownloadQueue.add(resolvedFont);
   }
 
-  if (missingCodeUnits.isNotEmpty && !notoDownloadQueue.isPending) {
-    if (!_registeredSymbolsAndEmoji) {
+  // We looked through the Noto font tree and didn't find any font families
+  // covering some code units, or we did find a font family, but when we
+  // downloaded the fonts we found that they actually didn't cover them. So
+  // we try looking them up in the symbols and emojis fonts.
+  if (missingCodeUnits.isNotEmpty || unmatchedCodeUnits.isNotEmpty) {
+    if (!data.registeredSymbolsAndEmoji) {
       _registerSymbolsAndEmoji();
     } else {
       if (!notoDownloadQueue.isPending) {
@@ -63,7 +125,7 @@ Future<void> findFontsForMissingCodeunits(List<int> codeunits) async {
             'Could not find a set of Noto fonts to display all missing '
             'characters. Please add a font asset for the missing characters.'
             ' See: https://flutter.dev/docs/cookbook/design/fonts');
-        codeUnitsWithNoKnownFont.addAll(missingCodeUnits);
+        data.codeUnitsWithNoKnownFont.addAll(missingCodeUnits);
       }
     }
   }
@@ -168,6 +230,11 @@ _ResolvedNotoFont? _makeResolvedNotoFontFromCss(String css, String name) {
     }
   }
 
+  if (rangesMap.isEmpty) {
+    html.window.console.warn('Parsed Google Fonts CSS was empty: $css');
+    return null;
+  }
+
   IntervalTree<_ResolvedNotoSubset> tree =
       IntervalTree<_ResolvedNotoSubset>.createFromRanges(rangesMap);
 
@@ -178,10 +245,11 @@ _ResolvedNotoFont? _makeResolvedNotoFontFromCss(String css, String name) {
 /// try the Symbols and Emoji fonts. We don't know the exact range of code units
 /// that are covered by these fonts, so we download them and hope for the best.
 Future<void> _registerSymbolsAndEmoji() async {
-  if (_registeredSymbolsAndEmoji) {
+  final FontFallbackData data = FontFallbackData.instance;
+  if (data.registeredSymbolsAndEmoji) {
     return;
   }
-  _registeredSymbolsAndEmoji = true;
+  data.registeredSymbolsAndEmoji = true;
   const String symbolsUrl =
       'https://fonts.googleapis.com/css2?family=Noto+Sans+Symbols';
   const String emojiUrl =
@@ -226,45 +294,47 @@ Future<void> _registerSymbolsAndEmoji() async {
   }
 }
 
-/// Finds the minimum set of fonts which covers all of the [codeunits].
+/// Finds the minimum set of fonts which covers all of the [codeUnits].
+///
+/// Removes all code units covered by [fonts] from [codeUnits]. The code
+/// units remaining in the [codeUnits] set after calling this function do not
+/// have a font that covers them and can be omitted next time to avoid
+/// searching for fonts unnecessarily.
 ///
 /// Since set cover is NP-complete, we approximate using a greedy algorithm
-/// which finds the font which covers the most codeunits. If multiple CJK
-/// fonts match the same number of codeunits, we choose one based on the user's
+/// which finds the font which covers the most code units. If multiple CJK
+/// fonts match the same number of code units, we choose one based on the user's
 /// locale.
-Set<NotoFont> findMinimumFontsForCodeunits(
-    Iterable<int> codeunits, Set<NotoFont> fonts) {
-  assert(fonts.isNotEmpty || codeunits.isEmpty);
-  List<int> unmatchedCodeunits = List<int>.from(codeunits);
+Set<NotoFont> findMinimumFontsForCodeUnits(
+    Set<int> codeUnits, Set<NotoFont> fonts) {
+  assert(fonts.isNotEmpty || codeUnits.isEmpty);
   Set<NotoFont> minimumFonts = <NotoFont>{};
   List<NotoFont> bestFonts = <NotoFont>[];
 
   String language = html.window.navigator.language;
 
-  // This is guaranteed to terminate because [codeunits] is a list of fonts
-  // which we've already determined are covered by [fonts].
-  while (unmatchedCodeunits.isNotEmpty) {
-    int maxCodeunitsCovered = 0;
+  while (codeUnits.isNotEmpty) {
+    int maxCodeUnitsCovered = 0;
     bestFonts.clear();
     for (var font in fonts) {
-      int codeunitsCovered = 0;
-      for (int codeunit in unmatchedCodeunits) {
-        if (font.matchesCodeunit(codeunit)) {
-          codeunitsCovered++;
+      int codeUnitsCovered = 0;
+      for (int codeUnit in codeUnits) {
+        if (font.resolvedFont?.tree.containsDeep(codeUnit) == true) {
+          codeUnitsCovered++;
         }
       }
-      if (codeunitsCovered > maxCodeunitsCovered) {
+      if (codeUnitsCovered > maxCodeUnitsCovered) {
         bestFonts.clear();
         bestFonts.add(font);
-        maxCodeunitsCovered = codeunitsCovered;
-      } else if (codeunitsCovered == maxCodeunitsCovered) {
+        maxCodeUnitsCovered = codeUnitsCovered;
+      } else if (codeUnitsCovered == maxCodeUnitsCovered) {
         bestFonts.add(font);
       }
     }
-    assert(
-      bestFonts.isNotEmpty,
-      'Did not find any fonts that cover code units: ${unmatchedCodeunits.join(', ')}',
-    );
+    if (maxCodeUnitsCovered == 0) {
+      // Fonts cannot cover remaining unmatched characters.
+      break;
+    }
     // If the list of best fonts are all CJK fonts, choose the best one based
     // on locale. Otherwise just choose the first font.
     NotoFont bestFont = bestFonts.first;
@@ -294,48 +364,22 @@ Set<NotoFont> findMinimumFontsForCodeunits(
         }
       }
     }
-    unmatchedCodeunits
-        .removeWhere((codeunit) => bestFont.matchesCodeunit(codeunit));
-    minimumFonts.add(bestFont);
+    codeUnits.removeWhere((codeUnit) {
+      return bestFont.resolvedFont!.tree.containsDeep(codeUnit);
+    });
+    minimumFonts.addAll(bestFonts);
   }
   return minimumFonts;
 }
 
-void _ensureNotoFontTreeCreated() {
-  if (_notoTree != null) {
-    return;
-  }
-
-  Map<NotoFont, List<CodeunitRange>> ranges =
-      <NotoFont, List<CodeunitRange>>{};
-
-  for (NotoFont font in _notoFonts) {
-    for (CodeunitRange range in font.unicodeRanges) {
-      ranges.putIfAbsent(font, () => <CodeunitRange>[]).add(range);
-    }
-  }
-
-  _notoTree = IntervalTree<NotoFont>.createFromRanges(ranges);
-}
-
 class NotoFont {
   final String name;
-  final List<CodeunitRange> unicodeRanges;
+  final List<CodeunitRange> approximateUnicodeRanges;
 
   Completer<void>? _decodingCompleter;
-
   _ResolvedNotoFont? resolvedFont;
 
-  NotoFont(this.name, this.unicodeRanges);
-
-  bool matchesCodeunit(int codeunit) {
-    for (CodeunitRange range in unicodeRanges) {
-      if (range.contains(codeunit)) {
-        return true;
-      }
-    }
-    return false;
-  }
+  NotoFont(this.name, this.approximateUnicodeRanges);
 
   String get googleFontsCssUrl =>
       'https://fonts.googleapis.com/css2?family=${name.replaceAll(' ', '+')}';
@@ -354,6 +398,11 @@ class NotoFont {
         await _decodingCompleter!.future;
       }
     }
+  }
+
+  void reset() {
+    resolvedFont = null;
+    _decodingCompleter = null;
   }
 }
 
@@ -505,7 +554,7 @@ List<NotoFont> _notoFonts = <NotoFont>[
     CodeunitRange(2304, 2431),
     CodeunitRange(7376, 7414),
     CodeunitRange(7416, 7417),
-    CodeunitRange(8204, 9205),
+    CodeunitRange(8204, 8205),
     CodeunitRange(8360, 8360),
     CodeunitRange(8377, 8377),
     CodeunitRange(9676, 9676),
@@ -623,48 +672,84 @@ class FallbackFontDownloadQueue {
   NotoDownloader downloader = NotoDownloader();
 
   final Set<_ResolvedNotoSubset> downloadedSubsets = <_ResolvedNotoSubset>{};
-  final Set<_ResolvedNotoSubset> pendingSubsets = <_ResolvedNotoSubset>{};
+  final Map<String, _ResolvedNotoSubset> pendingSubsets = <String, _ResolvedNotoSubset>{};
 
-  bool get isPending => pendingSubsets.isNotEmpty;
+  bool get isPending => pendingSubsets.isNotEmpty || _fontsLoading != null;
+
+  Future<void>? _fontsLoading;
+  bool get debugIsLoadingFonts => _fontsLoading != null;
+
+  Future<void> debugWhenIdle() async {
+    if (assertionsEnabled) {
+      await Future<void>.delayed(Duration.zero);
+      while (isPending) {
+        if (_fontsLoading != null) {
+          await _fontsLoading;
+        }
+        if (pendingSubsets.isNotEmpty) {
+          await Future<void>.delayed(const Duration(milliseconds: 100));
+          if (pendingSubsets.isEmpty) {
+            await Future<void>.delayed(const Duration(milliseconds: 100));
+          }
+        }
+      }
+    } else {
+      throw UnimplementedError();
+    }
+  }
 
   void add(_ResolvedNotoSubset subset) {
-    if (downloadedSubsets.contains(subset) || pendingSubsets.contains(subset)) {
+    if (downloadedSubsets.contains(subset) || pendingSubsets.containsKey(subset.url)) {
       return;
     }
     bool firstInBatch = pendingSubsets.isEmpty;
-    pendingSubsets.add(subset);
+    pendingSubsets[subset.url] = subset;
     if (firstInBatch) {
       Timer.run(startDownloads);
     }
   }
 
   Future<void> startDownloads() async {
-    List<Future<void>> downloads = <Future>[];
-    for (_ResolvedNotoSubset subset in pendingSubsets) {
-      downloads.add(Future<void>(() async {
+    final Map<String, Future<void>> downloads = <String, Future<void>>{};
+    final Map<String, Uint8List> downloadedData = <String, Uint8List>{};
+    for (_ResolvedNotoSubset subset in pendingSubsets.values) {
+      downloads[subset.url] = Future<void>(() async {
         ByteBuffer buffer;
         try {
           buffer = await downloader.downloadAsBytes(subset.url, debugDescription: subset.family);
         } catch (e) {
+          pendingSubsets.remove(subset.url);
           html.window.console
               .warn('Failed to load font ${subset.family} at ${subset.url}');
           html.window.console.warn(e);
           return;
         }
-
-        final Uint8List bytes = buffer.asUint8List();
-        skiaFontCollection.registerFallbackFont(subset.family, bytes);
-
-        pendingSubsets.remove(subset);
         downloadedSubsets.add(subset);
-        if (pendingSubsets.isEmpty) {
-          await skiaFontCollection.ensureFontsLoaded();
-          sendFontChangeMessage();
-        }
-      }));
+        downloadedData[subset.url] = buffer.asUint8List();
+      });
     }
 
-    await Future.wait<void>(downloads);
+    await Future.wait<void>(downloads.values);
+
+    // Register fallback fonts in a predictable order. Otherwise, the fonts
+    // change their precedence depending on the download order causing
+    // visual differences between app reloads.
+    final List<String> downloadOrder = (downloadedData.keys.toList()..sort()).reversed.toList();
+    for (String url in downloadOrder) {
+      final _ResolvedNotoSubset subset = pendingSubsets.remove(url)!;
+      final Uint8List bytes = downloadedData[url]!;
+      FontFallbackData.instance.registerFallbackFont(subset.family, bytes);
+      if (pendingSubsets.isEmpty) {
+        _fontsLoading = skiaFontCollection.ensureFontsLoaded();
+        try {
+          await _fontsLoading;
+        } finally {
+          _fontsLoading = null;
+        }
+        sendFontChangeMessage();
+      }
+    }
+
     if (pendingSubsets.isNotEmpty) {
       await startDownloads();
     }
@@ -672,6 +757,7 @@ class FallbackFontDownloadQueue {
 }
 
 class NotoDownloader {
+  int get debugActiveDownloadCount => _debugActiveDownloadCount;
   int _debugActiveDownloadCount = 0;
 
   /// Returns a future that resolves when there are no pending downloads.
@@ -733,15 +819,6 @@ class NotoDownloader {
     }
     return result;
   }
-}
-
-/// The Noto font interval tree.
-IntervalTree<NotoFont>? _notoTree;
-
-/// Returns the tree of Noto fonts for tests.
-IntervalTree<NotoFont> get debugNotoTree {
-  _ensureNotoFontTreeCreated();
-  return _notoTree!;
 }
 
 FallbackFontDownloadQueue notoDownloadQueue = FallbackFontDownloadQueue();

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -27,6 +27,9 @@ class FontFallbackData {
   /// Code units that no known font has a glyph for.
   final Set<int> codeUnitsWithNoKnownFont = <int>{};
 
+  /// Code units which are known to be covered by at least one fallback font.
+  final Set<int> knownCoveredCodeUnits = <int>{};
+
   /// Index of all font families by code unit range.
   final IntervalTree<NotoFont> notoTree = createNotoFontTree();
 
@@ -48,7 +51,6 @@ class FontFallbackData {
 
     return IntervalTree<NotoFont>.createFromRanges(ranges);
   }
-
 
   /// Fallback fonts which have been registered and loaded.
   final List<_RegisteredFont> registeredFallbackFonts = <_RegisteredFont>[];
@@ -672,7 +674,8 @@ class FallbackFontDownloadQueue {
   NotoDownloader downloader = NotoDownloader();
 
   final Set<_ResolvedNotoSubset> downloadedSubsets = <_ResolvedNotoSubset>{};
-  final Map<String, _ResolvedNotoSubset> pendingSubsets = <String, _ResolvedNotoSubset>{};
+  final Map<String, _ResolvedNotoSubset> pendingSubsets =
+      <String, _ResolvedNotoSubset>{};
 
   bool get isPending => pendingSubsets.isNotEmpty || _fontsLoading != null;
 
@@ -699,7 +702,8 @@ class FallbackFontDownloadQueue {
   }
 
   void add(_ResolvedNotoSubset subset) {
-    if (downloadedSubsets.contains(subset) || pendingSubsets.containsKey(subset.url)) {
+    if (downloadedSubsets.contains(subset) ||
+        pendingSubsets.containsKey(subset.url)) {
       return;
     }
     bool firstInBatch = pendingSubsets.isEmpty;
@@ -716,7 +720,8 @@ class FallbackFontDownloadQueue {
       downloads[subset.url] = Future<void>(() async {
         ByteBuffer buffer;
         try {
-          buffer = await downloader.downloadAsBytes(subset.url, debugDescription: subset.family);
+          buffer = await downloader.downloadAsBytes(subset.url,
+              debugDescription: subset.family);
         } catch (e) {
           pendingSubsets.remove(subset.url);
           html.window.console
@@ -734,7 +739,8 @@ class FallbackFontDownloadQueue {
     // Register fallback fonts in a predictable order. Otherwise, the fonts
     // change their precedence depending on the download order causing
     // visual differences between app reloads.
-    final List<String> downloadOrder = (downloadedData.keys.toList()..sort()).reversed.toList();
+    final List<String> downloadOrder =
+        (downloadedData.keys.toList()..sort()).reversed.toList();
     for (String url in downloadOrder) {
       final _ResolvedNotoSubset subset = pendingSubsets.remove(url)!;
       final Uint8List bytes = downloadedData[url]!;

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -177,5 +177,9 @@ class _RegisteredFont {
 
   _RegisteredFont(this.bytes, this.family)
       : this.typeface =
-            canvasKit.FontMgr.RefDefault().MakeTypefaceFromData(bytes);
+            canvasKit.FontMgr.RefDefault().MakeTypefaceFromData(bytes) {
+    // This is a hack which causes Skia to cache the decoded font.
+    SkFont skFont = SkFont(typeface);
+    skFont.getGlyphBounds([0], null, null);
+  }
 }

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -22,15 +22,8 @@ class SkiaFontCollection {
   /// Fonts which have been registered and loaded.
   final List<_RegisteredFont> _registeredFonts = <_RegisteredFont>[];
 
-  /// Fallback fonts which have been registered and loaded.
-  final List<_RegisteredFont> _registeredFallbackFonts = <_RegisteredFont>[];
-
   final Map<String, List<SkTypeface>> familyToTypefaceMap =
       <String, List<SkTypeface>>{};
-
-  final List<String> globalFontFallbacks = <String>['Roboto'];
-
-  final Map<String, int> _fontFallbackCounts = <String, int>{};
 
   Future<void> ensureFontsLoaded() async {
     await _loadFonts();
@@ -49,7 +42,7 @@ class SkiaFontCollection {
           .add(font.typeface);
     }
 
-    for (var font in _registeredFallbackFonts) {
+    for (var font in FontFallbackData.instance.registeredFallbackFonts) {
       fontProvider!.registerFont(font.bytes, font.family);
       familyToTypefaceMap
           .putIfAbsent(font.family, () => <SkTypeface>[])
@@ -151,15 +144,6 @@ class SkiaFontCollection {
     return _RegisteredFont(bytes, family);
   }
 
-  void registerFallbackFont(String family, Uint8List bytes) {
-    _fontFallbackCounts.putIfAbsent(family, () => 0);
-    int fontFallbackTag = _fontFallbackCounts[family]!;
-    _fontFallbackCounts[family] = _fontFallbackCounts[family]! + 1;
-    String countedFamily = '$family $fontFallbackTag';
-    _registeredFallbackFonts.add(_RegisteredFont(bytes, countedFamily));
-    globalFontFallbacks.add(countedFamily);
-  }
-
   String? _readActualFamilyName(Uint8List bytes) {
     final SkFontMgr tmpFontMgr = canvasKit.FontMgr.FromData([bytes])!;
     String? actualFamily = tmpFontMgr.getFamilyName(0);
@@ -172,14 +156,6 @@ class SkiaFontCollection {
     return fetchResult
         .arrayBuffer()
         .then<ByteBuffer>((dynamic x) => x as ByteBuffer);
-  }
-
-  /// Resets the fallback fonts. Used for tests.
-  void debugResetFallbackFonts() {
-    _registeredFallbackFonts.clear();
-    globalFontFallbacks.clear();
-    globalFontFallbacks.add('Roboto');
-    _fontFallbackCounts.clear();
   }
 
   SkFontMgr? skFontMgr;

--- a/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
@@ -17,6 +17,7 @@ class IntervalTree<T> {
   /// When the interval tree is queried, it will return a list of [T]s which
   /// have a range which contains the point.
   factory IntervalTree.createFromRanges(Map<T, List<CodeunitRange>> rangesMap) {
+    assert(rangesMap.isNotEmpty);
     // Get a list of all the ranges ordered by start index.
     final List<IntervalTreeNode<T>> intervals = <IntervalTreeNode<T>>[];
     rangesMap.forEach((T key, List<CodeunitRange> rangeList) {
@@ -24,6 +25,7 @@ class IntervalTree<T> {
         intervals.add(IntervalTreeNode<T>(key, range.start, range.end));
       }
     });
+    assert(intervals.isNotEmpty);
 
     intervals
         .sort((IntervalTreeNode<T> a, IntervalTreeNode<T> b) => a.low - b.low);
@@ -80,6 +82,11 @@ class IntervalTree<T> {
     root.searchForPoint(x, results);
     return results;
   }
+
+  /// Whether this tree contains at least one interval that includes [x].
+  bool containsDeep(int x) {
+    return root.containsDeep(x);
+  }
 }
 
 class IntervalTreeNode<T> {
@@ -103,8 +110,33 @@ class IntervalTreeNode<T> {
     }
   }
 
-  bool contains(int x) {
+  /// Whether this node contains [x].
+  ///
+  /// Does not recursively check whether child nodes contain [x].
+  bool containsShallow(int x) {
     return low <= x && x <= high;
+  }
+
+  /// Whether this sub-tree contains [x].
+  ///
+  /// Recursively checks whether child nodes contain [x].
+  bool containsDeep(int x) {
+    if (x > computedHigh) {
+      // x is above the highest possible value stored in this subtree.
+      // Don't bother checking intervals.
+      return false;
+    }
+    if (this.containsShallow(x)) {
+      return true;
+    }
+    if (left?.containsDeep(x) == true) {
+      return true;
+    }
+    if (x < low) {
+      // The right tree can't possible contain x. Don't bother checking.
+      return false;
+    }
+    return right?.containsDeep(x) == true;
   }
 
   // Searches the tree rooted at this node for all T containing [x].
@@ -113,7 +145,7 @@ class IntervalTreeNode<T> {
       return;
     }
     left?.searchForPoint(x, result);
-    if (this.contains(x)) {
+    if (this.containsShallow(x)) {
       result.add(value);
     }
     if (x < low) {

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -675,6 +675,26 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
     // TODO(hterkelsen): Make this faster for the common case where the text
     // is supported by the given fonts.
 
+    // A list of unique code units in the text.
+    final List<int> codeUnits = text.runes.toSet().toList();
+
+    // First, check if every code unit in the text is known to be covered by one
+    // of our global fallback fonts. We cache the set of code units covered by
+    // the global fallback fonts since this set is growing monotonically over
+    // the lifetime of the app.
+    if (_checkIfGlobalFallbacksSupport(codeUnits)) {
+      return;
+    }
+
+    // Next, check if all of the remaining code units are ones which are known
+    // to have no global font fallback. This means we know of no font we can
+    // download which will cover the remaining code units. In this case we can
+    // just skip the checks below, since we know there's nothing we can do to
+    // cover the code units.
+    if (_checkIfNoFallbackFontSupports(codeUnits)) {
+      return;
+    }
+
     // If the text is ASCII, then skip this check.
     bool isAscii = true;
     for (int i = 0; i < text.length; i++) {
@@ -686,8 +706,15 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
     if (isAscii) {
       return;
     }
+
     CkTextStyle style = _peekStyle();
-    List<String> fontFamilies = style.effectiveFontFamilies;
+    List<String> fontFamilies = <String>[];
+    if (style.fontFamily != null) {
+      fontFamilies.add(style.fontFamily!);
+    }
+    if (style.fontFamilyFallback != null) {
+      fontFamilies.addAll(style.fontFamilyFallback!);
+    }
     List<SkTypeface> typefaces = <SkTypeface>[];
     for (var font in fontFamilies) {
       List<SkTypeface>? typefacesForFamily =
@@ -696,11 +723,11 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
         typefaces.addAll(typefacesForFamily);
       }
     }
-    List<int> codeUnits = text.runes.toList();
     List<bool> codeUnitsSupported = List<bool>.filled(codeUnits.length, false);
+    String testString = String.fromCharCodes(codeUnits);
     for (SkTypeface typeface in typefaces) {
       SkFont font = SkFont(typeface);
-      Uint8List glyphs = font.getGlyphIDs(text);
+      Uint8List glyphs = font.getGlyphIDs(testString);
       assert(glyphs.length == codeUnitsSupported.length);
       for (int i = 0; i < glyphs.length; i++) {
         codeUnitsSupported[i] |= glyphs[i] != 0 || _isControlCode(codeUnits[i]);
@@ -721,6 +748,89 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
   /// Returns [true] if [codepoint] is a Unicode control code.
   bool _isControlCode(int codepoint) {
     return codepoint < 32 || (codepoint > 127 && codepoint < 160);
+  }
+
+  /// Returns `true` if every code unit in [codeUnits] is covered by a global
+  /// fallback font.
+  ///
+  /// Calling this method has 2 side effects:
+  ///   1. Updating the cache of known covered code units in the
+  ///      [FontFallbackData] instance.
+  ///   2. Removing known covered code units from [codeUnits]. When the list
+  ///      is used again in [_ensureFontsSupportText]
+  bool _checkIfGlobalFallbacksSupport(List<int> codeUnits) {
+    final FontFallbackData fallbackData = FontFallbackData.instance;
+    codeUnits.removeWhere((int codeUnit) =>
+        fallbackData.knownCoveredCodeUnits.contains(codeUnit));
+    if (codeUnits.isEmpty) {
+      return true;
+    }
+
+    // We don't know if the remaining code units are covered by our fallback
+    // fonts. Check them and update the cache.
+    List<bool> codeUnitsSupported = List<bool>.filled(codeUnits.length, false);
+    String testString = String.fromCharCodes(codeUnits);
+
+    for (String font in fallbackData.globalFontFallbacks) {
+      List<SkTypeface>? typefacesForFamily =
+          skiaFontCollection.familyToTypefaceMap[font];
+      if (typefacesForFamily == null) {
+        html.window.console.warn('A fallback font was registered but we '
+            'cannot retrieve the typeface for it.');
+        continue;
+      }
+      for (SkTypeface typeface in typefacesForFamily) {
+        SkFont font = SkFont(typeface);
+        Uint8List glyphs = font.getGlyphIDs(testString);
+        assert(glyphs.length == codeUnitsSupported.length);
+        for (int i = 0; i < glyphs.length; i++) {
+          bool codeUnitSupported = glyphs[i] != 0;
+          if (codeUnitSupported) {
+            fallbackData.knownCoveredCodeUnits.add(codeUnits[i]);
+          }
+          codeUnitsSupported[i] |=
+              codeUnitSupported || _isControlCode(codeUnits[i]);
+        }
+      }
+
+      // Once we've checked every typeface for this family, check to see if
+      // every code unit has been covered in order to avoid unnecessary checks.
+      bool keepGoing = false;
+      for (bool supported in codeUnitsSupported) {
+        if (!supported) {
+          keepGoing = true;
+          break;
+        }
+      }
+
+      if (!keepGoing) {
+        // Every code unit is supported, clear [codeUnits] and return `true`.
+        codeUnits.clear();
+        return true;
+      }
+    }
+
+    // If we reached here, then there are some code units which aren't covered
+    // by the global fallback fonts. Remove the ones which were covered and
+    // return false.
+    for (int i = codeUnits.length - 1; i >= 0; i--) {
+      if (codeUnitsSupported[i]) {
+        codeUnits.removeAt(i);
+      }
+    }
+    return false;
+  }
+
+  /// Returns `true` if every code unit in [codeUnits] is known to not have any
+  /// fallback font which can cover it.
+  ///
+  /// This method has a side effect of removing every code unit from [codeUnits]
+  /// which is known not to have a fallback font which covers it.
+  bool _checkIfNoFallbackFontSupports(List<int> codeUnits) {
+    final FontFallbackData fallbackData = FontFallbackData.instance;
+    codeUnits.removeWhere((int codeUnit) =>
+        fallbackData.codeUnitsWithNoKnownFont.contains(codeUnit));
+    return codeUnits.isEmpty;
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -869,6 +869,6 @@ List<String> _getEffectiveFontFamilies(String? fontFamily,
       !fontFamilyFallback.every((font) => fontFamily == font)) {
     fontFamilies.addAll(fontFamilyFallback);
   }
-  fontFamilies.addAll(skiaFontCollection.globalFontFallbacks);
+  fontFamilies.addAll(FontFallbackData.instance.globalFontFallbacks);
   return fontFamilies;
 }

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -35,6 +35,16 @@ void testMain() {
   group('CkCanvas', () {
     setUpCanvasKitTest();
 
+    setUp(() {
+      expect(notoDownloadQueue.downloader.debugActiveDownloadCount, 0);
+      expect(notoDownloadQueue.isPending, false);
+    });
+
+    tearDown(() {
+      expect(notoDownloadQueue.downloader.debugActiveDownloadCount, 0);
+      expect(notoDownloadQueue.isPending, false);
+    });
+
     test('renders using non-recording canvas if weak refs are supported',
         () async {
       expect(browserSupportsFinalizationRegistry, isTrue,
@@ -416,9 +426,6 @@ void testMain() {
     });
 
     test('text styles - old style figures', () async {
-      // TODO(yjbanov): we should not need to reset the fallbacks, see
-      //                https://github.com/flutter/flutter/issues/74741
-      skiaFontCollection.debugResetFallbackFonts();
       await testTextStyle(
         'old style figures',
         paragraphFontFamily: 'Roboto',
@@ -430,9 +437,6 @@ void testMain() {
     });
 
     test('text styles - stylistic set 1', () async {
-      // TODO(yjbanov): we should not need to reset the fallbacks, see
-      //                https://github.com/flutter/flutter/issues/74741
-      skiaFontCollection.debugResetFallbackFonts();
       await testTextStyle(
         'stylistic set 1',
         paragraphFontFamily: 'Roboto',
@@ -444,9 +448,6 @@ void testMain() {
     });
 
     test('text styles - stylistic set 2', () async {
-      // TODO(yjbanov): we should not need to reset the fallbacks, see
-      //                https://github.com/flutter/flutter/issues/74741
-      skiaFontCollection.debugResetFallbackFonts();
       await testTextStyle(
         'stylistic set 2',
         paragraphFontFamily: 'Roboto',
@@ -490,6 +491,29 @@ void testMain() {
         'override font style',
         paragraphFontStyle: ui.FontStyle.italic,
         fontStyle: ui.FontStyle.normal,
+      );
+    });
+
+    test('text style - characters from multiple fallback fonts', () async {
+      await testTextStyle(
+        'multi-font characters',
+        // This character is claimed by multiple fonts. This test makes sure
+        // we can find a font supporting it.
+        outerText: '欢',
+        innerText: '',
+      );
+    });
+
+    test('text style - symbols', () async {
+      // One of the CJK fonts loaded in one of the tests above also contains
+      // some of these symbols. To make sure the test produces predictable
+      // results we reset the fallback data forcing the engine to reload
+      // fallbacks, which for this test will only load Noto Symbols.
+      FontFallbackData.debugReset();
+      await testTextStyle(
+        'symbols',
+        outerText: '← ↑ → ↓ ',
+        innerText: '',
       );
     });
 
@@ -580,9 +604,144 @@ void testMain() {
         region: ui.Rect.fromLTRB(0, 0, testWidth, 850),
       );
     });
+
+    test('sample Chinese text', () async {
+      await testSampleText(
+        'chinese',
+        '也称乱数假文或者哑元文本， '
+        '是印刷及排版领域所常用的虚拟文字。'
+        '由于曾经一台匿名的打印机刻意打乱了'
+        '一盒印刷字体从而造出一本字体样品书',
+      );
+    });
+
+    test('sample Armenian text', () async {
+      await testSampleText(
+        'armenian',
+        'տպագրության և տպագրական արդյունաբերության համար նախատեսված մոդելային տեքստ է',
+      );
+    });
+
+    test('sample Albanian text', () async {
+      await testSampleText(
+        'albanian',
+        'është një tekst shabllon i industrisë së printimit dhe shtypshkronjave Lorem Ipsum ka qenë teksti shabllon',
+      );
+    });
+
+    test('sample Arabic text', () async {
+      await testSampleText(
+        'arabic',
+        'هناك حقيقة مثبتة منذ زمن طويل وهي أن المحتوى المقروء لصفحة ما سيلهي',
+        textDirection: ui.TextDirection.rtl,
+      );
+    });
+
+    test('sample Bulgarian text', () async {
+      await testSampleText(
+        'bulgarian',
+        'е елементарен примерен текст използван в печатарската и типографската индустрия',
+      );
+    });
+
+    test('sample Catalan text', () async {
+      await testSampleText(
+        'catalan',
+        'és un text de farciment usat per la indústria de la tipografia i la impremta',
+      );
+    });
+
+    test('sample English text', () async {
+      await testSampleText(
+        'english',
+        'Lorem Ipsum is simply dummy text of the printing and typesetting industry',
+      );
+    });
+
+    test('sample Greek text', () async {
+      await testSampleText(
+        'greek',
+        'είναι απλά ένα κείμενο χωρίς νόημα για τους επαγγελματίες της τυπογραφίας και στοιχειοθεσίας',
+      );
+    });
+
+    test('sample Hebrew text', () async {
+      await testSampleText(
+        'hebrew',
+        'זוהי עובדה מבוססת שדעתו של הקורא תהיה מוסחת על ידי טקטס קריא כאשר הוא יביט בפריסתו',
+        textDirection: ui.TextDirection.rtl,
+      );
+    });
+
+    test('sample Hindi text', () async {
+      await testSampleText(
+        'hindi',
+        'छपाई और अक्षर योजन उद्योग का एक साधारण डमी पाठ है सन १५०० के बाद से अभी तक इस उद्योग का मानक डमी पाठ मन गया जब एक अज्ञात मुद्रक ने नमूना लेकर एक नमूना किताब बनाई',
+      );
+    });
+
+    test('sample Thai text', () async {
+      await testSampleText(
+        'thai',
+        'คือ เนื้อหาจำลองแบบเรียบๆ ที่ใช้กันในธุรกิจงานพิมพ์หรืองานเรียงพิมพ์ มันได้กลายมาเป็นเนื้อหาจำลองมาตรฐานของธุรกิจดังกล่าวมาตั้งแต่ศตวรรษที่',
+      );
+    });
+
+    test('sample Georgian text', () async {
+      await testSampleText(
+        'georgian',
+        'საბეჭდი და ტიპოგრაფიული ინდუსტრიის უშინაარსო ტექსტია. იგი სტანდარტად',
+      );
+    });
+
+    // We've seen text break when we load many fonts simultaneously. This test
+    // combines text in multiple languages into one long paragraph to make sure
+    // we can handle it.
+    test('sample multilingual text', () async {
+      await testSampleText(
+        'multilingual',
+        '也称乱数假文或者哑元文本， 是印刷及排版领域所常用的虚拟文字。 '
+        'տպագրության և տպագրական արդյունաբերության համար '
+        'është një tekst shabllon i industrisë së printimit '
+        ' زمن طويل وهي أن المحتوى المقروء لصفحة ما سيلهي '
+        'е елементарен примерен текст използван в печатарската '
+        'és un text de farciment usat per la indústria de la '
+        'Lorem Ipsum is simply dummy text of the printing '
+        'είναι απλά ένα κείμενο χωρίς νόημα για τους επαγγελματίες '
+        ' זוהי עובדה מבוססת שדעתו של הקורא תהיה מוסחת על ידי טקטס קריא '
+        'छपाई और अक्षर योजन उद्योग का एक साधारण डमी पाठ है सन '
+        'คือ เนื้อหาจำลองแบบเรียบๆ ที่ใช้กันในธุรกิจงานพิมพ์หรืองานเรียงพิมพ์ '
+        'საბეჭდი და ტიპოგრაფიული ინდუსტრიის უშინაარსო ტექსტია ',
+      );
+    });
     // TODO: https://github.com/flutter/flutter/issues/60040
     // TODO: https://github.com/flutter/flutter/issues/71520
   }, skip: isIosSafari || isFirefox);
+}
+
+Future<void> testSampleText(String language, String text, { ui.TextDirection textDirection = ui.TextDirection.ltr, bool write = false }) async {
+  FontFallbackData.debugReset();
+  const double testWidth = 300;
+  double paragraphHeight = 0;
+  final CkPicture picture = await generatePictureWhenFontsStable(() {
+    final CkPictureRecorder recorder = CkPictureRecorder();
+    final CkCanvas canvas = recorder.beginRecording(ui.Rect.largest);
+    final CkParagraphBuilder paragraphBuilder = CkParagraphBuilder(CkParagraphStyle(
+      textDirection: textDirection,
+    ));
+    paragraphBuilder.addText(text);
+    final CkParagraph paragraph = paragraphBuilder.build();
+    paragraph.layout(ui.ParagraphConstraints(width: testWidth - 20));
+    canvas.drawParagraph(paragraph, const ui.Offset(10, 10));
+    paragraphHeight = paragraph.height;
+    return recorder.endRecording();
+  });
+  await matchPictureGolden(
+    'canvaskit_sample_text_$language.png',
+    picture,
+    region: ui.Rect.fromLTRB(0, 0, testWidth, paragraphHeight + 20),
+    write: write,
+  );
 }
 
 typedef ParagraphFactory = CkParagraph Function();
@@ -1067,15 +1226,30 @@ Future<void> testTextStyle(
   }
 
   // Render once to trigger font downloads.
-  renderPicture();
-  // Wait for fonts to finish loading.
-  await notoDownloadQueue.downloader.debugWhenIdle();
-  // Render again for actual screenshotting.
-  final CkPicture picture = renderPicture();
+  CkPicture picture = await generatePictureWhenFontsStable(renderPicture);
   await matchPictureGolden(
     'canvaskit_text_styles_${name.replaceAll(' ', '_')}.png',
     picture,
     region: region,
     write: write,
   );
+  expect(notoDownloadQueue.debugIsLoadingFonts, isFalse);
+  expect(notoDownloadQueue.pendingSubsets, isEmpty);
+  expect(notoDownloadQueue.downloader.debugActiveDownloadCount, 0);
+}
+
+typedef PictureGenerator = CkPicture Function();
+
+Future<CkPicture> generatePictureWhenFontsStable(PictureGenerator generator) async {
+  CkPicture picture = generator();
+  // Font downloading begins asynchronously so we inject a timer before checking the download queue.
+  await Future<void>.delayed(Duration.zero);
+  while (notoDownloadQueue.isPending || notoDownloadQueue.downloader.debugActiveDownloadCount > 0) {
+    await notoDownloadQueue.debugWhenIdle();
+    await notoDownloadQueue.downloader.debugWhenIdle();
+    picture = generator();
+    // Dummy timer for the same reason as above.
+    await Future<void>.delayed(Duration.zero);
+  }
+  return picture;
 }


### PR DESCRIPTION
- The missing CJK glyphs happened because we failed to download the font as the Noto tree is a superset of glyphs supported by actual fonts. This PR filters out fonts based on actual glyphs they support.
- The missing symbol glyphs were due to a simple typo in one of the code unit ranges.
- Unpredictable font precedence issue was due to us registering font fallbacks in order they are downloaded, which is usually random. This PR sorts fonts by URL. It is not clear if prioritizing by URL is the best strategy, but it should be better than random.
- Fallback reset wasn't resetting everything it should. This PR fixes that too.

Partially fixes https://github.com/flutter/flutter/issues/73628. This still needs @hterkelsen's CanvasKit 0.23 PR to reland.
