### PR TITLE
Add method to obtain native string resource in localization plugin.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
@@ -6,23 +6,70 @@ package io.flutter.embedding.engine.systemchannels;
 
 import android.os.Build;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.JSONMethodCodec;
+import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /** Sends the platform's locales to Dart. */
 public class LocalizationChannel {
   private static final String TAG = "LocalizationChannel";
 
   @NonNull public final MethodChannel channel;
+  @Nullable private LocalizationMessageHandler localizationMessageHandler;
+
+  private final MethodChannel.MethodCallHandler handler =
+      new MethodChannel.MethodCallHandler() {
+        @Override
+        public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+          if (localizationMessageHandler == null) {
+            // If no explicit LocalizationMessageHandler has been registered then we don't
+            // need to forward this call to an API. Return.
+            return;
+          }
+
+          String method = call.method;
+          switch (method) {
+            case "Localization.getStringResource":
+              JSONObject arguments = call.<JSONObject>arguments();
+              try {
+                String key = arguments.getString("key");
+                String localeString = null;
+                if (arguments.has("locale")) {
+                  localeString = arguments.getString("locale");
+                }
+                result.success(localizationMessageHandler.getStringResource(key, localeString));
+              } catch (JSONException exception) {
+                result.error("error", exception.getMessage(), null);
+              }
+              break;
+            default:
+              result.notImplemented();
+              break;
+          }
+        }
+      };
 
   public LocalizationChannel(@NonNull DartExecutor dartExecutor) {
     this.channel =
         new MethodChannel(dartExecutor, "flutter/localization", JSONMethodCodec.INSTANCE);
+    channel.setMethodCallHandler(handler);
+  }
+
+  /**
+   * Sets the {@link LocalizationMessageHandler} which receives all events and requests that are
+   * parsed from the underlying platform channel.
+   */
+  public void setLocalizationMessageHandler(
+      @Nullable LocalizationMessageHandler localizationMessageHandler) {
+    this.localizationMessageHandler = localizationMessageHandler;
   }
 
   /** Send the given {@code locales} to Dart. */
@@ -47,5 +94,20 @@ public class LocalizationChannel {
       data.add(locale.getVariant());
     }
     channel.invokeMethod("setLocale", data);
