### PR TITLE
Eliminate unnecessary conditional on UWP in build

### DIFF
--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -39,13 +39,8 @@ source_set("flutter_windows_headers") {
 
   public_deps = [ "//flutter/shell/platform/common:common_cpp_library_headers" ]
 
-  if (target_os == "winuwp") {
-    configs +=
-        [ "//flutter/shell/platform/common:desktop_library_implementation" ]
-  } else {
-    configs +=
-        [ "//flutter/shell/platform/common:desktop_library_implementation" ]
-  }
+  configs +=
+      [ "//flutter/shell/platform/common:desktop_library_implementation" ]
 
   public_configs =
       [ "//flutter/shell/platform/common:relative_flutter_library_headers" ]


### PR DESCRIPTION
This conditional unconditionally adds the common
desktop_library_implementation target, so we just do that instead.

No new tests added since this build cleanup is covered by existing tests.

Related: https://github.com/flutter/flutter/issues/70197

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
