### PR TITLE
Set automatic simulator rotation in scenario test

### DIFF
--- a/testing/scenario_app/README.md
+++ b/testing/scenario_app/README.md
@@ -30,6 +30,13 @@ platform channel.
 For PlatformView tests on iOS, you'll also have to edit the dictionaries in
 [AppDelegate.m](https://github.com/flutter/engine/blob/5d9509ae056b04c30295df27f201f31af9777842/testing/scenario_app/ios/Scenarios/Scenarios/AppDelegate.m#L29) and [PlatformViewGoldenTestManager.m](https://github.com/flutter/engine/blob/5d9509ae056b04c30295df27f201f31af9777842/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewGoldenTestManager.m#L24) so that the correct golden image can be found.  Also, you'll have to add a [GoldenPlatformViewTests](https://github.com/flutter/engine/blob/5d9509ae056b04c30295df27f201f31af9777842/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.h#L18) in [PlatformViewUITests.m](https://github.com/flutter/engine/blob/af2ffc02b72af2a89242ca3c89e18269b1584ce5/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewUITests.m).
 
+If `PlatformViewRotation` is failing, make sure Simulator app Device > Rotate Device Automatically
+is selected, or run:
+
+```bash
+defaults write com.apple.iphonesimulator RotateWindowWhenSignaledByGuest -int 1
+```
+
 ### Generating Golden Images on iOS
 
 Screenshots are saved as

--- a/testing/scenario_app/run_ios_tests.sh
+++ b/testing/scenario_app/run_ios_tests.sh
@@ -33,6 +33,10 @@ if [[ $# -eq 1 ]]; then
   FLUTTER_ENGINE="$1"
 fi
 
+# Make sure simulators rotate automatically for "PlatformViewRotation" test.
+# Can also be set via Simulator app Device > Rotate Device Automatically
+defaults write com.apple.iphonesimulator RotateWindowWhenSignaledByGuest -int 1
+
 cd ios/Scenarios
 set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme Scenarios \


### PR DESCRIPTION
The `PlatformViewRotation` iOS scenario test only passes if the Simulator app has `Rotate Device Automatically` selected.
<img width="353" alt="Screen Shot 2021-03-12 at 4 18 42 PM" src="https://user-images.githubusercontent.com/682784/111011548-a262be00-834e-11eb-8cb6-d99b758c3ca5.png">

Currently, the infrastructure team is manually selecting this menu item when installing Xcode.  Instead, set the `default` that controls this setting on the host before running the test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.