### PR TITLE
Update cppwinrt to build 2.0.210304.5

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -564,7 +564,7 @@ deps = {
     'packages': [
       {
         'package': 'flutter/cppwinrt/win-amd64',
-        'version': 'build:2.0.210301.1'
+        'version': 'build:2.0.210304.5'
       }
     ],
     'condition': 'download_windows_deps',

--- a/tools/cipd/cppwinrt/.gitignore
+++ b/tools/cipd/cppwinrt/.gitignore
@@ -1,5 +1,5 @@
 # Temp directory into which we unpack the .nupkg archive
-cppwinrt
+tmp
 
 # nupkg archives
 *.nupkg

--- a/tools/cipd/cppwinrt/README.md
+++ b/tools/cipd/cppwinrt/README.md
@@ -29,10 +29,9 @@ To update the CIPD package, follow these steps:
    ```
    unzip microsoft.windows.cppwinrt.<version_number>.nupkg -d tmp
    ```
-4. `cd` into the `tmp` directory.
 4. Create the CIPD package:
    ```
-   cipd create --pkg-def ../cppwinrt-win-amd64.cipd.yaml`
+   cipd create --pkg-def cppwinrt-win-amd64.cipd.yaml
    ```
    The tool should output that the package was successfully uploaded and
    verified, including the package path and an identifier SHA.
@@ -42,7 +41,7 @@ To update the CIPD package, follow these steps:
    ```
 6. Verify the package was successfully created and tagged:
    ```
-   cipd describe flutter/cppwinrt/win-amd64 <new_version_sha>
+   cipd describe flutter/cppwinrt/win-amd64 -version <new_version_sha>
    ```
 7. Delete the archive and temp directory:
    ```

--- a/tools/cipd/cppwinrt/cppwinrt-win-amd64.cipd.yaml
+++ b/tools/cipd/cppwinrt/cppwinrt-win-amd64.cipd.yaml
@@ -2,7 +2,7 @@ package: flutter/cppwinrt/win-amd64
 description: C++/WinRT tool used for building WinRT headers for Windows UWP builds
 install_mode: copy
 # The temp directory into which the nupkg archive is extracted.
-root: cppwinrt
+root: tmp
 data:
   # Contents of the cppwinrt/ directory are at the root of the CIPD package.
   - dir: .


### PR DESCRIPTION
This fixes an issue in CppWinRT related to std::terminate(); the tool
now uses abort() instead.

CppWinRT patch: https://github.com/microsoft/cppwinrt/pull/868

This also fixes a couple bugs in the README.md:
* Uses tmp as the temp dir into which we unpack the nupkg archive rather
  than cppwinrt to avoid confusion with the containing directory, which is
  named cppwinrt.
* Fixes a typo around the directory from which the cipd command should
  be executed.

No new tests added since this just updates a dependency.

Bug: https://github.com/flutter/flutter/issues/70205

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
