### PR TITLE
Avoid the deprecated SkFilterQuality in the Engine APIs

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -533,6 +533,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     Rect maskRect,
     BlendMode blendMode, {
     ShaderMaskEngineLayer? oldLayer,
+    FilterQuality filterQuality = FilterQuality.low,
   }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushShaderMask'));
     final EngineLayer engineLayer = EngineLayer._();
@@ -544,6 +545,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
       maskRect.top,
       maskRect.bottom,
       blendMode.index,
+      filterQuality.index,
       oldLayer?._nativeLayer,
     );
     final ShaderMaskEngineLayer layer = ShaderMaskEngineLayer._(engineLayer);
@@ -559,6 +561,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
       double maskRectTop,
       double maskRectBottom,
       int blendMode,
+      int filterQualityIndex,
       EngineLayer? oldLayer) native 'SceneBuilder_pushShaderMask';
 
   /// Pushes a physical layer operation for an arbitrary shape onto the

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -228,13 +228,13 @@ void SceneBuilder::pushShaderMask(Dart_Handle layer_handle,
                                   double maskRectTop,
                                   double maskRectBottom,
                                   int blendMode,
+                                  int filterQualityIndex,
                                   fml::RefPtr<EngineLayer> oldLayer) {
   SkRect rect = SkRect::MakeLTRB(maskRectLeft, maskRectTop, maskRectRight,
                                  maskRectBottom);
-  // TODO: Quality come from the caller
-  SkFilterQuality quality = kLow_SkFilterQuality;
+  auto sampling = ImageFilter::SamplingFromIndex(filterQualityIndex);
   auto layer = std::make_shared<flutter::ShaderMaskLayer>(
-      shader->shader(quality), rect, static_cast<SkBlendMode>(blendMode));
+      shader->shader(sampling), rect, static_cast<SkBlendMode>(blendMode));
   PushLayer(layer);
   EngineLayer::MakeRetained(layer_handle, layer);
 
@@ -286,10 +286,8 @@ void SceneBuilder::addTexture(double dx,
                               double height,
                               int64_t textureId,
                               bool freeze,
-                              int filterQuality) {
-  // TODO: take sampling directly from caller: filter-quality is deprecated
-  auto sampling = SkSamplingOptions(static_cast<SkFilterQuality>(filterQuality),
-                                    SkSamplingOptions::kMedium_asMipmapLinear);
+                              int filterQualityIndex) {
+  auto sampling = ImageFilter::SamplingFromIndex(filterQualityIndex);
   auto layer = std::make_unique<flutter::TextureLayer>(
       SkPoint::Make(dx, dy), SkSize::Make(width, height), textureId, freeze,
       sampling);

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -80,6 +80,7 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
                       double maskRectTop,
                       double maskRectBottom,
                       int blendMode,
+                      int filterQualityIndex,
                       fml::RefPtr<EngineLayer> oldLayer);
   void pushPhysicalShape(Dart_Handle layer_handle,
                          const CanvasPath* path,

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -110,7 +110,8 @@ class Canvas : public RefCountedDartWrappable<Canvas> {
                  double x,
                  double y,
                  const Paint& paint,
-                 const PaintData& paint_data);
+                 const PaintData& paint_data,
+                 int filterQualityIndex);
   void drawImageRect(const CanvasImage* image,
                      double src_left,
                      double src_top,
@@ -121,7 +122,8 @@ class Canvas : public RefCountedDartWrappable<Canvas> {
                      double dst_right,
                      double dst_bottom,
                      const Paint& paint,
-                     const PaintData& paint_data);
+                     const PaintData& paint_data,
+                     int filterQualityIndex);
   void drawImageNine(const CanvasImage* image,
                      double center_left,
                      double center_top,
@@ -132,7 +134,8 @@ class Canvas : public RefCountedDartWrappable<Canvas> {
                      double dst_right,
                      double dst_bottom,
                      const Paint& paint,
-                     const PaintData& paint_data);
+                     const PaintData& paint_data,
+                     int bitmapSamplingIndex);
   void drawPicture(Picture* picture);
 
   // The paint argument is first for the following functions because Paint
