### PR TITLE
Start of refactor of Android for pbuffer

### DIFF
--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -55,21 +55,14 @@ AndroidShellHolder::AndroidShellHolder(
   Shell::CreateCallback<PlatformView> on_create_platform_view =
       [is_background_view, &jni_facade, &weak_platform_view](Shell& shell) {
         std::unique_ptr<PlatformViewAndroid> platform_view_android;
-        if (is_background_view) {
-          platform_view_android = std::make_unique<PlatformViewAndroid>(
-              shell,                   // delegate
-              shell.GetTaskRunners(),  // task runners
-              jni_facade               // JNI interop
-          );
-        } else {
-          platform_view_android = std::make_unique<PlatformViewAndroid>(
-              shell,                   // delegate
-              shell.GetTaskRunners(),  // task runners
-              jni_facade,              // JNI interop
-              shell.GetSettings()
-                  .enable_software_rendering  // use software rendering
-          );
-        }
+        platform_view_android = std::make_unique<PlatformViewAndroid>(
+            shell,                   // delegate
+            shell.GetTaskRunners(),  // task runners
+            jni_facade,              // JNI interop
+            shell.GetSettings()
+                .enable_software_rendering,  // use software rendering
+            !is_background_view              // create onscreen surface
+        );
         weak_platform_view = platform_view_android->GetWeakPtr();
         auto display = Display(jni_facade->GetDisplayRefreshRate());
         shell.OnDisplayUpdates(DisplayUpdateType::kStartup, {display});

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -48,35 +48,53 @@ std::unique_ptr<AndroidSurface> AndroidSurfaceFactoryImpl::CreateSurface() {
                                                     jni_facade_);
 #endif  // SHELL_ENABLE_VULKAN
     default:
+      FML_DCHECK(false);
       return nullptr;
   }
-  return nullptr;
+}
+
+std::unique_ptr<AndroidSurface>
+AndroidSurfaceFactoryImpl::CreatePbufferSurface() {
+  switch (android_context_->RenderingApi()) {
+    case AndroidRenderingAPI::kOpenGLES:
+      return std::make_unique<AndroidSurfaceGL>(android_context_, jni_facade_);
+    case AndroidRenderingAPI::kSoftware:
+    case AndroidRenderingAPI::kVulkan:
+    default:
+      return nullptr;
+  }
+}
+
+static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
+    bool use_software_rendering,
+    bool create_onscreen_surface) {
+  if (!create_onscreen_surface) {
+    return nullptr;
+  }
+  if (use_software_rendering) {
+    return std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
+  }
+#if SHELL_ENABLE_VULKAN
+  return std::make_shared<AndroidContext>(AndroidRenderingAPI::kVulkan);
+#else   // SHELL_ENABLE_VULKAN
+  return std::make_unique<AndroidContextGL>(
+      AndroidRenderingAPI::kOpenGLES,
+      fml::MakeRefCounted<AndroidEnvironmentGL>());
+#endif  // SHELL_ENABLE_VULKAN
 }
 
 PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,
     flutter::TaskRunners task_runners,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-    bool use_software_rendering)
-    : PlatformView(delegate, std::move(task_runners)),
-      jni_facade_(jni_facade),
-      platform_view_android_delegate_(jni_facade) {
-  if (use_software_rendering) {
-    android_context_ =
-        std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
-  } else {
-#if SHELL_ENABLE_VULKAN
-    android_context_ =
-        std::make_shared<AndroidContext>(AndroidRenderingAPI::kVulkan);
-#else   // SHELL_ENABLE_VULKAN
-    android_context_ = std::make_unique<AndroidContextGL>(
-        AndroidRenderingAPI::kOpenGLES,
-        fml::MakeRefCounted<AndroidEnvironmentGL>());
-#endif  // SHELL_ENABLE_VULKAN
-  }
-  surface_factory_ = MakeSurfaceFactory(android_context_, *jni_facade_);
-  android_surface_ = MakeSurface(surface_factory_);
-}
+    bool use_software_rendering,
+    bool create_onscreen_surface)
+    : PlatformViewAndroid(
+          delegate,
+          std::move(task_runners),
+          std::move(jni_facade),
+          CreateAndroidContext(use_software_rendering, create_onscreen_surface),
+          create_onscreen_surface) {}
 
 PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,
@@ -85,42 +103,24 @@ PlatformViewAndroid::PlatformViewAndroid(
     const std::shared_ptr<flutter::AndroidContext>& android_context)
     : PlatformView(delegate, std::move(task_runners)),
       jni_facade_(jni_facade),
