### PR TITLE
Fuchsia: Filed crash reports marked as non-fatal

### DIFF
--- a/shell/platform/fuchsia/runtime/dart/utils/handle_exception.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/handle_exception.cc
@@ -82,6 +82,7 @@ fuchsia::feedback::CrashReport BuildCrashReport(
   fuchsia::feedback::CrashReport report;
   report.set_program_name(component_url);
   report.set_specific_report(std::move(specific_report));
+  report.set_is_fatal(false);
   return report;
 }
 


### PR DESCRIPTION
Flutter crash reports on Fuchsia are considered non-fatal because they're not filed in response to the termination of the Flutter application, just a Dart exception that was thrown.
