### PR TITLE
Rename `moduleName` to `componentName` for consistency

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/DeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/DeferredComponentManager.java
@@ -31,7 +31,7 @@ import io.flutter.embedding.engine.systemchannels.DeferredComponentChannel;
  * manually via platform channel messages. A full installDeferredComponent implementation should
  * call these two methods as needed.
  *
- * <p>A deferred component module is uniquely identified by a module name as defined in
+ * <p>A deferred component module is uniquely identified by a component name as defined in
  * bundle_config.yaml. Each feature module may contain one or more loading units, uniquely
  * identified by the loading unit ID and assets.
  */
@@ -82,16 +82,16 @@ public interface DeferredComponentManager {
    *
    * <p>Both parameters are not always necessary to identify which module to install. Asset-only
    * modules do not have an associated loadingUnitId. Instead, an invalid ID like -1 may be passed
-   * to download only with moduleName. On the other hand, it can be possible to resolve the
-   * moduleName based on the loadingUnitId. This resolution is done if moduleName is null. At least
-   * one of loadingUnitId or moduleName must be valid or non-null.
+   * to download only with componentName. On the other hand, it can be possible to resolve the
+   * componentName based on the loadingUnitId. This resolution is done if componentName is null. At least
+   * one of loadingUnitId or componentName must be valid or non-null.
    *
    * <p>Flutter will typically call this method in two ways. When invoked as part of a dart
-   * `loadLibrary()` call, a valid loadingUnitId is passed in while the moduleName is null. In this
+   * `loadLibrary()` call, a valid loadingUnitId is passed in while the componentName is null. In this
    * case, this method is responsible for figuring out what module the loadingUnitId corresponds to.
    *
    * <p>When invoked manually as part of loading an assets-only module, loadingUnitId is -1
-   * (invalid) and moduleName is supplied. Without a loadingUnitId, this method just downloads the
+   * (invalid) and componentName is supplied. Without a loadingUnitId, this method just downloads the
    * module by name and attempts to load assets via loadAssets while loadDartLibrary is skipped,
    * even if the deferred component module includes valid dart libs. To load dart libs, call
    * `loadLibrary()` using the first way described in the previous paragraph as the method channel
@@ -109,21 +109,21 @@ public interface DeferredComponentManager {
    *     Loading unit ids range from 0 to the number existing loading units. Passing a negative
    *     loading unit id indicates that no Dart deferred library should be loaded after download
    *     completes. This is the case when the deferred component module is an assets-only module. If
-   *     a negative loadingUnitId is passed, then moduleName must not be null. Passing a
+   *     a negative loadingUnitId is passed, then componentName must not be null. Passing a
    *     loadingUnitId larger than the highest valid loading unit's id will cause the Dart
    *     loadLibrary() to complete with a failure.
-   * @param moduleName The deferred component module name as defined in bundle_config.yaml. This may
+   * @param componentName The deferred component component name as defined in bundle_config.yaml. This may
    *     be null if the deferred component to be loaded is associated with a loading unit/deferred
    *     dart library. In this case, it is this method's responsibility to map the loadingUnitId to
-   *     its corresponding moduleName. When loading asset-only or other deferred components without
-   *     an associated Dart deferred library, loading unit id should a negative value and moduleName
+   *     its corresponding componentName. When loading asset-only or other deferred components without
+   *     an associated Dart deferred library, loading unit id should a negative value and componentName
    *     must be non-null.
    */
-  public abstract void installDeferredComponent(int loadingUnitId, String moduleName);
+  public abstract void installDeferredComponent(int loadingUnitId, String componentName);
 
   /**
    * Gets the current state of the installation session corresponding to the specified loadingUnitId
-   * and/or moduleName.
+   * and/or componentName.
    *
    * <p>Invocations of {@link installDeferredComponent} typically result in asynchronous downloading
    * and other tasks. This method enables querying of the state of the installation. Querying the
@@ -134,7 +134,7 @@ public interface DeferredComponentManager {
    * component.
    *
    * <p>If no deferred component has been installed or requested to be installed by the provided
-   * loadingUnitId or moduleName, then this method will return null.
+   * loadingUnitId or componentName, then this method will return null.
    *
    * <p>Depending on the implementation, the returned String may vary. The Play store default
    * implementation begins in the "requested" state before transitioning to the "downloading" and
@@ -147,14 +147,14 @@ public interface DeferredComponentManager {
    *
    * <p>Both parameters are not always necessary to identify which module to install. Asset-only
    * modules do not have an associated loadingUnitId. Instead, an invalid ID like -1 may be passed
-   * to query only with moduleName. On the other hand, it can be possible to resolve the moduleName
-   * based on the loadingUnitId. This resolution is done if moduleName is null. At least one of
-   * loadingUnitId or moduleName must be valid or non-null.
+   * to query only with componentName. On the other hand, it can be possible to resolve the componentName
+   * based on the loadingUnitId. This resolution is done if componentName is null. At least one of
+   * loadingUnitId or componentName must be valid or non-null.
    *
    * @param loadingUnitId The unique identifier associated with a Dart deferred library.
-   * @param moduleName The deferred component module name as defined in bundle_config.yaml.
+   * @param componentName The deferred component component name as defined in bundle_config.yaml.
    */
-  public abstract String getDeferredComponentInstallState(int loadingUnitId, String moduleName);
+  public abstract String getDeferredComponentInstallState(int loadingUnitId, String componentName);
 
   /**
    * Extract and load any assets and resources from the module for use by Flutter.
@@ -166,7 +166,7 @@ public interface DeferredComponentManager {
    * <p>If using the Play Store deferred component delivery, refresh the context via: {@code
    * context.createPackageContext(context.getPackageName(), 0);} This returns a new context, from
    * which an updated asset manager may be obtained and passed to updateAssetManager in FlutterJNI.
-   * This process does not require loadingUnitId or moduleName, however, the two parameters are
+   * This process does not require loadingUnitId or componentName, however, the two parameters are
    * still present for custom implementations that store assets outside of Android's native system.
    *
    * <p>Assets shoud be loaded before the Dart deferred library is loaded, as successful loading of
@@ -174,9 +174,9 @@ public interface DeferredComponentManager {
    * installDeferredComponent should invoke this after successful download.
    *
    * @param loadingUnitId The unique identifier associated with a Dart deferred library.
-   * @param moduleName The deferred component module name as defined in bundle_config.yaml.
+   * @param componentName The deferred component component name as defined in bundle_config.yaml.
    */
-  public abstract void loadAssets(int loadingUnitId, String moduleName);
+  public abstract void loadAssets(int loadingUnitId, String componentName);
 
   /**
    * Load the .so shared library file into the Dart VM.
@@ -199,11 +199,11 @@ public interface DeferredComponentManager {
    *     primarily used in loadDartLibrary to indicate to Dart which Dart library is being loaded.
    *     Loading unit ids range from 0 to the number existing loading units. Negative loading unit
    *     ids are considered invalid and this method will result in a no-op.
-   * @param moduleName The deferred component module name as defined in bundle_config.yaml. If using
+   * @param componentName The deferred component component name as defined in bundle_config.yaml. If using
    *     Play Store deferred component delivery, this name corresponds to the root name on the
    *     installed APKs in which to search for the desired shared library .so file.
    */
-  public abstract void loadDartLibrary(int loadingUnitId, String moduleName);
+  public abstract void loadDartLibrary(int loadingUnitId, String componentName);
 
   /**
    * Request that the specified feature module be uninstalled.
@@ -218,16 +218,16 @@ public interface DeferredComponentManager {
    *
    * <p>Both parameters are not always necessary to identify which module to uninstall. Asset-only
    * modules do not have an associated loadingUnitId. Instead, an invalid ID like -1 may be passed
-   * to download only with moduleName. On the other hand, it can be possible to resolve the
-   * moduleName based on the loadingUnitId. This resolution is done if moduleName is null. At least
-   * one of loadingUnitId or moduleName must be valid or non-null.
+   * to download only with componentName. On the other hand, it can be possible to resolve the
+   * componentName based on the loadingUnitId. This resolution is done if componentName is null. At least
+   * one of loadingUnitId or componentName must be valid or non-null.
    *
    * @return false if no deferred component was found matching the input, true if an uninstall was
    *     successfully requested.
    * @param loadingUnitId The unique identifier associated with a Dart deferred library.
-   * @param moduleName The deferred component module name as defined in bundle_config.yaml.
+   * @param componentName The deferred component component name as defined in bundle_config.yaml.
    */
-  public abstract boolean uninstallDeferredComponent(int loadingUnitId, String moduleName);
+  public abstract boolean uninstallDeferredComponent(int loadingUnitId, String componentName);
 
   /**
    * Cleans up and releases resources. This object is no longer usable after calling this method.

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/DeferredComponentChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/DeferredComponentChannel.java
@@ -33,7 +33,7 @@ public class DeferredComponentChannel {
   // Track the Result objects to be able to handle multiple install requests of
   // the same module at a time. When installation enters a terminal state, either
   // completeInstallSuccess or completeInstallError can be called.
-  @NonNull private Map<String, List<MethodChannel.Result>> moduleNameToResults;
+  @NonNull private Map<String, List<MethodChannel.Result>> componentNameToResults;
 
   @NonNull @VisibleForTesting
   final MethodChannel.MethodCallHandler parsingMethodHandler =
@@ -48,22 +48,22 @@ public class DeferredComponentChannel {
           Map<String, Object> args = call.arguments();
           Log.v(TAG, "Received '" + method + "' message.");
           final int loadingUnitId = (int) args.get("loadingUnitId");
-          final String moduleName = (String) args.get("moduleName");
+          final String componentName = (String) args.get("componentName");
           switch (method) {
             case "installDeferredComponent":
-              deferredComponentManager.installDeferredComponent(loadingUnitId, moduleName);
-              if (!moduleNameToResults.containsKey(moduleName)) {
-                moduleNameToResults.put(moduleName, new ArrayList<>());
+              deferredComponentManager.installDeferredComponent(loadingUnitId, componentName);
+              if (!componentNameToResults.containsKey(componentName)) {
+                componentNameToResults.put(componentName, new ArrayList<>());
               }
-              moduleNameToResults.get(moduleName).add(result);
+              componentNameToResults.get(componentName).add(result);
               break;
             case "getDeferredComponentInstallState":
               result.success(
                   deferredComponentManager.getDeferredComponentInstallState(
-                      loadingUnitId, moduleName));
+                      loadingUnitId, componentName));
               break;
             case "uninstallDeferredComponent":
-              deferredComponentManager.uninstallDeferredComponent(loadingUnitId, moduleName);
+              deferredComponentManager.uninstallDeferredComponent(loadingUnitId, componentName);
               result.success(null);
               break;
             default:
@@ -86,7 +86,7 @@ public class DeferredComponentChannel {
         new MethodChannel(dartExecutor, "flutter/deferredcomponent", StandardMethodCodec.INSTANCE);
     channel.setMethodCallHandler(parsingMethodHandler);
     deferredComponentManager = FlutterInjector.instance().deferredComponentManager();
-    moduleNameToResults = new HashMap<>();
+    componentNameToResults = new HashMap<>();
   }
 
   /**
@@ -101,36 +101,36 @@ public class DeferredComponentChannel {
   }
 
   /**
-   * Finishes the `installDeferredComponent` method channel call for the specified moduleName with a
+   * Finishes the `installDeferredComponent` method channel call for the specified componentName with a
    * success.
    *
-   * @param moduleName The name of the android deferred component module install request to
+   * @param componentName The name of the android deferred component module install request to
    *     complete.
    */
-  public void completeInstallSuccess(String moduleName) {
-    if (moduleNameToResults.containsKey(moduleName)) {
-      for (MethodChannel.Result result : moduleNameToResults.get(moduleName)) {
+  public void completeInstallSuccess(String componentName) {
+    if (componentNameToResults.containsKey(componentName)) {
+      for (MethodChannel.Result result : componentNameToResults.get(componentName)) {
         result.success(null);
       }
-      moduleNameToResults.get(moduleName).clear();
+      componentNameToResults.get(componentName).clear();
     }
     return;
   }
 
   /**
-   * Finishes the `installDeferredComponent` method channel call for the specified moduleName with
+   * Finishes the `installDeferredComponent` method channel call for the specified componentName with
    * an error/failure.
    *
-   * @param moduleName The name of the android deferred component module install request to
+   * @param componentName The name of the android deferred component module install request to
    *     complete.
    * @param errorMessage The error message to display to complete the future with.
    */
-  public void completeInstallError(String moduleName, String errorMessage) {
-    if (moduleNameToResults.containsKey(moduleName)) {
-      for (MethodChannel.Result result : moduleNameToResults.get(moduleName)) {
+  public void completeInstallError(String componentName, String errorMessage) {
+    if (componentNameToResults.containsKey(componentName)) {
+      for (MethodChannel.Result result : componentNameToResults.get(componentName)) {
         result.error("DeferredComponent Install failure", errorMessage, null);
       }
-      moduleNameToResults.get(moduleName).clear();
+      componentNameToResults.get(componentName).clear();
     }
     return;
   }

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -74,10 +74,10 @@ public class PlayStoreDeferredComponentManagerTest {
     }
 
     @Override
-    public void installDeferredComponent(int loadingUnitId, String moduleName) {
+    public void installDeferredComponent(int loadingUnitId, String componentName) {
       // Override this to skip the online SplitInstallManager portion.
-      loadAssets(loadingUnitId, moduleName);
-      loadDartLibrary(loadingUnitId, moduleName);
+      loadAssets(loadingUnitId, componentName);
+      loadDartLibrary(loadingUnitId, componentName);
     }
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/DeferredComponentChannelTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/systemchannels/DeferredComponentChannelTest.java
@@ -18,7 +18,7 @@ import org.robolectric.annotation.Config;
 
 class TestDeferredComponentManager implements DeferredComponentManager {
   DeferredComponentChannel channel;
-  String moduleName;
+  String componentName;
 
   public void setJNI(FlutterJNI flutterJNI) {}
 
@@ -26,23 +26,23 @@ class TestDeferredComponentManager implements DeferredComponentManager {
     this.channel = channel;
   }
 
-  public void installDeferredComponent(int loadingUnitId, String moduleName) {
-    this.moduleName = moduleName;
+  public void installDeferredComponent(int loadingUnitId, String componentName) {
+    this.componentName = componentName;
   }
 
   public void completeInstall() {
-    channel.completeInstallSuccess(moduleName);
+    channel.completeInstallSuccess(componentName);
   }
 
-  public String getDeferredComponentInstallState(int loadingUnitId, String moduleName) {
+  public String getDeferredComponentInstallState(int loadingUnitId, String componentName) {
     return "installed";
   }
 
-  public void loadAssets(int loadingUnitId, String moduleName) {}
+  public void loadAssets(int loadingUnitId, String componentName) {}
 
-  public void loadDartLibrary(int loadingUnitId, String moduleName) {}
+  public void loadDartLibrary(int loadingUnitId, String componentName) {}
 
-  public boolean uninstallDeferredComponent(int loadingUnitId, String moduleName) {
+  public boolean uninstallDeferredComponent(int loadingUnitId, String componentName) {
     return true;
   }
 
@@ -65,7 +65,7 @@ public class DeferredComponentChannelTest {
 
     Map<String, Object> args = new HashMap<>();
     args.put("loadingUnitId", -1);
-    args.put("moduleName", "hello");
+    args.put("componentName", "hello");
     MethodCall methodCall = new MethodCall("installDeferredComponent", args);
     MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
     fakeDeferredComponentChannel.parsingMethodHandler.onMethodCall(methodCall, mockResult);
@@ -87,7 +87,7 @@ public class DeferredComponentChannelTest {
 
     Map<String, Object> args = new HashMap<>();
     args.put("loadingUnitId", -1);
-    args.put("moduleName", "hello");
+    args.put("componentName", "hello");
     MethodCall methodCall = new MethodCall("installDeferredComponent", args);
     MethodChannel.Result mockResult1 = mock(MethodChannel.Result.class);
     MethodChannel.Result mockResult2 = mock(MethodChannel.Result.class);
@@ -112,7 +112,7 @@ public class DeferredComponentChannelTest {
 
     Map<String, Object> args = new HashMap<>();
     args.put("loadingUnitId", -1);
-    args.put("moduleName", "hello");
+    args.put("componentName", "hello");
     MethodCall methodCall = new MethodCall("getDeferredComponentInstallState", args);
     MethodChannel.Result mockResult = mock(MethodChannel.Result.class);
     fakeDeferredComponentChannel.parsingMethodHandler.onMethodCall(methodCall, mockResult);


### PR DESCRIPTION
Renames all instances of `moduleName` to `componentName` to avoid referencing android modules, which is play store implementation specific. Instead, we refer to it by `componentName` which is a flutter concept and is equivalent to the android module name in the default implementation.