@@ -152,6 +155,7 @@ class Canvas : public RefCountedDartWrappable<Canvas> {
 
   void drawAtlas(const Paint& paint,
                  const PaintData& paint_data,
+                 int filterQualityIndex,
                  CanvasImage* atlas,
                  const tonic::Float32List& transforms,
                  const tonic::Float32List& rects,

--- a/lib/ui/painting/gradient.h
+++ b/lib/ui/painting/gradient.h
@@ -62,7 +62,9 @@ class CanvasGradient : public Shader {
                            SkTileMode tile_mode,
                            const tonic::Float64List& matrix4);
 
-  sk_sp<SkShader> shader(SkFilterQuality) override { return sk_shader_.get(); }
+  sk_sp<SkShader> shader(SkSamplingOptions) override {
+    return sk_shader_.get();
+  }
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -40,6 +40,29 @@ fml::RefPtr<ImageFilter> ImageFilter::Create() {
   return fml::MakeRefCounted<ImageFilter>();
 }
 
+static const std::array<SkSamplingOptions, 4> filter_qualities = {
+    SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone),
+    SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone),
+    SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kLinear),
+    SkSamplingOptions(SkCubicResampler{1 / 3.0f, 1 / 3.0f}),
+};
+
+SkSamplingOptions ImageFilter::SamplingFromIndex(int filterQualityIndex) {
+  if (filterQualityIndex < 0)
+    return filter_qualities.front();
+  else if (((size_t)filterQualityIndex) >= filter_qualities.size())
+    return filter_qualities.back();
+  else
+    return filter_qualities[filterQualityIndex];
+}
+
+SkFilterMode ImageFilter::FilterModeFromIndex(int filterQualityIndex) {
+  if (filterQualityIndex <= 0)
+    return SkFilterMode::kNearest;
+  else
+    return SkFilterMode::kLinear;
+}
+
 ImageFilter::ImageFilter() {}
 
 ImageFilter::~ImageFilter() {}
@@ -59,9 +82,8 @@ void ImageFilter::initBlur(double sigma_x,
 }
 
 void ImageFilter::initMatrix(const tonic::Float64List& matrix4,
-                             int filterQuality) {
-  auto sampling = SkSamplingOptions(static_cast<SkFilterQuality>(filterQuality),
-                                    SkSamplingOptions::kMedium_asMipmapLinear);
+                             int filterQualityIndex) {
+  auto sampling = ImageFilter::SamplingFromIndex(filterQualityIndex);
   filter_ =
       SkImageFilters::MatrixTransform(ToSkMatrix(matrix4), sampling, nullptr);
 }

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -48,19 +48,20 @@ static const std::array<SkSamplingOptions, 4> filter_qualities = {
 };
 
 SkSamplingOptions ImageFilter::SamplingFromIndex(int filterQualityIndex) {
-  if (filterQualityIndex < 0)
+  if (filterQualityIndex < 0) {
     return filter_qualities.front();
-  else if (((size_t)filterQualityIndex) >= filter_qualities.size())
+  } else if (((size_t)filterQualityIndex) >= filter_qualities.size()) {
     return filter_qualities.back();
-  else
+  } else {
     return filter_qualities[filterQualityIndex];
+  }
 }
 
 SkFilterMode ImageFilter::FilterModeFromIndex(int filterQualityIndex) {
-  if (filterQualityIndex <= 0)
+  if (filterQualityIndex <= 0) {
     return SkFilterMode::kNearest;
-  else
-    return SkFilterMode::kLinear;
+  }
+  return SkFilterMode::kLinear;
 }
 
 ImageFilter::ImageFilter() {}

