### PR TITLE
build dart2js on linux arm host

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -287,10 +287,11 @@ def to_gn_args(args):
     if args.arm_float_abi:
       gn_args['arm_float_abi'] = args.arm_float_abi
 
-    # Whether to build trained Dart SDK snapshots of dart2js and dartdevc,
-    # including the web sdk kernel and source files.
-    if args.target_os is None:
-      # dart_platform_sdk is not declared for Android targets.
+    # dart_platform_sdk is only defined for host builds, linux arm host builds
+    # specify target_os=linux
+    if args.target_os is None or args.target_os == 'linux':
+      # dart_platform_sdk=True means exclude web-related files, e.g. dart2js,
+      # dartdevc, web SDK kernel and source files.
       gn_args['dart_platform_sdk'] = not args.full_dart_sdk
     gn_args['full_dart_sdk'] = args.full_dart_sdk
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/74928

Previously, this code was assuming that `args.target_os==None` means a host build, but I recently added a linux arm host build that specifies `args.target_os=='linux'`. Thus we were building the "platform" Dart SDK, which excludes web tooling.