### PR TITLE
Restore original value of the Dart advisory script URI

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -118,7 +118,7 @@ struct Settings {
 
   // Used as the script URI in debug messages. Does not affect how the Dart code
   // is executed.
-  std::string advisory_script_uri = "file:///main.dart";
+  std::string advisory_script_uri = "main.dart";
   // Used as the script entrypoint in debug messages. Does not affect how the
   // Dart code is executed.
   std::string advisory_script_entrypoint = "main";


### PR DESCRIPTION
Some flutter_tester scripts rely on the old value because Dart will convert
"main.dart" into a Platform.script URI containing a fully qualified path to
the script.
