### PR TITLE
Update docker image to match the LUCI and Framework images 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,6 +2,8 @@ gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def
 
 # LINUX
 task:
+  container:
+    dockerfile: "ci/docker/build/Dockerfile"
   gke_container:
     dockerfile: "ci/docker/build/Dockerfile"
     builder_image_name: docker-builder # gce vm image

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,11 +2,10 @@ gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def
 
 # LINUX
 task:
-  container:
-    dockerfile: "ci/docker/build/Dockerfile"
   gke_container:
     dockerfile: "ci/docker/build/Dockerfile"
     builder_image_name: docker-builder # gce vm image
+    builder_image_project: flutter-cirrus
     cluster_name: build-32-cluster
     zone: us-central1-a
     namespace: default

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+!/dev/ci/**/Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -130,4 +130,3 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
-!/dev/ci/**/Dockerfile

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -35,7 +35,4 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
 RUN apt-get update && apt-get install -y google-cloud-sdk && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true
-
-    gcloud config set core/disable_usage_reporting true && \
-    gcloud config set component_manager/disable_update_check true && \
     apt-get clean

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -8,6 +8,7 @@ ENV PATH $PATH:$DEPOT_TOOLS_PATH
 # Notes:
 # - libx11-dev is used by Flutter for desktop linux (see also install-build-deps-linux-desktop.sh)
 # - chrome is used by Flutter for web.
+
 RUN apt-get update && \
     apt-get install -y git wget curl unzip python lsb-release sudo apt-transport-https && \
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $DEPOT_TOOLS_PATH && \
@@ -18,13 +19,23 @@ RUN apt-get update && \
       dosfstools ifupdown libedit-dev libglib2.0-dev liblz4-tool libncurses5-dev libssl-dev lsof mtools nasm net-tools python2.7-dev \
       python-m2crypto tcpdump texinfo unzip uuid-dev vim xz-utils zlib1g-dev firefox-esr g++-multilib libblkid-dev libc6-dev-i386 \
       libfreetype6-dev libegl1-mesa libgles2-mesa-dev libglu1-mesa-dev libgtk-3-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev \
-      libxxf86vm-dev mesa-common-dev openjdk-8-jdk zip xvfb google-cloud-sdk google-chrome-stable && \
-    #./build/install-build-deps-android.sh --no-prompt && \
-    #(echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list) && \
-    #(curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -) && \
-    #(wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -) && \
-    #echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list && \
-    #apt-get update && apt-get install -y google-cloud-sdk google-chrome-stable && \
+      libxxf86vm-dev mesa-common-dev openjdk-8-jdk zip xvfb
+
+# Add repo for chrome stable
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
+
+# Add repo for gcloud sdk and install it
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+RUN apt-get update && apt-get install -y google-cloud-sdk && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true
+
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     apt-get clean

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -9,29 +9,96 @@ ENV PATH $PATH:$DEPOT_TOOLS_PATH
 # - libx11-dev is used by Flutter for desktop linux (see also install-build-deps-linux-desktop.sh)
 # - chrome is used by Flutter for web.
 
-RUN apt-get update && \
-    apt-get install -y git wget curl unzip python lsb-release sudo apt-transport-https && \
-    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $DEPOT_TOOLS_PATH && \
-    mkdir --parents $ENGINE_PATH && \
-    git clone https://github.com/flutter/buildroot.git $BUILDROOT_PATH && \
-    cd $BUILDROOT_PATH && \
-    apt-get install -y autoconf automake bison flex gettext gperf groff libtool pkg-config acpica-tools build-essential dejagnu \
-      dosfstools ifupdown libedit-dev libglib2.0-dev liblz4-tool libncurses5-dev libssl-dev lsof mtools nasm net-tools python2.7-dev \
-      python-m2crypto tcpdump texinfo uuid-dev vim xz-utils zlib1g-dev firefox-esr g++-multilib libblkid-dev libc6-dev-i386 \
-      libfreetype6-dev libegl1-mesa libgles2-mesa-dev libglu1-mesa-dev libgtk-3-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev \
-      libxxf86vm-dev mesa-common-dev openjdk-8-jdk zip xvfb ca-certificates gnupg
+# Updates the distribution.
+RUN apt-get update 
 
-# Add repo for chrome stable
+# Install generic tools.
+RUN apt-get install -y ca-certificates gnupg wget curl lsb-release sudo apt-transport-https
+
+# Add additional repos.
+#   chrome stable
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
 RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
-
-# Add repo for gcloud sdk and install it
+#   gcloud sdk
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
     tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
     apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+RUN apt-get update
 
+# Install basic tools and libraries
+RUN apt-get install -y \
+    acpica-tools       \
+    autoconf           \
+    automake           \
+    bison              \
+    build-essential    \
+    dejagnu            \
+    dosfstools         \
+    flex               \
+    g++-multilib       \
+    gettext            \
+    git                \
+    gperf              \
+    groff              \
+    ifupdown           \
+    libblkid-dev       \
+    libc6-dev-i386     \
+    libedit-dev        \
+    libfreetype6-dev   \
+    libglib2.0-dev     \
+    liblz4-tool        \
+    libncurses5-dev    \
+    libssl-dev         \
+    libtool            \
+    libxcursor-dev     \
+    libxinerama-dev    \
+    libxrandr-dev      \
+    libxxf86vm-dev     \
+    lsof               \
+    mtools             \
+    nasm               \
+    net-tools          \
+    openjdk-8-jdk      \
+    pkg-config         \
+    python             \
+    python-m2crypto    \
+    python2.7-dev      \
+    tcpdump            \
+    texinfo            \
+    unzip              \
+    uuid-dev           \
+    vim                \
+    xz-utils           \
+    zip                \
+    zlib1g-dev
+
+# Install x/gui deps
+RUN apt-get install -y \
+    libegl1-mesa       \
+    libgles2-mesa-dev  \
+    libglu1-mesa-dev   \
+    libgtk-3-dev       \
+    libx11-dev         \
+    mesa-common-dev    \
+    xvfb
+
+# Install browsers
+RUN apt-get install -y \
+    firefox-esr        \
+    google-chrome-stable
+
+# Install and config gcloud
 RUN apt-get update && apt-get install -y google-cloud-sdk && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true
