### PR TITLE
iOS: Started initializing the gpu disable sync switch based on the app state.

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -139,7 +139,8 @@ std::unique_ptr<Shell> Shell::Create(
     TaskRunners task_runners,
     Settings settings,
     const Shell::CreateCallback<PlatformView>& on_create_platform_view,
-    const Shell::CreateCallback<Rasterizer>& on_create_rasterizer) {
+    const Shell::CreateCallback<Rasterizer>& on_create_rasterizer,
+    bool is_gpu_disabled) {
   // This must come first as it initializes tracing.
   PerformInitializationTasks(settings);
 
@@ -165,7 +166,7 @@ std::unique_ptr<Shell> Shell::Create(
                             std::move(isolate_snapshot),         //
                             std::move(on_create_platform_view),  //
                             std::move(on_create_rasterizer),     //
-                            CreateEngine);
+                            CreateEngine, is_gpu_disabled);
 }
 
 std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
@@ -176,7 +177,8 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
     fml::RefPtr<const DartSnapshot> isolate_snapshot,
     const Shell::CreateCallback<PlatformView>& on_create_platform_view,
     const Shell::CreateCallback<Rasterizer>& on_create_rasterizer,
-    const Shell::EngineCreateCallback& on_create_engine) {
+    const Shell::EngineCreateCallback& on_create_engine,
+    bool is_gpu_disabled) {
   if (!task_runners.IsValid()) {
     FML_LOG(ERROR) << "Task runners to run the shell were invalid.";
     return nullptr;
@@ -186,7 +188,8 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
       new Shell(std::move(vm), task_runners, settings,
                 std::make_shared<VolatilePathTracker>(
                     task_runners.GetUITaskRunner(),
-                    !settings.skia_deterministic_rendering_on_cpu)));
+                    !settings.skia_deterministic_rendering_on_cpu),
+                is_gpu_disabled));
 
   // Create the rasterizer on the raster thread.
   std::promise<std::unique_ptr<Rasterizer>> rasterizer_promise;
@@ -315,7 +318,8 @@ std::unique_ptr<Shell> Shell::CreateWithSnapshot(
     fml::RefPtr<const DartSnapshot> isolate_snapshot,
     const Shell::CreateCallback<PlatformView>& on_create_platform_view,
     const Shell::CreateCallback<Rasterizer>& on_create_rasterizer,
-    const Shell::EngineCreateCallback& on_create_engine) {
+    const Shell::EngineCreateCallback& on_create_engine,
+    bool is_gpu_disabled) {
   // This must come first as it initializes tracing.
   PerformInitializationTasks(settings);
 
@@ -341,7 +345,8 @@ std::unique_ptr<Shell> Shell::CreateWithSnapshot(
            isolate_snapshot = std::move(isolate_snapshot),                //
            on_create_platform_view = std::move(on_create_platform_view),  //
            on_create_rasterizer = std::move(on_create_rasterizer),        //
-           on_create_engine = std::move(on_create_engine)]() mutable {
+           on_create_engine = std::move(on_create_engine),
+           is_gpu_disabled]() mutable {
             shell = CreateShellOnPlatformThread(
                 std::move(vm),                       //
                 std::move(task_runners),             //
@@ -350,7 +355,7 @@ std::unique_ptr<Shell> Shell::CreateWithSnapshot(
                 std::move(isolate_snapshot),         //
                 std::move(on_create_platform_view),  //
                 std::move(on_create_rasterizer),     //
-                std::move(on_create_engine));
+                std::move(on_create_engine), is_gpu_disabled);
             latch.Signal();
           }));
   latch.Wait();
@@ -360,11 +365,12 @@ std::unique_ptr<Shell> Shell::CreateWithSnapshot(
 Shell::Shell(DartVMRef vm,
              TaskRunners task_runners,
              Settings settings,
-             std::shared_ptr<VolatilePathTracker> volatile_path_tracker)
+             std::shared_ptr<VolatilePathTracker> volatile_path_tracker,
+             bool is_gpu_disabled)
     : task_runners_(std::move(task_runners)),
       settings_(std::move(settings)),
       vm_(std::move(vm)),