+  }
+
+  /**
+   * Handler that receives platform messages sent from Flutter to Android through a given {@link
+   * PlatformChannel}.
+   *
+   * <p>To register a {@code LocalizationMessageHandler} with a {@link PlatformChannel}, see {@link
+   * LocalizationChannel#setLocalizationMessageHandler(LocalizationMessageHandler)}.
+   */
+  public interface LocalizationMessageHandler {
+    /**
+     * The Flutter application would like to obtain the string resource of given {@code key} in
+     * {@code locale}.
+     */
+    String getStringResource(@NonNull String key, String locale);
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
@@ -7,6 +7,7 @@ package io.flutter.embedding.engine.systemchannels;
 import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.JSONMethodCodec;
@@ -25,7 +26,8 @@ public class LocalizationChannel {
   @NonNull public final MethodChannel channel;
   @Nullable private LocalizationMessageHandler localizationMessageHandler;
 
-  private final MethodChannel.MethodCallHandler handler =
+  @NonNull @VisibleForTesting
+  public final MethodChannel.MethodCallHandler handler =
       new MethodChannel.MethodCallHandler() {
         @Override
         public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {

--- a/shell/platform/android/io/flutter/plugin/localization/LocalizationPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/localization/LocalizationPlugin.java
@@ -34,17 +34,18 @@ public class LocalizationPlugin {
           if (localeString != null) {
             Locale locale = localeFromString(localeString);
 
+            // setLocale and createConfigurationContext is only available on API >= 17
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-              Configuration conf = new Configuration(context.getResources().getConfiguration());
-              conf.setLocale(locale);
-              localContext = context.createConfigurationContext(conf);
+              Configuration config = new Configuration(context.getResources().getConfiguration());
+              config.setLocale(locale);
+              localContext = context.createConfigurationContext(config);
             } else {
-              // setLocale and createConfigurationContext is only available on API >= 17
+              // In API < 17, we have to update the locale in Configuration.
               Resources resources = context.getResources();
-              Configuration conf = resources.getConfiguration();
-              savedLocale = conf.locale;
-              conf.locale = locale;
-              resources.updateConfiguration(conf, null);
+              Configuration config = resources.getConfiguration();
+              savedLocale = config.locale;
+              config.locale = locale;
+              resources.updateConfiguration(config, null);
             }
           }
 
@@ -55,11 +56,12 @@ public class LocalizationPlugin {
             stringToReturn = localContext.getResources().getString(resId);
           }
 
+          // In API < 17, we had to restore the original locale after using.
           if (localeString != null && Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1) {
             Resources resources = context.getResources();
-            Configuration conf = resources.getConfiguration();
-            conf.locale = savedLocale;
-            resources.updateConfiguration(conf, null);
+            Configuration config = resources.getConfiguration();
+            config.locale = savedLocale;
+            resources.updateConfiguration(config, null);
           }
 
           return stringToReturn;

--- a/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java
@@ -3,7 +3,9 @@ package io.flutter.embedding.engine;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.annotation.TargetApi;
@@ -14,10 +16,14 @@ import android.os.Build;
 import android.os.LocaleList;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.systemchannels.LocalizationChannel;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.localization.LocalizationPlugin;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Locale;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -319,6 +325,132 @@ public class LocalizationPluginTest {
     assertEquals(result[0], "fr");
     assertEquals(result[1], "");
     assertEquals(result[2], "");
+  }
+
+  // Tests the legacy pre API 21 algorithm.
+  @Config(sdk = 16)
+  @Test
+  public void localeFromString_languageOnly() {
+    Locale locale = LocalizationPlugin.localeFromString("en");
+    assertEquals(locale, new Locale("en"));
+  }
+
+  @Config(sdk = 16)
+  @Test
+  public void localeFromString_languageAndCountry() {
+    Locale locale = LocalizationPlugin.localeFromString("en-US");
+    assertEquals(locale, new Locale("en", "US"));
+  }
+
+  @Config(sdk = 16)
+  @Test
+  public void localeFromString_languageCountryAndVariant() {
+    Locale locale = LocalizationPlugin.localeFromString("zh-Hans-CN");
+    assertEquals(locale, new Locale("zh", "CN", "Hans"));
+  }
+
+  @Config(sdk = 16)
+  @Test
+  public void localeFromString_underscore() {
+    Locale locale = LocalizationPlugin.localeFromString("zh_Hans_CN");
+    assertEquals(locale, new Locale("zh", "CN", "Hans"));
+  }
+
+  @Config(sdk = 16)
+  @Test
+  public void localeFromString_additionalVariantsAreIgnored() {
+    Locale locale = LocalizationPlugin.localeFromString("de-DE-u-co-phonebk");
+    assertEquals(locale, new Locale("de", "DE"));
+  }
+
+  @Test
+  public void getStringResource_withoutLocale() throws JSONException {
+    Context context = mock(Context.class);
+    Resources resources = mock(Resources.class);
+    DartExecutor dartExecutor = mock(DartExecutor.class);
+    LocalizationChannel localizationChannel = new LocalizationChannel(dartExecutor);
+    LocalizationPlugin plugin = new LocalizationPlugin(context, localizationChannel);
+
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    String fakePackageName = "package_name";
+    String fakeKey = "test_key";
+    int fakeId = 123;
+
+    when(context.getPackageName()).thenReturn(fakePackageName);
+    when(context.getResources()).thenReturn(resources);
+    when(resources.getIdentifier(fakeKey, "string", fakePackageName)).thenReturn(fakeId);
+    when(resources.getString(fakeId)).thenReturn("test_value");
+
+    JSONObject param = new JSONObject();
+    param.put("key", fakeKey);
+
+    localizationChannel.handler.onMethodCall(
+        new MethodCall("Localization.getStringResource", param), mockResult);
+
+    verify(mockResult).success("test_value");
+  }
+
+  @Test
+  public void getStringResource_withLocale() throws JSONException {
+    Context context = mock(Context.class);
+    Context localContext = mock(Context.class);
+    Resources resources = mock(Resources.class);
+    Resources localResources = mock(Resources.class);
+    Configuration configuration = new Configuration();
+    DartExecutor dartExecutor = mock(DartExecutor.class);
+    LocalizationChannel localizationChannel = new LocalizationChannel(dartExecutor);
+    LocalizationPlugin plugin = new LocalizationPlugin(context, localizationChannel);
+
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    String fakePackageName = "package_name";
+    String fakeKey = "test_key";
+    int fakeId = 123;
+
+    when(context.getPackageName()).thenReturn(fakePackageName);
+    when(context.createConfigurationContext(any())).thenReturn(localContext);
+    when(context.getResources()).thenReturn(resources);
+    when(localContext.getResources()).thenReturn(localResources);
+    when(resources.getConfiguration()).thenReturn(configuration);
+    when(localResources.getIdentifier(fakeKey, "string", fakePackageName)).thenReturn(fakeId);
+    when(localResources.getString(fakeId)).thenReturn("test_value");
+
+    JSONObject param = new JSONObject();
+    param.put("key", fakeKey);
+    param.put("locale", "en-US");
+
+    localizationChannel.handler.onMethodCall(
+        new MethodCall("Localization.getStringResource", param), mockResult);
+
+    verify(mockResult).success("test_value");
+  }
+
+  @Test
+  public void getStringResource_nonExistentKey() throws JSONException {
+    Context context = mock(Context.class);
+    Resources resources = mock(Resources.class);
+    DartExecutor dartExecutor = mock(DartExecutor.class);
+    LocalizationChannel localizationChannel = new LocalizationChannel(dartExecutor);
+    LocalizationPlugin plugin = new LocalizationPlugin(context, localizationChannel);
+
+    MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
+
+    String fakePackageName = "package_name";
+    String fakeKey = "test_key";
+
+    when(context.getPackageName()).thenReturn(fakePackageName);
+    when(context.getResources()).thenReturn(resources);
+    when(resources.getIdentifier(fakeKey, "string", fakePackageName))
+        .thenReturn(0); // 0 means not exist
+
+    JSONObject param = new JSONObject();
+    param.put("key", fakeKey);
+
+    localizationChannel.handler.onMethodCall(
+        new MethodCall("Localization.getStringResource", param), mockResult);
+
+    verify(mockResult).success(null);
   }
 
   private static void setApiVersion(int apiVersion) {


### PR DESCRIPTION
Engine side implementation for go/flutter-locale-split.

Only Android implementation for now just for review. After this is reviewed I'll work on the iOS implementation in a separate PR.

Tests will follow.