### PR TITLE
fuchsia: Use SRGB formats for Vulkan surfaces.

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -27,7 +27,7 @@ namespace flutter_runner {
 namespace {
 
 constexpr SkColorType kSkiaColorType = kRGBA_8888_SkColorType;
-constexpr VkFormat kVulkanFormat = VK_FORMAT_R8G8B8A8_UNORM;
+constexpr VkFormat kVulkanFormat = VK_FORMAT_R8G8B8A8_SRGB;
 constexpr VkImageCreateFlags kVulkanImageCreateFlags = 0;
 // TODO: We should only keep usages that are actually required by Skia.
 constexpr VkImageUsageFlags kVkImageUsage =
@@ -354,12 +354,12 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrDirectContext> context,
   SkSurfaceProps sk_surface_props(0, kUnknown_SkPixelGeometry);
 
   auto sk_surface =
-      SkSurface::MakeFromBackendRenderTarget(context.get(),             //
-                                             sk_render_target,          //
-                                             kTopLeft_GrSurfaceOrigin,  //
-                                             color_type,                //
-                                             SkColorSpace::MakeSRGB(),  //
-                                             &sk_surface_props          //
+      SkSurface::MakeFromBackendRenderTarget(context.get(),                   //
+                                             sk_render_target,                //
+                                             kTopLeft_GrSurfaceOrigin,        //
+                                             color_type,                      //
+                                             SkColorSpace::MakeSRGBLinear(),  //
+                                             &sk_surface_props                //
       );
 
   if (!sk_surface || sk_surface->getCanvas() == nullptr) {


### PR DESCRIPTION
Scenic always uses SRGB Vulkan formats when creating images
from sysmem. This change modifies the VkFormat used in
Flutter for surfaces to VK_FORMAT_R8G8B8A8_SRGB so that it
matches the format used in Scenic.

This fixes the artifacts on FEMU (e.g. fxbug.dev/70232) where
artifacts occur when Scenic and client use different formats
without specifying VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT flag.

TEST=workstation.x64 on FEMU
Fixed: fxbug.dev/70232
