### PR TITLE
fix printing Failed to determine valid GL format

### DIFF
--- a/shell/platform/linux/fl_backing_store_provider.cc
+++ b/shell/platform/linux/fl_backing_store_provider.cc
@@ -77,27 +77,23 @@ uint32_t fl_backing_store_provider_get_gl_target(FlBackingStoreProvider* self) {
   return GL_TEXTURE_2D;
 }
 
-static int gl_version(uint32_t major, uint32_t minor) {
-  return (major << 16) | minor;
-}
-
 uint32_t fl_backing_store_provider_get_gl_format(FlBackingStoreProvider* self) {
   // Flutter defines SK_R32_SHIFT=16, so SK_PMCOLOR_BYTE_ORDER should be BGRA.
   // In Linux kN32_SkColorType is assumed to be kBGRA_8888_SkColorType.
   // So we must choose a valid gl format to be compatible with surface format
   // BGRA8.
-  // Following logics are copied from Skia GrGLCaps.cpp
+  // Following logics are copied from Skia GrGLCaps.cpp.
 
   if (epoxy_is_desktop_gl()) {
-    if (epoxy_gl_version() >= gl_version(1, 2) ||
-        epoxy_has_gl_extension("GL_EXT_bgra")) {
+    // For OpenGL.
+    if (epoxy_gl_version() >= 12 || epoxy_has_gl_extension("GL_EXT_bgra")) {
       return GL_RGBA8;
     }
   } else {
     // For OpenGL ES.
     if (epoxy_has_gl_extension("GL_EXT_texture_format_BGRA8888") ||
         (epoxy_has_gl_extension("GL_APPLE_texture_format_BGRA8888") &&
-         epoxy_gl_version() >= gl_version(3, 0))) {
+         epoxy_gl_version() >= 30)) {
       return GL_BGRA8_EXT;
     }
   }


### PR DESCRIPTION
This PR fixes incorrect treatment to return value of epoxy_gl_version()

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
