### PR TITLE
Clean up small typos in EncodableValue docs

### DIFF
--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -45,7 +45,7 @@ static_assert(sizeof(double) == 8, "EncodableValue requires a 64-bit double");
 // rather than:
 //   EncodableValue(CustomEncodableValue(MyType(...)))
 //
-// For extracting recieved custom types, it is implicitly convertible to
+// For extracting received custom types, it is implicitly convertible to
 // std::any. For example:
 //   const MyType& my_type_value =
 //        std::any_cast<MyType>(std::get<CustomEncodableValue>(value));
@@ -62,7 +62,7 @@ class CustomEncodableValue {
   explicit CustomEncodableValue(const std::any& value) : value_(value) {}
   ~CustomEncodableValue() = default;
 
-  // Allow implict conversion to std::any to allow direct use of any_cast.
+  // Allow implicit conversion to std::any to allow direct use of any_cast.
   operator std::any&() { return value_; }
   operator const std::any&() const { return value_; }
 
@@ -197,9 +197,10 @@ class EncodableValue : public internal::EncodableValueVariant {
   // other types, std::monostate uses aren't self-documenting.
   bool IsNull() const { return std::holds_alternative<std::monostate>(*this); }
 
-  // Convience method to simplify handling objects received from Flutter where
-  // the values may be larger than 32-bit, since they have the same type on the
-  // Dart side, but will be either 32-bit or 64-bit here depending on the value.
+  // Convenience method to simplify handling objects received from Flutter
+  // where the values may be larger than 32-bit, since they have the same type
+  // on the Dart side, but will be either 32-bit or 64-bit here depending on
+  // the value.
   //
   // Calling this method if the value doesn't contain either an int32_t or an
   // int64_t will throw an exception.


### PR DESCRIPTION
Spotted elsewhere in the file while taking a quick pass over 77a2b31
before merging.

No test changes since it only affects docs.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
