### PR TITLE
Workaround for iOS embedder preroll issue

### DIFF
--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -30,9 +30,9 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
     context->has_platform_view = true;
     std::unique_ptr<EmbeddedViewParams> params =
         std::make_unique<EmbeddedViewParams>(matrix, size_,
-                                            context->mutators_stack);
+                                             context->mutators_stack);
     context->view_embedder->PrerollCompositeEmbeddedView(view_id_,
-                                                        std::move(params));
+                                                         std::move(params));
   }
 }
 

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -26,12 +26,14 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
                       "does not support embedding";
     return;
   }
-  context->has_platform_view = true;
-  std::unique_ptr<EmbeddedViewParams> params =
-      std::make_unique<EmbeddedViewParams>(matrix, size_,
-                                           context->mutators_stack);
-  context->view_embedder->PrerollCompositeEmbeddedView(view_id_,
-                                                       std::move(params));
+  if (paint_bounds().intersects(context->cull_rect)) {
+    context->has_platform_view = true;
+    std::unique_ptr<EmbeddedViewParams> params =
+        std::make_unique<EmbeddedViewParams>(matrix, size_,
+                                            context->mutators_stack);
+    context->view_embedder->PrerollCompositeEmbeddedView(view_id_,
+                                                        std::move(params));
+  }
 }
 
 void PlatformViewLayer::Paint(PaintContext& context) const {


### PR DESCRIPTION
These changes are a potential fix for https://github.com/flutter/flutter/issues/76097

The problem appears to be that a fix integrated in November will now lead to all layers being prerolled even if they may not paint. Previously we would try to avoid prerolling them if we didn't think we would call their paint method, but that turned out to be too aggressive a heuristic and so the new code will always preroll every layer. As such, a layer (or an embedder) cannot assume that because it was prerolled, that it will also paint.

The changes here attempt to avoid calling the embedder's preroll method if the PlatformViewLayer does not think that its Paint method will be called., but the issue with that workaround is that the condition used here to predict if the Paint method will be called on the PlatformViewLayer is not precise. The actual test that determines culling in the Paint cycle uses a different algorithm that is based on information maintained by the SkCanvas. As a result we can't guarantee that this test will catch 100% of cases where paint will or will not be called.

Without this fix, the Android embedder does not exhibit the issue linked above, so that version of the embedder proves that it is possible for an embedder implementation to have its preroll methods called, but not paint residue on the screen. Only the iOS embedder is leaving a last sliver of the platform view visible after it is scrolled behind something.

A better fix would be to modify the iOS embedder so that it paints nothing if its Paint() method is not actually called.

I'm tagging some of the names that show up in the iOS FlutterPlatformViews.mm file s possible reviewers or contributors who can suggest a more complete fix: @blasten @cyanglaz @amirh @cbracken @iskakaushik 