### PR TITLE
Revert 24519 and 24376

### DIFF
--- a/flow/paint_utils.cc
+++ b/flow/paint_utils.cc
@@ -20,8 +20,7 @@ sk_sp<SkShader> CreateCheckerboardShader(SkColor c1, SkColor c2, int size) {
   bm.eraseColor(c1);
   bm.eraseArea(SkIRect::MakeLTRB(0, 0, size, size), c2);
   bm.eraseArea(SkIRect::MakeLTRB(size, size, 2 * size, 2 * size), c2);
-  return bm.makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat,
-                       SkSamplingOptions());
+  return bm.makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat);
 }
 
 }  // anonymous namespace

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -231,10 +231,8 @@ void SceneBuilder::pushShaderMask(Dart_Handle layer_handle,
                                   fml::RefPtr<EngineLayer> oldLayer) {
   SkRect rect = SkRect::MakeLTRB(maskRectLeft, maskRectTop, maskRectRight,
                                  maskRectBottom);
-  // TODO: should this come from the caller?
-  SkFilterQuality quality = kNone_SkFilterQuality;
   auto layer = std::make_shared<flutter::ShaderMaskLayer>(
-      shader->shader(quality), rect, static_cast<SkBlendMode>(blendMode));
+      shader->shader(), rect, static_cast<SkBlendMode>(blendMode));
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
 

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -231,8 +231,8 @@ void SceneBuilder::pushShaderMask(Dart_Handle layer_handle,
                                   fml::RefPtr<EngineLayer> oldLayer) {
   SkRect rect = SkRect::MakeLTRB(maskRectLeft, maskRectTop, maskRectRight,
                                  maskRectBottom);
-  // TODO: Quality come from the caller
-  SkFilterQuality quality = kLow_SkFilterQuality;
+  // TODO: should this come from the caller?
+  SkFilterQuality quality = kNone_SkFilterQuality;
   auto layer = std::make_shared<flutter::ShaderMaskLayer>(
       shader->shader(quality), rect, static_cast<SkBlendMode>(blendMode));
   PushLayer(layer);

--- a/lib/ui/painting/gradient.cc
+++ b/lib/ui/painting/gradient.cc
@@ -58,10 +58,10 @@ void CanvasGradient::initLinear(const tonic::Float32List& end_points,
     sk_matrix = ToSkMatrix(matrix4);
   }
 
-  sk_shader_ = UIDartState::CreateGPUObject(SkGradientShader::MakeLinear(
+  set_shader(UIDartState::CreateGPUObject(SkGradientShader::MakeLinear(
       reinterpret_cast<const SkPoint*>(end_points.data()),
       reinterpret_cast<const SkColor*>(colors.data()), color_stops.data(),
-      colors.num_elements(), tile_mode, 0, has_matrix ? &sk_matrix : nullptr));
+      colors.num_elements(), tile_mode, 0, has_matrix ? &sk_matrix : nullptr)));
 }
 
 void CanvasGradient::initRadial(double center_x,
@@ -83,10 +83,10 @@ void CanvasGradient::initRadial(double center_x,
     sk_matrix = ToSkMatrix(matrix4);
   }
 
-  sk_shader_ = UIDartState::CreateGPUObject(SkGradientShader::MakeRadial(
+  set_shader(UIDartState::CreateGPUObject(SkGradientShader::MakeRadial(
       SkPoint::Make(center_x, center_y), radius,
       reinterpret_cast<const SkColor*>(colors.data()), color_stops.data(),
-      colors.num_elements(), tile_mode, 0, has_matrix ? &sk_matrix : nullptr));
+      colors.num_elements(), tile_mode, 0, has_matrix ? &sk_matrix : nullptr)));
 }
 
 void CanvasGradient::initSweep(double center_x,
@@ -109,11 +109,11 @@ void CanvasGradient::initSweep(double center_x,
     sk_matrix = ToSkMatrix(matrix4);
   }
 
-  sk_shader_ = UIDartState::CreateGPUObject(SkGradientShader::MakeSweep(
+  set_shader(UIDartState::CreateGPUObject(SkGradientShader::MakeSweep(
       center_x, center_y, reinterpret_cast<const SkColor*>(colors.data()),
       color_stops.data(), colors.num_elements(), tile_mode,
       start_angle * 180.0 / M_PI, end_angle * 180.0 / M_PI, 0,
-      has_matrix ? &sk_matrix : nullptr));
+      has_matrix ? &sk_matrix : nullptr)));
 }
 
 void CanvasGradient::initTwoPointConical(double start_x,
@@ -138,13 +138,11 @@ void CanvasGradient::initTwoPointConical(double start_x,
     sk_matrix = ToSkMatrix(matrix4);
   }
 
-  sk_shader_ =
-      UIDartState::CreateGPUObject(SkGradientShader::MakeTwoPointConical(
-          SkPoint::Make(start_x, start_y), start_radius,
-          SkPoint::Make(end_x, end_y), end_radius,
-          reinterpret_cast<const SkColor*>(colors.data()), color_stops.data(),
-          colors.num_elements(), tile_mode, 0,
-          has_matrix ? &sk_matrix : nullptr));
+  set_shader(UIDartState::CreateGPUObject(SkGradientShader::MakeTwoPointConical(
+      SkPoint::Make(start_x, start_y), start_radius,
+      SkPoint::Make(end_x, end_y), end_radius,
+      reinterpret_cast<const SkColor*>(colors.data()), color_stops.data(),
+      colors.num_elements(), tile_mode, 0, has_matrix ? &sk_matrix : nullptr)));
 }
 
 CanvasGradient::CanvasGradient() = default;

