### PR TITLE
Expand FilterQuality API docs

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -825,7 +825,24 @@ enum BlendMode {
 
 /// Quality levels for image filters.
 ///
-/// See [Paint.filterQuality].
+/// When scaling up typically the quality is lowest at [none], higher at [low],
+/// even higher at [medium], and the highest at [high].
+///
+/// When scaling down, the higher the scale factor the less effective the [high]
+/// level is. Beyond certain scale level [medium] may provide better visual
+/// result than [high] (see example below).
+///
+/// When building for the web using the `--web-renderer=html` option, filter quality has
+/// no effect. All images are rendered using the respective browser's default setting.
+///
+/// Example:
+///
+/// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/filter_quality.png)
+///
+/// See also:
+///
+///  * [Paint.filterQuality], which is used to pass [FilterQuality] to the
+///    engine while painting.
 enum FilterQuality {
   // This list comes from Skia's SkFilterQuality.h and the values (order) should
   // be kept in sync.
@@ -842,13 +859,28 @@ enum FilterQuality {
 
   /// Better quality than [low], faster than [high].
   ///
+  /// When scaling down images, this is frequently better than [high].
+  ///
   /// Typically this implies a combination of bilinear interpolation and
   /// pyramidal parametric pre-filtering (mipmaps).
+  ///
+  /// {@template dart.ui.filterQuality.seeAlso}
+  /// See also:
+  ///
+  ///  * [FilterQuality] class-level documentation that goes into detail about
+  ///    relative qualities of the enum values.
+  /// {@endtemplate}
   medium,
 
-  /// Best possible quality filtering, albeit also the slowest.
+  /// Best possible quality when scaling up images.
+  ///
+  /// When images are scaled down, this is frequently worse than [medium].
+  ///
+  /// This option is the slowest.
   ///
   /// Typically this implies bicubic interpolation or better.
+  ///
+  /// {@macro dart.ui.filterQuality.seeAlso}
   high,
 }
 

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -830,14 +830,16 @@ enum BlendMode {
 ///
 /// When scaling down, the higher the scale factor the less effective the [high]
 /// level is. Beyond certain scale level [medium] may provide better visual
-/// result than [high] (see example below).
+/// result than [high].
 ///
-/// When building for the web using the `--web-renderer=html` option, filter quality has
-/// no effect. All images are rendered using the respective browser's default setting.
-///
-/// Example:
+/// To get high quality when scaling images up and down, or when the scale is
+/// unknown, [medium] is typically a good enough choice.
 ///
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/dart-ui/filter_quality.png)
+///
+/// When building for the web using the `--web-renderer=html` option, filter
+/// quality has no effect. All images are rendered using the respective
+/// browser's default setting.
 ///
 /// See also:
 ///


### PR DESCRIPTION
Document more precisely the effects of the `FilterQuality` enum values with a focus on relative quality when scaling images _up_ vs scaling them _down_. It turns out that the algorithm used for `high` is frequently _worse_ than `medium` when scaling down. Only when scaling images up do you get increase in quality as you go none => low => medium => high.

This PR depends on https://github.com/flutter/assets-for-api-docs/pull/134.

Fixes https://github.com/flutter/flutter/issues/76187
