### PR TITLE
NNBD cleanup

### DIFF
--- a/lib/web_ui/lib/src/engine/html/picture.dart
+++ b/lib/web_ui/lib/src/engine/html/picture.dart
@@ -406,24 +406,26 @@ class PersistedPicture extends PersistedLeafSurface {
 
   void _applyDomPaint(EngineCanvas? oldCanvas) {
     _recycleCanvas(_canvas);
-    _canvas = DomCanvas(rootElement!);
+    final DomCanvas domCanvas = DomCanvas(rootElement!);
+    _canvas = domCanvas;
     domRenderer.clearDom(rootElement!);
-    picture.recordingCanvas!.apply(_canvas!, _optimalLocalCullRect);
+    picture.recordingCanvas!.apply(domCanvas, _optimalLocalCullRect!);
   }
 
   void _applyBitmapPaint(EngineCanvas? oldCanvas) {
     if (oldCanvas is BitmapCanvas &&
         oldCanvas.doesFitBounds(_optimalLocalCullRect!, _density) &&
         oldCanvas.isReusable()) {
+      final BitmapCanvas reusedCanvas = oldCanvas;
       if (_debugShowCanvasReuseStats) {
         DebugCanvasReuseOverlay.instance.keptCount++;
       }
       // Re-use old bitmap canvas.
-      oldCanvas.bounds = _optimalLocalCullRect!;
-      _canvas = oldCanvas;
-      oldCanvas.setElementCache(_elementCache);
-      _canvas!.clear();
-      picture.recordingCanvas!.apply(_canvas!, _optimalLocalCullRect);
+      reusedCanvas.bounds = _optimalLocalCullRect!;
+      _canvas = reusedCanvas;
+      reusedCanvas.setElementCache(_elementCache);
+      reusedCanvas.clear();
+      picture.recordingCanvas!.apply(reusedCanvas, _optimalLocalCullRect!);
     } else {
       // We can't use the old canvas because the size has changed, so we put
       // it in a cache for later reuse.
@@ -439,19 +441,18 @@ class PersistedPicture extends PersistedLeafSurface {
       _paintQueue.add(_PaintRequest(
         canvasSize: _optimalLocalCullRect!.size,
         paintCallback: () {
-          _canvas = _findOrCreateCanvas(_optimalLocalCullRect!);
-          if (_canvas is BitmapCanvas) {
-            (_canvas as BitmapCanvas).setElementCache(_elementCache);
-          }
+          final BitmapCanvas bitmapCanvas =
+              _findOrCreateCanvas(_optimalLocalCullRect!);
+          _canvas = bitmapCanvas;
+          bitmapCanvas.setElementCache(_elementCache);
           if (_debugExplainSurfaceStats) {
-            final BitmapCanvas bitmapCanvas = _canvas as BitmapCanvas;
             _surfaceStatsFor(this).paintPixelCount +=
                 bitmapCanvas.bitmapPixelCount;
           }
           domRenderer.clearDom(rootElement!);
-          rootElement!.append(_canvas!.rootElement);
-          _canvas!.clear();
-          picture.recordingCanvas!.apply(_canvas!, _optimalLocalCullRect);
+          rootElement!.append(bitmapCanvas.rootElement);
+          bitmapCanvas.clear();
+          picture.recordingCanvas!.apply(bitmapCanvas, _optimalLocalCullRect!);
         },
       ));
     }

--- a/lib/web_ui/lib/src/engine/html/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/recording_canvas.dart
@@ -126,14 +126,14 @@ class RecordingCanvas {
   /// a minimum). The commands that fall outside the clip are skipped and are
   /// not applied to the [engineCanvas]. A command must have a non-zero
   /// intersection with the clip in order to be applied.
-  void apply(EngineCanvas engineCanvas, ui.Rect? clipRect) {
+  void apply(EngineCanvas engineCanvas, ui.Rect clipRect) {
     assert(_recordingEnded);
     if (_debugDumpPaintCommands) {
       final StringBuffer debugBuf = StringBuffer();
       int skips = 0;
       debugBuf.writeln(
           '--- Applying RecordingCanvas to ${engineCanvas.runtimeType} '
-          'with bounds $_paintBounds and clip $clipRect (w = ${clipRect!.width},'
+          'with bounds $_paintBounds and clip $clipRect (w = ${clipRect.width},'
           ' h = ${clipRect.height})');
       for (int i = 0; i < _commands.length; i++) {
         final PaintCommand command = _commands[i];
@@ -155,7 +155,7 @@ class RecordingCanvas {
       print(debugBuf);
     } else {
       try {
-        if (rectContainsOther(clipRect!, _pictureBounds!)) {
+        if (rectContainsOther(clipRect, _pictureBounds!)) {
           // No need to check if commands fit in the clip rect if we already
           // know that the entire picture fits it.
           for (int i = 0, len = _commands.length; i < len; i++) {
@@ -286,10 +286,10 @@ class RecordingCanvas {
     _commands.add(command);
   }
 
-  void clipRRect(ui.RRect rrect) {
+  void clipRRect(ui.RRect roundedRect) {
     assert(!_recordingEnded);
-    final PaintClipRRect command = PaintClipRRect(rrect);
-    _paintBounds.clipRect(rrect.outerRect, command);
+    final PaintClipRRect command = PaintClipRRect(roundedRect);
+    _paintBounds.clipRect(roundedRect.outerRect, command);
     renderStrategy.hasArbitraryPaint = true;
     _commands.add(command);
   }
@@ -654,14 +654,14 @@ abstract class DrawCommand extends PaintCommand {
   double bottomBound = double.infinity;
 
   /// Whether this command intersects with the [clipRect].
-  bool isInvisible(ui.Rect? clipRect) {
+  bool isInvisible(ui.Rect clipRect) {
     if (isClippedOut) {
       return true;
     }
 
     // Check top and bottom first because vertical scrolling is more common
     // than horizontal scrolling.
-    return bottomBound < clipRect!.top ||
+    return bottomBound < clipRect.top ||
         topBound > clipRect.bottom ||
         rightBound < clipRect.left ||
         leftBound > clipRect.right;


### PR DESCRIPTION
- Clean up of RecordingCanvas.apply api, to not allow null clipRect.
- Removes some unnecessary type cast and null checks.

Part of https://github.com/flutter/flutter/issues/60006

Tests: N/A

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