--- a/lib/ui/painting/gradient.h
+++ b/lib/ui/painting/gradient.h
@@ -62,13 +62,10 @@ class CanvasGradient : public Shader {
                            SkTileMode tile_mode,
                            const tonic::Float64List& matrix4);
 
-  sk_sp<SkShader> shader(SkFilterQuality) override { return sk_shader_.get(); }
-
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
   CanvasGradient();
-  flutter::SkiaGPUObject<SkShader> sk_shader_;
 };
 
 }  // namespace flutter

--- a/lib/ui/painting/image_shader.cc
+++ b/lib/ui/painting/image_shader.cc
@@ -43,23 +43,11 @@ void ImageShader::initWithImage(CanvasImage* image,
         ToDart("ImageShader constructor called with non-genuine Image."));
     return;
   }
-  sk_image_ = image->image();
-  tmx_ = tmx;
-  tmy_ = tmy;
-  local_matrix_ = ToSkMatrix(matrix4);
+  SkMatrix sk_matrix = ToSkMatrix(matrix4);
+  set_shader(UIDartState::CreateGPUObject(
+      image->image()->makeShader(tmx, tmy, &sk_matrix)));
 }
 
-sk_sp<SkShader> ImageShader::shader(SkFilterQuality quality) {
-  if (!cached_shader_.get() || cached_quality_ != quality) {
-    SkSamplingOptions sampling(quality,
-                               SkSamplingOptions::kMedium_asMipmapLinear);
-
-    cached_quality_ = quality;
-    cached_shader_ = UIDartState::CreateGPUObject(
-        sk_image_->makeShader(tmx_, tmy_, sampling, &local_matrix_));
-  }
-  return cached_shader_.get();
-}
 ImageShader::ImageShader() = default;
 
 ImageShader::~ImageShader() = default;

--- a/lib/ui/painting/image_shader.h
+++ b/lib/ui/painting/image_shader.h
@@ -33,20 +33,10 @@ class ImageShader : public Shader {
                      SkTileMode tmy,
                      const tonic::Float64List& matrix4);
 
-  sk_sp<SkShader> shader(SkFilterQuality) override;
-
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
   ImageShader();