-      is_gpu_disabled_sync_switch_(new fml::SyncSwitch()),
+      is_gpu_disabled_sync_switch_(new fml::SyncSwitch(is_gpu_disabled)),
       volatile_path_tracker_(std::move(volatile_path_tracker)),
       weak_factory_gpu_(nullptr),
       weak_factory_(this) {
@@ -481,25 +487,34 @@ std::unique_ptr<Shell> Shell::Spawn(
     const CreateCallback<PlatformView>& on_create_platform_view,
     const CreateCallback<Rasterizer>& on_create_rasterizer) const {
   FML_DCHECK(task_runners_.IsValid());
-  std::unique_ptr<Shell> result(CreateWithSnapshot(
-      PlatformData{}, task_runners_, GetSettings(), vm_,
-      vm_->GetVMData()->GetIsolateSnapshot(), on_create_platform_view,
-      on_create_rasterizer,
-      [engine = this->engine_.get()](
-          Engine::Delegate& delegate,
-          const PointerDataDispatcherMaker& dispatcher_maker, DartVM& vm,
-          fml::RefPtr<const DartSnapshot> isolate_snapshot,
-          TaskRunners task_runners, const PlatformData& platform_data,
-          Settings settings, std::unique_ptr<Animator> animator,
-          fml::WeakPtr<IOManager> io_manager,
-          fml::RefPtr<SkiaUnrefQueue> unref_queue,
-          fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-          std::shared_ptr<VolatilePathTracker> volatile_path_tracker) {
-        return engine->Spawn(/*delegate=*/delegate,
-                             /*dispatcher_maker=*/dispatcher_maker,
-                             /*settings=*/settings,
-                             /*animator=*/std::move(animator));
-      }));
+  auto shell_maker = [&](bool is_gpu_disabled) {
+    std::unique_ptr<Shell> result(CreateWithSnapshot(
+        PlatformData{}, task_runners_, GetSettings(), vm_,
+        vm_->GetVMData()->GetIsolateSnapshot(), on_create_platform_view,
+        on_create_rasterizer,
+        [engine = this->engine_.get()](
+            Engine::Delegate& delegate,
+            const PointerDataDispatcherMaker& dispatcher_maker, DartVM& vm,
+            fml::RefPtr<const DartSnapshot> isolate_snapshot,
+            TaskRunners task_runners, const PlatformData& platform_data,
+            Settings settings, std::unique_ptr<Animator> animator,
+            fml::WeakPtr<IOManager> io_manager,
+            fml::RefPtr<SkiaUnrefQueue> unref_queue,
+            fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+            std::shared_ptr<VolatilePathTracker> volatile_path_tracker) {
+          return engine->Spawn(/*delegate=*/delegate,
+                               /*dispatcher_maker=*/dispatcher_maker,
+                               /*settings=*/settings,
+                               /*animator=*/std::move(animator));
+        },
+        is_gpu_disabled));
+    return result;
+  };
+  std::unique_ptr<Shell> result;
+  GetIsGpuDisabledSyncSwitch()->Execute(
+      fml::SyncSwitch::Handlers()
+          .SetIfFalse([&] { result = shell_maker(false); })
+          .SetIfTrue([&] { result = shell_maker(true); }));
   result->shared_resource_context_ = io_manager_->GetSharedResourceContext();
   result->RunEngine(std::move(run_configuration));
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -134,6 +134,8 @@ class Shell final : public PlatformView::Delegate,
   ///                                      valid rasterizer. This will be called
   ///                                      on the render task runner before this
   ///                                      method returns.
+  /// @param[in]  is_gpu_disabled          The default value for the switch that
+  ///                                      turns off the GPU.
   ///
   /// @return     A full initialized shell if the settings and callbacks are
   ///             valid. The root isolate has been created but not yet launched.
@@ -148,7 +150,8 @@ class Shell final : public PlatformView::Delegate,
       TaskRunners task_runners,
       Settings settings,
       const CreateCallback<PlatformView>& on_create_platform_view,
-      const CreateCallback<Rasterizer>& on_create_rasterizer);
+      const CreateCallback<Rasterizer>& on_create_rasterizer,
+      bool is_gpu_disabled = false);
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys the shell. This is a synchronous operation and
@@ -413,7 +416,8 @@ class Shell final : public PlatformView::Delegate,
   Shell(DartVMRef vm,
         TaskRunners task_runners,
         Settings settings,
-        std::shared_ptr<VolatilePathTracker> volatile_path_tracker);
+        std::shared_ptr<VolatilePathTracker> volatile_path_tracker,
+        bool is_gpu_disabled);
 
   static std::unique_ptr<Shell> CreateShellOnPlatformThread(
       DartVMRef vm,
@@ -423,7 +427,8 @@ class Shell final : public PlatformView::Delegate,
       fml::RefPtr<const DartSnapshot> isolate_snapshot,
       const Shell::CreateCallback<PlatformView>& on_create_platform_view,
       const Shell::CreateCallback<Rasterizer>& on_create_rasterizer,
-      const EngineCreateCallback& on_create_engine);
+      const EngineCreateCallback& on_create_engine,
+      bool is_gpu_disabled);
   static std::unique_ptr<Shell> CreateWithSnapshot(
       const PlatformData& platform_data,
       TaskRunners task_runners,
@@ -432,7 +437,8 @@ class Shell final : public PlatformView::Delegate,
       fml::RefPtr<const DartSnapshot> isolate_snapshot,
       const CreateCallback<PlatformView>& on_create_platform_view,
       const CreateCallback<Rasterizer>& on_create_rasterizer,
-      const EngineCreateCallback& on_create_engine);
+      const EngineCreateCallback& on_create_engine,
+      bool is_gpu_disabled);
 
   bool Setup(std::unique_ptr<PlatformView> platform_view,
              std::unique_ptr<Engine> engine,

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -314,7 +314,8 @@ std::unique_ptr<Shell> ShellTest::CreateShell(
     TaskRunners task_runners,
     bool simulate_vsync,
     std::shared_ptr<ShellTestExternalViewEmbedder>
-        shell_test_external_view_embedder) {
+        shell_test_external_view_embedder,
+    bool is_gpu_disabled) {
   const auto vsync_clock = std::make_shared<ShellTestVsyncClock>();
   CreateVsyncWaiter create_vsync_waiter = [&]() {
     if (simulate_vsync) {
@@ -335,7 +336,8 @@ std::unique_ptr<Shell> ShellTest::CreateShell(
             ShellTestPlatformView::BackendType::kDefaultBackend,
             shell_test_external_view_embedder);
       },
-      [](Shell& shell) { return std::make_unique<Rasterizer>(shell); });
+      [](Shell& shell) { return std::make_unique<Rasterizer>(shell); },
+      is_gpu_disabled);
 }
 void ShellTest::DestroyShell(std::unique_ptr<Shell> shell) {
   DestroyShell(std::move(shell), GetTaskRunnersForFixture());

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -39,7 +39,8 @@ class ShellTest : public FixtureTest {
       TaskRunners task_runners,
       bool simulate_vsync = false,
       std::shared_ptr<ShellTestExternalViewEmbedder>
-          shell_test_external_view_embedder = nullptr);
+          shell_test_external_view_embedder = nullptr,
+      bool is_gpu_disabled = false);
   void DestroyShell(std::unique_ptr<Shell> shell);
   void DestroyShell(std::unique_ptr<Shell> shell, TaskRunners task_runners);
   TaskRunners GetTaskRunnersForFixture();

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -612,13 +612,14 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   );
 
   // Create the shell. This is a blocking operation.
