### PR TITLE
[fuchsia] stop using SmoothPointerDataDispatcher

### DIFF
--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -952,10 +952,4 @@ void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
   }
 }
 
-flutter::PointerDataDispatcherMaker PlatformView::GetDispatcherMaker() {
-  return [](flutter::DefaultPointerDataDispatcher::Delegate& delegate) {
-    return std::make_unique<flutter::SmoothPointerDataDispatcher>(delegate);
-  };
-}
-
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -82,9 +82,6 @@ class PlatformView final : public flutter::PlatformView,
   void DispatchSemanticsAction(int32_t node_id,
                                flutter::SemanticsAction action) override;
 
-  // |PlatformView|
-  flutter::PointerDataDispatcherMaker GetDispatcherMaker() override;
-
   // |flutter::PlatformView|
   std::shared_ptr<flutter::ExternalViewEmbedder> CreateExternalViewEmbedder()
       override;


### PR DESCRIPTION
This PR reverts https://github.com/flutter/engine/pull/14514.


SmoothPointerDataDispatcher does not make sense to use on Fuchsia as it does not increase performance, not to mention resampling logic is now available in the framework.