### PR TITLE
Revert "Default to bilerp for layers"

### DIFF
--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -231,8 +231,8 @@ void SceneBuilder::pushShaderMask(Dart_Handle layer_handle,
                                   fml::RefPtr<EngineLayer> oldLayer) {
   SkRect rect = SkRect::MakeLTRB(maskRectLeft, maskRectTop, maskRectRight,
                                  maskRectBottom);
-  // TODO: Quality come from the caller
-  SkFilterQuality quality = kLow_SkFilterQuality;
+  // TODO: should this come from the caller?
+  SkFilterQuality quality = kNone_SkFilterQuality;
   auto layer = std::make_shared<flutter::ShaderMaskLayer>(
       shader->shader(quality), rect, static_cast<SkBlendMode>(blendMode));
   PushLayer(layer);


### PR DESCRIPTION
Reverts flutter/engine#24519

This was an attempt to address the pixelation in the Google internal tests, but doesn't look good. So let's revert this one and #24376 for now.