### PR TITLE
More reverts for insecure http policy since the Dart implementation is reverted

### DIFF
--- a/lib/io/dart_io.cc
+++ b/lib/io/dart_io.cc
@@ -17,25 +17,8 @@ namespace flutter {
 
 void DartIO::InitForIsolate(bool may_insecurely_connect_to_all_domains,
                             std::string domain_network_policy) {
-  Dart_Handle io_lib = Dart_LookupLibrary(ToDart("dart:io"));
-  Dart_Handle result = Dart_SetNativeResolver(io_lib, dart::bin::LookupIONative,
-                                              dart::bin::LookupIONativeSymbol);
-  FML_CHECK(!LogIfError(result));
-
-  Dart_Handle embedder_config_type =
-      Dart_GetNonNullableType(io_lib, ToDart("_EmbedderConfig"), 0, nullptr);
-  FML_CHECK(!LogIfError(embedder_config_type));
-
-  Dart_Handle allow_insecure_connections_result = Dart_SetField(
-      embedder_config_type, ToDart("_mayInsecurelyConnectToAllDomains"),
-      ToDart(may_insecurely_connect_to_all_domains));
-  FML_CHECK(!LogIfError(allow_insecure_connections_result));
-
-  Dart_Handle dart_args[1];
-  dart_args[0] = ToDart(domain_network_policy);
-  Dart_Handle set_domain_network_policy_result = Dart_Invoke(
-      embedder_config_type, ToDart("_setDomainPolicies"), 1, dart_args);
-  FML_CHECK(!LogIfError(set_domain_network_policy_result));
+  // We should be setting fields on dart:io's _EmbedderConfig but they have
+  // been reverted due to https://github.com/flutter/flutter/issues/72723.
 }
 
 }  // namespace flutter

--- a/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
@@ -9,7 +9,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.XmlResourceParser;
 import android.os.Bundle;
-import android.security.NetworkSecurityPolicy;
 import androidx.annotation.NonNull;
 import java.io.IOException;
 import org.json.JSONArray;

--- a/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
@@ -148,9 +148,10 @@ public final class ApplicationInfoLoader {
     ApplicationInfo appInfo = getApplicationInfo(applicationContext);
     // Prior to API 23, cleartext traffic is allowed.
     boolean clearTextPermitted = true;
-    if (android.os.Build.VERSION.SDK_INT >= 23) {
-      clearTextPermitted = NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted();
-    }
+    // We should check NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted() from the OS
+    // as well to enforce it at the dart:io level but have reverted that feature due to
+    // https://github.com/flutter/flutter/issues/72723. Checking it is an expensive call that
+    // wouldn't be used in dart:io.
 
     return new FlutterApplicationInfo(
         getString(appInfo.metaData, PUBLIC_AOT_SHARED_LIBRARY_NAME),

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
@@ -51,10 +51,10 @@ public class ApplicationInfoLoaderTest {
 
   @Config(shadows = {ApplicationInfoLoaderTest.ShadowNetworkSecurityPolicy.class})
   @Test
-  public void itVotesAgainstClearTextIfSecurityPolicySaysSo() {
+  public void itIgnoresSystemSecurityPolicyDueToIssue72723() {
     FlutterApplicationInfo info = ApplicationInfoLoader.load(RuntimeEnvironment.application);
     assertNotNull(info);
-    assertEquals(false, info.clearTextPermitted);
+    assertEquals(true, info.clearTextPermitted);
   }
 
   @Implements(NetworkSecurityPolicy.class)


### PR DESCRIPTION
Reverting due to https://github.com/flutter/flutter/issues/72723. 

Need to be re-implemented at some point for https://github.com/flutter/flutter/issues/54448.   

Reverting this part because it uses APIs (via vm-entrypoint) to be reverted in https://dart-review.googlesource.com/c/sdk/+/195485. Removed an additional read against the Android SDK because it would be slow and doesn't feed into anything anymore.