### PR TITLE
[web] Fix framework material text field tests

### DIFF
--- a/lib/web_ui/lib/src/engine/text/layout_service.dart
+++ b/lib/web_ui/lib/src/engine/text/layout_service.dart
@@ -298,19 +298,6 @@ class TextLayoutService {
     // it possible to do hit testing. Once we find the box, we look inside that
     // box to find where exactly the `offset` is located.
 
-    // [offset] is above all the lines.
-    if (offset.dy < 0) {
-      return ui.TextPosition(offset: 0, affinity: ui.TextAffinity.downstream);
-    }
-
-    // [offset] is below all the lines.
-    if (offset.dy >= paragraph.height) {
-      return ui.TextPosition(
-        offset: paragraph.toPlainText().length,
-        affinity: ui.TextAffinity.upstream,
-      );
-    }
-
     final EngineLineMetrics line = _findLineForY(offset.dy);
     // [offset] is to the left of the line.
     if (offset.dx <= line.left) {
@@ -773,13 +760,6 @@ class LineBuilder {
 
   /// Extends the line by setting a [newEnd].
   void extendTo(LineBreakResult newEnd) {
-    // If the current end of the line is a hard break, the line shouldn't be
-    // extended any further.
-    assert(
-      isEmpty || !end.isHard || _isLastBoxAPlaceholder,
-      'Cannot extend a line that ends with a hard break.',
-    );
-
     ascent = math.max(ascent, spanometer.ascent);
     descent = math.max(descent, spanometer.descent);
 

--- a/lib/web_ui/test/text/canvas_paragraph_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_test.dart
@@ -320,7 +320,7 @@ void testMain() async {
       })
         ..layout(constrain(double.infinity));
 
-      // Above the line.
+      // Above the line, at the beginning.
       expect(
         paragraph.getPositionForOffset(ui.Offset(0, -5)),
         pos(0, ui.TextAffinity.downstream),
@@ -335,9 +335,9 @@ void testMain() async {
         paragraph.getPositionForOffset(ui.Offset(0, 5)),
         pos(0, ui.TextAffinity.downstream),
       );
-      // Below the line.
+      // Below the line, at the end.
       expect(
-        paragraph.getPositionForOffset(ui.Offset(0, 12)),
+        paragraph.getPositionForOffset(ui.Offset(130, 12)),
         pos(13, ui.TextAffinity.upstream),
       );
       // At the end of the line.
@@ -348,6 +348,16 @@ void testMain() async {
       // On the left half of "p" in "ipsum".
       expect(
         paragraph.getPositionForOffset(ui.Offset(74, 5)),
+        pos(7, ui.TextAffinity.downstream),
+      );
+      // On the left half of "p" in "ipsum" (above the line).
+      expect(
+        paragraph.getPositionForOffset(ui.Offset(74, -5)),
+        pos(7, ui.TextAffinity.downstream),
+      );
+      // On the left half of "p" in "ipsum" (below the line).
+      expect(
+        paragraph.getPositionForOffset(ui.Offset(74, 15)),
         pos(7, ui.TextAffinity.downstream),
       );
       // On the right half of "p" in "ipsum".
@@ -378,7 +388,7 @@ void testMain() async {
       //   "ipsum "
       //   "dolor sit"
 
-      // Above the first line.
+      // Above the first line, at the beginning.
       expect(
         paragraph.getPositionForOffset(ui.Offset(0, -5)),
         pos(0, ui.TextAffinity.downstream),
@@ -396,6 +406,11 @@ void testMain() async {
       // At the end of the first line.
       expect(
         paragraph.getPositionForOffset(ui.Offset(60, 5)),
+        pos(6, ui.TextAffinity.upstream),
+      );
+      // At the end of the first line (above the line).
+      expect(
+        paragraph.getPositionForOffset(ui.Offset(60, -5)),
         pos(6, ui.TextAffinity.upstream),
       );
       // After the end of the first line to the right.
@@ -430,9 +445,9 @@ void testMain() async {
         pos(12, ui.TextAffinity.upstream),
       );
 
-      // Below the third line "dolor sit".
+      // Below the third line "dolor sit", at the end.
       expect(
-        paragraph.getPositionForOffset(ui.Offset(0, 40)),
+        paragraph.getPositionForOffset(ui.Offset(90, 40)),
         pos(21, ui.TextAffinity.upstream),
       );
       // At the end of the third line.
@@ -473,7 +488,7 @@ void testMain() async {
       //   "ipsum "
       //   "dolor sit"
 
-      // Above the first line.
+      // Above the first line, at the beginning.
       expect(
         paragraph.getPositionForOffset(ui.Offset(0, -5)),
         pos(0, ui.TextAffinity.downstream),
@@ -520,9 +535,9 @@ void testMain() async {
         pos(12, ui.TextAffinity.upstream),
       );
 
-      // Below the third line "dolor sit".
+      // Below the third line "dolor sit", at the end.
       expect(
-        paragraph.getPositionForOffset(ui.Offset(0, 40)),
+        paragraph.getPositionForOffset(ui.Offset(90, 40)),
         pos(21, ui.TextAffinity.upstream),
       );
       // At the end of the third line.

--- a/lib/web_ui/test/text/layout_service_rich_test.dart
+++ b/lib/web_ui/test/text/layout_service_rich_test.dart
@@ -42,6 +42,21 @@ void main() {
 void testMain() async {
   await ui.webOnlyInitializeTestDomRenderer();
 
+  test('does not crash on empty spans', () {
+    final CanvasParagraph paragraph = rich(ahemStyle, (builder) {
+      builder.pushStyle(EngineTextStyle.only(color: blue));
+      builder.addText('');
+
+      builder.pushStyle(EngineTextStyle.only(color: red));
+      builder.addText('Lorem ipsum');
+
+      builder.pushStyle(EngineTextStyle.only(color: green));
+      builder.addText('');
+    });
+
+    expect(() => paragraph.layout(constrain(double.infinity)), returnsNormally);
+  });
+
   test('measures spans in the same line correctly', () {
     final CanvasParagraph paragraph = rich(ahemStyle, (builder) {
       builder.pushStyle(EngineTextStyle.only(fontSize: 12.0));


### PR DESCRIPTION
This PR does two things, to fix material text field tests in the framework:

### 1. Handling clicks above/below the paragraph
When a click is received above the paragraph, we used to return the beginning of the paragraph as the result position. But Flutter does this slightly differently.

Example: for the string "Lorem ipsum", if the user clicks between "i" and "p", the cursor is placed between "i" and "p". This has always been fine. But if the user clicks between "i" and "p" on the X axis, but above the text on the Y axis, the web engine used to place the cursor at the beginning of the paragraph (at position 0). This will now be fixed so it places the cursor between "i" and "p".

### 2. Assertions
The assertion in the `extendTo` method was supposed to help catch mistake in the layout algorithm. But so far it has caused more harm than good. So I'm removing it instead of adding more and more edge cases to it.

Related issue: https://github.com/flutter/flutter/issues/79070