### PR TITLE
Add Android accessibility global offset of FlutterView

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -693,7 +693,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     } else {
       result.setBoundsInParent(bounds);
     }
-    result.setBoundsInScreen(bounds);
+    final Rect boundsInScreen = getBoundsInScreen(bounds);
+    result.setBoundsInScreen(boundsInScreen);
     result.setVisibleToUser(true);
     result.setEnabled(
         !semanticsNode.hasFlag(Flag.HAS_ENABLED_STATE) || semanticsNode.hasFlag(Flag.IS_ENABLED));
@@ -867,6 +868,20 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
       result.addChild(rootAccessibilityView, child.id);
     }
     return result;
+  }
+
+  /**
+   * Get the bounds in screen with root FlutterView's offset.
+   *
+   * @param bounds the bounds in FlutterView
+   * @return the bounds with offset
+   */
+  private Rect getBoundsInScreen(Rect bounds) {
+    Rect boundsInScreen = new Rect(bounds);
+    int[] locationOnScreen = new int[2];
+    rootAccessibilityView.getLocationOnScreen(locationOnScreen);
+    boundsInScreen.offset(locationOnScreen[0], locationOnScreen[1]);
+    return boundsInScreen;
   }
 
   /**


### PR DESCRIPTION
When I'm embedding a FlutterView directly in my Activity without extends FlutterActivity, and FlutterView's location has a left or top margin, the Talkback's focused rectangle is wrongly located on the left top corner of screen.

This pull request takes  the global bounds offset into account when FlutterView's location is not left top corner.

Wrong:
![3191618912734_ pic_hd](https://user-images.githubusercontent.com/922837/115377470-39e6e680-a202-11eb-9f8f-fa1361a78380.jpg)

Right: 
![3201618912743_ pic_hd](https://user-images.githubusercontent.com/922837/115377492-3fdcc780-a202-11eb-9f14-529c061eec31.jpg)

*List which issues are fixed by this PR. You must list at least one issue.*

It fixes https://github.com/flutter/flutter/issues/59872

## Pre-launch Checklist

- [*] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [*] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [*] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [*] I listed at least one issue that this PR fixes in the description above.
- [*] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [*] I updated/added relevant documentation (doc comments with `///`).
- [*] I signed the [CLA].
- [*] All existing and new tests are passing.
- [*] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

