### PR TITLE
Make EncodableValue::LongValue const

### DIFF
--- a/shell/platform/common/client_wrapper/encodable_value_unittests.cc
+++ b/shell/platform/common/client_wrapper/encodable_value_unittests.cc
@@ -33,10 +33,10 @@ TEST(EncodableValueTest, Int) {
 
 // Test the int/long convenience wrapper.
 TEST(EncodableValueTest, LongValue) {
-  EncodableValue value(std::numeric_limits<int32_t>::max());
-  EXPECT_EQ(value.LongValue(), std::numeric_limits<int32_t>::max());
-  value = std::numeric_limits<int64_t>::max();
-  EXPECT_EQ(value.LongValue(), std::numeric_limits<int64_t>::max());
+  const EncodableValue int_value(std::numeric_limits<int32_t>::max());
+  EXPECT_EQ(int_value.LongValue(), std::numeric_limits<int32_t>::max());
+  const EncodableValue long_value(std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(long_value.LongValue(), std::numeric_limits<int64_t>::max());
 }
 
 TEST(EncodableValueTest, Long) {

--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -189,7 +189,7 @@ class EncodableValue : public internal::EncodableValueVariant {
   //
   // Calling this method if the value doesn't contain either an int32_t or an
   // int64_t will throw an exception.
-  int64_t LongValue() {
+  int64_t LongValue() const {
     if (std::holds_alternative<int32_t>(*this)) {
       return std::get<int32_t>(*this);
     }


### PR DESCRIPTION
This method doesn't mutate the value of the underlying variant.

Fixes https://github.com/flutter/flutter/issues/79472

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
