### PR TITLE
Revert "Adds set text action for voice access (#24734)"

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -38,7 +38,6 @@ class SemanticsAction {
   static const int _kDismissIndex = 1 << 18;
   static const int _kMoveCursorForwardByWordIndex = 1 << 19;
   static const int _kMoveCursorBackwardByWordIndex = 1 << 20;
-  static const int _kSetText = 1 << 21;
   // READ THIS: if you add an action here, you MUST update the
   // numSemanticsActions value in testing/dart/semantics_test.dart, or tests
   // will fail.
@@ -115,14 +114,6 @@ class SemanticsAction {
   /// The action includes a boolean argument, which indicates whether the cursor
   /// movement should extend (or start) a selection.
   static const SemanticsAction moveCursorBackwardByCharacter = SemanticsAction._(_kMoveCursorBackwardByCharacterIndex);
-
-  /// Replaces the current text in the text field.
-  ///
-  /// This is for example used by the text editing in voice access.
-  ///
-  /// The action includes a string argument, which is the new text to
-  /// replace.
-  static const SemanticsAction setText = SemanticsAction._(_kSetText);
 
   /// Set the text selection to the given range.
   ///
@@ -227,7 +218,6 @@ class SemanticsAction {
     _kDismissIndex: dismiss,
     _kMoveCursorForwardByWordIndex: moveCursorForwardByWord,
     _kMoveCursorBackwardByWordIndex: moveCursorBackwardByWord,
-    _kSetText: setText,
   };
 
   @override
@@ -275,8 +265,6 @@ class SemanticsAction {
         return 'SemanticsAction.moveCursorForwardByWord';
       case _kMoveCursorBackwardByWordIndex:
         return 'SemanticsAction.moveCursorBackwardByWord';
-      case _kSetText:
-        return 'SemanticsAction.setText';
     }
     assert(false, 'Unhandled index: $index');
     return '';

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -39,7 +39,6 @@ enum class SemanticsAction : int32_t {
   kDismiss = 1 << 18,
   kMoveCursorForwardByWordIndex = 1 << 19,
   kMoveCursorBackwardByWordIndex = 1 << 20,
-  kSetText = 1 << 21,
 };
 
 const int kScrollableSemanticsActions =

--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -29,7 +29,6 @@ class SemanticsAction {
   static const int _kDismissIndex = 1 << 18;
   static const int _kMoveCursorForwardByWordIndex = 1 << 19;
   static const int _kMoveCursorBackwardByWordIndex = 1 << 20;
-  static const int _kSetText = 1 << 21;
   final int index;
   static const SemanticsAction tap = SemanticsAction._(_kTapIndex);
   static const SemanticsAction longPress = SemanticsAction._(_kLongPressIndex);
@@ -58,7 +57,6 @@ class SemanticsAction {
       SemanticsAction._(_kMoveCursorForwardByWordIndex);
   static const SemanticsAction moveCursorBackwardByWord =
       SemanticsAction._(_kMoveCursorBackwardByWordIndex);
-  static const SemanticsAction setText = SemanticsAction._(_kSetText);
   static const Map<int, SemanticsAction> values = <int, SemanticsAction>{
     _kTapIndex: tap,
     _kLongPressIndex: longPress,

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1056,16 +1056,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
           accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.DISMISS);
           return true;
         }
-      case AccessibilityNodeInfo.ACTION_SET_TEXT:
-        {
-          // Set text APIs aren't available until API 21. We can't handle the case here so
-          // return false instead. It's extremely unlikely that this case would ever be
-          // triggered in the first place in API < 21.
-          if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            return false;
-          }
-          return performSetText(virtualViewId, arguments);
-        }
       default:
         // might be a custom accessibility accessibilityAction.
         final int flutterId = accessibilityAction - FIRST_RESOURCE_ID;
@@ -1123,22 +1113,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         break;
     }
     return false;
-  }
-
-  /**
-   * Handles the responsibilities of {@link #performAction(int, int, Bundle)} for the specific
-   * scenario of cursor movement.
-   */
-  @TargetApi(21)
-  @RequiresApi(21)
-  private boolean performSetText(int virtualViewId, @NonNull Bundle arguments) {
-    String newText = "";
-    if (arguments != null
-        && arguments.containsKey(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE)) {
-      newText = arguments.getString(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE);
-    }
-    accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.SET_TEXT, newText);
-    return true;
   }
 
   // TODO(ianh): implement findAccessibilityNodeInfosByText()
