### PR TITLE
Forward a11y methods from FlutterSwitchSemanticsObject

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -110,7 +110,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
-  return [_semanticsObject accessibilityScroll: direction];
+  return [_semanticsObject accessibilityScroll:direction];
 }
 
 - (BOOL)accessibilityPerformEscape {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -97,6 +97,34 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   }
 }
 
+- (BOOL)accessibilityActivate {
+  return [_semanticsObject accessibilityActivate];
+}
+
+- (void)accessibilityIncrement {
+  [_semanticsObject accessibilityIncrement];
+}
+
+- (void)accessibilityDecrement {
+  [_semanticsObject accessibilityDecrement];
+}
+
+- (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
+  return [_semanticsObject accessibilityScroll: direction];
+}
+
+- (BOOL)accessibilityPerformEscape {
+  return [_semanticsObject accessibilityPerformEscape];
+}
+
+- (void)accessibilityElementDidBecomeFocused {
+  [_semanticsObject accessibilityElementDidBecomeFocused];
+}
+
+- (void)accessibilityElementDidLoseFocus {
+  [_semanticsObject accessibilityElementDidLoseFocus];
+}
+
 @end  // FlutterSwitchSemanticsObject
 
 @implementation FlutterCustomAccessibilityAction {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -66,6 +66,10 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   [anInvocation invoke];
 }
 
+// The following methods are explicitly forwarded to the wrapped SemanticsObject because the
+// forwarding logic above doesn't apply to them since they are also implemented in the UISwitch
+// class, the base class.
+
 - (CGRect)accessibilityFrame {
   return [_semanticsObject accessibilityFrame];
 }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -229,4 +229,33 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   XCTAssertNil(weakObject);
 }
 
+- (void)testFlutterSwitchSemanticsObjectForwardsCalls {
+  SemanticsObject* mockSemanticsObject = OCMClassMock([SemanticsObject class]);
+  FlutterSwitchSemanticsObject* switchObj = [[FlutterSwitchSemanticsObject alloc] initWithSemanticsObject:mockSemanticsObject];
+  OCMStub([mockSemanticsObject accessibilityActivate]).andReturn(YES);
+  OCMStub([mockSemanticsObject accessibilityScroll:UIAccessibilityScrollDirectionRight]).andReturn(NO);
+  OCMStub([mockSemanticsObject accessibilityPerformEscape]).andReturn(YES);
+
+  XCTAssertTrue([switchObj accessibilityActivate]);
+  OCMVerify([mockSemanticsObject accessibilityActivate]);
+
+  [switchObj accessibilityIncrement];
+  OCMVerify([mockSemanticsObject accessibilityIncrement]);
+
+  [switchObj accessibilityDecrement];
+  OCMVerify([mockSemanticsObject accessibilityDecrement]);
+
+  XCTAssertFalse([switchObj accessibilityScroll:UIAccessibilityScrollDirectionRight]);
+  OCMVerify([mockSemanticsObject accessibilityScroll:UIAccessibilityScrollDirectionRight]);
+
+  XCTAssertTrue([switchObj accessibilityPerformEscape]);
+  OCMVerify([mockSemanticsObject accessibilityPerformEscape]);
+
+  [switchObj accessibilityElementDidBecomeFocused];
+  OCMVerify([mockSemanticsObject accessibilityElementDidBecomeFocused]);
+
+  [switchObj accessibilityElementDidLoseFocus];
+  OCMVerify([mockSemanticsObject accessibilityElementDidLoseFocus]);
+}
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -231,9 +231,11 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
 
 - (void)testFlutterSwitchSemanticsObjectForwardsCalls {
   SemanticsObject* mockSemanticsObject = OCMClassMock([SemanticsObject class]);
-  FlutterSwitchSemanticsObject* switchObj = [[FlutterSwitchSemanticsObject alloc] initWithSemanticsObject:mockSemanticsObject];
+  FlutterSwitchSemanticsObject* switchObj =
+      [[FlutterSwitchSemanticsObject alloc] initWithSemanticsObject:mockSemanticsObject];
   OCMStub([mockSemanticsObject accessibilityActivate]).andReturn(YES);
-  OCMStub([mockSemanticsObject accessibilityScroll:UIAccessibilityScrollDirectionRight]).andReturn(NO);
+  OCMStub([mockSemanticsObject accessibilityScroll:UIAccessibilityScrollDirectionRight])
+      .andReturn(NO);
   OCMStub([mockSemanticsObject accessibilityPerformEscape]).andReturn(YES);
 
   XCTAssertTrue([switchObj accessibilityActivate]);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/79878.