### PR TITLE
Make DartExecutor.isExecutingDart account for spawned engines

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -61,6 +61,11 @@ public class DartExecutor implements BinaryMessenger {
     this.dartMessenger = new DartMessenger(flutterJNI);
     dartMessenger.setMessageHandler("flutter/isolate", isolateChannelMessageHandler);
     this.binaryMessenger = new DefaultBinaryMessenger(dartMessenger);
+    // The JNI might already be attached if coming from a spawned engine. If so, correctly report
+    // that this DartExecutor is already running.
+    if (flutterJNI.isAttached()) {
+      isApplicationRunning = true;
+    }
   }
 
   /**

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -232,4 +232,23 @@ public class FlutterEngineTest {
 
     verify(flutterJNI, never()).attachToNative(false);
   }
+
+  @Test
+  public void itComesWithARunningDartExecutorIfJNIIsAlreadyAttached() throws NameNotFoundException {
+    Context context = mock(Context.class);
+    Context packageContext = mock(Context.class);
+
+    when(context.createPackageContext(any(), anyInt())).thenReturn(packageContext);
+    when(flutterJNI.isAttached()).thenReturn(true);
+
+    FlutterEngine engineUnderTest =
+        new FlutterEngine(
+            context,
+            mock(FlutterLoader.class),
+            flutterJNI,
+            /*dartVmArgs=*/ new String[] {},
+            /*automaticallyRegisterPlugins=*/ false);
+
+    assertTrue(engineUnderTest.getDartExecutor().isExecutingDart());
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/77784