### PR TITLE
Revert "Fix Windows external texture interference (#25193)"

### DIFF
--- a/shell/platform/windows/external_texture_gl.cc
+++ b/shell/platform/windows/external_texture_gl.cc
@@ -125,7 +125,6 @@ bool ExternalTextureGL::CopyPixelBuffer(size_t& width, size_t& height) {
   gl.glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pixel_buffer->width,
                   pixel_buffer->height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
                   pixel_buffer->buffer);
-  gl.glBindTexture(GL_TEXTURE_2D, 0);
   return true;
 }
 


### PR DESCRIPTION
This will cause the previous texture binding used by Skia to be
incorrectly unbound, such that should they need to re-used an existing
binding, we'll end up rendering blank instead.

Instead we should be using

    context->flushAndSubmit();
    context->resetContext(kAll_GrBackendState);

in `EmbedderExternalTextureGL::ResolveTexture` in order to notify Skia
that we've updated handles within the current binding and invalidate any
assumptions about previous modifications it has made to the context.

This reverts commit d6e5946037be82ccfdc675e99d1dc515fd4718bf.

Related https://github.com/flutter/flutter/issues/78648

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
