### PR TITLE
Removed superfluous copy operations in darwin flutter platform messages by wrapping data in custom NSData classes.

### DIFF
--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -40,6 +40,7 @@ source_set("flutter_channels") {
     "//flutter/common",
     "//flutter/flow",
     "//flutter/fml",
+    "//flutter/lib/ui:ui",
     "//flutter/runtime",
     "//flutter/shell/common",
     "//third_party/skia",

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -20,6 +20,7 @@ source_set("common") {
     "//flutter/common",
     "//flutter/flow",
     "//flutter/fml",
+    "//flutter/lib/ui:ui",
     "//flutter/runtime",
     "//flutter/shell/common",
     "//third_party/dart/runtime:dart_api",

--- a/shell/platform/darwin/common/buffer_conversions.h
+++ b/shell/platform/darwin/common/buffer_conversions.h
@@ -16,7 +16,7 @@ namespace flutter {
 
 std::vector<uint8_t> CopyNSDataToVector(NSData* data);
 
-std::unique_ptr<fml::Mapping> CopyNSDataToMapping(NSData* data);
+std::unique_ptr<fml::Mapping> CovertNSDataToMapping(NSData* data);
 
 NSData* ConvertMessageToNSData(fml::RefPtr<PlatformMessage> message);
 

--- a/shell/platform/darwin/common/buffer_conversions.h
+++ b/shell/platform/darwin/common/buffer_conversions.h
@@ -10,12 +10,17 @@
 #include <vector>
 
 #include "flutter/fml/mapping.h"
+#import "flutter/lib/ui/window/platform_message.h"
 
 namespace flutter {
 
 std::vector<uint8_t> CopyNSDataToVector(NSData* data);
 
 std::unique_ptr<fml::Mapping> CopyNSDataToMapping(NSData* data);
+
+NSData* ConvertMessageToNSData(fml::RefPtr<PlatformMessage> message);
+
+NSData* ConvertMappingToNSData(std::unique_ptr<fml::Mapping> mapping);
 
 }  // namespace flutter
 

--- a/shell/platform/darwin/common/buffer_conversions.h
+++ b/shell/platform/darwin/common/buffer_conversions.h
@@ -13,13 +13,9 @@
 
 namespace flutter {
 
-std::vector<uint8_t> GetVectorFromNSData(NSData* data);
+std::vector<uint8_t> CopyNSDataToVector(NSData* data);
 
-NSData* GetNSDataFromVector(const std::vector<uint8_t>& buffer);
-
-std::unique_ptr<fml::Mapping> GetMappingFromNSData(NSData* data);
-
-NSData* GetNSDataFromMapping(std::unique_ptr<fml::Mapping> mapping);
+std::unique_ptr<fml::Mapping> CopyNSDataToMapping(NSData* data);
 
 }  // namespace flutter
 

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -4,6 +4,95 @@
 
 #import "flutter/shell/platform/darwin/common/buffer_conversions.h"
 
+/// A proxy object that behaves like NSData represented in a Mapping.
+/// This isn't a subclass of NSData because NSData is in a class cluster.
+@interface FlutterMappingData : NSObject
+@end
+
+@implementation FlutterMappingData {
+  NSData* _data;
+  std::unique_ptr<fml::Mapping> _mapping;
+}
+
++ (NSData*)dataWithMapping:(std::unique_ptr<fml::Mapping>)mapping {
+  return (NSData*)[[[FlutterMappingData alloc] initWithMapping:std::move(mapping)] autorelease];
+}
+
+- (instancetype)initWithMapping:(std::unique_ptr<fml::Mapping>)mapping {
+  self = [super init];
+  if (self) {
+    const void* rawData = mapping->GetMapping();
+
+    // Const cast is required because the NSData API requires it despite
+    // guarentees that the buffer won't be deleted or modified.
+    _data = [[NSData alloc] initWithBytesNoCopy:const_cast<void*>(rawData)
+                                         length:mapping->GetSize()
+                                   freeWhenDone:NO];
+
+    _mapping = std::move(mapping);
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [_data release];
+  [super dealloc];
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+  return _data;
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  return [NSData instancesRespondToSelector:aSelector];
+}
+@end
+
+/// A proxy object that behaves like NSData represented in a PlatformMessage.
+/// This isn't a subclass of NSData because NSData is in a class cluster.
+@interface FlutterMessageData : NSObject
+@end
+
+@implementation FlutterMessageData {
+  NSData* _data;
+  fml::RefPtr<flutter::PlatformMessage> _platformMessage;
+}
+
++ (NSData*)dataWithMessage:(fml::RefPtr<flutter::PlatformMessage>)platformMessage {
+  return (NSData*)[[[FlutterMessageData alloc] initWithMessage:std::move(platformMessage)]
+      autorelease];
+}
+
+- (instancetype)initWithMessage:(fml::RefPtr<flutter::PlatformMessage>)platformMessage {
+  self = [super init];
+  if (self) {
+    const void* rawData = platformMessage->data().data();
+
+    // Const cast is required because the NSData API requires it despite
+    // guarentees that the buffer won't be deleted or modified.
+    _data = [[NSData alloc] initWithBytesNoCopy:const_cast<void*>(rawData)
+                                         length:platformMessage->data().size()
+                                   freeWhenDone:NO];
+
+    _platformMessage = std::move(platformMessage);
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [_data release];
+  [super dealloc];
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+  return _data;
+}
+
+- (BOOL)respondsToSelector:(SEL)aSelector {
+  return [NSData instancesRespondToSelector:aSelector];
+}
+@end
+
 namespace flutter {
 
 std::vector<uint8_t> CopyNSDataToVector(NSData* data) {
@@ -13,6 +102,14 @@ std::vector<uint8_t> CopyNSDataToVector(NSData* data) {
 
 std::unique_ptr<fml::Mapping> CopyNSDataToMapping(NSData* data) {
   return std::make_unique<fml::DataMapping>(CopyNSDataToVector(data));
+}
+
+NSData* ConvertMessageToNSData(fml::RefPtr<PlatformMessage> message) {
+  return [FlutterMessageData dataWithMessage:std::move(message)];
+}
+
+NSData* ConvertMappingToNSData(std::unique_ptr<fml::Mapping> mapping) {
+  return [FlutterMappingData dataWithMapping:std::move(mapping)];
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -3,6 +3,23 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/common/buffer_conversions.h"
+#import "flutter/fml/platform/darwin/scoped_nsobject.h"
+
+namespace {
+class NSDataMapping : public fml::Mapping {
+ public:
+  NSDataMapping(NSData* data) : data_([data retain]) {}
+
+  size_t GetSize() const override { return [data_.get() length]; }
+
+  const uint8_t* GetMapping() const override {
+    return static_cast<const uint8_t*>([data_.get() bytes]);
+  }
+
+ private:
+  fml::scoped_nsobject<NSData> data_;
+};
+}
 
 /// A proxy object that behaves like NSData represented in a Mapping.
 /// This isn't a subclass of NSData because NSData is in a class cluster.
@@ -100,8 +117,8 @@ std::vector<uint8_t> CopyNSDataToVector(NSData* data) {
   return std::vector<uint8_t>(bytes, bytes + data.length);
 }
 
-std::unique_ptr<fml::Mapping> CopyNSDataToMapping(NSData* data) {
-  return std::make_unique<fml::DataMapping>(CopyNSDataToVector(data));
+std::unique_ptr<fml::Mapping> CovertNSDataToMapping(NSData* data) {
+  return std::make_unique<NSDataMapping>(data);
 }
 
 NSData* ConvertMessageToNSData(fml::RefPtr<PlatformMessage> message) {

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -6,21 +6,13 @@
 
 namespace flutter {
 
-std::vector<uint8_t> GetVectorFromNSData(NSData* data) {
+std::vector<uint8_t> CopyNSDataToVector(NSData* data) {
   const uint8_t* bytes = reinterpret_cast<const uint8_t*>(data.bytes);
   return std::vector<uint8_t>(bytes, bytes + data.length);
 }
 
-NSData* GetNSDataFromVector(const std::vector<uint8_t>& buffer) {
-  return [NSData dataWithBytes:buffer.data() length:buffer.size()];
-}
-
-std::unique_ptr<fml::Mapping> GetMappingFromNSData(NSData* data) {
-  return std::make_unique<fml::DataMapping>(GetVectorFromNSData(data));
-}
-
-NSData* GetNSDataFromMapping(std::unique_ptr<fml::Mapping> mapping) {
-  return [NSData dataWithBytes:mapping->GetMapping() length:mapping->GetSize()];
+std::unique_ptr<fml::Mapping> CopyNSDataToMapping(NSData* data) {
+  return std::make_unique<fml::DataMapping>(CopyNSDataToVector(data));
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
@@ -16,7 +16,6 @@
 }
 
 - (NSData*)encode:(id)message {
-  NSAssert(!message || [message isKindOfClass:[NSData class]], @"");
   return message;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -807,7 +807,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   fml::RefPtr<flutter::PlatformMessage> platformMessage =
       (message == nil) ? fml::MakeRefCounted<flutter::PlatformMessage>(channel.UTF8String, response)
                        : fml::MakeRefCounted<flutter::PlatformMessage>(
-                             channel.UTF8String, flutter::GetVectorFromNSData(message), response);
+                             channel.UTF8String, flutter::CopyNSDataToVector(message), response);
 
   _shell->GetPlatformView()->DispatchPlatformMessage(platformMessage);
 }

--- a/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
@@ -4,6 +4,47 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h"
 
+/// A proxy object that behaves like NSData represented in a Mapping.
+/// This isn't a subclass of NSData because NSData is in a class cluster.
+@interface FlutterMappingData : NSObject
+@end
+
+@implementation FlutterMappingData {
+  NSData* _data;
+  std::unique_ptr<fml::Mapping> _mapping;
+}
+
++ (NSData*)dataWithMapping:(std::unique_ptr<fml::Mapping>)mapping {
+  return (NSData*)[[[FlutterMappingData alloc] initWithMapping:std::move(mapping)] autorelease];
+}
+
+- (instancetype)initWithMapping:(std::unique_ptr<fml::Mapping>)mapping {
+  self = [super init];
+  if (self) {
+    const void* rawData = mapping->GetMapping();
+
+    // Const cast is required because the NSData API requires it despite
+    // guarentees that the buffer won't be deleted or modified.
+    _data = [[NSData alloc] initWithBytesNoCopy:const_cast<void*>(rawData)
+                                         length:mapping->GetSize()
+                                   freeWhenDone:NO];
+
+    _mapping = std::move(mapping);
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [_data release];
+  [super dealloc];
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+  return _data;
+}
+
+@end
+
 namespace flutter {
 
 PlatformMessageResponseDarwin::PlatformMessageResponseDarwin(
@@ -17,7 +58,8 @@ PlatformMessageResponseDarwin::~PlatformMessageResponseDarwin() = default;
 void PlatformMessageResponseDarwin::Complete(std::unique_ptr<fml::Mapping> data) {
   fml::RefPtr<PlatformMessageResponseDarwin> self(this);
   platform_task_runner_->PostTask(fml::MakeCopyable([self, data = std::move(data)]() mutable {
-    self->callback_.get()(GetNSDataFromMapping(std::move(data)));
+    NSData* callbackData = [FlutterMappingData dataWithMapping:std::move(data)];
+    self->callback_.get()(callbackData);
   }));
 }
 

--- a/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
@@ -4,47 +4,6 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h"
 
-/// A proxy object that behaves like NSData represented in a Mapping.
-/// This isn't a subclass of NSData because NSData is in a class cluster.
-@interface FlutterMappingData : NSObject
-@end
-
-@implementation FlutterMappingData {
-  NSData* _data;
-  std::unique_ptr<fml::Mapping> _mapping;
-}
-
-+ (NSData*)dataWithMapping:(std::unique_ptr<fml::Mapping>)mapping {
-  return (NSData*)[[[FlutterMappingData alloc] initWithMapping:std::move(mapping)] autorelease];
-}
-
-- (instancetype)initWithMapping:(std::unique_ptr<fml::Mapping>)mapping {
-  self = [super init];
-  if (self) {
-    const void* rawData = mapping->GetMapping();
-
-    // Const cast is required because the NSData API requires it despite
-    // guarentees that the buffer won't be deleted or modified.
-    _data = [[NSData alloc] initWithBytesNoCopy:const_cast<void*>(rawData)
-                                         length:mapping->GetSize()
-                                   freeWhenDone:NO];
-
-    _mapping = std::move(mapping);
-  }
-  return self;
-}
-
-- (void)dealloc {
-  [_data release];
-  [super dealloc];
-}
-
-- (id)forwardingTargetForSelector:(SEL)aSelector {
-  return _data;
-}
-
-@end
-
 namespace flutter {
 
 PlatformMessageResponseDarwin::PlatformMessageResponseDarwin(
@@ -58,7 +17,7 @@ PlatformMessageResponseDarwin::~PlatformMessageResponseDarwin() = default;
 void PlatformMessageResponseDarwin::Complete(std::unique_ptr<fml::Mapping> data) {
   fml::RefPtr<PlatformMessageResponseDarwin> self(this);
   platform_task_runner_->PostTask(fml::MakeCopyable([self, data = std::move(data)]() mutable {
-    NSData* callbackData = [FlutterMappingData dataWithMapping:std::move(data)];
+    NSData* callbackData = ConvertMappingToNSData(std::move(data));
     self->callback_.get()(callbackData);
   }));
 }

--- a/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
@@ -8,48 +8,6 @@
 
 #import "flutter/shell/platform/darwin/common/buffer_conversions.h"
 
-/// A proxy object that behaves like NSData represented in a PlatformMessage.
-/// This isn't a subclass of NSData because NSData is in a class cluster.
-@interface FlutterMessageData : NSObject
-@end
-
-@implementation FlutterMessageData {
-  NSData* _data;
-  fml::RefPtr<flutter::PlatformMessage> _platformMessage;
-}
-
-+ (NSData*)dataWithMessage:(fml::RefPtr<flutter::PlatformMessage>)platformMessage {
-  return (NSData*)[[[FlutterMessageData alloc] initWithMessage:std::move(platformMessage)]
-      autorelease];
-}
-
-- (instancetype)initWithMessage:(fml::RefPtr<flutter::PlatformMessage>)platformMessage {
-  self = [super init];
-  if (self) {
-    const void* rawData = platformMessage->data().data();
-
-    // Const cast is required because the NSData API requires it despite
-    // guarentees that the buffer won't be deleted or modified.
-    _data = [[NSData alloc] initWithBytesNoCopy:const_cast<void*>(rawData)
-                                         length:platformMessage->data().size()
-                                   freeWhenDone:NO];
-
-    _platformMessage = std::move(platformMessage);
-  }
-  return self;
-}
-
-- (void)dealloc {
-  [_data release];
-  [super dealloc];
-}
-
-- (id)forwardingTargetForSelector:(SEL)aSelector {
-  return _data;
-}
-
-@end
-
 namespace flutter {
 
 PlatformMessageRouter::PlatformMessageRouter() = default;
@@ -64,7 +22,7 @@ void PlatformMessageRouter::HandlePlatformMessage(
     FlutterBinaryMessageHandler handler = it->second;
     NSData* data = nil;
     if (message->hasData()) {
-      data = [FlutterMessageData dataWithMessage:std::move(message)];
+      data = ConvertMessageToNSData(std::move(message));
     }
     handler(data, ^(NSData* reply) {
       if (completer) {

--- a/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
@@ -27,7 +27,7 @@ void PlatformMessageRouter::HandlePlatformMessage(
     handler(data, ^(NSData* reply) {
       if (completer) {
         if (reply) {
-          completer->Complete(CopyNSDataToMapping(reply));
+          completer->Complete(CovertNSDataToMapping(reply));
         } else {
           completer->CompleteEmpty();
         }

--- a/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
@@ -8,6 +8,48 @@
 
 #import "flutter/shell/platform/darwin/common/buffer_conversions.h"
 
+/// A proxy object that behaves like NSData represented in a PlatformMessage.
+/// This isn't a subclass of NSData because NSData is in a class cluster.
+@interface FlutterMessageData : NSObject
+@end
+
+@implementation FlutterMessageData {
+  NSData* _data;
+  fml::RefPtr<flutter::PlatformMessage> _platformMessage;
+}
+
++ (NSData*)dataWithMessage:(fml::RefPtr<flutter::PlatformMessage>)platformMessage {
+  return (NSData*)[[[FlutterMessageData alloc] initWithMessage:std::move(platformMessage)]
+      autorelease];
+}
+
+- (instancetype)initWithMessage:(fml::RefPtr<flutter::PlatformMessage>)platformMessage {
+  self = [super init];
+  if (self) {
+    const void* rawData = platformMessage->data().data();
+
+    // Const cast is required because the NSData API requires it despite
+    // guarentees that the buffer won't be deleted or modified.
+    _data = [[NSData alloc] initWithBytesNoCopy:const_cast<void*>(rawData)
+                                         length:platformMessage->data().size()
+                                   freeWhenDone:NO];
+
+    _platformMessage = std::move(platformMessage);
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [_data release];
+  [super dealloc];
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector {
+  return _data;
+}
+
+@end
+
 namespace flutter {
 
 PlatformMessageRouter::PlatformMessageRouter() = default;
@@ -22,12 +64,12 @@ void PlatformMessageRouter::HandlePlatformMessage(
     FlutterBinaryMessageHandler handler = it->second;
     NSData* data = nil;
     if (message->hasData()) {
-      data = GetNSDataFromVector(message->data());
+      data = [FlutterMessageData dataWithMessage:std::move(message)];
     }
     handler(data, ^(NSData* reply) {
       if (completer) {
         if (reply) {
-          completer->Complete(GetMappingFromNSData(reply));
+          completer->Complete(CopyNSDataToMapping(reply));
         } else {
           completer->CompleteEmpty();
         }


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/81559

- Renamed methods that copy data from Get* to Copy*
- Removed a few instances where we are doing an extra copy of data by using a proxy object that conforms to NSData but holds on the underlying data.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
