### PR TITLE
Add Image Extension for decode/rasterizer performance info query.

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1840,10 +1840,11 @@ class ImagePerfData {
   int resourceDecodeTime;
 }
 
+// ignore: avoid_classes_with_only_static_members
 class ImagePerfInfos {
   static Expando<ImagePerfData> expando = Expando<ImagePerfData>('ImagePerfInfos');
   static int getResourceDecodeTime(Image image) {
-    var info = expando[image] ;
+    final ImagePerfData? info = expando[image];
     if (info == null) {
       return 0;
     }
@@ -1855,9 +1856,9 @@ class ImagePerfInfos {
   static void setResourceDecodeTimePri(_Image image, int time) {
     if (!kReleaseMode) {
       image.resourceDecodeTime = time;
-      image.handles.forEach((imageh) {
-          setResourceDecodeTime(imageh, time);
-      });
+      for(final Image imageh in image.handles) {
+        setResourceDecodeTime(imageh, time);
+      }
     }
   }
 }
@@ -1879,7 +1880,7 @@ extension ImagePerfInfo on Image {
   int get resourceMemoryCachedSize => _getResourceMemoryCachedSize();
   int _getResourceMemoryCachedSize() {
     const int RGBA = 4;
-    return this.width * this.height * RGBA;
+    return width * height * RGBA;
   }
 }
 

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1864,21 +1864,15 @@ class ImagePerfInfos {
 }
 
 extension ImagePerfInfo on Image {
-  int get resourceDecodeTime => _getResourceDecodeTime();
-  set resourceDecodeTime(int time) {
-    _setResourceDecodeTime(time);
-  }
-
-  int _getResourceDecodeTime() {
+  int get resourceDecodeTime {
     return ImagePerfInfos.getResourceDecodeTime(this);
   }
 
-  void _setResourceDecodeTime(int time) {
+  set resourceDecodeTime(int time) {
     ImagePerfInfos.setResourceDecodeTime(this, time);
   }
 
-  int get resourceMemoryCachedSize => _getResourceMemoryCachedSize();
-  int _getResourceMemoryCachedSize() {
+  int get resourceMemoryCachedSize {
     const int RGBA = 4;
     return width * height * RGBA;
   }

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -46,6 +46,9 @@ Dart_Handle CanvasImage::toByteData(int format, Dart_Handle callback) {
 }
 
 void CanvasImage::setResourceDecodeTime(int microseconds) {
+  if (Dart_CurrentIsolate() == NULL){
+    return;
+  }
   Dart_Handle dartio_lib = Dart_LookupLibrary(tonic::ToDart("dart:ui"));
   if (!Dart_IsNull(dartio_lib)) {
     Dart_Handle ImagePerfInfos_cls =

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -46,7 +46,7 @@ Dart_Handle CanvasImage::toByteData(int format, Dart_Handle callback) {
 }
 
 void CanvasImage::setResourceDecodeTime(int microseconds) {
-  if (Dart_CurrentIsolate() == NULL){
+  if (Dart_CurrentIsolate() == NULL) {
     return;
   }
   Dart_Handle dartio_lib = Dart_LookupLibrary(tonic::ToDart("dart:ui"));

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -10,6 +10,8 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
+#include "third_party/tonic/logging/dart_invoke.h"
+
 namespace flutter {
 
 typedef CanvasImage Image;
@@ -41,6 +43,21 @@ CanvasImage::~CanvasImage() = default;
 
 Dart_Handle CanvasImage::toByteData(int format, Dart_Handle callback) {
   return EncodeImage(this, format, callback);
+}
+
+void CanvasImage::setResourceDecodeTime(int microseconds) {
+  Dart_Handle dartio_lib = Dart_LookupLibrary(tonic::ToDart("dart:ui"));
+  if (!Dart_IsNull(dartio_lib)) {
+    Dart_Handle ImagePerfInfos_cls =
+        Dart_GetClass(dartio_lib, tonic::ToDart("ImagePerfInfos"));
+    if (!Dart_IsNull(ImagePerfInfos_cls)) {
+      Dart_Handle setResourceDecodeTime_closure = Dart_GetStaticMethodClosure(
+          dartio_lib, ImagePerfInfos_cls,
+          tonic::ToDart("setResourceDecodeTimePri"));
+      tonic::DartInvoke(setResourceDecodeTime_closure,
+                        {tonic::ToDart(this), tonic::ToDart(microseconds)});
+    }
+  }
 }
 
 void CanvasImage::dispose() {

--- a/lib/ui/painting/image.h
+++ b/lib/ui/painting/image.h
@@ -39,6 +39,8 @@ class CanvasImage final : public RefCountedDartWrappable<CanvasImage> {
     image_ = std::move(image);
   }
 
+  void setResourceDecodeTime(int milliseconds);
+
   size_t GetAllocationSize() const override;
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -139,6 +139,7 @@ void MultiFrameCodec::State::GetNextFrameAndInvokeCallback(
     fml::RefPtr<flutter::SkiaUnrefQueue> unref_queue,
     size_t trace_id) {
   fml::RefPtr<CanvasImage> image = nullptr;
+  auto start_stamp = fml::TimePoint::Now();
   int duration = 0;
   sk_sp<SkImage> skImage = GetNextFrameImage(resourceContext);
   if (skImage) {
@@ -147,6 +148,8 @@ void MultiFrameCodec::State::GetNextFrameAndInvokeCallback(
     SkCodec::FrameInfo skFrameInfo{0};
     generator_->getFrameInfo(nextFrameIndex_, &skFrameInfo);
     duration = skFrameInfo.fDuration;
+    totalDecodeTime_ += (fml::TimePoint::Now() - start_stamp).ToMicroseconds();
+    image->setResourceDecodeTime(totalDecodeTime_);
   }
   nextFrameIndex_ = (nextFrameIndex_ + 1) % frameCount_;
 

--- a/lib/ui/painting/multi_frame_codec.h
+++ b/lib/ui/painting/multi_frame_codec.h
@@ -53,6 +53,8 @@ class MultiFrameCodec : public Codec {
     // The index of the last decoded required frame.
     int lastRequiredFrameIndex_ = -1;
 
+    int64_t totalDecodeTime_ = 0;  // in microseconds
+
     sk_sp<SkImage> GetNextFrameImage(
         fml::WeakPtr<GrDirectContext> resourceContext);
 

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -93,8 +93,8 @@ Dart_Handle Picture::RasterizeToImage(sk_sp<SkPicture> picture,
   auto picture_bounds = SkISize::Make(width, height);
 
   auto ui_task = fml::MakeCopyable([image_callback = std::move(image_callback),
-                                    unref_queue](
-                                       sk_sp<SkImage> raster_image) mutable {
+                                    unref_queue](sk_sp<SkImage> raster_image,
+                                                 int raster_cost) mutable {
     auto dart_state = image_callback->dart_state().lock();
     if (!dart_state) {
       // The root isolate could have died in the meantime.
@@ -109,6 +109,7 @@ Dart_Handle Picture::RasterizeToImage(sk_sp<SkPicture> picture,
 
     auto dart_image = CanvasImage::Create();
     dart_image->set_image({std::move(raster_image), std::move(unref_queue)});
+    dart_image->setResourceDecodeTime(raster_cost);
     auto* raw_dart_image = tonic::ToDart(std::move(dart_image));
 
     // All done!
@@ -123,12 +124,15 @@ Dart_Handle Picture::RasterizeToImage(sk_sp<SkPicture> picture,
   fml::TaskRunner::RunNowOrPostTask(
       raster_task_runner,
       [ui_task_runner, snapshot_delegate, picture, picture_bounds, ui_task] {
-        sk_sp<SkImage> raster_image =
+        sk_sp<SkImage> raster_image;
+        int raster_cost;
+        std::tie(raster_image, raster_cost) =
             snapshot_delegate->MakeRasterSnapshot(picture, picture_bounds);
 
         fml::TaskRunner::RunNowOrPostTask(
-            ui_task_runner,
-            [ui_task, raster_image]() { ui_task(raster_image); });
+            ui_task_runner, [ui_task, raster_image, raster_cost]() {
+              ui_task(raster_image, raster_cost);
+            });
       });
 
   return Dart_Null();

--- a/lib/ui/painting/single_frame_codec.cc
+++ b/lib/ui/painting/single_frame_codec.cc
@@ -62,8 +62,10 @@ Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
   fml::RefPtr<SingleFrameCodec>* raw_codec_ref =
       new fml::RefPtr<SingleFrameCodec>(this);
 
+  auto start_stamp = fml::TimePoint::Now();
   decoder->Decode(
-      descriptor_, target_width_, target_height_, [raw_codec_ref](auto image) {
+      descriptor_, target_width_, target_height_,
+      [raw_codec_ref, start_stamp](auto image) {
         std::unique_ptr<fml::RefPtr<SingleFrameCodec>> codec_ref(raw_codec_ref);
         fml::RefPtr<SingleFrameCodec> codec(std::move(*codec_ref));
 
@@ -81,6 +83,8 @@ Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
         if (image.get()) {
           auto canvas_image = fml::MakeRefCounted<CanvasImage>();
           canvas_image->set_image(std::move(image));
+          canvas_image->setResourceDecodeTime(
+              (fml::TimePoint::Now() - start_stamp).ToMicroseconds());
 
           codec->cached_image_ = std::move(canvas_image);
         }

--- a/lib/ui/snapshot_delegate.h
+++ b/lib/ui/snapshot_delegate.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_LIB_UI_SNAPSHOT_DELEGATE_H_
 #define FLUTTER_LIB_UI_SNAPSHOT_DELEGATE_H_
 
+#include <tuple>
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPicture.h"
 
@@ -12,8 +13,9 @@ namespace flutter {
 
 class SnapshotDelegate {
  public:
-  virtual sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
-                                            SkISize picture_size) = 0;
+  virtual std::tuple<sk_sp<SkImage>, int> MakeRasterSnapshot(
+      sk_sp<SkPicture> picture,
+      SkISize picture_size) = 0;
 
   virtual sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) = 0;
 };

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -342,6 +342,7 @@ abstract class Image {
   String toString() => '[$width\u00D7$height]';
 }
 
+// We don't have an easy way to compute ImagePerfData in web target.
 // no-op in web target
 class ImagePerfData {
   ImagePerfData(this.resourceDecodeTime);

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -349,6 +349,9 @@ class ImagePerfData {
 }
 
 // no-op in web target
+class _Image {
+}
+// no-op in web target
 // ignore: avoid_classes_with_only_static_members
 class ImagePerfInfos {
   static Expando<ImagePerfData> expando = Expando<ImagePerfData>('ImagePerfInfos');

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -342,6 +342,25 @@ abstract class Image {
   String toString() => '[$width\u00D7$height]';
 }
 
+// no-op in web target
+class ImagePerfData {
+  ImagePerfData(this.resourceDecodeTime);
+  int resourceDecodeTime;
+}
+
+// no-op in web target
+// ignore: avoid_classes_with_only_static_members
+class ImagePerfInfos {
+  static Expando<ImagePerfData> expando = Expando<ImagePerfData>('ImagePerfInfos');
+  static int getResourceDecodeTime(Image image) {
+    return 0;
+  }
+  static void setResourceDecodeTime(Image image, int time) {
+  }
+  static void setResourceDecodeTimePri(_Image image, int time) {
+  }
+}
+
 abstract class ColorFilter {
   const factory ColorFilter.mode(Color color, BlendMode blendMode) = engine.EngineColorFilter.mode;
   const factory ColorFilter.matrix(List<double> matrix) = engine.EngineColorFilter.matrix;

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -17,6 +17,7 @@
 #include "third_party/skia/include/core/SkSerialProcs.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkSurfaceCharacterization.h"
+#include "third_party/skia/include/core/SkTime.h"
 #include "third_party/skia/include/utils/SkBase64.h"
 
 // When screenshotting we want to ensure we call the base method for
@@ -215,15 +216,20 @@ void Rasterizer::Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline,
 }
 
 namespace {
-sk_sp<SkImage> DrawSnapshot(
+std::tuple<sk_sp<SkImage>, int> DrawSnapshot(
     sk_sp<SkSurface> surface,
     const std::function<void(SkCanvas*)>& draw_callback) {
   if (surface == nullptr || surface->getCanvas() == nullptr) {
-    return nullptr;
+    return std::make_tuple(nullptr, 0);
   }
+
+  double cost_start = SkTime::GetNSecs();
+  int cost = 0;
 
   draw_callback(surface->getCanvas());
   surface->getCanvas()->flush();
+  // as microseconds
+  cost += static_cast<int>(SkTime::GetNSecs() - cost_start) / 1000;
 
   sk_sp<SkImage> device_snapshot;
   {
@@ -232,25 +238,25 @@ sk_sp<SkImage> DrawSnapshot(
   }
 
   if (device_snapshot == nullptr) {
-    return nullptr;
+    return std::make_tuple(nullptr, 0);
   }
 
   {
     TRACE_EVENT0("flutter", "DeviceHostTransfer");
     if (auto raster_image = device_snapshot->makeRasterImage()) {
-      return raster_image;
+      return std::make_tuple(raster_image, cost);
     }
   }
 
-  return nullptr;
+  return std::make_tuple(nullptr, 0);
 }
 }  // namespace
 
-sk_sp<SkImage> Rasterizer::DoMakeRasterSnapshot(
+std::tuple<sk_sp<SkImage>, int> Rasterizer::DoMakeRasterSnapshot(
     SkISize size,
     std::function<void(SkCanvas*)> draw_callback) {
   TRACE_EVENT0("flutter", __FUNCTION__);
-  sk_sp<SkImage> result;
+  std::tuple<sk_sp<SkImage>, int> result;
   SkImageInfo image_info = SkImageInfo::MakeN32Premul(
       size.width(), size.height(), SkColorSpace::MakeSRGB());
   if (surface_ == nullptr || surface_->GetContext() == nullptr) {
@@ -302,8 +308,9 @@ sk_sp<SkImage> Rasterizer::DoMakeRasterSnapshot(
   return result;
 }
 
-sk_sp<SkImage> Rasterizer::MakeRasterSnapshot(sk_sp<SkPicture> picture,
-                                              SkISize picture_size) {
+std::tuple<sk_sp<SkImage>, int> Rasterizer::MakeRasterSnapshot(
+    sk_sp<SkPicture> picture,
+    SkISize picture_size) {
   return DoMakeRasterSnapshot(picture_size,
                               [picture = std::move(picture)](SkCanvas* canvas) {
                                 canvas->drawPicture(picture);
@@ -325,10 +332,12 @@ sk_sp<SkImage> Rasterizer::ConvertToRasterImage(sk_sp<SkImage> image) {
   }
 
   SkISize image_size = image->dimensions();
-  return DoMakeRasterSnapshot(image_size,
-                              [image = std::move(image)](SkCanvas* canvas) {
-                                canvas->drawImage(image, 0, 0);
-                              });
+  sk_sp<SkImage> result;
+  std::tie(result, std::ignore) = DoMakeRasterSnapshot(
+      image_size, [image = std::move(image)](SkCanvas* canvas) {
+        canvas->drawImage(image, 0, 0);
+      });
+  return result;
 }
 
 RasterStatus Rasterizer::DoDraw(

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -462,8 +462,9 @@ class Rasterizer final : public SnapshotDelegate {
   bool shared_engine_block_thread_merging_ = false;
 
   // |SnapshotDelegate|
-  sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
-                                    SkISize picture_size) override;
+  std::tuple<sk_sp<SkImage>, int> MakeRasterSnapshot(
+      sk_sp<SkPicture> picture,
+      SkISize picture_size) override;
 
   // |SnapshotDelegate|
   sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) override;
@@ -474,7 +475,7 @@ class Rasterizer final : public SnapshotDelegate {
       GrDirectContext* surface_context,
       bool compressed);
 
-  sk_sp<SkImage> DoMakeRasterSnapshot(
+  std::tuple<sk_sp<SkImage>, int> DoMakeRasterSnapshot(
       SkISize size,
       std::function<void(SkCanvas*)> draw_callback);
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2079,7 +2079,8 @@ TEST_F(ShellTest, RasterizerMakeRasterSnapshot) {
       shell->GetTaskRunners().GetRasterTaskRunner(), [&shell, &latch]() {
         SnapshotDelegate* delegate =
             reinterpret_cast<Rasterizer*>(shell->GetRasterizer().get());
-        sk_sp<SkImage> image = delegate->MakeRasterSnapshot(
+        sk_sp<SkImage> image;
+        std::tie(image, std::ignore) = delegate->MakeRasterSnapshot(
             SkPicture::MakePlaceholder({0, 0, 50, 50}), SkISize::Make(50, 50));
         EXPECT_NE(image, nullptr);
 


### PR DESCRIPTION
This patch originated from a fork by Alibaba.
Intended to support Resource Panel mentioned by the following link, https://github.com/flutter/devtools/issues/2835
The added interfaces are rewritten to remove dependencies on customized patches on Skia and framework SDK.
* extension ImagePerfInfo on Image provides ImagePerfData
* calculate decode time in single_frame_codec.cc and multi_frame_codec.cc
* calculate rasterizer cost in rasterizer.cc
* return 0s in web target

