### PR TITLE
Reland: Started waiting for the notifications locally before asserting side-effects

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -104,6 +104,7 @@ class MockDelegate : public PlatformView::Delegate {
   [self waitForExpectations:@[ backgroundExpectation ] timeout:5.0];
 
   OCMVerify([mockEngine notifyLowMemory]);
+  [mockEngine stopMocking];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -87,15 +87,21 @@ class MockDelegate : public PlatformView::Delegate {
   OCMVerify([mockEngine notifyLowMemory]);
   OCMReject([mockEngine notifyLowMemory]);
 
+  XCTNSNotificationExpectation* memoryExpectation = [[XCTNSNotificationExpectation alloc]
+      initWithName:UIApplicationDidReceiveMemoryWarningNotification];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationDidReceiveMemoryWarningNotification
                     object:nil];
+  [self waitForExpectations:@[ memoryExpectation ] timeout:5.0];
   OCMVerify([mockEngine notifyLowMemory]);
   OCMReject([mockEngine notifyLowMemory]);
 
+  XCTNSNotificationExpectation* backgroundExpectation = [[XCTNSNotificationExpectation alloc]
+      initWithName:UIApplicationDidEnterBackgroundNotification];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationDidEnterBackgroundNotification
                     object:nil];
+  [self waitForExpectations:@[ backgroundExpectation ] timeout:5.0];
 
   OCMVerify([mockEngine notifyLowMemory]);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegateTest.m
@@ -11,7 +11,6 @@
 FLUTTER_ASSERT_ARC
 
 @interface FlutterPluginAppLifeCycleDelegateTest : XCTestCase
-
 @end
 
 @implementation FlutterPluginAppLifeCycleDelegateTest
@@ -22,51 +21,71 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testDidEnterBackground {
+  XCTNSNotificationExpectation* expectation = [[XCTNSNotificationExpectation alloc]
+      initWithName:UIApplicationDidEnterBackgroundNotification];
   FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   [delegate addDelegate:plugin];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationDidEnterBackgroundNotification
                     object:nil];
+
+  [self waitForExpectations:@[ expectation ] timeout:5.0];
   OCMVerify([plugin applicationDidEnterBackground:[UIApplication sharedApplication]]);
 }
 
 - (void)testWillEnterForeground {
+  XCTNSNotificationExpectation* expectation = [[XCTNSNotificationExpectation alloc]
+      initWithName:UIApplicationWillEnterForegroundNotification];
+
   FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   [delegate addDelegate:plugin];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationWillEnterForegroundNotification
                     object:nil];
+  [self waitForExpectations:@[ expectation ] timeout:5.0];
   OCMVerify([plugin applicationWillEnterForeground:[UIApplication sharedApplication]]);
 }
 
-- (void)skip_testWillResignActive {
+- (void)testWillResignActive {
+  XCTNSNotificationExpectation* expectation =
+      [[XCTNSNotificationExpectation alloc] initWithName:UIApplicationWillResignActiveNotification];
+
   FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   [delegate addDelegate:plugin];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationWillResignActiveNotification
                     object:nil];
+  [self waitForExpectations:@[ expectation ] timeout:5.0];
   OCMVerify([plugin applicationWillResignActive:[UIApplication sharedApplication]]);
 }
 
-- (void)skip_testDidBecomeActive {
+- (void)testDidBecomeActive {
+  XCTNSNotificationExpectation* expectation =
+      [[XCTNSNotificationExpectation alloc] initWithName:UIApplicationDidBecomeActiveNotification];
+
   FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   [delegate addDelegate:plugin];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationDidBecomeActiveNotification
                     object:nil];
+  [self waitForExpectations:@[ expectation ] timeout:5.0];
   OCMVerify([plugin applicationDidBecomeActive:[UIApplication sharedApplication]]);
 }
 
 - (void)testWillTerminate {
+  XCTNSNotificationExpectation* expectation =
+      [[XCTNSNotificationExpectation alloc] initWithName:UIApplicationWillTerminateNotification];
+
   FlutterPluginAppLifeCycleDelegate* delegate = [[FlutterPluginAppLifeCycleDelegate alloc] init];
   id plugin = OCMProtocolMock(@protocol(FlutterPlugin));
   [delegate addDelegate:plugin];
   [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillTerminateNotification
                                                       object:nil];
+  [self waitForExpectations:@[ expectation ] timeout:5.0];
   OCMVerify([plugin applicationWillTerminate:[UIApplication sharedApplication]]);
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -885,9 +885,8 @@ FLUTTER_ASSERT_ARC
 
 - (void)testFlutterTextInputPluginRetainsFlutterTextInputView {
   FlutterTextInputPlugin* myInputPlugin;
-  id myEngine = OCMClassMock([FlutterEngine class]);
   myInputPlugin = [[FlutterTextInputPlugin alloc] init];
-  myInputPlugin.textInputDelegate = myEngine;
+  myInputPlugin.textInputDelegate = engine;
   __weak UIView* activeView;
   @autoreleasepool {
     FlutterMethodCall* setClientCall = [FlutterMethodCall

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -970,5 +970,6 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   });
   latch.Wait();
   OCMVerify([messenger cleanupConnection:connection]);
+  [engine stopMocking];
 }
 @end


### PR DESCRIPTION
Relanding https://github.com/flutter/engine/pull/25226

It had to be reverted because other tests were leaking FlutterViewControllers because of OCMock stubbing.  I couldn't get ocmock to release the objects so I had to make my own mock engine.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
