### PR TITLE
Use 'For example' in place of 'e.g.'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ The Flutter engine follows Google style for the languages it uses:
   - **Note**: The Linux embedding generally follows idiomatic GObject-based C style.
     Use of C++ is discouraged in that embedding to avoid creating hybrid code that
     feels unfamiliar to either developers used to working with GObject or C++ developers.
-    E.g., do not use STL collections or std::string. Exceptions:
+    For example, do not use STL collections or std::string. Exceptions:
       - C-style casts are forbidden; use C++ casts.
       - Use `nullptr` rather than `NULL`.
       - Avoid `#define`; for internal constants use `static constexpr` instead.


### PR DESCRIPTION
This avoids the awkward (albeit correct) capitalisation 'E.g.' but more
importantly triggers a build with the latest recipe update, which
includes Windows UWP build products.

https://github.com/flutter/flutter/issues/78627

No tests since the test is the ensuing UWP build.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
