### PR TITLE
fuchsia: Allow access to system services in tests.

### DIFF
--- a/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
@@ -5,6 +5,15 @@
        "ICU_TIMEZONE_FILES_DIR=/pkg/data/tzdata"
     ]
   },
+  "facets": {
+    "fuchsia.test": {
+      "system-services": [
+        "fuchsia.sysmem.Allocator",
+        "fuchsia.ui.scenic.Scenic",
+        "fuchsia.vulkan.loader.Loader"
+      ]
+    }
+  },
   "sandbox": {
     "features": [
       "deprecated-ambient-replace-as-executable",
@@ -18,7 +27,8 @@
       "fuchsia.process.Launcher",
       "fuchsia.vulkan.loader.Loader",
       "fuchsia.logger.LogSink",
-      "fuchsia.sysmem.Allocator"
+      "fuchsia.sysmem.Allocator",
+      "fuchsia.ui.scenic.Scenic"
     ]
   }
 }

--- a/testing/fuchsia/meta/fuchsia_test.cmx
+++ b/testing/fuchsia/meta/fuchsia_test.cmx
@@ -2,6 +2,14 @@
   "program": {
     "binary": "bin/app"
   },
+  "facets": {
+    "fuchsia.test": {
+      "system-services": [
+        "fuchsia.sysmem.Allocator",
+        "fuchsia.vulkan.loader.Loader"
+      ]
+    }
+  },
   "sandbox": {
     "features": [
       "vulkan",


### PR DESCRIPTION
Per https://fuchsia.dev/fuchsia-src/concepts/testing/v1_test_component,
in order to access non-basic system services like Vulkan loader and
sysmem allocator, we need to add "system-services" field to the cmx
metadata file.

Unittests like "shell_test" requires Vulkan to run properly, so we
add Vulkan loader and sysmem services; for Flutter runner tests,
we also need to add fuchsia.ui.scenic.Scenic since the test needs
to create a Scenic session as well.

TEST=shell_tests (SkpWarmupTest.Basic/SkpWarmupTest.Image)
     flutter_runner_tests (EngineTest.SkpWarmUp) on FEMU

Bug: https://github.com/flutter/flutter/issues/78650