### PR TITLE
Call CreateRenderSurface() after setting the Engine for a View on UWP

### DIFF
--- a/shell/platform/windows/flutter_windows_winuwp.cc
+++ b/shell/platform/windows/flutter_windows_winuwp.cc
@@ -35,11 +35,10 @@ FlutterDesktopViewControllerCreateFromCoreWindow(
   auto state = std::make_unique<FlutterDesktopViewControllerState>();
   state->view =
       std::make_unique<flutter::FlutterWindowsView>(std::move(window_wrapper));
-  state->view->CreateRenderSurface();
-
   // Take ownership of the engine, starting it if necessary.
   state->view->SetEngine(
       std::unique_ptr<flutter::FlutterWindowsEngine>(EngineFromHandle(engine)));
+  state->view->CreateRenderSurface();
   if (!state->view->GetEngine()->running()) {
     if (!state->view->GetEngine()->RunWithEntrypoint(nullptr)) {
       return nullptr;


### PR DESCRIPTION
Fixes an issue for Windows UWP where it would fail to initialise after https://github.com/flutter/flutter/issues/76132 was fixed for Win32.

No tests as we don't currently have a test harness for UWP - filed https://github.com/flutter/flutter/issues/79585 to track this.