### PR TITLE
Copy gtest_filters from femu_test.py.

### DIFF
--- a/testing/fuchsia/gtest_filters.yaml
+++ b/testing/fuchsia/gtest_filters.yaml
@@ -1,0 +1,8 @@
+# This configuration file specifies disabled tests as gtest_filters to be passed
+# as test arguments for flutter on FEMU tests.
+
+txt_tests: -ParagraphTest.*
+fml_tests: -MessageLoop.TimeSensistiveTest_*:FileTest.CanTruncateAndWrite:FileTest.CreateDirectoryStructure
+shell_tests: -ShellTest.ReportTimingsIsCalledLaterInReleaseMode:ShellTest.ReportTimingsIsCalledSoonerInNonReleaseMode:ShellTest.CacheSkSLWorks:ShellTest.FrameRasterizedCallbackIsCalled:ShellTest.ExternalEmbedderNoThreadMerger:ShellTest.OnPlatformViewDestroyWithoutRasterThreadMerger:ShellTest.ReportTimingsIsCalledImmediatelyAfterTheFirstFrame:ShellTest.DisallowedDartVMFlag:ShellTest.SetResourceCacheSize:ShellTest.SetResourceCacheSizeEarly:ShellTest.SetResourceCacheSizeNotifiesDart:ShellTest.Screenshot:ShellTest.RasterizerScreenshot:ShellTest.DiscardLayerTreeOnResize:SkpWarmupTest.Basic:SkpWarmupTest.Image:FuchsiaShellTest.LocaltimesVaryOnTimezoneChanges
+flutter_runner_scenic_tests: -SessionConnectionTest.*:CalculateNextLatchPointTest.*
+flutter_runner_tests: -EngineTest.SkpWarmup


### PR DESCRIPTION
Start migrating away from hard-coded gtest_filters in [femu_test.py](https://cs.opensource.google/flutter/recipes/+/master:recipes/femu_test.py;l=179-208)

See [fxb/73053](http://fxb/73053)