### PR TITLE
fuchsia: Support multiple formats of Vulkan surface images.

### DIFF
--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -142,7 +142,9 @@ bool VulkanProcTable::SetupDeviceProcAddresses(
   ACQUIRE_PROC(GetMemoryZirconHandleFUCHSIA, handle);
   ACQUIRE_PROC(ImportSemaphoreZirconHandleFUCHSIA, handle);
   ACQUIRE_PROC(SetBufferCollectionConstraintsFUCHSIA, handle);
+  ACQUIRE_PROC(SetBufferCollectionImageConstraintsFUCHSIA, handle);
   ACQUIRE_PROC(GetBufferCollectionPropertiesFUCHSIA, handle);
+  ACQUIRE_PROC(GetBufferCollectionProperties2FUCHSIA, handle);
 #endif  // OS_FUCHSIA
   device_ = {handle, nullptr};
   return true;

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -120,7 +120,9 @@ class VulkanProcTable : public fml::RefCountedThreadSafe<VulkanProcTable> {
   DEFINE_PROC(GetMemoryZirconHandleFUCHSIA);
   DEFINE_PROC(ImportSemaphoreZirconHandleFUCHSIA);
   DEFINE_PROC(SetBufferCollectionConstraintsFUCHSIA);
+  DEFINE_PROC(SetBufferCollectionImageConstraintsFUCHSIA);
   DEFINE_PROC(GetBufferCollectionPropertiesFUCHSIA);
+  DEFINE_PROC(GetBufferCollectionProperties2FUCHSIA);
 #endif  // OS_FUCHSIA
 
 #undef DEFINE_PROC


### PR DESCRIPTION
Change https://github.com/flutter/engine/pull/23488/
has switched all the Vulkan surfaces on Fuchsia to use
RGBA8 color type. However, Using RGBA8 format on Intel GPUs
has caused graphical artifacts on emulators
(See http://fxbug.dev/70232).

This change modifies vulkan_surface.cc to use the multi-format
vkSetBufferCollectionImageConstraintsFUCHSIA() Vulkan API,
so that it could specify multiple formats when allocating
buffer collections.

Bug: fxbug.dev/70232