### PR TITLE
#include <memory> in string_utils.h

### DIFF
--- a/third_party/accessibility/base/string_utils.h
+++ b/third_party/accessibility/base/string_utils.h
@@ -5,6 +5,7 @@
 #ifndef BASE_STRING_UTILS_H_
 #define BASE_STRING_UTILS_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Explicitly include `<memory>` in `string_utils.h`. Otherwise, the engine does not build locally on Windows without goma.