### PR TITLE
Fix const_finder to visit children of ConstructorInvocation

### DIFF
--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -65,15 +65,14 @@ class _ConstVisitor extends RecursiveVisitor<void> {
   @override
   void visitConstructorInvocation(ConstructorInvocation node) {
     final Class parentClass = node.target.parent as Class;
-    if (!_matches(parentClass)) {
-      super.visitConstructorInvocation(node);
-      return;
+    if (_matches(parentClass)) {
+      nonConstantLocations.add(<String, dynamic>{
+        'file': node.location.file.toString(),
+        'line': node.location.line,
+        'column': node.location.column,
+      });
     }
-    nonConstantLocations.add(<String, dynamic>{
-      'file': node.location.file.toString(),
-      'line': node.location.line,
-      'column': node.location.column,
-    });
+    super.visitConstructorInvocation(node);
   }
 
   @override


### PR DESCRIPTION
When visiting `ConstructorInvocation` nodes, const_finder should go deeper and visit its children nodes even if the node matches. This would guarantee that arguments of constructor invocation are also visited.

Fixes https://github.com/flutter/flutter/issues/78328.

