### PR TITLE
[web] Silence flaky history test

### DIFF
--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -182,7 +182,21 @@ void testMain() {
 
   test('can disable location strategy', () async {
     // Disable URL strategy.
-    expect(() => jsSetUrlStrategy(null), returnsNormally);
+    void disableUrlStrategy() {
+      try {
+        jsSetUrlStrategy(null);
+      } on AssertionError catch (e) {
+        if (e.message == 'Cannot set URL strategy more than once.') {
+          print('=' * 20);
+          // Print something easy to search for.
+          print('HISTORY_TEST_FLAKY_ASSERTION_FAILURE');
+          print('=' * 20);
+        } else {
+          rethrow;
+        }
+      }
+    }
+    expect(disableUrlStrategy, returnsNormally);
     // History should be initialized.
     expect(window.browserHistory, isNotNull);
     // But without a URL strategy.


### PR DESCRIPTION
In order to reduce the negative effect of the flaky test, I'm catching the assertion error in the test to avoid failing the test suite. I'm keeping the test running though because I want to find the root cause of the flakiness. In a future PR, I'll add more logging to help identify the problem.

Example flaky failures:
* https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Web%20Engine/4232/overview
* https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Web%20Engine/4228/overview