### PR TITLE
fix voice control delete line command does not delete line correctly

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -44,6 +44,10 @@
 
 @end
 
+/** A tokenizer used by `FlutterTextInputView` to customize string parsing. */
+@interface FlutterTokenizer : UITextInputStringTokenizer
+@end
+
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 FLUTTER_DARWIN_EXPORT
 #endif

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -401,7 +401,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   switch (granularity) {
     case UITextGranularityLine:
       // The default UITextInputStringTokenizer does not handle line granularity
-      // Correctly. We need to implement our own line tokenizer.
+      // correctly. We need to implement our own line tokenizer.
       result = [self lineEnclosingPosition:position];
       break;
     case UITextGranularityCharacter:

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -380,9 +380,13 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 
 #pragma mark - FlutterTokenizer
 
-@implementation FlutterTokenizer {
-  FlutterTextInputView* _textInputView;
-}
+@interface FlutterTokenizer ()
+
+@property(nonatomic, assign) FlutterTextInputView* textInputView;
+
+@end
+
+@implementation FlutterTokenizer
 
 - (instancetype)initWithTextInput:(UIResponder<UITextInput>*)textInput {
   NSAssert([textInput isKindOfClass:[FlutterTextInputView class]],
@@ -409,6 +413,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
     case UITextGranularitySentence:
     case UITextGranularityParagraph:
     case UITextGranularityDocument:
+      // The UITextInputStringTokenizer can handle all these cases correctly.
       result = [super rangeEnclosingPosition:position
                              withGranularity:granularity
                                  inDirection:direction];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -378,6 +378,68 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 }
 @end
 
+#pragma mark - FlutterTokenizer
+
+@implementation FlutterTokenizer {
+  FlutterTextInputView* _textInputView;
+}
+
+- (instancetype)initWithTextInput:(UIResponder<UITextInput>*)textInput {
+  NSAssert([textInput isKindOfClass:[FlutterTextInputView class]],
+           @"The FlutterTokenizer can only be used in a FlutterTextInputView");
+  self = [super initWithTextInput:textInput];
+  if (self) {
+    _textInputView = (FlutterTextInputView*)textInput;
+  }
+  return self;
+}
+
+- (UITextRange*)rangeEnclosingPosition:(UITextPosition*)position
+                       withGranularity:(UITextGranularity)granularity
+                           inDirection:(UITextDirection)direction {
+  UITextRange* result;
+  switch (granularity) {
+    case UITextGranularityLine:
+      // The default UITextInputStringTokenizer does not handle line granularity
+      // Correctly. We need to implement our own line tokenizer.
+      result = [self lineEnclosingPosition:position];
+      break;
+    case UITextGranularityCharacter:
+    case UITextGranularityWord:
+    case UITextGranularitySentence:
+    case UITextGranularityParagraph:
+    case UITextGranularityDocument:
+      result = [super rangeEnclosingPosition:position
+                             withGranularity:granularity
+                                 inDirection:direction];
+      break;
+  }
+  return result;
+}
+
+- (UITextRange*)lineEnclosingPosition:(UITextPosition*)position {
+  // Gets the first line break position after the input position.
+  NSString* textAfter = [_textInputView
+      textInRange:[_textInputView textRangeFromPosition:position
+                                             toPosition:[_textInputView endOfDocument]]];
+  NSArray<NSString*>* linesAfter = [textAfter componentsSeparatedByString:@"\n"];
+  NSInteger offSetToLineBreak = [linesAfter firstObject].length;
+  UITextPosition* lineBreakAfter = [_textInputView positionFromPosition:position
+                                                                 offset:offSetToLineBreak];
+  // Gets the first line break position before the input position.
+  NSString* textBefore = [_textInputView
+      textInRange:[_textInputView textRangeFromPosition:[_textInputView beginningOfDocument]
+                                             toPosition:position]];
+  NSArray<NSString*>* linesBefore = [textBefore componentsSeparatedByString:@"\n"];
+  NSInteger offSetFromLineBreak = [linesBefore lastObject].length;
+  UITextPosition* lineBreakBefore = [_textInputView positionFromPosition:position
+                                                                  offset:-offSetFromLineBreak];
+
+  return [_textInputView textRangeFromPosition:lineBreakBefore toPosition:lineBreakAfter];
+}
+
+@end
+
 // A FlutterTextInputView that masquerades as a UITextField, and forwards
 // selectors it can't respond to to a shared UITextField instance.
 //
@@ -629,7 +691,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 
 - (id<UITextInputTokenizer>)tokenizer {
   if (_tokenizer == nil) {
-    _tokenizer = [[UITextInputStringTokenizer alloc] initWithTextInput:self];
+    _tokenizer = [[FlutterTokenizer alloc] initWithTextInput:self];
   }
   return _tokenizer;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -133,6 +133,14 @@ FLUTTER_ASSERT_ARC
                                                                    [FlutterTextInputView class]]];
 }
 
