### PR TITLE
Tried to get iosurfaces deleting at more appropriate times

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -53,16 +53,18 @@ Animator::Animator(Delegate& delegate,
 
 Animator::~Animator() = default;
 
-void Animator::Stop() {
+void Animator::Pause() {
   paused_ = true;
+  waiter_->Pause();
 }
 
-void Animator::Start() {
+void Animator::Unpause() {
   if (!paused_) {
     return;
   }
 
   paused_ = false;
+  waiter_->Unpause();
   RequestFrame();
 }
 

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -69,9 +69,9 @@ class Animator final {
   void ScheduleSecondaryVsyncCallback(uintptr_t id,
                                       const fml::closure& callback);
 
-  void Start();
+  void Pause();
 
-  void Stop();
+  void Unpause();
 
   void SetDimensionChangePending();
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -259,13 +259,13 @@ tonic::DartErrorHandleType Engine::GetUIIsolateLastError() {
 
 void Engine::OnOutputSurfaceCreated() {
   have_surface_ = true;
-  StartAnimatorIfPossible();
+  UnpauseAnimatorIfPossible();
   ScheduleFrame();
 }
 
 void Engine::OnOutputSurfaceDestroyed() {
   have_surface_ = false;
-  StopAnimator();
+  PauseAnimator();
 }
 
 void Engine::SetViewportMetrics(const ViewportMetrics& metrics) {
@@ -319,11 +319,11 @@ bool Engine::HandleLifecyclePlatformMessage(PlatformMessage* message) {
   if (state == "AppLifecycleState.paused" ||
       state == "AppLifecycleState.detached") {
     activity_running_ = false;
-    StopAnimator();
+    PauseAnimator();
   } else if (state == "AppLifecycleState.resumed" ||
              state == "AppLifecycleState.inactive") {
     activity_running_ = true;
-    StartAnimatorIfPossible();
+    UnpauseAnimatorIfPossible();
   }
 
   // Always schedule a frame when the app does become active as per API
@@ -437,14 +437,16 @@ void Engine::SetAccessibilityFeatures(int32_t flags) {
   runtime_controller_->SetAccessibilityFeatures(flags);
 }
 
-void Engine::StopAnimator() {
-  animator_->Stop();
+void Engine::PauseAnimator() {
+  animator_->Pause();
 }
 
-void Engine::StartAnimatorIfPossible() {
+bool Engine::UnpauseAnimatorIfPossible() {
   if (activity_running_ && have_surface_) {
-    animator_->Start();
+    animator_->Unpause();
+    return true;
   }
+  return false;
 }
 
 std::string Engine::DefaultRouteName() {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -948,9 +948,9 @@ class Engine final : public RuntimeDelegate,
 
   void SetNeedsReportTimings(bool value) override;
 
-  void StopAnimator();
+  void PauseAnimator();
 
-  void StartAnimatorIfPossible();
+  bool UnpauseAnimatorIfPossible();
 
   bool HandleLifecyclePlatformMessage(PlatformMessage* message);
 

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -479,7 +479,7 @@ class PlatformView {
   ///             rendered before this call. The surface must remain valid till
   ///             the corresponding call to NotifyDestroyed.
   ///
-  void NotifyCreated();
+  virtual void NotifyCreated();
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedders to notify the shell that the platform view

--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -32,6 +32,10 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
   /// |Animator::ScheduleMaybeClearTraceFlowIds|.
   void ScheduleSecondaryCallback(uintptr_t id, const fml::closure& callback);
 
+  virtual void Pause() {}
+
+  virtual void Unpause() {}
+
  protected:
   // On some backends, the |FireCallback| needs to be made from a static C
   // method.

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -667,6 +667,7 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
   if (UIApplication.sharedApplication.applicationState == UIApplicationStateActive) {
     [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
   }
+
   [super viewDidAppear:animated];
 }
 
@@ -685,6 +686,8 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
     [self flushOngoingTouches];
     [_engine.get() notifyLowMemory];
   }
+
+  //[[NSNotificationCenter defaultCenter] postNotificationName:@"FlutterInvalidateDisplayLink" object:nil];
 
   [super viewDidDisappear:animated];
 }

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -44,8 +44,13 @@ class VsyncWaiterIOS final : public VsyncWaiter {
 
   ~VsyncWaiterIOS() override;
 
+  void Pause() override;
+
+  void Unpause() override;
+
  private:
   fml::scoped_nsobject<VSyncClient> client_;
+  fml::RefPtr<fml::TaskRunner> task_runner_;
 
   // |VsyncWaiter|
   void AwaitVSync() override;

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -172,6 +172,12 @@ class PlatformViewIOS final : public PlatformView {
   std::unique_ptr<std::vector<std::string>> ComputePlatformResolvedLocales(
       const std::vector<std::string>& supported_locale_data) override;
 
+  // |PlatformView|
+  void NotifyCreated() override;
+
+  // |PlatformView|
+  void NotifyDestroyed() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewIOS);
 };
 

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -82,11 +82,13 @@ fml::WeakPtr<FlutterViewController> PlatformViewIOS::GetOwnerViewController() co
 
 void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController> owner_controller) {
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
-  std::lock_guard<std::mutex> guard(ios_surface_mutex_);
-  if (ios_surface_ || !owner_controller) {
+  bool should_destroy;
+  {
+    std::lock_guard<std::mutex> guard(ios_surface_mutex_);
+    should_destroy = ios_surface_ || !owner_controller;
+  }
+  if (should_destroy) {
     NotifyDestroyed();
-    ios_surface_.reset();
-    accessibility_bridge_.reset();
   }
   owner_controller_ = owner_controller;
 
@@ -259,6 +261,26 @@ void PlatformViewIOS::ScopedObserver::reset(id<NSObject> observer) {
       [observer_ release];
     }
     observer_ = observer;
+  }
+}
+
+void PlatformViewIOS::NotifyCreated() {
+  {
+    std::lock_guard<std::mutex> guard(ios_surface_mutex_);
+    if (!ios_surface_ && owner_controller_ && [owner_controller_.get() isViewLoaded]) {
+      this->attachView();
+    }
+  }
+  PlatformView::NotifyCreated();
+}
+
+void PlatformViewIOS::NotifyDestroyed() {
+  FML_LOG(ERROR) << "foobar: NotifyDestroyed";
+  PlatformView::NotifyDestroyed();
+  std::lock_guard<std::mutex> guard(ios_surface_mutex_);
+  if (ios_surface_) {
+    ios_surface_.reset();
+    accessibility_bridge_.reset();
   }
 }
 


### PR DESCRIPTION
Tried to get iosurfaces deleting at more appropriate times by clearing out the PlatformViewIOS and invalidating the display link when
viewDidDisappear happens.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
