### PR TITLE
Respond to Skia.setResourceCacheMaxBytes

### DIFF
--- a/lib/web_ui/test/canvaskit/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/canvaskit/platform_dispatcher_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.12
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+import 'common.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('PlatformDispatcher', () {
+    setUpCanvasKitTest();
+
+    test('responds to flutter/skia Skia.setResourceCacheMaxBytes', () async {
+      const MethodCodec codec = JSONMethodCodec();
+      final Completer<ByteData?> completer = Completer<ByteData?>();
+      ui.PlatformDispatcher.instance.sendPlatformMessage(
+        'flutter/skia',
+        codec.encodeMethodCall(MethodCall(
+          'Skia.setResourceCacheMaxBytes',
+          512 * 1000 * 1000,
+        )),
+        completer.complete,
+      );
+
+      final ByteData? response = await completer.future;
+      expect(response, isNotNull);
+      expect(
+        codec.decodeEnvelope(response!),
+        [true],
+      );
+    });
+    // TODO: https://github.com/flutter/flutter/issues/60040
+  }, skip: isIosSafari);
+}

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.12
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('PlatformDispatcher', () {
+    test('responds to flutter/skia Skia.setResourceCacheMaxBytes', () async {
+      const MethodCodec codec = JSONMethodCodec();
+      final Completer<ByteData?> completer = Completer<ByteData?>();
+      ui.PlatformDispatcher.instance.sendPlatformMessage(
+        'flutter/skia',
+        codec.encodeMethodCall(MethodCall(
+          'Skia.setResourceCacheMaxBytes',
+          512 * 1000 * 1000,
+        )),
+        completer.complete,
+      );
+
+      final ByteData? response = await completer.future;
+      expect(response, isNotNull);
+      expect(
+        codec.decodeEnvelope(response!),
+        [true],
+      );
+    });
+  });
+}


### PR DESCRIPTION
Respond to `Skia.setResourceCacheMaxBytes` platform message so framework-side could await on it.

Fixes https://github.com/flutter/flutter/issues/77018