### PR TITLE
Convert cursor rect to device coordinates on Win32

### DIFF
--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -218,7 +218,7 @@ void FlutterWindowsView::OnScroll(double x,
 }
 
 void FlutterWindowsView::OnCursorRectUpdated(const Rect& rect) {
-  binding_handler_->UpdateCursorRect(rect);
+  binding_handler_->OnCursorRectUpdated(rect);
 }
 
 // Sends new size  information to FlutterEngine.

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -29,7 +29,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD0(OnWindowResized, void());
   MOCK_METHOD0(GetPhysicalWindowBounds, PhysicalWindowBounds());
   MOCK_METHOD1(UpdateFlutterCursor, void(const std::string& cursor_name));
-  MOCK_METHOD1(UpdateCursorRect, void(const Rect& rect));
+  MOCK_METHOD1(OnCursorRectUpdated, void(const Rect& rect));
 };
 
 }  // namespace testing

--- a/shell/platform/windows/text_input_plugin_delegate.h
+++ b/shell/platform/windows/text_input_plugin_delegate.h
@@ -12,7 +12,8 @@ namespace flutter {
 
 class TextInputPluginDelegate {
  public:
-  // Notifies delegate that the cursor position has changed.
+  // Notifies the delegate of the updated the cursor rect in Flutter root view
+  // coordinates.
   virtual void OnCursorRectUpdated(const Rect& rect) = 0;
 };
 

--- a/shell/platform/windows/win32_flutter_window.cc
+++ b/shell/platform/windows/win32_flutter_window.cc
@@ -194,12 +194,12 @@ void Win32FlutterWindow::OnScroll(double delta_x, double delta_y) {
                                       kScrollOffsetMultiplier);
 }
 
-void Win32FlutterWindow::UpdateCursorRect(const Rect& rect) {
+void Win32FlutterWindow::OnCursorRectUpdated(const Rect& rect) {
   // Convert the rect from Flutter logical coordinates to device coordinates.
   auto scale = GetDpiScale();
   Point origin(rect.left() * scale, rect.top() * scale);
   Size size(rect.width() * scale, rect.height() * scale);
-  text_input_manager_.UpdateCaretRect(Rect(origin, size));
+  UpdateCursorRect(Rect(origin, size));
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/win32_flutter_window.cc
+++ b/shell/platform/windows/win32_flutter_window.cc
@@ -195,7 +195,11 @@ void Win32FlutterWindow::OnScroll(double delta_x, double delta_y) {
 }
 
 void Win32FlutterWindow::UpdateCursorRect(const Rect& rect) {
-  text_input_manager_.UpdateCaretRect(rect);
+  // Convert the rect from Flutter logical coordinates to device coordinates.
+  auto scale = GetDpiScale();
+  Point origin(rect.left() * scale, rect.top() * scale);
+  Size size(rect.width() * scale, rect.height() * scale);
+  text_input_manager_.UpdateCaretRect(Rect(origin, size));
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/win32_flutter_window.h
+++ b/shell/platform/windows/win32_flutter_window.h
@@ -71,6 +71,9 @@ class Win32FlutterWindow : public Win32Window, public WindowBindingHandler {
   // |Win32Window|
   void OnComposeChange(const std::u16string& text, int cursor_pos) override;
 
+  // |FlutterWindowBindingHandler|
+  void OnCursorRectUpdated(const Rect& rect) override;
+
   // |Win32Window|
   void OnScroll(double delta_x, double delta_y) override;
 
@@ -88,9 +91,6 @@ class Win32FlutterWindow : public Win32Window, public WindowBindingHandler {
 
   // |FlutterWindowBindingHandler|
   void UpdateFlutterCursor(const std::string& cursor_name) override;
-
-  // |FlutterWindowBindingHandler|
-  void UpdateCursorRect(const Rect& rect) override;
 
   // |FlutterWindowBindingHandler|
   void OnWindowResized() override;

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -173,6 +173,10 @@ void Win32Window::OnImeRequest(UINT const message,
   // https://github.com/flutter/flutter/issues/74547
 }
 
+void Win32Window::UpdateCursorRect(const Rect& rect) {
+  text_input_manager_.UpdateCaretRect(rect);
+}
+
 LRESULT
 Win32Window::HandleMessage(UINT const message,
                            WPARAM const wparam,

--- a/shell/platform/windows/win32_window.h
+++ b/shell/platform/windows/win32_window.h
@@ -141,6 +141,11 @@ class Win32Window {
                     WPARAM const wparam,
                     LPARAM const lparam);
 
+  // Called when the cursor rect has been updated.
+  //
+  // |rect| is in Win32 window coordinates.
+  virtual void UpdateCursorRect(const Rect& rect);
+
   // Called when mouse scrollwheel input occurs.
   virtual void OnScroll(double delta_x, double delta_y) = 0;
 
@@ -186,7 +191,7 @@ class Win32Window {
   // message.
   int keycode_for_char_message_ = 0;
 
- protected:
+  // Manages IME state.
   TextInputManagerWin32 text_input_manager_;
 };
 

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -63,7 +63,7 @@ class WindowBindingHandler {
   // content. See mouse_cursor.dart for the values and meanings of cursor_name.
   virtual void UpdateFlutterCursor(const std::string& cursor_name) = 0;
 
-  // Sets the cursor rect in root view coordinates.
+  // Sets the cursor rect in Flutter root view coordinates.
   virtual void UpdateCursorRect(const Rect& rect) = 0;
 };
 

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -63,8 +63,8 @@ class WindowBindingHandler {
   // content. See mouse_cursor.dart for the values and meanings of cursor_name.
   virtual void UpdateFlutterCursor(const std::string& cursor_name) = 0;
 
-  // Sets the cursor rect in Flutter root view coordinates.
-  virtual void UpdateCursorRect(const Rect& rect) = 0;
+  // Invoked when the cursor/composing rect has been updated in the framework.
+  virtual void OnCursorRectUpdated(const Rect& rect) = 0;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
The handlers for the TextInput.setMarkedTextRect and
TextInput.setEditableSizeAndTransform in the win32 embedding deal in
Flutter root view co-ordinates. These need to be converted to window
co-ordinates before being passed to the TextInputManager, which deals in
Win32 window co-ordinates.

This fixes a bug wherein the IME candidates window for CJK input was
incorrectly positioned at display scales other than 100% in the OS
settings.

Fixes: https://github.com/flutter/flutter/issues/76902

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
