### PR TITLE
Allow embedders to set a custom log tag

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -962,6 +962,9 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
       callback(tag.c_str(), message.c_str(), user_data);
     };
   }
+  if (SAFE_ACCESS(args, log_tag, nullptr) != nullptr) {
+    settings.log_tag = SAFE_ACCESS(args, log_tag, nullptr);
+  }
 
   flutter::PlatformViewEmbedder::UpdateSemanticsNodesCallback
       update_semantics_nodes_callback = nullptr;

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1513,6 +1513,13 @@ typedef struct {
   // thread and embedders must re-thread if necessary. Performing blocking calls
   // in this callback may introduce application jank.
   FlutterLogMessageCallback log_message_callback;
+
+  // A tag string associated with application log messages.
+  //
+  // A log message tag string that can be used convey application, subsystem,
+  // or component name to embedder's logger. This string will be passed to to
+  // callbacks on `log_message_callback`. Defaults to "flutter" if unspecified.
+  const char* log_tag;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -217,6 +217,11 @@ void EmbedderConfigBuilder::SetLogMessageCallbackHook() {
       EmbedderTestContext::GetLogMessageCallbackHook();
 }
 
+void EmbedderConfigBuilder::SetLogTag(std::string tag) {
+  log_tag_ = std::move(tag);
+  project_args_.log_tag = log_tag_.c_str();
+}
+
 void EmbedderConfigBuilder::SetLocalizationCallbackHooks() {
   project_args_.compute_platform_resolved_locale_callback =
       EmbedderTestContext::GetComputePlatformResolvedLocaleCallbackHook();

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -72,7 +72,11 @@ class EmbedderConfigBuilder {
 
   void SetSemanticsCallbackHooks();
 
+  // Used to set a custom log message handler.
   void SetLogMessageCallbackHook();
+
+  // Used to set a custom log tag.
+  void SetLogTag(std::string tag);
 
   void SetLocalizationCallbackHooks();
 
@@ -117,6 +121,7 @@ class EmbedderConfigBuilder {
   FlutterCompositor compositor_ = {};
   std::vector<std::string> command_line_arguments_;
   std::vector<std::string> dart_entrypoint_arguments_;
+  std::string log_tag_;
 
   UniqueEngine SetupEngine(bool run) const;
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -453,7 +453,8 @@ TEST_F(EmbedderTest, InvalidPlatformMessages) {
 }
 
 //------------------------------------------------------------------------------
-/// Tests that setting a custom log callback works as expected.
+/// Tests that setting a custom log callback works as expected and defaults to
+/// using tag "flutter".
 TEST_F(EmbedderTest, CanSetCustomLogMessageCallback) {
   fml::AutoResetWaitableEvent callback_latch;
   auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
@@ -463,6 +464,26 @@ TEST_F(EmbedderTest, CanSetCustomLogMessageCallback) {
   context.SetLogMessageCallback(
       [&callback_latch](const char* tag, const char* message) {
         EXPECT_EQ(std::string(tag), "flutter");
+        EXPECT_EQ(std::string(message), "hello world");
+        callback_latch.Signal();
+      });
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+  callback_latch.Wait();
+}
+
+//------------------------------------------------------------------------------
+/// Tests that setting a custom log tag works.
+TEST_F(EmbedderTest, CanSetCustomLogTag) {
+  fml::AutoResetWaitableEvent callback_latch;
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
+  EmbedderConfigBuilder builder(context);
+  builder.SetDartEntrypoint("custom_logger");
+  builder.SetSoftwareRendererConfig();
+  builder.SetLogTag("butterfly");
+  context.SetLogMessageCallback(
+      [&callback_latch](const char* tag, const char* message) {
+        EXPECT_EQ(std::string(tag), "butterfly");
         EXPECT_EQ(std::string(message), "hello world");
         callback_latch.Signal();
       });


### PR DESCRIPTION
Embedders making use of the embedder API always ended up with a
hardcoded log tag of "flutter". Some embedders may wish to set a
different log tag. For example, the Fuchsia embedder sets its log tag
to a launch URL followed by "flutter".

If unspecified, we continue to default to "flutter".

Fixes https://github.com/flutter/flutter/issues/79819

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
