### PR TITLE
fuchsia: Correct PlatformView scale/transform

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -218,6 +218,9 @@ class EmbeddedViewParams {
     final_bounding_rect_ = other.final_bounding_rect_;
   };
 
+  // The trasnformation Matrix corresponding to the sum of all the
+  // transformations in the platform view's mutator stack.
+  const SkMatrix& transformMatrix() const { return matrix_; };
   // The original size of the platform view before any mutation matrix is
   // applied.
   const SkSize& sizePoints() const { return size_points_; };

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.cc
@@ -23,6 +23,41 @@ constexpr float kScenicZElevationBetweenLayers = 0.0001f;
 constexpr float kScenicZElevationForPlatformView = 100.f;
 constexpr float kScenicElevationForInputInterceptor = 500.f;
 
+SkScalar OpacityFromMutatorStack(const flutter::MutatorsStack& mutatorsStack) {
+  SkScalar mutatorsOpacity = 1.f;
+  for (auto i = mutatorsStack.Bottom(); i != mutatorsStack.Top(); ++i) {
+    const auto& mutator = *i;
+    switch (mutator->GetType()) {
+      case flutter::MutatorType::opacity: {
+        mutatorsOpacity *= std::clamp(mutator->GetAlphaFloat(), 0.f, 1.f);
+      } break;
+      default: {
+        break;
+      }
+    }
+  }
+
+  return mutatorsOpacity;
+}
+
+SkMatrix TransformFromMutatorStack(
+    const flutter::MutatorsStack& mutatorsStack) {
+  SkMatrix mutatorsTransform;
+  for (auto i = mutatorsStack.Bottom(); i != mutatorsStack.Top(); ++i) {
+    const auto& mutator = *i;
+    switch (mutator->GetType()) {
+      case flutter::MutatorType::transform: {
+        mutatorsTransform.preConcat(mutator->GetMatrix());
+      } break;
+      default: {
+        break;
+      }
+    }
+  }
+
+  return mutatorsTransform;
+}
+
 }  // namespace
 
 FuchsiaExternalViewEmbedder::FuchsiaExternalViewEmbedder(
@@ -214,32 +249,28 @@ void FuchsiaExternalViewEmbedder::SubmitFrame(
         FML_DCHECK(layer->second.embedded_view_params.has_value());
         auto& view_params = layer->second.embedded_view_params.value();
 
-        // Compute offset and size for the platform view.
-        SkPoint view_offset =
-            SkPoint::Make(view_params.finalBoundingRect().left(),
-                          view_params.finalBoundingRect().top());
-        SkSize view_size =
-            SkSize::Make(view_params.finalBoundingRect().width(),
-                         view_params.finalBoundingRect().height());
+        // Validate the MutatorsStack encodes the same transform as the
+        // transform matrix.
+        FML_DCHECK(TransformFromMutatorStack(view_params.mutatorsStack()) ==
+                   view_params.transformMatrix());
 
-        // Compute opacity for the platform view.
-        float view_opacity = 1.0f;
-        for (auto i = view_params.mutatorsStack().Bottom();
-             i != view_params.mutatorsStack().Top(); ++i) {
-          const auto& mutator = *i;
-          switch (mutator->GetType()) {
-            case flutter::MutatorType::opacity: {
-              view_opacity *= std::clamp(mutator->GetAlphaFloat(), 0.0f, 1.0f);
-            } break;
-            default: {
-              break;
-            }
-          }
-        }
-
+        // Get the ScenicView structure corresponding to the platform view.
         auto found = scenic_views_.find(layer_id.value());
         FML_DCHECK(found != scenic_views_.end());
         auto& view_holder = found->second;
+
+        // Compute offset and size for the platform view.
+        const SkMatrix& view_transform = view_params.transformMatrix();
+        const SkPoint view_offset = SkPoint::Make(
+            view_transform.getTranslateX(), view_transform.getTranslateY());
+        const SkSize view_size = view_params.sizePoints();
+        const SkSize view_scale = SkSize::Make(view_transform.getScaleX(),
+                                               view_transform.getScaleY());
+        FML_DCHECK(!view_size.isEmpty() && !view_scale.isEmpty());
+
+        // Compute opacity for the platform view.
+        const float view_opacity =
+            OpacityFromMutatorStack(view_params.mutatorsStack());
 
         // Set opacity.
         if (view_opacity != view_holder.opacity) {
@@ -247,14 +278,19 @@ void FuchsiaExternalViewEmbedder::SubmitFrame(
           view_holder.opacity = view_opacity;
         }
 
-        // Set offset and elevation.
+        // Set transform and elevation.
         const float view_elevation =
             kScenicZElevationBetweenLayers * scenic_layer_index +
             embedded_views_height;
         if (view_offset != view_holder.offset ||
+            view_scale != view_holder.scale ||
             view_elevation != view_holder.elevation) {
           view_holder.entity_node.SetTranslation(view_offset.fX, view_offset.fY,
                                                  -view_elevation);
+          view_holder.entity_node.SetScale(view_scale.fWidth,
+                                           view_scale.fHeight, 1.f);
+          view_holder.offset = view_offset;
+          view_holder.scale = view_scale;
           view_holder.elevation = view_elevation;
         }
 
@@ -277,8 +313,8 @@ void FuchsiaExternalViewEmbedder::SubmitFrame(
               .bounding_box =
                   {
                       .min = {.x = 0.f, .y = 0.f, .z = -1000.f},
-                      .max = {.x = view_size.width(),
-                              .y = view_size.height(),
+                      .max = {.x = view_size.fWidth,
+                              .y = view_size.fHeight,
                               .z = 0.f},
                   },
               .inset_from_min = {.x = 0.f, .y = 0.f, .z = 0.f},

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
@@ -86,8 +86,8 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
   bool SupportsDynamicThreadMerging() override { return false; }
 
   // View manipulation.
-  // |SetViewProperties| doesn't manipulate the view directly -- it sets
-  // prending properties for the next |UpdateView| call.
+  // |SetViewProperties| doesn't manipulate the view directly -- it sets pending
+  // properties for the next |UpdateView| call.
   void EnableWireframe(bool enable);
   void CreateView(int64_t view_id);
   void DestroyView(int64_t view_id);
@@ -119,6 +119,7 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
     scenic::ViewHolder view_holder;
 
     SkPoint offset = SkPoint::Make(0.f, 0.f);
+    SkSize scale = SkSize::MakeEmpty();
     SkSize size = SkSize::MakeEmpty();
     float elevation = 0.f;
     float opacity = 1.f;


### PR DESCRIPTION
The new embedder renderer for Fuchsia doesn't handle scale or transform for embedded views correctly, so they get scaled wrong on some devices.

Fixes b/180926644

Tested by flutter-embedder-tests in Fuchsia tree