### PR TITLE
Make internal BSTR private in ScopedBstr

### DIFF
--- a/third_party/accessibility/base/win/scoped_bstr.h
+++ b/third_party/accessibility/base/win/scoped_bstr.h
@@ -83,10 +83,8 @@ class BASE_EXPORT ScopedBstr {
   bool operator==(const ScopedBstr& bstr2) const = delete;
   bool operator!=(const ScopedBstr& bstr2) const = delete;
 
- protected:
-  BSTR bstr_ = nullptr;
-
  private:
+  BSTR bstr_ = nullptr;
   BASE_DISALLOW_COPY_AND_ASSIGN(ScopedBstr);
 };
 


### PR DESCRIPTION
There are no subclasses of this class in our codebase that would
necessitate a protected member.

Internal visibility cleanup, covered by existing build/test.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
