### PR TITLE
[fuchsia][shader warmup] Avoid recursively iterating over assets directory when loading skp's due to high cost of openat() on pkgfs

### DIFF
--- a/assets/asset_manager.cc
+++ b/assets/asset_manager.cc
@@ -77,7 +77,8 @@ std::unique_ptr<fml::Mapping> AssetManager::GetAsMapping(
 
 // |AssetResolver|
 std::vector<std::unique_ptr<fml::Mapping>> AssetManager::GetAsMappings(
-    const std::string& asset_pattern) const {
+    const std::string& asset_pattern,
+    const std::optional<std::string>& subdir) const {
   std::vector<std::unique_ptr<fml::Mapping>> mappings;
   if (asset_pattern.size() == 0) {
     return mappings;
@@ -85,7 +86,7 @@ std::vector<std::unique_ptr<fml::Mapping>> AssetManager::GetAsMappings(
   TRACE_EVENT1("flutter", "AssetManager::GetAsMappings", "pattern",
                asset_pattern.c_str());
   for (const auto& resolver : resolvers_) {
-    auto resolver_mappings = resolver->GetAsMappings(asset_pattern);
+    auto resolver_mappings = resolver->GetAsMappings(asset_pattern, subdir);
     mappings.insert(mappings.end(),
                     std::make_move_iterator(resolver_mappings.begin()),
                     std::make_move_iterator(resolver_mappings.end()));

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include <optional>
 #include "flutter/assets/asset_resolver.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted.h"
@@ -70,7 +71,8 @@ class AssetManager final : public AssetResolver {
 
   // |AssetResolver|
   std::vector<std::unique_ptr<fml::Mapping>> GetAsMappings(
-      const std::string& asset_pattern) const override;
+      const std::string& asset_pattern,
+      const std::optional<std::string>& subdir) const override;
 
  private:
   std::deque<std::unique_ptr<AssetResolver>> resolvers_;

--- a/assets/asset_resolver.h
+++ b/assets/asset_resolver.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include <optional>
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
 
@@ -59,10 +60,24 @@ class AssetResolver {
   [[nodiscard]] virtual std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const = 0;
 
-  // Same as GetAsMapping() but returns mappings for all files who's name
-  // matches |pattern|. Returns empty vector if no matching assets are found
+  //--------------------------------------------------------------------------
+  /// @brief      Same as GetAsMapping() but returns mappings for all files
+  ///             who's name matches a given pattern. Returns empty vector
+  ///             if no matching assets are found.
+  ///
+  /// @param[in]  asset_pattern  The pattern to match file names against.
+  ///
+  /// @param[in]  subdir  Optional subdirectory in which to search for files.
+  ///             If supplied this function does a flat search within the
+  ///             subdirectory instead of a recursive search through the entire
+  ///             assets directory.
+  ///
+  /// @return     Returns a vector of mappings of files which match the search
+  ///             parameters.
+  ///
   [[nodiscard]] virtual std::vector<std::unique_ptr<fml::Mapping>>
-  GetAsMappings(const std::string& asset_pattern) const {
+  GetAsMappings(const std::string& asset_pattern,
+                const std::optional<std::string>& subdir) const {
     return {};
   };
 

--- a/assets/directory_asset_bundle.h
+++ b/assets/directory_asset_bundle.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_ASSETS_DIRECTORY_ASSET_BUNDLE_H_
 #define FLUTTER_ASSETS_DIRECTORY_ASSET_BUNDLE_H_
 
+#include <optional>
 #include "flutter/assets/asset_resolver.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted.h"
@@ -39,7 +40,8 @@ class DirectoryAssetBundle : public AssetResolver {
 
   // |AssetResolver|
   std::vector<std::unique_ptr<fml::Mapping>> GetAsMappings(
-      const std::string& asset_pattern) const override;
+      const std::string& asset_pattern,
+      const std::optional<std::string>& subdir) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(DirectoryAssetBundle);
 };

--- a/common/graphics/persistent_cache.cc
+++ b/common/graphics/persistent_cache.cc
@@ -410,7 +410,7 @@ PersistentCache::GetSkpsFromAssetManager() const {
         << "PersistentCache::GetSkpsFromAssetManager: Asset manager not set!";
     return std::vector<std::unique_ptr<fml::Mapping>>();
   }
-  return asset_manager_->GetAsMappings(".*\\.skp$");
+  return asset_manager_->GetAsMappings(".*\\.skp$", "shaders");
 }
 
 }  // namespace flutter

--- a/fml/platform/posix/file_posix.cc
+++ b/fml/platform/posix/file_posix.cc
@@ -16,6 +16,7 @@
 #include "flutter/fml/eintr_wrapper.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/mapping.h"
+#include "flutter/fml/trace_event.h"
 #include "flutter/fml/unique_fd.h"
 
 namespace fml {
@@ -72,6 +73,7 @@ fml::UniqueFD OpenFile(const fml::UniqueFD& base_directory,
                        const char* path,
                        bool create_if_necessary,
                        FilePermission permission) {
+  TRACE_EVENT0("flutter", "fml::OpenFile");
   if (path == nullptr) {
     return {};
   }

--- a/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
@@ -59,8 +59,9 @@ class EngineTest : public ::testing::Test {
     // otherwise we segfault creating the VulkanSurfaceProducer
     auto loop = fml::MessageLoopImpl::Create();
 
-    fuchsia::ui::scenic::SessionPtr session_ptr;
-    scenic::Session session(std::move(session_ptr));
+    context_ = sys::ComponentContext::CreateAndServeOutgoingDirectory();
+    scenic_ = context_->svc()->Connect<fuchsia::ui::scenic::Scenic>();
+    scenic::Session session(scenic_.get());
     surface_producer_ = std::make_unique<VulkanSurfaceProducer>(&session);
 
     Engine::WarmupSkps(&concurrent_task_runner_, &raster_task_runner_,
@@ -71,6 +72,9 @@ class EngineTest : public ::testing::Test {
   MockTaskRunner concurrent_task_runner_;
   MockTaskRunner raster_task_runner_;
   std::unique_ptr<VulkanSurfaceProducer> surface_producer_;
+
+  std::unique_ptr<sys::ComponentContext> context_;
+  fuchsia::ui::scenic::ScenicPtr scenic_;
 };
 
 TEST_F(EngineTest, SkpWarmup) {

--- a/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
@@ -102,8 +102,10 @@ TEST_F(EngineTest, SkpWarmup) {
   fml::ScopedTemporaryDirectory asset_dir;
   fml::UniqueFD asset_dir_fd = fml::OpenDirectory(
       asset_dir.path().c_str(), false, fml::FilePermission::kRead);
+  fml::UniqueFD subdir_fd = fml::OpenDirectory(asset_dir_fd, "shaders", true,
+                                               fml::FilePermission::kReadWrite);
 
-  bool success = fml::WriteAtomically(asset_dir_fd, "test.skp", mapping);
+  bool success = fml::WriteAtomically(subdir_fd, "test.skp", mapping);
   ASSERT_TRUE(success);
 
   auto asset_manager = std::make_shared<AssetManager>();


### PR DESCRIPTION
[fuchsia][shader warmup] Avoid recursively iterating over assets directory when loading skp's due to high cost of openat() on pkgfs

Mitigation for b/181883382

Unit testing of new code paths included

