### PR TITLE
Enables semantics when voice control is turned on

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1036,6 +1036,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterView.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/IOKit.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -186,6 +186,7 @@ source_set("ios_test_flutter_mrc") {
     "framework/Source/FlutterEngineTest_mrc.mm",
     "framework/Source/FlutterPlatformPluginTest.mm",
     "framework/Source/FlutterPlatformViewsTest.mm",
+    "framework/Source/FlutterViewTest.mm",
     "framework/Source/accessibility_bridge_test.mm",
   ]
   deps = [

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -769,7 +769,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   return _shell->Screenshot(type, base64Encode);
 }
 
-- (void)futterViewAccessibilityDidCall {
+- (void)flutterViewAccessibilityDidCall {
   if (self.viewController.view.accessibilityElements == nil) {
     [self ensureSemanticsEnabled];
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -761,12 +761,18 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                               arguments:@[ @(client), @(start), @(end) ]];
 }
 
-#pragma mark - Screenshot Delegate
+#pragma mark - FlutterViewEngineDelegate
 
 - (flutter::Rasterizer::Screenshot)takeScreenshot:(flutter::Rasterizer::ScreenshotType)type
                                   asBase64Encoded:(BOOL)base64Encode {
   FML_DCHECK(_shell) << "Cannot takeScreenshot without a shell";
   return _shell->Screenshot(type, base64Encode);
+}
+
+- (void)futterViewAccessibilityDidCall {
+  if (self.viewController.view.accessibilityElements == nil) {
+    [self ensureSemanticsEnabled];
+  }
 }
 
 - (NSObject<FlutterBinaryMessenger>*)binaryMessenger {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest_mrc.mm
@@ -12,6 +12,18 @@
 
 FLUTTER_ASSERT_NOT_ARC
 
+@interface FlutterEngineSpy : FlutterEngine
+@property(nonatomic) BOOL ensureSemanticsEnabledCalled;
+@end
+
+@implementation FlutterEngineSpy
+
+- (void)ensureSemanticsEnabled {
+  _ensureSemanticsEnabledCalled = YES;
+}
+
+@end
+
 @interface FlutterEngineTest_mrc : XCTestCase
 @end
 
@@ -39,6 +51,13 @@ FLUTTER_ASSERT_NOT_ARC
   XCTAssertEqual(engine_context->GetMainContext(), spawn_context->GetMainContext());
   [engine release];
   [spawn release];
+}
+
+- (void)testEnableSemanticsWhenFlutterViewAccessibilityDidCall {
+  FlutterEngineSpy* engine = [[FlutterEngineSpy alloc] initWithName:@"foobar"];
+  engine.ensureSemanticsEnabledCalled = NO;
+  [engine flutterViewAccessibilityDidCall];
+  XCTAssertTrue(engine.ensureSemanticsEnabledCalled);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -30,7 +30,7 @@
  * this callback to enable semantics in order to catch the case that voice control is
  * on.
  */
-- (void)futterViewAccessibilityDidCall;
+- (void)flutterViewAccessibilityDidCall;
 @end
 
 @interface FlutterView : UIView

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -21,6 +21,7 @@
                                   asBase64Encoded:(BOOL)base64Encode;
 
 - (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
+- (void)ensureSemanticsEnabled;
 @end
 
 @interface FlutterView : UIView

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -21,7 +21,16 @@
                                   asBase64Encoded:(BOOL)base64Encode;
 
 - (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
-- (void)ensureSemanticsEnabled;
+
+/**
+ * A callback that is called when iOS queries accessibility information of the Flutter view.
+ *
+ * This is useful to predict the current iOS accessibility status. For example, there is
+ * no API to listen whether voice control is turned on or off. The Flutter engine uses
+ * this callback to enable semantics in order to catch the case that voice control is
+ * on.
+ */
+- (void)futterViewAccessibilityDidCall;
 @end
 
 @interface FlutterView : UIView

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -140,9 +140,6 @@ static BOOL _forceSoftwareRendering;
   // API to query whether voice control is enabled.
   // https://github.com/flutter/flutter/issues/76808.
   [_delegate flutterViewAccessibilityDidCall];
-  // if (self.accessibilityElements == nil) {
-  //   [_delegate flutterViewAccessibilityDidCall];
-  // }
   return NO;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -139,9 +139,9 @@ static BOOL _forceSoftwareRendering;
   // TODO(chunhtai): Remove this workaround once iOS provides an
   // API to query whether voice control is enabled.
   // https://github.com/flutter/flutter/issues/76808.
-  [_delegate futterViewAccessibilityDidCall];
+  [_delegate flutterViewAccessibilityDidCall];
   // if (self.accessibilityElements == nil) {
-  //   [_delegate futterViewAccessibilityDidCall];
+  //   [_delegate flutterViewAccessibilityDidCall];
   // }
   return NO;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -130,4 +130,19 @@ static BOOL _forceSoftwareRendering;
   CGContextRestoreGState(context);
 }
 
+- (BOOL)isAccessibilityElement {
+  // iOS does not provide an API to query whether the voice control
+  // is turned on or off. It is likely at least one of the assitive
+  // technologies is turned on if this method is called. If we do
+  // not catch it in notification center, we will catch it here.
+  //
+  // TODO(chunhtai): Remove this workaround once iOS provides an
+  // API to query whether voice control is enabled.
+  // https://github.com/flutter/flutter/issues/76808.
+  if (self.accessibilityElements == nil) {
+    [_delegate ensureSemanticsEnabled];
+  }
+  return NO;
+}
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -139,9 +139,10 @@ static BOOL _forceSoftwareRendering;
   // TODO(chunhtai): Remove this workaround once iOS provides an
   // API to query whether voice control is enabled.
   // https://github.com/flutter/flutter/issues/76808.
-  if (self.accessibilityElements == nil) {
-    [_delegate ensureSemanticsEnabled];
-  }
+  [_delegate futterViewAccessibilityDidCall];
+  // if (self.accessibilityElements == nil) {
+  //   [_delegate futterViewAccessibilityDidCall];
+  // }
   return NO;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
@@ -4,33 +4,19 @@
 
 #import <XCTest/XCTest.h>
 
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 
-@interface FakeDelegate : NSObject<FlutterViewEngineDelegate>
+@interface FakeDelegate : FlutterEngine
 @property(nonatomic) BOOL ensureSemanticsEnabledCalled;
 @end
 
-@implementation FakeDelegate {
-  std::shared_ptr<flutter::FlutterPlatformViewsController> _platformViewsController;
-}
+@implementation FakeDelegate
 
-- (instancetype)init{
-  _ensureSemanticsEnabledCalled = NO;
-  _platformViewsController = std::shared_ptr<flutter::FlutterPlatformViewsController>(nullptr);
-  return self;
-}
-
-- (flutter::Rasterizer::Screenshot)takeScreenshot:(flutter::Rasterizer::ScreenshotType)type
-                                  asBase64Encoded:(BOOL)base64Encode {
-  return {};
-}
-
-- (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController {
-  return _platformViewsController;
-}
 - (void)ensureSemanticsEnabled {
   _ensureSemanticsEnabledCalled = YES;
 }
+
 @end
 
 @interface FlutterViewTest : XCTestCase
@@ -39,9 +25,8 @@
 @implementation FlutterViewTest
 
 - (void)testFlutterViewEnableSemanticsWhenIsAccessibilityElementIsCalled {
-  FakeDelegate* delegate = [[FakeDelegate alloc] init];
-  FlutterView* view = [[FlutterView alloc] initWithDelegate:delegate
-                                                      opaque:NO];
+  FakeDelegate* delegate = [[FakeDelegate alloc] initWithName:@"foobar"];
+  FlutterView* view = [[FlutterView alloc] initWithDelegate:delegate opaque:NO];
   delegate.ensureSemanticsEnabledCalled = NO;
   XCTAssertFalse(view.isAccessibilityElement);
   XCTAssertTrue(delegate.ensureSemanticsEnabledCalled);

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <XCTest/XCTest.h>
+
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
+
+@interface FakeDelegate : NSObject<FlutterViewEngineDelegate>
+@property(nonatomic) BOOL ensureSemanticsEnabledCalled;
+@end
+
+@implementation FakeDelegate {
+  std::shared_ptr<flutter::FlutterPlatformViewsController> _platformViewsController;
+}
+
+- (instancetype)init{
+  _ensureSemanticsEnabledCalled = NO;
+  _platformViewsController = std::shared_ptr<flutter::FlutterPlatformViewsController>(nullptr);
+  return self;
+}
+
+- (flutter::Rasterizer::Screenshot)takeScreenshot:(flutter::Rasterizer::ScreenshotType)type
+                                  asBase64Encoded:(BOOL)base64Encode {
+  return {};
+}
+
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController {
+  return _platformViewsController;
+}
+- (void)ensureSemanticsEnabled {
+  _ensureSemanticsEnabledCalled = YES;
+}
+@end
+
+@interface FlutterViewTest : XCTestCase
+@end
+
+@implementation FlutterViewTest
+
+- (void)testFlutterViewEnableSemanticsWhenIsAccessibilityElementIsCalled {
+  FakeDelegate* delegate = [[FakeDelegate alloc] init];
+  FlutterView* view = [[FlutterView alloc] initWithDelegate:delegate
+                                                      opaque:NO];
+  delegate.ensureSemanticsEnabledCalled = NO;
+  XCTAssertFalse(view.isAccessibilityElement);
+  XCTAssertTrue(delegate.ensureSemanticsEnabledCalled);
+}
+
+@end

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewTest.mm
@@ -7,14 +7,31 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 
-@interface FakeDelegate : FlutterEngine
-@property(nonatomic) BOOL ensureSemanticsEnabledCalled;
+@interface FakeDelegate : NSObject <FlutterViewEngineDelegate>
+@property(nonatomic) BOOL callbackCalled;
 @end
 
-@implementation FakeDelegate
+@implementation FakeDelegate {
+  std::shared_ptr<flutter::FlutterPlatformViewsController> _platformViewsController;
+}
 
-- (void)ensureSemanticsEnabled {
-  _ensureSemanticsEnabledCalled = YES;
+- (instancetype)init {
+  _callbackCalled = NO;
+  _platformViewsController = std::shared_ptr<flutter::FlutterPlatformViewsController>(nullptr);
+  return self;
+}
+
+- (flutter::Rasterizer::Screenshot)takeScreenshot:(flutter::Rasterizer::ScreenshotType)type
+                                  asBase64Encoded:(BOOL)base64Encode {
+  return {};
+}
+
+- (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController {
+  return _platformViewsController;
+}
+
+- (void)flutterViewAccessibilityDidCall {
+  _callbackCalled = YES;
 }
 
 @end
@@ -25,11 +42,11 @@
 @implementation FlutterViewTest
 
 - (void)testFlutterViewEnableSemanticsWhenIsAccessibilityElementIsCalled {
-  FakeDelegate* delegate = [[FakeDelegate alloc] initWithName:@"foobar"];
+  FakeDelegate* delegate = [[FakeDelegate alloc] init];
   FlutterView* view = [[FlutterView alloc] initWithDelegate:delegate opaque:NO];
-  delegate.ensureSemanticsEnabledCalled = NO;
+  delegate.callbackCalled = NO;
   XCTAssertFalse(view.isAccessibilityElement);
-  XCTAssertTrue(delegate.ensureSemanticsEnabledCalled);
+  XCTAssertTrue(delegate.callbackCalled);
 }
 
 @end


### PR DESCRIPTION
Added a catch all workaround to make sure semantics is enabled.
https://github.com/flutter/flutter/issues/75887

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
