### PR TITLE
[web] Remove dart language versions from engine files

### DIFF
--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 @JS()
 library engine;
 

--- a/lib/web_ui/lib/src/engine/alarm_clock.dart
+++ b/lib/web_ui/lib/src/engine/alarm_clock.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A function that returns current system time.

--- a/lib/web_ui/lib/src/engine/assets.dart
+++ b/lib/web_ui/lib/src/engine/assets.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// This class downloads assets over the network.

--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A raw HTML canvas that is directly written to.

--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// The HTML engine used by the current browser.

--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Allocates and caches 0 or more canvas(s) for [BitmapCanvas].

--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Memoized value for ClipOp.Intersect, so we don't have to hit JS-interop

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -7,7 +7,6 @@
 /// Prefer keeping the original CanvasKit names so it is easier to locate
 /// the API behind these bindings in the Skia source code.
 
-// @dart = 2.12
 part of engine;
 
 /// Entrypoint into the CanvasKit API.

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_canvas.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// An implementation of [ui.Canvas] that is backed by a CanvasKit canvas.

--- a/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/color_filter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A concrete [ManagedSkiaObject] subclass that owns a [SkColorFilter] and

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// This composites HTML views into the [ui.Scene].

--- a/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/font_fallbacks.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Global static font fallback data.

--- a/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/fonts.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 // This URL was found by using the Google Fonts Developer API to find the URL

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Instantiates a [ui.Codec] backed by an `SkAnimatedImage` from Skia.

--- a/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image_filter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// An [ImageFilter] that can create a managed skia [SkImageFilter] object.

--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A JavaScript entrypoint that allows developer to set rendering backend

--- a/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/interval_tree.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A tree which stores a set of intervals that can be queried for intersection.

