### PR TITLE
Win32: Support Korean input

### DIFF
--- a/shell/platform/windows/flutter_window_win32.cc
+++ b/shell/platform/windows/flutter_window_win32.cc
@@ -176,6 +176,10 @@ void FlutterWindowWin32::OnComposeBegin() {
   binding_handler_delegate_->OnComposeBegin();
 }
 
+void FlutterWindowWin32::OnComposeCommit() {
+  binding_handler_delegate_->OnComposeCommit();
+}
+
 void FlutterWindowWin32::OnComposeEnd() {
   binding_handler_delegate_->OnComposeEnd();
 }

--- a/shell/platform/windows/flutter_window_win32.h
+++ b/shell/platform/windows/flutter_window_win32.h
@@ -66,6 +66,9 @@ class FlutterWindowWin32 : public WindowWin32, public WindowBindingHandler {
   void OnComposeBegin() override;
 
   // |WindowWin32|
+  void OnComposeCommit() override;
+
+  // |WindowWin32|
   void OnComposeEnd() override;
 
   // |WindowWin32|

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -78,6 +78,7 @@ class SpyKeyboardKeyHandler : public KeyboardHandlerBase {
   MOCK_METHOD2(TextHook,
                void(FlutterWindowsView* window, const std::u16string& text));
   MOCK_METHOD0(ComposeBeginHook, void());
+  MOCK_METHOD0(ComposeCommitHook, void());
   MOCK_METHOD0(ComposeEndHook, void());
   MOCK_METHOD2(ComposeChangeHook,
                void(const std::u16string& text, int cursor_pos));
@@ -112,6 +113,7 @@ class SpyTextInputPlugin : public KeyboardHandlerBase,
   MOCK_METHOD2(TextHook,
                void(FlutterWindowsView* window, const std::u16string& text));
   MOCK_METHOD0(ComposeBeginHook, void());
+  MOCK_METHOD0(ComposeCommitHook, void());
   MOCK_METHOD0(ComposeEndHook, void());
   MOCK_METHOD2(ComposeChangeHook,
                void(const std::u16string& text, int cursor_pos));

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -210,6 +210,10 @@ void FlutterWindowsView::OnComposeBegin() {
   SendComposeBegin();
 }
 
+void FlutterWindowsView::OnComposeCommit() {
+  SendComposeCommit();
+}
+
 void FlutterWindowsView::OnComposeEnd() {
   SendComposeEnd();
 }
@@ -326,6 +330,12 @@ bool FlutterWindowsView::SendKey(int key,
 void FlutterWindowsView::SendComposeBegin() {
   for (const auto& handler : keyboard_handlers_) {
     handler->ComposeBeginHook();
+  }
+}
+
+void FlutterWindowsView::SendComposeCommit() {
+  for (const auto& handler : keyboard_handlers_) {
+    handler->ComposeCommitHook();
   }
 }
 

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -112,6 +112,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   void OnComposeBegin() override;
 
   // |WindowBindingHandlerDelegate|
+  void OnComposeCommit() override;
+
+  // |WindowBindingHandlerDelegate|
   void OnComposeEnd() override;
 
   // |WindowBindingHandlerDelegate|
@@ -201,6 +204,13 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   // Triggered when the user begins editing composing text using a multi-step
   // input method such as in CJK text input.
   void SendComposeBegin();
+
+  // Reports an IME compose commit event.
+  //
+  // Triggered when the user commits the current composing text while using a
+  // multi-step input method such as in CJK text input. Composing continues with
+  // the next keypress.
+  void SendComposeCommit();
 
   // Reports an IME compose end event.
   //

--- a/shell/platform/windows/keyboard_handler_base.h
+++ b/shell/platform/windows/keyboard_handler_base.h
@@ -45,10 +45,17 @@ class KeyboardHandlerBase {
   // input method such as in CJK text input.
   virtual void ComposeBeginHook() = 0;
 
+  // Handler for IME compose commit events.
+  //
+  // Triggered when the user commits the current composing text while using a
+  // multi-step input method such as in CJK text input. Composing continues with
+  // the next keypress.
+  virtual void ComposeCommitHook() = 0;
+
   // Handler for IME compose end events.
   //
-  // Triggered when the user commits the composing text while using a multi-step
-  // input method such as in CJK text input.
+  // Triggered when the user ends editing composing text while using a
+  // multi-step input method such as in CJK text input.
   virtual void ComposeEndHook() = 0;
 
   // Handler for IME compose change events.

--- a/shell/platform/windows/keyboard_key_handler.cc
+++ b/shell/platform/windows/keyboard_key_handler.cc
@@ -181,6 +181,10 @@ void KeyboardKeyHandler::ComposeBeginHook() {
   // Ignore.
 }
 
+void KeyboardKeyHandler::ComposeCommitHook() {
+  // Ignore.
+}
+
 void KeyboardKeyHandler::ComposeEndHook() {
   // Ignore.
 }

--- a/shell/platform/windows/keyboard_key_handler.h
+++ b/shell/platform/windows/keyboard_key_handler.h
@@ -108,6 +108,9 @@ class KeyboardKeyHandler : public KeyboardHandlerBase {
   void ComposeBeginHook() override;
 
   // |KeyboardHandlerBase|
+  void ComposeCommitHook() override;
+
+  // |KeyboardHandlerBase|
   void ComposeEndHook() override;
 
   // |KeyboardHandlerBase|

--- a/shell/platform/windows/testing/mock_window_win32.h
+++ b/shell/platform/windows/testing/mock_window_win32.h
@@ -42,6 +42,7 @@ class MockWin32Window : public WindowWin32 {
   MOCK_METHOD6(OnKey, bool(int, int, int, char32_t, bool, bool));
   MOCK_METHOD2(OnScroll, void(double, double));
   MOCK_METHOD0(OnComposeBegin, void());
+  MOCK_METHOD0(OnComposeCommit, void());
   MOCK_METHOD0(OnComposeEnd, void());
   MOCK_METHOD2(OnComposeChange, void(const std::u16string&, int));
   MOCK_METHOD4(DefaultWindowProc, LRESULT(HWND, UINT, WPARAM, LPARAM));

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -111,6 +111,14 @@ void TextInputPlugin::ComposeBeginHook() {
   SendStateUpdate(*active_model_);
 }
 
+void TextInputPlugin::ComposeCommitHook() {
+  if (active_model_ == nullptr) {
+    return;
+  }
+  active_model_->CommitComposing();
+  SendStateUpdate(*active_model_);
+}
+
 void TextInputPlugin::ComposeEndHook() {
   if (active_model_ == nullptr) {
     return;

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -48,6 +48,9 @@ class TextInputPlugin : public KeyboardHandlerBase {
   void ComposeBeginHook() override;
 
   // |KeyboardHandlerBase|
+  void ComposeCommitHook() override;
+
+  // |KeyboardHandlerBase|
   void ComposeEndHook() override;
 
   // |KeyboardHandlerBase|

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -59,6 +59,13 @@ class WindowBindingHandlerDelegate {
   // input method such as in CJK text input.
   virtual void OnComposeBegin() = 0;
 
+  // Notifies the delegate that IME composing region have been committed.
+  //
+  // Triggered when the user commits the current composing text while using a
+  // multi-step input method such as in CJK text input. Composing continues with
+  // the next keypress.
+  virtual void OnComposeCommit() = 0;
+
   // Notifies the delegate that IME composing mode has ended.
   //
   // Triggered when the user commits the composing text while using a multi-step

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -142,18 +142,13 @@ void WindowWin32::OnImeComposition(UINT const message,
       OnComposeChange(text.value(), pos);
     }
   } else if (lparam & GCS_RESULTSTR) {
+    // Commit but don't end composing.
     // Read the committed composing string.
     long pos = text_input_manager_.GetComposingCursorPosition();
     std::optional<std::u16string> text = text_input_manager_.GetResultString();
     if (text) {
       OnComposeChange(text.value(), pos);
-    }
-    // Next, try reading the composing string. Some Japanese IMEs send a message
-    // containing both a GCS_RESULTSTR and a GCS_COMPSTR when one composition is
-    // committed and another immediately started.
-    text = text_input_manager_.GetResultString();
-    if (text) {
-      OnComposeChange(text.value(), pos);
+      OnComposeCommit();
     }
   }
 }

--- a/shell/platform/windows/window_win32.h
+++ b/shell/platform/windows/window_win32.h
@@ -107,6 +107,9 @@ class WindowWin32 {
   // Called when IME composing begins.
   virtual void OnComposeBegin() = 0;
 
+  // Called when IME composing text is committed.
+  virtual void OnComposeCommit() = 0;
+
   // Called when IME composing ends.
   virtual void OnComposeEnd() = 0;
 


### PR DESCRIPTION
This change fixes a bug in Korean input whereby WM_IME_COMPOSITION
messages of type GCS_RESULTSTR were assumed to end composing mode.

This change breaks out an additional handler for "commit composing text"
events. In Japanese/Chinese IMEs, these events typically occur on
selection of a candidate from the candidates list and are mostly
synonymous with an "end composing" event.

In Korean text input, there is no candidates list, but rather a
character is built up as keypresses are handled, and committed as soon
as the character is unambiguously complete; in other words, when either
space/return is pressed or a keypress is received that cannot be
interpreted as a modification of the character being composed and
therefore must be the first keystroke of a new character. In these
cases, we want to commit the previous character without ending the
composition.

To illustrate with an example:
1. User focuses on a text field and sets input mode to Hangul.
2. User presses 'ㄱ'. Composing region contains 'ㄱ'.
3. User presses 'ㅏ'. Composing region is updated to '가'.
4. User presses 'ㄴ'. Composing region is updated to '간'.
5. User presses 'ㅏ'. Result string '가' is committed. Composing region is
   updated to '나'.
6. User presses 'ㄷ'. Composing string is updated to '낟'.
7. User presses 'ㅏ'. Result string '나' is committed. Composing region is
   updated to '다'.
8. User presses space or enter. Result string '다' is committed.
   Composing is ended.

On a non-Korean QWERTY keyboard the following key mappings serve to
perform the above input:
* r -> ㄱ
* k -> ㅏ
* s -> ㄴ
* e -> ㄷ

To support the above, we break out a separate "commit composing" method
and commit on WM_IME_COMPOSITION events of type GCS_RESULTSTR and end
composing on WM_IME_ENDCOMPOSITION events. Further, we eliminate the
workaround in the GCS_RESULTSTR handler for continued composition on
Chinese/Japanese IMEs now that we're no longer ending composition on
that event type.

Fixes https://github.com/flutter/flutter/issues/74812.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