@@ -1781,8 +1755,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     CUSTOM_ACTION(1 << 17),
     DISMISS(1 << 18),
     MOVE_CURSOR_FORWARD_BY_WORD(1 << 19),
-    MOVE_CURSOR_BACKWARD_BY_WORD(1 << 20),
-    SET_TEXT(1 << 21);
+    MOVE_CURSOR_BACKWARD_BY_WORD(1 << 20);
 
     public final int value;
 

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -20,7 +20,6 @@ import android.annotation.TargetApi;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.graphics.Rect;
-import android.os.Bundle;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewParent;
@@ -331,45 +330,6 @@ public class AccessibilityBridgeTest {
     sentences = event.getText();
     assertEquals(sentences.size(), 1);
     assertEquals(sentences.get(0).toString(), "new_node2");
-  }
-
-  @TargetApi(21)
-  @Test
-  public void itCanPerformSetText() {
-    AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
-    AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
-    AccessibilityManager mockManager = mock(AccessibilityManager.class);
-    View mockRootView = mock(View.class);
-    Context context = mock(Context.class);
-    when(mockRootView.getContext()).thenReturn(context);
-    when(context.getPackageName()).thenReturn("test");
-    AccessibilityBridge accessibilityBridge =
-        setUpBridge(
-            /*rootAccessibilityView=*/ mockRootView,
-            /*accessibilityChannel=*/ mockChannel,
-            /*accessibilityManager=*/ mockManager,
-            /*contentResolver=*/ null,
-            /*accessibilityViewEmbedder=*/ mockViewEmbedder,
-            /*platformViewsAccessibilityDelegate=*/ null);
-
-    ViewParent mockParent = mock(ViewParent.class);
-    when(mockRootView.getParent()).thenReturn(mockParent);
-    when(mockManager.isEnabled()).thenReturn(true);
-
-    TestSemanticsNode root = new TestSemanticsNode();
-    root.id = 0;
-    TestSemanticsNode node1 = new TestSemanticsNode();
-    node1.id = 1;
-    node1.addFlag(AccessibilityBridge.Flag.IS_TEXT_FIELD);
-    root.children.add(node1);
-    TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
-    accessibilityBridge.updateSemantics(testSemanticsUpdate.buffer, testSemanticsUpdate.strings);
-    Bundle bundle = new Bundle();
-    String expectedText = "some string";
-    bundle.putString(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, expectedText);
-    accessibilityBridge.performAction(1, AccessibilityNodeInfo.ACTION_SET_TEXT, bundle);
-    verify(mockChannel)
-        .dispatchSemanticsAction(1, AccessibilityBridge.Action.SET_TEXT, expectedText);
   }
 
   @Test

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -20,7 +20,7 @@ void main() {
   });
 
   // This must match the number of actions in lib/ui/semantics.dart
