### PR TITLE
Call `requestDartDeferredLibrary` on platform thread

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1339,7 +1339,12 @@ void Shell::UpdateAssetResolverByType(
 
 // |Engine::Delegate|
 void Shell::RequestDartDeferredLibrary(intptr_t loading_unit_id) {
-  platform_view_->RequestDartDeferredLibrary(loading_unit_id);
+  task_runners_.GetPlatformTaskRunner()->PostTask(
+      [view = platform_view_->GetWeakPtr(), loading_unit_id] {
+        if (view) {
+          view->RequestDartDeferredLibrary(loading_unit_id);
+        }
+      });
 }
 
 void Shell::ReportTimings() {


### PR DESCRIPTION
Ensures RequestDartDeferredLibrary is called on platform thread, which is required to properly interface with the embedder(s).

Fixes https://github.com/flutter/flutter/issues/78204