### PR TITLE
Revert "[web] Fix url updates when using Router (#24798)"

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -44,17 +44,13 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
   /// button, etc.
   @visibleForTesting
   BrowserHistory get browserHistory {
-    return _browserHistory ??=
-        MultiEntriesBrowserHistory(urlStrategy: _urlStrategyForInitialization);
-  }
-
-  UrlStrategy? get _urlStrategyForInitialization {
     final UrlStrategy? urlStrategy = _isUrlStrategySet
         ? _customUrlStrategy
         : _createDefaultUrlStrategy();
     // Prevent any further customization of URL strategy.
     _isUrlStrategySet = true;
-    return urlStrategy;
+    return _browserHistory ??=
+        MultiEntriesBrowserHistory(urlStrategy: urlStrategy);
   }
 
   BrowserHistory? _browserHistory;
@@ -63,14 +59,8 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     if (_browserHistory is SingleEntryBrowserHistory) {
       return;
     }
-
-    final UrlStrategy? strategy;
-    if (_browserHistory == null) {
-      strategy = _urlStrategyForInitialization;
-    } else {
-      strategy = _browserHistory?.urlStrategy;
-      await _browserHistory?.tearDown();
-    }
+    final UrlStrategy? strategy = _browserHistory?.urlStrategy;
+    await _browserHistory?.tearDown();
     _browserHistory = SingleEntryBrowserHistory(urlStrategy: strategy);
   }
 
@@ -78,14 +68,8 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     if (_browserHistory is MultiEntriesBrowserHistory) {
       return;
     }
-
-    final UrlStrategy? strategy;
-    if (_browserHistory == null) {
-      strategy = _urlStrategyForInitialization;
-    } else {
-      strategy = _browserHistory?.urlStrategy;
-      await _browserHistory?.tearDown();
-    }
+    final UrlStrategy? strategy = _browserHistory?.urlStrategy;
+    await _browserHistory?.tearDown();
     _browserHistory = MultiEntriesBrowserHistory(urlStrategy: strategy);
   }
 
@@ -277,7 +261,7 @@ external set _jsSetUrlStrategy(_JsSetUrlStrategy? newJsSetUrlStrategy);
 
 UrlStrategy? _createDefaultUrlStrategy() {
   return ui.debugEmulateFlutterTesterEnvironment
-      ? TestUrlStrategy.fromEntry(TestHistoryEntry('default', null, '/default'))
+      ? null
       : const HashUrlStrategy();
 }
 

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -128,51 +128,6 @@ void testMain() {
     expect(window.browserHistory.urlStrategy.getPath(), '/baz');
   });
 
-  test('initialize browser history with default url strategy (single)', () async {
-    // On purpose, we don't initialize history on the window. We want to let the
-    // window to self-initialize when it receives a navigation message.
-
-    Completer<void> callback = Completer<void>();
-    window.sendPlatformMessage(
-      'flutter/navigation',
-      JSONMethodCodec().encodeMethodCall(MethodCall(
-        'routeUpdated',
-        <String, dynamic>{'routeName': '/bar'},
-      )),
-      (_) { callback.complete(); },
-    );
-    await callback.future;
-    expect(window.browserHistory is SingleEntryBrowserHistory, true);
-    // The url strategy should've been set to the default, and the path
-    // should've been correctly set to "/bar".
-    expect(window.browserHistory.urlStrategy, isNot(isNull));
-    expect(window.browserHistory.urlStrategy.getPath(), '/bar');
-  }, skip: browserEngine == BrowserEngine.webkit); // https://github.com/flutter/flutter/issues/50836
-
-  test('initialize browser history with default url strategy (multiple)', () async {
-    // On purpose, we don't initialize history on the window. We want to let the
-    // window to self-initialize when it receives a navigation message.
-
-    Completer<void> callback = Completer<void>();
-    window.sendPlatformMessage(
-      'flutter/navigation',
-      JSONMethodCodec().encodeMethodCall(MethodCall(
-        'routeInformationUpdated',
-        <String, dynamic>{
-          'location': '/baz',
-          'state': null,
-        },
-      )),
-      (_) { callback.complete(); },
-    );
-    await callback.future;
-    expect(window.browserHistory is MultiEntriesBrowserHistory, true);
-    // The url strategy should've been set to the default, and the path
-    // should've been correctly set to "/baz".
-    expect(window.browserHistory.urlStrategy, isNot(isNull));
-    expect(window.browserHistory.urlStrategy.getPath(), '/baz');
-  }, skip: browserEngine == BrowserEngine.webkit); // https://github.com/flutter/flutter/issues/50836
-
   test('can disable location strategy', () async {
     // Disable URL strategy.
     expect(() => jsSetUrlStrategy(null), returnsNormally);


### PR DESCRIPTION
Seeing many web tests fail with errors like:

```
00:07 +0 -11: test/cupertino/search_field_test.dart: clear button removes text
══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞═════════════════════════════════════════════════════════
The following message was thrown:
Could not navigate to initial route.
The requested route name was: "/default"
There was no corresponding route in the app, and therefore the initial route specified will be
ignored and "/" will be used instead.
════════════════════════════════════════════════════════════════════════════════════════════════════

00:07 +0 -12: test/cupertino/search_field_test.dart: clear button removes text [E]
  Test failed. See exception logs above.
  The test description was: clear button removes text
```

This reverts commit 510d2abfb9e6832b0f949b5274c66289cd9f99f3.