### PR TITLE
Update FlutterFragment to implement ComponentCallbacks2.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -5,6 +5,7 @@
 package io.flutter.embedding.android;
 
 import android.app.Activity;
+import android.content.ComponentCallbacks2;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
@@ -35,7 +36,6 @@ import io.flutter.plugin.platform.PlatformPlugin;
  *   <li>{@link #onRequestPermissionsResult(int, String[], int[])} ()}
  *   <li>{@link #onNewIntent(Intent)} ()}
  *   <li>{@link #onUserLeaveHint()}
- *   <li>{@link #onTrimMemory(int)}
  * </ol>
  *
  * Additionally, when starting an {@code Activity} for a result from this {@code Fragment}, be sure
@@ -81,7 +81,8 @@ import io.flutter.plugin.platform.PlatformPlugin;
  * FlutterView}. Using a {@link FlutterView} requires forwarding some calls from an {@code
  * Activity}, as well as forwarding lifecycle calls from an {@code Activity} or a {@code Fragment}.
  */
-public class FlutterFragment extends Fragment implements FlutterActivityAndFragmentDelegate.Host {
+public class FlutterFragment extends Fragment
+    implements FlutterActivityAndFragmentDelegate.Host, ComponentCallbacks2 {
   private static final String TAG = "FlutterFragment";
 
   /** The Dart entrypoint method name that is executed upon initialization. */
@@ -791,7 +792,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
    *
    * @param level level
    */
-  @ActivityCallThrough
+  @Override
   public void onTrimMemory(int level) {
     if (stillAttachedForEvent("onTrimMemory")) {
       delegate.onTrimMemory(level);


### PR DESCRIPTION
This avoids the need for clients to call through to onTrimMemory. Fragment already implements ComponentCallbacks, so this is all that's needed for everything to just work.

*List which issues are fixed by this PR. You must list at least one issue.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
