### PR TITLE
Handle iOS Universal Links

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -42,4 +42,26 @@ FLUTTER_ASSERT_ARC
   OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
 }
 
+- (void)skip_testLaunchUniversalLink {
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
+  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
+  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
+  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
+  OCMStub([viewController engine]).andReturn(engine);
+  OCMStub([engine waitForFirstFrame:3.0 callback:([OCMArg invokeBlockWithArgs:@(NO), nil])]);
+  appDelegate.rootFlutterViewControllerGetter = ^{
+    return viewController;
+  };
+  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
+  NSUserActivity* userActivity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+  userActivity.webpageURL = url;
+  BOOL result = [appDelegate application:[UIApplication sharedApplication]
+                                continueUserActivity:userActivity
+                                restorationHandler: ^(NSArray<id<UIUserActivityRestoring>>* __nullable
+                                                      restorableObjects){}];
+  XCTAssertTrue(result);
+  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
+}
+
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -54,12 +54,14 @@ FLUTTER_ASSERT_ARC
     return viewController;
   };
   NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
-  NSUserActivity* userActivity = [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+  NSUserActivity* userActivity =
+      [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
   userActivity.webpageURL = url;
-  BOOL result = [appDelegate application:[UIApplication sharedApplication]
-                                continueUserActivity:userActivity
-                                restorationHandler: ^(NSArray<id<UIUserActivityRestoring>>* __nullable
-                                                      restorableObjects){}];
+  BOOL result = [appDelegate
+               application:[UIApplication sharedApplication]
+      continueUserActivity:userActivity
+        restorationHandler: ^(NSArray<id<UIUserActivityRestoring>>* __nullable restorableObjects){
+        }];
   XCTAssertTrue(result);
   OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -60,7 +60,7 @@ FLUTTER_ASSERT_ARC
   BOOL result = [appDelegate
                application:[UIApplication sharedApplication]
       continueUserActivity:userActivity
-        restorationHandler: ^(NSArray<id<UIUserActivityRestoring>>* __nullable restorableObjects){
+        restorationHandler:^(NSArray<id<UIUserActivityRestoring>>* __nullable restorableObjects){
         }];
   XCTAssertTrue(result);
   OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);


### PR DESCRIPTION
iOS universal links were not handled by the engine. With this PR, the `FlutterAppDelegate` sends the link path to the navigation channel method `pushRoute` (similarly to Android App/Deep link or iOS Custom scheme link)

[Issues fixed: Android AppLinks is working but not iOS Universal Links](https://github.com/flutter/flutter/issues/80580)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