-  std::unique_ptr<flutter::Shell> shell =
-      flutter::Shell::Create(std::move(platformData),  // window data
-                             std::move(task_runners),  // task runners
-                             std::move(settings),      // settings
-                             on_create_platform_view,  // platform view creation
-                             on_create_rasterizer      // rasterzier creation
-      );
+  std::unique_ptr<flutter::Shell> shell = flutter::Shell::Create(
+      std::move(platformData),  // window data
+      std::move(task_runners),  // task runners
+      std::move(settings),      // settings
+      on_create_platform_view,  // platform view creation
+      on_create_rasterizer,     // rasterzier creation
+      /*is_gpu_disabled=*/[UIApplication sharedApplication].applicationState !=
+          UIApplicationStateActive);
 
   if (shell == nullptr) {
     FML_LOG(ERROR) << "Could not start a shell FlutterEngine with entrypoint: "


### PR DESCRIPTION
We've seen a few issues related to flutter apps launching in the background (https://github.com/flutter/flutter/issues/76068 and https://github.com/flutter/flutter/issues/71074).  I've been unable to reproduce these bugs but I theorize that there is a race condition between launching the app and actually having the ability to access the GPU.  In both cases it appears to be a result of the io thread using the GPU, possibly before the surface is created.  This PR will make any accidental usage of the GPU [fallback to the CPU](https://github.com/gaaclarke/engine/blob/7a672981c18bf1d83afa444d69fa02efc6a43a19/lib/ui/painting/image_decoder.cc#L191:L191) if it happens before the app has actually become active.

I place a print statement in `-[FlutterEngine createShell:libraryURI:initialRoute:]` and it appears even during normal app launching that the app state is not active which offers further support that this is possible.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
