### PR TITLE
Add Metal to the FlutterCompositor struct in the Embedder API

### DIFF
--- a/shell/gpu/gpu_surface_metal.h
+++ b/shell/gpu/gpu_surface_metal.h
@@ -16,7 +16,8 @@ namespace flutter {
 class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetal : public Surface {
  public:
   GPUSurfaceMetal(GPUSurfaceMetalDelegate* delegate,
-                  sk_sp<GrDirectContext> context);
+                  sk_sp<GrDirectContext> context,
+                  bool render_to_surface = true);
 
   // |Surface|
   ~GPUSurfaceMetal();
@@ -30,6 +31,11 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetal : public Surface {
   GrMTLHandle next_drawable_ = nullptr;
   sk_sp<GrDirectContext> context_;
   GrDirectContext* precompiled_sksl_context_ = nullptr;
+  // TODO(38466): Refactor GPU surface APIs take into account the fact that an
+  // external view embedder may want to render to the root surface. This is a
+  // hack to make avoid allocating resources for the root surface when an
+  // external view embedder is present.
+  bool render_to_surface_;
 
   // |Surface|
   std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) override;

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -230,6 +230,8 @@ if (enable_unittests) {
 
     if (test_enable_metal) {
       sources += [
+        "tests/embedder_test_compositor_metal.cc",
+        "tests/embedder_test_compositor_metal.h",
         "tests/embedder_test_context_metal.cc",
         "tests/embedder_test_context_metal.h",
         "tests/embedder_unittests_metal.mm",

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -571,7 +571,8 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
     const FlutterMetalBackingStore* metal) {
 #ifdef SHELL_ENABLE_METAL
   GrMtlTextureInfo texture_info;
-  texture_info.fTexture = sk_cf_obj<FlutterMetalTextureHandle>{metal->texture.texture};
+  texture_info.fTexture =
+      sk_cf_obj<FlutterMetalTextureHandle>{metal->texture.texture};
 
   GrBackendTexture backend_texture(config.size.width,   //
                                    config.size.height,  //

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -571,7 +571,7 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
     const FlutterMetalBackingStore* metal) {
 #ifdef SHELL_ENABLE_METAL
   GrMtlTextureInfo texture_info;
-  texture_info.fTexture.reset(metal->texture.texture);
+  texture_info.fTexture = sk_cf_obj<FlutterMetalTextureHandle>{metal->texture.texture};
 
   GrBackendTexture backend_texture(config.size.width,   //
                                    config.size.height,  //

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -591,8 +591,8 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
       backend_texture,           // back-end texture
       kTopLeft_GrSurfaceOrigin,  // surface origin
       1,                         // sample count
-      kN32_SkColorType,          // color type
-      SkColorSpace::MakeSRGB(),  // color space
+      kBGRA_8888_SkColorType,    // color type
+      nullptr,                   // color space
       &surface_properties,       // surface properties
       static_cast<SkSurface::TextureReleaseProc>(
           metal->texture.destruction_callback),  // release proc
@@ -601,9 +601,6 @@ static sk_sp<SkSurface> MakeSkSurfaceFromBackingStore(
 
   if (!surface) {
     FML_LOG(ERROR) << "Could not wrap embedder supplied Metal render texture.";
-    if (metal->texture.destruction_callback) {
-      metal->texture.destruction_callback(metal->texture.user_data);
-    }
     return nullptr;
   }
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -495,6 +495,13 @@ typedef struct {
   /// Handle to the MTLTexture that is owned by the embedder. Engine will render
   /// the frame into this texture.
   FlutterMetalTextureHandle texture;
+  /// A baton that is not interpreted by the engine in any way. It will be given
+  /// back to the embedder in the destruction callback below. Embedder resources
+  /// may be associated with this baton.
+  void* user_data;
+  /// The callback invoked by the engine when it no longer needs this backing
+  /// store.
+  VoidCallback destruction_callback;
 } FlutterMetalTexture;
 
 /// Callback for when a metal texture is requested.
@@ -945,8 +952,10 @@ typedef struct {
 } FlutterSoftwareBackingStore;
 
 typedef struct {
-  // A Metal texture for Flutter to render into.
-  FlutterMetalTexture texture;
+  union {
+    // A Metal texture for Flutter to render into.
+    FlutterMetalTexture texture;
+  };
 } FlutterMetalBackingStore;
 
 typedef enum {

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -944,6 +944,11 @@ typedef struct {
   VoidCallback destruction_callback;
 } FlutterSoftwareBackingStore;
 
+typedef struct {
+  // A Metal texture for Flutter to render into.
+  FlutterMetalTexture texture;
+} FlutterMetalBackingStore;
+
 typedef enum {
   /// Indicates that the Flutter application requested that an opacity be
   /// applied to the platform view.
@@ -1001,6 +1006,8 @@ typedef enum {
   kFlutterBackingStoreTypeOpenGL,
   /// Specified an software allocation for Flutter to render into using the CPU.
   kFlutterBackingStoreTypeSoftware,
+  /// Specifies a Metal backing store. This is backed by a Metal texture.
+  kFlutterBackingStoreTypeMetal,
 } FlutterBackingStoreType;
 
 typedef struct {
@@ -1020,6 +1027,8 @@ typedef struct {
     FlutterOpenGLBackingStore open_gl;
     /// The description of the software backing store.
     FlutterSoftwareBackingStore software;
+    // The description of the Metal backing store.
+    FlutterMetalBackingStore metal;
   };
 } FlutterBackingStore;
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -952,8 +952,12 @@ typedef struct {
 } FlutterSoftwareBackingStore;
 
 typedef struct {
+  /// The size of this struct. Must be sizeof(FlutterMetalBackingStore).
+  size_t struct_size;
   union {
-    // A Metal texture for Flutter to render into.
+    // A Metal texture for Flutter to render into. Ownership is not transferred
+    // to Flutter; the texture is CFRetained on successfully being passed in and
+    // CFReleased when no longer used.
     FlutterMetalTexture texture;
   };
 } FlutterMetalBackingStore;

--- a/shell/platform/embedder/embedder_surface_metal.mm
+++ b/shell/platform/embedder/embedder_surface_metal.mm
@@ -39,7 +39,8 @@ std::unique_ptr<Surface> EmbedderSurfaceMetal::CreateGPUSurface() {
     return nullptr;
   }
 
-  auto surface = std::make_unique<GPUSurfaceMetal>(this, main_context_);
+  const bool render_to_surface = !external_view_embedder_;
+  auto surface = std::make_unique<GPUSurfaceMetal>(this, main_context_, render_to_surface);
 
   if (!surface->IsValid()) {
     return nullptr;

--- a/shell/platform/embedder/tests/embedder_assertions.h
+++ b/shell/platform/embedder/tests/embedder_assertions.h
@@ -65,6 +65,16 @@ inline bool operator==(const FlutterOpenGLFramebuffer& a,
          a.destruction_callback == b.destruction_callback;
 }
 
+inline bool operator==(const FlutterMetalTexture& a,
+                       const FlutterMetalTexture& b) {
+  return a.texture_id == b.texture_id && a.texture == b.texture;
+}
+
+inline bool operator==(const FlutterMetalBackingStore& a,
+                       const FlutterMetalBackingStore& b) {
+  return a.texture == b.texture;
+}
+
 inline bool operator==(const FlutterOpenGLBackingStore& a,
                        const FlutterOpenGLBackingStore& b) {
   if (!(a.type == b.type)) {
@@ -100,6 +110,8 @@ inline bool operator==(const FlutterBackingStore& a,
       return a.open_gl == b.open_gl;
     case kFlutterBackingStoreTypeSoftware:
       return a.software == b.software;
+    case kFlutterBackingStoreTypeMetal:
+      return a.metal == b.metal;
   }
 
   return false;
@@ -216,6 +228,8 @@ inline std::string FlutterBackingStoreTypeToString(
       return "kFlutterBackingStoreTypeOpenGL";
     case kFlutterBackingStoreTypeSoftware:
       return "kFlutterBackingStoreTypeSoftware";
+    case kFlutterBackingStoreTypeMetal:
+      return "kFlutterBackingStoreTypeMetal";
   }
   return "Unknown";
 }
@@ -236,6 +250,12 @@ inline std::ostream& operator<<(std::ostream& out,
              << reinterpret_cast<void*>(item.destruction_callback);
 }
 
+inline std::ostream& operator<<(std::ostream& out,
+                                const FlutterMetalTexture& item) {
+  return out << "(FlutterMetalTexture) Texture ID: " << std::hex
+             << item.texture_id << std::dec << " Handle: 0x" << std::hex
+             << item.texture;
+}
 inline std::string FlutterPlatformViewMutationTypeToString(
     FlutterPlatformViewMutationType type) {
   switch (type) {
@@ -323,6 +343,11 @@ inline std::ostream& operator<<(std::ostream& out,
 }
 
 inline std::ostream& operator<<(std::ostream& out,
+                                const FlutterMetalBackingStore& item) {
+  return out << "(FlutterMetalBackingStore) Texture: " << item.texture;
+}
+
+inline std::ostream& operator<<(std::ostream& out,
                                 const FlutterBackingStore& backing_store) {
   out << "(FlutterBackingStore) Struct size: " << backing_store.struct_size
       << " User Data: " << backing_store.user_data
@@ -336,6 +361,10 @@ inline std::ostream& operator<<(std::ostream& out,
 
     case kFlutterBackingStoreTypeSoftware:
       out << backing_store.software;
+      break;
+
+    case kFlutterBackingStoreTypeMetal:
+      out << backing_store.metal;
       break;
   }
 

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -400,7 +400,8 @@ void EmbedderConfigBuilder::InitializeMetalRendererConfig() {
       metal_context.GetTestMetalContext()->GetMetalCommandQueue();
   metal_renderer_config_.get_next_drawable_callback =
       [](void* user_data, const FlutterFrameInfo* frame_info) {
-        return reinterpret_cast<EmbedderTestContextMetal*>(user_data)->GetNextDrawable(frame_info);
+        return reinterpret_cast<EmbedderTestContextMetal*>(user_data)
+            ->GetNextDrawable(frame_info);
       };
   metal_renderer_config_.present_drawable_callback =
       [](void* user_data, const FlutterMetalTexture* texture) -> bool {

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -400,19 +400,7 @@ void EmbedderConfigBuilder::InitializeMetalRendererConfig() {
       metal_context.GetTestMetalContext()->GetMetalCommandQueue();
   metal_renderer_config_.get_next_drawable_callback =
       [](void* user_data, const FlutterFrameInfo* frame_info) {
-        EmbedderTestContextMetal* metal_context =
-            reinterpret_cast<EmbedderTestContextMetal*>(user_data);
-        SkISize surface_size =
-            SkISize::Make(frame_info->size.width, frame_info->size.height);
-        TestMetalContext::TextureInfo texture_info =
-            metal_context->GetTestMetalContext()->CreateMetalTexture(
-                surface_size);
-        FlutterMetalTexture texture;
-        texture.struct_size = sizeof(FlutterMetalTexture);
-        texture.texture_id = texture_info.texture_id;
-        texture.texture =
-            reinterpret_cast<FlutterMetalTextureHandle>(texture_info.texture);
-        return texture;
+        return reinterpret_cast<EmbedderTestContextMetal*>(user_data)->GetNextDrawable(frame_info);
       };
   metal_renderer_config_.present_drawable_callback =
       [](void* user_data, const FlutterMetalTexture* texture) -> bool {

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -14,20 +14,23 @@
 namespace flutter {
 namespace testing {
 
-EmbedderTestBackingStoreProducer::EmbedderTestBackingStoreProducer(sk_sp<GrDirectContext> context,
-                                                                   RenderTargetType type)
-    : context_(context)
-    , type_(type)
+EmbedderTestBackingStoreProducer::EmbedderTestBackingStoreProducer(
+    sk_sp<GrDirectContext> context,
+    RenderTargetType type)
+    : context_(context),
+      type_(type)
 #ifdef SHELL_ENABLE_METAL
-    , test_metal_context_(std::make_unique<TestMetalContext>())
+      ,
+      test_metal_context_(std::make_unique<TestMetalContext>())
 #endif
 {
 }
 
 EmbedderTestBackingStoreProducer::~EmbedderTestBackingStoreProducer() = default;
 
-bool EmbedderTestBackingStoreProducer::Create(const FlutterBackingStoreConfig* config,
-                                              FlutterBackingStore* renderer_out) {
+bool EmbedderTestBackingStoreProducer::Create(
+    const FlutterBackingStoreConfig* config,
+    FlutterBackingStore* renderer_out) {
   switch (type_) {
     case RenderTargetType::kSoftwareBuffer:
       return CreateSoftware(config, renderer_out);
@@ -46,18 +49,21 @@ bool EmbedderTestBackingStoreProducer::Create(const FlutterBackingStoreConfig* c
   }
 }
 
-bool EmbedderTestBackingStoreProducer::CreateFramebuffer(const FlutterBackingStoreConfig* config,
-                                                         FlutterBackingStore* backing_store_out) {
+bool EmbedderTestBackingStoreProducer::CreateFramebuffer(
+    const FlutterBackingStoreConfig* config,
+    FlutterBackingStore* backing_store_out) {
 #ifdef SHELL_ENABLE_GL
-  const auto image_info = SkImageInfo::MakeN32Premul(config->size.width, config->size.height);
+  const auto image_info =
+      SkImageInfo::MakeN32Premul(config->size.width, config->size.height);
 
-  auto surface = SkSurface::MakeRenderTarget(context_.get(),               // context
-                                             SkBudgeted::kNo,              // budgeted
-                                             image_info,                   // image info
-                                             1,                            // sample count
-                                             kBottomLeft_GrSurfaceOrigin,  // surface origin
-                                             nullptr,                      // surface properties
-                                             false                         // mipmaps
+  auto surface = SkSurface::MakeRenderTarget(
+      context_.get(),               // context
+      SkBudgeted::kNo,              // budgeted
+      image_info,                   // image info
+      1,                            // sample count
+      kBottomLeft_GrSurfaceOrigin,  // surface origin
+      nullptr,                      // surface properties
+      false                         // mipmaps
   );
 
   if (!surface) {
@@ -87,9 +93,8 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(const FlutterBackingSto
   // The balancing unref is in the destruction callback.
   surface->ref();
   backing_store_out->open_gl.framebuffer.user_data = surface.get();
-  backing_store_out->open_gl.framebuffer.destruction_callback = [](void* user_data) {
-    reinterpret_cast<SkSurface*>(user_data)->unref();
-  };
+  backing_store_out->open_gl.framebuffer.destruction_callback =
+      [](void* user_data) { reinterpret_cast<SkSurface*>(user_data)->unref(); };
 
   return true;
 #else
@@ -97,18 +102,21 @@ bool EmbedderTestBackingStoreProducer::CreateFramebuffer(const FlutterBackingSto
 #endif
 }
 
-bool EmbedderTestBackingStoreProducer::CreateTexture(const FlutterBackingStoreConfig* config,
-                                                     FlutterBackingStore* backing_store_out) {
+bool EmbedderTestBackingStoreProducer::CreateTexture(
+    const FlutterBackingStoreConfig* config,
+    FlutterBackingStore* backing_store_out) {
 #ifdef SHELL_ENABLE_GL
-  const auto image_info = SkImageInfo::MakeN32Premul(config->size.width, config->size.height);
+  const auto image_info =
+      SkImageInfo::MakeN32Premul(config->size.width, config->size.height);
 
-  auto surface = SkSurface::MakeRenderTarget(context_.get(),               // context
-                                             SkBudgeted::kNo,              // budgeted
-                                             image_info,                   // image info
-                                             1,                            // sample count
-                                             kBottomLeft_GrSurfaceOrigin,  // surface origin
-                                             nullptr,                      // surface properties
-                                             false                         // mipmaps
+  auto surface = SkSurface::MakeRenderTarget(
+      context_.get(),               // context
+      SkBudgeted::kNo,              // budgeted
+      image_info,                   // image info
+      1,                            // sample count
+      kBottomLeft_GrSurfaceOrigin,  // surface origin
+      nullptr,                      // surface properties
+      false                         // mipmaps
   );
 
   if (!surface) {
@@ -116,8 +124,8 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(const FlutterBackingStoreCo
     return false;
   }
 
-  GrBackendTexture render_texture =
-      surface->getBackendTexture(SkSurface::BackendHandleAccess::kDiscardWrite_BackendHandleAccess);
+  GrBackendTexture render_texture = surface->getBackendTexture(
+      SkSurface::BackendHandleAccess::kDiscardWrite_BackendHandleAccess);
 
   if (!render_texture.isValid()) {
     FML_LOG(ERROR) << "Backend render texture was invalid.";
@@ -139,9 +147,8 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(const FlutterBackingStoreCo
   // The balancing unref is in the destruction callback.
   surface->ref();
   backing_store_out->open_gl.texture.user_data = surface.get();
-  backing_store_out->open_gl.texture.destruction_callback = [](void* user_data) {
-    reinterpret_cast<SkSurface*>(user_data)->unref();
-  };
+  backing_store_out->open_gl.texture.destruction_callback =
+      [](void* user_data) { reinterpret_cast<SkSurface*>(user_data)->unref(); };
 
   return true;
 #else
@@ -149,13 +156,15 @@ bool EmbedderTestBackingStoreProducer::CreateTexture(const FlutterBackingStoreCo
 #endif
 }
 
-bool EmbedderTestBackingStoreProducer::CreateSoftware(const FlutterBackingStoreConfig* config,
-                                                      FlutterBackingStore* backing_store_out) {
-  auto surface =
-      SkSurface::MakeRaster(SkImageInfo::MakeN32Premul(config->size.width, config->size.height));
+bool EmbedderTestBackingStoreProducer::CreateSoftware(
+    const FlutterBackingStoreConfig* config,
+    FlutterBackingStore* backing_store_out) {
+  auto surface = SkSurface::MakeRaster(
+      SkImageInfo::MakeN32Premul(config->size.width, config->size.height));
 
   if (!surface) {
-    FML_LOG(ERROR) << "Could not create the render target for compositor layer.";
+    FML_LOG(ERROR)
+        << "Could not create the render target for compositor layer.";
     return false;
   }
 
@@ -180,8 +189,9 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware(const FlutterBackingStoreC
   return true;
 }
 
-bool EmbedderTestBackingStoreProducer::CreateMTLTexture(const FlutterBackingStoreConfig* config,
-                                                        FlutterBackingStore* backing_store_out) {
+bool EmbedderTestBackingStoreProducer::CreateMTLTexture(
+    const FlutterBackingStoreConfig* config,
+    FlutterBackingStore* backing_store_out) {
 #ifdef SHELL_ENABLE_METAL
   // TODO(gw280): Use SkSurface::MakeRenderTarget instead of generating our
   // own MTLTexture and wrapping it.
@@ -192,12 +202,17 @@ bool EmbedderTestBackingStoreProducer::CreateMTLTexture(const FlutterBackingStor
 
   GrMtlTextureInfo skia_texture_info;
   skia_texture_info.fTexture = texture;
-  GrBackendTexture backend_texture(surface_size.width(), surface_size.height(), GrMipmapped::kNo,
-                                   skia_texture_info);
+  GrBackendTexture backend_texture(surface_size.width(), surface_size.height(),
+                                   GrMipmapped::kNo, skia_texture_info);
+
+  SkSurface::TextureReleaseProc release_mtltexture = [](void* user_data) {
+    SkCFSafeRelease(user_data);
+  };
 
   sk_sp<SkSurface> surface = SkSurface::MakeFromBackendTexture(
       context_.get(), backend_texture, kTopLeft_GrSurfaceOrigin, 1,
-      kBGRA_8888_SkColorType, nullptr, nullptr);
+      kBGRA_8888_SkColorType, nullptr, nullptr, release_mtltexture,
+      texture_info.texture);
 
   if (!surface) {
     FML_LOG(ERROR) << "Could not create Skia surface from a Metal texture.";

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -29,6 +29,10 @@ bool EmbedderTestBackingStoreProducer::Create(
     case RenderTargetType::kOpenGLFramebuffer:
       return CreateFramebuffer(config, renderer_out);
 #endif
+#ifdef SHELL_ENABLE_METAL
+    case RenderTargetType::kMetalTexture:
+      return CreateMTLTexture(config, renderer_out);
+#endif
     default:
       return false;
   }
@@ -172,6 +176,57 @@ bool EmbedderTestBackingStoreProducer::CreateSoftware(
   };
 
   return true;
+}
+
+bool EmbedderTestBackingStoreProducer::CreateMTLTexture(
+    const FlutterBackingStoreConfig* config,
+    FlutterBackingStore* backing_store_out) {
+#ifdef SHELL_ENABLE_METAL
+  const auto image_info =
+      SkImageInfo::MakeN32Premul(config->size.width, config->size.height);
+
+  auto surface = SkSurface::MakeRenderTarget(
+      context_.get(),               // context
+      SkBudgeted::kNo,              // budgeted
+      image_info,                   // image info
+      1,                            // sample count
+      kTopLeft_GrSurfaceOrigin,     // surface origin
+      nullptr,                      // surface properties
+      false                         // mipmaps
+  );
+
+  if (!surface) {
+    FML_LOG(ERROR) << "Could not create render target for compositor layer.";
+    return false;
+  }
+
+  GrBackendTexture render_texture = surface->getBackendTexture(
+      SkSurface::BackendHandleAccess::kDiscardWrite_BackendHandleAccess);
+
+  if (!render_texture.isValid()) {
+    FML_LOG(ERROR) << "Backend render texture was invalid.";
+    return false;
+  }
+
+  GrMtlTextureInfo texture_info = {};
+  if (!render_texture.getMtlTextureInfo(&texture_info)) {
+    FML_LOG(ERROR) << "Could not access backend texture info.";
+    return false;
+  }
+
+  backing_store_out->type = kFlutterBackingStoreTypeMetal;
+  backing_store_out->user_data = surface.get();
+  backing_store_out->metal.texture.texture = texture_info.fTexture.get();
+  // The balancing unref is in the destruction callback.
+  surface->ref();
+  backing_store_out->metal.texture.user_data = surface.get();
+  backing_store_out->metal.texture.destruction_callback =
+      [](void* user_data) { reinterpret_cast<SkSurface*>(user_data)->unref(); };
+
+  return true;
+#else
+  return false;
+#endif
 }
 
 }  // namespace testing

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -219,6 +219,7 @@ bool EmbedderTestBackingStoreProducer::CreateMTLTexture(
   backing_store_out->metal.texture.texture = texture_info.fTexture.get();
   // The balancing unref is in the destruction callback.
   surface->ref();
+  backing_store_out->metal.struct_size = sizeof(FlutterMetalBackingStore);
   backing_store_out->metal.texture.user_data = surface.get();
   backing_store_out->metal.texture.destruction_callback = [](void* user_data) {
     reinterpret_cast<SkSurface*>(user_data)->unref();

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.cc
@@ -185,15 +185,15 @@ bool EmbedderTestBackingStoreProducer::CreateMTLTexture(
   const auto image_info =
       SkImageInfo::MakeN32Premul(config->size.width, config->size.height);
 
-  auto surface = SkSurface::MakeRenderTarget(
-      context_.get(),               // context
-      SkBudgeted::kNo,              // budgeted
-      image_info,                   // image info
-      1,                            // sample count
-      kTopLeft_GrSurfaceOrigin,     // surface origin
-      nullptr,                      // surface properties
-      false                         // mipmaps
-  );
+  auto surface =
+      SkSurface::MakeRenderTarget(context_.get(),            // context
+                                  SkBudgeted::kNo,           // budgeted
+                                  image_info,                // image info
+                                  1,                         // sample count
+                                  kTopLeft_GrSurfaceOrigin,  // surface origin
+                                  nullptr,  // surface properties
+                                  false     // mipmaps
+      );
 
   if (!surface) {
     FML_LOG(ERROR) << "Could not create render target for compositor layer.";
@@ -220,8 +220,9 @@ bool EmbedderTestBackingStoreProducer::CreateMTLTexture(
   // The balancing unref is in the destruction callback.
   surface->ref();
   backing_store_out->metal.texture.user_data = surface.get();
-  backing_store_out->metal.texture.destruction_callback =
-      [](void* user_data) { reinterpret_cast<SkSurface*>(user_data)->unref(); };
+  backing_store_out->metal.texture.destruction_callback = [](void* user_data) {
+    reinterpret_cast<SkSurface*>(user_data)->unref();
+  };
 
   return true;
 #else

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -19,6 +19,7 @@ class EmbedderTestBackingStoreProducer {
     kSoftwareBuffer,
     kOpenGLFramebuffer,
     kOpenGLTexture,
+    kMetalTexture,
   };
 
   EmbedderTestBackingStoreProducer(sk_sp<GrDirectContext> context,
@@ -37,6 +38,9 @@ class EmbedderTestBackingStoreProducer {
 
   bool CreateSoftware(const FlutterBackingStoreConfig* config,
                       FlutterBackingStore* backing_store_out);
+
+  bool CreateMTLTexture(const FlutterBackingStoreConfig* config,
+                        FlutterBackingStore* renderer_out);
 
   sk_sp<GrDirectContext> context_;
   RenderTargetType type_;

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -8,8 +8,11 @@
 #include <memory>
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
-#include "flutter/testing/test_metal_context.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
+
+#ifdef SHELL_ENABLE_METAL
+#include "flutter/testing/test_metal_context.h"
+#endif
 
 namespace flutter {
 namespace testing {

--- a/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
+++ b/shell/platform/embedder/tests/embedder_test_backingstore_producer.h
@@ -5,9 +5,10 @@
 #ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_TEST_BACKINGSTORE_PRODUCER_H_
 #define FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_TEST_BACKINGSTORE_PRODUCER_H_
 
+#include <memory>
 #include "flutter/fml/macros.h"
 #include "flutter/shell/platform/embedder/embedder.h"
-
+#include "flutter/testing/test_metal_context.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {
@@ -44,6 +45,10 @@ class EmbedderTestBackingStoreProducer {
 
   sk_sp<GrDirectContext> context_;
   RenderTargetType type_;
+
+#ifdef SHELL_ENABLE_METAL
+  std::unique_ptr<TestMetalContext> test_metal_context_;
+#endif
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderTestBackingStoreProducer);
 };

--- a/shell/platform/embedder/tests/embedder_test_compositor_metal.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_metal.cc
@@ -59,7 +59,6 @@ bool EmbedderTestCompositorMetal::UpdateOffscrenComposition(
         layer_image =
             reinterpret_cast<SkSurface*>(layer->backing_store->user_data)
                 ->makeImageSnapshot();
-
         break;
       case kFlutterLayerContentTypePlatformView:
         layer_image =

--- a/shell/platform/embedder/tests/embedder_test_compositor_metal.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor_metal.cc
@@ -1,0 +1,110 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/embedder/tests/embedder_test_compositor_metal.h"
+
+#include "flutter/fml/logging.h"
+#include "flutter/shell/platform/embedder/tests/embedder_assertions.h"
+#include "third_party/skia/include/core/SkSurface.h"
+
+namespace flutter {
+namespace testing {
+
+EmbedderTestCompositorMetal::EmbedderTestCompositorMetal(
+    SkISize surface_size,
+    sk_sp<GrDirectContext> context)
+    : EmbedderTestCompositor(surface_size, context) {}
+
+EmbedderTestCompositorMetal::~EmbedderTestCompositorMetal() = default;
+
+bool EmbedderTestCompositorMetal::UpdateOffscrenComposition(
+    const FlutterLayer** layers,
+    size_t layers_count) {
+  last_composition_ = nullptr;
+
+  const auto image_info = SkImageInfo::MakeN32Premul(surface_size_);
+
+  auto surface =
+      SkSurface::MakeRenderTarget(context_.get(),            // context
+                                  SkBudgeted::kNo,           // budgeted
+                                  image_info,                // image info
+                                  1,                         // sample count
+                                  kTopLeft_GrSurfaceOrigin,  // surface origin
+                                  nullptr,  // surface properties
+                                  false     // create mipmaps
+      );
+
+  if (!surface) {
+    FML_LOG(ERROR) << "Could not update the off-screen composition.";
+    return false;
+  }
+
+  auto canvas = surface->getCanvas();
+
+  // This has to be transparent because we are going to be compositing this
+  // sub-hierarchy onto the on-screen surface.
+  canvas->clear(SK_ColorTRANSPARENT);
+
+  for (size_t i = 0; i < layers_count; ++i) {
+    const auto* layer = layers[i];
+
+    sk_sp<SkImage> platform_rendered_contents;
+
+    sk_sp<SkImage> layer_image;
+    SkIPoint canvas_offset = SkIPoint::Make(0, 0);
+
+    switch (layer->type) {
+      case kFlutterLayerContentTypeBackingStore:
+        layer_image =
+            reinterpret_cast<SkSurface*>(layer->backing_store->user_data)
+                ->makeImageSnapshot();
+
+        break;
+      case kFlutterLayerContentTypePlatformView:
+        layer_image =
+            platform_view_renderer_callback_
+                ? platform_view_renderer_callback_(*layer, context_.get())
+                : nullptr;
+        canvas_offset = SkIPoint::Make(layer->offset.x, layer->offset.y);
+        break;
+    };
+
+    // If the layer is not a platform view but the engine did not specify an
+    // image for the backing store, it is an error.
+    if (!layer_image && layer->type != kFlutterLayerContentTypePlatformView) {
+      FML_LOG(ERROR) << "Could not snapshot layer in test compositor: "
+                     << *layer;
+      return false;
+    }
+
+    // The test could have just specified no contents to be rendered in place of
+    // a platform view. This is not an error.
+    if (layer_image) {
+      // The image rendered by Flutter already has the correct offset and
+      // transformation applied. The layers offset is meant for the platform.
+      canvas->drawImage(layer_image.get(), canvas_offset.x(),
+                        canvas_offset.y());
+    }
+  }
+
+  last_composition_ = surface->makeImageSnapshot();
+
+  if (!last_composition_) {
+    FML_LOG(ERROR) << "Could not update the contents of the sub-composition.";
+    return false;
+  }
+
+  if (next_scene_callback_) {
+    auto last_composition_snapshot = last_composition_->makeRasterImage();
+    FML_CHECK(last_composition_snapshot);
+    auto callback = next_scene_callback_;
+    next_scene_callback_ = nullptr;
+    callback(std::move(last_composition_snapshot));
+  }
+
+  return true;
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_compositor_metal.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor_metal.h
@@ -15,7 +15,7 @@ namespace testing {
 class EmbedderTestCompositorMetal : public EmbedderTestCompositor {
  public:
   EmbedderTestCompositorMetal(SkISize surface_size,
-                           sk_sp<GrDirectContext> context);
+                              sk_sp<GrDirectContext> context);
 
   ~EmbedderTestCompositorMetal() override;
 

--- a/shell/platform/embedder/tests/embedder_test_compositor_metal.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor_metal.h
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_TEST_COMPOSITOR_METAL_H_
+#define FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_TEST_COMPOSITOR_METAL_H_
+
+#include "flutter/fml/macros.h"
+#include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/embedder/tests/embedder_test_compositor.h"
+
+namespace flutter {
+namespace testing {
+
+class EmbedderTestCompositorMetal : public EmbedderTestCompositor {
+ public:
+  EmbedderTestCompositorMetal(SkISize surface_size,
+                           sk_sp<GrDirectContext> context);
+
+  ~EmbedderTestCompositorMetal() override;
+
+ private:
+  bool UpdateOffscrenComposition(const FlutterLayer** layers,
+                                 size_t layers_count) override;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(EmbedderTestCompositorMetal);
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_TEST_COMPOSITOR_METAL_H_

--- a/shell/platform/embedder/tests/embedder_test_context_metal.cc
+++ b/shell/platform/embedder/tests/embedder_test_context_metal.cc
@@ -47,9 +47,8 @@ TestMetalContext* EmbedderTestContextMetal::GetTestMetalContext() {
 }
 
 bool EmbedderTestContextMetal::Present(int64_t texture_id) {
-  FireRootSurfacePresentCallbackIfPresent([&]() {
-    return metal_surface_->GetRasterSurfaceSnapshot();
-  });
+  FireRootSurfacePresentCallbackIfPresent(
+      [&]() { return metal_surface_->GetRasterSurfaceSnapshot(); });
   present_count_++;
   return metal_context_->Present(texture_id);
 }
@@ -71,7 +70,8 @@ bool EmbedderTestContextMetal::PopulateExternalTexture(
   }
 }
 
-FlutterMetalTexture EmbedderTestContextMetal::GetNextDrawable(const FlutterFrameInfo* frame_info) {
+FlutterMetalTexture EmbedderTestContextMetal::GetNextDrawable(
+    const FlutterFrameInfo* frame_info) {
   auto texture_info = metal_surface_->GetTextureInfo();
 
   FlutterMetalTexture texture;
@@ -81,7 +81,6 @@ FlutterMetalTexture EmbedderTestContextMetal::GetNextDrawable(const FlutterFrame
       reinterpret_cast<FlutterMetalTextureHandle>(texture_info.texture);
   return texture;
 }
-
 
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_context_metal.cc
+++ b/shell/platform/embedder/tests/embedder_test_context_metal.cc
@@ -71,5 +71,17 @@ bool EmbedderTestContextMetal::PopulateExternalTexture(
   }
 }
 
+FlutterMetalTexture EmbedderTestContextMetal::GetNextDrawable(const FlutterFrameInfo* frame_info) {
+  auto texture_info = metal_surface_->GetTextureInfo();
+
+  FlutterMetalTexture texture;
+  texture.struct_size = sizeof(FlutterMetalTexture);
+  texture.texture_id = texture_info.texture_id;
+  texture.texture =
+      reinterpret_cast<FlutterMetalTextureHandle>(texture_info.texture);
+  return texture;
+}
+
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_context_metal.h
+++ b/shell/platform/embedder/tests/embedder_test_context_metal.h
@@ -45,6 +45,8 @@ class EmbedderTestContextMetal : public EmbedderTestContext {
 
   TestMetalContext* GetTestMetalContext();
 
+  FlutterMetalTexture GetNextDrawable(const FlutterFrameInfo* frame_info);
+
  private:
   // This allows the builder to access the hooks.
   friend class EmbedderConfigBuilder;

--- a/shell/platform/embedder/tests/embedder_test_context_metal.h
+++ b/shell/platform/embedder/tests/embedder_test_context_metal.h
@@ -52,6 +52,7 @@ class EmbedderTestContextMetal : public EmbedderTestContext {
   TestExternalTextureCallback external_texture_frame_callback_ = nullptr;
   SkISize surface_size_ = SkISize::MakeEmpty();
   std::unique_ptr<TestMetalContext> metal_context_;
+  std::unique_ptr<TestMetalSurface> metal_surface_;
   size_t present_count_ = 0;
 
   void SetupSurface(SkISize surface_size) override;

--- a/shell/platform/embedder/tests/embedder_unittests_metal.mm
+++ b/shell/platform/embedder/tests/embedder_unittests_metal.mm
@@ -125,8 +125,7 @@ TEST_F(EmbedderTest, MetalCompositorMustBeAbleToRenderPlatformViews) {
   builder.SetCompositor();
   builder.SetDartEntrypoint("can_composite_platform_views");
 
-  builder.SetRenderTargetType(
-      EmbedderTestBackingStoreProducer::RenderTargetType::kMetalTexture);
+  builder.SetRenderTargetType(EmbedderTestBackingStoreProducer::RenderTargetType::kMetalTexture);
 
   fml::CountDownLatch latch(3);
   context.GetCompositor().SetNextPresentCallback(
@@ -185,8 +184,7 @@ TEST_F(EmbedderTest, MetalCompositorMustBeAbleToRenderPlatformViews) {
 
   context.AddNativeCallback(
       "SignalNativeTest",
-      CREATE_NATIVE_ENTRY(
-          [&latch](Dart_NativeArguments args) { latch.CountDown(); }));
+      CREATE_NATIVE_ENTRY([&latch](Dart_NativeArguments args) { latch.CountDown(); }));
 
   auto engine = builder.LaunchEngine();
 
@@ -196,13 +194,11 @@ TEST_F(EmbedderTest, MetalCompositorMustBeAbleToRenderPlatformViews) {
   event.width = 800;
   event.height = 600;
   event.pixel_ratio = 1.0;
-  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
-            kSuccess);
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event), kSuccess);
   ASSERT_TRUE(engine.is_valid());
 
   latch.Wait();
 }
-
 
 TEST_F(EmbedderTest, CanRenderSceneWithoutCustomCompositorMetal) {
   auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
@@ -223,11 +219,9 @@ TEST_F(EmbedderTest, CanRenderSceneWithoutCustomCompositorMetal) {
   event.width = 800;
   event.height = 600;
   event.pixel_ratio = 1.0;
-  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
-            kSuccess);
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event), kSuccess);
 
-  ASSERT_TRUE(ImageMatchesFixture("scene_without_custom_compositor.png",
-                                  rendered_scene));
+  ASSERT_TRUE(ImageMatchesFixture("scene_without_custom_compositor.png", rendered_scene));
 }
 
 }  // namespace testing

--- a/shell/platform/embedder/tests/embedder_unittests_metal.mm
+++ b/shell/platform/embedder/tests/embedder_unittests_metal.mm
@@ -204,5 +204,31 @@ TEST_F(EmbedderTest, MetalCompositorMustBeAbleToRenderPlatformViews) {
 }
 
 
+TEST_F(EmbedderTest, CanRenderSceneWithoutCustomCompositorMetal) {
+  auto& context = GetEmbedderContext(EmbedderTestContextType::kMetalContext);
+
+  EmbedderConfigBuilder builder(context);
+
+  builder.SetDartEntrypoint("can_render_scene_without_custom_compositor");
+  builder.SetMetalRendererConfig(SkISize::Make(800, 600));
+
+  auto rendered_scene = context.GetNextSceneImage();
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+
+  // Send a window metrics events so frames may be scheduled.
+  FlutterWindowMetricsEvent event = {};
+  event.struct_size = sizeof(event);
+  event.width = 800;
+  event.height = 600;
+  event.pixel_ratio = 1.0;
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
+            kSuccess);
+
+  ASSERT_TRUE(ImageMatchesFixture("scene_without_custom_compositor.png",
+                                  rendered_scene));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/testing/test_metal_surface.cc
+++ b/testing/test_metal_surface.cc
@@ -48,4 +48,8 @@ sk_sp<SkImage> TestMetalSurface::GetRasterSurfaceSnapshot() {
   return impl_ ? impl_->GetRasterSurfaceSnapshot() : nullptr;
 }
 
+TestMetalContext::TextureInfo TestMetalSurface::GetTextureInfo() {
+  return impl_ ? impl_->GetTextureInfo() : TestMetalContext::TextureInfo();
+}
+
 }  // namespace flutter

--- a/testing/test_metal_surface.h
+++ b/testing/test_metal_surface.h
@@ -40,6 +40,8 @@ class TestMetalSurface {
 
   virtual sk_sp<SkImage> GetRasterSurfaceSnapshot();
 
+  virtual TestMetalContext::TextureInfo GetTextureInfo();
+
  protected:
   TestMetalSurface();
 

--- a/testing/test_metal_surface_impl.h
+++ b/testing/test_metal_surface_impl.h
@@ -30,6 +30,7 @@ class TestMetalSurfaceImpl : public TestMetalSurface {
   const TestMetalContext& test_metal_context_;
   bool is_valid_ = false;
   sk_sp<SkSurface> surface_;
+  TestMetalContext::TextureInfo texture_info_;
 
   // |TestMetalSurface|
   bool IsValid() const override;
@@ -42,6 +43,9 @@ class TestMetalSurfaceImpl : public TestMetalSurface {
 
   // |TestMetalSurface|
   sk_sp<SkImage> GetRasterSurfaceSnapshot() override;
+
+  // |TestMetalSurface|
+  TestMetalContext::TextureInfo GetTextureInfo() override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(TestMetalSurfaceImpl);
 };

--- a/testing/test_metal_surface_impl.mm
+++ b/testing/test_metal_surface_impl.mm
@@ -9,6 +9,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/testing/test_metal_context.h"
+#include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
@@ -48,6 +49,7 @@ void TestMetalSurfaceImpl::Init(const TestMetalContext::TextureInfo& texture_inf
   }
 
   surface_ = std::move(surface);
+  texture_info_ = std::move(texture_info);
   is_valid_ = true;
 }
 
@@ -118,6 +120,11 @@ sk_sp<GrDirectContext> TestMetalSurfaceImpl::GetGrContext() const {
 // |TestMetalSurface|
 sk_sp<SkSurface> TestMetalSurfaceImpl::GetSurface() const {
   return IsValid() ? surface_ : nullptr;
+}
+
+// |TestMetalSurface|
+TestMetalContext::TextureInfo TestMetalSurfaceImpl::GetTextureInfo() {
+  return IsValid() ? texture_info_ : TestMetalContext::TextureInfo();
 }
 
 }  // namespace flutter


### PR DESCRIPTION
This adds a Metal rendering type to the Embedder API's FlutterCompositor struct. 

https://github.com/flutter/flutter/issues/80396

Needs tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
