### PR TITLE
[fuchsia] create component context in main

### DIFF
--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -65,6 +65,7 @@ template("runner") {
              "$fuchsia_sdk_root/pkg:async-loop-cpp",
              "$fuchsia_sdk_root/pkg:async-loop-default",
              "$fuchsia_sdk_root/pkg:fidl_cpp",
+             "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
              "$fuchsia_sdk_root/pkg:sys_cpp",
              "$fuchsia_sdk_root/pkg:syslog",
              "$fuchsia_sdk_root/pkg:trace",

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -124,6 +124,7 @@ template("runner_sources") {
     public_deps = [
                     "$fuchsia_sdk_root/pkg:scenic_cpp",
                     "$fuchsia_sdk_root/pkg:sys_cpp",
+                    "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
                     "//flutter/shell/platform/fuchsia/runtime/dart/utils",
                   ] + flutter_public_deps
 

--- a/shell/platform/fuchsia/flutter/main.cc
+++ b/shell/platform/fuchsia/flutter/main.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <lib/async-loop/cpp/loop.h>
+#include <lib/sys/inspect/cpp/component.h>
 #include <lib/trace-provider/provider.h>
 #include <lib/trace/event.h>
 
@@ -15,6 +16,16 @@
 
 int main(int argc, char const* argv[]) {
   std::unique_ptr<async::Loop> loop(flutter_runner::MakeObservableLoop(true));
+
+  // Create our component context which is served later.
+  auto context = sys::ComponentContext::Create();
+  sys::ComponentInspector inspector(context.get());
+
+  inspect::Node& root = inspector.inspector()->GetRoot();
+
+  // We inject the 'vm' node into the dart vm so that it can add any inspect
+  // data that it needs to the inspect tree.
+  dart::SetDartVmNode(std::make_unique<inspect::Node>(root.CreateChild("vm")));
 
   std::unique_ptr<trace::TraceProviderWithFdio> provider;
   {
@@ -29,7 +40,10 @@ int main(int argc, char const* argv[]) {
 
   FML_DLOG(INFO) << "Flutter application services initialized.";
 
-  flutter_runner::Runner runner(loop.get(), dart::ComponentContext());
+  flutter_runner::Runner runner(loop.get(), context.get());
+
+  // Wait to serve until we have finished all of our setup.
+  context->outgoing()->ServeFromStartupInfo();
 
   loop->Run();
   FML_DLOG(INFO) << "Flutter application services terminated.";


### PR DESCRIPTION
This code changes how the component context is created and served. We now create the component context in main and not when the vm is creatd.

*List which issues are fixed by this PR. You must list at least one issue.*
fxbug.dev/69558


