### PR TITLE
WINUWP: Conditionalize plugin related wrapper

### DIFF
--- a/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/plugin_registrar_windows.h
@@ -49,6 +49,7 @@ class PluginRegistrarWindows : public PluginRegistrar {
 
   FlutterView* GetView() { return view_.get(); }
 
+#ifndef WINUWP
   // Registers |delegate| to receive WindowProc callbacks for the top-level
   // window containing this Flutter instance. Returns an ID that can be used to
   // unregister the handler.
@@ -80,8 +81,10 @@ class PluginRegistrarWindows : public PluginRegistrar {
           registrar(), PluginRegistrarWindows::OnTopLevelWindowProc);
     }
   }
+#endif
 
  private:
+#ifndef WINUWP
   // A FlutterDesktopWindowProcCallback implementation that forwards back to
   // a PluginRegistarWindows instance provided as |user_data|.
   static bool OnTopLevelWindowProc(HWND hwnd,
@@ -113,14 +116,17 @@ class PluginRegistrarWindows : public PluginRegistrar {
     }
     return result;
   }
+#endif
 
   // The associated FlutterView, if any.
   std::unique_ptr<FlutterView> view_;
 
+#ifndef WINUWP
   // The next ID to return from RegisterWindowProcDelegate.
   int next_window_proc_delegate_id_ = 1;
 
   std::map<int, WindowProcDelegate> window_proc_delegates_;
+#endif
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Add missing conditionalization into relevant plugin header to enable a plugin to correctly compile in the winuwp context where there is no WNDPROC.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
