### PR TITLE
WIP: Windows: Use direct composition if available

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -210,7 +210,7 @@ bool AngleSurfaceManager::CreateSurface(WindowsRenderTarget* render_target,
 
   std::vector<EGLint> surface_attributes;
 
-  if (!DirectCompositionSupported()) {
+  if (!CompositionSupported()) {
     // eglPostSubBufferNV during resizing causes significant artifacts on
     // Windows 7, so use fixed size surface instead
     // TODO(knopp): This will not be necessary after
@@ -267,7 +267,9 @@ void AngleSurfaceManager::ResizeSurface(WindowsRenderTarget* render_target,
     // avoiding the need to destory and recreate the underlying SwapChain.
     surface_width_ = width;
     surface_height_ = height;
-    if (!DirectCompositionSupported()) {
+    if (!CompositionSupported()) {
+      // Withoutcomposition the surface is created with fixed size.
+      // See AngleSurfaceManager::CreateSurface for details.
       ClearContext();
       DestroySurface();
       CreateSurface(render_target, width, height);
@@ -317,7 +319,7 @@ EGLBoolean AngleSurfaceManager::SwapBuffers() {
   return (eglSwapBuffers(egl_display_, render_surface_));
 }
 
-bool AngleSurfaceManager::DirectCompositionSupported() {
+bool AngleSurfaceManager::CompositionSupported() {
 #ifdef WINUWP
   return true;
 #else

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -81,6 +81,10 @@ class AngleSurfaceManager {
       const EGLint* config,
       bool should_log);
 
+  // Returns whether current system supports presenting surface through
+  // direct composition
+  static bool DirectCompositionSupported();
+
   // EGL representation of native display.
   EGLDisplay egl_display_;
 

--- a/shell/platform/windows/angle_surface_manager.h
+++ b/shell/platform/windows/angle_surface_manager.h
@@ -83,7 +83,7 @@ class AngleSurfaceManager {
 
   // Returns whether current system supports presenting surface through
   // direct composition
-  static bool DirectCompositionSupported();
+  static bool CompositionSupported();
 
   // EGL representation of native display.
   EGLDisplay egl_display_;


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/76789

Supersedes https://github.com/flutter/engine/pull/24629

This PR will use direct composition when available. Tested on Windows 7.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
