### PR TITLE
fixes reference retaining issue in flutter text input plugin

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1236,7 +1236,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 // The current password-autofillable input fields that have yet to be saved.
 @property(nonatomic, readonly)
     NSMutableDictionary<NSString*, FlutterTextInputView*>* autofillContext;
-@property(nonatomic, assign) FlutterTextInputView* activeView;
+@property(nonatomic, strong) FlutterTextInputView* activeView;
 @property(nonatomic, strong) FlutterTextInputViewAccessibilityHider* inputHider;
 @end
 
@@ -1253,7 +1253,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
     _reusableInputView = [[FlutterTextInputView alloc] init];
     _reusableInputView.secureTextEntry = NO;
     _autofillContext = [[NSMutableDictionary alloc] init];
-    _activeView = _reusableInputView;
+    _activeView = [_reusableInputView retain];
     _inputHider = [[FlutterTextInputViewAccessibilityHider alloc] init];
   }
 
@@ -1263,6 +1263,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 - (void)dealloc {
   [self hideTextInput];
   [_reusableInputView release];
+  [_activeView release];
   [_inputHider release];
   [_autofillContext release];
   [super dealloc];
@@ -1386,19 +1387,19 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   [self changeInputViewsAutofillVisibility:NO];
   switch (autofillTypeOf(configuration)) {
     case FlutterAutofillTypeNone:
-      _activeView = [self updateAndShowReusableInputView:configuration];
+      self.activeView = [self updateAndShowReusableInputView:configuration];
       break;
     case FlutterAutofillTypeRegular:
       // If the group does not involve password autofill, only install the
       // input view that's being focused.
-      _activeView = [self updateAndShowAutofillViews:nil
-                                        focusedField:configuration
-                                   isPasswordRelated:NO];
+      self.activeView = [self updateAndShowAutofillViews:nil
+                                            focusedField:configuration
+                                       isPasswordRelated:NO];
       break;
     case FlutterAutofillTypePassword:
-      _activeView = [self updateAndShowAutofillViews:configuration[kAssociatedAutofillFields]
-                                        focusedField:configuration
-                                   isPasswordRelated:YES];
+      self.activeView = [self updateAndShowAutofillViews:configuration[kAssociatedAutofillFields]
+                                            focusedField:configuration
+                                       isPasswordRelated:YES];
       break;
   }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -888,7 +888,7 @@ FLUTTER_ASSERT_ARC
                              }];
     XCTAssertNotNil(activeView);
   }
-  // This assert proves the myInputPlugin.textInputView is not gc'd.
+  // This assert proves the myInputPlugin.textInputView is not deallocated.
   XCTAssertNotNil(activeView);
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -888,7 +888,7 @@ FLUTTER_ASSERT_ARC
                              }];
     XCTAssertNotNil(activeView);
   }
-  // This assert proves we released the old active view.
+  // This assert proves the myInputPlugin.textInputView is not gc'd.
   XCTAssertNotNil(activeView);
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -865,4 +865,31 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(range.range.length, 20u);
 }
 
+- (void)testFlutterTextInputPluginRetainsFlutterTextInputView {
+  FlutterTextInputPlugin* myInputPlugin;
+  id myEngine = OCMClassMock([FlutterEngine class]);
+  myInputPlugin = [[FlutterTextInputPlugin alloc] init];
+  myInputPlugin.textInputDelegate = myEngine;
+  __weak UIView* activeView;
+  @autoreleasepool {
+    FlutterMethodCall* setClientCall = [FlutterMethodCall
+        methodCallWithMethodName:@"TextInput.setClient"
+                       arguments:@[
+                         [NSNumber numberWithInt:123], self.mutablePasswordTemplateCopy
+                       ]];
+    [myInputPlugin handleMethodCall:setClientCall
+                             result:^(id _Nullable result){
+                             }];
+    activeView = myInputPlugin.textInputView;
+    FlutterMethodCall* hideCall = [FlutterMethodCall methodCallWithMethodName:@"TextInput.hide"
+                                                                    arguments:@[]];
+    [myInputPlugin handleMethodCall:hideCall
+                             result:^(id _Nullable result){
+                             }];
+    XCTAssertNotNil(activeView);
+  }
+  // This assert proves we released the old active view.
+  XCTAssertNotNil(activeView);
+}
+
 @end


### PR DESCRIPTION
The inputview is created without anyone retaining, it work prior to this pr because the inputview was never detached from the flutterview, so the flutter view retains one reference.

My previous commit https://github.com/flutter/engine/commit/b3a18f5182827ca6db20f3e75bfe11b39368b4ec detaches the inputview when user hides it, this makes it to be gc'd. This causes _activeView hold an invalid pointer.


fixes https://github.com/flutter/flutter/issues/77139

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
