### PR TITLE
maintain at most single overlay for each view in hybrid composition

### DIFF
--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -137,7 +137,14 @@ void AndroidExternalViewEmbedder::SubmitFrame(
         // slighly larger. For example, {0.3, 0.5, 3.1, 4.7} becomes {0, 0, 4,
         // 5}.
         intersection_rect.set(intersection_rect.roundOut());
-        overlay_layers.at(view_id).push_back(intersection_rect);
+        if (overlay_layers.at(view_id).empty()) {
+          overlay_layers.at(view_id).push_back(intersection_rect);
+        } else if (intersection_rect.contains(
+                       overlay_layers.at(view_id).back())) {
+          overlay_layers.at(view_id).back() = intersection_rect;
+        } else {
+          overlay_layers.at(view_id).back().join(intersection_rect);
+        }
         // Clip the background canvas, so it doesn't contain any of the pixels
         // drawn on the overlay layer.
         background_canvas->clipRect(intersection_rect, SkClipOp::kDifference);


### PR DESCRIPTION
Fixed rendering of single widget in multiple overlays on top of each hybrid composition PlatformView

I wasn't able to come up with any meaningful test for this scenario (besides snapshot test on android device), would appreciate any help here.

reproduction examples:

simple case in multiple_overlays branch (from original [issue](https://github.com/flutter/flutter/issues/79371)): https://github.com/2ZeroSix/flutter_android_surface_activity_destroy_bug_example/tree/multiple_overlays
<details>
<summary> screenshots </summary>

||1 view|2 views|
|-|-|-|
|before|<img src="https://user-images.githubusercontent.com/14371067/113096927-4fc74400-9220-11eb-9a85-cd54fe9474d9.jpg" width=300>|<img src="https://user-images.githubusercontent.com/14371067/113096940-55248e80-9220-11eb-8b15-480faf581664.jpg" width=300>|
|after|<img src="https://user-images.githubusercontent.com/14371067/113096947-56ee5200-9220-11eb-8575-786a21c789fc.jpg" width=300>|<img src="https://user-images.githubusercontent.com/14371067/113096952-58b81580-9220-11eb-86cc-5d84a959acb8.jpg" width=300>|

</details>


complex case in multiple_scrollable_overlays branch: https://github.com/2ZeroSix/flutter_android_surface_activity_destroy_bug_example/tree/multiple_scrollable_overlays

<details>
<summary>videos</summary>

## before
https://user-images.githubusercontent.com/14371067/113097470-22c76100-9221-11eb-86c2-bd1d5b11b5cb.mp4 
## after
https://user-images.githubusercontent.com/14371067/113097496-2ce95f80-9221-11eb-8a76-1cb0de4738af.mp4


</details>

*List which issues are fixed by this PR. You must list at least one issue.*
fixes https://github.com/flutter/flutter/issues/79371

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
