### PR TITLE
[web] Add few awaits in history tests

### DIFF
--- a/lib/web_ui/test/engine/history_test.dart
+++ b/lib/web_ui/test/engine/history_test.dart
@@ -8,7 +8,6 @@
 
 import 'dart:async';
 import 'dart:html' as html;
-import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
@@ -31,8 +30,6 @@ const Map<String, bool> originState = <String, bool>{'origin': true};
 const Map<String, bool> flutterState = <String, bool>{'flutter': true};
 
 const MethodCodec codec = JSONMethodCodec();
-
-void emptyCallback(ByteData date) {}
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -6,7 +6,6 @@
 import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js_util' as js_util;
-import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -18,8 +18,6 @@ import 'matchers.dart';
 
 const MethodCodec codec = JSONMethodCodec();
 
-void emptyCallback(ByteData data) {}
-
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
@@ -57,13 +55,15 @@ void testMain() {
     // Reading it multiple times should return the same value.
     expect(window.defaultRouteName, '/initial');
     expect(window.defaultRouteName, '/initial');
+
+    Completer<void> callback = Completer<void>();
     window.sendPlatformMessage(
       'flutter/navigation',
       JSONMethodCodec().encodeMethodCall(MethodCall(
         'routeUpdated',
         <String, dynamic>{'routeName': '/bar'},
       )),
-      emptyCallback,
+      (_) { callback.complete(); },
     );
     // After a navigation platform message, [window.defaultRouteName] should
     // reset to "/".
@@ -192,7 +192,7 @@ void testMain() {
     expect(window.browserHistory.currentPath, '/');
 
     // Perform some navigation operations.
-    routeInformationUpdated('/foo/bar', null);
+    await routeInformationUpdated('/foo/bar', null);
     // Path should not be updated because URL strategy is disabled.
     expect(window.browserHistory.currentPath, '/');
   });


### PR DESCRIPTION
History-related tests have been failing in LUCI but not when run locally. This could be a race condition somewhere. Example failures:

1. https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Web%20Engine/4218/overview
2. https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Web%20Engine/4219/overview

In an attempt to address the race condition, this PR adds a few missing `await`s in a few places that are doing asynchronous work.