### PR TITLE
[Android Input] Passthrough movement keys when there's no selection

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -735,5 +735,11 @@ public class TextInputChannel {
       this.composingStart = composingStart;
       this.composingEnd = composingEnd;
     }
+
+    public boolean hasSelection() {
+      // When selectionStart == -1, it's guaranteed that selectionEnd will also
+      // be -1.
+      return selectionStart >= 0;
+    }
   }
 }

--- a/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
+++ b/shell/platform/android/io/flutter/plugin/editing/ListenableEditingState.java
@@ -137,7 +137,7 @@ class ListenableEditingState extends SpannableStringBuilder {
     beginBatchEdit();
     replace(0, length(), newState.text);
 
-    if (newState.selectionStart >= 0) {
+    if (newState.hasSelection()) {
       Selection.setSelection(this, newState.selectionStart, newState.selectionEnd);
     } else {
       Selection.removeSelection(this);

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -84,6 +84,7 @@ public class InputConnectionAdaptorTest {
     TextInputChannel textInputChannel = new TextInputChannel(dartExecutor);
     AndroidKeyProcessor mockKeyProcessor = mock(AndroidKeyProcessor.class);
     ListenableEditingState mEditable = new ListenableEditingState(null, testView);
+    Selection.setSelection(mEditable, 0, 0);
     ListenableEditingState spyEditable = spy(mEditable);
     EditorInfo outAttrs = new EditorInfo();
     outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
@@ -909,6 +910,37 @@ public class InputConnectionAdaptorTest {
     // Checks the caret moved right (to some following character). Selection.moveDown() behaves
     // different in tests than on a real device, we can't verify the exact position.
     assertTrue(Selection.getSelectionStart(editable) > selStart);
+  }
+
+  @Test
+  public void testSendKeyEvent_MovementKeysAreNopWhenNoSelection() {
+    // Regression test for https://github.com/flutter/flutter/issues/76283.
+    ListenableEditingState editable = sampleEditable(-1, -1);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent keyEvent = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_DOWN);
+    boolean didConsume = adaptor.sendKeyEvent(keyEvent);
+    assertFalse(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), -1);
+    assertEquals(Selection.getSelectionEnd(editable), -1);
+
+    keyEvent = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_UP);
+    didConsume = adaptor.sendKeyEvent(keyEvent);
+    assertFalse(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), -1);
+    assertEquals(Selection.getSelectionEnd(editable), -1);
+
+    keyEvent = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_LEFT);
+    didConsume = adaptor.sendKeyEvent(keyEvent);
+    assertFalse(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), -1);
+    assertEquals(Selection.getSelectionEnd(editable), -1);
+
+    keyEvent = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT);
+    didConsume = adaptor.sendKeyEvent(keyEvent);
+    assertFalse(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), -1);
+    assertEquals(Selection.getSelectionEnd(editable), -1);
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/76283

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
