### PR TITLE
Roll ICU from c2a4cae1 to e05b663d

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -136,7 +136,7 @@ deps = {
    Var('chromium_git') + '/chromium/src/ios.git' + '@' + Var('ios_tools_revision'),
 
   'src/third_party/icu':
-   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + 'c2a4cae149aae7fd30c4cbe3cf1b30df03b386f1',
+   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + 'e05b663d1c50b4e9ecc3ff9325f5158f1d071471',
 
   'src/third_party/khronos':
    Var('chromium_git') + '/chromium/src/third_party/khronos.git' + '@' + '7122230e90547962e0f0c627f62eeed3c701f275',


### PR DESCRIPTION
Flutter's ICU was out of sync with chromium. As result chromium roll to Fuchsia is currently blocked. See fxbug.dev/70621 for details.

