### PR TITLE
[web] Fix placeholder-only paragraphs

### DIFF
--- a/lib/web_ui/lib/src/engine/text/layout_service.dart
+++ b/lib/web_ui/lib/src/engine/text/layout_service.dart
@@ -107,6 +107,8 @@ class TextLayoutService {
       // *** THE MAIN MEASUREMENT PART *** //
       // ********************************* //
 
+      final isLastSpan = spanIndex == spanCount - 1;
+
       if (span is PlaceholderSpan) {
         if (currentLine.widthIncludingSpace + span.width <= constraints.width) {
           // The placeholder fits on the current line.
@@ -118,6 +120,11 @@ class TextLayoutService {
             currentLine = currentLine.nextLine();
           }
           currentLine.addPlaceholder(span);
+        }
+
+        if (isLastSpan) {
+          lines.add(currentLine.build());
+          break;
         }
       } else if (span is FlatTextSpan) {
         spanometer.currentSpan = span;
@@ -171,15 +178,9 @@ class TextLayoutService {
       // ********************************************* //
 
       // Only go to the next span if we've reached the end of this span.
-      if (currentLine.end.index >= span.end) {
+      if (currentLine.end.index >= span.end && spanIndex < spanCount - 1) {
         currentLine.createBox();
-        if (spanIndex < spanCount - 1) {
-          span = paragraph.spans[++spanIndex];
-        } else {
-          // We reached the end of the last span in the paragraph.
-          lines.add(currentLine.build());
-          break;
-        }
+        span = paragraph.spans[++spanIndex];
       }
     }
 

--- a/lib/web_ui/test/text/layout_service_rich_test.dart
+++ b/lib/web_ui/test/text/layout_service_rich_test.dart
@@ -149,4 +149,22 @@ void testMain() async {
       l('ipsum', 6, 11, hardBreak: true, width: 50.0, left: 0.0),
     ]);
   });
+
+  test('should handle placeholder-only paragraphs', () {
+    final EngineParagraphStyle paragraphStyle = EngineParagraphStyle(
+      fontFamily: 'ahem',
+      fontSize: 10,
+      textAlign: ui.TextAlign.center,
+    );
+    final CanvasParagraph paragraph = rich(paragraphStyle, (builder) {
+      builder.addPlaceholder(300.0, 50.0, ui.PlaceholderAlignment.baseline, baseline: ui.TextBaseline.alphabetic);
+    })..layout(constrain(500.0));
+
+    expect(paragraph.maxIntrinsicWidth, 300.0);
+    expect(paragraph.minIntrinsicWidth, 300.0);
+    expect(paragraph.height, 50.0);
+    expectLines(paragraph, [
+      l('', 0, 0, hardBreak: false, width: 300.0, left: 100.0),
+    ]);
+  });
 }


### PR DESCRIPTION
When a paragraph contains only one placeholder and no text, it causes 3 issues:

* An infinite loop during paragraph layout.
* Max intrinsic width is wrong.
* Line width is wrong.

This PR fixes all three issues.

Fixes https://github.com/flutter/flutter/issues/76122