### PR TITLE
fix AccessibilityBridgeMacDelegate to grab nswindow from appdelegate

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1111,6 +1111,7 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FlutterView
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Info.plist
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterBackingStore.mm

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -167,6 +167,7 @@ executable("flutter_desktop_darwin_unittests") {
   testonly = true
 
   sources = [
+    "framework/Source/AccessibilityBridgeMacDelegateTest.mm",
     "framework/Source/FlutterChannelKeyResponderUnittests.mm",
     "framework/Source/FlutterEmbedderExternalTextureUnittests.mm",
     "framework/Source/FlutterEmbedderKeyResponderUnittests.mm",

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h
@@ -48,8 +48,8 @@ class AccessibilityBridgeMacDelegate : public AccessibilityBridge::Accessibility
   ///             accessibility notification system.
   /// @param[in]  native_node       The event target, must not be nil.
   /// @param[in]  mac_notification  The event name, must not be nil.
-  void DispatchMacOSNotification(gfx::NativeViewAccessible native_node,
-                                 NSAccessibilityNotificationName mac_notification);
+  virtual void DispatchMacOSNotification(gfx::NativeViewAccessible native_node,
+                                         NSAccessibilityNotificationName mac_notification);
 
   //---------------------------------------------------------------------------
   /// @brief      Posts the given event against the given node with the

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -342,7 +342,8 @@ void AccessibilityBridgeMacDelegate::DispatchAccessibilityAction(ui::AXNode::AXI
                                                                  const std::vector<uint8_t>& data) {
   NSCAssert(flutter_engine_, @"Flutter engine should not be deallocated");
   NSCAssert(flutter_engine_.viewController.viewLoaded && flutter_engine_.viewController.view.window,
-            @"A headless engine should not receive accessibility actions");
+            @"The accessibility bridge should not receive accessibility actions if the flutter view"
+            @"is not loaded or attaches to a NSWindow.");
   [flutter_engine_ dispatchSemanticsAction:action toTarget:target withData:data];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -27,6 +27,11 @@ AccessibilityBridgeMacDelegate::AccessibilityBridgeMacDelegate(__weak FlutterEng
 
 void AccessibilityBridgeMacDelegate::OnAccessibilityEvent(
     ui::AXEventGenerator::TargetedEvent targeted_event) {
+  if (!flutter_engine_.viewController) {
+    // For headless engine, we don't need to send accessibility events
+    // because there is no view.
+    return;
+  }
   ui::AXNode* ax_node = targeted_event.node;
   std::vector<AccessibilityBridgeMacDelegate::NSAccessibilityEvent> events =
       MacOSEventsFromAXEvent(targeted_event.event_params.event, *ax_node);
@@ -337,6 +342,8 @@ void AccessibilityBridgeMacDelegate::DispatchAccessibilityAction(ui::AXNode::AXI
                                                                  FlutterSemanticsAction action,
                                                                  const std::vector<uint8_t>& data) {
   NSCAssert(flutter_engine_, @"Flutter engine should not be deallocated");
+  NSCAssert(flutter_engine_.viewController,
+            @"A headless engine should not receive accessibility actions");
   [flutter_engine_ dispatchSemanticsAction:action toTarget:target withData:data];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -4,9 +4,9 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h"
 
-#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 
 namespace flutter {
@@ -266,10 +266,10 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
     case ui::AXEventGenerator::Event::CHILDREN_CHANGED: {
       // NSAccessibilityCreatedNotification seems to be the only way to let
       // Voiceover pick up layout changes.
-      FlutterAppDelegate* appDelegate = (FlutterAppDelegate*)[NSApp delegate];
+      NSCAssert(flutter_engine_.viewController, @"The viewController must not be nil");
       events.push_back({
           .name = NSAccessibilityCreatedNotification,
-          .target = appDelegate.mainFlutterWindow,
+          .target = flutter_engine_.viewController.view.window,
           .user_info = nil,
       });
       break;

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -4,6 +4,7 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h"
 
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -265,9 +266,10 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
     case ui::AXEventGenerator::Event::CHILDREN_CHANGED: {
       // NSAccessibilityCreatedNotification seems to be the only way to let
       // Voiceover pick up layout changes.
+      FlutterAppDelegate* appDelegate = (FlutterAppDelegate*)[NSApp delegate];
       events.push_back({
           .name = NSAccessibilityCreatedNotification,
-          .target = [NSApp mainWindow],
+          .target = appDelegate.mainFlutterWindow,
           .user_info = nil,
       });
       break;

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -27,9 +27,8 @@ AccessibilityBridgeMacDelegate::AccessibilityBridgeMacDelegate(__weak FlutterEng
 
 void AccessibilityBridgeMacDelegate::OnAccessibilityEvent(
     ui::AXEventGenerator::TargetedEvent targeted_event) {
-  if (!flutter_engine_.viewController) {
-    // For headless engine, we don't need to send accessibility events
-    // because there is no view.
+  if (!flutter_engine_.viewController.viewLoaded || !flutter_engine_.viewController.view.window) {
+    // We don't need to send accessibility events if the there is no view or window.
     return;
   }
   ui::AXNode* ax_node = targeted_event.node;
@@ -342,7 +341,7 @@ void AccessibilityBridgeMacDelegate::DispatchAccessibilityAction(ui::AXNode::AXI
                                                                  FlutterSemanticsAction action,
                                                                  const std::vector<uint8_t>& data) {
   NSCAssert(flutter_engine_, @"Flutter engine should not be deallocated");
-  NSCAssert(flutter_engine_.viewController,
+  NSCAssert(flutter_engine_.viewController.viewLoaded && flutter_engine_.viewController.view.window,
             @"A headless engine should not receive accessibility actions");
   [flutter_engine_ dispatchSemanticsAction:action toTarget:target withData:data];
 }

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -343,7 +343,7 @@ void AccessibilityBridgeMacDelegate::DispatchAccessibilityAction(ui::AXNode::AXI
   NSCAssert(flutter_engine_, @"Flutter engine should not be deallocated");
   NSCAssert(flutter_engine_.viewController.viewLoaded && flutter_engine_.viewController.view.window,
             @"The accessibility bridge should not receive accessibility actions if the flutter view"
-            @"is not loaded or attaches to a NSWindow.");
+            @"is not loaded or attached to a NSWindow.");
   [flutter_engine_ dispatchSemanticsAction:action toTarget:target withData:data];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
@@ -1,0 +1,94 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+#include "flutter/testing/testing.h"
+
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
+namespace flutter::testing {
+
+namespace {
+
+class AccessibilityBridgeMacDelegateSpy : public AccessibilityBridgeMacDelegate {
+ public:
+  AccessibilityBridgeMacDelegateSpy(__weak FlutterEngine* flutter_engine) : AccessibilityBridgeMacDelegate(flutter_engine) {}
+
+  std::unordered_map<std::string, gfx::NativeViewAccessible> actual_notifications;
+ 
+ private:
+  void DispatchMacOSNotification(gfx::NativeViewAccessible native_node,
+                                 NSAccessibilityNotificationName mac_notification) override {
+    actual_notifications[[mac_notification UTF8String]] = native_node;
+  }
+};
+
+// Returns an engine configured for the text fixture resource configuration.
+FlutterEngine* CreateTestEngine() {
+  NSString* fixtures = @(testing::GetFixturesPath());
+  FlutterDartProject* project = [[FlutterDartProject alloc]
+      initWithAssetsPath:fixtures
+             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
+  return [[FlutterEngine alloc] initWithName:@"test" project:project allowHeadlessExecution:true];
+}
+}  // namespace
+
+TEST(AccessibilityBridgeMacDelegateTest, sendsAccessibilityCreateNotificationToMainFlutterWindow) {
+  // Mocks NSApp.
+  NSApp = [[NSApplication alloc] init];
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  NSWindow* expectedTarget = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
+                                                         styleMask:NSBorderlessWindowMask
+                                                           backing:NSBackingStoreBuffered
+                                                             defer:NO];
+  appDelegate.mainFlutterWindow = expectedTarget;
+  NSApp.delegate = appDelegate;
+  FlutterEngine* engine = CreateTestEngine();
+  // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
+  // can query semantics information from.
+  engine.semanticsEnabled = YES;
+  auto bridge = engine.accessibilityBridge.lock();
+  FlutterSemanticsNode root;
+  root.id = 0;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
+  root.actions = static_cast<FlutterSemanticsAction>(0);
+  root.text_selection_base = -1;
+  root.text_selection_extent = -1;
+  root.label = "root";
+  root.hint = "";
+  root.value = "";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.child_count = 0;
+  root.custom_accessibility_actions_count = 0;
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+
+  bridge->CommitUpdates();
+  auto platform_node_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+
+  AccessibilityBridgeMacDelegateSpy spy(engine);
+
+  // Creates a targeted event.
+  ui::AXTree tree;
+  ui::AXNode ax_node(&tree, nullptr, 0, 0);
+  ui::AXNodeData node_data;
+  node_data.id = 0;
+  ax_node.SetData(node_data);
+  std::vector<ui::AXEventIntent> intent;
+  ui::AXEventGenerator::EventParams event_params(
+    ui::AXEventGenerator::Event::CHILDREN_CHANGED,
+    ax::mojom::EventFrom::kNone,
+    intent
+  );
+  ui::AXEventGenerator::TargetedEvent targeted_event(&ax_node, event_params);
+
+  spy.OnAccessibilityEvent(targeted_event);
+  
+  EXPECT_EQ(spy.actual_notifications.size(), 1u);
+  EXPECT_EQ(spy.actual_notifications.find([NSAccessibilityCreatedNotification UTF8String])->second, expectedTarget);
+  [engine shutDownEngine];
+  NSApp = nil;
+}
+
+}  // flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
@@ -186,7 +186,7 @@ TEST(AccessibilityBridgeMacDelegateTest, doesNotSendAccessibilityCreateNotificat
 
   spy.OnAccessibilityEvent(targeted_event);
 
-  // Does not send any notification if the engine is headless.
+  // Does not send any notification if the flutter view is not attached to a NSWindow.
   EXPECT_EQ(spy.actual_notifications.size(), 0u);
   [engine shutDownEngine];
 }

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
@@ -94,4 +94,48 @@ TEST(AccessibilityBridgeMacDelegateTest,
   [engine shutDownEngine];
 }
 
+TEST(AccessibilityBridgeMacDelegateTest, doesNotSendAccessibilityCreateNotificationWhenHeadless) {
+  FlutterEngine* engine = CreateTestEngine();
+  // Setting up bridge so that the AccessibilityBridgeMacDelegateSpy
+  // can query semantics information from.
+  engine.semanticsEnabled = YES;
+  auto bridge = engine.accessibilityBridge.lock();
+  FlutterSemanticsNode root;
+  root.id = 0;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
+  root.actions = static_cast<FlutterSemanticsAction>(0);
+  root.text_selection_base = -1;
+  root.text_selection_extent = -1;
+  root.label = "root";
+  root.hint = "";
+  root.value = "";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.child_count = 0;
+  root.custom_accessibility_actions_count = 0;
+  bridge->AddFlutterSemanticsNodeUpdate(&root);
+
+  bridge->CommitUpdates();
+  auto platform_node_delegate = bridge->GetFlutterPlatformNodeDelegateFromID(0).lock();
+
+  AccessibilityBridgeMacDelegateSpy spy(engine);
+
+  // Creates a targeted event.
+  ui::AXTree tree;
+  ui::AXNode ax_node(&tree, nullptr, 0, 0);
+  ui::AXNodeData node_data;
+  node_data.id = 0;
+  ax_node.SetData(node_data);
+  std::vector<ui::AXEventIntent> intent;
+  ui::AXEventGenerator::EventParams event_params(ui::AXEventGenerator::Event::CHILDREN_CHANGED,
+                                                 ax::mojom::EventFrom::kNone, intent);
+  ui::AXEventGenerator::TargetedEvent targeted_event(&ax_node, event_params);
+
+  spy.OnAccessibilityEvent(targeted_event);
+
+  // Does not send any notification if the engine is headless.
+  EXPECT_EQ(spy.actual_notifications.size(), 0u);
+  [engine shutDownEngine];
+}
+
 }  // flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegateTest.mm
@@ -13,10 +13,11 @@ namespace {
 
 class AccessibilityBridgeMacDelegateSpy : public AccessibilityBridgeMacDelegate {
  public:
-  AccessibilityBridgeMacDelegateSpy(__weak FlutterEngine* flutter_engine) : AccessibilityBridgeMacDelegate(flutter_engine) {}
+  AccessibilityBridgeMacDelegateSpy(__weak FlutterEngine* flutter_engine)
+      : AccessibilityBridgeMacDelegate(flutter_engine) {}
 
   std::unordered_map<std::string, gfx::NativeViewAccessible> actual_notifications;
- 
+
  private:
   void DispatchMacOSNotification(gfx::NativeViewAccessible native_node,
                                  NSAccessibilityNotificationName mac_notification) override {
@@ -76,17 +77,15 @@ TEST(AccessibilityBridgeMacDelegateTest, sendsAccessibilityCreateNotificationToM
   node_data.id = 0;
   ax_node.SetData(node_data);
   std::vector<ui::AXEventIntent> intent;
-  ui::AXEventGenerator::EventParams event_params(
-    ui::AXEventGenerator::Event::CHILDREN_CHANGED,
-    ax::mojom::EventFrom::kNone,
-    intent
-  );
+  ui::AXEventGenerator::EventParams event_params(ui::AXEventGenerator::Event::CHILDREN_CHANGED,
+                                                 ax::mojom::EventFrom::kNone, intent);
   ui::AXEventGenerator::TargetedEvent targeted_event(&ax_node, event_params);
 
   spy.OnAccessibilityEvent(targeted_event);
-  
+
   EXPECT_EQ(spy.actual_notifications.size(), 1u);
-  EXPECT_EQ(spy.actual_notifications.find([NSAccessibilityCreatedNotification UTF8String])->second, expectedTarget);
+  EXPECT_EQ(spy.actual_notifications.find([NSAccessibilityCreatedNotification UTF8String])->second,
+            expectedTarget);
   [engine shutDownEngine];
   NSApp = nil;
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
@@ -156,4 +156,87 @@ TEST(FlutterEngine, CanToggleAccessibility) {
   [engine shutDownEngine];
 }
 
+TEST(FlutterEngine, CanToggleAccessibilityWhenHeadless) {
+  FlutterEngine* engine = CreateTestEngine();
+  // Capture the update callbacks before the embedder API initializes.
+  auto original_init = engine.embedderAPI.Initialize;
+  std::function<void(const FlutterSemanticsNode*, void*)> update_node_callback;
+  std::function<void(const FlutterSemanticsCustomAction*, void*)> update_action_callback;
+  engine.embedderAPI.Initialize = MOCK_ENGINE_PROC(
+      Initialize, ([&update_action_callback, &update_node_callback, &original_init](
+                       size_t version, const FlutterRendererConfig* config,
+                       const FlutterProjectArgs* args, void* user_data, auto engine_out) {
+        update_node_callback = args->update_semantics_node_callback;
+        update_action_callback = args->update_semantics_custom_action_callback;
+        return original_init(version, config, args, user_data, engine_out);
+      }));
+  EXPECT_TRUE([engine runWithEntrypoint:@"main"]);
+
+  // Enable the semantics without attaching a view controller.
+  bool enabled_called = false;
+  engine.embedderAPI.UpdateSemanticsEnabled =
+      MOCK_ENGINE_PROC(UpdateSemanticsEnabled, ([&enabled_called](auto engine, bool enabled) {
+                         enabled_called = enabled;
+                         return kSuccess;
+                       }));
+  engine.semanticsEnabled = YES;
+  EXPECT_TRUE(enabled_called);
+  // Send flutter semantics updates.
+  FlutterSemanticsNode root;
+  root.id = 0;
+  root.flags = static_cast<FlutterSemanticsFlag>(0);
+  root.actions = static_cast<FlutterSemanticsAction>(0);
+  root.text_selection_base = -1;
+  root.text_selection_extent = -1;
+  root.label = "root";
+  root.hint = "";
+  root.value = "";
+  root.increased_value = "";
+  root.decreased_value = "";
+  root.child_count = 1;
+  int32_t children[] = {1};
+  root.children_in_traversal_order = children;
+  root.custom_accessibility_actions_count = 0;
+  update_node_callback(&root, (void*)CFBridgingRetain(engine));
+
+  FlutterSemanticsNode child1;
+  child1.id = 1;
+  child1.flags = static_cast<FlutterSemanticsFlag>(0);
+  child1.actions = static_cast<FlutterSemanticsAction>(0);
+  child1.text_selection_base = -1;
+  child1.text_selection_extent = -1;
+  child1.label = "child 1";
+  child1.hint = "";
+  child1.value = "";
+  child1.increased_value = "";
+  child1.decreased_value = "";
+  child1.child_count = 0;
+  child1.custom_accessibility_actions_count = 0;
+  update_node_callback(&child1, (void*)CFBridgingRetain(engine));
+
+  FlutterSemanticsNode node_batch_end;
+  node_batch_end.id = kFlutterSemanticsNodeIdBatchEnd;
+  update_node_callback(&node_batch_end, (void*)CFBridgingRetain(engine));
+
+  FlutterSemanticsCustomAction action_batch_end;
+  action_batch_end.id = kFlutterSemanticsNodeIdBatchEnd;
+  update_action_callback(&action_batch_end, (void*)CFBridgingRetain(engine));
+
+  // No crashes.
+  EXPECT_EQ(engine.viewController, nil);
+
+  // Disable the semantics.
+  bool semanticsEnabled = true;
+  engine.embedderAPI.UpdateSemanticsEnabled =
+      MOCK_ENGINE_PROC(UpdateSemanticsEnabled, ([&semanticsEnabled](auto engine, bool enabled) {
+                         semanticsEnabled = enabled;
+                         return kSuccess;
+                       }));
+  engine.semanticsEnabled = NO;
+  EXPECT_FALSE(semanticsEnabled);
+  // Still no crashes
+  EXPECT_EQ(engine.viewController, nil);
+  [engine shutDownEngine];
+}
+
 }  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -9,6 +9,7 @@
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMac.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
 #include "flutter/shell/platform/embedder/test_utils/proc_table_replacement.h"
 #include "flutter/third_party/accessibility/ax/ax_action_data.h"
 
@@ -135,6 +136,15 @@ TEST(FlutterPlatformNodeDelegateMac, SelectableTextWithoutSelectionReturnZeroRan
 
 TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   FlutterEngine* engine = CreateTestEngine();
+
+  // Set up view controller.
+  NSString* fixtures = @(testing::GetFixturesPath());
+  FlutterDartProject* project = [[FlutterDartProject alloc]
+      initWithAssetsPath:fixtures
+             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
+  [engine setViewController:viewController];
+
   engine.semanticsEnabled = YES;
   auto bridge = engine.accessibilityBridge.lock();
   // Initialize ax node data.

--- a/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterPlatformNodeDelegateMacTest.mm
@@ -145,6 +145,13 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
   FlutterViewController* viewController = [[FlutterViewController alloc] initWithProject:project];
   [engine setViewController:viewController];
 
+  // Attach the view to a NSWindow.
+  NSWindow* window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 800, 600)
+                                                 styleMask:NSBorderlessWindowMask
+                                                   backing:NSBackingStoreBuffered
+                                                     defer:NO];
+  window.contentView = viewController.view;
+
   engine.semanticsEnabled = YES;
   auto bridge = engine.accessibilityBridge.lock();
   // Initialize ax node data.
@@ -196,6 +203,8 @@ TEST(FlutterPlatformNodeDelegateMac, CanPerformAction) {
 
   EXPECT_EQ(called_action, FlutterSemanticsAction::kFlutterSemanticsActionTap);
   EXPECT_EQ(called_id, 1u);
+
+  [engine setViewController:nil];
   [engine shutDownEngine];
 }
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/80490

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
