### PR TITLE
fix selectable text selections are not announced in voice over

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -129,7 +129,7 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
   NSAccessibilityElement* native_accessibility =
       root_platform_node_delegate->GetNativeViewAccessible();
   NSRange selection = native_accessibility.accessibilitySelectedTextRange;
-  EXPECT_EQ(selection.location, 0u);
+  EXPECT_TRUE(selection.location == NSNotFound);
   EXPECT_EQ(selection.length, 0u);
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -59,6 +59,80 @@ TEST(FlutterPlatformNodeDelegateMac, Basics) {
   [engine shutDownEngine];
 }
 
+TEST(FlutterPlatformNodeDelegateMac, SelectableTextHasCorrectSemantics) {
+  FlutterEngine* engine = CreateTestEngine();
+  engine.semanticsEnabled = YES;
+  auto bridge = engine.accessibilityBridge.lock();
+  // Initialize ax node data.
+  FlutterSemanticsNode root;
+  root.id = 0;
+  root.flags =
+      static_cast<FlutterSemanticsFlag>(FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
+                                        FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly);
+  root.actions = static_cast<FlutterSemanticsAction>(0);
+  root.text_selection_base = 1;
+  root.text_selection_extent = 3;
+  root.label = "";
+  root.hint = "";
+  // Selectable text store its text in value
+  root.value = "selectable text";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.child_count = 0;
+  root.custom_accessibility_actions_count = 0;
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+
+  bridge->CommitUpdates();
+
+  auto root_platform_node_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  // Verify the accessibility attribute matches.
+  NSAccessibilityElement* native_accessibility =
+      root_platform_node_delegate->GetNativeViewAccessible();
+  std::string value = [native_accessibility.accessibilityValue UTF8String];
+  EXPECT_EQ(value, "selectable text");
+  EXPECT_EQ(native_accessibility.accessibilityRole, NSAccessibilityStaticTextRole);
+  EXPECT_EQ([native_accessibility.accessibilityChildren count], 0u);
+  NSRange selection = native_accessibility.accessibilitySelectedTextRange;
+  EXPECT_EQ(selection.location, 1u);
+  EXPECT_EQ(selection.length, 2u);
+  std::string selected_text = [native_accessibility.accessibilitySelectedText UTF8String];
+  EXPECT_EQ(selected_text, "el");
+}
+
+TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRange) {
+  FlutterEngine* engine = CreateTestEngine();
+  engine.semanticsEnabled = YES;
+  auto bridge = engine.accessibilityBridge.lock();
+  // Initialize ax node data.
+  FlutterSemanticsNode root;
+  root.id = 0;
+  root.flags =
+      static_cast<FlutterSemanticsFlag>(FlutterSemanticsFlag::kFlutterSemanticsFlagIsTextField |
+                                        FlutterSemanticsFlag::kFlutterSemanticsFlagIsReadOnly);
+  root.actions = static_cast<FlutterSemanticsAction>(0);
+  root.text_selection_base = -1;
+  root.text_selection_extent = -1;
+  root.label = "";
+  root.hint = "";
+  // Selectable text store its text in value
+  root.value = "selectable text";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.child_count = 0;
+  root.custom_accessibility_actions_count = 0;
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+
+  bridge->CommitUpdates();
+
+  auto root_platform_node_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+  // Verify the accessibility attribute matches.
+  NSAccessibilityElement* native_accessibility =
+      root_platform_node_delegate->GetNativeViewAccessible();
+  NSRange selection = native_accessibility.accessibilitySelectedTextRange;
+  EXPECT_EQ(selection.location, 0u);
+  EXPECT_EQ(selection.length, 0u);
+}
+
 TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   FlutterEngine* engine = CreateTestEngine();
   engine.semanticsEnabled = YES;

--- a/third_party/accessibility/ax/platform/ax_platform_node_mac.mm
+++ b/third_party/accessibility/ax/platform/ax_platform_node_mac.mm
@@ -710,10 +710,11 @@ bool AlsoUseShowMenuActionForDefaultAction(const ui::AXNodeData& data) {
     start = _node->GetIntAttribute(ax::mojom::IntAttribute::kTextSelStart);
     end = _node->GetIntAttribute(ax::mojom::IntAttribute::kTextSelEnd);
   }
+  NSAssert((start >= 0 && end >= 0) || (start == -1 && end == -1), @"selection is invalid");
+
   if (start == -1 && end == -1) {
-    return [NSValue valueWithRange:{0, 0}];
+    return [NSValue valueWithRange:{NSNotFound, 0}];
   }
-  NSAssert(start >= 0 && end >= 0, @"selection is invalid");
 
   // NSRange cannot represent the direction the text was selected in.
   return [NSValue valueWithRange:{static_cast<NSUInteger>(std::min(start, end)),

--- a/third_party/accessibility/ax/platform/ax_platform_node_mac.mm
+++ b/third_party/accessibility/ax/platform/ax_platform_node_mac.mm
@@ -602,8 +602,9 @@ bool AlsoUseShowMenuActionForDefaultAction(const ui::AXNodeData& data) {
 
   if (ui::IsNameExposedInAXValueForRole(role)) {
     if (role == ax::mojom::Role::kStaticText) {
-      // static text may store its text in the value attribute. for
-      // example, the selectable text does this.
+      // Static texts may store their texts in the value attributes. For
+      // example, the selectable text stores its text in value instead of
+      // name.
       NSString* value = [self getName];
       if (value.length == 0) {
         value = [self getStringAttribute:ax::mojom::StringAttribute::kValue];


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/77833

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
