### PR TITLE
Rename EngineEmbedderApiModifier to EngineModifier

### DIFF
--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -216,7 +216,7 @@ executable("flutter_windows_unittests") {
     # "flutter_windows_engine_unittests.cc", //TODO failing to send / receive platform message get plugins working first.  Blocked on https://github.com/flutter/flutter/issues/74155
     "string_conversion_unittests.cc",
     "system_utils_unittests.cc",
-    "testing/engine_embedder_api_modifier.h",
+    "testing/engine_modifier.h",
   ]
 
   # Target-specific sources.

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -8,7 +8,7 @@
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 #include "flutter/shell/platform/windows/keyboard_key_channel_handler.h"
 #include "flutter/shell/platform/windows/keyboard_key_handler.h"
-#include "flutter/shell/platform/windows/testing/engine_embedder_api_modifier.h"
+#include "flutter/shell/platform/windows/testing/engine_modifier.h"
 #include "flutter/shell/platform/windows/testing/flutter_window_win32_test.h"
 #include "flutter/shell/platform/windows/testing/mock_window_binding_handler.h"
 #include "flutter/shell/platform/windows/text_input_plugin.h"
@@ -247,7 +247,7 @@ std::unique_ptr<FlutterWindowsEngine> GetTestEngine() {
   FlutterProjectBundle project(properties);
   auto engine = std::make_unique<FlutterWindowsEngine>(project);
 
-  EngineEmbedderApiModifier modifier(engine.get());
+  EngineModifier modifier(engine.get());
   // Force the non-AOT path unless overridden by the test.
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
 

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -140,7 +140,7 @@ class FlutterWindowsEngine {
 
  private:
   // Allows swapping out embedder_api_ calls in tests.
-  friend class EngineEmbedderApiModifier;
+  friend class EngineModifier;
 
   // Sends system settings (e.g., locale) to the engine.
   //

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -6,7 +6,7 @@
 
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
-#include "flutter/shell/platform/windows/testing/engine_embedder_api_modifier.h"
+#include "flutter/shell/platform/windows/testing/engine_modifier.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
@@ -22,7 +22,7 @@ std::unique_ptr<FlutterWindowsEngine> GetTestEngine() {
   FlutterProjectBundle project(properties);
   auto engine = std::make_unique<FlutterWindowsEngine>(project);
 
-  EngineEmbedderApiModifier modifier(engine.get());
+  EngineModifier modifier(engine.get());
   // Force the non-AOT path unless overridden by the test.
   modifier.embedder_api().RunsAOTCompiledDartCode = []() { return false; };
 
@@ -32,7 +32,7 @@ std::unique_ptr<FlutterWindowsEngine> GetTestEngine() {
 
 TEST(FlutterWindowsEngine, RunDoesExpectedInitialization) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
-  EngineEmbedderApiModifier modifier(engine.get());
+  EngineModifier modifier(engine.get());
 
   // The engine should be run with expected configuration values.
   bool run_called = false;
@@ -103,7 +103,7 @@ TEST(FlutterWindowsEngine, RunDoesExpectedInitialization) {
 
 TEST(FlutterWindowsEngine, RunWithoutANGLEUsesSoftware) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
-  EngineEmbedderApiModifier modifier(engine.get());
+  EngineModifier modifier(engine.get());
 
   // The engine should be run with expected configuration values.
   bool run_called = false;
@@ -142,7 +142,7 @@ TEST(FlutterWindowsEngine, RunWithoutANGLEUsesSoftware) {
 
 TEST(FlutterWindowsEngine, SendPlatformMessageWithoutResponse) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
-  EngineEmbedderApiModifier modifier(engine.get());
+  EngineModifier modifier(engine.get());
 
   const char* channel = "test";
   const std::vector<uint8_t> test_message = {1, 2, 3, 4};
@@ -168,7 +168,7 @@ TEST(FlutterWindowsEngine, SendPlatformMessageWithoutResponse) {
 
 TEST(FlutterWindowsEngine, SendPlatformMessageWithResponse) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
-  EngineEmbedderApiModifier modifier(engine.get());
+  EngineModifier modifier(engine.get());
 
   const char* channel = "test";
   const std::vector<uint8_t> test_message = {1, 2, 3, 4};

--- a/shell/platform/windows/flutter_windows_texture_registrar_unittests.cc
+++ b/shell/platform/windows/flutter_windows_texture_registrar_unittests.cc
@@ -7,7 +7,7 @@
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 #include "flutter/shell/platform/windows/flutter_windows_texture_registrar.h"
-#include "flutter/shell/platform/windows/testing/engine_embedder_api_modifier.h"
+#include "flutter/shell/platform/windows/testing/engine_modifier.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
@@ -35,7 +35,7 @@ TEST(FlutterWindowsTextureRegistrarTest, CreateDestroy) {
 
 TEST(FlutterWindowsTextureRegistrarTest, RegisterUnregisterTexture) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
-  EngineEmbedderApiModifier modifier(engine.get());
+  EngineModifier modifier(engine.get());
 
   FlutterWindowsTextureRegistrar registrar(engine.get());
 
@@ -90,7 +90,7 @@ TEST(FlutterWindowsTextureRegistrarTest, RegisterUnregisterTexture) {
 
 TEST(FlutterWindowsTextureRegistrarTest, RegisterUnknownTextureType) {
   std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
-  EngineEmbedderApiModifier modifier(engine.get());
+  EngineModifier modifier(engine.get());
 
   FlutterWindowsTextureRegistrar registrar(engine.get());
 

--- a/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler_unittests.cc
@@ -9,7 +9,7 @@
 
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
-#include "flutter/shell/platform/windows/testing/engine_embedder_api_modifier.h"
+#include "flutter/shell/platform/windows/testing/engine_modifier.h"
 #include "gtest/gtest.h"
 
 namespace flutter {

--- a/shell/platform/windows/testing/engine_modifier.h
+++ b/shell/platform/windows/testing/engine_modifier.h
@@ -12,10 +12,9 @@ namespace flutter {
 // This simply provides a way to access the normally-private embedder proc
 // table, so the lifetime of any changes made to the proc table is that of the
 // engine object, not this helper.
-class EngineEmbedderApiModifier {
+class EngineModifier {
  public:
-  explicit EngineEmbedderApiModifier(FlutterWindowsEngine* engine)
-      : engine_(engine) {}
+  explicit EngineModifier(FlutterWindowsEngine* engine) : engine_(engine) {}
 
   // Returns the engine's embedder API proc table, allowing for modification.
   //


### PR DESCRIPTION
Just a quick rename as it doesn't just handle the Embedder API proctable