### PR TITLE
[Android] Avoid missing any system channel messages before registering PlatformMessageHandler.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -15,8 +15,8 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingDeque;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -32,10 +32,10 @@ public class PlatformChannel {
   @Nullable private PlatformMessageHandler platformMessageHandler;
 
   private static class PendingTaskQueue {
-    private final Queue<Runnable> queue;
+    private final BlockingQueue<Runnable> queue;
 
     public PendingTaskQueue() {
-      queue = new ConcurrentLinkedQueue<Runnable>();
+      queue = new LinkedBlockingDeque<Runnable>();
     }
 
     public void addTask(Runnable task) {

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -56,7 +56,6 @@ public class PlatformChannel {
   }
   private PendingTaskQueue pendingTasks = new PendingTaskQueue();
 
-
   @NonNull @VisibleForTesting
   final MethodChannel.MethodCallHandler parsingMethodCallHandler =
       new MethodChannel.MethodCallHandler() {

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -15,8 +15,8 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingDeque;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -32,10 +32,10 @@ public class PlatformChannel {
   @Nullable private PlatformMessageHandler platformMessageHandler;
 
   private static class PendingTaskQueue {
-    private final BlockingQueue<Runnable> queue;
+    private final Queue<Runnable> queue;
 
     public PendingTaskQueue() {
-      queue = new LinkedBlockingDeque<Runnable>();
+      queue = new ConcurrentLinkedQueue<Runnable>();
     }
 
     public void addTask(Runnable task) {

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -54,22 +54,25 @@ public class PlatformChannel {
       }
     }
   }
+
   private PendingTaskQueue pendingTasks = new PendingTaskQueue();
 
   @NonNull @VisibleForTesting
   final MethodChannel.MethodCallHandler parsingMethodCallHandler =
       new MethodChannel.MethodCallHandler() {
         @Override
-        public void onMethodCall(@NonNull final MethodCall call, @NonNull final MethodChannel.Result result) {
+        public void onMethodCall(
+            @NonNull final MethodCall call, @NonNull final MethodChannel.Result result) {
           if (platformMessageHandler == null) {
             // If no explicit PlatformMessageHandler has been registered then we
             // need to forward this call to an API later.
-            pendingTasks.addTask(new Runnable() {
-              @Override
-              public void run() {
-                onMethodCall(call, result);
-              }
-            });
+            pendingTasks.addTask(
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    onMethodCall(call, result);
+                  }
+                });
             return;
           }
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -5,25 +5,21 @@
 package io.flutter.embedding.engine.systemchannels;
 
 import android.content.pm.ActivityInfo;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * System channel that receives requests for host platform behavior, e.g., haptic and sound effects,


### PR DESCRIPTION
# Steps to Reproduce

1. Checkout [Flutter samples](https://github.com/flutter/samples/tree/master/add_to_app)
2. Open [main.dart](https://github.com/flutter/samples/blob/master/add_to_app/fullscreen/flutter_module/lib/main.dart) and add the following code and run 

> ![image](https://user-images.githubusercontent.com/26625149/113683322-a50ac600-96f6-11eb-8eff-41d1ce471753.png)
