### PR TITLE
Gracefully handle mouse up before mouse down

### DIFF
--- a/lib/ui/window/pointer_data_packet_converter.cc
+++ b/lib/ui/window/pointer_data_packet_converter.cc
@@ -186,7 +186,16 @@ void PointerDataPacketConverter::ConvertPointerData(
         auto iter = states_.find(pointer_data.device);
         FML_DCHECK(iter != states_.end());
         PointerState state = iter->second;
-        FML_DCHECK(state.is_down);
+        if (!state.is_down) {
+          // Synthesizes a down event if we got an up without a down.
+          PointerData synthesized_down_event = pointer_data;
+          synthesized_down_event.change = PointerData::Change::kDown;
+          synthesized_down_event.synthesized = 1;
+          state.is_down = true;
+          state.buttons = 1;
+          states_[synthesized_down_event.device] = state;
+          converted_pointers.push_back(synthesized_down_event);
+        }
 
         UpdatePointerIdentifier(pointer_data, state, false);
 


### PR DESCRIPTION
See my comment on the issue:
https://github.com/flutter/flutter/issues/46793#issuecomment-659605517

It is possible to get a mouse up event without a previous mouse down
event. That is correct behavior on X11 when you click a window that does
not have focus. The assert here is removed as that is not correct. I
added a synthetic down event in that scenario as that seems inline with
the rest of the code here for handling edge cases like this.

Fixes https://github.com/flutter/flutter/issues/46793