### PR TITLE
[web] Fix pointer events for Wacom pen

### DIFF
--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -510,7 +510,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
   @override
   void setup() {
     _addPointerEventListener('pointerdown', (html.PointerEvent event) {
-      final int device = event.pointerId!;
+      final int device = _getPointerId(event);
       final List<ui.PointerData> pointerData = <ui.PointerData>[];
       final _ButtonSanitizer sanitizer = _ensureSanitizer(device);
       final _SanitizedDetails? up =
@@ -528,7 +528,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     });
 
     _addPointerEventListener('pointermove', (html.PointerEvent event) {
-      final int device = event.pointerId!;
+      final int device = _getPointerId(event);
       final _ButtonSanitizer sanitizer = _ensureSanitizer(device);
       final List<ui.PointerData> pointerData = <ui.PointerData>[];
       final List<html.PointerEvent> expandedEvents = _expandEvents(event);
@@ -544,7 +544,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     }, acceptOutsideGlasspane: true);
 
     _addPointerEventListener('pointerup', (html.PointerEvent event) {
-      final int device = event.pointerId!;
+      final int device = _getPointerId(event);
       final List<ui.PointerData> pointerData = <ui.PointerData>[];
       final _SanitizedDetails? details = _getSanitizer(device).sanitizeUpEvent(buttons: event.buttons);
       _removePointerIfUnhoverable(event);
@@ -557,7 +557,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     // A browser fires cancel event if it concludes the pointer will no longer
     // be able to generate events (example: device is deactivated)
     _addPointerEventListener('pointercancel', (html.PointerEvent event) {
-      final int device = event.pointerId!;
+      final int device = _getPointerId(event);
       final List<ui.PointerData> pointerData = <ui.PointerData>[];
       final _SanitizedDetails details = _getSanitizer(device).sanitizeCancelEvent();
       _removePointerIfUnhoverable(event);
@@ -581,10 +581,6 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
     assert(event != null); // ignore: unnecessary_null_comparison
     assert(details != null); // ignore: unnecessary_null_comparison
     final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
-    // We force `device: _mouseDeviceId` on mouse pointers because Wheel events
-    // might come before any PointerEvents, and since wheel events don't contain
-    // pointerId we always assign `device: _mouseDeviceId` to them.
-    final int device = kind == ui.PointerDeviceKind.mouse ? _mouseDeviceId : event.pointerId!;
     final double tilt = _computeHighestTilt(event);
     final Duration timeStamp = _BaseAdapter._eventTimeStampToDuration(event.timeStamp!);
     _pointerDataConverter.convert(
@@ -593,7 +589,7 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       timeStamp: timeStamp,
       kind: kind,
       signalKind: ui.PointerSignalKind.none,
-      device: device,
+      device: _getPointerId(event),
       physicalX: event.client.x.toDouble() * ui.window.devicePixelRatio,
       physicalY: event.client.y.toDouble() * ui.window.devicePixelRatio,
       buttons: details.buttons,
@@ -630,6 +626,14 @@ class _PointerAdapter extends _BaseAdapter with _WheelEventListenerMixin {
       default:
         return ui.PointerDeviceKind.unknown;
     }
+  }
+
+  int _getPointerId(html.PointerEvent event) {
+    // We force `device: _mouseDeviceId` on mouse pointers because Wheel events
+    // might come before any PointerEvents, and since wheel events don't contain
+    // pointerId we always assign `device: _mouseDeviceId` to them.
+    final ui.PointerDeviceKind kind = _pointerTypeToDeviceKind(event.pointerType!);
+    return kind == ui.PointerDeviceKind.mouse ? _mouseDeviceId : event.pointerId!;
   }
 
   /// Tilt angle is -90 to + 90. Take maximum deflection and convert to radians.


### PR DESCRIPTION
When a mouse is being used, we always seem to be sending `-1` as the pointer ID to Flutter. But the logic that tracks the up/down states is using the real pointer ID (the one that the browser gives to us, which is usually `1`, but sometimes could be random as described below).

In some devices, like Wacom, the pen events are handled by the browser as if they were mouse events. But the pointer ID seems to be randomly generated (i.e. `pointerdown` is received with `pointerId=21`, and `pointerup` is received with `pointerId=45` even though it's the same pen, see [example](https://github.com/flutter/flutter/issues/75559#issuecomment-784436165)).

By making sure to always use `-1` for mouse, we will fix both issues at once.

Initially, I thought this could cause issues when there is more than one mouse attached to the device. But it turns out that the browser assigns the same pointer ID to all the attached mice. So we can also do the same.

Fixes https://github.com/flutter/flutter/issues/75559