### PR TITLE
Fix memory leak and bug in the RunsOnCreationTaskRunner check

### DIFF
--- a/fml/memory/task_runner_checker.cc
+++ b/fml/memory/task_runner_checker.cc
@@ -7,14 +7,18 @@
 namespace fml {
 
 TaskRunnerChecker::TaskRunnerChecker()
-    : initialized_queue_id_(InitTaskQueueId()){};
+    : initialized_queue_id_(InitTaskQueueId()),
+      subsumed_queue_id_(
+          MessageLoopTaskQueues::GetInstance()->GetSubsumedTaskQueueId(
+              initialized_queue_id_)){};
 
 TaskRunnerChecker::~TaskRunnerChecker() = default;
 
 bool TaskRunnerChecker::RunsOnCreationTaskRunner() const {
   FML_CHECK(fml::MessageLoop::IsInitializedForCurrentThread());
   const auto current_queue_id = MessageLoop::GetCurrentTaskQueueId();
-  return RunsOnTheSameThread(current_queue_id, initialized_queue_id_);
+  return RunsOnTheSameThread(current_queue_id, initialized_queue_id_) ||
+         RunsOnTheSameThread(current_queue_id, subsumed_queue_id_);
 };
 
 bool TaskRunnerChecker::RunsOnTheSameThread(TaskQueueId queue_a,

--- a/fml/memory/task_runner_checker.h
+++ b/fml/memory/task_runner_checker.h
@@ -22,6 +22,7 @@ class TaskRunnerChecker final {
 
  private:
   TaskQueueId initialized_queue_id_;
+  TaskQueueId subsumed_queue_id_;
 
   TaskQueueId InitTaskQueueId();
 };

--- a/fml/message_loop_task_queues.cc
+++ b/fml/message_loop_task_queues.cc
@@ -238,7 +238,14 @@ bool MessageLoopTaskQueues::Unmerge(TaskQueueId owner) {
 bool MessageLoopTaskQueues::Owns(TaskQueueId owner,
                                  TaskQueueId subsumed) const {
   std::lock_guard guard(queue_mutex_);
-  return subsumed == queue_entries_.at(owner)->owner_of;
+  return owner != _kUnmerged && subsumed != _kUnmerged &&
+         subsumed == queue_entries_.at(owner)->owner_of;
+}
+
+TaskQueueId MessageLoopTaskQueues::GetSubsumedTaskQueueId(
+    TaskQueueId owner) const {
+  std::lock_guard guard(queue_mutex_);
+  return queue_entries_.at(owner)->owner_of;
 }
 
 // Subsumed queues will never have pending tasks.

--- a/fml/message_loop_task_queues.h
+++ b/fml/message_loop_task_queues.h
@@ -122,6 +122,10 @@ class MessageLoopTaskQueues
   // Returns true if owner owns the subsumed task queue.
   bool Owns(TaskQueueId owner, TaskQueueId subsumed) const;
 
+  // Returns the subsumed task queue if any or |TaskQueueId::kUnmerged|
+  // otherwise.
+  TaskQueueId GetSubsumedTaskQueueId(TaskQueueId owner) const;
+
  private:
   class MergedQueuesRunner;
 

--- a/fml/message_loop_task_queues_unittests.cc
+++ b/fml/message_loop_task_queues_unittests.cc
@@ -185,6 +185,13 @@ TEST(MessageLoopTaskQueue, QueueDoNotOwnItself) {
   ASSERT_FALSE(task_queue->Owns(queue_id, queue_id));
 }
 
+TEST(MessageLoopTaskQueue, QueueDoNotOwnUnmergedTaskQueueId) {
+  auto task_queue = fml::MessageLoopTaskQueues::GetInstance();
+  ASSERT_FALSE(task_queue->Owns(task_queue->CreateTaskQueue(), _kUnmerged));
+  ASSERT_FALSE(task_queue->Owns(_kUnmerged, task_queue->CreateTaskQueue()));
+  ASSERT_FALSE(task_queue->Owns(_kUnmerged, _kUnmerged));
+}
+
 // TODO(chunhtai): This unit-test is flaky and sometimes fails asynchronizely
 // after the test has finished.
 // https://github.com/flutter/flutter/issues/43858

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -458,6 +458,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     if (platformViewsChannel != null) {
       platformViewsChannel.setPlatformViewsHandler(null);
     }
+    destroyOverlaySurfaces();
     platformViewsChannel = null;
     context = null;
     textureRegistry = null;
@@ -761,6 +762,9 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   }
 
   public void onDisplayOverlaySurface(int id, int x, int y, int width, int height) {
+    if (!overlayLayerViews.contains(id)) {
+      throw new IllegalStateException("The overlay surface (id:" + id + ") doesn't exist");
+    }
     initializeRootImageViewIfNeeded();
 
     final FlutterImageView overlayView = overlayLayerViews.get(id);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -762,7 +762,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   }
 
   public void onDisplayOverlaySurface(int id, int x, int y, int width, int height) {
-    if (!overlayLayerViews.contains(id)) {
+    if (overlayLayerViews.get(id) == null) {
       throw new IllegalStateException("The overlay surface (id:" + id + ") doesn't exist");
     }
     initializeRootImageViewIfNeeded();

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -563,6 +563,61 @@ public class PlatformViewsControllerTest {
   }
 
   @Test
+  @Config(shadows = {ShadowFlutterSurfaceView.class, ShadowFlutterJNI.class})
+  public void detach__destroysOverlaySurfaces() {
+    final PlatformViewsController platformViewsController = new PlatformViewsController();
+
+    final int platformViewId = 0;
+    assertNull(platformViewsController.getPlatformViewById(platformViewId));
+
+    final PlatformViewFactory viewFactory = mock(PlatformViewFactory.class);
+    final PlatformView platformView = mock(PlatformView.class);
+    when(platformView.getView()).thenReturn(mock(View.class));
+    when(viewFactory.create(any(), eq(platformViewId), any())).thenReturn(platformView);
+
+    platformViewsController.getRegistry().registerViewFactory("testType", viewFactory);
+
+    final FlutterJNI jni = new FlutterJNI();
+    jni.attachToNative(false);
+    attach(jni, platformViewsController);
+
+    jni.onFirstFrame();
+
+    // Simulate create call from the framework.
+    createPlatformView(jni, platformViewsController, platformViewId, "testType");
+
+    // Produce a frame that displays a platform view and an overlay surface.
+    platformViewsController.onBeginFrame();
+    platformViewsController.onDisplayPlatformView(
+        platformViewId,
+        /* x=*/ 0,
+        /* y=*/ 0,
+        /* width=*/ 10,
+        /* height=*/ 10,
+        /* viewWidth=*/ 10,
+        /* viewHeight=*/ 10,
+        /* mutatorsStack=*/ new FlutterMutatorsStack());
+
+    final FlutterImageView overlayImageView = mock(FlutterImageView.class);
+    when(overlayImageView.acquireLatestImage()).thenReturn(true);
+
+    platformViewsController.createOverlaySurface(overlayImageView);
+
+    // This is OK.
+    platformViewsController.onDisplayOverlaySurface(
+        overlaySurface.getId(), /* x=*/ 0, /* y=*/ 0, /* width=*/ 10, /* height=*/ 10);
+
+    platformViewsController.detach();
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> {
+          platformViewsController.onDisplayOverlaySurface(
+              overlaySurface.getId(), /* x=*/ 0, /* y=*/ 0, /* width=*/ 10, /* height=*/ 10);
+        });
+  }
+
+  @Test
   public void checkInputConnectionProxy__falseIfViewIsNull() {
     final PlatformViewsController platformViewsController = new PlatformViewsController();
     boolean shouldProxying = platformViewsController.checkInputConnectionProxy(null);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -601,8 +601,8 @@ public class PlatformViewsControllerTest {
     final FlutterImageView overlayImageView = mock(FlutterImageView.class);
     when(overlayImageView.acquireLatestImage()).thenReturn(true);
 
-    platformViewsController.createOverlaySurface(overlayImageView);
-
+    final FlutterOverlaySurface overlaySurface =
+        platformViewsController.createOverlaySurface(overlayImageView);
     // This is OK.
     platformViewsController.onDisplayOverlaySurface(
         overlaySurface.getId(), /* x=*/ 0, /* y=*/ 0, /* width=*/ 10, /* height=*/ 10);

--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.facebook.testing.screenshot'
 
+def leakcanary_version = '2.6'
+
 screenshots {
     failureDir = "${rootProject.buildDir}/reports/diff_failures"
     recordDir = "${rootProject.projectDir}/reports/screenshots"
@@ -13,12 +15,14 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
     defaultConfig {
-        applicationId "dev.flutter.scenarios"
+        applicationId 'dev.flutter.scenarios'
         minSdkVersion 18
         targetSdkVersion 30
         versionCode 1
-        versionName "1.0"
-        testInstrumentationRunner "dev.flutter.TestRunner"
+        versionName '1.0'
+        testInstrumentationRunner 'dev.flutter.TestRunner'
+        testInstrumentationRunnerArgument 'listener', 'leakcanary.FailTestOnLeakRunListener'
+        testInstrumentationRunnerArguments clearPackageData: 'true'
     }
     buildTypes {
         release {
@@ -38,8 +42,10 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0-alpha01'
+    implementation "com.squareup.leakcanary:leakcanary-android:$leakcanary_version"
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    androidTestImplementation "com.squareup.leakcanary:leakcanary-android-instrumentation:$leakcanary_version"
 }

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/MemoryLeakTests.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/MemoryLeakTests.java
@@ -17,7 +17,6 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 @LargeTest
 public class MemoryLeakTests {
-
   @Rule
   public ActivityTestRule<TextPlatformViewActivity> activityRule =
       new ActivityTestRule<>(
@@ -30,6 +29,6 @@ public class MemoryLeakTests {
     intent.putExtra("scenario", "platform_view");
     intent.putExtra("use_android_view", true);
 
-    TextPlatformViewActivity activity = activityRule.launchActivity(intent);
+    activityRule.launchActivity(intent);
   }
 }

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/MemoryLeakTests.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenariosui/MemoryLeakTests.java
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.flutter.scenariosui;
+
+import android.content.Intent;
+import androidx.test.filters.LargeTest;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.runner.AndroidJUnit4;
+import dev.flutter.scenarios.TextPlatformViewActivity;
+import leakcanary.FailTestOnLeak;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class MemoryLeakTests {
+
+  @Rule
+  public ActivityTestRule<TextPlatformViewActivity> activityRule =
+      new ActivityTestRule<>(
+          TextPlatformViewActivity.class, /*initialTouchMode=*/ false, /*launchActivity=*/ false);
+
+  @Test
+  @FailTestOnLeak
+  public void platformViewHybridComposition_launchActivityFinishAndLaunchAgain() throws Exception {
+    Intent intent = new Intent(Intent.ACTION_MAIN);
+    intent.putExtra("scenario", "platform_view");
+    intent.putExtra("use_android_view", true);
+
+    TextPlatformViewActivity activity = activityRule.launchActivity(intent);
+  }
+}

--- a/testing/scenario_app/android/app/src/main/res/values/strings.xml
+++ b/testing/scenario_app/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Scenarios</string>
     <string name="title_activity_main">MainActivity</string>
+    <string name="leak_canary_test_class_name">assertk.Assert</string>
 </resources>


### PR DESCRIPTION
I encountered these issues while debugging customer:money app.

1. Memory leak:
```
┬───
│ GC Root: Global variable in native code
│
├─ android.database.ContentObserver$Transport instance
│    Leaking: UNKNOWN
│    ↓ ContentObserver$Transport.mContentObserver
│                                ~~~~~~~~~~~~~~~~
├─ io.flutter.view.AccessibilityBridge$3 instance
│    Leaking: UNKNOWN
│    Anonymous subclass of android.database.ContentObserver
│    ↓ AccessibilityBridge$3.this$0
│                            ~~~~~~
├─ io.flutter.view.AccessibilityBridge instance
│    Leaking: UNKNOWN
│    ↓ AccessibilityBridge.platformViewsAccessibilityDelegate
│                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
├─ io.flutter.plugin.platform.PlatformViewsController instance
│    Leaking: UNKNOWN
│    ↓ PlatformViewsController.overlayLayerViews
│                              ~~~~~~~~~~~~~~~~~
├─ android.util.SparseArray instance
│    Leaking: UNKNOWN
│    ↓ SparseArray.mValues
│                  ~~~~~~~
├─ java.lang.Object[] array
│    Leaking: UNKNOWN
│    ↓ Object[].[0]
│               ~~~
├─ io.flutter.embedding.android.FlutterImageView instance
│    Leaking: YES (View.mContext references a destroyed activity)
│    mContext instance of *****.app.MainActivity with mDestroyed = true
│    View#mParent is set
│    View#mAttachInfo is null (view detached)
│    View.mWindowAttachCount = 1
│    ↓ FlutterImageView.mContext
╰→ *****.app.MainActivity instance
```

2. `RunsOnCreationTaskRunner`/`FML_DCHECK_TASK_RUNNER_IS_CURRENT` check had a bug if thread merging is enabled. The unit test shows the bug. 

3. Added `leakcanary` to start performing memory leak tests in the scenario app. (Will follow up with more instructions on how to use it as I learn more).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.


If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
