### PR TITLE
Detach the newly created EGL context from the main thread in the embedder unit tests

### DIFF
--- a/shell/platform/embedder/tests/embedder_test_context_gl.cc
+++ b/shell/platform/embedder/tests/embedder_test_context_gl.cc
@@ -115,6 +115,7 @@ void EmbedderTestContextGL::SetupCompositor() {
       << "Set up the GL surface before setting up a compositor.";
   compositor_ = std::make_unique<EmbedderTestCompositorGL>(
       gl_surface_->GetSurfaceSize(), gl_surface_->GetGrContext());
+  GLClearCurrent();
 }
 
 }  // namespace testing


### PR DESCRIPTION
The EGL context will be used by other threads during test execution, and it
should not be active on multiple threads at the same time.  This was not
noticed previously because SwiftShader was not checking for this, but other
EGL implementations may enforce this constraint.