-      android_context_(android_context),
+      android_context_(std::move(android_context)),
       platform_view_android_delegate_(jni_facade) {
-  surface_factory_ = MakeSurfaceFactory(android_context_, *jni_facade_);
-  android_surface_ = MakeSurface(surface_factory_);
-}
+  // TODO(dnfield): always create a pbuffer surface for background use to
+  // resolve https://github.com/flutter/flutter/issues/73675
+  if (android_context) {
+    FML_CHECK(android_context->IsValid())
+        << "Could not create surface from invalid Android context.";
+    surface_factory_ = std::make_shared<AndroidSurfaceFactoryImpl>(
+        android_context, jni_facade_);
+    android_surface_ = surface_factory_->CreateSurface();
 
-PlatformViewAndroid::PlatformViewAndroid(
-    PlatformView::Delegate& delegate,
-    flutter::TaskRunners task_runners,
-    std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
-    : PlatformView(delegate, std::move(task_runners)),
-      jni_facade_(jni_facade),
-      platform_view_android_delegate_(jni_facade) {}
+    FML_CHECK(android_surface_ && android_surface_->IsValid())
+        << "Could not create an OpenGL, Vulkan or Software surface to set up "
+           "rendering.";
+  }
+}
 
 PlatformViewAndroid::~PlatformViewAndroid() = default;
-
-std::shared_ptr<AndroidSurfaceFactoryImpl>
-PlatformViewAndroid::MakeSurfaceFactory(
-    const std::shared_ptr<AndroidContext>& android_context,
-    const PlatformViewAndroidJNI& jni_facade) {
-  FML_CHECK(android_context->IsValid())
-      << "Could not create surface from invalid Android context.";
-
-  return std::make_shared<AndroidSurfaceFactoryImpl>(android_context,
-                                                     jni_facade_);
-}
-
-std::unique_ptr<AndroidSurface> PlatformViewAndroid::MakeSurface(
-    const std::shared_ptr<AndroidSurfaceFactoryImpl>& surface_factory) {
-  auto surface = surface_factory->CreateSurface();
-
-  FML_CHECK(surface && surface->IsValid())
-      << "Could not create an OpenGL, Vulkan or Software surface to set up "
-         "rendering.";
-  return surface;
-}
 
 void PlatformViewAndroid::NotifyCreated(
     fml::RefPtr<AndroidNativeWindow> native_window) {

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -53,18 +53,6 @@ std::unique_ptr<AndroidSurface> AndroidSurfaceFactoryImpl::CreateSurface() {
   }
 }
 
-std::unique_ptr<AndroidSurface>
-AndroidSurfaceFactoryImpl::CreatePbufferSurface() {
-  switch (android_context_->RenderingApi()) {
-    case AndroidRenderingAPI::kOpenGLES:
-      return std::make_unique<AndroidSurfaceGL>(android_context_, jni_facade_);
-    case AndroidRenderingAPI::kSoftware:
-    case AndroidRenderingAPI::kVulkan:
-    default:
-      return nullptr;
-  }
-}
-
 static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
     bool use_software_rendering,
     bool create_onscreen_surface) {
@@ -89,12 +77,11 @@ PlatformViewAndroid::PlatformViewAndroid(
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
     bool use_software_rendering,
     bool create_onscreen_surface)
-    : PlatformViewAndroid(
-          delegate,
-          std::move(task_runners),
-          std::move(jni_facade),
-          CreateAndroidContext(use_software_rendering, create_onscreen_surface),
-          create_onscreen_surface) {}
+    : PlatformViewAndroid(delegate,
+                          std::move(task_runners),
+                          std::move(jni_facade),
+                          CreateAndroidContext(use_software_rendering,
+                                               create_onscreen_surface)) {}
 
 PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -41,17 +41,11 @@ class PlatformViewAndroid final : public PlatformView {
  public:
   static bool Register(JNIEnv* env);
 
-  // Creates a PlatformViewAndroid with no rendering surface for use with
-  // background execution.
-  PlatformViewAndroid(PlatformView::Delegate& delegate,
-                      flutter::TaskRunners task_runners,
-                      std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
-
-  // Creates a PlatformViewAndroid with a rendering surface.
   PlatformViewAndroid(PlatformView::Delegate& delegate,
                       flutter::TaskRunners task_runners,
                       std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
-                      bool use_software_rendering);
+                      bool use_software_rendering,
+                      bool create_onscreen_surface);
 
   //----------------------------------------------------------------------------
   /// @brief      Creates a new PlatformViewAndroid but using an existing
@@ -169,13 +163,6 @@ class PlatformViewAndroid final : public PlatformView {
 
   // |PlatformView|
   void RequestDartDeferredLibrary(intptr_t loading_unit_id) override;
-
-  std::shared_ptr<AndroidSurfaceFactoryImpl> MakeSurfaceFactory(
-      const std::shared_ptr<AndroidContext>& android_context,
-      const PlatformViewAndroidJNI& jni_facade);
-
-  std::unique_ptr<AndroidSurface> MakeSurface(
-      const std::shared_ptr<AndroidSurfaceFactoryImpl>& surface_factory);
 
   void InstallFirstFrameCallback();
 


### PR DESCRIPTION
This is a minor cleanup of the constructors in `PlatformViewAndroid` in preparation for a fix for https://github.com/flutter/flutter/issues/73675. For that fix, the Android platform view will need to keep a pbuffer surface around so that Skia will be able to use it when rasterizing cross context images in the background.

This PR does not introduce any changes at runtime, and should be covered as long as existing tests pass and it compiles :)

I mainly want to split it out from what will be a slightly larger PR that adds a pbuffer to avoid confusion.