### PR TITLE
Allow calls to legacyMakeTypeface in the AssetFontManager

### DIFF
--- a/third_party/txt/src/txt/asset_font_manager.cc
+++ b/third_party/txt/src/txt/asset_font_manager.cc
@@ -105,7 +105,6 @@ sk_sp<SkTypeface> AssetFontManager::onMakeFromFile(const char path[],
 sk_sp<SkTypeface> AssetFontManager::onLegacyMakeTypeface(
     const char familyName[],
     SkFontStyle) const {
-  FML_DCHECK(false);
   return nullptr;
 }
 


### PR DESCRIPTION
This API is used by SkParagraph in some cases.
