### PR TITLE
Fix handling of external texture transforms on Android

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -118,7 +118,7 @@ targets:
       - DEPS
       - .ci.yaml
       - testing/**
-      - shell/platforms/android/**
+      - shell/platform/android/**
 
   - name: Linux Benchmarks
     enabled_branches:

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -64,8 +64,13 @@ void AndroidExternalTextureGL::Paint(SkCanvas& canvas,
       kPremul_SkAlphaType, nullptr);
   if (image) {
     SkAutoCanvasRestore autoRestore(&canvas, true);
-    canvas.translate(bounds.x(), bounds.y());
-    canvas.scale(bounds.width(), bounds.height());
+
+    // The incoming texture is vertically flipped, so we flip it
+    // back. OpenGL's coordinate system has Positive Y equivalent to up, while
+    // Skia's coordinate system has Negative Y equvalent to up.
+    canvas.translate(bounds.x(), bounds.y() + bounds.height());
+    canvas.scale(bounds.width(), -bounds.height());
+
     if (!transform.isIdentity()) {
       sk_sp<SkShader> shader = image->makeShader(
           SkTileMode::kRepeat, SkTileMode::kRepeat, sampling, transform);
@@ -83,14 +88,17 @@ void AndroidExternalTextureGL::UpdateTransform() {
   jni_facade_->SurfaceTextureGetTransformMatrix(
       fml::jni::ScopedJavaLocalRef<jobject>(surface_texture_), transform);
 
+  // Android's SurfaceTexture transform matrix works on texture coordinate
+  // lookups in the range 0.0-1.0, while Skia's Shader transform matrix works on
+  // the image itself, as if it were inscribed inside a clip rect.
+  // An Android transform that scales lookup by 0.5 (displaying 50% of the
+  // texture) is the same as a Skia transform by 2.0 (scaling 50% of the image
+  // outside of the virtual "clip rect"), so we invert the incoming matrix.
   SkMatrix inverted;
   if (!transform.invert(&inverted)) {
     FML_LOG(FATAL) << "Invalid SurfaceTexture transformation matrix";
   }
   transform = inverted;
-
-  transform.preScale(1.0, -1.0);
-  transform.postTranslate(0.0, -1.0);
 }
 
 void AndroidExternalTextureGL::OnGrContextDestroyed() {

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -75,7 +75,10 @@ void AndroidExternalTextureGL::Paint(SkCanvas& canvas,
       sk_sp<SkShader> shader = image->makeShader(
           SkTileMode::kRepeat, SkTileMode::kRepeat, sampling, transform);
 
-      SkPaint paintWithShader = *paint;
+      SkPaint paintWithShader;
+      if (paint) {
+        paintWithShader = *paint;
+      }
       paintWithShader.setShader(shader);
       canvas.drawRect(SkRect::MakeWH(1, 1), paintWithShader);
     } else {


### PR DESCRIPTION
Android provides a transformation matrix for SurfaceTextures to allow decoders, cameras, etc. to have the flexibility with the buffers they output, while allowing applications to sample them regardless of layout. However, outside of identity matrices, Flutter was not using this correctly:

- Android returns a 4x4 matrix, Skia accepts a 3x3. The "conversion" between the two was incorrect.
- ScaleToFill is a hack added due to the previous point, and ends up (weirdly) normalizing the scale transforms.
- The surface transform was applied to the surface rectangle itself, not the texture lookup, which causes the surface to escape its layer bounds depending on the incoming transform.

Fixes: flutter/flutter#58138 (And possibly more issues with stranger device buffer layouts)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