+
+# Clone depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $DEPOT_TOOLS_PATH
+
+# Clone buildroot
+RUN git clone https://github.com/flutter/buildroot.git $BUILDROOT_PATH
+
+# Make engine path and start change directory to buildroot.
+RUN mkdir --parents $ENGINE_PATH && \
+    cd $BUILDROOT_PATH

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -15,11 +15,11 @@ RUN apt-get update && \
     mkdir --parents $ENGINE_PATH && \
     git clone https://github.com/flutter/buildroot.git $BUILDROOT_PATH && \
     cd $BUILDROOT_PATH && \
-    apt-get install -y autoconf automake bison flex gettext gperf groff libtool pkg-config wget acpica-tools build-essential curl dejagnu \
+    apt-get install -y autoconf automake bison flex gettext gperf groff libtool pkg-config acpica-tools build-essential dejagnu \
       dosfstools ifupdown libedit-dev libglib2.0-dev liblz4-tool libncurses5-dev libssl-dev lsof mtools nasm net-tools python2.7-dev \
-      python-m2crypto tcpdump texinfo unzip uuid-dev vim xz-utils zlib1g-dev firefox-esr g++-multilib libblkid-dev libc6-dev-i386 \
+      python-m2crypto tcpdump texinfo uuid-dev vim xz-utils zlib1g-dev firefox-esr g++-multilib libblkid-dev libc6-dev-i386 \
       libfreetype6-dev libegl1-mesa libgles2-mesa-dev libglu1-mesa-dev libgtk-3-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev \
-      libxxf86vm-dev mesa-common-dev openjdk-8-jdk zip xvfb
+      libxxf86vm-dev mesa-common-dev openjdk-8-jdk zip xvfb ca-certificates gnupg
 
 # Add repo for chrome stable
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -35,4 +35,3 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
 RUN apt-get update && apt-get install -y google-cloud-sdk && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true
-    apt-get clean

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -1,5 +1,4 @@
-FROM ubuntu:16.04
-
+FROM debian:stretch
 
 ENV DEPOT_TOOLS_PATH $HOME/depot_tools
 ENV BUILDROOT_PATH $HOME/buildroot

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:16.04
 
+
 ENV DEPOT_TOOLS_PATH $HOME/depot_tools
 ENV BUILDROOT_PATH $HOME/buildroot
 ENV ENGINE_PATH $HOME/engine

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -14,7 +14,11 @@ RUN apt-get update && \
     mkdir --parents $ENGINE_PATH && \
     git clone https://github.com/flutter/buildroot.git $BUILDROOT_PATH && \
     cd $BUILDROOT_PATH && \
-    ./build/install-build-deps.sh --no-prompt && \
+    apt-get install -y autoconf automake bison flex gettext gperf groff libtool pkg-config wget acpica-tools build-essential curl dejagnu \
+      dosfstools ifupdown libedit-dev libglib2.0-dev liblz4-tool libncurses5-dev libssl-dev lsof mtools nasm net-tools python2.7-dev \
+      python-m2crypto tcpdump texinfo unzip uuid-dev vim xz-utils zlib1g-dev firefox-esr g++-multilib libblkid-dev libc6-dev-i386 \
+      libfreetype6-dev libegl1-mesa libgles2-mesa-dev libglu1-mesa-dev libgtk-3-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev \
+      libxxf86vm-dev mesa-common-dev openjdk-8-jdk zip xvfb && \
     ./build/install-build-deps-android.sh --no-prompt && \
     (echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list) && \
     (curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -) && \

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -18,13 +18,13 @@ RUN apt-get update && \
       dosfstools ifupdown libedit-dev libglib2.0-dev liblz4-tool libncurses5-dev libssl-dev lsof mtools nasm net-tools python2.7-dev \
       python-m2crypto tcpdump texinfo unzip uuid-dev vim xz-utils zlib1g-dev firefox-esr g++-multilib libblkid-dev libc6-dev-i386 \
       libfreetype6-dev libegl1-mesa libgles2-mesa-dev libglu1-mesa-dev libgtk-3-dev libx11-dev libxcursor-dev libxinerama-dev libxrandr-dev \
-      libxxf86vm-dev mesa-common-dev openjdk-8-jdk zip xvfb && \
-    ./build/install-build-deps-android.sh --no-prompt && \
-    (echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list) && \
-    (curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -) && \
-    (wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -) && \
-    echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list && \
-    apt-get update && apt-get install -y google-cloud-sdk google-chrome-stable libx11-dev && \
+      libxxf86vm-dev mesa-common-dev openjdk-8-jdk zip xvfb google-cloud-sdk google-chrome-stable && \
+    #./build/install-build-deps-android.sh --no-prompt && \
+    #(echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list) && \
+    #(curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -) && \
+    #(wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -) && \
+    #echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list && \
+    #apt-get update && apt-get install -y google-cloud-sdk google-chrome-stable && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     apt-get clean


### PR DESCRIPTION
Updates the docker image to use debian:stretch to match LUCI and Framework. This is in preparation to improve Cirrus CI usage at Flutter.

Bug: https://github.com/flutter/flutter/issues/77624


