### PR TITLE
Revert "[fuchsia] Use scenic allocator service"

### DIFF
--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -134,7 +134,6 @@ template("runner_sources") {
              "$fuchsia_sdk_root/fidl:fuchsia.images",
              "$fuchsia_sdk_root/fidl:fuchsia.intl",
              "$fuchsia_sdk_root/fidl:fuchsia.io",
-             "$fuchsia_sdk_root/fidl:fuchsia.scenic.allocation",
              "$fuchsia_sdk_root/fidl:fuchsia.sys",
              "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
              "$fuchsia_sdk_root/fidl:fuchsia.ui.scenic",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -20,7 +20,6 @@
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.posix.socket.Provider",
-      "fuchsia.scenic.allocation.Allocator",
       "fuchsia.sysmem.Allocator",
       "fuchsia.timezone.Timezone",
       "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
@@ -20,7 +20,6 @@
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.posix.socket.Provider",
-      "fuchsia.scenic.allocation.Allocator",
       "fuchsia.sysmem.Allocator",
       "fuchsia.timezone.Timezone",
       "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -21,7 +21,6 @@
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.posix.socket.Provider",
-      "fuchsia.scenic.allocation.Allocator",
       "fuchsia.sysmem.Allocator",
       "fuchsia.timezone.Timezone",
       "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
@@ -21,7 +21,6 @@
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.posix.socket.Provider",
-      "fuchsia.scenic.allocation.Allocator",
       "fuchsia.sysmem.Allocator",
       "fuchsia.timezone.Timezone",
       "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/flutter/meta/flutter_runner_scenic_tests.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_runner_scenic_tests.cmx
@@ -12,7 +12,6 @@
     "services": [
       "fuchsia.logger.LogSink",
       "fuchsia.sys.Environment",
-      "fuchsia.scenic.allocation.Allocator",
       "fuchsia.sysmem.Allocator",
       "fuchsia.tracing.provider.Registry",
       "fuchsia.ui.input.ImeService",

--- a/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
@@ -8,7 +8,6 @@
   "facets": {
     "fuchsia.test": {
       "system-services": [
-        "fuchsia.scenic.allocation.Allocator",
         "fuchsia.sysmem.Allocator",
         "fuchsia.ui.scenic.Scenic",
         "fuchsia.vulkan.loader.Loader"
@@ -28,7 +27,6 @@
       "fuchsia.process.Launcher",
       "fuchsia.vulkan.loader.Loader",
       "fuchsia.logger.LogSink",
-      "fuchsia.scenic.allocation.Allocator",
       "fuchsia.sysmem.Allocator",
       "fuchsia.ui.scenic.Scenic"
     ]

--- a/shell/platform/fuchsia/flutter/vulkan_surface.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.h
@@ -71,10 +71,10 @@ class VulkanSurface final : public SurfaceProducerSurface {
  public:
   VulkanSurface(vulkan::VulkanProvider& vulkan_provider,
                 fuchsia::sysmem::AllocatorSyncPtr& sysmem_allocator,
-                fuchsia::scenic::allocation::AllocatorPtr& scenic_allocator,
                 sk_sp<GrDirectContext> context,
                 scenic::Session* session,
-                const SkISize& size);
+                const SkISize& size,
+                uint32_t buffer_id);
 
   ~VulkanSurface() override;
 
@@ -144,12 +144,10 @@ class VulkanSurface final : public SurfaceProducerSurface {
                      zx_status_t status,
                      const zx_packet_signal_t* signal);
 
-  bool AllocateDeviceMemory(
-      fuchsia::sysmem::AllocatorSyncPtr& sysmem_allocator,
-      fuchsia::scenic::allocation::AllocatorPtr& scenic_allocator,
-      fuchsia::scenic::allocation::BufferCollectionExportToken export_token,
-      sk_sp<GrDirectContext> context,
-      const SkISize& size);
+  bool AllocateDeviceMemory(fuchsia::sysmem::AllocatorSyncPtr& sysmem_allocator,
+                            sk_sp<GrDirectContext> context,
+                            const SkISize& size,
+                            uint32_t buffer_id);
 
   bool CreateVulkanImage(vulkan::VulkanProvider& vulkan_provider,
                          const SkISize& size,
@@ -163,9 +161,7 @@ class VulkanSurface final : public SurfaceProducerSurface {
 
   bool CreateFences();
 
-  void PushSessionImageSetupOps(
-      scenic::Session* session,
-      fuchsia::scenic::allocation::BufferCollectionImportToken import_token);
+  void PushSessionImageSetupOps(scenic::Session* session);
 
   void Reset();
 
@@ -179,6 +175,7 @@ class VulkanSurface final : public SurfaceProducerSurface {
   VkMemoryAllocateInfo vk_memory_info_;
   vulkan::VulkanHandle<VkFence> command_buffer_fence_;
   sk_sp<SkSurface> sk_surface_;
+  uint32_t buffer_id_ = 0;
   uint32_t image_id_ = 0;
   vulkan::VulkanHandle<VkBufferCollectionFUCHSIA> collection_;
   zx::event acquire_event_;

--- a/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
@@ -41,10 +41,6 @@ VulkanSurfacePool::VulkanSurfacePool(vulkan::VulkanProvider& vulkan_provider,
   sysmem_allocator_->SetDebugClientInfo(GetCurrentProcessName(),
                                         GetCurrentProcessId());
   FML_DCHECK(status != ZX_OK);
-  status = fdio_service_connect(
-      "/svc/fuchsia.scenic.allocation.Allocator",
-      scenic_allocator_.NewRequest().TakeChannel().release());
-  FML_DCHECK(status != ZX_OK);
 }
 
 VulkanSurfacePool::~VulkanSurfacePool() {}
@@ -118,8 +114,8 @@ std::unique_ptr<VulkanSurface> VulkanSurfacePool::CreateSurface(
   TRACE_EVENT2("flutter", "VulkanSurfacePool::CreateSurface", "width",
                size.width(), "height", size.height());
   auto surface = std::make_unique<VulkanSurface>(
-      vulkan_provider_, sysmem_allocator_, scenic_allocator_, context_,
-      scenic_session_, size);
+      vulkan_provider_, sysmem_allocator_, context_, scenic_session_, size,
+      buffer_id_++);
   if (!surface->IsValid()) {
     return nullptr;
   }

--- a/shell/platform/fuchsia/flutter/vulkan_surface_pool.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_pool.h
@@ -42,10 +42,10 @@ class VulkanSurfacePool final {
   sk_sp<GrDirectContext> context_;
   scenic::Session* scenic_session_;
   fuchsia::sysmem::AllocatorSyncPtr sysmem_allocator_;
-  fuchsia::scenic::allocation::AllocatorPtr scenic_allocator_;
   std::vector<std::unique_ptr<VulkanSurface>> available_surfaces_;
   std::unordered_map<uintptr_t, std::unique_ptr<VulkanSurface>>
       pending_surfaces_;
+  uint32_t buffer_id_ = 1;
 
   size_t trace_surfaces_created_ = 0;
   size_t trace_surfaces_reused_ = 0;

--- a/testing/fuchsia/meta/fuchsia_test.cmx
+++ b/testing/fuchsia/meta/fuchsia_test.cmx
@@ -5,7 +5,6 @@
   "facets": {
     "fuchsia.test": {
       "system-services": [
-        "fuchsia.scenic.allocation.Allocator",
         "fuchsia.sysmem.Allocator",
         "fuchsia.vulkan.loader.Loader"
       ]
@@ -26,7 +25,6 @@
       "fuchsia.logger.LogSink",
       "fuchsia.process.Launcher",
       "fuchsia.settings.Intl",
-      "fuchsia.scenic.allocation.Allocator",
       "fuchsia.sysmem.Allocator",
       "fuchsia.tracing.provider.Registry",
       "fuchsia.ui.input3.Keyboard",


### PR DESCRIPTION
Reverts flutter/engine#25385

Unfortunately, this is causing some internal test failures.  See: https://fusion2.corp.google.com/invocations/ba54fcaf-2046-42ef-9d41-9a4e00b52da1/targets/%2F%2Fassistant%2Fgallium%2Fdragonglass%2Fplatform%2Ffuchsia%2Fdeployment%2Ftest:emulator_opal_screen_test_x86_64_SMART_DISPLAY_ARRESTED_X64_SWIFTSHADER/details