### PR TITLE
Add framebuffer destruction_callback for Linux

### DIFF
--- a/shell/platform/linux/fl_renderer_gl.cc
+++ b/shell/platform/linux/fl_renderer_gl.cc
@@ -61,6 +61,10 @@ static gboolean fl_renderer_gl_create_backing_store(
   backing_store_out->open_gl.framebuffer.user_data = provider;
   backing_store_out->open_gl.framebuffer.name = name;
   backing_store_out->open_gl.framebuffer.target = format;
+  backing_store_out->open_gl.framebuffer.destruction_callback = [](void* p) {
+    // Backing store destroyed in fl_renderer_gl_collect_backing_store(), set
+    // on FlutterCompositor.collect_backing_store_callback during engine start.
+  };
 
   return TRUE;
 }


### PR DESCRIPTION
While we no longer crash when the framebuffer destruction_callback is
null (patched in https://github.com/flutter/engine/pull/24845) we should
be setting one for readability reasons, even if it's a no-op containing
a comment pointing to where cleanup is implemented.

Related: https://github.com/flutter/flutter/issues/76881

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
