### PR TITLE
Revert "[Android Text Input] Remove Samsung restart input workaround for newer Samsung keyboards"

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -6,7 +6,6 @@ package io.flutter.plugin.editing;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
@@ -500,27 +499,7 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
             mView.getContext().getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
     // The Samsung keyboard is called "com.sec.android.inputmethod/.SamsungKeypad" but look
     // for "Samsung" just in case Samsung changes the name of the keyboard.
-    if (!keyboardName.contains("Samsung")) {
-      return false;
-    }
-
-    final long versionCode;
-    try {
-      versionCode =
-          mView
-              .getContext()
-              .getPackageManager()
-              .getPackageInfo("com.sec.android.inputmethod", 0)
-              .getLongVersionCode();
-    } catch (PackageManager.NameNotFoundException e) {
-      Log.w(TAG, "com.sec.android.inputmethod is not installed.");
-      return false;
-    }
-
-    // 3.3.23.33 is a known version that's free of the aforementioned bug.
-    // 3.0.24.96 still has this bug.
-    // TODO(LongCatIsLooong): Find the minimum version that has the fix.
-    return versionCode < 332333999;
+    return keyboardName.contains("Samsung");
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Reverts flutter/engine#24288 as per https://github.com/flutter/engine/pull/24288#discussion_r578625557.