### PR TITLE
[deferred components] Handle base module loading units

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -248,12 +248,14 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
 
   // Obtain and parses the metadata string. An example encoded string is:
   //
-  //    "2:component2,3:component3,4:component1:libcomponent4.so"
+  //    "2:component2,3:component3,4:component1:libcomponent4.so,5:"
   //
   // Where loading unit 2 is included in component2, loading unit 3 is
   // included in component3, and loading unit 4 is included in component1.
   // An optional third parameter can be added to indicate the name of
-  // the shared library of the loading unit.
+  // the shared library of the loading unit. Loading unit 5 maps to an empty
+  // string, indicating it is included in the base module and no dynamic
+  // feature modules need to be downloaded.
   private void initLoadingUnitMappingToComponentNames() {
     String mappingKey = DeferredComponentManager.class.getName() + ".loadingUnitMapping";
     ApplicationInfo applicationInfo = getApplicationInfo();
@@ -269,7 +271,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
                   + "' is defined in the base module's AndroidManifest.");
         } else {
           for (String entry : rawMappingString.split(",")) {
-            String[] splitEntry = entry.split(":");
+            String[] splitEntry = entry.split(":", -1);
             int loadingUnitId = Integer.parseInt(splitEntry[0]);
             loadingUnitIdToComponentNames.put(loadingUnitId, splitEntry[1]);
             if (splitEntry.length > 2) {
@@ -287,6 +289,13 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
     if (resolvedComponentName == null) {
       Log.e(
           TAG, "Deferred component name was null and could not be resolved from loading unit id.");
+      return;
+    }
+
+    // Handle a loading unit that is included in the base module that does not need download.
+    if (resolvedComponentName.equals("") && loadingUnitId > 0) {
+      // No need to load assets as base assets are already loaded.
+      loadDartLibrary(loadingUnitId, resolvedComponentName);
       return;
     }
 

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -271,6 +271,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
                   + "' is defined in the base module's AndroidManifest.");
         } else {
           for (String entry : rawMappingString.split(",")) {
+            // Split with -1 param to include empty string following trailing ":"
             String[] splitEntry = entry.split(":", -1);
             int loadingUnitId = Integer.parseInt(splitEntry[0]);
             loadingUnitIdToComponentNames.put(loadingUnitId, splitEntry[1]);

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -199,8 +199,8 @@ public class PlayStoreDeferredComponentManagerTest {
     String soTestFilename = "libapp.so-3.part.so";
     String soTestPath = "test/path/" + soTestFilename;
     doReturn(new File(soTestPath)).when(spyContext).getFilesDir();
-    TestPlayStoreDeferredComponentManager playStoreManager =
-        new TestPlayStoreDeferredComponentManager(spyContext, jni);
+    PlayStoreDeferredComponentManager playStoreManager =
+        new PlayStoreDeferredComponentManager(spyContext, jni);
     jni.setDeferredComponentManager(playStoreManager);
     assertEquals(jni.loadingUnitId, 0);
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -185,12 +185,12 @@ public class PlayStoreDeferredComponentManagerTest {
   }
 
   @Test
-  public void manifestMappingHandlesBaseModuleEmptyString()
-      throws NameNotFoundException {
+  public void manifestMappingHandlesBaseModuleEmptyString() throws NameNotFoundException {
     TestFlutterJNI jni = new TestFlutterJNI();
 
     Bundle bundle = new Bundle();
-    bundle.putString(PlayStoreDeferredComponentManager.MAPPING_KEY, "123:module:custom_name.so,3:,4:");
+    bundle.putString(
+        PlayStoreDeferredComponentManager.MAPPING_KEY, "123:module:custom_name.so,3:,4:");
     bundle.putString(ApplicationInfoLoader.PUBLIC_FLUTTER_ASSETS_DIR_KEY, "custom_assets");
 
     Context spyContext = createSpyContext(bundle);

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -185,6 +185,37 @@ public class PlayStoreDeferredComponentManagerTest {
   }
 
   @Test
+  public void manifestMappingHandlesBaseModuleEmptyString()
+      throws NameNotFoundException {
+    TestFlutterJNI jni = new TestFlutterJNI();
+
+    Bundle bundle = new Bundle();
+    bundle.putString(PlayStoreDeferredComponentManager.MAPPING_KEY, "123:module:custom_name.so,3:,4:");
+    bundle.putString(ApplicationInfoLoader.PUBLIC_FLUTTER_ASSETS_DIR_KEY, "custom_assets");
+
+    Context spyContext = createSpyContext(bundle);
+    doReturn(null).when(spyContext).getAssets();
+
+    String soTestFilename = "libapp.so-3.part.so";
+    String soTestPath = "test/path/" + soTestFilename;
+    doReturn(new File(soTestPath)).when(spyContext).getFilesDir();
+    TestPlayStoreDeferredComponentManager playStoreManager =
+        new TestPlayStoreDeferredComponentManager(spyContext, jni);
+    jni.setDeferredComponentManager(playStoreManager);
+    assertEquals(jni.loadingUnitId, 0);
+
+    playStoreManager.installDeferredComponent(3, null);
+    assertEquals(jni.loadDartDeferredLibraryCalled, 1);
+    assertEquals(jni.updateAssetManagerCalled, 0); // no assets to load for base
+    assertEquals(jni.deferredComponentInstallFailureCalled, 0);
+
+    assertEquals(jni.searchPaths[0], soTestFilename);
+    assertTrue(jni.searchPaths[1].endsWith(soTestPath));
+    assertEquals(jni.searchPaths.length, 2);
+    assertEquals(jni.loadingUnitId, 3);
+  }
+
+  @Test
   public void searchPathsAddsApks() throws NameNotFoundException {
     TestFlutterJNI jni = new TestFlutterJNI();
     Context spyContext = createSpyContext(null);


### PR DESCRIPTION
This implements handling for unassigned loading units that are default placed in the base module.

This adds an additional variant in the mapping format where mapping a loading unit id to emptystring indicates that the loading unit is part of base and can be directly loaded.

The encoding of the mapping is implemented in https://github.com/flutter/flutter/pull/78079