### PR TITLE
Send a null response to signal that a message is not implemented on the web text input channel

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -1373,9 +1373,13 @@ class TextEditingChannel {
         // UITextInput.firstRecForRange.
         break;
 
+      case 'TextInput.setCaretRect':
+        // No-op: not supported on this platform.
+        break;
+
       default:
-        throw StateError(
-            'Unsupported method call on the flutter/textinput channel: ${call.method}');
+        EnginePlatformDispatcher.instance._replyToPlatformMessage(callback, null);
+        return;
     }
     EnginePlatformDispatcher.instance
         ._replyToPlatformMessage(callback, codec.encodeSuccessEnvelope(true));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/79389