--- a/lib/web_ui/lib/src/engine/canvaskit/layer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A layer to be composed into a scene.

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_scene_builder.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class LayerScene implements ui.Scene {

--- a/lib/web_ui/lib/src/engine/canvaskit/layer_tree.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/layer_tree.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A tree of [Layer]s that, together with a [Size] compose a frame.

--- a/lib/web_ui/lib/src/engine/canvaskit/mask_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/mask_filter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// The CanvasKit implementation of [ui.MaskFilter].

--- a/lib/web_ui/lib/src/engine/canvaskit/n_way_canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/n_way_canvas.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A virtual canvas that applies operations to multiple canvases at once.

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// The implementation of [ui.Paint] used by the CanvasKit backend.

--- a/lib/web_ui/lib/src/engine/canvaskit/path.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/path.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// An implementation of [ui.Path] which is backed by an `SkPath`.

--- a/lib/web_ui/lib/src/engine/canvaskit/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/path_metrics.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class CkPathMetrics extends IterableBase<ui.PathMetric>

--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {

--- a/lib/web_ui/lib/src/engine/canvaskit/picture_recorder.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture_recorder.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class CkPictureRecorder implements ui.PictureRecorder {

--- a/lib/web_ui/lib/src/engine/canvaskit/platform_message.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/platform_message.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class PlatformMessage {

--- a/lib/web_ui/lib/src/engine/canvaskit/raster_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/raster_cache.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A cache of [Picture]s that have already been rasterized.

--- a/lib/web_ui/lib/src/engine/canvaskit/rasterizer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/rasterizer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A class that can rasterize [LayerTree]s into a given [Surface].

--- a/lib/web_ui/lib/src/engine/canvaskit/shader.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/shader.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 abstract class CkShader extends ManagedSkiaObject<SkShader>

--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A cache of Skia objects whose memory Flutter manages.

--- a/lib/web_ui/lib/src/engine/canvaskit/surface.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 typedef SubmitCallback = bool Function(SurfaceFrame, CkCanvas);

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 @immutable

--- a/lib/web_ui/lib/src/engine/canvaskit/util.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/util.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// An error related to the CanvasKit rendering backend.

--- a/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/vertices.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class CkVertices extends ManagedSkiaObject<SkVertices> implements ui.Vertices {

--- a/lib/web_ui/lib/src/engine/canvaskit/viewport_metrics.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/viewport_metrics.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class ViewportMetrics {

--- a/lib/web_ui/lib/src/engine/clipboard.dart
+++ b/lib/web_ui/lib/src/engine/clipboard.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Handles clipboard related platform messages.

--- a/lib/web_ui/lib/src/engine/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/color_filter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A description of a color filter to apply when drawing a shape or compositing

--- a/lib/web_ui/lib/src/engine/dom_canvas.dart
+++ b/lib/web_ui/lib/src/engine/dom_canvas.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A canvas that renders to DOM elements and CSS properties.

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class DomRenderer {

--- a/lib/web_ui/lib/src/engine/engine_canvas.dart
+++ b/lib/web_ui/lib/src/engine/engine_canvas.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Defines canvas interface common across canvases that the [SceneBuilder]

--- a/lib/web_ui/lib/src/engine/frame_reference.dart
+++ b/lib/web_ui/lib/src/engine/frame_reference.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A monotonically increasing frame number being rendered.

--- a/lib/web_ui/lib/src/engine/html/backdrop_filter.dart
+++ b/lib/web_ui/lib/src/engine/html/backdrop_filter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A surface that applies an image filter to background.

--- a/lib/web_ui/lib/src/engine/html/canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/canvas.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class SurfaceCanvas implements ui.Canvas {

--- a/lib/web_ui/lib/src/engine/html/clip.dart
+++ b/lib/web_ui/lib/src/engine/html/clip.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Mixin used by surfaces that clip their contents using an overflowing DOM

--- a/lib/web_ui/lib/src/engine/html/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/html/color_filter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A surface that applies an [ColorFilter] to its children.

--- a/lib/web_ui/lib/src/engine/html/debug_canvas_reuse_overlay.dart
+++ b/lib/web_ui/lib/src/engine/html/debug_canvas_reuse_overlay.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 html.HtmlElement _createContainer() {

--- a/lib/web_ui/lib/src/engine/html/image_filter.dart
+++ b/lib/web_ui/lib/src/engine/html/image_filter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A surface that applies an [imageFilter] to its children.

--- a/lib/web_ui/lib/src/engine/html/offset.dart
+++ b/lib/web_ui/lib/src/engine/html/offset.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A surface that translates its children using CSS transform and translate.

--- a/lib/web_ui/lib/src/engine/html/opacity.dart
+++ b/lib/web_ui/lib/src/engine/html/opacity.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A surface that makes its children transparent.

--- a/lib/web_ui/lib/src/engine/html/painting.dart
+++ b/lib/web_ui/lib/src/engine/html/painting.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Implementation of [ui.Paint] used by the HTML rendering backend.

--- a/lib/web_ui/lib/src/engine/html/path/conic.dart
+++ b/lib/web_ui/lib/src/engine/html/path/conic.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Converts conic curve to a list of quadratic curves for rendering on

--- a/lib/web_ui/lib/src/engine/html/path/cubic.dart
+++ b/lib/web_ui/lib/src/engine/html/path/cubic.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Chops cubic at Y extrema points and writes result to [dest].

--- a/lib/web_ui/lib/src/engine/html/path/path.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A complex, one-dimensional subset of a plane.

--- a/lib/web_ui/lib/src/engine/html/path/path_metrics.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_metrics.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 const double kEpsilon = 0.000000001;

--- a/lib/web_ui/lib/src/engine/html/path/path_ref.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_ref.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Stores the path verbs, points and conic weights.

--- a/lib/web_ui/lib/src/engine/html/path/path_to_svg.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_to_svg.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Converts [path] to SVG path syntax to be used as "d" attribute in path

--- a/lib/web_ui/lib/src/engine/html/path/path_utils.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_utils.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Mask used to keep track of types of verbs used in a path segment.

--- a/lib/web_ui/lib/src/engine/html/path/path_windings.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_windings.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Computes winding number and onCurveCount for a path and point.

--- a/lib/web_ui/lib/src/engine/html/path/tangent.dart
+++ b/lib/web_ui/lib/src/engine/html/path/tangent.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Computes tangent at point x,y on a line.

--- a/lib/web_ui/lib/src/engine/html/picture.dart
+++ b/lib/web_ui/lib/src/engine/html/picture.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 // TODO(yjbanov): this is currently very naive. We probably want to cache

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A surface containing a platform view, which is an HTML element.

--- a/lib/web_ui/lib/src/engine/html/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/recording_canvas.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Enable this to print every command applied by a canvas.

--- a/lib/web_ui/lib/src/engine/html/render_vertices.dart
+++ b/lib/web_ui/lib/src/engine/html/render_vertices.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 _GlRenderer? _glRenderer;

--- a/lib/web_ui/lib/src/engine/html/scene.dart
+++ b/lib/web_ui/lib/src/engine/html/scene.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class SurfaceScene implements ui.Scene {

--- a/lib/web_ui/lib/src/engine/html/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/scene_builder.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class SurfaceSceneBuilder implements ui.SceneBuilder {

--- a/lib/web_ui/lib/src/engine/html/shader_mask.dart
+++ b/lib/web_ui/lib/src/engine/html/shader_mask.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A surface that applies a shader to its children.

--- a/lib/web_ui/lib/src/engine/html/shaders/normalized_gradient.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/normalized_gradient.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Converts colors and stops to typed array of bias, scale and threshold to use

--- a/lib/web_ui/lib/src/engine/html/shaders/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 abstract class EngineGradient implements ui.Gradient {

--- a/lib/web_ui/lib/src/engine/html/shaders/shader_builder.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader_builder.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Creates shader program for target webgl version.

--- a/lib/web_ui/lib/src/engine/html/surface.dart
+++ b/lib/web_ui/lib/src/engine/html/surface.dart
@@ -4,7 +4,6 @@
 
 /// When `true` prints statistics about what happened to the surface tree when
 
-// @dart = 2.12
 part of engine;
 /// it was composited.
 ///

--- a/lib/web_ui/lib/src/engine/html/surface_stats.dart
+++ b/lib/web_ui/lib/src/engine/html/surface_stats.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Surfaces that were retained this frame.

--- a/lib/web_ui/lib/src/engine/html/transform.dart
+++ b/lib/web_ui/lib/src/engine/html/transform.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A surface that transforms its children using CSS transform.

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 final bool _supportsDecode = js_util.getProperty(

--- a/lib/web_ui/lib/src/engine/key_map.dart
+++ b/lib/web_ui/lib/src/engine/key_map.dart
@@ -9,7 +9,6 @@
 // Edit the template dev/tools/gen_keycodes/data/web_key_map_dart.tmpl instead.
 // See dev/tools/gen_keycodes/README.md for more information.
 
-// @dart = 2.12
 part of engine;
 
 /// Maps Web KeyboardEvent codes to the matching LogicalKeyboardKey id.

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// After a keydown is received, this is the duration we wait for a repeat event

--- a/lib/web_ui/lib/src/engine/keyboard_binding.dart
+++ b/lib/web_ui/lib/src/engine/keyboard_binding.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 typedef _VoidCallback = void Function();

--- a/lib/web_ui/lib/src/engine/mouse_cursor.dart
+++ b/lib/web_ui/lib/src/engine/mouse_cursor.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Provides mouse cursor bindings, such as the `flutter/mousecursor` channel.

--- a/lib/web_ui/lib/src/engine/navigation/history.dart
+++ b/lib/web_ui/lib/src/engine/navigation/history.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// An abstract class that provides the API for [EngineWindow] to delegate its

--- a/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
+++ b/lib/web_ui/lib/src/engine/navigation/js_url_strategy.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 typedef _PathGetter = String Function();

--- a/lib/web_ui/lib/src/engine/navigation/url_strategy.dart
+++ b/lib/web_ui/lib/src/engine/navigation/url_strategy.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Represents and reads route state from the browser's URL.

--- a/lib/web_ui/lib/src/engine/onscreen_logging.dart
+++ b/lib/web_ui/lib/src/engine/onscreen_logging.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 html.Element? _logElement;

--- a/lib/web_ui/lib/src/engine/picture.dart
+++ b/lib/web_ui/lib/src/engine/picture.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// An implementation of [ui.PictureRecorder] backed by a [RecordingCanvas].

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Requests that the browser schedule a frame.

--- a/lib/web_ui/lib/src/engine/platform_views.dart
+++ b/lib/web_ui/lib/src/engine/platform_views.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 // TODO(yjbanov): The code in this file was temporarily moved to lib/web_ui/lib/ui.dart

--- a/lib/web_ui/lib/src/engine/plugins.dart
+++ b/lib/web_ui/lib/src/engine/plugins.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 Future<void> Function(String, ByteData?, ui.PlatformMessageResponseCallback?)? pluginMessageCallHandler;

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Set this flag to true to see all the fired events in the console.

--- a/lib/web_ui/lib/src/engine/pointer_converter.dart
+++ b/lib/web_ui/lib/src/engine/pointer_converter.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 const bool _debugLogPointerConverter = false;

--- a/lib/web_ui/lib/src/engine/profiler.dart
+++ b/lib/web_ui/lib/src/engine/profiler.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A function that receives a benchmark [value] labeleb by [name].

--- a/lib/web_ui/lib/src/engine/rrect_renderer.dart
+++ b/lib/web_ui/lib/src/engine/rrect_renderer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Renders an RRect using path primitives.

--- a/lib/web_ui/lib/src/engine/semantics/accessibility.dart
+++ b/lib/web_ui/lib/src/engine/semantics/accessibility.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Singleton for accessing accessibility announcements from the platform.

--- a/lib/web_ui/lib/src/engine/semantics/checkable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/checkable.dart
@@ -11,7 +11,6 @@
 //                framework. Currently the framework does not report the
 //                grouping of radio buttons.
 
-// @dart = 2.12
 part of engine;
 
 /// The specific type of checkable control.

--- a/lib/web_ui/lib/src/engine/semantics/image.dart
+++ b/lib/web_ui/lib/src/engine/semantics/image.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Represents semantic objects that deliver information in a visual manner.

--- a/lib/web_ui/lib/src/engine/semantics/incrementable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/incrementable.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Adds increment/decrement event handling to a semantics object.

--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Renders [_label] and [_value] to the semantics DOM.

--- a/lib/web_ui/lib/src/engine/semantics/live_region.dart
+++ b/lib/web_ui/lib/src/engine/semantics/live_region.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Manages semantics configurations that represent live regions.

--- a/lib/web_ui/lib/src/engine/semantics/scrollable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/scrollable.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Implements vertical and horizontal scrolling functionality for semantics

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Set this flag to `true` to cause the engine to visualize the semantics tree

--- a/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// The maximum [semanticsActivationAttempts] before we give up waiting for

--- a/lib/web_ui/lib/src/engine/semantics/tappable.dart
+++ b/lib/web_ui/lib/src/engine/semantics/tappable.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Listens to HTML "click" gestures detected by the browser.

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Text editing used by accesibility mode.

--- a/lib/web_ui/lib/src/engine/services/buffers.dart
+++ b/lib/web_ui/lib/src/engine/services/buffers.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 abstract class _TypedDataBuffer<E> extends ListBase<E> {

--- a/lib/web_ui/lib/src/engine/services/message_codec.dart
+++ b/lib/web_ui/lib/src/engine/services/message_codec.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A message encoding/decoding mechanism.

--- a/lib/web_ui/lib/src/engine/services/message_codecs.dart
+++ b/lib/web_ui/lib/src/engine/services/message_codecs.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// [MessageCodec] with unencoded binary messages represented using [ByteData].

--- a/lib/web_ui/lib/src/engine/services/serialization.dart
+++ b/lib/web_ui/lib/src/engine/services/serialization.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Write-only buffer for incrementally building a [ByteData] instance.

--- a/lib/web_ui/lib/src/engine/shadow.dart
+++ b/lib/web_ui/lib/src/engine/shadow.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// How far is the light source from the surface of the UI.

--- a/lib/web_ui/lib/src/engine/test_embedding.dart
+++ b/lib/web_ui/lib/src/engine/test_embedding.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 const bool _debugLogHistoryActions = false;

--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A paragraph made up of a flat list of text spans and placeholders.

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 const String _ahemFontFamily = 'Ahem';

--- a/lib/web_ui/lib/src/engine/text/layout_service.dart
+++ b/lib/web_ui/lib/src/engine/text/layout_service.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Performs layout on a [CanvasParagraph].

--- a/lib/web_ui/lib/src/engine/text/line_break_properties.dart
+++ b/lib/web_ui/lib/src/engine/text/line_break_properties.dart
@@ -12,7 +12,6 @@
 // # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 // # For terms of use, see http://www.unicode.org/terms_of_use.html
 
-// @dart = 2.12
 part of engine;
 
 /// For an explanation of these enum values, see:

--- a/lib/web_ui/lib/src/engine/text/line_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/line_breaker.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Various types of line breaks as defined by the Unicode spec.

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 // TODO(yjbanov): this is a hack we use to compute ideographic baseline; this

--- a/lib/web_ui/lib/src/engine/text/paint_service.dart
+++ b/lib/web_ui/lib/src/engine/text/paint_service.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Responsible for painting a [CanvasParagraph] on a [BitmapCanvas].

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 const ui.Color _defaultTextColor = ui.Color(0xFFFF0000);

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 String _buildCssFontString({

--- a/lib/web_ui/lib/src/engine/text/unicode_range.dart
+++ b/lib/web_ui/lib/src/engine/text/unicode_range.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 const int _kChar_0 = 48;

--- a/lib/web_ui/lib/src/engine/text/word_break_properties.dart
+++ b/lib/web_ui/lib/src/engine/text/word_break_properties.dart
@@ -12,7 +12,6 @@
 // # Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
 // # For terms of use, see http://www.unicode.org/terms_of_use.html
 
-// @dart = 2.12
 part of engine;
 
 /// For an explanation of these enum values, see:

--- a/lib/web_ui/lib/src/engine/text/word_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/word_breaker.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class _FindBreakDirection {

--- a/lib/web_ui/lib/src/engine/text_editing/autofill_hint.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/autofill_hint.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Maps AutofillHints from the framework to the autofill hints that is used for

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Various types of inputs used in text fields.

--- a/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_capitalization.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Controls the capitalization of the text.

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Make the content editable span visible to facilitate debugging.

--- a/lib/web_ui/lib/src/engine/ulps.dart
+++ b/lib/web_ui/lib/src/engine/ulps.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 // This is a small library to handle stability for floating point operations.

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// Generic callback signature, used by [_futurize].

--- a/lib/web_ui/lib/src/engine/validators.dart
+++ b/lib/web_ui/lib/src/engine/validators.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 bool rectIsValid(ui.Rect rect) {

--- a/lib/web_ui/lib/src/engine/vector_math.dart
+++ b/lib/web_ui/lib/src/engine/vector_math.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 class Matrix4 {

--- a/lib/web_ui/lib/src/engine/web_experiments.dart
+++ b/lib/web_ui/lib/src/engine/web_experiments.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// A bag of all experiment flags in the web engine.

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of engine;
 
 /// When set to true, all platform messages will be printed to the console.

--- a/lib/web_ui/lib/src/ui/annotations.dart
+++ b/lib/web_ui/lib/src/ui/annotations.dart
@@ -4,7 +4,6 @@
 
 // TODO(dnfield): Remove unused_import ignores when https://github.com/dart-lang/sdk/issues/35164 is resolved.
 
-// @dart = 2.12
 part of ui;
 
 // TODO(dnfield): Update this if/when we default this to on in the tool,

--- a/lib/web_ui/lib/src/ui/canvas.dart
+++ b/lib/web_ui/lib/src/ui/canvas.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 enum PointMode {

--- a/lib/web_ui/lib/src/ui/channel_buffers.dart
+++ b/lib/web_ui/lib/src/ui/channel_buffers.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 // This is identical to ../../../../ui/channel_buffers.dart with the
 // following exceptions:

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 abstract class Scene {

--- a/lib/web_ui/lib/src/ui/geometry.dart
+++ b/lib/web_ui/lib/src/ui/geometry.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 abstract class OffsetBase {

--- a/lib/web_ui/lib/src/ui/hash_codes.dart
+++ b/lib/web_ui/lib/src/ui/hash_codes.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 class _HashEnd {

--- a/lib/web_ui/lib/src/ui/initialization.dart
+++ b/lib/web_ui/lib/src/ui/initialization.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 Future<void> webOnlyInitializePlatform({

--- a/lib/web_ui/lib/src/ui/key.dart
+++ b/lib/web_ui/lib/src/ui/key.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 part of ui;
 

--- a/lib/web_ui/lib/src/ui/lerp.dart
+++ b/lib/web_ui/lib/src/ui/lerp.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 /// Linearly interpolate between two numbers, `a` and `b`, by an extrapolation

--- a/lib/web_ui/lib/src/ui/natives.dart
+++ b/lib/web_ui/lib/src/ui/natives.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 List<int> saveCompilationTrace() {

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 // ignore: unused_element, Used in Shader assert.

--- a/lib/web_ui/lib/src/ui/path.dart
+++ b/lib/web_ui/lib/src/ui/path.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 abstract class Path {

--- a/lib/web_ui/lib/src/ui/path_metrics.dart
+++ b/lib/web_ui/lib/src/ui/path_metrics.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 abstract class PathMetrics extends collection.IterableBase<PathMetric> {

--- a/lib/web_ui/lib/src/ui/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/ui/platform_dispatcher.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 typedef VoidCallback = void Function();

--- a/lib/web_ui/lib/src/ui/pointer.dart
+++ b/lib/web_ui/lib/src/ui/pointer.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 enum PointerChange {

--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 class SemanticsAction {

--- a/lib/web_ui/lib/src/ui/test_embedding.dart
+++ b/lib/web_ui/lib/src/ui/test_embedding.dart
@@ -4,7 +4,6 @@
 
 // TODO(flutter_web): the Web-only API below need to be cleaned up.
 
-// @dart = 2.12
 part of ui;
 
 Future<void>? _testPlatformInitializedFuture;

--- a/lib/web_ui/lib/src/ui/text.dart
+++ b/lib/web_ui/lib/src/ui/text.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 enum FontStyle {

--- a/lib/web_ui/lib/src/ui/tile_mode.dart
+++ b/lib/web_ui/lib/src/ui/tile_mode.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 // These enum values must be kept in sync with SkShader::TileMode.

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 part of ui;
 
 abstract class FlutterView {

--- a/lib/web_ui/lib/ui.dart
+++ b/lib/web_ui/lib/ui.dart
@@ -5,7 +5,6 @@
 /// This library defines the web equivalent of the native dart:ui.
 ///
 /// All types in this library are public.
-// @dart = 2.12
 library ui;
 
 import 'dart:async';

--- a/lib/web_ui/test/browser_detect_test.dart
+++ b/lib/web_ui/test/browser_detect_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:html' as html;
 import 'dart:math' as math;
 import 'dart:typed_data';

--- a/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/color_filter_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:async';
 import 'dart:html' as html;
 

--- a/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:async';
 import 'dart:math' as math;
 import 'dart:typed_data';

--- a/lib/web_ui/test/canvaskit/initialization_test.dart
+++ b/lib/web_ui/test/canvaskit/initialization_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:html' as html;
 
 import 'package:test/bootstrap/browser.dart';

--- a/lib/web_ui/test/canvaskit/interval_tree_test.dart
+++ b/lib/web_ui/test/canvaskit/interval_tree_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 import 'package:ui/src/engine.dart';
 

--- a/lib/web_ui/test/canvaskit/layer_test.dart
+++ b/lib/web_ui/test/canvaskit/layer_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';

--- a/lib/web_ui/test/canvaskit/linear_gradient_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/linear_gradient_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:math' as math;
 
 import 'package:test/bootstrap/browser.dart';

--- a/lib/web_ui/test/canvaskit/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/canvaskit/platform_dispatcher_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:async';
 import 'dart:typed_data';
 

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:html' as html;
 
 import 'package:test/bootstrap/browser.dart';

--- a/lib/web_ui/test/canvaskit/sweep_gradient_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/sweep_gradient_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:math' as math;
 
 import 'package:test/bootstrap/browser.dart';

--- a/lib/web_ui/test/canvaskit/test_data.dart
+++ b/lib/web_ui/test/canvaskit/test_data.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 import 'dart:typed_data';
 

--- a/lib/web_ui/test/engine/history_test.dart
+++ b/lib/web_ui/test/engine/history_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 @TestOn('!safari')
 // TODO(nurhan): https://github.com/flutter/flutter/issues/51169
 

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:async';
 import 'dart:typed_data';
 

--- a/lib/web_ui/test/engine/surface/path/path_winding_test.dart
+++ b/lib/web_ui/test/engine/surface/path/path_winding_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 import 'dart:math' as math;
 import 'package:test/bootstrap/browser.dart';

--- a/lib/web_ui/test/golden_tests/engine/canvas_paragraph/helper.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_paragraph/helper.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:html' as html;
 
 import 'package:ui/src/engine.dart';

--- a/lib/web_ui/test/golden_tests/engine/color_filter_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/color_filter_golden_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:html' as html;
 import 'dart:js_util' as js_util;
 

--- a/lib/web_ui/test/keyboard_converter_test.dart
+++ b/lib/web_ui/test/keyboard_converter_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.10
-
 import 'package:quiver/testing/async.dart';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';

--- a/lib/web_ui/test/lerp_test.dart
+++ b/lib/web_ui/test/lerp_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 

--- a/lib/web_ui/test/matchers.dart
+++ b/lib/web_ui/test/matchers.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 /// Provides utilities for testing engine code.
-// @dart = 2.12
 library matchers;
 
 import 'dart:html' as html;

--- a/lib/web_ui/test/paragraph_builder_test.dart
+++ b/lib/web_ui/test/paragraph_builder_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';

--- a/lib/web_ui/test/path_test.dart
+++ b/lib/web_ui/test/path_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 import 'dart:js_util' as js_util;
 import 'dart:html' as html;

--- a/lib/web_ui/test/spy.dart
+++ b/lib/web_ui/test/spy.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart' hide window;

--- a/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_builder_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';

--- a/lib/web_ui/test/text/canvas_paragraph_test.dart
+++ b/lib/web_ui/test/text/canvas_paragraph_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';

--- a/lib/web_ui/test/text/layout_service_helper.dart
+++ b/lib/web_ui/test/text/layout_service_helper.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';

--- a/lib/web_ui/test/text/layout_service_plain_test.dart
+++ b/lib/web_ui/test/text/layout_service_plain_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';

--- a/lib/web_ui/test/text/layout_service_rich_test.dart
+++ b/lib/web_ui/test/text/layout_service_rich_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';

--- a/lib/web_ui/test/text/line_breaker_test.dart
+++ b/lib/web_ui/test/text/line_breaker_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 

--- a/lib/web_ui/test/text/line_breaker_test_helper.dart
+++ b/lib/web_ui/test/text/line_breaker_test_helper.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 // The following test cases contradict rule LB25, so we are replacing them
 // with correct expectations.

--- a/lib/web_ui/test/text/line_breaker_test_raw_data.dart
+++ b/lib/web_ui/test/text/line_breaker_test_raw_data.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 
 /// The list of test cases from:
 /// - https://www.unicode.org/Public/13.0.0/ucd/auxiliary/LineBreakTest.txt

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.12
 import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js_util' as js_util;


### PR DESCRIPTION
This PR removes dart language versions from null-safe files (i.e. using `@dart = 2.10` or `@dart = 2.12`).

Files that aren't null-safe yet will keep their language versions for now (i.e. `@dart = 2.6`).