### PR TITLE
Fix web EditableText Widget composing range error

### DIFF
--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -1577,7 +1577,9 @@ void testMain() {
           <String, dynamic>{
             'text': 'something',
             'selectionBase': 9,
-            'selectionExtent': 9
+            'selectionExtent': 9,
+            'composingBase': -1,
+            'composingExtent': -1
           }
         ],
       );
@@ -1601,7 +1603,9 @@ void testMain() {
           <String, dynamic>{
             'text': 'something',
             'selectionBase': 2,
-            'selectionExtent': 5
+            'selectionExtent': 5,
+            'composingBase': -1,
+            'composingExtent': -1
           }
         ],
       );
@@ -1674,7 +1678,9 @@ void testMain() {
             hintForFirstElement: <String, dynamic>{
               'text': 'something',
               'selectionBase': 9,
-              'selectionExtent': 9
+              'selectionExtent': 9,
+              'composingBase': -1,
+              'composingExtent': -1
             }
           },
         ],
@@ -1733,6 +1739,8 @@ void testMain() {
             'text': 'something\nelse',
             'selectionBase': 14,
             'selectionExtent': 14,
+            'composingBase': -1,
+            'composingExtent': -1
           }
         ],
       );
@@ -1747,6 +1755,8 @@ void testMain() {
             'text': 'something\nelse',
             'selectionBase': 2,
             'selectionExtent': 5,
+            'composingBase': -1,
+            'composingExtent': -1
           }
         ],
       );


### PR DESCRIPTION
EditableText widget should receive correct composing range, I fix it.

example code:

```
EditableText(
                controller: controller,
                focusNode: node,
                autocorrect: false,
                style: TextStyle(
                  fontSize: 20.0,
                  color: Colors.red,
                ),
                cursorColor: Colors.red,
                backgroundCursorColor: Colors.black,
                inputFormatters: [LengthLimitingTextInputFormatter(5)],
              )
```
before:
https://user-images.githubusercontent.com/1343893/115393137-ef6e6580-a213-11eb-8246-6540ba6da13d.mov

fixed:
https://user-images.githubusercontent.com/1343893/115393169-fac19100-a213-11eb-866e-0cea96a626fe.mov




*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/65357



## Pre-launch Checklist

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ x ] I listed at least one issue that this PR fixes in the description above.
- [ x ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ x ] I updated/added relevant documentation (doc comments with `///`).
- [ x ] I signed the [CLA].
- [ x ] All existing and new tests are passing.
- [ x ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

