### PR TITLE
Restore call to setFilterQuality

### DIFF
--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -77,7 +77,8 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
   const uint32_t* uint_data = static_cast<const uint32_t*>(byte_data.data());
   const float* float_data = static_cast<const float*>(byte_data.data());
 
-  auto filter_quality = static_cast<SkFilterQuality>(uint_data[kFilterQualityIndex]);
+  auto filter_quality =
+      static_cast<SkFilterQuality>(uint_data[kFilterQualityIndex]);
 
   Dart_Handle values[kObjectCount];
   if (!Dart_IsNull(paint_objects)) {

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -77,6 +77,8 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
   const uint32_t* uint_data = static_cast<const uint32_t*>(byte_data.data());
   const float* float_data = static_cast<const float*>(byte_data.data());
 
+  auto filter_quality = static_cast<SkFilterQuality>(uint_data[kFilterQualityIndex]);
+
   Dart_Handle values[kObjectCount];
   if (!Dart_IsNull(paint_objects)) {
     FML_DCHECK(Dart_IsList(paint_objects));
@@ -92,9 +94,7 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
     Dart_Handle shader = values[kShaderIndex];
     if (!Dart_IsNull(shader)) {
       Shader* decoded = tonic::DartConverter<Shader*>::FromDart(shader);
-      uint32_t filter_quality = uint_data[kFilterQualityIndex];
-      paint_.setShader(
-          decoded->shader(static_cast<SkFilterQuality>(filter_quality)));
+      paint_.setShader(decoded->shader(filter_quality));
     }
 
     Dart_Handle color_filter = values[kColorFilterIndex];
@@ -113,6 +113,7 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
   }
 
   paint_.setAntiAlias(uint_data[kIsAntiAliasIndex] == 0);
+  paint_.setFilterQuality(filter_quality);
 
   uint32_t encoded_color = uint_data[kColorIndex];
   if (encoded_color) {


### PR DESCRIPTION
While the current code correctly passing filter_quality to the shader, so it can pass sampling-options to the shader's factory, we still need to set it on the paint (for now), since drawImage and friends still rely on reading filter-quality from the paint to deduce their sampling.