-
-  sk_sp<SkImage> sk_image_;
-  SkTileMode tmx_;
-  SkTileMode tmy_;
-  SkMatrix local_matrix_;
-
-  SkFilterQuality cached_quality_ = kNone_SkFilterQuality;
-  flutter::SkiaGPUObject<SkShader> cached_shader_;
 };
 
 }  // namespace flutter

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -71,12 +71,6 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
     return;
   }
 
-  tonic::DartByteData byte_data(paint_data);
-  FML_CHECK(byte_data.length_in_bytes() == kDataByteCount);
-
-  const uint32_t* uint_data = static_cast<const uint32_t*>(byte_data.data());
-  const float* float_data = static_cast<const float*>(byte_data.data());
-
   Dart_Handle values[kObjectCount];
   if (!Dart_IsNull(paint_objects)) {
     FML_DCHECK(Dart_IsList(paint_objects));
@@ -92,9 +86,7 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
     Dart_Handle shader = values[kShaderIndex];
     if (!Dart_IsNull(shader)) {
       Shader* decoded = tonic::DartConverter<Shader*>::FromDart(shader);
-      uint32_t filter_quality = uint_data[kFilterQualityIndex];
-      paint_.setShader(
-          decoded->shader(static_cast<SkFilterQuality>(filter_quality)));
+      paint_.setShader(decoded->shader());
     }
 
     Dart_Handle color_filter = values[kColorFilterIndex];
@@ -111,6 +103,12 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
       paint_.setImageFilter(decoded->filter());
     }
   }
+
+  tonic::DartByteData byte_data(paint_data);
+  FML_CHECK(byte_data.length_in_bytes() == kDataByteCount);
+
+  const uint32_t* uint_data = static_cast<const uint32_t*>(byte_data.data());
+  const float* float_data = static_cast<const float*>(byte_data.data());
 
   paint_.setAntiAlias(uint_data[kIsAntiAliasIndex] == 0);
 
@@ -149,6 +147,11 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
   float stroke_miter_limit = float_data[kStrokeMiterLimitIndex];
   if (stroke_miter_limit != 0.0) {
     paint_.setStrokeMiter(stroke_miter_limit + kStrokeMiterLimitDefault);
+  }
+
+  uint32_t filter_quality = uint_data[kFilterQualityIndex];
+  if (filter_quality) {
+    paint_.setFilterQuality(static_cast<SkFilterQuality>(filter_quality));
   }
 
   if (uint_data[kInvertColorIndex]) {

--- a/lib/ui/painting/shader.cc
+++ b/lib/ui/painting/shader.cc
@@ -10,6 +10,9 @@ namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, Shader);
 
+Shader::Shader(flutter::SkiaGPUObject<SkShader> shader)
+    : shader_(std::move(shader)) {}
+
 Shader::~Shader() = default;
 
 }  // namespace flutter

--- a/lib/ui/painting/shader.h
+++ b/lib/ui/painting/shader.h
@@ -8,7 +8,6 @@
 #include "flutter/flow/skia_gpu_object.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/ui_dart_state.h"
-#include "third_party/skia/include/core/SkFilterQuality.h"
 #include "third_party/skia/include/core/SkShader.h"
 
 namespace flutter {
@@ -20,13 +19,17 @@ class Shader : public RefCountedDartWrappable<Shader> {
  public:
   ~Shader() override;
 
-  virtual sk_sp<SkShader> shader(SkFilterQuality) = 0;
+  sk_sp<SkShader> shader() { return shader_.get(); }
+
+  void set_shader(flutter::SkiaGPUObject<SkShader> shader) {
+    shader_ = std::move(shader);
+  }
 
  protected:
-  Shader() {}
+  Shader(flutter::SkiaGPUObject<SkShader> shader = {});
 
  private:
-  //  flutter::SkiaGPUObject<SkShader> shader_;
+  flutter::SkiaGPUObject<SkShader> shader_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
#24376 caused some strange pixelation in Google internal tests. #24519 was an attempt to fix this but was not successful. Let's revert these changes so they don't block the internal roll.

Ref: test/OCL:358506232:BASE:358524276:1613792169016:e73eef70
