### PR TITLE
Prevent race condition while switching surfaces

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -118,9 +118,6 @@ public class FlutterImageView extends View implements RenderSurface {
    */
   @Override
   public void attachToRenderer(@NonNull FlutterRenderer flutterRenderer) {
-    if (isAttachedToFlutterRenderer) {
-      return;
-    }
     switch (kind) {
       case background:
         flutterRenderer.swapSurface(imageReader.getSurface());

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -1068,7 +1068,9 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
           public void onFlutterUiDisplayed() {
             renderer.removeIsDisplayingFlutterUiListener(this);
             onDone.run();
-            flutterImageView.detachFromRenderer();
+            if (!(renderSurface instanceof FlutterImageView)) {
+              flutterImageView.detachFromRenderer();
+            }
           }
 
           @Override


### PR DESCRIPTION
Reworks https://github.com/flutter/engine/pull/24363 to address the _real_ root cause, and fix https://b.corp.google.com/issues/181010760.

When a platform view widget is rebuilt, the previous platform view is disposed, and a new one is initialized.
However, a frame is pushed in the middle of this operation that does not contain a platform view layer in the
layer tree as it can be seen [here](https://github.com/flutter/flutter/blob/88809aa24720705d1cd8de0bfc46faf932fe0b6e/packages/flutter/lib/src/widgets/platform_view.dart#L844-L846).

This causes the Flutter surface to change back and forth (from FlutterImageView to FlutterSurfaceView to FlutterImageView).
During this process, we currently insert a listener that waits for the first frame in the `FlutterSurfaceView`'s buffer before completely dropping `FlutterImageView`. However, by that time, the new `FlutterImageView` buffer is used.
As a result, the UI is stuck as it assumed that `FlutterSurfaceView` is rendering Flutter pixels, but it isn't.

Tests: This change will be tested in the framework - I'd like to have an e2e test for this change.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
