### PR TITLE
Fix usage of (soon to be removed) Name.name

### DIFF
--- a/tools/const_finder/lib/const_finder.dart
+++ b/tools/const_finder/lib/const_finder.dart
@@ -87,7 +87,7 @@ class _ConstVisitor extends RecursiveVisitor<void> {
         continue;
       }
       final PrimitiveConstant<dynamic> value = kvp.value as PrimitiveConstant<dynamic>;
-      instance[kvp.key.asField.name.name] = value.value;
+      instance[kvp.key.asField.name.text] = value.value;
     }
     if (_visitedInstances.add(instance.toString())) {
       constantInstances.add(instance);


### PR DESCRIPTION
In kernel we some time ago renamed `Name`s `name` value to `text` but inserted `String get name => text;` to avoid breakage.
This PR replaces the single user of `name` with the more correct `text` to avoid breakage now that we're going to remove the getter.