-  const int numSemanticsActions = 22;
+  const int numSemanticsActions = 21;
   test('SemanticsAction.values refers to all actions.', () async {
     expect(SemanticsAction.values.length, equals(numSemanticsActions));
     for (int index = 0; index < numSemanticsActions; ++index) {


### PR DESCRIPTION
Triggers the following framework test failure:
```
00:11 +86 ~2: /opt/s/w/ir/k/flutter/packages/flutter_test/test/matchers_test.dart: matchesSemanticsData Can match all semantics flags and actions
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure object was thrown running a test:
  Expected: has semantics with actions: [
            SemanticsAction:SemanticsAction.tap,
            SemanticsAction:SemanticsAction.longPress,
            SemanticsAction:SemanticsAction.scrollLeft,
            SemanticsAction:SemanticsAction.scrollRight,
            SemanticsAction:SemanticsAction.scrollUp,
            SemanticsAction:SemanticsAction.scrollDown,
            SemanticsAction:SemanticsAction.increase,
            SemanticsAction:SemanticsAction.decrease,
            SemanticsAction:SemanticsAction.showOnScreen,
            SemanticsAction:SemanticsAction.moveCursorForwardByCharacter,
            SemanticsAction:SemanticsAction.moveCursorBackwardByCharacter,
            SemanticsAction:SemanticsAction.setSelection,
            SemanticsAction:SemanticsAction.copy,
            SemanticsAction:SemanticsAction.cut,
            SemanticsAction:SemanticsAction.paste,
            SemanticsAction:SemanticsAction.didGainAccessibilityFocus,
            SemanticsAction:SemanticsAction.didLoseAccessibilityFocus,
            SemanticsAction:SemanticsAction.customAction,
            SemanticsAction:SemanticsAction.dismiss,
            SemanticsAction:SemanticsAction.moveCursorForwardByWord,
            SemanticsAction:SemanticsAction.moveCursorBackwardByWord
          ] with flags: [
            SemanticsFlag:SemanticsFlag.hasCheckedState,
            SemanticsFlag:SemanticsFlag.isChecked,
            SemanticsFlag:SemanticsFlag.isSelected,
            SemanticsFlag:SemanticsFlag.isButton,
            SemanticsFlag:SemanticsFlag.isSlider,
            SemanticsFlag:SemanticsFlag.isLink,
            SemanticsFlag:SemanticsFlag.isTextField,
            SemanticsFlag:SemanticsFlag.isReadOnly,
            SemanticsFlag:SemanticsFlag.isFocused,
            SemanticsFlag:SemanticsFlag.isFocusable,
            SemanticsFlag:SemanticsFlag.hasEnabledState,
            SemanticsFlag:SemanticsFlag.isEnabled,
            SemanticsFlag:SemanticsFlag.isInMutuallyExclusiveGroup,
            SemanticsFlag:SemanticsFlag.isHeader,
            SemanticsFlag:SemanticsFlag.isObscured,
            SemanticsFlag:SemanticsFlag.namesRoute,
            SemanticsFlag:SemanticsFlag.scopesRoute,
            SemanticsFlag:SemanticsFlag.isHidden,
            SemanticsFlag:SemanticsFlag.isImage,
            SemanticsFlag:SemanticsFlag.isLiveRegion,
            SemanticsFlag:SemanticsFlag.hasToggledState,
            SemanticsFlag:SemanticsFlag.isToggled,
            SemanticsFlag:SemanticsFlag.hasImplicitScrolling,
            SemanticsFlag:SemanticsFlag.isSlider
          ] with rect: Rect.fromLTRB(0.0, 0.0, 10.0, 10.0) with size: Size(10.0, 10.0) with
elevation: 3.0 with thickness: 4.0 with platformViewId: 105 with maxValueLength: 15 with
currentValueLength: 10 with custom actions: [CustomSemanticsAction(7, label:test, hint:null,
action:null)]
  Actual: _FakeSemanticsNode:<_FakeSemanticsNode#1(Rect.fromLTRB(0.0, 0.0, 0.0, 0.0), invisible)>
   Which: actions were: [tap, longPress, scrollLeft, scrollRight, scrollUp, scrollDown, increase,
decrease, showOnScreen, moveCursorForwardByCharacter, moveCursorBackwardByCharacter, setSelection,
copy, cut, paste, didGainAccessibilityFocus, didLoseAccessibilityFocus, customAction, dismiss,
moveCursorForwardByWord, moveCursorBackwardByWord, setText]

When the exception was thrown, this was the stack:
<asynchronous suspension>
<asynchronous suspension>
(elided one frame from package:stack_trace)

This was caught by the test expectation on the following line:
  file:///opt/s/w/ir/k/flutter/packages/flutter_test/test/matchers_test.dart line 563
The test description was:
  Can match all semantics flags and actions
════════════════════════════════════════════════════════════════════════════════════════════════════
```

This reverts commit 9a6734c1771803bb6a30152988cbe086faa31902.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
