### PR TITLE
Add Image Extension for decode/rasterizer performance info query.

### DIFF
--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -10,6 +10,8 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
+#include "third_party/tonic/logging/dart_invoke.h"
+
 namespace flutter {
 
 typedef CanvasImage Image;
@@ -41,6 +43,23 @@ CanvasImage::~CanvasImage() = default;
 
 Dart_Handle CanvasImage::toByteData(int format, Dart_Handle callback) {
   return EncodeImage(this, format, callback);
+}
+
+void CanvasImage::setResourceDecodeTime(int microseconds) {
+  Dart_Handle dartio_lib = Dart_LookupLibrary(tonic::ToDart("dart:ui"));
+  if (!Dart_IsNull(dartio_lib)) {
+    Dart_Handle ImagePerfInfos_cls = Dart_GetClass(dartio_lib, tonic::ToDart("ImagePerfInfos"));
+    if (!Dart_IsNull(ImagePerfInfos_cls)) {
+      Dart_Handle setResourceDecodeTime_closure =
+        Dart_GetStaticMethodClosure(
+                dartio_lib,
+                ImagePerfInfos_cls,
+                tonic::ToDart("setResourceDecodeTimePri"));
+      tonic::DartInvoke(setResourceDecodeTime_closure, {
+          tonic::ToDart(this),
+          tonic::ToDart(microseconds)});
+    }
+  }
 }
 
 void CanvasImage::dispose() {

--- a/lib/ui/painting/image.h
+++ b/lib/ui/painting/image.h
@@ -39,6 +39,8 @@ class CanvasImage final : public RefCountedDartWrappable<CanvasImage> {
     image_ = std::move(image);
   }
 
+  void setResourceDecodeTime(int milliseconds);
+
   size_t GetAllocationSize() const override;
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -139,6 +139,7 @@ void MultiFrameCodec::State::GetNextFrameAndInvokeCallback(
     fml::RefPtr<flutter::SkiaUnrefQueue> unref_queue,
     size_t trace_id) {
   fml::RefPtr<CanvasImage> image = nullptr;
+  auto start_stamp = fml::TimePoint::Now();
   int duration = 0;
   sk_sp<SkImage> skImage = GetNextFrameImage(resourceContext);
   if (skImage) {
@@ -147,6 +148,8 @@ void MultiFrameCodec::State::GetNextFrameAndInvokeCallback(
     SkCodec::FrameInfo skFrameInfo{0};
     generator_->getFrameInfo(nextFrameIndex_, &skFrameInfo);
     duration = skFrameInfo.fDuration;
+    totalDecodeTime_ += (fml::TimePoint::Now() - start_stamp).ToMicroseconds();
+    image->setResourceDecodeTime(totalDecodeTime_);
   }
   nextFrameIndex_ = (nextFrameIndex_ + 1) % frameCount_;
 

--- a/lib/ui/painting/multi_frame_codec.h
+++ b/lib/ui/painting/multi_frame_codec.h
@@ -53,6 +53,8 @@ class MultiFrameCodec : public Codec {
     // The index of the last decoded required frame.
     int lastRequiredFrameIndex_ = -1;
 
+    int64_t totalDecodeTime_ = 0; // in microseconds
+
     sk_sp<SkImage> GetNextFrameImage(
         fml::WeakPtr<GrDirectContext> resourceContext);
 

--- a/lib/ui/painting/single_frame_codec.cc
+++ b/lib/ui/painting/single_frame_codec.cc
@@ -62,8 +62,10 @@ Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
   fml::RefPtr<SingleFrameCodec>* raw_codec_ref =
       new fml::RefPtr<SingleFrameCodec>(this);
 
+  auto start_stamp = fml::TimePoint::Now();
   decoder->Decode(
-      descriptor_, target_width_, target_height_, [raw_codec_ref](auto image) {
+      descriptor_, target_width_, target_height_,
+      [raw_codec_ref, start_stamp](auto image) {
         std::unique_ptr<fml::RefPtr<SingleFrameCodec>> codec_ref(raw_codec_ref);
         fml::RefPtr<SingleFrameCodec> codec(std::move(*codec_ref));
 
@@ -81,6 +83,8 @@ Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
         if (image.get()) {
           auto canvas_image = fml::MakeRefCounted<CanvasImage>();
           canvas_image->set_image(std::move(image));
+          canvas_image->setResourceDecodeTime(
+              (fml::TimePoint::Now() - start_stamp).ToMicroseconds());
 
           codec->cached_image_ = std::move(canvas_image);
         }

--- a/lib/ui/snapshot_delegate.h
+++ b/lib/ui/snapshot_delegate.h
@@ -7,12 +7,13 @@
 
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPicture.h"
+#include <tuple>
 
 namespace flutter {
 
 class SnapshotDelegate {
  public:
-  virtual sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
+  virtual std::tuple<sk_sp<SkImage>, int> MakeRasterSnapshot(sk_sp<SkPicture> picture,
                                             SkISize picture_size) = 0;
 
   virtual sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) = 0;

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -462,7 +462,7 @@ class Rasterizer final : public SnapshotDelegate {
   bool shared_engine_block_thread_merging_ = false;
 
   // |SnapshotDelegate|
-  sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
+  std::tuple<sk_sp<SkImage>, int> MakeRasterSnapshot(sk_sp<SkPicture> picture,
                                     SkISize picture_size) override;
 
   // |SnapshotDelegate|
@@ -474,7 +474,7 @@ class Rasterizer final : public SnapshotDelegate {
       GrDirectContext* surface_context,
       bool compressed);
 
-  sk_sp<SkImage> DoMakeRasterSnapshot(
+  std::tuple<sk_sp<SkImage>, int> DoMakeRasterSnapshot(
       SkISize size,
       std::function<void(SkCanvas*)> draw_callback);
 


### PR DESCRIPTION
This patch originated from a fork by Alibaba.
Intended to support Resource Panel mentioned by the following link, https://github.com/flutter/devtools/issues/2835
The added interfaces are rewritten to remove dependencies on customized patches on Skia and framework SDK.
* extension ImagePerfInfo on Image provides ImagePerfData
* calculate decode time in single_frame_codec.cc and multi_frame_codec.cc
* calculate rasterizer cost in rasterizer.cc
* return 0s in web target
