### PR TITLE
[tracing] Add trace events for DartIsolate::HandleMessage

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -445,8 +445,13 @@ void DartIsolate::SetMessageHandlingTaskRunner(
 
   message_handling_task_runner_ = runner;
 
-  message_handler().Initialize(
-      [runner](std::function<void()> task) { runner->PostTask(task); });
+  message_handler().Initialize([runner](std::function<void()> task) {
+    TRACE_EVENT0("flutter", "DartIsolate::PostMessage");
+    runner->PostTask([task = std::move(task)]() {
+      TRACE_EVENT0("flutter", "DartIsolate::HandleMessage");
+      task();
+    });
+  });
 }
 
 // Updating thread names here does not change the underlying OS thread names.


### PR DESCRIPTION
This captures majority of the non frame related workload happening on the UI thread.
