### PR TITLE
Fixes UI freezes when multiple Flutter VC shared one engine

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -645,6 +645,8 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 
 - (void)viewWillAppear:(BOOL)animated {
   TRACE_EVENT0("flutter", "viewWillAppear");
+    
+  [_engine.get() viewController] = self;
 
   // Send platform settings to Flutter, e.g., platform brightness.
   [self onUserSettingsChanged:nil];
@@ -673,6 +675,8 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 - (void)viewWillDisappear:(BOOL)animated {
   TRACE_EVENT0("flutter", "viewWillDisappear");
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
+    
+  [_engine.get() viewController] = nil;
 
   [super viewWillDisappear:animated];
 }


### PR DESCRIPTION
## Use case

1. using engine to create a FlutterViewController named `MainViewController`
2. using `MainViewController` to start a NativeVC named  `NativeViewController`
3. using `NativeViewController` to start a FlutterViewController called `SecondViewController` share the same engine with `MainViewController`
4. pop `SecondViewController`, pop `NativeViewController`, then the ui freeze, even crash.

## Analysis

By extension the `FlutterViewController` with `MyFlutterViewController`, I found that in `FlutterViewController`'s function `viewWillAppear()` the `engine.viewController` is not equal `self`, the the follow code `if (_viewportMetrics.physical_width)` won't execute, so the ui freeze.

## Solution

In the Demo, I use `engine.viewController = self`, but I think it's should appear in `FlutterViewController`'s `viewWillAppear()`

so I modify the `FlutterViewController`'s `viewWillAppear` and `viewWillDisappear` to fix the issue

## Demo

[Demo](https://github.com/o0starshine0o/FlutterDemo)

uncomment `viewWillAppear` and `viewWillDisappear` in `MainViewController` and `SecondViewController` you will see.

## Issue

[issue](https://github.com/flutter/flutter/issues/78015)

## Environment

by `flutter doctor -v`
```bash
[✓] Flutter (Channel master, 2.1.0-11.0.pre.229, on Mac OS X 10.15.7 19H15 darwin-x64, locale en-GB)
    • Flutter version 2.1.0-11.0.pre.229 at /Users/admin/flutter
    • Framework revision d20ec4c7d8 (28 minutes ago), 2021-03-11 22:18:51 -0800
    • Engine revision 1b68503bc8
    • Dart version 2.13.0 (build 2.13.0-125.0.dev)
    • Pub download mirror https://pub.flutter-io.cn
    • Flutter download mirror https://storage.flutter-io.cn

[✓] Android toolchain - develop for Android devices (Android SDK version 30.0.0)
    • Android SDK at /Users/admin/Library/Android/sdk
    • Platform android-30, build-tools 30.0.0
    • ANDROID_HOME = /Users/admin/Library/Android/sdk
    • Java binary at: /Applications/Android Studio.app/Contents/jre/jdk/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build 1.8.0_242-release-1644-b3-6915495)
    • All Android licenses accepted.

[✓] Xcode - develop for iOS and macOS
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Xcode 12.4, Build version 12D4e
    • CocoaPods version 1.10.1

[✓] Chrome - develop for the web
    • Chrome at /Applications/Google Chrome.app/Contents/MacOS/Google Chrome

[✓] Android Studio (version 4.1)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 1.8.0_242-release-1644-b3-6915495)

[✓] Connected device (3 available)
    • Le X620 (mobile)       • LE67A06270363201                         • android-arm64  • Android 6.0 (API 23)
    • AbelHu iPhone (mobile) • 5ef35097bf6353b37514d2d357e7b6336552785f • ios            • iOS 14.4
    • Chrome (web)           • chrome                                   • web-javascript • Google Chrome 89.0.4389.82
    
• No issues found!
```## Use case

1. using engine to create a FlutterViewController named `MainViewController`
2. using `MainViewController` to start a NativeVC named  `NativeViewController`
3. using `NativeViewController` to start a FlutterViewController called `SecondViewController` share the same engine with `MainViewController`
4. pop `SecondViewController`, pop `NativeViewController`, then the ui freeze, even crash.

## Analysis

By extension the `FlutterViewController` with `MyFlutterViewController`, I found that in `FlutterViewController`'s function `viewWillAppear()` the `engine.viewController` is not equal `self`, the the follow code `if (_viewportMetrics.physical_width)` won't execute, so the ui freeze.

## Solution

In the Demo, I use `engine.viewController = self`, but I think it's should appear in `FlutterViewController`'s `viewWillAppear()`

so I modify the `FlutterViewController`'s `viewWillAppear` and `viewWillDisappear` to fix the issue

## Demo

[Demo](https://github.com/o0starshine0o/FlutterDemo)

uncomment `viewWillAppear` and `viewWillDisappear` in `MainViewController` and `SecondViewController` you will see.

## Issue

[issue](https://github.com/flutter/flutter/issues/78015)

## Environment

by `flutter doctor -v`
```bash
[✓] Flutter (Channel master, 2.1.0-11.0.pre.229, on Mac OS X 10.15.7 19H15 darwin-x64, locale en-GB)
    • Flutter version 2.1.0-11.0.pre.229 at /Users/admin/flutter
    • Framework revision d20ec4c7d8 (28 minutes ago), 2021-03-11 22:18:51 -0800
    • Engine revision 1b68503bc8
    • Dart version 2.13.0 (build 2.13.0-125.0.dev)
    • Pub download mirror https://pub.flutter-io.cn
    • Flutter download mirror https://storage.flutter-io.cn

[✓] Android toolchain - develop for Android devices (Android SDK version 30.0.0)
    • Android SDK at /Users/admin/Library/Android/sdk
    • Platform android-30, build-tools 30.0.0
    • ANDROID_HOME = /Users/admin/Library/Android/sdk
    • Java binary at: /Applications/Android Studio.app/Contents/jre/jdk/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build 1.8.0_242-release-1644-b3-6915495)
    • All Android licenses accepted.

[✓] Xcode - develop for iOS and macOS
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Xcode 12.4, Build version 12D4e
    • CocoaPods version 1.10.1

[✓] Chrome - develop for the web
    • Chrome at /Applications/Google Chrome.app/Contents/MacOS/Google Chrome

[✓] Android Studio (version 4.1)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 1.8.0_242-release-1644-b3-6915495)

[✓] Connected device (3 available)
    • Le X620 (mobile)       • LE67A06270363201                         • android-arm64  • Android 6.0 (API 23)
    • AbelHu iPhone (mobile) • 5ef35097bf6353b37514d2d357e7b6336552785f • ios            • iOS 14.4
    • Chrome (web)           • chrome                                   • web-javascript • Google Chrome 89.0.4389.82
    
• No issues found!
```