--- a/lib/ui/painting/image_filter.h
+++ b/lib/ui/painting/image_filter.h
@@ -22,10 +22,13 @@ class ImageFilter : public RefCountedDartWrappable<ImageFilter> {
   ~ImageFilter() override;
   static fml::RefPtr<ImageFilter> Create();
 
+  static SkSamplingOptions SamplingFromIndex(int filterQualityIndex);
+  static SkFilterMode FilterModeFromIndex(int index);
+
   void initImage(CanvasImage* image);
   void initPicture(Picture*);
   void initBlur(double sigma_x, double sigma_y, SkTileMode tile_mode);
-  void initMatrix(const tonic::Float64List& matrix4, int filter_quality);
+  void initMatrix(const tonic::Float64List& matrix4, int filter_quality_index);
   void initColorFilter(ColorFilter* colorFilter);
   void initComposeFilter(ImageFilter* outer, ImageFilter* inner);
 

--- a/lib/ui/painting/image_shader.h
+++ b/lib/ui/painting/image_shader.h
@@ -31,9 +31,10 @@ class ImageShader : public Shader {
   void initWithImage(CanvasImage* image,
                      SkTileMode tmx,
                      SkTileMode tmy,
+                     int filter_quality_index,
                      const tonic::Float64List& matrix4);
 
-  sk_sp<SkShader> shader(SkFilterQuality) override;
+  sk_sp<SkShader> shader(SkSamplingOptions) override;
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
@@ -44,8 +45,9 @@ class ImageShader : public Shader {
   SkTileMode tmx_;
   SkTileMode tmy_;
   SkMatrix local_matrix_;
+  bool sampling_is_locked_;
 
-  SkFilterQuality cached_quality_ = kNone_SkFilterQuality;
+  SkSamplingOptions cached_sampling_;
   flutter::SkiaGPUObject<SkShader> cached_shader_;
 };
 

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -77,9 +77,6 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
   const uint32_t* uint_data = static_cast<const uint32_t*>(byte_data.data());
   const float* float_data = static_cast<const float*>(byte_data.data());
 
-  auto filter_quality =
-      static_cast<SkFilterQuality>(uint_data[kFilterQualityIndex]);
-
   Dart_Handle values[kObjectCount];
   if (!Dart_IsNull(paint_objects)) {
     FML_DCHECK(Dart_IsList(paint_objects));
@@ -95,7 +92,9 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
     Dart_Handle shader = values[kShaderIndex];
     if (!Dart_IsNull(shader)) {
       Shader* decoded = tonic::DartConverter<Shader*>::FromDart(shader);
-      paint_.setShader(decoded->shader(filter_quality));
+      auto sampling =
+          ImageFilter::SamplingFromIndex(uint_data[kFilterQualityIndex]);
+      paint_.setShader(decoded->shader(sampling));
     }
 
     Dart_Handle color_filter = values[kColorFilterIndex];
@@ -114,7 +113,6 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
   }
 
   paint_.setAntiAlias(uint_data[kIsAntiAliasIndex] == 0);
-  paint_.setFilterQuality(filter_quality);
 
   uint32_t encoded_color = uint_data[kColorIndex];
   if (encoded_color) {

--- a/lib/ui/painting/shader.h
+++ b/lib/ui/painting/shader.h
@@ -8,7 +8,6 @@
 #include "flutter/flow/skia_gpu_object.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/ui_dart_state.h"
-#include "third_party/skia/include/core/SkFilterQuality.h"
 #include "third_party/skia/include/core/SkShader.h"
 
 namespace flutter {
@@ -20,7 +19,7 @@ class Shader : public RefCountedDartWrappable<Shader> {
  public:
   ~Shader() override;
 
-  virtual sk_sp<SkShader> shader(SkFilterQuality) = 0;
+  virtual sk_sp<SkShader> shader(SkSamplingOptions) = 0;
 
  protected:
   Shader() {}

--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -65,6 +65,7 @@ class CkCanvas {
     );
   }
 
+  // TODO(flar): CanvasKit does not expose sampling options available on SkCanvas.drawAtlas
   void drawAtlasRaw(
     CkPaint paint,
     CkImage atlas,
@@ -108,30 +109,57 @@ class CkCanvas {
   }
 
   void drawImage(CkImage image, ui.Offset offset, CkPaint paint) {
-    skCanvas.drawImage(
-      image.skImage,
-      offset.dx,
-      offset.dy,
-      paint.skiaObject,
-    );
+    ui.FilterQuality filterQuality = paint.filterQuality;
+    if (filterQuality == ui.FilterQuality.high) {
+      skCanvas.drawImageCubic(
+        image.skImage,
+        offset.dx,
+        offset.dy,
+        1.0 / 3.0,
+        1.0 / 3.0,
+        paint.skiaObject,
+      );
+    } else {
+      skCanvas.drawImageOptions(
+        image.skImage,
+        offset.dx,
+        offset.dy,
+        toSkFilterMode(filterQuality),
+        toSkMipmapMode(filterQuality),
+        paint.skiaObject,
+      );
+    }
   }
 
   void drawImageRect(CkImage image, ui.Rect src, ui.Rect dst, CkPaint paint) {
-    skCanvas.drawImageRect(
-      image.skImage,
-      toSkRect(src),
-      toSkRect(dst),
-      paint.skiaObject,
-      false,
-    );
+    ui.FilterQuality filterQuality = paint.filterQuality;
+    if (filterQuality == ui.FilterQuality.high) {
+      skCanvas.drawImageRectCubic(
+        image.skImage,
+        toSkRect(src),
+        toSkRect(dst),
+        1.0 / 3.0,
+        1.0 / 3.0,
+        paint.skiaObject,
+      );
+    } else {
+      skCanvas.drawImageRectOptions(
+        image.skImage,
+        toSkRect(src),
+        toSkRect(dst),
+        toSkFilterMode(filterQuality),
+        toSkMipmapMode(filterQuality),
+        paint.skiaObject,
+      );
+    }
   }
 
-  void drawImageNine(
-      CkImage image, ui.Rect center, ui.Rect dst, CkPaint paint) {
+  void drawImageNine(CkImage image, ui.Rect center, ui.Rect dst, CkPaint paint) {
     skCanvas.drawImageNine(
       image.skImage,
       toSkRect(center),
       toSkRect(dst),
+      toSkFilterMode(paint.filterQuality),
       paint.skiaObject,
     );
   }
@@ -934,12 +962,26 @@ class CkDrawImageCommand extends CkPaintCommand {
 
   @override
   void apply(SkCanvas canvas) {
-    canvas.drawImage(
-      image.skImage,
-      offset.dx,
-      offset.dy,
-      paint.skiaObject,
-    );
+    ui.FilterQuality filterQuality = paint.filterQuality;
+    if (filterQuality == ui.FilterQuality.high) {
+      canvas.drawImageCubic(
+        image.skImage,
+        offset.dx,
+        offset.dy,
+        1.0 / 3.0,
+        1.0 / 3.0,
+        paint.skiaObject,
+      );
+    } else {
+      canvas.drawImageOptions(
+        image.skImage,
+        offset.dx,
+        offset.dy,
+        toSkFilterMode(filterQuality),
+        toSkMipmapMode(filterQuality),
+        paint.skiaObject,
+      );
+    }
   }
 
   @override
@@ -959,13 +1001,26 @@ class CkDrawImageRectCommand extends CkPaintCommand {
 
   @override
   void apply(SkCanvas canvas) {
-    canvas.drawImageRect(
-      image.skImage,
-      toSkRect(src),
-      toSkRect(dst),
-      paint.skiaObject,
-      false,
-    );
+    ui.FilterQuality filterQuality = paint.filterQuality;
+    if (filterQuality == ui.FilterQuality.high) {
+      canvas.drawImageRectCubic(
+        image.skImage,
+        toSkRect(src),
+        toSkRect(dst),
+        1.0 / 3.0,
+        1.0 / 3.0,
+        paint.skiaObject,
+      );
+    } else {
+      canvas.drawImageRectOptions(
+        image.skImage,
+        toSkRect(src),
+        toSkRect(dst),
+        toSkFilterMode(filterQuality),
+        toSkMipmapMode(filterQuality),
+        paint.skiaObject,
+      );
+    }
   }
 
   @override
@@ -989,6 +1044,7 @@ class CkDrawImageNineCommand extends CkPaintCommand {
       image.skImage,
       toSkRect(center),
       toSkRect(dst),
+      toSkFilterMode(paint.filterQuality),
       paint.skiaObject,
     );
   }

--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -14,6 +14,11 @@ final SkClipOp _clipOpIntersect = canvasKit.ClipOp.Intersect;
 /// This is intentionally not memory-managing the underlying [SkCanvas]. See
 /// the docs on [SkCanvas], which explain the reason.
 class CkCanvas {
+  // Cubic equation coefficients recommended by Mitchell & Netravali
+  // in their paper on cubic interpolation.
+  static const double _kMitchellNetravali_B = 1.0 / 3.0;
+  static const double _kMitchellNetravali_C = 1.0 / 3.0;
+
   final SkCanvas skCanvas;
 
   CkCanvas(this.skCanvas);
@@ -115,8 +120,8 @@ class CkCanvas {
         image.skImage,
         offset.dx,
         offset.dy,
-        1.0 / 3.0,
-        1.0 / 3.0,
+        _kMitchellNetravali_B,
+        _kMitchellNetravali_C,
         paint.skiaObject,
       );
     } else {
@@ -138,8 +143,8 @@ class CkCanvas {
         image.skImage,
         toSkRect(src),
         toSkRect(dst),
-        1.0 / 3.0,
-        1.0 / 3.0,
+        _kMitchellNetravali_B,
+        _kMitchellNetravali_C,
         paint.skiaObject,
       );
     } else {
@@ -968,8 +973,8 @@ class CkDrawImageCommand extends CkPaintCommand {
         image.skImage,
         offset.dx,
         offset.dy,
-        1.0 / 3.0,
-        1.0 / 3.0,
+        CkCanvas._kMitchellNetravali_B,
+        CkCanvas._kMitchellNetravali_C,
         paint.skiaObject,
       );
     } else {
@@ -1007,8 +1012,8 @@ class CkDrawImageRectCommand extends CkPaintCommand {
         image.skImage,
         toSkRect(src),
         toSkRect(dst),
-        1.0 / 3.0,
-        1.0 / 3.0,
+        CkCanvas._kMitchellNetravali_B,
+        CkCanvas._kMitchellNetravali_C,
         paint.skiaObject,
       );
     } else {

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -665,6 +665,12 @@ class SkFilterMode {
   external int get value;
 }
 
+SkFilterMode toSkFilterMode(ui.FilterQuality filterQuality) {
+  return filterQuality == ui.FilterQuality.none
+      ? canvasKit.FilterMode.Nearest
+      : canvasKit.FilterMode.Linear;
+}
+
 @JS()
 class SkMipmapModeEnum {
   external SkMipmapMode get None;
@@ -675,6 +681,12 @@ class SkMipmapModeEnum {
 @JS()
 class SkMipmapMode {
   external int get value;
+}
+
+SkMipmapMode toSkMipmapMode(ui.FilterQuality filterQuality) {
+  return filterQuality == ui.FilterQuality.medium
+      ? canvasKit.MipmapMode.Linear
+      : canvasKit.MipmapMode.None;
 }
 
 @JS()
@@ -734,6 +746,13 @@ class SkImage {
   external void delete();
   external int width();
   external int height();
+  external SkShader makeShaderCubic(
+    SkTileMode tileModeX,
+    SkTileMode tileModeY,
+    double B,
+    double C,
+    Float32List? matrix, // 3x3 matrix
+  );
   external SkShader makeShaderOptions(
     SkTileMode tileModeX,
     SkTileMode tileModeY,
@@ -1351,23 +1370,43 @@ class SkCanvas {
     Float32List inner,
     SkPaint paint,
   );
-  external void drawImage(
+  external void drawImageCubic(
     SkImage image,
     double x,
     double y,
+    double B,
+    double C,
     SkPaint paint,
   );
-  external void drawImageRect(
+  external void drawImageOptions(
+    SkImage image,
+    double x,
+    double y,
+    SkFilterMode filterMode,
+    SkMipmapMode mipmapMode,
+    SkPaint paint,
+  );
+  external void drawImageRectCubic(
     SkImage image,
     Float32List src,
     Float32List dst,
+    double B,
+    double C,
     SkPaint paint,
-    bool fastSample,
+  );
+  external void drawImageRectOptions(
+    SkImage image,
+    Float32List src,
+    Float32List dst,
+    SkFilterMode filterMode,
+    SkMipmapMode mipmapMode,
+    SkPaint paint,
   );
   external void drawImageNine(
     SkImage image,
     Float32List center,
     Float32List dst,
+    SkFilterMode filterMode,
     SkPaint paint,
   );
   external void drawLine(

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_canvas.dart
@@ -260,11 +260,6 @@ class CanvasKitCanvas implements ui.Canvas {
     assert(rectIsValid(center));
     assert(rectIsValid(dst));
     assert(paint != null); // ignore: unnecessary_null_comparison
-    _drawImageNine(image, center, dst, paint);
-  }
-
-  void _drawImageNine(
-      ui.Image image, ui.Rect center, ui.Rect dst, ui.Paint paint) {
     _canvas.drawImageNine(image as CkImage, center, dst, paint as CkPaint);
   }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -379,11 +379,12 @@ class ImageFilterEngineLayer extends ContainerLayer implements ui.ImageFilterEng
 }
 
 class ShaderMaskEngineLayer extends ContainerLayer implements ui.ShaderMaskEngineLayer {
-  ShaderMaskEngineLayer(this.shader, this.maskRect, this.blendMode);
+  ShaderMaskEngineLayer(this.shader, this.maskRect, this.blendMode, this.filterQuality);
 
   final ui.Shader shader;
   final ui.Rect maskRect;
   final ui.BlendMode blendMode;
+  final ui.FilterQuality filterQuality;
 
   @override
   void paint(PaintContext paintContext) {
@@ -395,6 +396,7 @@ class ShaderMaskEngineLayer extends ContainerLayer implements ui.ShaderMaskEngin
     CkPaint paint = CkPaint();
     paint.shader = shader;
     paint.blendMode = blendMode;
+    paint.filterQuality = filterQuality;
 
     paintContext.leafNodesCanvas!.save();
     paintContext.leafNodesCanvas!.translate(maskRect.left, maskRect.top);

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -192,9 +192,10 @@ class LayerSceneBuilder implements ui.SceneBuilder {
     ui.Rect maskRect,
     ui.BlendMode blendMode, {
     ui.EngineLayer? oldLayer,
+    ui.FilterQuality filterQuality = ui.FilterQuality.low,
   }) {
     return pushLayer<ShaderMaskEngineLayer>(ShaderMaskEngineLayer(
-        shader, maskRect, blendMode));
+        shader, maskRect, blendMode, filterQuality));
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -124,7 +124,7 @@ class CkPaint extends ManagedSkiaObject<SkPaint> implements ui.Paint {
       return;
     }
     _shader = value as CkShader?;
-    skiaObject.setShader(_shader?.skiaObject);
+    skiaObject.setShader(_shader?.withQuality(_filterQuality));
   }
 
   CkShader? _shader;
@@ -159,6 +159,7 @@ class CkPaint extends ManagedSkiaObject<SkPaint> implements ui.Paint {
       return;
     }
     _filterQuality = value;
+    skiaObject.setShader(_shader?.withQuality(value));
     skiaObject.setFilterQuality(toSkFilterQuality(value));
   }
 
@@ -227,7 +228,7 @@ class CkPaint extends ManagedSkiaObject<SkPaint> implements ui.Paint {
     paint.setStrokeWidth(_strokeWidth);
     paint.setAntiAlias(_isAntiAlias);
     paint.setColorInt(_color.value);
-    paint.setShader(_shader?.skiaObject);
+    paint.setShader(_shader?.withQuality(_filterQuality));
     paint.setMaskFilter(_ckMaskFilter?.skiaObject);
     paint.setColorFilter(_managedColorFilter?.skiaObject);
     paint.setImageFilter(_managedImageFilter?.skiaObject);

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -234,10 +234,12 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     ui.Rect maskRect,
     ui.BlendMode blendMode, {
     ui.ShaderMaskEngineLayer? oldLayer,
+    ui.FilterQuality filterQuality = ui.FilterQuality.low,
   }) {
     assert(blendMode != null); // ignore: unnecessary_null_comparison
     return _pushSurface<PersistedShaderMask>(PersistedShaderMask(
-        oldLayer as PersistedShaderMask?, shader, maskRect, blendMode));
+        oldLayer as PersistedShaderMask?,
+        shader, maskRect, blendMode, filterQuality));
   }
 
   /// Pushes a physical layer operation for an arbitrary shape onto the
@@ -384,12 +386,11 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     bool freeze = false,
     ui.FilterQuality filterQuality = ui.FilterQuality.low,
   }) {
-    _addTexture(
-        offset.dx, offset.dy, width, height, textureId, filterQuality.index);
+    _addTexture(offset.dx, offset.dy, width, height, textureId, filterQuality);
   }
 
   void _addTexture(double dx, double dy, double width, double height,
-      int textureId, int filterQuality) {
+      int textureId, ui.FilterQuality filterQuality) {
     // In test mode, allow this to be a no-op.
     if (!ui.debugEmulateFlutterTesterEnvironment) {
       throw UnimplementedError('Textures are not supported in Flutter Web');

--- a/lib/web_ui/lib/src/engine/html/shader_mask.dart
+++ b/lib/web_ui/lib/src/engine/html/shader_mask.dart
@@ -23,12 +23,14 @@ class PersistedShaderMask extends PersistedContainerSurface
     this.shader,
     this.maskRect,
     this.blendMode,
+    this.filterQuality,
   ) : super(oldLayer);
 
   html.Element? _childContainer;
   final ui.Shader shader;
   final ui.Rect maskRect;
   final ui.BlendMode blendMode;
+  final ui.FilterQuality filterQuality;
   html.Element? _shaderElement;
   static int activeShaderMaskCount = 0;
   final bool isWebKit = browserEngine == BrowserEngine.webkit;

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -86,6 +86,7 @@ abstract class SceneBuilder {
     Rect maskRect,
     BlendMode blendMode, {
     ShaderMaskEngineLayer? oldLayer,
+    FilterQuality filterQuality = FilterQuality.low,
   });
   PhysicalShapeEngineLayer? pushPhysicalShape({
     required Path path,

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -385,8 +385,6 @@ class MaskFilter {
 }
 
 enum FilterQuality {
-  // This list comes from Skia's SkFilterQuality.h and the values (order) should
-  // be kept in sync.
   none,
   low,
   medium,
@@ -690,9 +688,11 @@ class Shadow {
 }
 
 class ImageShader extends Shader {
-  factory ImageShader(Image image, TileMode tmx, TileMode tmy, Float64List matrix4) {
+  factory ImageShader(Image image, TileMode tmx, TileMode tmy, Float64List matrix4, {
+    FilterQuality? filterQuality,
+  }) {
     if (engine.useCanvasKit) {
-      return engine.CkImageShader(image, tmx, tmy, matrix4);
+      return engine.CkImageShader(image, tmx, tmy, matrix4, filterQuality);
     }
     throw UnsupportedError('ImageShader not implemented for web platform.');
   }

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -980,26 +980,55 @@ void _canvasTests() {
     );
   });
 
-  test('drawImage', () {
+  test('drawImageOptions', () {
     final SkAnimatedImage image =
         canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
-    canvas.drawImage(
+    canvas.drawImageOptions(
       image.getCurrentFrame(),
       10,
       20,
+      canvasKit.FilterMode.Linear,
+      canvasKit.MipmapMode.None,
       SkPaint(),
     );
   });
 
-  test('drawImageRect', () {
+  test('drawImageCubic', () {
     final SkAnimatedImage image =
-        canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
-    canvas.drawImageRect(
+    canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
+    canvas.drawImageCubic(
+      image.getCurrentFrame(),
+      10,
+      20,
+      0.3,
+      0.3,
+      SkPaint(),
+    );
+  });
+
+  test('drawImageRectOptions', () {
+    final SkAnimatedImage image =
+    canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
+    canvas.drawImageRectOptions(
       image.getCurrentFrame(),
       Float32List.fromList([0, 0, 1, 1]),
       Float32List.fromList([0, 0, 1, 1]),
+      canvasKit.FilterMode.Linear,
+      canvasKit.MipmapMode.None,
       SkPaint(),
-      false,
+    );
+  });
+
+  test('drawImageRectCubic', () {
+    final SkAnimatedImage image =
+    canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage);
+    canvas.drawImageRectCubic(
+      image.getCurrentFrame(),
+      Float32List.fromList([0, 0, 1, 1]),
+      Float32List.fromList([0, 0, 1, 1]),
+      0.3,
+      0.3,
+      SkPaint(),
     );
   });
 
@@ -1010,6 +1039,7 @@ void _canvasTests() {
       image.getCurrentFrame(),
       Float32List.fromList([0, 0, 1, 1]),
       Float32List.fromList([0, 0, 1, 1]),
+      canvasKit.FilterMode.Linear,
       SkPaint(),
     );
   });


### PR DESCRIPTION
Flutter is transitioning away from the SkFilterQuality enum upon which the Flutter FilterQuality enum is based.

This PR is a WIP to transition our public FilterQuality name to a new class that implements all or most of the functionality of the new SkSamplingOptions. A number of issues remain outstanding:

- Need to upgrade our canvaskit so we can implement this for Web
- FilterQuality is disappearing from SkPaint, upon which our Paint object is closely based
- In Skia, the sampling options tend to be associated with a number of objects (for instance ImageShader) for which we don't take any FilterQuality or similar object
- In Skia, a number of the rendering calls (mostly drawImage variants) now take a SkSamplingOptions parameter directly rather than taking this value from the Paint object
- Should we expose the implementation classes `_MipmapFilterQuality` and `_CubicFilterQuality` or just have them exposed via the factories on FilterQuality?
- Should we support custom cubic filters (the equations take 2 coefficients and we expose a hard-coded B=.3/C=.3 pair for compatibility, but other options might be suitable for some developers).

This PR will currently fail due to not implementing a lot of the new API changes on web, but it is good to provide a baseline on discussions about what to do with our APIs.

Fixes: https://github.com/flutter/flutter/issues/76737