### PR TITLE
Fix attribute replace bug in TextAXNodeWrapper

### DIFF
--- a/third_party/accessibility/ax/platform/test_ax_node_wrapper.cc
+++ b/third_party/accessibility/ax/platform/test_ax_node_wrapper.cc
@@ -369,9 +369,10 @@ void TestAXNodeWrapper::ReplaceIntAttribute(int32_t node_id,
   std::vector<std::pair<ax::mojom::IntAttribute, int32_t>>& attributes =
       new_data.int_attributes;
 
-  attributes.erase(std::remove_if(
+  auto it = std::remove_if(
       attributes.begin(), attributes.end(),
-      [attribute](auto& pair) { return pair.first == attribute; }));
+      [attribute](auto& pair) { return pair.first == attribute; });
+  attributes.erase(it, attributes.end());
 
   new_data.AddIntAttribute(attribute, value);
   node->SetData(new_data);
@@ -384,9 +385,10 @@ void TestAXNodeWrapper::ReplaceFloatAttribute(
   std::vector<std::pair<ax::mojom::FloatAttribute, float>>& attributes =
       new_data.float_attributes;
 
-  attributes.erase(std::remove_if(
+  auto it = std::remove_if(
       attributes.begin(), attributes.end(),
-      [attribute](auto& pair) { return pair.first == attribute; }));
+      [attribute](auto& pair) { return pair.first == attribute; });
+  attributes.erase(it, attributes.end());
 
   new_data.AddFloatAttribute(attribute, value);
   node_->SetData(new_data);
@@ -398,9 +400,10 @@ void TestAXNodeWrapper::ReplaceBoolAttribute(ax::mojom::BoolAttribute attribute,
   std::vector<std::pair<ax::mojom::BoolAttribute, bool>>& attributes =
       new_data.bool_attributes;
 
-  attributes.erase(std::remove_if(
+  auto it = std::remove_if(
       attributes.begin(), attributes.end(),
-      [attribute](auto& pair) { return pair.first == attribute; }));
+      [attribute](auto& pair) { return pair.first == attribute; });
+  attributes.erase(it, attributes.end());
 
   new_data.AddBoolAttribute(attribute, value);
   node_->SetData(new_data);
@@ -413,9 +416,10 @@ void TestAXNodeWrapper::ReplaceStringAttribute(
   std::vector<std::pair<ax::mojom::StringAttribute, std::string>>& attributes =
       new_data.string_attributes;
 
-  attributes.erase(std::remove_if(
+  auto it = std::remove_if(
       attributes.begin(), attributes.end(),
-      [attribute](auto& pair) { return pair.first == attribute; }));
+      [attribute](auto& pair) { return pair.first == attribute; });
+  attributes.erase(it, attributes.end());
 
   new_data.AddStringAttribute(attribute, value);
   node_->SetData(new_data);


### PR DESCRIPTION
Fixes a bug in the Replace.*Attribute methods of TextAXNodeWrapper
test helper class.

When replacing an int/float/bool attribute on the test node, we want to
erase the range from the iterator returned by remove_if to end(), which
may be an empty range. In the case where remove_if() returns end(), the
single-parameter variant of erase() attempts to remove an element past
the end of the container.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
