### PR TITLE
fuchsia: Reliably pass View insets

### DIFF
--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -206,17 +206,12 @@ void SceneUpdateContext::UpdateView(int64_t view_id,
     return;
   }
 
-  if (size.width() > 0.f && size.height() > 0.f) {
-    view_holder->SetProperties(size.width(), size.height(), 0, 0, 0, 0,
-                               view_holder->focusable());
+  if (override_hit_testable.has_value()) {
+    view_holder->set_hit_testable(*override_hit_testable);
   }
-
-  bool hit_testable = override_hit_testable.has_value()
-                          ? *override_hit_testable
-                          : view_holder->hit_testable();
+  view_holder->set_size(size);
   view_holder->UpdateScene(session_.get(), top_entity_->embedder_node(), offset,
-                           size, SkScalarRoundToInt(alphaf() * 255),
-                           hit_testable);
+                           SkScalarRoundToInt(alphaf() * 255));
 
   // Assume embedded views are 10 "layers" wide.
   next_elevation_ += 10 * kScenicZElevationBetweenLayers;
@@ -238,6 +233,7 @@ void SceneUpdateContext::CreateView(int64_t view_id,
 }
 
 void SceneUpdateContext::UpdateView(int64_t view_id,
+                                    const SkRect& view_occlusion_hint,
                                     bool hit_testable,
                                     bool focusable) {
   auto* view_holder = ViewHolder::FromId(view_id);
@@ -248,6 +244,7 @@ void SceneUpdateContext::UpdateView(int64_t view_id,
 
   view_holder->set_hit_testable(hit_testable);
   view_holder->set_focusable(focusable);
+  view_holder->set_occlusion_hint(view_occlusion_hint);
 }
 
 void SceneUpdateContext::DestroyView(

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -175,7 +175,10 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
                   bool focusable);
   void DestroyView(int64_t view_id,
                    ViewHolder::ViewIdCallback on_view_destroyed);
-  void UpdateView(int64_t view_id, bool hit_testable, bool focusable);
+  void UpdateView(int64_t view_id,
+                  const SkRect& view_occlusion_hint,
+                  bool hit_testable,
+                  bool focusable);
   void UpdateView(int64_t view_id,
                   const SkPoint& offset,
                   const SkSize& size,

--- a/flow/view_holder.h
+++ b/flow/view_holder.h
@@ -19,6 +19,7 @@
 #include "flutter/fml/task_runner.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "third_party/skia/include/core/SkPoint.h"
+#include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkSize.h"
 
 namespace flutter {
@@ -45,7 +46,7 @@ class ViewHolder {
 
   ~ViewHolder() = default;
 
-  // Sets the properties/opacity of the child view by issuing a Scenic command.
+  // Sets the properties of the child view by issuing a Scenic command.
   void SetProperties(double width,
                      double height,
                      double insetTop,
@@ -59,15 +60,14 @@ class ViewHolder {
   void UpdateScene(scenic::Session* session,
                    scenic::ContainerNode& container_node,
                    const SkPoint& offset,
-                   const SkSize& size,
-                   SkAlpha opacity,
-                   bool hit_testable);
+                   SkAlpha opacity);
 
-  bool hit_testable() { return hit_testable_; }
-  void set_hit_testable(bool value) { hit_testable_ = value; }
-
-  bool focusable() { return focusable_; }
-  void set_focusable(bool value) { focusable_ = value; }
+  // Alters various apsects of the ViewHolder's ViewProperties.  The updates
+  // are applied to Scenic on the new |UpdateScene| call.
+  void set_hit_testable(bool value);
+  void set_focusable(bool value);
+  void set_size(const SkSize& size);
+  void set_occlusion_hint(const SkRect& occlusion_hint);
 
  private:
   ViewHolder(fuchsia::ui::views::ViewHolderToken view_holder_token,
@@ -78,14 +78,11 @@ class ViewHolder {
   std::unique_ptr<scenic::ViewHolder> view_holder_;
 
   fuchsia::ui::views::ViewHolderToken pending_view_holder_token_;
-
-  bool hit_testable_ = true;
-  bool focusable_ = true;
-
   ViewIdCallback on_view_created_;
 
-  fuchsia::ui::gfx::ViewProperties pending_properties_;
-  bool has_pending_properties_ = false;
+  fuchsia::ui::gfx::HitTestBehavior hit_test_behavior_ =
+      fuchsia::ui::gfx::HitTestBehavior::kDefault;
+  fuchsia::ui::gfx::ViewProperties view_properties_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ViewHolder);
 };

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -180,9 +180,9 @@ Engine::Engine(Delegate& delegate,
       &Engine::CreateView, this, std::placeholders::_1, std::placeholders::_2,
       std::placeholders::_3, std::placeholders::_4);
 
-  OnUpdateView on_update_view_callback =
-      std::bind(&Engine::UpdateView, this, std::placeholders::_1,
-                std::placeholders::_2, std::placeholders::_3);
+  OnUpdateView on_update_view_callback = std::bind(
+      &Engine::UpdateView, this, std::placeholders::_1, std::placeholders::_2,
+      std::placeholders::_3, std::placeholders::_4);
 
   OnDestroyView on_destroy_view_callback = std::bind(
       &Engine::DestroyView, this, std::placeholders::_1, std::placeholders::_2);
@@ -600,28 +600,31 @@ void Engine::CreateView(int64_t view_id,
           FML_CHECK(external_view_embedder_);
           external_view_embedder_->CreateView(view_id,
                                               std::move(on_view_bound));
-          external_view_embedder_->SetViewProperties(view_id, hit_testable,
-                                                     focusable);
+          external_view_embedder_->SetViewProperties(
+              view_id, SkRect::MakeEmpty(), hit_testable, focusable);
         }
       });
 }
 
-void Engine::UpdateView(int64_t view_id, bool hit_testable, bool focusable) {
+void Engine::UpdateView(int64_t view_id,
+                        SkRect occlusion_hint,
+                        bool hit_testable,
+                        bool focusable) {
   FML_CHECK(shell_);
 
   shell_->GetTaskRunners().GetRasterTaskRunner()->PostTask(
-      [this, view_id, hit_testable, focusable]() {
+      [this, view_id, occlusion_hint, hit_testable, focusable]() {
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
         if (use_legacy_renderer_) {
           FML_CHECK(legacy_external_view_embedder_);
-          legacy_external_view_embedder_->UpdateView(view_id, hit_testable,
-                                                     focusable);
+          legacy_external_view_embedder_->UpdateView(view_id, occlusion_hint,
+                                                     hit_testable, focusable);
         } else
 #endif
         {
           FML_CHECK(external_view_embedder_);
-          external_view_embedder_->SetViewProperties(view_id, hit_testable,
-                                                     focusable);
+          external_view_embedder_->SetViewProperties(view_id, occlusion_hint,
+                                                     hit_testable, focusable);
         }
       });
 }

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -110,8 +110,12 @@ class Engine final {
                   ViewIdCallback on_view_bound,
                   bool hit_testable,
                   bool focusable);
-  void UpdateView(int64_t view_id, bool hit_testable, bool focusable);
+  void UpdateView(int64_t view_id,
+                  SkRect occlusion_hint,
+                  bool hit_testable,
+                  bool focusable);
   void DestroyView(int64_t view_id, ViewIdCallback on_view_unbound);
+
   std::shared_ptr<flutter::ExternalViewEmbedder> GetExternalViewEmbedder();
 
   std::unique_ptr<flutter::Surface> CreateSurface();

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
@@ -23,6 +23,7 @@
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 #include "third_party/skia/include/core/SkPoint.h"
+#include "third_party/skia/include/core/SkRect.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 
@@ -94,7 +95,10 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
   void EnableWireframe(bool enable);
   void CreateView(int64_t view_id, ViewIdCallback on_view_bound);
   void DestroyView(int64_t view_id, ViewIdCallback on_view_unbound);
-  void SetViewProperties(int64_t view_id, bool hit_testable, bool focusable);
+  void SetViewProperties(int64_t view_id,
+                         const SkRect& occlusion_hint,
+                         bool hit_testable,
+                         bool focusable);
 
  private:
   // Reset state for a new frame.
@@ -124,13 +128,15 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
     SkPoint offset = SkPoint::Make(0.f, 0.f);
     SkSize scale = SkSize::MakeEmpty();
     SkSize size = SkSize::MakeEmpty();
+    SkRect occlusion_hint = SkRect::MakeEmpty();
     float elevation = 0.f;
     float opacity = 1.f;
-    bool hit_testable = false;
-    bool focusable = false;
+    bool hit_testable = true;
+    bool focusable = true;
 
-    bool pending_hit_testable = false;
-    bool pending_focusable = false;
+    SkRect pending_occlusion_hint = SkRect::MakeEmpty();
+    bool pending_hit_testable = true;
+    bool pending_focusable = true;
   };
 
   struct ScenicLayer {

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -30,7 +30,7 @@ namespace flutter_runner {
 
 using OnEnableWireframe = fit::function<void(bool)>;
 using OnCreateView = fit::function<void(int64_t, ViewIdCallback, bool, bool)>;
-using OnUpdateView = fit::function<void(int64_t, bool, bool)>;
+using OnUpdateView = fit::function<void(int64_t, SkRect, bool, bool)>;
 using OnDestroyView = fit::function<void(int64_t, ViewIdCallback)>;
 using OnCreateSurface = fit::function<std::unique_ptr<flutter::Surface>()>;
 

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -597,7 +597,7 @@ TEST_F(PlatformViewTests, CreateViewTest) {
   // Test wireframe callback function. If the message sent to the platform
   // view was properly handled and parsed, this function should be called,
   // setting |wireframe_enabled| to true.
-  int64_t create_view_called = false;
+  bool create_view_called = false;
   auto CreateViewCallback = [&create_view_called](
                                 int64_t view_id,
                                 flutter_runner::ViewIdCallback on_view_bound,
@@ -651,9 +651,10 @@ TEST_F(PlatformViewTests, UpdateViewTest) {
   // Test wireframe callback function. If the message sent to the platform
   // view was properly handled and parsed, this function should be called,
   // setting |wireframe_enabled| to true.
-  int64_t update_view_called = false;
+  bool update_view_called = false;
   auto UpdateViewCallback = [&update_view_called](
-                                int64_t view_id, bool hit_testable,
+                                int64_t view_id, SkRect occlusion_hint,
+                                bool hit_testable,
                                 bool focusable) { update_view_called = true; };
 
   flutter_runner::PlatformView platform_view =
@@ -707,7 +708,7 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
   // Test wireframe callback function. If the message sent to the platform
   // view was properly handled and parsed, this function should be called,
   // setting |wireframe_enabled| to true.
-  int64_t destroy_view_called = false;
+  bool destroy_view_called = false;
   auto DestroyViewCallback =
       [&destroy_view_called](int64_t view_id,
                              flutter_runner::ViewIdCallback on_view_unbound) {


### PR DESCRIPTION
This CL allows view insets / occlusion hint to be set from Dart code with both legacy and platform views paths.

The legacy View code has some confusing code-paths, and this results in it always stomping the view insets with 0's.  Fix this bug, and make the ViewHolder's properties write-only to avoid confusion like this in the future.

Second, add support for setting the occlusion hint to the new embedder renderer and new platform views path.  This requires parsing the occlusion hint from the "View.update" message and plumbing it through.  

Fixes: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=73596
