### PR TITLE
Use GN instead of Ninja to generate compile commands and save ~1sec off of no-op builds.

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -33,7 +33,7 @@ DART_BIN="${SRC_DIR}/third_party/dart/tools/sdks/dart-sdk/bin"
 DART="${DART_BIN}/dart"
 PUB="${DART_BIN}/pub"
 
-COMPILE_COMMANDS="$SRC_DIR/out/compile_commands.json"
+COMPILE_COMMANDS="$SRC_DIR/out/host_debug/compile_commands.json"
 if [ ! -f "$COMPILE_COMMANDS" ]; then
   (cd "$SRC_DIR"; ./flutter/tools/gn)
 fi

--- a/tools/gn
+++ b/tools/gn
@@ -449,6 +449,7 @@ def main(argv):
     '%s/flutter/third_party/gn/gn%s' % (SRC_ROOT, exe),
     'gen',
     '--check',
+    '--export-compile-commands',
   ]
 
   if args.ide != '':
@@ -472,30 +473,6 @@ def main(argv):
   except subprocess.CalledProcessError as exc:
     print("Failed to generate gn files: ", exc.returncode, exc.output)
     sys.exit(1)
-
-  if gn_call_result == 0:
-    # Generate/Replace the compile commands database in out.
-    compile_cmd_gen_cmd = [
-      'ninja',
-      '-C',
-      out_dir,
-      '-t',
-      'compdb',
-      'cc',
-      'cxx',
-      'objc',
-      'objcxx',
-      'asm',
-    ]
-
-    try:
-      contents = subprocess.check_output(compile_cmd_gen_cmd, cwd=SRC_ROOT)
-    except subprocess.CalledProcessError as exc:
-      print("Failed to run ninja: ", exc.returncode, exc.output)
-      sys.exit(1)
-    compile_commands = open('%s/out/compile_commands.json' % SRC_ROOT, 'w+')
-    compile_commands.write(contents)
-    compile_commands.close()
 
   return gn_call_result
 


### PR DESCRIPTION
It used to be that GN could not generate compile commands on its own. Instead,
we would use Ninja to do the same in a separate invocation after GN. This worked
but the invocation took about a second to complete. Now that GN can generate the
compile commands as it is generating the Ninja build rules, we ask it generate
the compile commands directly. The commands seem identical and IDE integrations
continue to work.

One difference now is that the compile commands are now generated in the build
directory instead of the out directory like earlier. I think this is easier to
reason about but if others think we need the old behavior, I can add a symlink
to the compile_commands.json.

This knocks 0.9 to 1 seconds off of a no-op build compared to numbers in
https://github.com/flutter/flutter/issues/81074.

```
$ time ./flutter/tools/gn --unopt
Generating GN files in: out/host_debug_unopt
Generating Xcode projects took 244ms
Generating compile_commands took 104ms
Done. Made 739 targets from 228 files in 1781ms
./flutter/tools/gn --unopt  3.07s user 3.04s system 325% cpu 1.875 total

```

Related to https://github.com/flutter/flutter/issues/81074