### PR TITLE
[Windows] Hide Win32 API of the keyboard system behind ifdef

### DIFF
--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -268,10 +268,10 @@ void FlutterWindowWinUWP::OnKeyUp(
   auto status = args.KeyStatus();
   unsigned int scancode = status.ScanCode;
   int key = static_cast<int>(args.VirtualKey());
-  char32_t chararacter = static_cast<char32_t>(key | 32);
   int action = 0x0101;
-  binding_handler_delegate_->OnKey(key, scancode, action, chararacter,
-                                   false /* extended */, true /* was_down */);
+  binding_handler_delegate_->OnKey(key, scancode, action, 0,
+                                   status.IsExtendedKey /* extended */,
+                                   status.WasKeyDown /* was_down */);
 }
 
 void FlutterWindowWinUWP::OnKeyDown(
@@ -286,8 +286,9 @@ void FlutterWindowWinUWP::OnKeyDown(
   int key = static_cast<int>(args.VirtualKey());
   char32_t chararacter = static_cast<char32_t>(key | 32);
   int action = 0x0100;
-  binding_handler_delegate_->OnKey(key, scancode, action, chararacter,
-                                   false /* extended */, false /* was_down */);
+  binding_handler_delegate_->OnKey(key, scancode, action, 0,
+                                   status.IsExtendedKey /* extended */,
+                                   status.WasKeyDown /* was_down */);
 }
 
 void FlutterWindowWinUWP::OnCharacterReceived(

--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -284,7 +284,6 @@ void FlutterWindowWinUWP::OnKeyDown(
   auto status = args.KeyStatus();
   unsigned int scancode = status.ScanCode;
   int key = static_cast<int>(args.VirtualKey());
-  char32_t chararacter = static_cast<char32_t>(key | 32);
   int action = 0x0100;
   binding_handler_delegate_->OnKey(key, scancode, action, 0,
                                    status.IsExtendedKey /* extended */,

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -78,7 +78,14 @@ void FlutterWindowsView::RegisterKeyboardHandlers(
   // of the event. In order to allow the same real event in the future, the
   // handler is "toggled" when events pass through, therefore the redispatching
   // algorithm does not allow more than 1 handler that takes |SendInput|.
-  auto key_handler = std::make_unique<flutter::KeyboardKeyHandler>(SendInput);
+#ifdef WINUWP
+  flutter::KeyboardKeyHandler::EventRedispatcher redispatch_event = nullptr;
+  flutter::KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state = nullptr;
+#else
+  flutter::KeyboardKeyHandler::EventRedispatcher redispatch_event = SendInput;
+  flutter::KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state = GetKeyState;
+#endif
+  auto key_handler = std::make_unique<flutter::KeyboardKeyHandler>(redispatch_event);
   key_handler->AddDelegate(
       std::make_unique<KeyboardKeyChannelHandler>(messenger));
   key_handler->AddDelegate(std::make_unique<KeyboardKeyEmbedderHandler>(
@@ -86,7 +93,7 @@ void FlutterWindowsView::RegisterKeyboardHandlers(
              void* user_data) {
         return engine_->SendKeyEvent(event, callback, user_data);
       },
-      GetKeyState));
+      get_key_state));
   AddKeyboardHandler(std::move(key_handler));
   AddKeyboardHandler(
       std::make_unique<flutter::TextInputPlugin>(messenger, this));

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -80,12 +80,15 @@ void FlutterWindowsView::RegisterKeyboardHandlers(
   // algorithm does not allow more than 1 handler that takes |SendInput|.
 #ifdef WINUWP
   flutter::KeyboardKeyHandler::EventRedispatcher redispatch_event = nullptr;
-  flutter::KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state = nullptr;
+  flutter::KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state =
+      nullptr;
 #else
   flutter::KeyboardKeyHandler::EventRedispatcher redispatch_event = SendInput;
-  flutter::KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state = GetKeyState;
+  flutter::KeyboardKeyEmbedderHandler::GetKeyStateHandler get_key_state =
+      GetKeyState;
 #endif
-  auto key_handler = std::make_unique<flutter::KeyboardKeyHandler>(redispatch_event);
+  auto key_handler =
+      std::make_unique<flutter::KeyboardKeyHandler>(redispatch_event);
   key_handler->AddDelegate(
       std::make_unique<KeyboardKeyChannelHandler>(messenger));
   key_handler->AddDelegate(std::make_unique<KeyboardKeyEmbedderHandler>(

--- a/shell/platform/windows/keyboard_key_channel_handler.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler.cc
@@ -96,7 +96,8 @@ int GetModsForKeyState() {
 
 }  // namespace
 
-KeyboardKeyChannelHandler::KeyboardKeyChannelHandler(flutter::BinaryMessenger* messenger)
+KeyboardKeyChannelHandler::KeyboardKeyChannelHandler(
+    flutter::BinaryMessenger* messenger)
     : channel_(
           std::make_unique<flutter::BasicMessageChannel<rapidjson::Document>>(
               messenger,

--- a/shell/platform/windows/keyboard_key_channel_handler.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler.cc
@@ -55,6 +55,11 @@ static constexpr int kScrollLock = 1 << 13;
 /// with the re-defined values declared above for compatibility with the Flutter
 /// framework.
 int GetModsForKeyState() {
+  // TODO(clarkezone) need to add support for get modifier state for UWP
+  // https://github.com/flutter/flutter/issues/70202
+#ifdef WINUWP
+  return 0;
+#else
   int mods = 0;
 
   if (GetKeyState(VK_SHIFT) < 0)
@@ -86,12 +91,12 @@ int GetModsForKeyState() {
   if (GetKeyState(VK_SCROLL) < 0)
     mods |= kScrollLock;
   return mods;
+#endif
 }
 
 }  // namespace
 
-KeyboardKeyChannelHandler::KeyboardKeyChannelHandler(
-    flutter::BinaryMessenger* messenger)
+KeyboardKeyChannelHandler::KeyboardKeyChannelHandler(flutter::BinaryMessenger* messenger)
     : channel_(
           std::make_unique<flutter::BasicMessageChannel<rapidjson::Document>>(
               messenger,

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -56,9 +56,7 @@ constexpr SHORT kStateMaskPressed = 0x80;
 }  // namespace
 
 KeyboardKeyEmbedderHandler::KeyboardKeyEmbedderHandler(
-    std::function<void(const FlutterKeyEvent&,
-                       FlutterKeyEventCallback,
-                       void* user_data)> send_event,
+    SendEvent send_event,
     GetKeyStateHandler get_key_state)
     : sendEvent_(send_event), get_key_state_(get_key_state), response_id_(1) {
   InitCriticalKeys();
@@ -264,6 +262,11 @@ void KeyboardKeyEmbedderHandler::UpdateLastSeenCritialKey(
 
 void KeyboardKeyEmbedderHandler::SynchronizeCritialToggledStates(
     int toggle_virtual_key) {
+  // TODO(dkwingsmt) consider adding support for synchronizing key state for UWP
+  // https://github.com/flutter/flutter/issues/70202
+#ifdef WINUWP
+  return;
+#else
   for (auto& kv : critical_keys_) {
     UINT virtual_key = kv.first;
     CriticalKey& key_info = kv.second;
@@ -301,9 +304,15 @@ void KeyboardKeyEmbedderHandler::SynchronizeCritialToggledStates(
       key_info.toggled_on = should_toggled;
     }
   }
+#endif
 }
 
 void KeyboardKeyEmbedderHandler::SynchronizeCritialPressedStates() {
+  // TODO(dkwingsmt) consider adding support for synchronizing key state for UWP
+  // https://github.com/flutter/flutter/issues/70202
+#ifdef WINUWP
+  return;
+#else
   for (auto& kv : critical_keys_) {
     UINT virtual_key = kv.first;
     CriticalKey& key_info = kv.second;
@@ -333,6 +342,7 @@ void KeyboardKeyEmbedderHandler::SynchronizeCritialPressedStates() {
       }
     }
   }
+#endif
 }
 
 void KeyboardKeyEmbedderHandler::HandleResponse(bool handled, void* user_data) {
@@ -342,6 +352,9 @@ void KeyboardKeyEmbedderHandler::HandleResponse(bool handled, void* user_data) {
 }
 
 void KeyboardKeyEmbedderHandler::InitCriticalKeys() {
+#ifdef WINUWP
+  return;
+#else
   auto createCheckedKey = [this](UINT virtual_key, bool extended,
                                  bool check_pressed,
                                  bool check_toggled) -> CriticalKey {
@@ -374,6 +387,7 @@ void KeyboardKeyEmbedderHandler::InitCriticalKeys() {
                          createCheckedKey(VK_SCROLL, false, true, true));
   critical_keys_.emplace(VK_NUMLOCK,
                          createCheckedKey(VK_NUMLOCK, true, true, true));
+#endif
 }
 
 void KeyboardKeyEmbedderHandler::ConvertUtf32ToUtf8_(char* out, char32_t ch) {

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -352,6 +352,8 @@ void KeyboardKeyEmbedderHandler::HandleResponse(bool handled, void* user_data) {
 }
 
 void KeyboardKeyEmbedderHandler::InitCriticalKeys() {
+  // TODO(dkwingsmt) consider adding support for synchronizing key state for UWP
+  // https://github.com/flutter/flutter/issues/70202
 #ifdef WINUWP
   return;
 #else

--- a/shell/platform/windows/keyboard_key_embedder_handler.h
+++ b/shell/platform/windows/keyboard_key_embedder_handler.h
@@ -37,7 +37,8 @@ class KeyboardKeyEmbedderHandler
   // of the SendEvent call might be nullptr.
   //
   // Use `get_key_state` to define how the class should get a reliable result of
-  // the state for a virtual key. It's typically Win32's GetKeyState.
+  // the state for a virtual key. It's typically Win32's GetKeyState, but can
+  // also be nullptr (for UWP).
   explicit KeyboardKeyEmbedderHandler(SendEvent send_event,
                                       GetKeyStateHandler get_key_state);
 

--- a/shell/platform/windows/keyboard_key_handler.cc
+++ b/shell/platform/windows/keyboard_key_handler.cc
@@ -39,7 +39,6 @@ KeyboardKeyHandler::KeyboardKeyHandlerDelegate::~KeyboardKeyHandlerDelegate() =
 
 KeyboardKeyHandler::KeyboardKeyHandler(EventRedispatcher redispatch_event)
     : redispatch_event_(redispatch_event), last_sequence_id_(1) {
-  assert(redispatch_event_ != nullptr);
 }
 
 KeyboardKeyHandler::~KeyboardKeyHandler() = default;
@@ -57,6 +56,12 @@ size_t KeyboardKeyHandler::RedispatchedCount() {
 }
 
 void KeyboardKeyHandler::RedispatchEvent(std::unique_ptr<PendingEvent> event) {
+  // TODO(dkwingsmt) consider adding support for redispatching events for UWP
+  // in order to support add-to-app.
+  // https://github.com/flutter/flutter/issues/70202
+#ifdef WINUWP
+  return;
+#else
   uint8_t scancode = event->scancode;
   char32_t character = event->character;
 
@@ -81,6 +86,7 @@ void KeyboardKeyHandler::RedispatchEvent(std::unique_ptr<PendingEvent> event) {
                  "with scancode "
               << scancode << " (character " << character << ")" << std::endl;
   }
+#endif
 }
 
 bool KeyboardKeyHandler::KeyboardHook(FlutterWindowsView* view,

--- a/shell/platform/windows/keyboard_key_handler.cc
+++ b/shell/platform/windows/keyboard_key_handler.cc
@@ -38,8 +38,7 @@ KeyboardKeyHandler::KeyboardKeyHandlerDelegate::~KeyboardKeyHandlerDelegate() =
     default;
 
 KeyboardKeyHandler::KeyboardKeyHandler(EventRedispatcher redispatch_event)
-    : redispatch_event_(redispatch_event), last_sequence_id_(1) {
-}
+    : redispatch_event_(redispatch_event), last_sequence_id_(1) {}
 
 KeyboardKeyHandler::~KeyboardKeyHandler() = default;
 

--- a/shell/platform/windows/keyboard_key_handler.h
+++ b/shell/platform/windows/keyboard_key_handler.h
@@ -58,7 +58,8 @@ class KeyboardKeyHandler : public KeyboardHandlerBase {
 
   // Create a KeyboardKeyHandler and specify where to redispatch events.
   //
-  // The |redispatch_event| is typically |SendInput|.
+  // The |redispatch_event| is typically |SendInput|, but can also be nullptr
+  // (for UWP).
   explicit KeyboardKeyHandler(EventRedispatcher redispatch_event);
 
   ~KeyboardKeyHandler();


### PR DESCRIPTION
Fix UWP compilation by hiding Win32 API used in the keyboard system behind `ifdef WINUWP`.

It also includes a fix for the UWP keyboard dispatching, written by @clarkezone, so that dispatched events use 0 for `character` and correct states for `was_down` and `extended`. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
