### PR TITLE
Fix flutter_frontend_server test - name parameter is required now.

### DIFF
--- a/flutter_frontend_server/test/to_string_test.dart
+++ b/flutter_frontend_server/test/to_string_test.dart
@@ -93,7 +93,7 @@ void main(List<String> args) async {
     when(procedure.name).thenReturn(Name('toString'));
     when(procedure.annotations).thenReturn(const <Expression>[]);
     when(procedure.enclosingLibrary).thenReturn(library);
-    when(procedure.enclosingClass).thenReturn(Class());
+    when(procedure.enclosingClass).thenReturn(Class(name: 'foo'));
     when(procedure.isAbstract).thenReturn(true);
     when(procedure.isStatic).thenReturn(false);
     when(function.body).thenReturn(statement);
@@ -112,7 +112,7 @@ void main(List<String> args) async {
     when(procedure.name).thenReturn(Name('toString'));
     when(procedure.annotations).thenReturn(const <Expression>[]);
     when(procedure.enclosingLibrary).thenReturn(library);
-    when(procedure.enclosingClass).thenReturn(Class());
+    when(procedure.enclosingClass).thenReturn(Class(name: 'foo'));
     when(procedure.isAbstract).thenReturn(false);
     when(procedure.isStatic).thenReturn(true);
     when(function.body).thenReturn(statement);
@@ -131,7 +131,7 @@ void main(List<String> args) async {
     when(procedure.name).thenReturn(Name('toString'));
     when(procedure.annotations).thenReturn(const <Expression>[]);
     when(procedure.enclosingLibrary).thenReturn(library);
-    when(procedure.enclosingClass).thenReturn(Class()..isEnum = true);
+    when(procedure.enclosingClass).thenReturn(Class(name: 'foo')..isEnum = true);
     when(procedure.isAbstract).thenReturn(false);
     when(procedure.isStatic).thenReturn(false);
     when(function.body).thenReturn(statement);
@@ -150,7 +150,7 @@ void main(List<String> args) async {
     when(procedure.name).thenReturn(Name('toString'));
     when(procedure.annotations).thenReturn(const <Expression>[]);
     when(procedure.enclosingLibrary).thenReturn(library);
-    when(procedure.enclosingClass).thenReturn(Class());
+    when(procedure.enclosingClass).thenReturn(Class(name: 'foo'));
     when(procedure.isAbstract).thenReturn(false);
     when(procedure.isStatic).thenReturn(false);
     when(function.body).thenReturn(statement);
@@ -181,7 +181,7 @@ void main(List<String> args) async {
     ]);
 
     when(procedure.enclosingLibrary).thenReturn(library);
-    when(procedure.enclosingClass).thenReturn(Class());
+    when(procedure.enclosingClass).thenReturn(Class(name: 'foo'));
     when(procedure.isAbstract).thenReturn(false);
     when(procedure.isStatic).thenReturn(false);
     when(function.body).thenReturn(statement);
@@ -209,7 +209,7 @@ void main(List<String> args) async {
     when(procedure.name).thenReturn(name);
     when(procedure.annotations).thenReturn(const <Expression>[]);
     when(procedure.enclosingLibrary).thenReturn(library);
-    when(procedure.enclosingClass).thenReturn(Class());
+    when(procedure.enclosingClass).thenReturn(Class(name: 'foo'));
     when(procedure.isAbstract).thenReturn(false);
     when(procedure.isStatic).thenReturn(false);
     when(function.body).thenReturn(statement);
@@ -230,7 +230,7 @@ void main(List<String> args) async {
     when(procedure.name).thenReturn(name);
     when(procedure.annotations).thenReturn(const <Expression>[]);
     when(procedure.enclosingLibrary).thenReturn(library);
-    when(procedure.enclosingClass).thenReturn(Class());
+    when(procedure.enclosingClass).thenReturn(Class(name: 'foo'));
     when(procedure.isAbstract).thenReturn(false);
     when(procedure.isStatic).thenReturn(false);
     when(function.body).thenReturn(statement);


### PR DESCRIPTION
'name' parameter for Class is required since https://dart-review.googlesource.com/c/sdk/+/185083.

This unblocks dart->engine roll.
