### PR TITLE
[web] Fix firefox crash during font loading

### DIFF
--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -182,9 +182,9 @@ class FontManager {
         // ```
         // html.document.fonts!.add(fontFace);
         // ```
-        // But dart:html expects the return value to be non-null, and firefox
-        // returns null. This causes the app to crash with a null check
-        // exception.
+        // But dart:html expects the return value to be non-null, and Firefox
+        // returns null. This causes the app to crash in Firefox with a null
+        // check exception.
         //
         // TODO(mdebbar): Revert this once the dart:html type is fixed.
         //                https://github.com/dart-lang/sdk/issues/45676

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -178,7 +178,17 @@ class FontManager {
     try {
       final html.FontFace fontFace = html.FontFace(family, asset, descriptors);
       _fontLoadingFutures.add(fontFace.load().then((_) {
-        html.document.fonts!.add(fontFace);
+        // We could do:
+        // ```
+        // html.document.fonts!.add(fontFace);
+        // ```
+        // But dart:html expects the return value to be non-null, and firefox
+        // returns null. This causes the app to crash with a null check
+        // exception.
+        //
+        // TODO(mdebbar): Revert this once the dart:html type is fixed.
+        //                https://github.com/dart-lang/sdk/issues/45676
+        js_util.callMethod(html.document.fonts!, 'add', [fontFace]);
       }, onError: (dynamic e) {
         printWarning('Error while trying to load font family "$family":\n$e');
       }));


### PR DESCRIPTION
This PR works around a `dart:html` null check that's failing in Firefox. Using js interop, we are able to bypass the `dart:html` implementation that performs the null check.

Dart SDK issue: https://github.com/dart-lang/sdk/issues/45676

Fixes https://github.com/flutter/flutter/issues/80378