### PR TITLE
Fix bug when build_fuchsia_artifacts.py is called without --targets.

### DIFF
--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -377,7 +377,7 @@ def main():
         if not args.skip_build:
           BuildTarget(runtime_mode, arch, optimized, enable_lto, enable_legacy,
                       args.asan, not args.no_dart_version_git_info,
-                      args.targets.split(","))
+                      args.targets.split(",") if args.targets else [])
         BuildBucket(runtime_mode, arch, optimized, product)
 
   # Create and optionally upload CIPD package


### PR DESCRIPTION
Example before:

```
$ ./tools/fuchsia/build_fuchsia_artifacts.py \
    --engine-version HEAD \
    --no-lto \
    --archs x64 \
    --runtime-mode debug

Running gn for variant "fuchsia_debug_x64" with flags: --fuchsia,--fuchsia-cpu,x64,--runtime-mode,debug,--no-lto
Generating GN files in: out/fuchsia_debug_x64
Done. Made 1085 targets from 221 files in 532ms
ninja: Entering directory `/usr/local/google/home/hjfreyer/flutter/engine/src/flutter/tools/fuchsia/../../../out/fuchsia_debug_x64'
ninja: error: empty path
Traceback (most recent call last):
  File "./tools/fuchsia/build_fuchsia_artifacts.py", line 391, in <module>
    sys.exit(main())
  File "./tools/fuchsia/build_fuchsia_artifacts.py", line 380, in main
    args.targets.split(","))
  File "./tools/fuchsia/build_fuchsia_artifacts.py", line 283, in BuildTarget
    BuildNinjaTargets(out_dir, [ 'flutter' ] + additional_targets)
  File "./tools/fuchsia/build_fuchsia_artifacts.py", line 72, in BuildNinjaTargets
    os.path.join(_out_dir, variant_dir)] + targets)
  File "./tools/fuchsia/build_fuchsia_artifacts.py", line 55, in RunExecutable
    subprocess.check_call(command, cwd=_src_root_dir)
  File "/usr/lib/python2.7/subprocess.py", line 190, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['ninja', '-C', '/usr/local/google/home/hjfreyer/flutter/engine/src/flutter/tools/fuchsia/../../../out/fuchsia_debug_x64', 'flutter', '']' returned non-zero exit status 1
```