### PR TITLE
Add support for right-click in GLFW.

### DIFF
--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -345,14 +345,15 @@ static void SetEventLocationFromCursorPosition(
 // engine.
 static void SetEventPhaseFromCursorButtonState(
     GLFWwindow* window,
-    FlutterPointerEvent* event_data) {
+    FlutterPointerEvent* event_data,
+    int64_t buttons) {
   auto* controller = GetWindowController(window);
   event_data->phase =
-      (controller->buttons == 0)
-          ? (controller->pointer_currently_down ? FlutterPointerPhase::kUp
-                                                : FlutterPointerPhase::kHover)
-          : (controller->pointer_currently_down ? FlutterPointerPhase::kMove
-                                                : FlutterPointerPhase::kDown);
+      buttons
+        ? (controller->pointer_currently_down ? FlutterPointerPhase::kUp
+                                              : FlutterPointerPhase::kHover)
+        : (controller->pointer_currently_down ? FlutterPointerPhase::kMove
+                                              : FlutterPointerPhase::kDown);
 }
 
 // Reports the mouse entering or leaving the Flutter view.
@@ -369,7 +370,8 @@ static void GLFWCursorPositionCallback(GLFWwindow* window, double x, double y) {
   FlutterPointerEvent event = {};
   event.x = x;
   event.y = y;
-  SetEventPhaseFromCursorButtonState(window, &event);
+  auto* controller = GetWindowController(window);
+  SetEventPhaseFromCursorButtonState(window, &event, controller->buttons);
   SendPointerEventWithData(window, event);
 }
 
@@ -392,7 +394,7 @@ static void GLFWMouseButtonCallback(GLFWwindow* window,
                                                : controller->buttons & ~button;
 
   FlutterPointerEvent event = {};
-  SetEventPhaseFromCursorButtonState(window, &event);
+  SetEventPhaseFromCursorButtonState(window, &event, controller->buttons);
   SetEventLocationFromCursorPosition(window, &event);
   SendPointerEventWithData(window, event);
 
@@ -420,7 +422,8 @@ static void GLFWScrollCallback(GLFWwindow* window,
                                double delta_y) {
   FlutterPointerEvent event = {};
   SetEventLocationFromCursorPosition(window, &event);
-  SetEventPhaseFromCursorButtonState(window, &event);
+  auto* controller = GetWindowController(window);
+  SetEventPhaseFromCursorButtonState(window, &event, controller->buttons);
   event.signal_kind = FlutterPointerSignalKind::kFlutterPointerSignalKindScroll;
   // TODO: See if this can be queried from the OS; this value is chosen
   // arbitrarily to get something that feels reasonable.

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -349,11 +349,11 @@ static void SetEventPhaseFromCursorButtonState(
     int64_t buttons) {
   auto* controller = GetWindowController(window);
   event_data->phase =
-      buttons
-        ? (controller->pointer_currently_down ? FlutterPointerPhase::kUp
-                                              : FlutterPointerPhase::kHover)
-        : (controller->pointer_currently_down ? FlutterPointerPhase::kMove
-                                              : FlutterPointerPhase::kDown);
+      (buttons == 0)
+          ? (controller->pointer_currently_down ? FlutterPointerPhase::kUp
+                                                : FlutterPointerPhase::kHover)
+          : (controller->pointer_currently_down ? FlutterPointerPhase::kMove
+                                                : FlutterPointerPhase::kDown);
 }
 
 // Reports the mouse entering or leaving the Flutter view.

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -341,12 +341,11 @@ static void SetEventLocationFromCursorPosition(
 
 // Set's |event_data|'s phase depending on the current mouse state.
 // If a kUp or kDown event is triggered while the current state is already
-// up/down, a hover/move will be called instead to avoid a crash in the Flutter 
+// up/down, a hover/move will be called instead to avoid a crash in the Flutter
 // engine.
-static void SetEventPhaseFromCursorButtonState(
-    GLFWwindow* window,
-    FlutterPointerEvent* event_data,
-    int64_t buttons) {
+static void SetEventPhaseFromCursorButtonState(GLFWwindow* window,
+                                               FlutterPointerEvent* event_data,
+                                               int64_t buttons) {
   auto* controller = GetWindowController(window);
   event_data->phase =
       (buttons == 0)


### PR DESCRIPTION
GLFW currently does not support right-click events for Flutter. This adds buttons to FlutterPointerEvents sent from GLFW.

flutter/flutter#77943

#25074

This is attempting to copy the functionality from MacOS here:

https://github.com/flutter/engine/blob/master/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm#L424