### PR TITLE
fuchsia: Handle multiple views in platformViews path

### DIFF
--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -223,13 +223,13 @@ void SceneUpdateContext::UpdateView(int64_t view_id,
 }
 
 void SceneUpdateContext::CreateView(int64_t view_id,
+                                    ViewHolder::ViewIdCallback on_view_created,
                                     bool hit_testable,
                                     bool focusable) {
   FML_LOG(INFO) << "CreateView for view holder: " << view_id;
   zx_handle_t handle = (zx_handle_t)view_id;
-  flutter::ViewHolder::Create(handle, nullptr,
-                              scenic::ToViewHolderToken(zx::eventpair(handle)),
-                              nullptr);
+  flutter::ViewHolder::Create(handle, std::move(on_view_created),
+                              scenic::ToViewHolderToken(zx::eventpair(handle)));
   auto* view_holder = ViewHolder::FromId(view_id);
   FML_DCHECK(view_holder);
 
@@ -250,8 +250,10 @@ void SceneUpdateContext::UpdateView(int64_t view_id,
   view_holder->set_focusable(focusable);
 }
 
-void SceneUpdateContext::DestroyView(int64_t view_id) {
-  ViewHolder::Destroy(view_id);
+void SceneUpdateContext::DestroyView(
+    int64_t view_id,
+    ViewHolder::ViewIdCallback on_view_destroyed) {
+  ViewHolder::Destroy(view_id, std::move(on_view_destroyed));
 }
 
 SceneUpdateContext::Entity::Entity(std::shared_ptr<SceneUpdateContext> context)

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "flutter/flow/embedded_views.h"
+#include "flutter/flow/view_holder.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkRect.h"
@@ -167,9 +168,14 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
     return nullptr;
   }
 
-  void CreateView(int64_t view_id, bool hit_testable, bool focusable);
+  // View manipulation.
+  void CreateView(int64_t view_id,
+                  ViewHolder::ViewIdCallback on_view_created,
+                  bool hit_testable,
+                  bool focusable);
+  void DestroyView(int64_t view_id,
+                   ViewHolder::ViewIdCallback on_view_destroyed);
   void UpdateView(int64_t view_id, bool hit_testable, bool focusable);
-  void DestroyView(int64_t view_id);
   void UpdateView(int64_t view_id,
                   const SkPoint& offset,
                   const SkSize& size,

--- a/flow/view_holder.cc
+++ b/flow/view_holder.cc
@@ -51,9 +51,8 @@ fuchsia::ui::gfx::ViewProperties ToViewProperties(float width,
 namespace flutter {
 
 void ViewHolder::Create(zx_koid_t id,
-                        fml::RefPtr<fml::TaskRunner> ui_task_runner,
-                        fuchsia::ui::views::ViewHolderToken view_holder_token,
-                        const BindCallback& on_bind_callback) {
+                        ViewIdCallback on_view_created,
+                        fuchsia::ui::views::ViewHolderToken view_holder_token) {
   // This raster thread contains at least 1 ViewHolder.  Initialize the
   // per-thread bindings.
   if (tls_view_holder_bindings.get() == nullptr) {
@@ -64,16 +63,20 @@ void ViewHolder::Create(zx_koid_t id,
   FML_DCHECK(bindings);
   FML_DCHECK(bindings->find(id) == bindings->end());
 
-  auto view_holder = std::make_unique<ViewHolder>(std::move(ui_task_runner),
-                                                  std::move(view_holder_token),
-                                                  on_bind_callback);
+  auto view_holder = std::unique_ptr<ViewHolder>(
+      new ViewHolder(std::move(view_holder_token), std::move(on_view_created)));
   bindings->emplace(id, std::move(view_holder));
 }
 
-void ViewHolder::Destroy(zx_koid_t id) {
+void ViewHolder::Destroy(zx_koid_t id, ViewIdCallback on_view_destroyed) {
   auto* bindings = tls_view_holder_bindings.get();
   FML_DCHECK(bindings);
+  auto binding = bindings->find(id);
+  FML_DCHECK(binding != bindings->end());
 
+  if (binding->second->view_holder_) {
+    on_view_destroyed(binding->second->view_holder_->id());
+  }
   bindings->erase(id);
 }
 
@@ -91,12 +94,10 @@ ViewHolder* ViewHolder::FromId(zx_koid_t id) {
   return binding->second.get();
 }
 
-ViewHolder::ViewHolder(fml::RefPtr<fml::TaskRunner> ui_task_runner,
-                       fuchsia::ui::views::ViewHolderToken view_holder_token,
-                       const BindCallback& on_bind_callback)
-    : ui_task_runner_(std::move(ui_task_runner)),
-      pending_view_holder_token_(std::move(view_holder_token)),
-      pending_bind_callback_(on_bind_callback) {
+ViewHolder::ViewHolder(fuchsia::ui::views::ViewHolderToken view_holder_token,
+                       ViewIdCallback on_view_created)
+    : pending_view_holder_token_(std::move(view_holder_token)),
+      on_view_created_(std::move(on_view_created)) {
   FML_DCHECK(pending_view_holder_token_.value);
 }
 
@@ -114,12 +115,13 @@ void ViewHolder::UpdateScene(scenic::Session* session,
     opacity_node_->AddChild(*entity_node_);
     opacity_node_->SetLabel("flutter::ViewHolder");
     entity_node_->Attach(*view_holder_);
-    if (ui_task_runner_ && pending_view_holder_token_.value) {
-      ui_task_runner_->PostTask(
-          [bind_callback = std::move(pending_bind_callback_),
-           view_holder_id = view_holder_->id()]() {
-            bind_callback(view_holder_id);
-          });
+
+    // Inform the rest of Flutter about the view being created.
+    // As long as we do this before calling `Present` on the session,
+    // View-related messages sent to the UI thread will never be processed
+    // before this internal message is delivered to the UI thread.
+    if (on_view_created_) {
+      on_view_created_(view_holder_->id());
     }
   }
   FML_DCHECK(entity_node_);

--- a/lib/ui/compositing/scene_host.h
+++ b/lib/ui/compositing/scene_host.h
@@ -12,6 +12,7 @@
 
 #include "dart-pkg/zircon/sdk_ext/handle.h"
 #include "flutter/fml/memory/ref_counted.h"
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "third_party/tonic/dart_library_natives.h"
@@ -59,7 +60,12 @@ class SceneHost : public RefCountedDartWrappable<SceneHost> {
   tonic::DartPersistentValue view_disconnected_callback_;
   tonic::DartPersistentValue view_state_changed_callback_;
   std::string isolate_service_id_;
+  scenic::ResourceId resource_id_ = 0;
   zx_koid_t koid_ = ZX_KOID_INVALID;
+
+  fml::WeakPtrFactory<SceneHost> weak_factory_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(SceneHost);
 };
 
 }  // namespace flutter

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -13,6 +13,7 @@
 #include <fuchsia/ui/views/cpp/fidl.h>
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/sys/cpp/service_directory.h>
+#include <lib/ui/scenic/cpp/id.h>
 #include <lib/ui/scenic/cpp/view_ref_pair.h>
 #include <lib/zx/event.h>
 
@@ -105,9 +106,12 @@ class Engine final {
   void Terminate();
 
   void DebugWireframeSettingsChanged(bool enabled);
-  void CreateView(int64_t view_id, bool hit_testable, bool focusable);
+  void CreateView(int64_t view_id,
+                  ViewIdCallback on_view_bound,
+                  bool hit_testable,
+                  bool focusable);
   void UpdateView(int64_t view_id, bool hit_testable, bool focusable);
-  void DestroyView(int64_t view_id);
+  void DestroyView(int64_t view_id, ViewIdCallback on_view_unbound);
   std::shared_ptr<flutter::ExternalViewEmbedder> GetExternalViewEmbedder();
 
   std::unique_ptr<flutter::Surface> CreateSurface();

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_FUCHSIA_EXTERNAL_VIEW_EMBEDDER_H_
 
 #include <fuchsia/ui/views/cpp/fidl.h>
+#include <lib/ui/scenic/cpp/id.h>
 #include <lib/ui/scenic/cpp/resources.h>
 #include <lib/ui/scenic/cpp/view_ref_pair.h>
 
@@ -29,6 +30,8 @@
 #include "vulkan_surface_producer.h"
 
 namespace flutter_runner {
+
+using ViewIdCallback = std::function<void(scenic::ResourceId)>;
 
 // This class orchestrates interaction with the Scenic compositor on Fuchsia. It
 // ensures that flutter content and platform view content are both rendered
@@ -89,8 +92,8 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
   // |SetViewProperties| doesn't manipulate the view directly -- it sets pending
   // properties for the next |UpdateView| call.
   void EnableWireframe(bool enable);
-  void CreateView(int64_t view_id);
-  void DestroyView(int64_t view_id);
+  void CreateView(int64_t view_id, ViewIdCallback on_view_bound);
+  void DestroyView(int64_t view_id, ViewIdCallback on_view_unbound);
   void SetViewProperties(int64_t view_id, bool hit_testable, bool focusable);
 
  private:


### PR DESCRIPTION
The new platformViews path we are introducing for Fuchsia is not able to handle multiple platform views at once.  This PR fixes that and enables proper view IDs with platform_view channel events.

Fixes: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=71337
