### PR TITLE
Decode empty message to nil in standard codec

### DIFF
--- a/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
@@ -78,7 +78,7 @@
 }
 
 - (id)decode:(NSData*)message {
-  if (message == nil)
+  if ([message length] == 0)
     return nil;
   BOOL isSimpleValue = NO;
   id decoded = nil;

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
@@ -45,7 +45,7 @@
 }
 
 - (id)decode:(NSData*)message {
-  if (message == nil)
+  if ([message length] == 0)
     return nil;
   FlutterStandardReader* reader = [_readerWriter readerWithData:message];
   id value = [reader readValue];

--- a/shell/platform/darwin/common/framework/Source/flutter_codecs_unittest.mm
+++ b/shell/platform/darwin/common/framework/Source/flutter_codecs_unittest.mm
@@ -42,6 +42,11 @@ TEST(FlutterStringCodec, CanEncodeAndDecodeNonBMPString) {
   ASSERT_TRUE([value isEqualTo:decoded]);
 }
 
+TEST(FlutterJSONCodec, CanDecodeZeroLength) {
+  FlutterJSONMessageCodec* codec = [FlutterJSONMessageCodec sharedInstance];
+  ASSERT_TRUE([codec decode:[NSData data]] == nil);
+}
+
 TEST(FlutterJSONCodec, CanEncodeAndDecodeNil) {
   FlutterJSONMessageCodec* codec = [FlutterJSONMessageCodec sharedInstance];
   ASSERT_TRUE([codec encode:nil] == nil);

--- a/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
+++ b/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
@@ -30,6 +30,12 @@ void checkEncodeDecode(id value) {
     ASSERT_TRUE([value isEqual:decoded]);
 }
 
+TEST(FlutterStandardCodec, CanDecodeZeroLength) {
+  FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
+  id decoded = [codec decode:[NSData data]];
+  ASSERT_TRUE(decoded == nil);
+}
+
 TEST(FlutterStandardCodec, CanEncodeAndDecodeNil) {
   checkEncodeDecode(nil, nil);
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -495,9 +495,12 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
 }
 
 - (void)engineCallbackOnPlatformMessage:(const FlutterPlatformMessage*)message {
-  NSData* messageData = [NSData dataWithBytesNoCopy:(void*)message->message
-                                             length:message->message_size
-                                       freeWhenDone:NO];
+  NSData* messageData = nil;
+  if (message->message_size > 0) {
+    messageData = [NSData dataWithBytesNoCopy:(void*)message->message
+                                       length:message->message_size
+                                 freeWhenDone:NO];
+  }
   NSString* channel = @(message->channel);
   __block const FlutterPlatformMessageResponseHandle* responseHandle = message->response_handle;
 


### PR DESCRIPTION
This updates Flutter.*Codec `decode:` implementations to treat empty
messages as equivalent to nil or NSNull, which avoids a crash when we
subsequently otherwise try to read the type/value from the message. This
handles the case where the sender were to send `null` over the channel.
e.g.,

    final channel = BasicMessageChannel<Object?>('somechannel', StandardMessageCodec());
    channel.send(null);

It also updates the macOS embedder to send nil to the decoder when a
zero-length message is received in order to be consistent with the iOS
embedding.

Previously, the macOS embedder always encoded platform messages as
NSData regardless of length:
https://github.com/flutter/engine/blob/ba93431e6885f94614d91c291ae0336bac6b70b0/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm#L498-L500

The iOS embedder did not have this issue since it special-cased
zero-length messages as nil:
https://github.com/flutter/engine/blob/ba93431e6885f94614d91c291ae0336bac6b70b0/shell/platform/darwin/ios/framework/Source/platform_message_router.mm#L23-L26

Bug: flutter/flutter#78003

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
