### PR TITLE
TalkBack shouldn't announce platform views that aren't in the a11y tree

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1449,6 +1449,14 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       if (semanticsNode.hadPreviousConfig) {
         updated.add(semanticsNode);
       }
+      if (semanticsNode.platformViewId != -1
+          && !platformViewsAccessibilityDelegate.usesVirtualDisplay(semanticsNode.platformViewId)) {
+        View embeddedView =
+            platformViewsAccessibilityDelegate.getPlatformViewById(semanticsNode.platformViewId);
+        if (embeddedView != null) {
+          embeddedView.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
+        }
+      }
     }
 
     Set<SemanticsNode> visitedObjects = new HashSet<>();
@@ -1802,6 +1810,18 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
           embeddedAccessibilityFocusedNodeId,
           AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED);
       embeddedAccessibilityFocusedNodeId = null;
+    }
+
+    if (semanticsNodeToBeRemoved.platformViewId != -1
+        && !platformViewsAccessibilityDelegate.usesVirtualDisplay(
+            semanticsNodeToBeRemoved.platformViewId)) {
+      View embeddedView =
+          platformViewsAccessibilityDelegate.getPlatformViewById(
+              semanticsNodeToBeRemoved.platformViewId);
+      if (embeddedView != null) {
+        embeddedView.setImportantForAccessibility(
+            View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+      }
     }
 
     if (accessibilityFocusedSemanticsNode == semanticsNodeToBeRemoved) {

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1784,6 +1784,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
    * Hook called just before a {@link SemanticsNode} is removed from the Android cache of Flutter's
    * semantics tree.
    */
+  @TargetApi(19)
+  @RequiresApi(19)
   private void willRemoveSemanticsNode(SemanticsNode semanticsNodeToBeRemoved) {
     if (BuildConfig.DEBUG) {
       if (!flutterSemanticsTree.containsKey(semanticsNodeToBeRemoved.id)) {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -832,6 +832,88 @@ public class AccessibilityBridgeTest {
   }
 
   @Test
+  public void itMakesPlatformViewImportantForAccessibility() {
+    PlatformViewsAccessibilityDelegate accessibilityDelegate =
+        mock(PlatformViewsAccessibilityDelegate.class);
+
+    Context context = RuntimeEnvironment.application.getApplicationContext();
+    View rootAccessibilityView = new View(context);
+    AccessibilityViewEmbedder accessibilityViewEmbedder = mock(AccessibilityViewEmbedder.class);
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(
+            rootAccessibilityView,
+            /*accessibilityChannel=*/ null,
+            /*accessibilityManager=*/ null,
+            /*contentResolver=*/ null,
+            accessibilityViewEmbedder,
+            accessibilityDelegate);
+
+    TestSemanticsNode root = new TestSemanticsNode();
+    root.id = 0;
+
+    TestSemanticsNode platformView = new TestSemanticsNode();
+    platformView.id = 1;
+    platformView.platformViewId = 1;
+    root.addChild(platformView);
+
+    View embeddedView = mock(View.class);
+    when(accessibilityDelegate.getPlatformViewById(1)).thenReturn(embeddedView);
+    when(accessibilityDelegate.usesVirtualDisplay(1)).thenReturn(false);
+
+    TestSemanticsUpdate testSemanticsRootUpdate = root.toUpdate();
+    accessibilityBridge.updateSemantics(
+        testSemanticsRootUpdate.buffer, testSemanticsRootUpdate.strings);
+
+    verify(embeddedView).setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_AUTO);
+  }
+
+  @Test
+  public void itMakesPlatformViewNoImportantForAccessibility() {
+    PlatformViewsAccessibilityDelegate accessibilityDelegate =
+        mock(PlatformViewsAccessibilityDelegate.class);
+
+    Context context = RuntimeEnvironment.application.getApplicationContext();
+    View rootAccessibilityView = new View(context);
+    AccessibilityViewEmbedder accessibilityViewEmbedder = mock(AccessibilityViewEmbedder.class);
+    AccessibilityBridge accessibilityBridge =
+        setUpBridge(
+            rootAccessibilityView,
+            /*accessibilityChannel=*/ null,
+            /*accessibilityManager=*/ null,
+            /*contentResolver=*/ null,
+            accessibilityViewEmbedder,
+            accessibilityDelegate);
+
+    TestSemanticsNode rootWithPlatformView = new TestSemanticsNode();
+    rootWithPlatformView.id = 0;
+
+    TestSemanticsNode platformView = new TestSemanticsNode();
+    platformView.id = 1;
+    platformView.platformViewId = 1;
+    rootWithPlatformView.addChild(platformView);
+
+    View embeddedView = mock(View.class);
+    when(accessibilityDelegate.getPlatformViewById(1)).thenReturn(embeddedView);
+    when(accessibilityDelegate.usesVirtualDisplay(1)).thenReturn(false);
+
+    TestSemanticsUpdate testSemanticsRootWithPlatformViewUpdate = rootWithPlatformView.toUpdate();
+    accessibilityBridge.updateSemantics(
+        testSemanticsRootWithPlatformViewUpdate.buffer,
+        testSemanticsRootWithPlatformViewUpdate.strings);
+
+    TestSemanticsNode rootWithoutPlatformView = new TestSemanticsNode();
+    rootWithoutPlatformView.id = 0;
+    TestSemanticsUpdate testSemanticsRootWithoutPlatformViewUpdate =
+        rootWithoutPlatformView.toUpdate();
+    accessibilityBridge.updateSemantics(
+        testSemanticsRootWithoutPlatformViewUpdate.buffer,
+        testSemanticsRootWithoutPlatformViewUpdate.strings);
+
+    verify(embeddedView)
+        .setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS);
+  }
+
+  @Test
   public void itProducesPlatformViewNodeForVirtualDisplay() {
     PlatformViewsAccessibilityDelegate accessibilityDelegate =
         mock(PlatformViewsAccessibilityDelegate.class);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/80765

Removing the accessibility node from the Android accessibility isn't sufficient to make a platform view fully ignored by TalkBack.

`View#setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO_HIDE_DESCENDANTS)` is also required as described in the yaqs linked in the internal bug.