### PR TITLE
Highlight VSync support for embedders

### DIFF
--- a/shell/common/vsync_waiter_fallback.cc
+++ b/shell/common/vsync_waiter_fallback.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/common/vsync_waiter_fallback.h"
 
 #include "flutter/fml/logging.h"
+#include "flutter/fml/trace_event.h"
 
 namespace flutter {
 namespace {
@@ -27,6 +28,8 @@ VsyncWaiterFallback::~VsyncWaiterFallback() = default;
 
 // |VsyncWaiter|
 void VsyncWaiterFallback::AwaitVSync() {
+  TRACE_EVENT0("flutter", "VSYNC");
+
   constexpr fml::TimeDelta kSingleFrameInterval =
       fml::TimeDelta::FromSecondsF(1.0 / 60.0);
 


### PR DESCRIPTION
Chrome Trace viewer treats events labeled "VSYNC" as special and highlights them (when the "Highlight Vsync" checkbox is enabled). We do this for ios and android already, this PR also does this for fallback vsync waiters which are used by embedders by default.