### PR TITLE
Remove duplicate and inconsistent kInvalidAXID definition, and ensure the default AXID for a Node isn't the invalid ID.

### DIFF
--- a/third_party/accessibility/ax/ax_node_data.h
+++ b/third_party/accessibility/ax/ax_node_data.h
@@ -35,10 +35,6 @@ struct AX_BASE_EXPORT AXNodeData {
   // Defines the type used for AXNode IDs.
   using AXID = int32_t;
 
-  // If a node is not yet or no longer valid, its ID should have a value of
-  // kInvalidAXID.
-  static constexpr AXID kInvalidAXID = 0;
-
   AXNodeData();
   virtual ~AXNodeData();
 
@@ -274,7 +270,7 @@ struct AX_BASE_EXPORT AXNodeData {
 
   // As much as possible this should behave as a simple, serializable,
   // copyable struct.
-  int32_t id = -1;
+  int32_t id = 0;
   ax::mojom::Role role;
   uint32_t state;
   uint64_t actions;


### PR DESCRIPTION
There was a duplicate definition of kInvalidAXID in AXNodeData which differed from the one in AXNode. Delete the one in AXNodeData and only use the AXNode definition.

Since the invalid ID used to be 0 before we imported this code, and is now -1, the default ID of -1 can no longer be used for AXNodeData, so change that to 0.