### PR TITLE
Signal an error if an Isolate.spwanUri call uses an unsupported URI

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -118,7 +118,7 @@ struct Settings {
 
   // Used as the script URI in debug messages. Does not affect how the Dart code
   // is executed.
-  std::string advisory_script_uri = "main.dart";
+  std::string advisory_script_uri = "file:///main.dart";
   // Used as the script entrypoint in debug messages. Does not affect how the
   // Dart code is executed.
   std::string advisory_script_entrypoint = "main";

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -34,6 +34,8 @@ namespace flutter {
 
 namespace {
 
+constexpr std::string_view kFileUriPrefix = "file://";
+
 class DartErrorString {
  public:
   DartErrorString() : str_(nullptr) {}
@@ -928,6 +930,14 @@ Dart_Isolate DartIsolate::DartIsolateGroupCreateCallback(
 
   DartIsolateGroupData& parent_group_data =
       (*parent_isolate_data)->GetIsolateGroupData();
+
+  if (strncmp(advisory_script_uri, kFileUriPrefix.data(),
+              kFileUriPrefix.size())) {
+    std::string error_msg =
+        std::string("Unsupported isolate URI: ") + advisory_script_uri;
+    *error = fml::strdup(error_msg.c_str());
+    return nullptr;
+  }
 
   auto isolate_group_data =
       std::make_unique<std::shared_ptr<DartIsolateGroupData>>(

--- a/testing/dart/isolate_test.dart
+++ b/testing/dart/isolate_test.dart
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('Invalid isolate URI', () async {
+    final Future<Isolate> isolate = Isolate.spawnUri(Uri.parse('http://127.0.0.1/foo.dart'), <String>[], null);
+    expect(() async => await isolate, throwsA(const TypeMatcher<IsolateSpawnException>()));
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/76371
