### PR TITLE
Fixed problem where AndroidShellHolder was trashing the ThreadHost in its deconstructor

### DIFF
--- a/shell/common/thread_host.cc
+++ b/shell/common/thread_host.cc
@@ -35,7 +35,7 @@ ThreadHost::ThreadHost(std::string name_prefix_arg, uint64_t mask)
 
 ThreadHost::~ThreadHost() = default;
 
-void ThreadHost::Reset() {
+void ThreadHost::ResetThreads() {
   platform_thread.reset();
   ui_thread.reset();
   raster_thread.reset();

--- a/shell/common/thread_host.cc
+++ b/shell/common/thread_host.cc
@@ -35,12 +35,4 @@ ThreadHost::ThreadHost(std::string name_prefix_arg, uint64_t mask)
 
 ThreadHost::~ThreadHost() = default;
 
-void ThreadHost::ResetThreads() {
-  platform_thread.reset();
-  ui_thread.reset();
-  raster_thread.reset();
-  io_thread.reset();
-  profiler_thread.reset();
-}
-
 }  // namespace flutter

--- a/shell/common/thread_host.h
+++ b/shell/common/thread_host.h
@@ -39,7 +39,7 @@ struct ThreadHost {
 
   ~ThreadHost();
 
-  void Reset();
+  void ResetThreads();
 };
 
 }  // namespace flutter

--- a/shell/common/thread_host.h
+++ b/shell/common/thread_host.h
@@ -38,8 +38,6 @@ struct ThreadHost {
   ThreadHost(std::string name_prefix, uint64_t type_mask);
 
   ~ThreadHost();
-
-  void ResetThreads();
 };
 
 }  // namespace flutter

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -170,7 +170,7 @@ AndroidShellHolder::AndroidShellHolder(
 
 AndroidShellHolder::~AndroidShellHolder() {
   shell_.reset();
-  thread_host_->Reset();
+  thread_host_.reset();
 }
 
 bool AndroidShellHolder::IsValid() const {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/76597

There was a typo where we were clearing out a threadhost instead of reseting the reference.  I removed the method since `foo->Reset()` and `foo.reset()` are very similar, in order to avoid future bugs.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
