### PR TITLE
Eliminate error message for missing CMAP table

### DIFF
--- a/third_party/txt/src/minikin/FontFamily.cpp
+++ b/third_party/txt/src/minikin/FontFamily.cpp
@@ -181,7 +181,8 @@ void FontFamily::computeCoverage() {
   const uint32_t cmapTag = MinikinFont::MakeTag('c', 'm', 'a', 'p');
   HbBlob cmapTable(getFontTable(typeface, cmapTag));
   if (cmapTable.get() == nullptr) {
-    ALOGE("Could not get cmap table size!\n");
+    // Missing or corrupt font cmap table; bail out.
+    // The cmap table maps charcodes to glyph indices in a font.
     return;
   }
   mCoverage = CmapCoverage::getCoverage(cmapTable.get(), cmapTable.size(),


### PR DESCRIPTION
CMAP tables are a component of fonts which map character codes to glyph
indices used in the font. In cases where this is missing/corrupt for a font
that we attempt to load, there is not much gained by logging this. It's also
a common source of false positive bug reports, or misleading log messages.

Instead of logging the error, simply suppress it, since it's not
actionable by the user.

No new test since this simply suppresses a log message but does
not affect logic otherwise.

CMAP Reference:
https://docs.microsoft.com/en-us/typography/opentype/spec/cmap

Fixes https://github.com/flutter/flutter/issues/78929

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