+- (FlutterTextRange*)getLineRangeFromTokenizer:(id<UITextInputTokenizer>)tokenizer
+                                       atIndex:(NSInteger)index {
+  return (FlutterTextRange*)[tokenizer
+      rangeEnclosingPosition:[FlutterTextPosition positionWithIndex:index]
+             withGranularity:UITextGranularityLine
+                 inDirection:UITextLayoutDirectionRight];
+}
+
 #pragma mark - Tests
 
 - (void)testSecureInput {
@@ -816,6 +824,43 @@ FLUTTER_ASSERT_ARC
 
   XCTAssertEqual(inputView.receivedNotification, UIAccessibilityScreenChangedNotification);
   XCTAssertEqual(inputView.receivedNotificationTarget, backing);
+}
+
+- (void)testFlutterTokenizerCanParseLines {
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
+  inputView.textInputDelegate = engine;
+  id<UITextInputTokenizer> tokenizer = [inputView tokenizer];
+
+  // The tokenizer returns zero range When text is empty.
+  FlutterTextRange* range = [self getLineRangeFromTokenizer:tokenizer atIndex:0];
+  XCTAssertEqual(range.range.location, 0u);
+  XCTAssertEqual(range.range.length, 0u);
+
+  [inputView insertText:@"how are you\nI am fine, Thank you"];
+
+  range = [self getLineRangeFromTokenizer:tokenizer atIndex:0];
+  XCTAssertEqual(range.range.location, 0u);
+  XCTAssertEqual(range.range.length, 11u);
+
+  range = [self getLineRangeFromTokenizer:tokenizer atIndex:2];
+  XCTAssertEqual(range.range.location, 0u);
+  XCTAssertEqual(range.range.length, 11u);
+
+  range = [self getLineRangeFromTokenizer:tokenizer atIndex:11];
+  XCTAssertEqual(range.range.location, 0u);
+  XCTAssertEqual(range.range.length, 11u);
+
+  range = [self getLineRangeFromTokenizer:tokenizer atIndex:12];
+  XCTAssertEqual(range.range.location, 12u);
+  XCTAssertEqual(range.range.length, 20u);
+
+  range = [self getLineRangeFromTokenizer:tokenizer atIndex:15];
+  XCTAssertEqual(range.range.location, 12u);
+  XCTAssertEqual(range.range.length, 20u);
+
+  range = [self getLineRangeFromTokenizer:tokenizer atIndex:32];
+  XCTAssertEqual(range.range.location, 12u);
+  XCTAssertEqual(range.range.length, 20u);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -135,10 +135,12 @@ FLUTTER_ASSERT_ARC
 
 - (FlutterTextRange*)getLineRangeFromTokenizer:(id<UITextInputTokenizer>)tokenizer
                                        atIndex:(NSInteger)index {
-  return (FlutterTextRange*)[tokenizer
-      rangeEnclosingPosition:[FlutterTextPosition positionWithIndex:index]
-             withGranularity:UITextGranularityLine
-                 inDirection:UITextLayoutDirectionRight];
+  UITextRange* range =
+      [tokenizer rangeEnclosingPosition:[FlutterTextPosition positionWithIndex:index]
+                        withGranularity:UITextGranularityLine
+                            inDirection:UITextLayoutDirectionRight];
+  XCTAssertTrue([range isKindOfClass:[FlutterTextRange class]]);
+  return (FlutterTextRange*)range;
 }
 
 #pragma mark - Tests


### PR DESCRIPTION
The `UITextInputStringTokenizer` does not parse the line correctly, This pr fixes it.

fixes https://github.com/flutter/flutter/issues/77274

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
