### PR TITLE
[doc] EncodableValue:  added dart type mapping in declaration comment

### DIFF
--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -144,6 +144,20 @@ using EncodableValueVariant = std::variant<std::monostate,
 //
 // The order/indexes of the variant types is part of the API surface, and is
 // guaranteed not to change.
+//
+// The variant types are mapped with Dart types in following ways:
+// std::monostate       -> null
+// bool                 -> bool
+// int32_t              -> int
+// int64_t              -> int
+// double               -> double
+// std::string          -> String
+// std::vector<uint8_t> -> Uint8List
+// std::vector<int32_t> -> Int32List
+// std::vector<int64_t> -> Int64List
+// std::vector<double>  -> Float64List
+// EncodableList        -> List
+// EncodableMap         -> Map
 class EncodableValue : public internal::EncodableValueVariant {
  public:
   // Rely on std::variant for most of the constructors/operators.


### PR DESCRIPTION
Added declaration comment section for `EncodableValue` enlisting how variant types will be mapped with Dart types

Closes https://github.com/flutter/flutter/issues/79200

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- ~~I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on writing and running engine tests.~~
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
