### PR TITLE
revert auto-enabling semantics

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -1472,10 +1472,7 @@ class EngineSemanticsOwner {
   /// Updates the semantics tree from data in the [uiUpdate].
   void updateSemantics(ui.SemanticsUpdate uiUpdate) {
     if (!_semanticsEnabled) {
-      // If we're receiving a semantics update from the framework, it means the
-      // developer enabled it programmatically, so we enable it in the engine
-      // too.
-      semanticsEnabled = true;
+      return;
     }
 
     final SemanticsUpdate update = uiUpdate as SemanticsUpdate;


### PR DESCRIPTION
Revert auto-enabling semantics. This broke framework tests.
