### PR TITLE
[Android Text Input] restart when framework changes composing region

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -741,5 +741,9 @@ public class TextInputChannel {
       // be -1.
       return selectionStart >= 0;
     }
+
+    public boolean hasComposing() {
+      return composingStart >= 0 && composingEnd > composingStart;
+    }
   }
 }

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -9,7 +9,6 @@ import android.content.Context;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
-import android.provider.Settings;
 import android.text.Editable;
 import android.text.InputType;
 import android.util.SparseArray;
@@ -22,7 +21,6 @@ import android.view.autofill.AutofillValue;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
-import android.view.inputmethod.InputMethodSubtype;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -49,7 +47,6 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
   @Nullable private InputConnection lastInputConnection;
   @NonNull private PlatformViewsController platformViewsController;
   @Nullable private Rect lastClientRect;
-  private final boolean restartAlwaysRequired;
   private ImeSyncDeferringInsetsCallback imeSyncCallback;
   private AndroidKeyProcessor keyProcessor;
 
@@ -161,7 +158,6 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
 
     this.platformViewsController = platformViewsController;
     this.platformViewsController.attachTextInputPlugin(this);
-    restartAlwaysRequired = isRestartAlwaysRequired();
   }
 
   @NonNull
@@ -421,12 +417,20 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
   // latest TextEditState from the framework.
   @VisibleForTesting
   void setTextInputEditingState(View view, TextInputChannel.TextEditState state) {
+    mRestartInputPending =
+        mRestartInputPending
+            // Also restart input if the framework decides to remove the composing
+            // region (which is discouraged).
+            || (mLastKnownFrameworkTextEditingState != null
+                && mLastKnownFrameworkTextEditingState.hasComposing()
+                && !state.hasComposing());
+
     mLastKnownFrameworkTextEditingState = state;
     mEditable.setEditingState(state);
 
     // Restart if there is a pending restart or the device requires a force restart
     // (see isRestartAlwaysRequired). Restarting will also update the selection.
-    if (restartAlwaysRequired || mRestartInputPending) {
+    if (mRestartInputPending) {
       mImm.restartInput(view);
       mRestartInputPending = false;
     }
@@ -474,32 +478,6 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
             (int) (minMax[2] * density),
             (int) Math.ceil(minMax[1] * density),
             (int) Math.ceil(minMax[3] * density));
-  }
-
-  // Samsung's Korean keyboard has a bug where it always attempts to combine characters based on
-  // its internal state, ignoring if and when the cursor is moved programmatically. The same bug
-  // also causes non-korean keyboards to occasionally duplicate text when tapping in the middle
-  // of existing text to edit it.
-  //
-  // Fully restarting the IMM works around this because it flushes the keyboard's internal state
-  // and stops it from trying to incorrectly combine characters. However this also has some
-  // negative performance implications, so we don't want to apply this workaround in every case.
-  @SuppressLint("NewApi") // New API guard is inline, the linter can't see it.
-  @SuppressWarnings("deprecation")
-  private boolean isRestartAlwaysRequired() {
-    InputMethodSubtype subtype = mImm.getCurrentInputMethodSubtype();
-    // Impacted devices all shipped with Android Lollipop or newer.
-    if (subtype == null
-        || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP
-        || !Build.MANUFACTURER.equals("samsung")) {
-      return false;
-    }
-    String keyboardName =
-        Settings.Secure.getString(
-            mView.getContext().getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
-    // The Samsung keyboard is called "com.sec.android.inputmethod/.SamsungKeypad" but look
-    // for "Samsung" just in case Samsung changes the name of the keyboard.
-    return keyboardName.contains("Samsung");
   }
 
   @VisibleForTesting

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -419,8 +419,10 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
   void setTextInputEditingState(View view, TextInputChannel.TextEditState state) {
     mRestartInputPending =
         mRestartInputPending
-            // Also restart input if the framework decides to remove the composing
-            // region (which is discouraged).
+            // Also restart input if the framework decides to remove the
+            // composing region (which is discouraged).
+            // Many IMEs don't expect editors to commit composing text, so a
+            // restart is needed to reset their internal states.
             || (mLastKnownFrameworkTextEditingState != null
                 && mLastKnownFrameworkTextEditingState.hasComposing()
                 && !state.hasComposing());

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -441,7 +441,9 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       // to reset their internal states.
       mRestartInputPending = composingChanged(mLastKnownFrameworkTextEditingState, state);
       if (mRestartInputPending) {
-        Log.w(TAG, "Changing the content within the the composing region is discouraged.");
+        Log.w(
+            TAG,
+            "Changing the content within the the composing region may cause the input method to behave strangely, and is therefore discouraged. See https://github.com/flutter/flutter/issues/78827 for more details");
       }
     }
 

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -345,16 +345,13 @@ public class TextInputPluginTest {
   // https://github.com/flutter/flutter/issues/31512
   // All modern Samsung keybords are affected including non-korean languages and thus
   // need the restart.
+  // Update: many other keyboards need this too:
+  // https://github.com/flutter/flutter/issues/78827
   @Test
-  public void setTextInputEditingState_alwaysRestartsOnAffectedDevices2() {
+  public void setTextInputEditingState_restartsIMEOnlyWhenFrameworkRemovesComposingRegion() {
     // Initialize a TextInputPlugin that needs to be always restarted.
-    ShadowBuild.setManufacturer("samsung");
     InputMethodSubtype inputMethodSubtype =
         new InputMethodSubtype(0, 0, /*locale=*/ "en", "", "", false, false);
-    Settings.Secure.putString(
-        RuntimeEnvironment.application.getContentResolver(),
-        Settings.Secure.DEFAULT_INPUT_METHOD,
-        "com.sec.android.inputmethod/.SamsungKeypad");
     TestImm testImm =
         Shadow.extract(
             RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
@@ -370,7 +367,7 @@ public class TextInputPluginTest {
             false,
             true,
             TextInputChannel.TextCapitalization.NONE,
-            null,
+            new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false),
             null,
             null,
             null,
@@ -378,57 +375,26 @@ public class TextInputPluginTest {
     // There's a pending restart since we initialized the text input client. Flush that now.
     textInputPlugin.setTextInputEditingState(
         testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
+    assertEquals(1, testImm.getRestartCount(testView));
+    InputConnection connection = textInputPlugin.createInputConnection(testView, new EditorInfo());
+    connection.setComposingText("POWERRRRR", 9);
 
-    // Move the cursor.
+    textInputPlugin.setTextInputEditingState(
+        testView, new TextInputChannel.TextEditState("UNLIMITED", 0, 0, 0, 9));
+    // Does not restart since the composing region is still there.
+    assertEquals(1, testImm.getRestartCount(testView));
+
+    connection.finishComposingText();
+    // Does not restart since the composing text is committed by the IME.
+    assertEquals(1, testImm.getRestartCount(testView));
+
+    connection.setComposingText("POWERRRRR", 9);
     assertEquals(1, testImm.getRestartCount(testView));
     textInputPlugin.setTextInputEditingState(
-        testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
+        testView, new TextInputChannel.TextEditState("POWERRRRR", 0, 0, -1, -1));
 
     // Verify that we've restarted the input.
     assertEquals(2, testImm.getRestartCount(testView));
-  }
-
-  @Test
-  public void setTextInputEditingState_doesNotRestartOnUnaffectedDevices() {
-    // Initialize a TextInputPlugin that needs to be always restarted.
-    ShadowBuild.setManufacturer("samsung");
-    InputMethodSubtype inputMethodSubtype =
-        new InputMethodSubtype(0, 0, /*locale=*/ "en", "", "", false, false);
-    Settings.Secure.putString(
-        RuntimeEnvironment.application.getContentResolver(),
-        Settings.Secure.DEFAULT_INPUT_METHOD,
-        "com.fake.test.blah/.NotTheRightKeyboard");
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
-    testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    View testView = new View(RuntimeEnvironment.application);
-    TextInputChannel textInputChannel = new TextInputChannel(mock(DartExecutor.class));
-    TextInputPlugin textInputPlugin =
-        new TextInputPlugin(testView, textInputChannel, mock(PlatformViewsController.class));
-    textInputPlugin.setTextInputClient(
-        0,
-        new TextInputChannel.Configuration(
-            false,
-            false,
-            true,
-            TextInputChannel.TextCapitalization.NONE,
-            null,
-            null,
-            null,
-            null,
-            null));
-    // There's a pending restart since we initialized the text input client. Flush that now.
-    textInputPlugin.setTextInputEditingState(
-        testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
-
-    // Move the cursor.
-    assertEquals(1, testImm.getRestartCount(testView));
-    textInputPlugin.setTextInputEditingState(
-        testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
-
-    // Verify that we've restarted the input.
-    assertEquals(1, testImm.getRestartCount(testView));
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -348,7 +348,7 @@ public class TextInputPluginTest {
   // Update: many other keyboards need this too:
   // https://github.com/flutter/flutter/issues/78827
   @Test
-  public void setTextInputEditingState_restartsIMEOnlyWhenFrameworkRemovesComposingRegion() {
+  public void setTextInputEditingState_restartsIMEOnlyWhenFrameworkChangesComposingRegion() {
     // Initialize a TextInputPlugin that needs to be always restarted.
     InputMethodSubtype inputMethodSubtype =
         new InputMethodSubtype(0, 0, /*locale=*/ "en", "", "", false, false);
@@ -380,16 +380,19 @@ public class TextInputPluginTest {
     connection.setComposingText("POWERRRRR", 1);
 
     textInputPlugin.setTextInputEditingState(
-        testView, new TextInputChannel.TextEditState("UNLIMITED", 0, 0, 0, 9));
-    // Does not restart since the composing region is still there.
+        testView, new TextInputChannel.TextEditState("UNLIMITED POWERRRRR", 0, 0, 10, 19));
+    // Does not restart since the composing text is not changed.
     assertEquals(1, testImm.getRestartCount(testView));
 
     connection.finishComposingText();
     // Does not restart since the composing text is committed by the IME.
     assertEquals(1, testImm.getRestartCount(testView));
 
+    // Does not restart since the composing text is changed by the IME.
     connection.setComposingText("POWERRRRR", 1);
     assertEquals(1, testImm.getRestartCount(testView));
+
+    // The framework tries to commit the composing region.
     textInputPlugin.setTextInputEditingState(
         testView, new TextInputChannel.TextEditState("POWERRRRR", 0, 0, -1, -1));
 

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -377,7 +377,7 @@ public class TextInputPluginTest {
         testView, new TextInputChannel.TextEditState("", 0, 0, -1, -1));
     assertEquals(1, testImm.getRestartCount(testView));
     InputConnection connection = textInputPlugin.createInputConnection(testView, new EditorInfo());
-    connection.setComposingText("POWERRRRR", 9);
+    connection.setComposingText("POWERRRRR", 1);
 
     textInputPlugin.setTextInputEditingState(
         testView, new TextInputChannel.TextEditState("UNLIMITED", 0, 0, 0, 9));
@@ -388,7 +388,7 @@ public class TextInputPluginTest {
     // Does not restart since the composing text is committed by the IME.
     assertEquals(1, testImm.getRestartCount(testView));
 
-    connection.setComposingText("POWERRRRR", 9);
+    connection.setComposingText("POWERRRRR", 1);
     assertEquals(1, testImm.getRestartCount(testView));
     textInputPlugin.setTextInputEditingState(
         testView, new TextInputChannel.TextEditState("POWERRRRR", 0, 0, -1, -1));


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/78827: there're multiple android duplicate input issues involving the framework committing a non-empty composing region (the Samsung input bug could be a manifest of this too, since in framework when done is pressed we call `clearComposing`).

Fixes flutter/flutter#73433
Fixes https://github.com/flutter/flutter/issues/72980

maybe fixes https://github.com/flutter/flutter/issues/78066
maybe fixes https://github.com/flutter/flutter/issues/61097 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
