### PR TITLE
[web] Don't set both color and foreground at the same time

### DIFF
--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -403,7 +403,7 @@ abstract class StyleNode {
     return style;
   }
 
-  ui.Color get _color;
+  ui.Color? get _color;
   ui.TextDecoration? get _decoration;
   ui.Color? get _decorationColor;
   ui.TextDecorationStyle? get _decorationStyle;
@@ -439,7 +439,7 @@ class ChildStyleNode extends StyleNode {
   // property isn't defined, go to the parent node.
 
   @override
-  ui.Color get _color => style._color ?? parent._color;
+  ui.Color? get _color => style._color ?? (_foreground == null ? parent._color : null);
 
   @override
   ui.TextDecoration? get _decoration => style._decoration ?? parent._decoration;


### PR DESCRIPTION
When `foreground` is set, we shouldn't set a `color`. The code right now always sets `color` to the default, even if the user didn't specify it.

This PR is to unblock the [Dart sdk/engine roll](https://github.com/flutter/engine/pull/24821). A recent change in dart2js surfaced this test failure.