### PR TITLE
[web] Render PlatformViews with SLOT tags.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -543,6 +543,8 @@ FILE: ../../../flutter/lib/web_ui/lib/src/engine/onscreen_logging.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/picture.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_views.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/plugins.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/pointer_converter.dart

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -545,6 +545,7 @@ FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_dispatcher.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_views.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_views/slots.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/plugins.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/pointer_converter.dart

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -250,6 +250,7 @@ part 'engine/platform_dispatcher.dart';
 part 'engine/platform_views.dart';
 part 'engine/platform_views/content_manager.dart';
 part 'engine/platform_views/message_handler.dart';
+part 'engine/platform_views/slots.dart';
 part 'engine/profiler.dart';
 part 'engine/rrect_renderer.dart';
 part 'engine/semantics/accessibility.dart';

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -415,11 +415,10 @@ class NullTreeSanitizer implements html.NodeTreeSanitizer {
   void sanitizeTree(html.Node node) {}
 }
 
-/// Enable the Slots technique to render HtmlPlatformViews.
-const bool _platformViewSlots =
-    bool.fromEnvironment('FLUTTER_WEB_USE_SLOTS', defaultValue: false);
-
-final PlatformViewContentManager platformViewContentManager = PlatformViewContentManager();
+/// The shared instance of PlatformViewManager shared across the engine to handle
+/// rendering of PlatformViews into the web app.
+/// TODO(dit): How to make this overridable from tests?
+final PlatformViewManager platformViewManager = PlatformViewManager();
 
 /// Converts a matrix represented using [Float64List] to one represented using
 /// [Float32List].

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -248,6 +248,8 @@ part 'engine/onscreen_logging.dart';
 part 'engine/picture.dart';
 part 'engine/platform_dispatcher.dart';
 part 'engine/platform_views.dart';
+part 'engine/platform_views/content_manager.dart';
+part 'engine/platform_views/message_handler.dart';
 part 'engine/profiler.dart';
 part 'engine/rrect_renderer.dart';
 part 'engine/semantics/accessibility.dart';
@@ -412,6 +414,12 @@ class NullTreeSanitizer implements html.NodeTreeSanitizer {
   @override
   void sanitizeTree(html.Node node) {}
 }
+
+/// Enable the Slots technique to render HtmlPlatformViews.
+const bool _platformViewSlots =
+    bool.fromEnvironment('FLUTTER_WEB_USE_SLOTS', defaultValue: false);
+
+final PlatformViewContentManager platformViewContentManager = PlatformViewContentManager();
 
 /// Converts a matrix represented using [Float64List] to one represented using
 /// [Float32List].

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -126,6 +126,9 @@ class HtmlViewEmbedder {
   }
 
   void _compositeWithParams(int viewId, EmbeddedViewParams params) {
+    // We need to do something similar in [PersistedPlatformView.createElement],
+    // because tests often short-circuit the lifecycle of a Platform View, and
+    // getSlot will throw an unwanted assertion!
     if (!platformViewManager.knowsViewId(viewId)) {
       // The view has been disposed of. Noop here.
       // [submitFrame] will report the deletion of this (and maybe other) views at once.

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -18,6 +18,12 @@ import 'path.dart';
 import 'picture_recorder.dart';
 import 'surface.dart';
 
+// An Exception to signal that a given `viewId` has already been created.
+class _PlatformViewAlreadyCreatedException implements Exception {
+  final int viewId;
+  _PlatformViewAlreadyCreatedException(this.viewId);
+}
+
 /// This composites HTML views into the [ui.Scene].
 class HtmlViewEmbedder {
   /// A picture recorder associated with a view id.
@@ -73,6 +79,10 @@ class HtmlViewEmbedder {
 
   /// Links a `viewId` and `slot` into this `HtmlViewEmbedder` instance.
   void create(int viewId, html.Element slot) {
+    if (_rootViews.containsKey(viewId)) {
+      // This will be handled by the MessageHandler
+      throw _PlatformViewAlreadyCreatedException(viewId);
+    }
     _rootViews[viewId] = slot;
   }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -3,13 +3,11 @@
 // found in the LICENSE file.
 
 import 'dart:html' as html;
-import 'dart:typed_data';
 
-import 'package:ui/src/engine.dart' show window, NullTreeSanitizer;
+import 'package:ui/src/engine.dart' show window, NullTreeSanitizer, platformViewManager;
 import 'package:ui/ui.dart' as ui;
 
 import '../html/path_to_svg_clip.dart';
-import '../services.dart';
 import '../util.dart';
 import '../vector_math.dart';
 import 'canvas.dart';

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -48,9 +48,6 @@ class HtmlViewEmbedder {
   /// The views that need to be recomposited into the scene on the next frame.
   final Set<int> _viewsToRecomposite = <int>{};
 
-  /// The views that need to be disposed of on the next frame.
-  final Set<int> _viewsToDispose = <int>{};
-
   /// The list of view ids that should be composited, in order.
   List<int> _compositionOrder = <int>[];
 

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -115,32 +115,16 @@ class HtmlViewEmbedder {
     return _pictureRecorders[viewId]!.recordingCanvas;
   }
 
-  // Applies the required sizing information from `params` to the `content` element.
-  //
-  // See `_applyOnContent` in the PersistedPlatformView class for the HTML version
-  // of this code.
-  void _updateContentSize(html.Element content, EmbeddedViewParams params) {
-    content.style.width = '${params.size.width}px';
-    content.style.height = '${params.size.height}px';
-    content.style.position = 'absolute';
-  }
-
   void _compositeWithParams(int viewId, EmbeddedViewParams params) {
-    // Here, `slot` refers to the <slot> tag in the shadowDOM, which this class
-    // may re-root if needed (see _reconstructClipViewsChain).
+    // See [PlatformViewManager] for more info about PlatformView `slot` and `content`.
     final html.Element slot = platformViewManager.getSlot(viewId);
 
-    // Because of how slots project content, the width/height of the DOM needs to
-    // be set in the `content`, which should never be moved from its position in
-    // the DOM.
-    final html.Element content = platformViewManager.getContent(viewId);
-
-    // Apply the sizing information to the contents...
-    _updateContentSize(content, params);
-
-    // <flt-scene-host> disables pointer events. Reenable them here because the
-    // underlying platform view would want to handle the pointer events.
-    slot.style.pointerEvents = 'auto';
+    // See `apply()` in the PersistedPlatformView class for the HTML version
+    // of this code.
+    slot.style
+        ..width = '${params.size.width}px'
+        ..height = '${params.size.height}px'
+        ..position = 'absolute';
 
     // Recompute the position in the DOM of the `slot` element...
     final int currentClippingCount = _countClips(params.mutators);
@@ -156,8 +140,7 @@ class HtmlViewEmbedder {
       _rootViews[viewId] = newPlatformViewRoot;
     }
 
-    // Apply mutators in the `content` element...
-    _applyMutators(params.mutators, content, viewId);
+    _applyMutators(params.mutators, slot, viewId);
   }
 
   int _countClips(MutatorsStack mutators) {

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -126,6 +126,12 @@ class HtmlViewEmbedder {
   }
 
   void _compositeWithParams(int viewId, EmbeddedViewParams params) {
+    if (!platformViewManager.knowsViewId(viewId)) {
+      // The view has been disposed of. Noop here.
+      // [submitFrame] will report the deletion of this (and maybe other) views at once.
+      return;
+    }
+
     // See [PlatformViewManager] for more info about PlatformView `slot` and `content`.
     final html.Element slot = platformViewManager.getSlot(viewId);
 

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -4,7 +4,7 @@
 
 import 'dart:html' as html;
 
-import 'package:ui/src/engine.dart' show window, NullTreeSanitizer, platformViewManager;
+import 'package:ui/src/engine.dart' show window, NullTreeSanitizer, platformViewManager, createPlatformViewSlot;
 import 'package:ui/ui.dart' as ui;
 
 import '../html/path_to_svg_clip.dart';
@@ -102,7 +102,7 @@ class HtmlViewEmbedder {
 
   void _compositeWithParams(int viewId, EmbeddedViewParams params) {
     // See [PlatformViewManager] for more info about PlatformView `slot` and `content`.
-    final html.Element slot = platformViewManager.renderSlot(viewId);
+    final html.Element slot = createPlatformViewSlot(viewId);
 
     // We haven't seen this viewId yet, let's cache its root for clips/transforms.
     if (!_rootViews.containsKey(viewId)) {

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -12,7 +12,10 @@ class DomRenderer {
 
     reset();
 
-    TextMeasurementService.initialize(rulerCacheCapacity: 10);
+    TextMeasurementService.initialize(
+      rulerCacheCapacity: 10,
+      root: _glassPaneShadow!,
+    );
 
     assert(() {
       _setupHotRestart();

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -154,8 +154,9 @@ class DomRenderer {
   html.Element? get glassPaneElement => _glassPaneElement;
   html.Element? _glassPaneElement;
 
-  // The ShadowRoot of the [glassPaneElement].
-  // html.ShadowRoot? _glassPaneElementShadowRoot; // unused externally, for now...
+  /// The ShadowRoot of the [glassPaneElement].
+  html.ShadowRoot? get glassPaneShadow => _glassPaneShadow;
+  html.ShadowRoot? _glassPaneShadow;
 
   final html.Element rootElement = html.document.body!;
 
@@ -457,6 +458,7 @@ flt-glass-pane * {
       'mode': 'open',
       'delegatesFocus': 'true',
     });
+    _glassPaneShadow = glassPaneElementShadowRoot;
 
     // _glassPaneElementShadowRoot = glassPaneElementShadowRoot;
 

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -29,6 +29,9 @@ class DomRenderer {
   static const int vibrateHeavyImpact = 30;
   static const int vibrateSelectionClick = 10;
 
+  // The tag name for the root view of the flutter app (glass-pane)
+  static const String _glassPaneTagName = 'flt-glass-pane';
+
   /// Fires when browser language preferences change.
   static const html.EventStreamProvider<html.Event> languageChangeEvent =
       const html.EventStreamProvider<html.Event>('languagechange');
@@ -345,7 +348,7 @@ flt-semantics [contentEditable="true"] {
     // on using gray background. This CSS rule disables that.
     if (isWebKit) {
       sheet.insertRule('''
-flt-glass-pane * {
+$_glassPaneTagName * {
   -webkit-tap-highlight-color: transparent;
 }
 ''', sheet.cssRules.length);
@@ -446,7 +449,7 @@ flt-glass-pane * {
     // IMPORTANT: the glass pane element must come after the scene element in the DOM node list so
     //            it can intercept input events.
     _glassPaneElement?.remove();
-    final html.Element glassPaneElement = createElement('flt-glass-pane');
+    final html.Element glassPaneElement = createElement(_glassPaneTagName);
     _glassPaneElement = glassPaneElement;
     glassPaneElement.style
       ..position = 'absolute'

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -155,7 +155,7 @@ class DomRenderer {
   html.Element? _glassPaneElement;
 
   // The ShadowRoot of the [glassPaneElement].
-  html.ShadowRoot? _glassPaneElementShadowRoot;
+  // html.ShadowRoot? _glassPaneElementShadowRoot; // unused externally, for now...
 
   final html.Element rootElement = html.document.body!;
 
@@ -458,11 +458,12 @@ flt-glass-pane * {
       'delegatesFocus': 'true',
     });
 
-    _glassPaneElementShadowRoot = glassPaneElementShadowRoot;
+    // _glassPaneElementShadowRoot = glassPaneElementShadowRoot;
 
     bodyElement.append(glassPaneElement);
 
     final html.StyleElement shadowRootStyleElement = html.StyleElement();
+    // The shadowRootStyleElement must be appended to the DOM, or its `sheet` will be null later...
     glassPaneElementShadowRoot.append(shadowRootStyleElement);
 
     final html.CssStyleSheet shadowRootStyleSheet = shadowRootStyleElement.sheet as html.CssStyleSheet;

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -466,8 +466,6 @@ $_glassPaneTagName * {
     });
     _glassPaneShadow = glassPaneElementShadowRoot;
 
-    // _glassPaneElementShadowRoot = glassPaneElementShadowRoot;
-
     bodyElement.append(glassPaneElement);
 
     final html.StyleElement shadowRootStyleElement = html.StyleElement();

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -154,6 +154,9 @@ class DomRenderer {
   html.Element? get glassPaneElement => _glassPaneElement;
   html.Element? _glassPaneElement;
 
+  // The ShadowRoot of the [glassPaneElement].
+  html.ShadowRoot? _glassPaneElementShadowRoot;
+
   final html.Element rootElement = html.document.body!;
 
   void addElementClass(html.Element element, String className) {
@@ -252,11 +255,8 @@ class DomRenderer {
   static const String defaultCssFont =
       '$defaultFontStyle $defaultFontWeight ${defaultFontSize}px $defaultFontFamily';
 
-  void reset() {
-    _styleElement?.remove();
-    _styleElement = html.StyleElement();
-    html.document.head!.append(_styleElement!);
-    final html.CssStyleSheet sheet = _styleElement!.sheet as html.CssStyleSheet;
+  // Applies the required global CSS to an incoming [html.CssStyleSheet] `sheet`.
+  void _applyCssRulesToSheet(html.CssStyleSheet sheet) {
     final bool isWebKit = browserEngine == BrowserEngine.webkit;
     final bool isFirefox = browserEngine == BrowserEngine.firefox;
     // TODO(butterfly): use more efficient CSS selectors; descendant selectors
@@ -360,6 +360,16 @@ flt-glass-pane * {
 }
 ''', sheet.cssRules.length);
     }
+  }
+
+  void reset() {
+    final bool isWebKit = browserEngine == BrowserEngine.webkit;
+
+    _styleElement?.remove();
+    _styleElement = html.StyleElement();
+    html.document.head!.append(_styleElement!);
+    final html.CssStyleSheet sheet = _styleElement!.sheet as html.CssStyleSheet;
+    _applyCssRulesToSheet(sheet);
 
     final html.BodyElement bodyElement = html.document.body!;
 
@@ -440,9 +450,28 @@ flt-glass-pane * {
       ..right = '0'
       ..bottom = '0'
       ..left = '0';
+
+    // Create a Shadow Root under the glass panel, and attach everything there,
+    // instead of directly underneath the glass panel.
+    final html.ShadowRoot glassPaneElementShadowRoot = glassPaneElement.attachShadow(<String, String>{
+      'mode': 'open',
+      'delegatesFocus': 'true',
+    });
+
+    _glassPaneElementShadowRoot = glassPaneElementShadowRoot;
+
     bodyElement.append(glassPaneElement);
 
-    _sceneHostElement = createElement('flt-scene-host');
+    final html.StyleElement shadowRootStyleElement = html.StyleElement();
+    glassPaneElementShadowRoot.append(shadowRootStyleElement);
+
+    final html.CssStyleSheet shadowRootStyleSheet = shadowRootStyleElement.sheet as html.CssStyleSheet;
+    _applyCssRulesToSheet(shadowRootStyleSheet); // TODO: Apply only rules for the shadow root
+
+    // Don't allow the scene to receive pointer events.
+    _sceneHostElement = createElement('flt-scene-host')
+      ..style
+        .pointerEvents = 'none';
 
     final html.Element semanticsHostElement =
         createElement('flt-semantics-host');
@@ -451,23 +480,16 @@ flt-glass-pane * {
       ..transformOrigin = '0 0 0';
     _semanticsHostElement = semanticsHostElement;
     updateSemanticsScreenProperties();
-    glassPaneElement.append(semanticsHostElement);
 
-    // Don't allow the scene to receive pointer events.
-    _sceneHostElement!.style.pointerEvents = 'none';
-
-    glassPaneElement.append(_sceneHostElement!);
-
-    final html.Element _accesibilityPlaceholder = EngineSemanticsOwner
+    final html.Element _accessibilityPlaceholder = EngineSemanticsOwner
         .instance.semanticsHelper
         .prepareAccessibilityPlaceholder();
 
-    // Insert the semantics placeholder after the scene host. For all widgets
-    // in the scene, except for platform widgets, the scene host will pass the
-    // pointer events through to the semantics tree. However, for platform
-    // views, the pointer events will not pass through, and will be handled
-    // by the platform view.
-    glassPaneElement.insertBefore(_accesibilityPlaceholder, _sceneHostElement);
+    glassPaneElementShadowRoot.nodes.addAll([
+      semanticsHostElement,
+      _accessibilityPlaceholder,
+      _sceneHostElement!,
+    ]);
 
     // When debugging semantics, make the scene semi-transparent so that the
     // semantics tree is visible.

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -16,7 +16,7 @@ class PersistedPlatformView extends PersistedLeafSurface {
 
   @override
   html.Element createElement() {
-    return platformViewManager.renderSlot(viewId);
+    return createPlatformViewSlot(viewId);
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -22,23 +22,14 @@ class PersistedPlatformView extends PersistedLeafSurface {
   @override
   Matrix4? get localTransformInverse => null;
 
-  // Applies the width/height information in the `content` element of the Platform View.
-  //
-  // See `_updateContentSize` in the HtmlViewEmbedder for the canvaskit version.
-  void _applyOnContent() {
-    final html.Element content = platformViewManager.getContent(viewId);
-    content.style
+  @override
+  void apply() {
+    // See `_compositeWithParams` in the HtmlViewEmbedder for the canvaskit equivalent.
+    rootElement!.style
+      ..transform = 'translate(${dx}px, ${dy}px)'
       ..width = '${width}px'
       ..height = '${height}px'
       ..position = 'absolute';
-  }
-
-  @override
-  void apply() {
-    rootElement!.style
-      ..transform = 'translate(${dx}px, ${dy}px)';
-
-    _applyOnContent();
   }
 
   // Platform Views can only be updated if their viewId matches.

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -16,17 +16,7 @@ class PersistedPlatformView extends PersistedLeafSurface {
 
   @override
   html.Element createElement() {
-    // We need to do something similar in [HtmlViewEmbedder._compositeWithParams],
-    // because tests often short-circuit the lifecycle of a Platform View, and
-    // getSlot will throw an unwanted assertion.
-    // Instead, we return a non-functional PlatformView, as the previous iteration
-    // of the code did, so old (framework) tests keep passing.
-    // See: https://github.com/flutter/engine/blob/ee1696721b02539d5f32b1cbfdf6bfa107663e91/lib/web_ui/lib/src/engine/html/platform_view.dart#L49-L55
-    if (assertionsEnabled && !platformViewManager.knowsViewId(viewId)) {
-      return html.DivElement()..id = 'only-to-vw-flutter/test/widgets/html_element_view_test.dart';
-    }
-
-    return platformViewManager.getSlot(viewId);
+    return platformViewManager.renderSlot(viewId);
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -16,6 +16,16 @@ class PersistedPlatformView extends PersistedLeafSurface {
 
   @override
   html.Element createElement() {
+    // We need to do something similar in [HtmlViewEmbedder._compositeWithParams],
+    // because tests often short-circuit the lifecycle of a Platform View, and
+    // getSlot will throw an unwanted assertion.
+    // Instead, we return a non-functional PlatformView, as the previous iteration
+    // of the code did, so old (framework) tests keep passing.
+    // See: https://github.com/flutter/engine/blob/ee1696721b02539d5f32b1cbfdf6bfa107663e91/lib/web_ui/lib/src/engine/html/platform_view.dart#L49-L55
+    if (assertionsEnabled && !platformViewManager.knowsViewId(viewId)) {
+      return html.DivElement()..id = 'only-to-vw-flutter/test/widgets/html_element_view_test.dart';
+    }
+
     return platformViewManager.getSlot(viewId);
   }
 

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -18,6 +18,10 @@ class PersistedPlatformView extends PersistedLeafSurface {
 
   @override
   html.Element createElement() {
+    if (_platformViewSlots) {
+      return ui.platformViewRegistry.getCreatedView(viewId)!;
+    }
+
     html.Element element = defaultCreateElement('flt-platform-view');
 
     // Allow the platform view host element to receive pointer events.
@@ -59,8 +63,22 @@ class PersistedPlatformView extends PersistedLeafSurface {
   @override
   Matrix4? get localTransformInverse => null;
 
+  void _applyOnContent() {
+    rootElement!.style
+      ..transform = 'translate(${dx}px, ${dy}px)';
+
+    final html.Element content = platformViewContentManager.getContent(viewId);
+    content.style
+      ..width = '${width}px'
+      ..height = '${height}px';
+  }
+
   @override
   void apply() {
+    if (_platformViewSlots) {
+      return _applyOnContent();
+    }
+
     rootElement!.style
       ..transform = 'translate(${dx}px, ${dy}px)'
       ..width = '${width}px'

--- a/lib/web_ui/lib/src/engine/html/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/html/platform_view.dart
@@ -12,85 +12,33 @@ class PersistedPlatformView extends PersistedLeafSurface {
   final double width;
   final double height;
 
-  late html.ShadowRoot _shadowRoot;
-
   PersistedPlatformView(this.viewId, this.dx, this.dy, this.width, this.height);
 
   @override
   html.Element createElement() {
-    if (_platformViewSlots) {
-      return ui.platformViewRegistry.getCreatedView(viewId)!;
-    }
-
-    html.Element element = defaultCreateElement('flt-platform-view');
-
-    // Allow the platform view host element to receive pointer events.
-    //
-    // This is to allow platform view HTML elements to be interactive.
-    //
-    // ACCESSIBILITY NOTE: The way we enable accessibility on Flutter for web
-    // is to have a full-page button which waits for a double tap. Placing this
-    // full-page button in front of the scene would cause platform views not
-    // to receive pointer events. The tradeoff is that by placing the scene in
-    // front of the semantics placeholder will cause platform views to block
-    // pointer events from reaching the placeholder. This means that in order
-    // to enable accessibility, you must double tap the app *outside of a
-    // platform view*. As a consequence, a full-screen platform view will make
-    // it impossible to enable accessibility.
-    element.style.pointerEvents = 'auto';
-
-    // Enforce the effective size of the PlatformView.
-    element.style.overflow = 'hidden';
-
-    _shadowRoot = element.attachShadow(<String, String>{'mode': 'open'});
-    final html.StyleElement _styleReset = html.StyleElement();
-    _styleReset.innerHtml = '''
-      :host {
-        all: initial;
-        cursor: inherit;
-      }''';
-    _shadowRoot.append(_styleReset);
-    final html.Element? platformView =
-        ui.platformViewRegistry.getCreatedView(viewId);
-    if (platformView != null) {
-      _shadowRoot.append(platformView);
-    } else {
-      printWarning('No platform view created for id $viewId');
-    }
-    return element;
+    return platformViewManager.getSlot(viewId);
   }
 
   @override
   Matrix4? get localTransformInverse => null;
 
+  // Applies the width/height information in the `content` element of the Platform View.
+  //
+  // See `_updateContentSize` in the HtmlViewEmbedder for the canvaskit version.
   void _applyOnContent() {
-    rootElement!.style
-      ..transform = 'translate(${dx}px, ${dy}px)';
-
-    final html.Element content = platformViewContentManager.getContent(viewId);
+    final html.Element content = platformViewManager.getContent(viewId);
     content.style
       ..width = '${width}px'
-      ..height = '${height}px';
+      ..height = '${height}px'
+      ..position = 'absolute';
   }
 
   @override
   void apply() {
-    if (_platformViewSlots) {
-      return _applyOnContent();
-    }
-
     rootElement!.style
-      ..transform = 'translate(${dx}px, ${dy}px)'
-      ..width = '${width}px'
-      ..height = '${height}px';
-    // Set size of the root element created by the PlatformView.
-    final html.Element? platformView =
-        ui.platformViewRegistry.getCreatedView(viewId);
-    if (platformView != null) {
-      platformView.style
-        ..width = '${width}px'
-        ..height = '${height}px';
-    }
+      ..transform = 'translate(${dx}px, ${dy}px)';
+
+    _applyOnContent();
   }
 
   // Platform Views can only be updated if their viewId matches.

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -451,14 +451,12 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         return;
 
       case 'flutter/platform_views':
-        if (_platformViewMessageHandler == null) {
-          _platformViewMessageHandler = PlatformViewMessageHandler(
+        _platformViewMessageHandler ??= PlatformViewMessageHandler(
             contentManager: platformViewManager,
             contentHandler: (html.Element content) {
               domRenderer.glassPaneElement!.append(content);
             }
           );
-        }
         _platformViewMessageHandler!.handlePlatformViewCall(data, callback!);
         return;
 

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -450,28 +450,22 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
                 _handleWebTestEnd2EndMessage(codec, data)));
         return;
 
-      // Here's the entrypoint to create/dispose platform views...
-      // Good opportunity to inject a new component that handles them!
       case 'flutter/platform_views':
-        if (_platformViewSlots) {
-          if (_platformViewMessageHandler == null) {
-            _platformViewMessageHandler = PlatformViewMessageHandler(
-              contentManager: platformViewContentManager,
-              viewContentHandler: (int _, html.Element content) {
-                domRenderer.glassPaneElement!.append(content);
-              },
-              viewSlotHandler: useCanvasKit ? 
-                  rasterizer!.surface.viewEmbedder.embed : 
-                  ui.platformViewRegistry.embed,
-            );
-          }
-          _platformViewMessageHandler!.handlePlatformViewCall(data, callback!);
-        } else if (useCanvasKit) {
-          rasterizer!.surface.viewEmbedder
-              .handlePlatformViewCall(data, callback);
-        } else {
-          ui.handlePlatformViewCall(data!, callback!);
+        if (_platformViewMessageHandler == null) {
+          _platformViewMessageHandler = PlatformViewMessageHandler(
+            contentManager: platformViewManager,
+            contentHandler: (int _, html.Element content) {
+              domRenderer.glassPaneElement!.append(content);
+            },
+            slotHandler: useCanvasKit ?
+                rasterizer!.surface.viewEmbedder.create :
+                null, // noop, everything is handled by the `platformViewManager`
+            disposeHandler: useCanvasKit ?
+                rasterizer!.surface.viewEmbedder.dispose :
+                null, // noop, everything is handled by the `platformViewManager`
+          );
         }
+        _platformViewMessageHandler!.handlePlatformViewCall(data, callback!);
         return;
 
       case 'flutter/accessibility':

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -454,15 +454,9 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
         if (_platformViewMessageHandler == null) {
           _platformViewMessageHandler = PlatformViewMessageHandler(
             contentManager: platformViewManager,
-            contentHandler: (int _, html.Element content) {
+            contentHandler: (html.Element content) {
               domRenderer.glassPaneElement!.append(content);
-            },
-            slotHandler: useCanvasKit ?
-                rasterizer!.surface.viewEmbedder.create :
-                null, // noop, everything is handled by the `platformViewManager`
-            disposeHandler: useCanvasKit ?
-                rasterizer!.surface.viewEmbedder.dispose :
-                null, // noop, everything is handled by the `platformViewManager`
+            }
           );
         }
         _platformViewMessageHandler!.handlePlatformViewCall(data, callback!);

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -4,8 +4,6 @@
 
 part of engine;
 
-// import 'dart:html' as html;
-
 /// A function which takes a unique `id` and some `params` and creates an HTML element.
 ///
 /// This is made available to end-users through dart:ui in web.
@@ -164,7 +162,10 @@ class PlatformViewManager {
       // Note there's also no getContent(viewId) function anymore, to prevent
       // from later modifications too.
       if (content.style.height.isEmpty) {
-        printWarning('Height of Platform View type: [$viewType] may not be set. Defaulting to `height: 100%`.\nSet `style.height` to any appropriate value to stop this message.');
+        printWarning('Height of Platform View type: [$viewType] may not be set.'
+            ' Defaulting to `height: 100%`.\n'
+            'Set `style.height` to any appropriate value to stop this message.');
+
         content.style.height = '100%';
       }
 

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -1,0 +1,86 @@
+part of engine;
+
+// import 'dart:html' as html;
+
+/// A function which takes a unique [id] and creates an HTML element.
+typedef ParameterizedPlatformViewFactory = html.Element Function(int viewId, { Map<dynamic, dynamic>? params });
+typedef PlatformViewFactory = html.Element Function(int viewId);
+
+/// Keeps pointers to platform views and their keys.
+class PlatformViewContentManager {
+  /// The factory functions, indexed by the viewType
+  final Map<String, Function> _factories = {};
+  /// The references to <slot> tags, indexed by their framework-given ID.
+  final Map<int, html.SlotElement> _slots = {};
+  /// The references to content tags, indexed by their framework-given ID.
+  final Map<int, html.Element> _content = {};
+
+  String _getSlotName(String viewType, int viewId) {
+    return 'flt-pv-${viewType}-$viewId';
+  }
+
+  bool knowsViewType(String viewType) {
+    return _factories.containsKey(viewType);
+  }
+
+  bool registerFactory(String platformViewId, Function factoryFunction) {
+    assert(factoryFunction is PlatformViewFactory || factoryFunction is ParameterizedPlatformViewFactory);
+    if (_factories.containsKey(platformViewId)) {
+      return false;
+    }
+    _factories[platformViewId] = factoryFunction;
+    return true;
+  }
+
+  html.SlotElement getSlot(int viewId) {
+    assert(_slots.containsKey(viewId));
+    return _slots[viewId]!;
+  }
+
+  html.SlotElement renderSlot(String viewType, int viewId) {
+    assert(!knowsViewType(viewType), 'Attempted to get slot of unregistered viewType: $viewType');
+
+    final String slotName = _getSlotName(viewType, viewId);
+
+    return _slots.putIfAbsent(viewId, () {
+      final html.Element slot = html.document.createElement('slot')
+          ..setAttribute('name', slotName)
+          ..style
+            .pointerEvents = 'auto';
+      return slot as html.SlotElement;
+    });
+  }
+
+  html.Element getContent(int viewId) {
+    assert(_content.containsKey(viewId));
+    return _content[viewId]!;
+  }
+
+  html.Element renderContent(String viewType, int viewId, Map<dynamic, dynamic>? params) {
+    assert(!knowsViewType(viewType), 'Attempted to get contents of unregistered viewType: $viewType');
+
+    final String slotName = _getSlotName(viewType, viewId);
+
+    return _content.putIfAbsent(viewId, () {
+      final html.Element wrapper = html.DivElement()..slot = slotName;
+      final Function factoryFunction = _factories[viewType]!;
+      late html.Element content;
+
+      if (factoryFunction is ParameterizedPlatformViewFactory) {
+        content = factoryFunction(viewId, params: params);
+      } else {
+        content = factoryFunction(viewId);
+      }
+
+      content.style.height = '100%';
+
+      return wrapper..append(content);
+    });
+  }
+
+  void clearPlatformView(int viewId) {
+    // Remove from our cache, and then from the DOM...
+    _slots.remove(viewId)?.remove();
+    _content.remove(viewId)?.remove();
+  }
+}

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -46,7 +46,7 @@ class PlatformViewManager {
 
   /// Returns `true` if the passed in `viewId` has been rendered (and not disposed) before.
   ///
-  /// See [renderContent] and [renderSlot] to understand how platform views are
+  /// See [renderContent] and [createPlatformViewSlot] to understand how platform views are
   /// rendered.
   bool knowsViewId(int viewId) {
     return _contents.containsKey(viewId);

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -18,76 +18,144 @@ typedef ParameterizedPlatformViewFactory = html.Element Function(
 /// This is made available to end-users through dart:ui in web.
 typedef PlatformViewFactory = html.Element Function(int viewId);
 
-/// Keeps pointers to factories to create platform views, the created platform views,
-/// and the slot tags for these platform views.
+/// This class handles the lifecycle of Platform Views in the DOM of a Flutter Web App.
+///
+/// There are three important parts of Platform Views that this class manages:
+///
+/// * `factories`: The functions used to render the contents of any given Platform
+/// View by its `viewType`.
+/// * `contents`: The result [html.Element] of calling a `factory` function.
+/// * `slots`: A special HTML tag that will be used by the framework to "reveal"
+/// the `contents` of a Platform View.
+///
+/// This class keeps a registry of `factories`, `slots` and `contents` so the
+/// framework can CRUD Platform Views as needed, regardless of the rendering backend.
 class PlatformViewManager {
   // The factory functions, indexed by the viewType
   final Map<String, Function> _factories = {};
 
   // The references to <slot> tags, indexed by their framework-given ID.
-  final Map<int, html.SlotElement> _slots = {};
+  final Map<int, html.Element> _slots = {};
 
   // The references to content tags, indexed by their framework-given ID.
-  final Map<int, html.Element> _content = {};
+  final Map<int, html.Element> _contents = {};
 
   String _getSlotName(String viewType, int viewId) {
     return 'flt-pv-${viewType}-$viewId';
   }
 
+  /// Returns `true` if the passed in `viewType` has been registered before.
+  ///
+  /// See [registerViewFactory] to understand how factories are registered.
   bool knowsViewType(String viewType) {
     return _factories.containsKey(viewType);
   }
 
+  /// Returns `true` if the passed in `viewId` has been rendered (and not disposed) before.
+  ///
+  /// See [renderContent] and [renderSlot] to understand how platform views are
+  /// rendered.
   bool knowsViewId(int viewId) {
-    return _content.containsKey(viewId);
+    return _contents.containsKey(viewId);
   }
 
-  bool registerFactory(String platformViewId, Function factoryFunction) {
+  /// Registers a `factoryFunction` that knows how to render a Platform View of `viewType`.
+  ///
+  /// `viewType` is selected by the programmer, but it can't be overridden once
+  /// it's been set.
+  ///
+  /// `factoryFunction` needs to be a [PlatformViewFactory].
+  bool registerFactory(String viewType, Function factoryFunction) {
     assert(factoryFunction is PlatformViewFactory ||
         factoryFunction is ParameterizedPlatformViewFactory);
 
-    if (_factories.containsKey(platformViewId)) {
+    if (_factories.containsKey(viewType)) {
       return false;
     }
-    _factories[platformViewId] = factoryFunction;
+    _factories[viewType] = factoryFunction;
     return true;
   }
 
-  html.SlotElement getSlot(int viewId) {
+  /// Returns the `slot` associated to a `viewId`, if it's been rendered (and not disposed of).
+  ///
+  /// See [renderSlot] to understand how `slots` are rendered.
+  html.Element getSlot(int viewId) {
     assert(_slots.containsKey(viewId));
     return _slots[viewId]!;
   }
 
-  html.SlotElement renderSlot(String viewType, int viewId) {
-    assert(!knowsViewType(viewType),
+  /// Creates the HTML markup for the `slot` of a Platform View.
+  ///
+  /// The result of this call is cached in the `_slots` Map, so it can be accessed
+  /// later for CRUD operations.
+  ///
+  /// The resulting DOM for a `slot` looks like this:
+  ///
+  /// ```html
+  /// <flt-platform-view-slot style="...">
+  ///   <slot name="..." />
+  /// </flt-platform-view-slot>
+  /// ```
+  ///
+  /// The inner `SLOT` tag is standard HTML to reveal an element that is rendered
+  /// elsewhere in the DOM. Its `name` attribute must match the value of the `slot`
+  /// attribute of the contents being revealed (see [renderContent].)
+  ///
+  /// The outer `flt-platform-view-slot` tag is a simple wrapper that the framework
+  /// can position/style as needed.
+  ///
+  /// (When the framework accesses a `slot`, it's really accessing its wrapper
+  /// `flt-platform-view-slot` tag)
+  html.Element renderSlot(String viewType, int viewId) {
+    assert(knowsViewType(viewType),
         'Attempted to render slot of unregistered viewType: $viewType');
 
     final String slotName = _getSlotName(viewType, viewId);
 
     return _slots.putIfAbsent(viewId, () {
+      final html.Element wrapper = html.document
+          .createElement('flt-platform-view-slot')
+          ..style.pointerEvents = 'auto';
+
       final html.Element slot = html.document.createElement('slot')
-        ..setAttribute('name', slotName)
-        ..style.pointerEvents = 'auto';
-      return slot as html.SlotElement;
+        ..setAttribute('name', slotName);
+
+      return wrapper..append(slot);
     });
   }
 
-  html.Element getContent(int viewId) {
-    assert(_content.containsKey(viewId));
-    return _content[viewId]!;
-  }
-
+  /// Creates the HTML markup for the `contents` of a Platform View.
+  ///
+  /// The result of this call is cached in the `_contents` Map. This is only
+  /// cached so it can be disposed of later by [clearPlatformView]. _Note that
+  /// there's no `getContents` function in this class._
+  ///
+  /// The resulting DOM for the `contents` of a Platform View looks like this:
+  ///
+  /// ```html
+  /// <flt-platform-view slot="...">
+  ///   <arbitrary-html-elements />
+  /// </flt-platform-view-slot>
+  /// ```
+  ///
+  /// The `arbitrary-html-elements` are the result of the call to the user-supplied
+  /// `factory` function for this Platform View (see [registerFactory]).
+  ///
+  /// The outer `flt-platform-view` tag is a simple wrapper that we add to have
+  /// a place where to attach the `slot` property, that will tell the browser
+  /// what `slot` tag will reveal this `contents`, **without modifying the returned
+  /// html from the `factory` function**.
   html.Element renderContent(
     String viewType,
     int viewId,
     Map<dynamic, dynamic>? params,
   ) {
-    assert(!knowsViewType(viewType),
+    assert(knowsViewType(viewType),
         'Attempted to render contents of unregistered viewType: $viewType');
 
     final String slotName = _getSlotName(viewType, viewId);
 
-    return _content.putIfAbsent(viewId, () {
+    return _contents.putIfAbsent(viewId, () {
       final html.Element wrapper = html.document
           .createElement('flt-platform-view')
             ..setAttribute('slot', slotName);
@@ -101,16 +169,22 @@ class PlatformViewManager {
         content = factoryFunction(viewId);
       }
 
-      // We could move this to a CSS stylesheet
-      content.style.height = 'inherit';
+      // Scrutinize closely any modifications to `content`.
+      // We shouldn't modify users' returned `content` if at all possible.
+      // Note there's also no getContent(viewId) function anymore, to prevent
+      // from later modifications too.
 
       return wrapper..append(content);
     });
   }
 
+  /// Removes a PlatformView by its `viewId` from the manager, and from the DOM.
+  ///
+  /// Once a view has been cleared, calls to [getSlot] or [knowsViewId] will fail,
+  /// as if it had never been rendered before.
   void clearPlatformView(int viewId) {
     // Remove from our cache, and then from the DOM...
     _slots.remove(viewId)?.remove();
-    _content.remove(viewId)?.remove();
+    _contents.remove(viewId)?.remove();
   }
 }

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -1,18 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 part of engine;
 
 // import 'dart:html' as html;
 
-/// A function which takes a unique [id] and creates an HTML element.
-typedef ParameterizedPlatformViewFactory = html.Element Function(int viewId, { Map<dynamic, dynamic>? params });
+/// A function which takes a unique `id` and some `params` and creates an HTML element.
+///
+/// This is made available to end-users through dart:ui in web.
+typedef ParameterizedPlatformViewFactory = html.Element Function(
+  int viewId, {
+  Map<dynamic, dynamic>? params,
+});
+/// A function which takes a unique `id` and creates an HTML element.
+///
+/// This is made available to end-users through dart:ui in web.
 typedef PlatformViewFactory = html.Element Function(int viewId);
 
-/// Keeps pointers to platform views and their keys.
-class PlatformViewContentManager {
-  /// The factory functions, indexed by the viewType
+/// Keeps pointers to factories to create platform views, the created platform views,
+/// and the slot tags for these platform views.
+class PlatformViewManager {
+  // The factory functions, indexed by the viewType
   final Map<String, Function> _factories = {};
-  /// The references to <slot> tags, indexed by their framework-given ID.
+
+  // The references to <slot> tags, indexed by their framework-given ID.
   final Map<int, html.SlotElement> _slots = {};
-  /// The references to content tags, indexed by their framework-given ID.
+
+  // The references to content tags, indexed by their framework-given ID.
   final Map<int, html.Element> _content = {};
 
   String _getSlotName(String viewType, int viewId) {
@@ -23,8 +38,14 @@ class PlatformViewContentManager {
     return _factories.containsKey(viewType);
   }
 
+  bool knowsViewId(int viewId) {
+    return _content.containsKey(viewId);
+  }
+
   bool registerFactory(String platformViewId, Function factoryFunction) {
-    assert(factoryFunction is PlatformViewFactory || factoryFunction is ParameterizedPlatformViewFactory);
+    assert(factoryFunction is PlatformViewFactory ||
+        factoryFunction is ParameterizedPlatformViewFactory);
+
     if (_factories.containsKey(platformViewId)) {
       return false;
     }
@@ -38,15 +59,15 @@ class PlatformViewContentManager {
   }
 
   html.SlotElement renderSlot(String viewType, int viewId) {
-    assert(!knowsViewType(viewType), 'Attempted to get slot of unregistered viewType: $viewType');
+    assert(!knowsViewType(viewType),
+        'Attempted to render slot of unregistered viewType: $viewType');
 
     final String slotName = _getSlotName(viewType, viewId);
 
     return _slots.putIfAbsent(viewId, () {
       final html.Element slot = html.document.createElement('slot')
-          ..setAttribute('name', slotName)
-          ..style
-            .pointerEvents = 'auto';
+        ..setAttribute('name', slotName)
+        ..style.pointerEvents = 'auto';
       return slot as html.SlotElement;
     });
   }
@@ -56,13 +77,21 @@ class PlatformViewContentManager {
     return _content[viewId]!;
   }
 
-  html.Element renderContent(String viewType, int viewId, Map<dynamic, dynamic>? params) {
-    assert(!knowsViewType(viewType), 'Attempted to get contents of unregistered viewType: $viewType');
+  html.Element renderContent(
+    String viewType,
+    int viewId,
+    Map<dynamic, dynamic>? params,
+  ) {
+    assert(!knowsViewType(viewType),
+        'Attempted to render contents of unregistered viewType: $viewType');
 
     final String slotName = _getSlotName(viewType, viewId);
 
     return _content.putIfAbsent(viewId, () {
-      final html.Element wrapper = html.DivElement()..slot = slotName;
+      final html.Element wrapper = html.document
+          .createElement('flt-platform-view')
+            ..setAttribute('slot', slotName);
+
       final Function factoryFunction = _factories[viewType]!;
       late html.Element content;
 
@@ -72,7 +101,8 @@ class PlatformViewContentManager {
         content = factoryFunction(viewId);
       }
 
-      content.style.height = '100%';
+      // We could move this to a CSS stylesheet
+      content.style.height = 'inherit';
 
       return wrapper..append(content);
     });

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -9,7 +9,7 @@ part of engine;
 /// This is made available to end-users through dart:ui in web.
 typedef ParameterizedPlatformViewFactory = html.Element Function(
   int viewId, {
-  Map<dynamic, dynamic>? params,
+  Object? params,
 });
 /// A function which takes a unique `id` and creates an HTML element.
 ///
@@ -135,7 +135,7 @@ class PlatformViewManager {
   html.Element renderContent(
     String viewType,
     int viewId,
-    Map<dynamic, dynamic>? params,
+    Object? params,
   ) {
     assert(knowsViewType(viewType),
         'Attempted to render contents of unregistered viewType: $viewType');
@@ -151,7 +151,6 @@ class PlatformViewManager {
       late html.Element content;
 
       if (factoryFunction is ParameterizedPlatformViewFactory) {
-        // TODO: Determine `params` better, maybe it needs to be a subset?
         content = factoryFunction(viewId, params: params);
       } else {
         content = factoryFunction(viewId);

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -40,8 +40,8 @@ class PlatformViewManager {
   // The references to content tags, indexed by their framework-given ID.
   final Map<int, html.Element> _contents = {};
 
-  String _getSlotName(String viewType, int viewId) {
-    return 'flt-pv-${viewType}-$viewId';
+  String _getSlotName(int viewId) {
+    return 'flt-pv-slot-$viewId';
   }
 
   /// Returns `true` if the passed in `viewType` has been registered before.
@@ -76,14 +76,6 @@ class PlatformViewManager {
     return true;
   }
 
-  /// Returns the `slot` associated to a `viewId`, if it's been rendered (and not disposed of).
-  ///
-  /// See [renderSlot] to understand how `slots` are rendered.
-  html.Element getSlot(int viewId) {
-    assert(_slots.containsKey(viewId));
-    return _slots[viewId]!;
-  }
-
   /// Creates the HTML markup for the `slot` of a Platform View.
   ///
   /// The result of this call is cached in the `_slots` Map, so it can be accessed
@@ -106,11 +98,8 @@ class PlatformViewManager {
   ///
   /// (When the framework accesses a `slot`, it's really accessing its wrapper
   /// `flt-platform-view-slot` tag)
-  html.Element renderSlot(String viewType, int viewId) {
-    assert(knowsViewType(viewType),
-        'Attempted to render slot of unregistered viewType: $viewType');
-
-    final String slotName = _getSlotName(viewType, viewId);
+  html.Element renderSlot(int viewId) {
+    final String slotName = _getSlotName(viewId);
 
     return _slots.putIfAbsent(viewId, () {
       final html.Element wrapper = html.document
@@ -153,7 +142,7 @@ class PlatformViewManager {
     assert(knowsViewType(viewType),
         'Attempted to render contents of unregistered viewType: $viewType');
 
-    final String slotName = _getSlotName(viewType, viewId);
+    final String slotName = _getSlotName(viewId);
 
     return _contents.putIfAbsent(viewId, () {
       final html.Element wrapper = html.document
@@ -164,6 +153,7 @@ class PlatformViewManager {
       late html.Element content;
 
       if (factoryFunction is ParameterizedPlatformViewFactory) {
+        // TODO: Determine `params` better, maybe it needs to be a subset?
         content = factoryFunction(viewId, params: params);
       } else {
         content = factoryFunction(viewId);

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -114,17 +114,7 @@ class PlatformViewManager {
         content = factoryFunction(viewId);
       }
 
-      // Scrutinize closely any other modifications to `content`.
-      // We shouldn't modify users' returned `content` if at all possible.
-      // Note there's also no getContent(viewId) function anymore, to prevent
-      // from later modifications too.
-      if (content.style.height.isEmpty) {
-        printWarning('Height of Platform View type: [$viewType] may not be set.'
-            ' Defaulting to `height: 100%`.\n'
-            'Set `style.height` to any appropriate value to stop this message.');
-
-        content.style.height = '100%';
-      }
+      _ensureContentCorrectlySized(content, viewType);
 
       return wrapper..append(content);
     });
@@ -137,5 +127,29 @@ class PlatformViewManager {
   void clearPlatformView(int viewId) {
     // Remove from our cache, and then from the DOM...
     _contents.remove(viewId)?.remove();
+  }
+
+  /// Attempt to ensure that the contents of the user-supplied DOM element will
+  /// fill the space allocated for this platform view by the framework.
+  void _ensureContentCorrectlySized(html.Element content, String viewType) {
+    // Scrutinize closely any other modifications to `content`.
+    // We shouldn't modify users' returned `content` if at all possible.
+    // Note there's also no getContent(viewId) function anymore, to prevent
+    // from later modifications too.
+    if (content.style.height.isEmpty) {
+      printWarning('Height of Platform View type: [$viewType] may not be set.'
+          ' Defaulting to `height: 100%`.\n'
+          'Set `style.height` to any appropriate value to stop this message.');
+
+      content.style.height = '100%';
+    }
+
+    if (content.style.width.isEmpty) {
+      printWarning('Width of Platform View type: [$viewType] may not be set.'
+          ' Defaulting to `width: 100%`.\n'
+          'Set `style.width` to any appropriate value to stop this message.');
+
+      content.style.width = '100%';
+    }
   }
 }

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -169,10 +169,14 @@ class PlatformViewManager {
         content = factoryFunction(viewId);
       }
 
-      // Scrutinize closely any modifications to `content`.
+      // Scrutinize closely any other modifications to `content`.
       // We shouldn't modify users' returned `content` if at all possible.
       // Note there's also no getContent(viewId) function anymore, to prevent
       // from later modifications too.
+      if (content.style.height.isEmpty) {
+        printWarning('Height of Platform View type: [$viewType] may not be set. Defaulting to `height: 100%`.\nSet `style.height` to any appropriate value to stop this message.');
+        content.style.height = '100%';
+      }
 
       return wrapper..append(content);
     });

--- a/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
@@ -1,0 +1,82 @@
+part of engine;
+
+// import 'dart:html' as html;
+
+// import 'dart:typed_data';
+
+// import '../../engine.dart' show MethodCodec, MethodCall, StandardMethodCodec;
+// import '../../../ui.dart' as ui show PlatformMessageResponseCallback;
+// import './content_manager.dart';
+
+typedef ContentSlotHandler = void Function(int, html.SlotElement);
+typedef ContentViewHandler = void Function(int, html.Element);
+
+// This class 
+class PlatformViewMessageHandler {
+  final MethodCodec _codec = StandardMethodCodec();
+
+  final ContentSlotHandler viewSlotHandler;
+  final ContentViewHandler viewContentHandler;
+  final PlatformViewContentManager contentManager;
+
+  PlatformViewMessageHandler({
+    required this.contentManager, required this.viewSlotHandler, required this.viewContentHandler
+  });
+
+  void _createPlatformView(
+      MethodCall methodCall, ui.PlatformMessageResponseCallback callback) {
+
+    final Map<dynamic, dynamic> args = methodCall.arguments;
+    final int viewId = args['id'];
+    final String viewType = args['viewType'];
+
+    if (!contentManager.knowsViewType(viewType)) {
+      callback(_codec.encodeErrorEnvelope(
+        code: 'Unregistered factory',
+        message: "No factory registered for viewtype '$viewType'",
+      ));
+      return;
+    }
+
+    final html.Element content = contentManager.renderContent(viewType, viewId, args);
+    final html.SlotElement slot = contentManager.renderSlot(viewType, viewId);
+
+    try {
+      viewContentHandler(viewId, content);
+      viewSlotHandler(viewId, slot);
+
+      callback(_codec.encodeSuccessEnvelope(null));
+    } catch (e) {
+      callback(_codec.encodeErrorEnvelope(
+        code: 'Failure rendering platform view',
+        message: e.toString(),
+      ));
+    }
+  }
+
+  void _disposePlatformView(
+      MethodCall methodCall, ui.PlatformMessageResponseCallback callback) {
+
+    final int viewId = methodCall.arguments;
+
+    contentManager.clearPlatformView(viewId);
+
+    callback(_codec.encodeSuccessEnvelope(null));
+  }
+
+  void handlePlatformViewCall(
+    ByteData? data,
+    ui.PlatformMessageResponseCallback callback,
+  ) {
+    final MethodCall decoded = _codec.decodeMethodCall(data);
+    switch (decoded.method) {
+      case 'create':
+        _createPlatformView(decoded, callback);
+        return;
+      case 'dispose':
+        _disposePlatformView(decoded, callback);
+        return;
+    }
+    callback(null);
+  }
+}

--- a/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
@@ -4,25 +4,9 @@
 
 part of engine;
 
-// import 'dart:html' as html;
-
-// import 'dart:typed_data';
-
-// import '../../engine.dart' show MethodCodec, MethodCall, StandardMethodCodec;
-// import '../../../ui.dart' as ui show PlatformMessageResponseCallback;
-// import './content_manager.dart';
-
-/// A function that handles a newly created [html.Element] for a platform
-/// view SLOT (insertion point) with a unique [int] id.
-typedef PlatformViewSlotHandler = void Function(int, html.Element);
-
 /// A function that handle a newly created [html.Element] with the contents of a
 /// platform view with a unique [int] id.
-typedef PlatformViewContentHandler = void Function(int, html.Element);
-
-/// A function that handles part of the `dispose` lifecycle of a platform view
-/// with a unique [int] id.
-typedef PlatformViewDisposeHandler = void Function(int);
+typedef PlatformViewContentHandler = void Function(html.Element);
 
 /// This class handles incoming framework messages to create/dispose Platform Views.
 ///
@@ -34,42 +18,38 @@ typedef PlatformViewDisposeHandler = void Function(int);
 /// all operations related to platform views (registration, rendering, etc...),
 /// regardless of the rendering backend.
 ///
-/// When a platform view is created, the injection into the App DOM is delegated
-/// to a [PlatformViewSlotHandler] and a [PlatformViewContentHandler] function,
-/// which will decide where in the global DOM to inject the different parts
-/// of the Platform View.
+/// When the `contents` of a Platform View are created, a [PlatformViewContentHandler]
+/// function (passed from the outside) will decide where in the DOM to inject
+/// said content.
+///
+/// The rendering/compositing of Platform Views will have access to the other "half"
+/// of the Platform View: the `slot`, through the shared `contentManager` object,
+/// through its [PlatformViewManager.renderSlot] method.
 ///
 /// When a Platform View is disposed of, it is removed from the cache (and DOM)
-/// directly by the `contentManager`. However, we give the framework a final chance
-/// to do cleanup by calling a [PlatformViewDisposeHandler] with the `viewId` that
-/// is being disposed of.
+/// directly by the `contentManager`. The canvaskit rendering backend needs to do
+/// some extra cleanup of its internal state, but it can do it automatically. See
+/// [HtmlViewEmbedder.disposeViews]
 class PlatformViewMessageHandler {
   final MethodCodec _codec = StandardMethodCodec();
 
   final PlatformViewManager _contentManager;
-  final PlatformViewSlotHandler? _slotHandler;
   final PlatformViewContentHandler? _contentHandler;
-  final PlatformViewDisposeHandler? _disposeHandler;
 
   PlatformViewMessageHandler({
     required PlatformViewManager contentManager,
-    PlatformViewSlotHandler? slotHandler,
     PlatformViewContentHandler? contentHandler,
-    PlatformViewDisposeHandler? disposeHandler,
   }) : this._contentManager = contentManager,
-       this._slotHandler = slotHandler,
-       this._contentHandler = contentHandler,
-       this._disposeHandler = disposeHandler;
+       this._contentHandler = contentHandler;
 
   /// Handle a `create` Platform View message.
   ///
-  /// This will attempt to render the `contents` and `slot` of a Platform View,
-  /// if its `viewType` has been registered previously.
+  /// This will attempt to render the `contents` and of a Platform View, if its
+  /// `viewType` has been registered previously.
   ///
   /// (See [PlatformViewContentManager.registerFactory] for more details.)
   ///
-  /// When the `contents` and `slot` of the Platform View are created, they are
-  /// delegated to the [_slotHandler] and [_contentHandler] functions, so the
+  /// The `contents` are delegated to a [_contentHandler] function, so the
   /// active rendering backend can inject them in the right place of the DOM.
   ///
   /// If all goes well, this function will `callback` with an empty success envelope.
@@ -91,31 +71,27 @@ class PlatformViewMessageHandler {
       return;
     }
 
+    if (_contentManager.knowsViewId(viewId)) {
+      callback(_codec.encodeErrorEnvelope(
+        code: 'recreating_view',
+        message: 'trying to create an already created view',
+        details: 'view id: $viewId',
+      ));
+      return;
+    }
+
     final html.Element content = _contentManager.renderContent(
       viewType,
       viewId,
       args,
     );
-    final html.Element slot = _contentManager.renderSlot(viewType, viewId);
 
-    try {
-      // For now, we don't need anything fancier. If needed, this can be converted
-      // to a PlatformViewStrategy class for each web-renderer backend?
-      if (_contentHandler != null) {
-        _contentHandler!(viewId, content);
-      }
-      if (_slotHandler != null) {
-        _slotHandler!(viewId, slot);
-      }
-
-      callback(_codec.encodeSuccessEnvelope(null));
-    } on _PlatformViewAlreadyCreatedException catch (e) {
-      callback(_codec.encodeErrorEnvelope(
-        code: 'recreating_view',
-        message: 'trying to create an already created view',
-        details: 'view id: ${e.viewId}',
-      ));
+    // For now, we don't need anything fancier. If needed, this can be converted
+    // to a PlatformViewStrategy class for each web-renderer backend?
+    if (_contentHandler != null) {
+      _contentHandler!(content);
     }
+    callback(_codec.encodeSuccessEnvelope(null));
   }
 
   /// Handle a `dispose` Platform View message.
@@ -137,12 +113,6 @@ class PlatformViewMessageHandler {
     // The contentManager removes the slot and the contents from its internal
     // cache, and the DOM.
     _contentManager.clearPlatformView(viewId);
-
-    // However, the canvaskit renderer needs to perform some extra cleanup, so
-    // we call it now.
-    if (_disposeHandler != null) {
-      _disposeHandler!(viewId);
-    }
 
     callback(_codec.encodeSuccessEnvelope(null));
   }

--- a/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
@@ -4,6 +4,10 @@
 
 part of engine;
 
+/// The signature for a callback for a Platform Message. From the `ui` package.
+/// Copied here so there's no circular dependencies.
+typedef _PlatformMessageResponseCallback = void Function(ByteData? data);
+
 /// A function that handle a newly created [html.Element] with the contents of a
 /// platform view with a unique [int] id.
 typedef PlatformViewContentHandler = void Function(html.Element);
@@ -56,7 +60,7 @@ class PlatformViewMessageHandler {
   /// In case of error, this will `callback` with an error envelope describing the error.
   void _createPlatformView(
     MethodCall methodCall,
-    ui.PlatformMessageResponseCallback callback,
+    _PlatformMessageResponseCallback callback,
   ) {
     final Map<dynamic, dynamic> args = methodCall.arguments;
     final int viewId = args['id'];
@@ -107,7 +111,7 @@ class PlatformViewMessageHandler {
   /// This function should always `callback` with an empty success envelope.
   void _disposePlatformView(
     MethodCall methodCall,
-    ui.PlatformMessageResponseCallback callback,
+    _PlatformMessageResponseCallback callback,
   ) {
     final int viewId = methodCall.arguments;
 
@@ -125,7 +129,7 @@ class PlatformViewMessageHandler {
   /// * `dispose`: See [_disposePlatformView]
   void handlePlatformViewCall(
     ByteData? data,
-    ui.PlatformMessageResponseCallback callback,
+    _PlatformMessageResponseCallback callback,
   ) {
     final MethodCall decoded = _codec.decodeMethodCall(data);
     switch (decoded.method) {

--- a/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 part of engine;
 
 // import 'dart:html' as html;
@@ -8,29 +12,59 @@ part of engine;
 // import '../../../ui.dart' as ui show PlatformMessageResponseCallback;
 // import './content_manager.dart';
 
-typedef ContentSlotHandler = void Function(int, html.SlotElement);
-typedef ContentViewHandler = void Function(int, html.Element);
+/// A function that handles a newly created [html.SlotElement] for a platform
+/// view with a unique [int] id.
+typedef PlatformViewSlotHandler = void Function(int, html.SlotElement);
 
-// This class 
+/// A function that handle a newly created [html.Element] with the contents of a
+/// platform view with a unique [int] id.
+typedef PlatformViewContentHandler = void Function(int, html.Element);
+
+/// A function that handles part of the `dispose` lifecycle of a platform view
+/// with a unique [int] id.
+typedef PlatformViewDisposeHandler = void Function(int);
+
+/// This class handles incoming framework messages to create/dispose Platform Views.
+///
+/// It uses a [PlatformViewManager] to manage the creation of the DOM of
+/// the PlatformViews. This `contentManager` is shared across the engine, to perform
+/// all operations related to platform views (registration, rendering, etc...)
+///
+/// When a platform view is created, the injection into the App DOM is delegated
+/// to a [PlatformViewSlotHandler] and a [ConventViewHandler] function, which will
+/// decide where in the global DOM to inject the different components of the view.
+///
+/// When a platform view is disposed of, it is removed from the cache (and DOM)
+/// directly by the `contentManager`. However, we give the framework a final chance
+/// to do cleanup by calling a [PlatformViewDisposeHandler] with the `viewId` that
+/// is being disposed of.
 class PlatformViewMessageHandler {
   final MethodCodec _codec = StandardMethodCodec();
 
-  final ContentSlotHandler viewSlotHandler;
-  final ContentViewHandler viewContentHandler;
-  final PlatformViewContentManager contentManager;
+  final PlatformViewManager _contentManager;
+  final PlatformViewSlotHandler? _slotHandler;
+  final PlatformViewContentHandler? _contentHandler;
+  final PlatformViewDisposeHandler? _disposeHandler;
 
   PlatformViewMessageHandler({
-    required this.contentManager, required this.viewSlotHandler, required this.viewContentHandler
-  });
+    required PlatformViewManager contentManager,
+    PlatformViewSlotHandler? slotHandler,
+    PlatformViewContentHandler? contentHandler,
+    PlatformViewDisposeHandler? disposeHandler,
+  }) : this._contentManager = contentManager,
+       this._slotHandler = slotHandler,
+       this._contentHandler = contentHandler,
+       this._disposeHandler = disposeHandler;
 
   void _createPlatformView(
-      MethodCall methodCall, ui.PlatformMessageResponseCallback callback) {
-
+    MethodCall methodCall,
+    ui.PlatformMessageResponseCallback callback,
+  ) {
     final Map<dynamic, dynamic> args = methodCall.arguments;
     final int viewId = args['id'];
     final String viewType = args['viewType'];
 
-    if (!contentManager.knowsViewType(viewType)) {
+    if (!_contentManager.knowsViewType(viewType)) {
       callback(_codec.encodeErrorEnvelope(
         code: 'Unregistered factory',
         message: "No factory registered for viewtype '$viewType'",
@@ -38,12 +72,23 @@ class PlatformViewMessageHandler {
       return;
     }
 
-    final html.Element content = contentManager.renderContent(viewType, viewId, args);
-    final html.SlotElement slot = contentManager.renderSlot(viewType, viewId);
+    final html.Element content = _contentManager.renderContent(
+      viewType,
+      viewId,
+      args,
+    );
+    final html.SlotElement slot = _contentManager.renderSlot(viewType, viewId);
 
     try {
-      viewContentHandler(viewId, content);
-      viewSlotHandler(viewId, slot);
+      // For now, we don't need anything fancier. If needed, this can be converted
+      // to a PlatformViewStrategy class for each web-renderer backend.
+      // The Strategy can also be expanded to take care of disposal, too.
+      if (_contentHandler != null) {
+        _contentHandler!(viewId, content);
+      }
+      if (_slotHandler != null) {
+        _slotHandler!(viewId, slot);
+      }
 
       callback(_codec.encodeSuccessEnvelope(null));
     } catch (e) {
@@ -55,11 +100,20 @@ class PlatformViewMessageHandler {
   }
 
   void _disposePlatformView(
-      MethodCall methodCall, ui.PlatformMessageResponseCallback callback) {
-
+    MethodCall methodCall,
+    ui.PlatformMessageResponseCallback callback,
+  ) {
     final int viewId = methodCall.arguments;
 
-    contentManager.clearPlatformView(viewId);
+    // The contentManager removes the slot and the contents from its internal
+    // cache, and the DOM.
+    _contentManager.clearPlatformView(viewId);
+
+    // However, the canvaskit renderer needs to perform some extra cleanup, so
+    // we call it now.
+    if (_disposeHandler != null) {
+      _disposeHandler!(viewId);
+    }
 
     callback(_codec.encodeSuccessEnvelope(null));
   }

--- a/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
@@ -26,9 +26,8 @@ typedef PlatformViewContentHandler = void Function(html.Element);
 /// function (passed from the outside) will decide where in the DOM to inject
 /// said content.
 ///
-/// The rendering/compositing of Platform Views will have access to the other "half"
-/// of the Platform View: the `slot`, through the shared `contentManager` object,
-/// through its [PlatformViewManager.renderSlot] method.
+/// The rendering/compositing of Platform Views can create the other "half" of a
+/// Platform View: the `slot`, through the [createPlatformViewSlot] method.
 ///
 /// When a Platform View is disposed of, it is removed from the cache (and DOM)
 /// directly by the `contentManager`. The canvaskit rendering backend needs to do

--- a/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
@@ -80,6 +80,7 @@ class PlatformViewMessageHandler {
       return;
     }
 
+    // TODO: How can users add extra `args` from the HtmlElementView widget?
     final html.Element content = _contentManager.renderContent(
       viewType,
       viewId,

--- a/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/message_handler.dart
@@ -84,8 +84,9 @@ class PlatformViewMessageHandler {
 
     if (!_contentManager.knowsViewType(viewType)) {
       callback(_codec.encodeErrorEnvelope(
-        code: 'Unregistered factory',
-        message: "No factory registered for viewtype '$viewType'",
+        code: 'unregistered_view_type',
+        message: 'trying to create a view with an unregistered type',
+        details: 'unregistered view type: $viewType',
       ));
       return;
     }
@@ -108,10 +109,11 @@ class PlatformViewMessageHandler {
       }
 
       callback(_codec.encodeSuccessEnvelope(null));
-    } catch (e) {
+    } on _PlatformViewAlreadyCreatedException catch (e) {
       callback(_codec.encodeErrorEnvelope(
-        code: 'Failure rendering platform view',
-        message: e.toString(),
+        code: 'recreating_view',
+        message: 'trying to create an already created view',
+        details: 'view id: ${e.viewId}',
       ));
     }
   }

--- a/lib/web_ui/lib/src/engine/platform_views/slots.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/slots.dart
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of engine;
+
+/// Returns the name of a Slot from its viewId.
+///
+/// This is used by the [renderContent] function of the [PlatformViewManager]
+/// class, and the [createPlatformViewSlot] method below, to keep the slot name
+/// attribute consistent across the framework.
+String getPlatformViewSlotName(int viewId) {
+  return 'flt-pv-slot-$viewId';
+}
+
+/// Creates the HTML markup for the `slot` of a Platform View.
+///
+/// The resulting DOM for a `slot` looks like this:
+///
+/// ```html
+/// <flt-platform-view-slot style="...">
+///   <slot name="..." />
+/// </flt-platform-view-slot>
+/// ```
+///
+/// The inner `SLOT` tag is standard HTML to reveal an element that is rendered
+/// elsewhere in the DOM. Its `name` attribute must match the value of the `slot`
+/// attribute of the contents being revealed (see [getPlatformViewSlotName].)
+///
+/// The outer `flt-platform-view-slot` tag is a simple wrapper that the framework
+/// can position/style as needed.
+///
+/// (When the framework accesses a `slot`, it's really accessing its wrapper
+/// `flt-platform-view-slot` tag)
+html.Element createPlatformViewSlot(int viewId) {
+  final String slotName = getPlatformViewSlotName(viewId);
+
+  final html.Element wrapper = html.document
+      .createElement('flt-platform-view-slot')
+      ..style.pointerEvents = 'auto';
+
+  final html.Element slot = html.document.createElement('slot')
+    ..setAttribute('name', slotName);
+
+  return wrapper..append(slot);
+}

--- a/lib/web_ui/lib/src/engine/platform_views/slots.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/slots.dart
@@ -4,7 +4,7 @@
 
 part of engine;
 
-/// Returns the name of a Slot from its viewId.
+/// Returns the name of a slot from its `viewId`.
 ///
 /// This is used by the [renderContent] function of the [PlatformViewManager]
 /// class, and the [createPlatformViewSlot] method below, to keep the slot name

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -22,9 +22,11 @@ bool _newlinePredicate(int char) {
       prop == LineCharProperty.CR;
 }
 
-/// Hosts ruler DOM elements in a hidden container.
+/// Hosts ruler DOM elements in a hidden container under a `root` [html.Node].
+///
+/// The `root` [html.Node] is optional. Defaults to [domRenderer.glassPaneShadow].
 class RulerHost {
-  RulerHost() {
+  RulerHost({html.Node? root}) {
     _rulerHost.style
       ..position = 'fixed'
       ..visibility = 'hidden'
@@ -33,7 +35,8 @@ class RulerHost {
       ..left = '0'
       ..width = '0'
       ..height = '0';
-    html.document.body!.append(_rulerHost);
+
+    (root ?? domRenderer.glassPaneShadow!).append(_rulerHost);
     registerHotRestartListener(dispose);
   }
 
@@ -62,8 +65,14 @@ class RulerHost {
 /// [ParagraphGeometricStyle].
 ///
 /// All instances of [ParagraphRuler] should be created through this class.
+///
+/// An optional `root` [html.Node] can be passed, under which the DOM required
+/// to perform measurements will be hosted.
 class RulerManager extends RulerHost {
-  RulerManager({required this.rulerCacheCapacity}): super();
+  RulerManager({
+    required this.rulerCacheCapacity,
+    html.Node? root,
+  }) : super(root: root);
 
   final int rulerCacheCapacity;
 
@@ -174,10 +183,16 @@ abstract class TextMeasurementService {
 
   /// Initializes the text measurement service with a specific
   /// [rulerCacheCapacity] that gets passed to the [RulerManager].
-  static void initialize({required int rulerCacheCapacity}) {
+  ///
+  /// An optional `root` [html.Node] can be passed, under which the DOM required
+  /// to perform measurements will be hosted. Defaults to [domRenderer.glassPaneShadow].
+  static void initialize({required int rulerCacheCapacity, html.Node? root}) {
     rulerManager?.dispose();
     rulerManager = null;
-    rulerManager = RulerManager(rulerCacheCapacity: rulerCacheCapacity);
+    rulerManager = RulerManager(
+      rulerCacheCapacity: rulerCacheCapacity,
+      root: root,
+    );
   }
 
   @visibleForTesting

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -33,7 +33,9 @@ class RulerHost {
       ..left = '0'
       ..width = '0'
       ..height = '0';
-    html.document.body!.append(_rulerHost);
+
+    // Inject the ruler host into the shadowRoot of the glass-pane of this app.
+    domRenderer.glassPaneElement!.shadowRoot!.append(_rulerHost);
     registerHotRestartListener(dispose);
   }
 
@@ -63,7 +65,7 @@ class RulerHost {
 ///
 /// All instances of [ParagraphRuler] should be created through this class.
 class RulerManager extends RulerHost {
-  RulerManager({required this.rulerCacheCapacity}): super();
+  RulerManager({required this.rulerCacheCapacity}) : super();
 
   final int rulerCacheCapacity;
 
@@ -690,7 +692,7 @@ double _measureSubstring(
     width = _lastWidth;
   } else {
     final String sub =
-      start == 0 && end == text.length ? text : text.substring(start, end);
+        start == 0 && end == text.length ? text : text.substring(start, end);
     width = _canvasContext.measureText(sub).width!.toDouble();
   }
 

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -33,9 +33,7 @@ class RulerHost {
       ..left = '0'
       ..width = '0'
       ..height = '0';
-
-    // Inject the ruler host into the shadowRoot of the glass-pane of this app.
-    domRenderer.glassPaneElement!.shadowRoot!.append(_rulerHost);
+    html.document.body!.append(_rulerHost);
     registerHotRestartListener(dispose);
   }
 
@@ -65,7 +63,7 @@ class RulerHost {
 ///
 /// All instances of [ParagraphRuler] should be created through this class.
 class RulerManager extends RulerHost {
-  RulerManager({required this.rulerCacheCapacity}) : super();
+  RulerManager({required this.rulerCacheCapacity}): super();
 
   final int rulerCacheCapacity;
 
@@ -692,7 +690,7 @@ double _measureSubstring(
     width = _lastWidth;
   } else {
     final String sub =
-        start == 0 && end == text.length ? text : text.substring(start, end);
+      start == 0 && end == text.length ? text : text.substring(start, end);
     width = _canvasContext.measureText(sub).width!.toDouble();
   }
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -26,11 +26,11 @@ const String transparentTextEditingClass = 'transparentTextEditing';
 
 void _emptyCallback(dynamic _) {}
 
-/// The root node that hosts all DOM required for text editing.
+/// The default root that hosts all DOM required for text editing when a11y is not enabled.
 ///
 /// This is something similar to [html.Document]. Currently, it's a [html.ShadowRoot].
 @visibleForTesting
-html.ShadowRoot get textEditingRoot => html.document.querySelector('flt-glass-pane')!.shadowRoot!;
+html.ShadowRoot get defaultTextEditingRoot => domRenderer.glassPaneShadow!;
 
 /// These style attributes are constant throughout the life time of an input
 /// element.
@@ -238,7 +238,7 @@ class EngineAutofillForm {
 
   void placeForm(html.HtmlElement mainTextEditingElement) {
     formElement.append(mainTextEditingElement);
-    textEditingRoot.append(formElement);
+    defaultTextEditingRoot.append(formElement);
   }
 
   void storeForm() {
@@ -838,7 +838,7 @@ abstract class DefaultTextEditingStrategy implements TextEditingStrategy {
       // DOM later, when the first location information arrived.
       // Otherwise, on Blink based Desktop browsers, the autofill menu appears
       // on top left of the screen.
-      textEditingRoot.append(activeDomElement);
+      defaultTextEditingRoot.append(activeDomElement);
       _appendedToForm = false;
     }
 
@@ -1213,7 +1213,7 @@ class AndroidTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
     if (hasAutofillGroup) {
       placeForm();
     } else {
-      textEditingRoot.append(activeDomElement);
+      defaultTextEditingRoot.append(activeDomElement);
     }
     inputConfig.textCapitalization.setAutocapitalizeAttribute(activeDomElement);
   }

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -26,6 +26,12 @@ const String transparentTextEditingClass = 'transparentTextEditing';
 
 void _emptyCallback(dynamic _) {}
 
+/// The root node that hosts all DOM required for text editing.
+///
+/// This is something similar to [html.Document]. Currently, it's a [html.ShadowRoot].
+@visibleForTesting
+html.ShadowRoot get textEditingRoot => domRenderer.glassPaneElement!.shadowRoot!;
+
 /// These style attributes are constant throughout the life time of an input
 /// element.
 ///
@@ -232,7 +238,7 @@ class EngineAutofillForm {
 
   void placeForm(html.HtmlElement mainTextEditingElement) {
     formElement.append(mainTextEditingElement);
-    domRenderer.glassPaneElement!.append(formElement);
+    textEditingRoot.append(formElement);
   }
 
   void storeForm() {
@@ -832,7 +838,7 @@ abstract class DefaultTextEditingStrategy implements TextEditingStrategy {
       // DOM later, when the first location information arrived.
       // Otherwise, on Blink based Desktop browsers, the autofill menu appears
       // on top left of the screen.
-      domRenderer.glassPaneElement!.append(activeDomElement);
+      textEditingRoot.append(activeDomElement);
       _appendedToForm = false;
     }
 
@@ -1207,7 +1213,7 @@ class AndroidTextEditingStrategy extends GloballyPositionedTextEditingStrategy {
     if (hasAutofillGroup) {
       placeForm();
     } else {
-      domRenderer.glassPaneElement!.append(activeDomElement);
+      textEditingRoot.append(activeDomElement);
     }
     inputConfig.textCapitalization.setAutocapitalizeAttribute(activeDomElement);
   }

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -28,10 +28,9 @@ void _emptyCallback(dynamic _) {}
 
 /// The root node that hosts all DOM required for text editing.
 ///
-/// This needs to be something similar to [html.Document].
-/// Currently, it's a [html.ShadowRoot].
+/// This is something similar to [html.Document]. Currently, it's a [html.ShadowRoot].
 @visibleForTesting
-html.ShadowRoot get textEditingRoot => domRenderer.glassPaneElement!.shadowRoot!;
+html.ShadowRoot get textEditingRoot => html.document.querySelector('flt-glass-pane')!.shadowRoot!;
 
 /// These style attributes are constant throughout the life time of an input
 /// element.
@@ -383,13 +382,11 @@ class AutofillInfo {
 /// The current text and selection state of a text field.
 @visibleForTesting
 class EditingState {
-  // Don't allow negative offsets.
-  // For `baseOffset`, pick the smallest selection index.
-  // For `extentOffset`, pick the greatest selection index.
-  EditingState({this.text, int? baseOffset, int? extentOffset})
-      : baseOffset = math.max(0, math.min(baseOffset ?? 0, extentOffset ?? 0)),
-        extentOffset =
-            math.max(0, math.max(baseOffset ?? 0, extentOffset ?? 0));
+  EditingState({this.text, int? baseOffset, int? extentOffset}) :
+    // Don't allow negative numbers. Pick the smallest selection index for base.
+    baseOffset = math.max(0, math.min(baseOffset ?? 0, extentOffset ?? 0)),
+    // Don't allow negative numbers. Pick the greatest selection index for extent.
+    extentOffset = math.max(0, math.max(baseOffset ?? 0, extentOffset ?? 0));
 
   /// Creates an [EditingState] instance using values from an editing state Map
   /// coming from Flutter.
@@ -1615,8 +1612,7 @@ class TextEditingChannel {
         break;
 
       default:
-        EnginePlatformDispatcher.instance
-            ._replyToPlatformMessage(callback, null);
+        EnginePlatformDispatcher.instance._replyToPlatformMessage(callback, null);
         return;
     }
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -28,7 +28,8 @@ void _emptyCallback(dynamic _) {}
 
 /// The root node that hosts all DOM required for text editing.
 ///
-/// This is something similar to [html.Document]. Currently, it's a [html.ShadowRoot].
+/// This needs to be something similar to [html.Document].
+/// Currently, it's a [html.ShadowRoot].
 @visibleForTesting
 html.ShadowRoot get textEditingRoot => domRenderer.glassPaneElement!.shadowRoot!;
 
@@ -382,11 +383,13 @@ class AutofillInfo {
 /// The current text and selection state of a text field.
 @visibleForTesting
 class EditingState {
-  EditingState({this.text, int? baseOffset, int? extentOffset}) :
-    // Don't allow negative numbers. Pick the smallest selection index for base.
-    baseOffset = math.max(0, math.min(baseOffset ?? 0, extentOffset ?? 0)),
-    // Don't allow negative numbers. Pick the greatest selection index for extent.
-    extentOffset = math.max(0, math.max(baseOffset ?? 0, extentOffset ?? 0));
+  // Don't allow negative offsets.
+  // For `baseOffset`, pick the smallest selection index.
+  // For `extentOffset`, pick the greatest selection index.
+  EditingState({this.text, int? baseOffset, int? extentOffset})
+      : baseOffset = math.max(0, math.min(baseOffset ?? 0, extentOffset ?? 0)),
+        extentOffset =
+            math.max(0, math.max(baseOffset ?? 0, extentOffset ?? 0));
 
   /// Creates an [EditingState] instance using values from an editing state Map
   /// coming from Flutter.
@@ -1612,7 +1615,8 @@ class TextEditingChannel {
         break;
 
       default:
-        EnginePlatformDispatcher.instance._replyToPlatformMessage(callback, null);
+        EnginePlatformDispatcher.instance
+            ._replyToPlatformMessage(callback, null);
         return;
     }
 

--- a/lib/web_ui/lib/ui.dart
+++ b/lib/web_ui/lib/ui.dart
@@ -70,11 +70,18 @@ class PlatformViewRegistry {
 
   /// Register [viewTypeId] as being creating by the given [factory].
   bool registerViewFactory(String viewTypeId, PlatformViewFactory factory) {
+
+    engine.platformViewContentManager.registerFactory(viewTypeId, factory);
+
     if (registeredFactories.containsKey(viewTypeId)) {
       return false;
     }
     registeredFactories[viewTypeId] = factory;
     return true;
+  }
+
+  void embed(int viewId, html.Element content) {
+    _createdViews[viewId] = content;
   }
 
   /// Returns the view that has been created with the given [id], or `null` if
@@ -130,7 +137,8 @@ void _createPlatformView(
   // TODO(het): Use creation parameters.
   final html.Element element = platformViewFactory(id);
 
-  platformViewRegistry._createdViews[id] = element;
+  platformViewRegistry.embed(id, element);
+
   callback(codec.encodeSuccessEnvelope(null));
 }
 

--- a/lib/web_ui/lib/ui.dart
+++ b/lib/web_ui/lib/ui.dart
@@ -58,101 +58,20 @@ void webOnlySetPluginHandler(Future<void> Function(String, ByteData?, PlatformMe
 //                does not allow exported non-migrated libraries from migrated libraries. When `dart:_engine`
 //                is migrated, we can move it back.
 
-/// A registry for factories that create platform views.
-class PlatformViewRegistry {
-  final Map<String, PlatformViewFactory> registeredFactories =
-      <String, PlatformViewFactory>{};
-
-  final Map<int, html.Element> _createdViews = <int, html.Element>{};
-
-  /// Private constructor so this class can be a singleton.
-  PlatformViewRegistry._();
-
-  /// Register [viewTypeId] as being creating by the given [factory].
-  bool registerViewFactory(String viewTypeId, PlatformViewFactory factory) {
-
-    engine.platformViewContentManager.registerFactory(viewTypeId, factory);
-
-    if (registeredFactories.containsKey(viewTypeId)) {
-      return false;
-    }
-    registeredFactories[viewTypeId] = factory;
-    return true;
-  }
-
-  void embed(int viewId, html.Element content) {
-    _createdViews[viewId] = content;
-  }
-
-  /// Returns the view that has been created with the given [id], or `null` if
-  /// no such view exists.
-  html.Element? getCreatedView(int id) {
-    return _createdViews[id];
-  }
-}
-
-/// A function which takes a unique [id] and creates an HTML element.
+/// A function which takes a unique `id` and creates an HTML element.
 typedef PlatformViewFactory = html.Element Function(int viewId);
 
+/// A registry for factories that create platform views.
+class PlatformViewRegistry {
+  /// Register [viewTypeId] as being creating by the given [factory].
+  bool registerViewFactory(String viewTypeId, PlatformViewFactory viewFactory) {
+    // TODO(web): Deprecate this once there's another way of calling `registerFactory` (js interop?)
+    return engine.platformViewManager.registerFactory(viewTypeId, viewFactory);
+  }
+}
+
 /// The platform view registry for this app.
-final PlatformViewRegistry platformViewRegistry = PlatformViewRegistry._();
-
-/// Handles a platform call to `flutter/platform_views`.
-///
-/// Used to create platform views.
-void handlePlatformViewCall(
-  ByteData data,
-  PlatformMessageResponseCallback callback,
-) {
-  const engine.MethodCodec codec = engine.StandardMethodCodec();
-  final engine.MethodCall decoded = codec.decodeMethodCall(data);
-
-  switch (decoded.method) {
-    case 'create':
-      _createPlatformView(decoded, callback);
-      return;
-    case 'dispose':
-      _disposePlatformView(decoded, callback);
-      return;
-  }
-  callback(null);
-}
-
-void _createPlatformView(
-    engine.MethodCall methodCall, PlatformMessageResponseCallback callback) {
-  final Map<dynamic, dynamic> args = methodCall.arguments;
-  final int id = args['id'];
-  final String viewType = args['viewType'];
-  const engine.MethodCodec codec = engine.StandardMethodCodec();
-
-  // TODO(het): Use 'direction', 'width', and 'height'.
-  final PlatformViewFactory? platformViewFactory = platformViewRegistry.registeredFactories[viewType];
-  if (platformViewFactory == null) {
-    callback(codec.encodeErrorEnvelope(
-      code: 'Unregistered factory',
-      message: "No factory registered for viewtype '$viewType'",
-    ));
-    return;
-  }
-  // TODO(het): Use creation parameters.
-  final html.Element element = platformViewFactory(id);
-
-  platformViewRegistry.embed(id, element);
-
-  callback(codec.encodeSuccessEnvelope(null));
-}
-
-void _disposePlatformView(
-    engine.MethodCall methodCall, PlatformMessageResponseCallback callback) {
-  final int id = methodCall.arguments;
-  const engine.MethodCodec codec = engine.StandardMethodCodec();
-
-  // Remove the root element of the view from the DOM.
-  platformViewRegistry._createdViews[id]?.remove();
-  platformViewRegistry._createdViews.remove(id);
-
-  callback(codec.encodeSuccessEnvelope(null));
-}
+final PlatformViewRegistry platformViewRegistry = PlatformViewRegistry();
 
 // TODO(yjbanov): remove _Callback, _Callbacker, and _futurize. They are here only
 //                because the analyzer wasn't able to infer the correct types during

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -45,14 +45,25 @@ void testMain() {
       sb.pushOffset(0, 0);
       sb.addPlatformView(0, width: 10, height: 10);
       dispatcher.rasterizer!.draw(sb.build().layerTree);
-      expect(
-        domRenderer.sceneElement!
-            .querySelectorAll('#view-0')
-            .single
-            .style
-            .pointerEvents,
-        'auto',
-      );
+
+      // The platform view is now split in two parts. The contents live
+      // as a child of the glassPane, and the slot lives in the glassPane
+      // shadow root. The slot is the one that has pointer events auto.
+      final contents = domRenderer.glassPaneElement!.querySelector('#view-0')!;
+      final slot = domRenderer.sceneElement!.querySelector('slot')!;
+      final contentsHost = contents.parent!;
+      final slotHost = slot.parent!;
+
+      expect(contents, isNotNull,
+          reason: 'The view from the factory is injected in the DOM.');
+
+      expect(contentsHost.tagName, equalsIgnoringCase('flt-platform-view'));
+      expect(slotHost.tagName, equalsIgnoringCase('flt-platform-view-slot'));
+
+      expect(slotHost.style.pointerEvents, 'auto',
+          reason: 'The slot reenables pointer events.');
+      expect(contentsHost.getAttribute('slot'), slot.getAttribute('name'),
+          reason: 'The contents and slot are correctly related.');
     });
 
     test('clips platform views with RRects', () async {
@@ -69,6 +80,7 @@ void testMain() {
       sb.pushClipRRect(ui.RRect.fromLTRBR(0, 0, 10, 10, ui.Radius.circular(3)));
       sb.addPlatformView(0, width: 10, height: 10);
       dispatcher.rasterizer!.draw(sb.build().layerTree);
+
       expect(
         domRenderer.sceneElement!.querySelectorAll('#sk_path_defs').single,
         isNotNull,
@@ -109,12 +121,12 @@ void testMain() {
       sb.pushOffset(3, 3);
       sb.addPlatformView(0, width: 10, height: 10);
       dispatcher.rasterizer!.draw(sb.build().layerTree);
+
+      // Transformations happen on the slot element.
+      final html.Element slotHost = domRenderer.sceneElement!.querySelector('flt-platform-view-slot')!;
+
       expect(
-        domRenderer.sceneElement!
-            .querySelectorAll('#view-0')
-            .single
-            .style
-            .transform,
+        slotHost.style.transform,
         // We should apply the scale matrix first, then the offset matrix.
         // So the translate should be 515 (5 * 100 + 5 * 3), and not
         // 503 (5 * 100 + 3).
@@ -150,11 +162,12 @@ void testMain() {
       sb.pushOffset(3, 3);
       sb.addPlatformView(0, width: 10, height: 10);
       dispatcher.rasterizer!.draw(sb.build().layerTree);
-      final html.Element viewHost =
-          domRenderer.sceneElement!.querySelectorAll('#view-0').single;
+
+      // Transformations happen on the slot element.
+      final html.Element slotHost = domRenderer.sceneElement!.querySelector('flt-platform-view-slot')!;
 
       expect(
-        getTransformChain(viewHost),
+        getTransformChain(slotHost),
         <String>['matrix(0.25, 0, 0, 0.25, 1.5, 1.5)'],
       );
     });
@@ -177,11 +190,12 @@ void testMain() {
       sb.pushOffset(9, 9);
       sb.addPlatformView(0, width: 10, height: 10);
       dispatcher.rasterizer!.draw(sb.build().layerTree);
-      final html.Element viewHost =
-          domRenderer.sceneElement!.querySelectorAll('#view-0').single;
+
+      // Transformations happen on the slot element.
+      final html.Element slotHost = domRenderer.sceneElement!.querySelector('flt-platform-view-slot')!;
 
       expect(
-        getTransformChain(viewHost),
+        getTransformChain(slotHost),
         <String>[
           'matrix(1, 0, 0, 1, 9, 9)',
           'matrix(1, 0, 0, 1, 6, 6)',
@@ -314,8 +328,12 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        domRenderer.sceneElement!.querySelectorAll('#view-0'),
-        hasLength(1),
+        domRenderer.sceneElement!.querySelector('flt-platform-view-slot'),
+        isNotNull,
+      );
+      expect(
+        domRenderer.glassPaneElement!.querySelector('flt-platform-view'),
+        isNotNull,
       );
 
       await _disposePlatformView(0);
@@ -325,8 +343,12 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        domRenderer.sceneElement!.querySelectorAll('#view-0'),
-        hasLength(0),
+        domRenderer.sceneElement!.querySelector('flt-platform-view-slot'),
+        isNull,
+      );
+      expect(
+        domRenderer.glassPaneElement!.querySelector('flt-platform-view'),
+        isNull,
       );
     });
 
@@ -346,8 +368,12 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        domRenderer.sceneElement!.querySelectorAll('#view-0'),
-        hasLength(1),
+        domRenderer.sceneElement!.querySelector('flt-platform-view-slot'),
+        isNotNull,
+      );
+      expect(
+        domRenderer.glassPaneElement!.querySelector('flt-platform-view'),
+        isNotNull,
       );
 
       // Render a frame without a platform view, but also without disposing of
@@ -357,8 +383,14 @@ void testMain() {
       dispatcher.rasterizer!.draw(sb.build().layerTree);
 
       expect(
-        domRenderer.sceneElement!.querySelectorAll('#view-0'),
-        hasLength(0),
+        domRenderer.sceneElement!.querySelector('flt-platform-view-slot'),
+        isNull,
+      );
+      // The actual contents of the platform view are kept in the dom, until
+      // it's actually disposed of!
+      expect(
+        domRenderer.glassPaneElement!.querySelector('flt-platform-view'),
+        isNotNull,
       );
     });
 

--- a/lib/web_ui/test/dom_renderer_test.dart
+++ b/lib/web_ui/test/dom_renderer_test.dart
@@ -113,7 +113,11 @@ void testMain() {
   test('accesibility placeholder is attached after creation', () {
     DomRenderer();
 
-    expect(html.document.getElementsByTagName('flt-semantics-placeholder'),
+    expect(
+        html.document
+            .querySelector('flt-glass-pane')
+            ?.shadowRoot
+            ?.querySelectorAll('flt-semantics-placeholder'),
         isNotEmpty);
   });
 }

--- a/lib/web_ui/test/dom_renderer_test.dart
+++ b/lib/web_ui/test/dom_renderer_test.dart
@@ -111,13 +111,11 @@ void testMain() {
           browserEngine == BrowserEngine.edge));
 
   test('accesibility placeholder is attached after creation', () {
-    DomRenderer();
+    final DomRenderer renderer = DomRenderer();
 
     expect(
-        html.document
-            .querySelector('flt-glass-pane')
-            ?.shadowRoot
-            ?.querySelectorAll('flt-semantics-placeholder'),
-        isNotEmpty);
+      renderer.glassPaneShadow?.querySelectorAll('flt-semantics-placeholder'),
+      isNotEmpty,
+    );
   });
 }

--- a/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -41,6 +41,9 @@ void testMain() {
         expect(contentManager.knowsViewId(viewId), isFalse);
 
         contentManager.registerFactory(viewType, (int id) => html.DivElement());
+
+        expect(contentManager.knowsViewId(viewId), isFalse);
+
         contentManager.renderContent(viewType, viewId, null);
 
         expect(contentManager.knowsViewId(viewId), isTrue);
@@ -97,9 +100,9 @@ void testMain() {
 
       test('returns cached instances of already-rendered slots', () async {
         final html.Element firstSlot = contentManager.renderSlot(viewId);
-        final html.Element sameSlot = contentManager.renderSlot(viewId);
+        final html.Element otherSlot = contentManager.renderSlot(viewId);
 
-        expect(firstSlot, sameSlot);
+        expect(firstSlot, same(otherSlot));
       });
     });
 
@@ -160,10 +163,10 @@ void testMain() {
       test('returns cached instances of already-rendered content', () async {
         final html.Element firstRender =
             contentManager.renderContent(viewType, viewId, null);
-        final html.Element renderAgain =
+        final html.Element anotherRender =
             contentManager.renderContent(viewType, viewId, null);
 
-        expect(firstRender, renderAgain);
+        expect(firstRender, same(anotherRender));
       });
     });
   });

--- a/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:html' as html;
-import 'dart:typed_data';
 
 import 'package:ui/src/engine.dart';
 

--- a/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -78,34 +78,6 @@ void testMain() {
       });
     });
 
-    group('renderSlot', () {
-      test(
-          'can render slot, even for views that might have never been rendered before',
-          () async {
-        final html.Element slot = contentManager.renderSlot(viewId);
-        expect(slot, isNotNull);
-        expect(slot.querySelector('slot'), isNotNull);
-      });
-
-      test('rendered markup contains required attributes', () async {
-        final html.Element slot = contentManager.renderSlot(viewId);
-        expect(slot.style.pointerEvents, 'auto',
-            reason:
-                'Should re-enable pointer events for the contents of the view.');
-        final html.Element innerSlot = slot.querySelector('slot')!;
-        expect(innerSlot.getAttribute('name'), contains('$viewId'),
-            reason:
-                'The name attribute of the inner SLOT tag must refer to the viewId.');
-      });
-
-      test('returns cached instances of already-rendered slots', () async {
-        final html.Element firstSlot = contentManager.renderSlot(viewId);
-        final html.Element otherSlot = contentManager.renderSlot(viewId);
-
-        expect(firstSlot, same(otherSlot));
-      });
-    });
-
     group('renderContent', () {
       final String unregisteredViewType = 'unregisteredForTest';
       final String anotherViewType = 'anotherViewType';
@@ -141,10 +113,10 @@ void testMain() {
         expect(userContent.style.height, '100%');
       });
 
-      test('slot property has the same value as renderSlot', () async {
+      test('slot property has the same value as createPlatformViewSlot', () async {
         final html.Element content =
             contentManager.renderContent(viewType, viewId, null);
-        final html.Element slot = contentManager.renderSlot(viewId);
+        final html.Element slot = createPlatformViewSlot(viewId);
         final html.Element innerSlot = slot.querySelector('slot')!;
 
         expect(content.getAttribute('slot'), innerSlot.getAttribute('name'),

--- a/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -90,7 +90,8 @@ void testMain() {
         contentManager.registerFactory(anotherViewType, (int id) {
           return html.DivElement()
             ..setAttribute('data-viewId', '$id')
-            ..style.height = 'auto';
+            ..style.height = 'auto'
+            ..style.width = '55%';
         });
       });
 
@@ -111,6 +112,7 @@ void testMain() {
 
         final html.Element userContent = content.querySelector('div')!;
         expect(userContent.style.height, '100%');
+        expect(userContent.style.width, '100%');
       });
 
       test('slot property has the same value as createPlatformViewSlot', () async {
@@ -124,12 +126,13 @@ void testMain() {
                 'The slot attribute of the rendered content must match the name attribute of the SLOT of a given viewId');
       });
 
-      test('do not modify style.height if passed by the user (anotherViewType)',
+      test('do not modify style.height / style.width if passed by the user (anotherViewType)',
           () async {
         final html.Element content =
             contentManager.renderContent(anotherViewType, viewId, null);
         final html.Element userContent = content.querySelector('div')!;
         expect(userContent.style.height, 'auto');
+        expect(userContent.style.width, '55%');
       });
 
       test('returns cached instances of already-rendered content', () async {

--- a/lib/web_ui/test/engine/platform_views/content_manager_test.dart
+++ b/lib/web_ui/test/engine/platform_views/content_manager_test.dart
@@ -1,0 +1,172 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+import 'package:ui/src/engine.dart';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+import '../../matchers.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('PlatformViewManager', () {
+    final String viewType = 'forTest';
+    final int viewId = 6;
+
+    late PlatformViewManager contentManager;
+
+    setUp(() {
+      contentManager = PlatformViewManager();
+    });
+
+    group('knowsViewType', () {
+      test('recognizes viewTypes after registering them', () async {
+        expect(contentManager.knowsViewType(viewType), isFalse);
+
+        contentManager.registerFactory(viewType, (int id) => html.DivElement());
+
+        expect(contentManager.knowsViewType(viewType), isTrue);
+      });
+    });
+
+    group('knowsViewId', () {
+      test('recognizes viewIds after *rendering* them', () async {
+        expect(contentManager.knowsViewId(viewId), isFalse);
+
+        contentManager.registerFactory(viewType, (int id) => html.DivElement());
+        contentManager.renderContent(viewType, viewId, null);
+
+        expect(contentManager.knowsViewId(viewId), isTrue);
+      });
+
+      test('forgets viewIds after clearing them', () {
+        contentManager.registerFactory(viewType, (int id) => html.DivElement());
+        contentManager.renderContent(viewType, viewId, null);
+
+        expect(contentManager.knowsViewId(viewId), isTrue);
+
+        contentManager.clearPlatformView(viewId);
+
+        expect(contentManager.knowsViewId(viewId), isFalse);
+      });
+    });
+
+    group('registerFactory', () {
+      test('does NOT re-register factories', () async {
+        contentManager.registerFactory(
+            viewType, (int id) => html.DivElement()..id = 'pass');
+        // this should be rejected
+        contentManager.registerFactory(
+            viewType, (int id) => html.SpanElement()..id = 'fail');
+
+        final html.Element contents =
+            contentManager.renderContent(viewType, viewId, null);
+
+        expect(contents.querySelector('#pass'), isNotNull);
+        expect(contents.querySelector('#fail'), isNull,
+            reason: 'Factories cannot be overridden once registered');
+      });
+    });
+
+    group('renderSlot', () {
+      test(
+          'can render slot, even for views that might have never been rendered before',
+          () async {
+        final html.Element slot = contentManager.renderSlot(viewId);
+        expect(slot, isNotNull);
+        expect(slot.querySelector('slot'), isNotNull);
+      });
+
+      test('rendered markup contains required attributes', () async {
+        final html.Element slot = contentManager.renderSlot(viewId);
+        expect(slot.style.pointerEvents, 'auto',
+            reason:
+                'Should re-enable pointer events for the contents of the view.');
+        final html.Element innerSlot = slot.querySelector('slot')!;
+        expect(innerSlot.getAttribute('name'), contains('$viewId'),
+            reason:
+                'The name attribute of the inner SLOT tag must refer to the viewId.');
+      });
+
+      test('returns cached instances of already-rendered slots', () async {
+        final html.Element firstSlot = contentManager.renderSlot(viewId);
+        final html.Element sameSlot = contentManager.renderSlot(viewId);
+
+        expect(firstSlot, sameSlot);
+      });
+    });
+
+    group('renderContent', () {
+      final String unregisteredViewType = 'unregisteredForTest';
+      final String anotherViewType = 'anotherViewType';
+
+      setUp(() {
+        contentManager.registerFactory(viewType, (int id) {
+          return html.DivElement()..setAttribute('data-viewId', '$id');
+        });
+
+        contentManager.registerFactory(anotherViewType, (int id) {
+          return html.DivElement()
+            ..setAttribute('data-viewId', '$id')
+            ..style.height = 'auto';
+        });
+      });
+
+      test('refuse to render views for unregistered factories', () async {
+        try {
+          contentManager.renderContent(unregisteredViewType, viewId, null);
+          fail('renderContent should have thrown an Assertion error!');
+        } catch (e) {
+          expect(e, isAssertionError);
+          expect((e as AssertionError).message, contains(unregisteredViewType));
+        }
+      });
+
+      test('rendered markup contains required attributes', () async {
+        final html.Element content =
+            contentManager.renderContent(viewType, viewId, null);
+        expect(content.getAttribute('slot'), contains('$viewId'));
+
+        final html.Element userContent = content.querySelector('div')!;
+        expect(userContent.style.height, '100%');
+      });
+
+      test('slot property has the same value as renderSlot', () async {
+        final html.Element content =
+            contentManager.renderContent(viewType, viewId, null);
+        final html.Element slot = contentManager.renderSlot(viewId);
+        final html.Element innerSlot = slot.querySelector('slot')!;
+
+        expect(content.getAttribute('slot'), innerSlot.getAttribute('name'),
+            reason:
+                'The slot attribute of the rendered content must match the name attribute of the SLOT of a given viewId');
+      });
+
+      test('do not modify style.height if passed by the user (anotherViewType)',
+          () async {
+        final html.Element content =
+            contentManager.renderContent(anotherViewType, viewId, null);
+        final html.Element userContent = content.querySelector('div')!;
+        expect(userContent.style.height, 'auto');
+      });
+
+      test('returns cached instances of already-rendered content', () async {
+        final html.Element firstRender =
+            contentManager.renderContent(viewType, viewId, null);
+        final html.Element renderAgain =
+            contentManager.renderContent(viewType, viewId, null);
+
+        expect(firstRender, renderAgain);
+      });
+    });
+  });
+}

--- a/lib/web_ui/test/engine/platform_views/message_handler_test.dart
+++ b/lib/web_ui/test/engine/platform_views/message_handler_test.dart
@@ -1,0 +1,181 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+import 'package:ui/src/engine.dart';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+final MethodCodec codec = StandardMethodCodec();
+
+void testMain() {
+  group('PlatformViewMessageHandler', () {
+    group('handlePlatformViewCall', () {
+      final String viewType = 'forTest';
+      final int viewId = 6;
+      late PlatformViewManager contentManager;
+      late Completer<ByteData?> completer;
+      late Completer<html.Element> contentCompleter;
+
+      setUp(() {
+        contentManager = PlatformViewManager();
+        completer = Completer<ByteData?>();
+        contentCompleter = Completer<html.Element>();
+      });
+
+      group('"create" message', () {
+        test('unregistered viewType, fails with descriptive exception',
+            () async {
+          final messageHandler = PlatformViewMessageHandler(
+            contentManager: contentManager,
+          );
+          final ByteData? message = _getCreateMessage(viewType, viewId);
+
+          messageHandler.handlePlatformViewCall(message, completer.complete);
+
+          final ByteData? response = await completer.future;
+          try {
+            codec.decodeEnvelope(response!);
+          } on PlatformException catch (e) {
+            expect(e.code, 'unregistered_view_type');
+            expect(e.details, contains(viewType));
+          }
+        });
+
+        test('duplicate viewId, fails with descriptive exception', () async {
+          contentManager.registerFactory(
+              viewType, (int id) => html.DivElement());
+          contentManager.renderContent(viewType, viewId, null);
+          final messageHandler = PlatformViewMessageHandler(
+            contentManager: contentManager,
+          );
+          final ByteData? message = _getCreateMessage(viewType, viewId);
+
+          messageHandler.handlePlatformViewCall(message, completer.complete);
+
+          final ByteData? response = await completer.future;
+          try {
+            codec.decodeEnvelope(response!);
+          } on PlatformException catch (e) {
+            expect(e.code, 'recreating_view');
+            expect(e.details, contains('$viewId'));
+          }
+        });
+
+        test('returns a successEnvelope when the view is created normally',
+            () async {
+          contentManager.registerFactory(
+              viewType, (int id) => html.DivElement()..id = 'success');
+          final messageHandler = PlatformViewMessageHandler(
+            contentManager: contentManager,
+          );
+          final ByteData? message = _getCreateMessage(viewType, viewId);
+
+          messageHandler.handlePlatformViewCall(message, completer.complete);
+
+          final ByteData? response = await completer.future;
+          expect(codec.decodeEnvelope(response!), isNull,
+              reason:
+                  'The response should be a success envelope, with null in it.');
+        });
+
+        test('calls a contentHandler with the result of creating a view',
+            () async {
+          contentManager.registerFactory(
+              viewType, (int id) => html.DivElement()..id = 'success');
+          final messageHandler = PlatformViewMessageHandler(
+            contentManager: contentManager,
+            contentHandler: contentCompleter.complete,
+          );
+          final ByteData? message = _getCreateMessage(viewType, viewId);
+
+          messageHandler.handlePlatformViewCall(message, completer.complete);
+
+          final html.Element contents = await contentCompleter.future;
+          final ByteData? response = await completer.future;
+
+          expect(contents.querySelector('div#success'), isNotNull,
+              reason:
+                  'The element created by the factory should be present in the created view.');
+          expect(codec.decodeEnvelope(response!), isNull,
+              reason:
+                  'The response should be a success envelope, with null in it.');
+        });
+      });
+
+      group('"dispose" message', () {
+        late Completer<int> viewIdCompleter;
+
+        setUp(() {
+          viewIdCompleter = Completer<int>();
+        });
+
+        test('never fails, even for unknown viewIds', () async {
+          final messageHandler = PlatformViewMessageHandler(
+            contentManager: contentManager,
+          );
+          final ByteData? message = _getDisposeMessage(viewId);
+
+          messageHandler.handlePlatformViewCall(message, completer.complete);
+
+          final ByteData? response = await completer.future;
+          expect(codec.decodeEnvelope(response!), isNull,
+              reason:
+                  'The response should be a success envelope, with null in it.');
+        });
+
+        test('never fails, even for unknown viewIds', () async {
+          final messageHandler = PlatformViewMessageHandler(
+            contentManager: _FakePlatformViewManager(viewIdCompleter.complete),
+          );
+          final ByteData? message = _getDisposeMessage(viewId);
+
+          messageHandler.handlePlatformViewCall(message, completer.complete);
+
+          final int disposedViewId = await viewIdCompleter.future;
+          expect(disposedViewId, viewId,
+              reason:
+                  'The viewId to dispose should be passed to the contentManager');
+        });
+      });
+    });
+  });
+}
+
+class _FakePlatformViewManager extends PlatformViewManager {
+  _FakePlatformViewManager(void Function(int) clearFunction)
+      : this._clearPlatformView = clearFunction;
+
+  void Function(int) _clearPlatformView;
+
+  @override
+  void clearPlatformView(int viewId) {
+    return _clearPlatformView(viewId);
+  }
+}
+
+ByteData? _getCreateMessage(String viewType, int viewId) {
+  return codec.encodeMethodCall(MethodCall(
+    'create',
+    {
+      'id': viewId,
+      'viewType': viewType,
+    },
+  ));
+}
+
+ByteData? _getDisposeMessage(int viewId) {
+  return codec.encodeMethodCall(MethodCall(
+    'dispose',
+    viewId,
+  ));
+}

--- a/lib/web_ui/test/engine/platform_views/slots_test.dart
+++ b/lib/web_ui/test/engine/platform_views/slots_test.dart
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+
+import 'package:ui/src/engine.dart';
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('PlatformViewManager', () {
+    final int viewId = 6;
+
+    group('createPlatformViewSlot', () {
+      test(
+          'can render slot, even for views that might have never been rendered before',
+          () async {
+        final html.Element slot = createPlatformViewSlot(viewId);
+        expect(slot, isNotNull);
+        expect(slot.querySelector('slot'), isNotNull);
+      });
+
+      test('rendered markup contains required attributes', () async {
+        final html.Element slot = createPlatformViewSlot(viewId);
+        expect(slot.style.pointerEvents, 'auto',
+            reason:
+                'Should re-enable pointer events for the contents of the view.');
+        final html.Element innerSlot = slot.querySelector('slot')!;
+        expect(innerSlot.getAttribute('name'), contains('$viewId'),
+            reason:
+                'The name attribute of the inner SLOT tag must refer to the viewId.');
+      });
+    });
+  });
+}

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.6
 @TestOn('chrome || safari || firefox')
 
 import 'dart:async';

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
 @TestOn('chrome || safari || firefox')
 
 import 'dart:async';

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -88,9 +88,8 @@ void _testEngineSemanticsOwner() {
     expect(semantics().semanticsEnabled, false);
 
     // Synthesize a click on the placeholder.
-    final root = getRootDocument();
     final html.Element placeholder =
-        root.querySelector('flt-semantics-placeholder');
+        appShadowRoot.querySelector('flt-semantics-placeholder');
 
     expect(placeholder.isConnected, true);
 
@@ -356,10 +355,10 @@ void _testContainer() {
   </sem-c>
 </sem>''');
 
-    final root = getRootDocument();
-    final html.Element parentElement = root.querySelector('flt-semantics');
+    final html.Element parentElement =
+        appShadowRoot.querySelector('flt-semantics');
     final html.Element container =
-        root.querySelector('flt-semantics-container');
+        appShadowRoot.querySelector('flt-semantics-container');
 
     if (isMacOrIOS) {
       expect(parentElement.style.top, '0px');
@@ -404,10 +403,10 @@ void _testContainer() {
   </sem-c>
 </sem>''');
 
-    final root = getRootDocument();
-    final html.Element parentElement = root.querySelector('flt-semantics');
+    final html.Element parentElement =
+        appShadowRoot.querySelector('flt-semantics');
     final html.Element container =
-        root.querySelector('flt-semantics-container');
+        appShadowRoot.querySelector('flt-semantics-container');
 
     expect(parentElement.style.transform, 'matrix(1, 0, 0, 1, 10, 10)');
     expect(parentElement.style.transformOrigin, '0px 0px 0px');
@@ -450,10 +449,10 @@ void _testContainer() {
 </sem>''');
     }
 
-    final root = getRootDocument();
-    final html.Element parentElement = root.querySelector('flt-semantics');
+    final html.Element parentElement =
+        appShadowRoot.querySelector('flt-semantics');
     final html.Element container =
-        root.querySelector('flt-semantics-container');
+        appShadowRoot.querySelector('flt-semantics-container');
 
     if (isMacOrIOS) {
       expect(parentElement.style.top, '0px');
@@ -809,8 +808,7 @@ void _testIncrementables() {
   <input aria-valuenow="1" aria-valuetext="d" aria-valuemax="2" aria-valuemin="1">
 </sem>''');
 
-    final root = getRootDocument();
-    final html.InputElement input = root.querySelector('input');
+    final html.InputElement input = appShadowRoot.querySelector('input');
     input.value = '2';
     input.dispatchEvent(html.Event('change'));
 
@@ -844,8 +842,7 @@ void _testIncrementables() {
   <input aria-valuenow="1" aria-valuetext="d" aria-valuemax="1" aria-valuemin="0">
 </sem>''');
 
-    final root = getRootDocument();
-    final html.InputElement input = root.querySelector('input');
+    final html.InputElement input = appShadowRoot.querySelector('input');
     input.value = '0';
     input.dispatchEvent(html.Event('change'));
 
@@ -938,16 +935,14 @@ void _testTextField() {
 
     semantics().updateSemantics(builder.build());
 
-    final root = getRootDocument();
-
     final html.Element textField =
-        root.querySelector('input[data-semantics-role="text-field"]');
+        appShadowRoot.querySelector('input[data-semantics-role="text-field"]');
 
-    expect(root.activeElement, isNot(textField));
+    expect(appShadowRoot.activeElement, isNot(textField));
 
     textField.focus();
 
-    expect(root.activeElement, textField);
+    expect(appShadowRoot.activeElement, textField);
     expect(await logger.idLog.first, 0);
     expect(await logger.actionLog.first, ui.SemanticsAction.tap);
 

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -115,7 +115,8 @@ void _testEngineSemanticsOwner() {
     expect(semantics().semanticsEnabled, false);
 
     final html.Element placeholder =
-        html.document.querySelectorAll('flt-semantics-placeholder').single;
+        appShadowRoot.querySelector('flt-semantics-placeholder');
+
     expect(placeholder.isConnected, true);
 
     // Sending a semantics update should auto-enable engine semantics.

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
 @TestOn('chrome || safari || firefox')
 
 import 'dart:async';
@@ -88,9 +88,12 @@ void _testEngineSemanticsOwner() {
     expect(semantics().semanticsEnabled, false);
 
     // Synthesize a click on the placeholder.
+    final root = getRootDocument();
     final html.Element placeholder =
-        html.document.querySelectorAll('flt-semantics-placeholder').single;
+        root.querySelector('flt-semantics-placeholder');
+
     expect(placeholder.isConnected, true);
+
     final html.Rectangle<num> rect = placeholder.getBoundingClientRect();
     placeholder.dispatchEvent(html.MouseEvent(
       'click',
@@ -353,10 +356,10 @@ void _testContainer() {
   </sem-c>
 </sem>''');
 
-    final html.Element parentElement =
-        html.document.querySelector('flt-semantics');
+    final root = getRootDocument();
+    final html.Element parentElement = root.querySelector('flt-semantics');
     final html.Element container =
-        html.document.querySelector('flt-semantics-container');
+        root.querySelector('flt-semantics-container');
 
     if (isMacOrIOS) {
       expect(parentElement.style.top, '0px');
@@ -401,10 +404,10 @@ void _testContainer() {
   </sem-c>
 </sem>''');
 
-    final html.Element parentElement =
-        html.document.querySelector('flt-semantics');
+    final root = getRootDocument();
+    final html.Element parentElement = root.querySelector('flt-semantics');
     final html.Element container =
-        html.document.querySelector('flt-semantics-container');
+        root.querySelector('flt-semantics-container');
 
     expect(parentElement.style.transform, 'matrix(1, 0, 0, 1, 10, 10)');
     expect(parentElement.style.transformOrigin, '0px 0px 0px');
@@ -446,10 +449,12 @@ void _testContainer() {
   </sem-c>
 </sem>''');
     }
-    final html.Element parentElement =
-        html.document.querySelector('flt-semantics');
+
+    final root = getRootDocument();
+    final html.Element parentElement = root.querySelector('flt-semantics');
     final html.Element container =
-        html.document.querySelector('flt-semantics-container');
+        root.querySelector('flt-semantics-container');
+
     if (isMacOrIOS) {
       expect(parentElement.style.top, '0px');
       expect(parentElement.style.left, '0px');
@@ -804,8 +809,8 @@ void _testIncrementables() {
   <input aria-valuenow="1" aria-valuetext="d" aria-valuemax="2" aria-valuemin="1">
 </sem>''');
 
-    final html.InputElement input =
-        html.document.querySelectorAll('input').single;
+    final root = getRootDocument();
+    final html.InputElement input = root.querySelector('input');
     input.value = '2';
     input.dispatchEvent(html.Event('change'));
 
@@ -839,8 +844,8 @@ void _testIncrementables() {
   <input aria-valuenow="1" aria-valuetext="d" aria-valuemax="1" aria-valuemin="0">
 </sem>''');
 
-    final html.InputElement input =
-        html.document.querySelectorAll('input').single;
+    final root = getRootDocument();
+    final html.InputElement input = root.querySelector('input');
     input.value = '0';
     input.dispatchEvent(html.Event('change'));
 
@@ -933,20 +938,21 @@ void _testTextField() {
 
     semantics().updateSemantics(builder.build());
 
-    final html.Element textField = html.document
-        .querySelectorAll('input[data-semantics-role="text-field"]')
-        .single;
+    final root = getRootDocument();
 
-    expect(html.document.activeElement, isNot(textField));
+    final html.Element textField =
+        root.querySelector('input[data-semantics-role="text-field"]');
+
+    expect(root.activeElement, isNot(textField));
 
     textField.focus();
 
-    expect(html.document.activeElement, textField);
+    expect(root.activeElement, textField);
     expect(await logger.idLog.first, 0);
     expect(await logger.actionLog.first, ui.SemanticsAction.tap);
 
     semantics().semanticsEnabled = false;
-  },  // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
+  }, // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
       skip: (browserEngine != BrowserEngine.blink));

--- a/lib/web_ui/test/engine/semantics/semantics_tester.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_tester.dart
@@ -12,6 +12,27 @@ import 'package:ui/ui.dart' as ui;
 
 import '../../matchers.dart';
 
+/// Gets the root document or shadow root where the Flutter app is being rendered.
+///
+/// This function returns the correct root for the flutter app under testing,
+/// instead of hardcoding html.document across the test.
+///
+/// The root of a normal flutter app used to be html.document, but now that the
+/// whole app is wrapped in a Shadow DOM, that's not the case anymore.
+///
+/// A [html.ShadowRoot] quacks very similarly to a [html.Document], but unfortunately
+/// they don't share any class/implement any interface that let us use them interchangeably.
+/// To do so, just:
+///
+///   final root = getRootDocument();
+///
+/// So getRootDocument can be changed to return ShadowRoot or Document without
+/// the need to modify your code.
+///
+html.ShadowRoot getRootDocument() {
+  return html.document.querySelector('flt-glass-pane')!.shadowRoot!;
+}
+
 /// CSS style applied to the root of the semantics tree.
 // TODO(yjbanov): this should be handled internally by [expectSemanticsTree].
 //                No need for every test to inject it.
@@ -336,14 +357,14 @@ class SemanticsTester {
 /// Verifies the HTML structure of the current semantics tree.
 void expectSemanticsTree(String semanticsHtml) {
   expect(
-    canonicalizeHtml(html.document.querySelector('flt-semantics')!.outerHtml!),
+    canonicalizeHtml(getRootDocument().querySelector('flt-semantics')!.outerHtml!),
     canonicalizeHtml(semanticsHtml),
   );
 }
 
 /// Finds the first HTML element in the semantics tree used for scrolling.
 html.Element? findScrollable() {
-  return html.document.querySelectorAll('flt-semantics').cast<html.Element?>().firstWhere(
+  return getRootDocument().querySelectorAll('flt-semantics').cast<html.Element?>().firstWhere(
         (html.Element? element) =>
             element!.style.overflow == 'hidden' ||
             element.style.overflowY == 'scroll' ||

--- a/lib/web_ui/test/engine/semantics/text_field_test.dart
+++ b/lib/web_ui/test/engine/semantics/text_field_test.dart
@@ -75,15 +75,14 @@ void testMain() {
 
     createTextFieldSemantics(value: 'hello');
 
-    final html.Element textField = html.document
-        .querySelectorAll('input[data-semantics-role="text-field"]')
-        .single;
+    final html.Element textField = appShadowRoot
+        .querySelector('input[data-semantics-role="text-field"]')!;
 
-    expect(html.document.activeElement, isNot(textField));
+    expect(appShadowRoot.activeElement, isNot(textField));
 
     textField.focus();
 
-    expect(html.document.activeElement, textField);
+    expect(appShadowRoot.activeElement, textField);
     expect(await logger.idLog.first, 0);
     expect(await logger.actionLog.first, ui.SemanticsAction.tap);
 
@@ -99,6 +98,7 @@ void testMain() {
         ..semanticsEnabled = true;
 
       expect(html.document.activeElement, html.document.body);
+      expect(appShadowRoot.activeElement, null);
 
       int changeCount = 0;
       int actionCount = 0;
@@ -121,8 +121,9 @@ void testMain() {
       );
 
       TextField textField = textFieldSemantics.debugRoleManagerFor(Role.textField) as TextField;
+      expect(html.document.activeElement, domRenderer.glassPaneElement);
+      expect(appShadowRoot.activeElement, strategy.domElement);
       expect(textField.editableElement, strategy.domElement);
-      expect(html.document.activeElement, strategy.domElement);
       expect((textField.editableElement as dynamic).value, 'hello');
       expect(textField.editableElement.getAttribute('aria-label'), 'greeting');
       expect(textField.editableElement.style.width, '10px');
@@ -137,6 +138,7 @@ void testMain() {
       );
 
       expect(html.document.activeElement, html.document.body);
+      expect(appShadowRoot.activeElement, null);
       expect(strategy.domElement, null);
       expect((textField.editableElement as dynamic).value, 'bye');
       expect(textField.editableElement.getAttribute('aria-label'), 'farewell');
@@ -158,6 +160,8 @@ void testMain() {
         ..semanticsEnabled = true;
 
       expect(html.document.activeElement, html.document.body);
+      expect(appShadowRoot.activeElement, null);
+
       strategy.enable(
         singlelineConfig,
         onChange: (_) {},
@@ -170,11 +174,13 @@ void testMain() {
 
       final TextField textField = textFieldSemantics.debugRoleManagerFor(Role.textField) as TextField;
       expect(textField.editableElement, strategy.domElement);
-      expect(html.document.activeElement, strategy.domElement);
+      expect(html.document.activeElement, domRenderer.glassPaneElement);
+      expect(appShadowRoot.activeElement, strategy.domElement);
 
       // The input should not refocus after blur.
       textField.editableElement.blur();
       expect(html.document.activeElement, html.document.body);
+      expect(appShadowRoot.activeElement, null);
       strategy.disable();
       semantics().semanticsEnabled = false;
     });
@@ -199,17 +205,19 @@ void testMain() {
         isFocused: true,
       );
       expect(strategy.domElement, isNotNull);
-      expect(html.document.activeElement, strategy.domElement);
+      expect(html.document.activeElement, domRenderer.glassPaneElement);
+      expect(appShadowRoot.activeElement, strategy.domElement);
 
       strategy.disable();
       expect(strategy.domElement, isNull);
 
       // It doesn't remove the DOM element.
       final TextField textField = textFieldSemantics.debugRoleManagerFor(Role.textField) as TextField;
-      expect(html.document.body!.contains(textField.editableElement), isTrue);
+      expect(appShadowRoot.contains(textField.editableElement), isTrue);
       // Editing element is not enabled.
       expect(strategy.isEnabled, isFalse);
       expect(html.document.activeElement, html.document.body);
+      expect(appShadowRoot.activeElement, null);
       semantics().semanticsEnabled = false;
     });
 
@@ -229,11 +237,13 @@ void testMain() {
         isFocused: true,
       );
       expect(strategy.domElement, isNotNull);
-      expect(html.document.activeElement, strategy.domElement);
+      expect(html.document.activeElement, domRenderer.glassPaneElement);
+      expect(appShadowRoot.activeElement, strategy.domElement);
 
       // Blur the element without telling the framework.
       strategy.activeDomElement.blur();
       expect(html.document.activeElement, html.document.body);
+      expect(appShadowRoot.activeElement, null);
 
       // The input will have focus after editing state is set and semantics updated.
       strategy.setEditingState(EditingState(text: 'foo'));
@@ -251,7 +261,8 @@ void testMain() {
         value: 'hello',
         isFocused: true,
       );
-      expect(html.document.activeElement, strategy.domElement);
+      expect(html.document.activeElement, domRenderer.glassPaneElement);
+      expect(appShadowRoot.activeElement, strategy.domElement);
 
       strategy.disable();
       semantics().semanticsEnabled = false;
@@ -274,7 +285,10 @@ void testMain() {
       );
 
       final html.TextAreaElement textArea = strategy.domElement as html.TextAreaElement;
-      expect(html.document.activeElement, textArea);
+
+      expect(html.document.activeElement, domRenderer.glassPaneElement);
+      expect(appShadowRoot.activeElement, strategy.domElement);
+
       strategy.enable(
         singlelineConfig,
         onChange: (_) {},
@@ -283,10 +297,11 @@ void testMain() {
 
       textArea.blur();
       expect(html.document.activeElement, html.document.body);
+      expect(appShadowRoot.activeElement, null);
 
       strategy.disable();
       // It doesn't remove the textarea from the DOM.
-      expect(html.document.body!.contains(textArea), isTrue);
+      expect(appShadowRoot.contains(textArea), isTrue);
       // Editing element is not enabled.
       expect(strategy.isEnabled, isFalse);
       semantics().semanticsEnabled = false;
@@ -376,12 +391,14 @@ void testMain() {
         final SemanticsTester tester = SemanticsTester(semantics());
         createTwoFieldSemantics(tester, focusFieldId: 1);
         expect(tester.apply().length, 3);
-        expect(html.document.activeElement, tester.getTextField(1).editableElement);
+
+        expect(html.document.activeElement, domRenderer.glassPaneElement);
+        expect(appShadowRoot.activeElement, tester.getTextField(1).editableElement);
         expect(strategy.domElement, tester.getTextField(1).editableElement);
 
         createTwoFieldSemantics(tester, focusFieldId: 2);
         expect(tester.apply().length, 3);
-        expect(html.document.activeElement, tester.getTextField(2).editableElement);
+        expect(appShadowRoot.activeElement, tester.getTextField(2).editableElement);
         expect(strategy.domElement, tester.getTextField(2).editableElement);
       }
 

--- a/lib/web_ui/test/engine/surface/platform_view_test.dart
+++ b/lib/web_ui/test/engine/surface/platform_view_test.dart
@@ -69,14 +69,11 @@ void testMain() {
     });
 
     group('createElement', () {
-      test('adds reset to stylesheet', () {
+      test('creates slot element that can receive pointer events', () {
         final element = view.createElement();
-        _assertShadowRootStylesheetContains(element, 'all: initial;');
-      });
 
-      test('creates element transparent to "cursor" property', () {
-        final element = view.createElement();
-        _assertShadowRootStylesheetContains(element, 'cursor: inherit;');
+        expect(element.tagName, equalsIgnoringCase('flt-platform-view-slot'));
+        expect(element.style.pointerEvents, 'auto');
       });
     });
   });
@@ -97,15 +94,4 @@ Future<void> _createPlatformView(int id, String viewType) {
     (dynamic _) => completer.complete(),
   );
   return completer.future;
-}
-
-void _assertShadowRootStylesheetContains(html.Element element, String rule) {
-  final shadow = element.shadowRoot;
-
-  expect(shadow, isNotNull);
-
-  final html.StyleElement style = shadow.children.first;
-
-  expect(style, isNotNull);
-  expect(style.innerHtml, contains(rule));
 }

--- a/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
@@ -27,13 +27,13 @@ void testMain() async {
     // Create a <flt-scene> element to make sure our CSS reset applies correctly.
     final html.Element testScene = html.Element.tag('flt-scene');
     testScene.append(canvas.rootElement);
-    html.document.querySelector('flt-scene-host')!.append(testScene);
+    domRenderer.glassPaneShadow!.querySelector('flt-scene-host')!.append(testScene);
   }
 
   setUpStableTestFonts();
 
   tearDown(() {
-    html.document.querySelector('flt-scene')!.remove();
+    domRenderer.glassPaneShadow?.querySelector('flt-scene')?.remove();
   });
 
   /// Draws several lines, some aligned precisely with the pixel grid, and some
@@ -249,7 +249,7 @@ void testMain() async {
     final html.Element sceneElement = scene.webOnlyRootElement!;
 
     sceneElement.querySelector('flt-clip')!.append(canvas.rootElement);
-    html.document.querySelector('flt-scene-host')!.append(sceneElement);
+    domRenderer.glassPaneShadow!.querySelector('flt-scene-host')!.append(sceneElement);
 
     await matchGoldenFile(
       'bitmap_canvas_draws_text_on_top_of_canvas.png',

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.9
+// @dart = 2.6
 import 'dart:async';
 import 'dart:html';
 import 'dart:js_util' as js_util;

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
 import 'dart:async';
 import 'dart:html';
 import 'dart:js_util' as js_util;

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.9
 import 'dart:async';
 import 'dart:html';
 import 'dart:js_util' as js_util;
@@ -79,32 +79,38 @@ void testMain() {
       // The focus initially is on the body.
       expect(document.activeElement, document.body);
 
+      // The line below, initializes the whole flutter app structure. Up until now,
+      // the DOM is completely empty.
       editingStrategy.enable(
         singlelineConfig,
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
+
       expect(
-        document.getElementsByTagName('input'),
+        textEditingRoot.querySelectorAll('input'),
         hasLength(1),
       );
-      final InputElement input = document.getElementsByTagName('input')[0];
+      final InputElement input = textEditingRoot.querySelector('input');
       // Now the editing element should have focus.
-      expect(document.activeElement, input);
+
+      expect(document.activeElement, domRenderer.glassPaneElement);
+      expect(textEditingRoot.activeElement, input);
+
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('type'), null);
 
-      // Input is appended to the glass pane.
-      expect(domRenderer.glassPaneElement.contains(editingStrategy.domElement),
-          isTrue);
+      // Input is appended to the right point of the DOM.
+      expect(textEditingRoot.contains(editingStrategy.domElement), isTrue);
 
       editingStrategy.disable();
       expect(
-        document.getElementsByTagName('input'),
+        textEditingRoot.querySelectorAll('input'),
         hasLength(0),
       );
       // The focus is back to the body.
       expect(document.activeElement, document.body);
+      expect(textEditingRoot.activeElement, null);
     });
 
     test('Respects read-only config', () {
@@ -116,8 +122,8 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(document.getElementsByTagName('input'), hasLength(1));
-      final InputElement input = document.getElementsByTagName('input')[0];
+      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
+      final InputElement input = textEditingRoot.querySelector('input');
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('readonly'), 'readonly');
 
@@ -133,8 +139,8 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(document.getElementsByTagName('input'), hasLength(1));
-      final InputElement input = document.getElementsByTagName('input')[0];
+      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
+      final InputElement input = textEditingRoot.querySelector('input');
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('type'), 'password');
 
@@ -150,8 +156,8 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(document.getElementsByTagName('input'), hasLength(1));
-      final InputElement input = document.getElementsByTagName('input')[0];
+      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
+      final InputElement input = textEditingRoot.querySelector('input');
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('autocorrect'), 'off');
 
@@ -167,8 +173,8 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(document.getElementsByTagName('input'), hasLength(1));
-      final InputElement input = document.getElementsByTagName('input')[0];
+      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
+      final InputElement input = textEditingRoot.querySelector('input');
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('autocorrect'), 'on');
 
@@ -224,18 +230,18 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(document.getElementsByTagName('textarea'), hasLength(1));
+      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(1));
 
       final TextAreaElement textarea =
-          document.getElementsByTagName('textarea')[0];
+          textEditingRoot.querySelector('textarea');
       // Now the textarea should have focus.
-      expect(document.activeElement, textarea);
+      expect(textEditingRoot.activeElement, textarea);
       expect(editingStrategy.domElement, textarea);
 
       textarea.value = 'foo\nbar';
       textarea.dispatchEvent(Event.eventType('Event', 'input'));
       textarea.setSelectionRange(4, 6);
-      textarea.dispatchEvent(Event.eventType('Event', 'selectionchange'));
+      document.dispatchEvent(Event.eventType('Event', 'selectionchange'));
       // Can read textarea state correctly (and preserves new lines).
       expect(
         lastEditingState,
@@ -249,9 +255,9 @@ void testMain() {
 
       editingStrategy.disable();
       // The textarea should be cleaned up.
-      expect(document.getElementsByTagName('textarea'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(0));
       // The focus is back to the body.
-      expect(document.activeElement, document.body);
+      expect(textEditingRoot.activeElement, null);
 
       // There should be no input action.
       expect(lastInputAction, isNull);
@@ -268,13 +274,13 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(document.getElementsByTagName('input'), hasLength(1));
-      expect(document.getElementsByTagName('textarea'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
+      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(0));
 
       // Disable and check that all DOM elements were removed.
       editingStrategy.disable();
-      expect(document.getElementsByTagName('input'), hasLength(0));
-      expect(document.getElementsByTagName('textarea'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('input'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(0));
 
       // Use multi-line config and expect an `<textarea>` to be created.
       editingStrategy.enable(
@@ -282,13 +288,13 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(document.getElementsByTagName('input'), hasLength(0));
-      expect(document.getElementsByTagName('textarea'), hasLength(1));
+      expect(textEditingRoot.querySelectorAll('input'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(1));
 
       // Disable again and check that all DOM elements were removed.
       editingStrategy.disable();
-      expect(document.getElementsByTagName('input'), hasLength(0));
-      expect(document.getElementsByTagName('textarea'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('input'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(0));
 
       // There should be no input action.
       expect(lastInputAction, isNull);
@@ -549,7 +555,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setEditingState));
 
       // Editing shouldn't have started yet.
-      expect(document.activeElement, document.body);
+      expect(textEditingRoot.activeElement, null);
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
@@ -570,13 +576,13 @@ void testMain() {
             spy.messages[0].methodName, 'TextInputClient.onConnectionClosed');
         await Future<void>.delayed(Duration.zero);
         // DOM element loses the focus.
-        expect(document.activeElement, document.body);
+        expect(textEditingRoot.activeElement, null);
       } else {
         // No connection close message sent.
         expect(spy.messages, hasLength(0));
         await Future<void>.delayed(Duration.zero);
         // DOM element still keeps the focus.
-        expect(document.activeElement, textEditing.strategy.domElement);
+        expect(textEditingRoot.activeElement, textEditing.strategy.domElement);
       }
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
@@ -597,7 +603,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setEditingState));
 
       // Editing shouldn't have started yet.
-      expect(document.activeElement, document.body);
+      expect(textEditingRoot.activeElement, null);
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
@@ -620,7 +626,7 @@ void testMain() {
       );
       spy.messages.clear();
       // Input element is removed from DOM.
-      expect(document.getElementsByTagName('input'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('input'), hasLength(0));
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
         skip: browserEngine == BrowserEngine.edge);
@@ -661,7 +667,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // Form is added to DOM.
-      expect(document.getElementsByTagName('form'), isNotEmpty);
+      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
 
       const MethodCall clearClient = MethodCall('TextInput.clearClient');
       sendFrameworkMessage(codec.encodeMethodCall(clearClient));
@@ -669,7 +675,7 @@ void testMain() {
       // Confirm that [HybridTextEditing] didn't send any messages.
       expect(spy.messages, isEmpty);
       // Form stays on the DOM until autofill context is finalized.
-      expect(document.getElementsByTagName('form'), isNotEmpty);
+      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
 
       const MethodCall finishAutofillContext =
@@ -677,7 +683,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(finishAutofillContext));
 
       // Form element is removed from DOM.
-      expect(document.getElementsByTagName('form'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('form'), isEmpty);
       expect(formsOnTheDom, hasLength(0));
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
@@ -717,8 +723,8 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // Form is added to DOM.
-      expect(document.getElementsByTagName('form'), isNotEmpty);
-      FormElement formElement = document.getElementsByTagName('form')[0];
+      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
+      FormElement formElement = textEditingRoot.querySelector('form');
       final Completer<bool> submittedForm = Completer<bool>();
       formElement.addEventListener(
           'submit', (event) => submittedForm.complete(true));
@@ -770,8 +776,8 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // Form is added to DOM.
-      expect(document.getElementsByTagName('form'), isNotEmpty);
-      FormElement formElement = document.getElementsByTagName('form')[0];
+      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
+      FormElement formElement = textEditingRoot.querySelector('form');
       final Completer<bool> submittedForm = Completer<bool>();
       formElement.addEventListener(
           'submit', (event) => submittedForm.complete(true));
@@ -789,7 +795,7 @@ void testMain() {
       // `submit` action is called on form.
       await expectLater(await submittedForm.future, true);
       // Form element is removed from DOM.
-      expect(document.getElementsByTagName('form'), hasLength(0));
+      expect(textEditingRoot.querySelectorAll('form'), hasLength(0));
       expect(formsOnTheDom, hasLength(0));
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
@@ -896,7 +902,7 @@ void testMain() {
       checkInputEditingState(
           textEditing.strategy.domElement, 'abcd', 2, 3);
 
-      final FormElement formElement = document.getElementsByTagName('form')[0];
+      final FormElement formElement = textEditingRoot.querySelector('form');
       // The form has one input element and one submit button.
       expect(formElement.childNodes, hasLength(2));
 
@@ -906,7 +912,7 @@ void testMain() {
       // Confirm that [HybridTextEditing] didn't send any messages.
       expect(spy.messages, isEmpty);
       // Form stays on the DOM until autofill context is finalized.
-      expect(document.getElementsByTagName('form'), isNotEmpty);
+      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
     });
 
@@ -939,7 +945,7 @@ void testMain() {
         // In Safari Desktop Autofill menu appears as soon as an element is
         // focused, therefore the input element is only focused after the
         // location is received.
-        expect(document.activeElement, inputElement);
+        expect(textEditingRoot.activeElement, inputElement);
         expect(inputElement.selectionStart, 2);
         expect(inputElement.selectionEnd, 3);
       }
@@ -952,7 +958,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // Check the element still has focus. User can keep editing.
-      expect(document.activeElement, textEditing.strategy.domElement);
+      expect(textEditingRoot.activeElement, textEditing.strategy.domElement);
 
       // Check the cursor location is the same.
       checkInputEditingState(
@@ -964,7 +970,7 @@ void testMain() {
       // Confirm that [HybridTextEditing] didn't send any messages.
       expect(spy.messages, isEmpty);
       // Form stays on the DOM until autofill context is finalized.
-      expect(document.getElementsByTagName('form'), isNotEmpty);
+      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
     });
 
@@ -1005,7 +1011,7 @@ void testMain() {
       checkInputEditingState(
           textEditing.strategy.domElement, 'abcd', 2, 3);
 
-      final FormElement formElement = document.getElementsByTagName('form')[0];
+      final FormElement formElement = textEditingRoot.querySelector('form');
       // The form has 4 input elements and one submit button.
       expect(formElement.childNodes, hasLength(5));
 
@@ -1015,17 +1021,17 @@ void testMain() {
       // Confirm that [HybridTextEditing] didn't send any messages.
       expect(spy.messages, isEmpty);
       // Form stays on the DOM until autofill context is finalized.
-      expect(document.getElementsByTagName('form'), isNotEmpty);
+      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
     });
 
-    test('No capitilization: setClient, setEditingState, show', () {
+    test('No capitalization: setClient, setEditingState, show', () {
       // Create a configuration with an AutofillGroup of four text fields.
-      final Map<String, dynamic> capitilizeWordsConfig = createFlutterConfig(
+      final Map<String, dynamic> capitalizeWordsConfig = createFlutterConfig(
           'text',
           textCapitalization: 'TextCapitalization.none');
       final MethodCall setClient = MethodCall(
-          'TextInput.setClient', <dynamic>[123, capitilizeWordsConfig]);
+          'TextInput.setClient', <dynamic>[123, capitalizeWordsConfig]);
       sendFrameworkMessage(codec.encodeMethodCall(setClient));
 
       const MethodCall setEditingState1 =
@@ -1059,13 +1065,13 @@ void testMain() {
       hideKeyboard();
     });
 
-    test('All characters capitilization: setClient, setEditingState, show', () {
+    test('All characters capitalization: setClient, setEditingState, show', () {
       // Create a configuration with an AutofillGroup of four text fields.
-      final Map<String, dynamic> capitilizeWordsConfig = createFlutterConfig(
+      final Map<String, dynamic> capitalizeWordsConfig = createFlutterConfig(
           'text',
           textCapitalization: 'TextCapitalization.characters');
       final MethodCall setClient = MethodCall(
-          'TextInput.setClient', <dynamic>[123, capitilizeWordsConfig]);
+          'TextInput.setClient', <dynamic>[123, capitalizeWordsConfig]);
       sendFrameworkMessage(codec.encodeMethodCall(setClient));
 
       const MethodCall setEditingState1 =
@@ -1417,7 +1423,7 @@ void testMain() {
       checkInputEditingState(
           textEditing.strategy.domElement, 'abcd', 2, 3);
 
-      final FormElement formElement = document.getElementsByTagName('form')[0];
+      final FormElement formElement = textEditingRoot.querySelector('form');
       // The form has 4 input elements and one submit button.
       expect(formElement.childNodes, hasLength(5));
 
@@ -1461,7 +1467,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setClient));
 
       // Editing shouldn't have started yet.
-      expect(document.activeElement, document.body);
+      expect(textEditingRoot.activeElement, null);
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
@@ -1719,7 +1725,7 @@ void testMain() {
     });
 
     test('place and store form', () {
-      expect(document.getElementsByTagName('form'), isEmpty);
+      expect(textEditingRoot.querySelectorAll('form'), isEmpty);
 
       final List<dynamic> fields = createFieldValues(
           ['username', 'password', 'newPassword'],
@@ -1736,12 +1742,12 @@ void testMain() {
       final FormElement form = autofillForm.formElement;
       expect(form.childNodes, hasLength(4));
 
-      final FormElement formOnDom = document.getElementsByTagName('form')[0];
+      final FormElement formOnDom = textEditingRoot.querySelector('form');
       // Form is attached to the DOM.
       expect(form, equals(formOnDom));
 
       autofillForm.storeForm();
-      expect(document.getElementsByTagName('form'), isNotEmpty);
+      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
     });
 
@@ -1887,7 +1893,7 @@ void testMain() {
     });
 
     test('Configure input element from the editing state', () {
-      final InputElement input = document.getElementsByTagName('input')[0];
+      final InputElement input = textEditingRoot.querySelector('input');
       _editingState =
           EditingState(text: 'Test', baseOffset: 1, extentOffset: 2);
 
@@ -1907,7 +1913,7 @@ void testMain() {
       );
 
       final TextAreaElement textArea =
-          document.getElementsByTagName('textarea')[0];
+          textEditingRoot.querySelector('textarea');
       _editingState =
           EditingState(text: 'Test', baseOffset: 1, extentOffset: 2);
 
@@ -1919,7 +1925,7 @@ void testMain() {
     });
 
     test('Get Editing State from input element', () {
-      final InputElement input = document.getElementsByTagName('input')[0];
+      final InputElement input = textEditingRoot.querySelector('input');
       input.value = 'Test';
       input.selectionStart = 1;
       input.selectionEnd = 2;
@@ -1940,7 +1946,7 @@ void testMain() {
       );
 
       final TextAreaElement input =
-          document.getElementsByTagName('textarea')[0];
+          textEditingRoot.querySelector('textarea');
       input.value = 'Test';
       input.selectionStart = 1;
       input.selectionEnd = 2;
@@ -1953,7 +1959,7 @@ void testMain() {
     });
 
     test('Compare two editing states', () {
-      final InputElement input = document.getElementsByTagName('input')[0];
+      final InputElement input = textEditingRoot.querySelector('input');
       input.value = 'Test';
       input.selectionStart = 1;
       input.selectionEnd = 2;
@@ -2027,7 +2033,7 @@ void cleanTestFlags() {
 
 void checkInputEditingState(
     InputElement input, String text, int start, int end) {
-  expect(document.activeElement, input);
+  expect(textEditingRoot.activeElement, input);
   expect(input.value, text);
   expect(input.selectionStart, start);
   expect(input.selectionEnd, end);
@@ -2036,11 +2042,11 @@ void checkInputEditingState(
 /// In case of an exception backup DOM element(s) can still stay on the DOM.
 void clearBackUpDomElementIfExists() {
   List<Node> domElementsToRemove = <Node>[];
-  if (document.getElementsByTagName('input').length > 0) {
-    domElementsToRemove..addAll(document.getElementsByTagName('input'));
+  if (textEditingRoot.querySelectorAll('input').length > 0) {
+    domElementsToRemove..addAll(textEditingRoot.querySelectorAll('input'));
   }
-  if (document.getElementsByTagName('textarea').length > 0) {
-    domElementsToRemove..addAll(document.getElementsByTagName('textarea'));
+  if (textEditingRoot.querySelectorAll('textarea').length > 0) {
+    domElementsToRemove..addAll(textEditingRoot.querySelectorAll('textarea'));
   }
   domElementsToRemove.forEach((Node n) => n.remove());
 }
@@ -2051,7 +2057,7 @@ void checkTextAreaEditingState(
   int start,
   int end,
 ) {
-  expect(document.activeElement, textarea);
+  expect(textEditingRoot.activeElement, textarea);
   expect(textarea.value, text);
   expect(textarea.selectionStart, start);
   expect(textarea.selectionEnd, end);
@@ -2130,8 +2136,8 @@ Map<String, dynamic> createOneFieldValue(String hint, String uniqueId) =>
 
 /// In order to not leak test state, clean up the forms from dom if any remains.
 void clearForms() {
-  while (document.getElementsByTagName('form').length > 0) {
-    document.getElementsByTagName('form').last.remove();
+  while (textEditingRoot.querySelectorAll('form').length > 0) {
+    textEditingRoot.querySelectorAll('form').last.remove();
   }
   formsOnTheDom.clear();
 }

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -1945,8 +1945,7 @@ void testMain() {
         onAction: trackInputAction,
       );
 
-      final TextAreaElement input =
-          textEditingRoot.querySelector('textarea');
+      final TextAreaElement input = textEditingRoot.querySelector('textarea');
       input.value = 'Test';
       input.selectionStart = 1;
       input.selectionEnd = 2;

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -69,6 +69,8 @@ void testMain() {
       editingStrategy = GloballyPositionedTextEditingStrategy(testTextEditing);
       testTextEditing.debugTextEditingStrategyOverride = editingStrategy;
       testTextEditing.configuration = singlelineConfig;
+      // Ensure the glass-pane and its shadow root exist.
+      domRenderer.reset();
     });
 
     test('Creates element when enabled and removes it when disabled', () {
@@ -78,9 +80,8 @@ void testMain() {
       );
       // The focus initially is on the body.
       expect(document.activeElement, document.body);
+      expect(textEditingRoot.activeElement, null);
 
-      // The line below, initializes the whole flutter app structure. Up until now,
-      // the DOM is completely empty.
       editingStrategy.enable(
         singlelineConfig,
         onChange: trackEditingState,

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -80,7 +80,7 @@ void testMain() {
       );
       // The focus initially is on the body.
       expect(document.activeElement, document.body);
-      expect(textEditingRoot.activeElement, null);
+      expect(defaultTextEditingRoot.activeElement, null);
 
       editingStrategy.enable(
         singlelineConfig,
@@ -89,29 +89,29 @@ void testMain() {
       );
 
       expect(
-        textEditingRoot.querySelectorAll('input'),
+        defaultTextEditingRoot.querySelectorAll('input'),
         hasLength(1),
       );
-      final InputElement input = textEditingRoot.querySelector('input');
+      final InputElement input = defaultTextEditingRoot.querySelector('input');
       // Now the editing element should have focus.
 
       expect(document.activeElement, domRenderer.glassPaneElement);
-      expect(textEditingRoot.activeElement, input);
+      expect(defaultTextEditingRoot.activeElement, input);
 
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('type'), null);
 
       // Input is appended to the right point of the DOM.
-      expect(textEditingRoot.contains(editingStrategy.domElement), isTrue);
+      expect(defaultTextEditingRoot.contains(editingStrategy.domElement), isTrue);
 
       editingStrategy.disable();
       expect(
-        textEditingRoot.querySelectorAll('input'),
+        defaultTextEditingRoot.querySelectorAll('input'),
         hasLength(0),
       );
       // The focus is back to the body.
       expect(document.activeElement, document.body);
-      expect(textEditingRoot.activeElement, null);
+      expect(defaultTextEditingRoot.activeElement, null);
     });
 
     test('Respects read-only config', () {
@@ -123,8 +123,8 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
-      final InputElement input = textEditingRoot.querySelector('input');
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(1));
+      final InputElement input = defaultTextEditingRoot.querySelector('input');
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('readonly'), 'readonly');
 
@@ -140,8 +140,8 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
-      final InputElement input = textEditingRoot.querySelector('input');
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(1));
+      final InputElement input = defaultTextEditingRoot.querySelector('input');
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('type'), 'password');
 
@@ -157,8 +157,8 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
-      final InputElement input = textEditingRoot.querySelector('input');
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(1));
+      final InputElement input = defaultTextEditingRoot.querySelector('input');
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('autocorrect'), 'off');
 
@@ -174,8 +174,8 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
-      final InputElement input = textEditingRoot.querySelector('input');
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(1));
+      final InputElement input = defaultTextEditingRoot.querySelector('input');
       expect(editingStrategy.domElement, input);
       expect(input.getAttribute('autocorrect'), 'on');
 
@@ -231,12 +231,12 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(1));
+      expect(defaultTextEditingRoot.querySelectorAll('textarea'), hasLength(1));
 
       final TextAreaElement textarea =
-          textEditingRoot.querySelector('textarea');
+          defaultTextEditingRoot.querySelector('textarea');
       // Now the textarea should have focus.
-      expect(textEditingRoot.activeElement, textarea);
+      expect(defaultTextEditingRoot.activeElement, textarea);
       expect(editingStrategy.domElement, textarea);
 
       textarea.value = 'foo\nbar';
@@ -256,9 +256,9 @@ void testMain() {
 
       editingStrategy.disable();
       // The textarea should be cleaned up.
-      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(0));
+      expect(defaultTextEditingRoot.querySelectorAll('textarea'), hasLength(0));
       // The focus is back to the body.
-      expect(textEditingRoot.activeElement, null);
+      expect(defaultTextEditingRoot.activeElement, null);
 
       // There should be no input action.
       expect(lastInputAction, isNull);
@@ -275,13 +275,13 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(textEditingRoot.querySelectorAll('input'), hasLength(1));
-      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(0));
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(1));
+      expect(defaultTextEditingRoot.querySelectorAll('textarea'), hasLength(0));
 
       // Disable and check that all DOM elements were removed.
       editingStrategy.disable();
-      expect(textEditingRoot.querySelectorAll('input'), hasLength(0));
-      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(0));
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(0));
+      expect(defaultTextEditingRoot.querySelectorAll('textarea'), hasLength(0));
 
       // Use multi-line config and expect an `<textarea>` to be created.
       editingStrategy.enable(
@@ -289,13 +289,13 @@ void testMain() {
         onChange: trackEditingState,
         onAction: trackInputAction,
       );
-      expect(textEditingRoot.querySelectorAll('input'), hasLength(0));
-      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(1));
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(0));
+      expect(defaultTextEditingRoot.querySelectorAll('textarea'), hasLength(1));
 
       // Disable again and check that all DOM elements were removed.
       editingStrategy.disable();
-      expect(textEditingRoot.querySelectorAll('input'), hasLength(0));
-      expect(textEditingRoot.querySelectorAll('textarea'), hasLength(0));
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(0));
+      expect(defaultTextEditingRoot.querySelectorAll('textarea'), hasLength(0));
 
       // There should be no input action.
       expect(lastInputAction, isNull);
@@ -556,7 +556,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setEditingState));
 
       // Editing shouldn't have started yet.
-      expect(textEditingRoot.activeElement, null);
+      expect(defaultTextEditingRoot.activeElement, null);
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
@@ -577,13 +577,14 @@ void testMain() {
             spy.messages[0].methodName, 'TextInputClient.onConnectionClosed');
         await Future<void>.delayed(Duration.zero);
         // DOM element loses the focus.
-        expect(textEditingRoot.activeElement, null);
+        expect(defaultTextEditingRoot.activeElement, null);
       } else {
         // No connection close message sent.
         expect(spy.messages, hasLength(0));
         await Future<void>.delayed(Duration.zero);
         // DOM element still keeps the focus.
-        expect(textEditingRoot.activeElement, textEditing.strategy.domElement);
+        expect(defaultTextEditingRoot.activeElement,
+            textEditing.strategy.domElement);
       }
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
@@ -604,7 +605,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setEditingState));
 
       // Editing shouldn't have started yet.
-      expect(textEditingRoot.activeElement, null);
+      expect(defaultTextEditingRoot.activeElement, null);
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
@@ -627,7 +628,7 @@ void testMain() {
       );
       spy.messages.clear();
       // Input element is removed from DOM.
-      expect(textEditingRoot.querySelectorAll('input'), hasLength(0));
+      expect(defaultTextEditingRoot.querySelectorAll('input'), hasLength(0));
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
         skip: browserEngine == BrowserEngine.edge);
@@ -668,7 +669,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // Form is added to DOM.
-      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isNotEmpty);
 
       const MethodCall clearClient = MethodCall('TextInput.clearClient');
       sendFrameworkMessage(codec.encodeMethodCall(clearClient));
@@ -676,7 +677,7 @@ void testMain() {
       // Confirm that [HybridTextEditing] didn't send any messages.
       expect(spy.messages, isEmpty);
       // Form stays on the DOM until autofill context is finalized.
-      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
 
       const MethodCall finishAutofillContext =
@@ -684,7 +685,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(finishAutofillContext));
 
       // Form element is removed from DOM.
-      expect(textEditingRoot.querySelectorAll('form'), isEmpty);
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isEmpty);
       expect(formsOnTheDom, hasLength(0));
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
@@ -724,8 +725,8 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // Form is added to DOM.
-      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
-      FormElement formElement = textEditingRoot.querySelector('form');
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isNotEmpty);
+      FormElement formElement = defaultTextEditingRoot.querySelector('form');
       final Completer<bool> submittedForm = Completer<bool>();
       formElement.addEventListener(
           'submit', (event) => submittedForm.complete(true));
@@ -777,8 +778,8 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // Form is added to DOM.
-      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
-      FormElement formElement = textEditingRoot.querySelector('form');
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isNotEmpty);
+      FormElement formElement = defaultTextEditingRoot.querySelector('form');
       final Completer<bool> submittedForm = Completer<bool>();
       formElement.addEventListener(
           'submit', (event) => submittedForm.complete(true));
@@ -796,7 +797,7 @@ void testMain() {
       // `submit` action is called on form.
       await expectLater(await submittedForm.future, true);
       // Form element is removed from DOM.
-      expect(textEditingRoot.querySelectorAll('form'), hasLength(0));
+      expect(defaultTextEditingRoot.querySelectorAll('form'), hasLength(0));
       expect(formsOnTheDom, hasLength(0));
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
@@ -903,7 +904,7 @@ void testMain() {
       checkInputEditingState(
           textEditing.strategy.domElement, 'abcd', 2, 3);
 
-      final FormElement formElement = textEditingRoot.querySelector('form');
+      final FormElement formElement = defaultTextEditingRoot.querySelector('form');
       // The form has one input element and one submit button.
       expect(formElement.childNodes, hasLength(2));
 
@@ -913,7 +914,7 @@ void testMain() {
       // Confirm that [HybridTextEditing] didn't send any messages.
       expect(spy.messages, isEmpty);
       // Form stays on the DOM until autofill context is finalized.
-      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
     });
 
@@ -946,7 +947,7 @@ void testMain() {
         // In Safari Desktop Autofill menu appears as soon as an element is
         // focused, therefore the input element is only focused after the
         // location is received.
-        expect(textEditingRoot.activeElement, inputElement);
+        expect(defaultTextEditingRoot.activeElement, inputElement);
         expect(inputElement.selectionStart, 2);
         expect(inputElement.selectionEnd, 3);
       }
@@ -959,7 +960,8 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setSizeAndTransform));
 
       // Check the element still has focus. User can keep editing.
-      expect(textEditingRoot.activeElement, textEditing.strategy.domElement);
+      expect(defaultTextEditingRoot.activeElement,
+          textEditing.strategy.domElement);
 
       // Check the cursor location is the same.
       checkInputEditingState(
@@ -971,7 +973,7 @@ void testMain() {
       // Confirm that [HybridTextEditing] didn't send any messages.
       expect(spy.messages, isEmpty);
       // Form stays on the DOM until autofill context is finalized.
-      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
     });
 
@@ -1012,7 +1014,7 @@ void testMain() {
       checkInputEditingState(
           textEditing.strategy.domElement, 'abcd', 2, 3);
 
-      final FormElement formElement = textEditingRoot.querySelector('form');
+      final FormElement formElement = defaultTextEditingRoot.querySelector('form');
       // The form has 4 input elements and one submit button.
       expect(formElement.childNodes, hasLength(5));
 
@@ -1022,7 +1024,7 @@ void testMain() {
       // Confirm that [HybridTextEditing] didn't send any messages.
       expect(spy.messages, isEmpty);
       // Form stays on the DOM until autofill context is finalized.
-      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
     });
 
@@ -1424,7 +1426,7 @@ void testMain() {
       checkInputEditingState(
           textEditing.strategy.domElement, 'abcd', 2, 3);
 
-      final FormElement formElement = textEditingRoot.querySelector('form');
+      final FormElement formElement = defaultTextEditingRoot.querySelector('form');
       // The form has 4 input elements and one submit button.
       expect(formElement.childNodes, hasLength(5));
 
@@ -1468,7 +1470,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(setClient));
 
       // Editing shouldn't have started yet.
-      expect(textEditingRoot.activeElement, null);
+      expect(defaultTextEditingRoot.activeElement, null);
 
       const MethodCall show = MethodCall('TextInput.show');
       sendFrameworkMessage(codec.encodeMethodCall(show));
@@ -1726,7 +1728,7 @@ void testMain() {
     });
 
     test('place and store form', () {
-      expect(textEditingRoot.querySelectorAll('form'), isEmpty);
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isEmpty);
 
       final List<dynamic> fields = createFieldValues(
           ['username', 'password', 'newPassword'],
@@ -1743,12 +1745,12 @@ void testMain() {
       final FormElement form = autofillForm.formElement;
       expect(form.childNodes, hasLength(4));
 
-      final FormElement formOnDom = textEditingRoot.querySelector('form');
+      final FormElement formOnDom = defaultTextEditingRoot.querySelector('form');
       // Form is attached to the DOM.
       expect(form, equals(formOnDom));
 
       autofillForm.storeForm();
-      expect(textEditingRoot.querySelectorAll('form'), isNotEmpty);
+      expect(defaultTextEditingRoot.querySelectorAll('form'), isNotEmpty);
       expect(formsOnTheDom, hasLength(1));
     });
 
@@ -1894,7 +1896,7 @@ void testMain() {
     });
 
     test('Configure input element from the editing state', () {
-      final InputElement input = textEditingRoot.querySelector('input');
+      final InputElement input = defaultTextEditingRoot.querySelector('input');
       _editingState =
           EditingState(text: 'Test', baseOffset: 1, extentOffset: 2);
 
@@ -1914,7 +1916,7 @@ void testMain() {
       );
 
       final TextAreaElement textArea =
-          textEditingRoot.querySelector('textarea');
+          defaultTextEditingRoot.querySelector('textarea');
       _editingState =
           EditingState(text: 'Test', baseOffset: 1, extentOffset: 2);
 
@@ -1926,7 +1928,7 @@ void testMain() {
     });
 
     test('Get Editing State from input element', () {
-      final InputElement input = textEditingRoot.querySelector('input');
+      final InputElement input = defaultTextEditingRoot.querySelector('input');
       input.value = 'Test';
       input.selectionStart = 1;
       input.selectionEnd = 2;
@@ -1946,7 +1948,7 @@ void testMain() {
         onAction: trackInputAction,
       );
 
-      final TextAreaElement input = textEditingRoot.querySelector('textarea');
+      final TextAreaElement input = defaultTextEditingRoot.querySelector('textarea');
       input.value = 'Test';
       input.selectionStart = 1;
       input.selectionEnd = 2;
@@ -1959,7 +1961,7 @@ void testMain() {
     });
 
     test('Compare two editing states', () {
-      final InputElement input = textEditingRoot.querySelector('input');
+      final InputElement input = defaultTextEditingRoot.querySelector('input');
       input.value = 'Test';
       input.selectionStart = 1;
       input.selectionEnd = 2;
@@ -2033,7 +2035,7 @@ void cleanTestFlags() {
 
 void checkInputEditingState(
     InputElement input, String text, int start, int end) {
-  expect(textEditingRoot.activeElement, input);
+  expect(defaultTextEditingRoot.activeElement, input);
   expect(input.value, text);
   expect(input.selectionStart, start);
   expect(input.selectionEnd, end);
@@ -2042,11 +2044,11 @@ void checkInputEditingState(
 /// In case of an exception backup DOM element(s) can still stay on the DOM.
 void clearBackUpDomElementIfExists() {
   List<Node> domElementsToRemove = <Node>[];
-  if (textEditingRoot.querySelectorAll('input').length > 0) {
-    domElementsToRemove..addAll(textEditingRoot.querySelectorAll('input'));
+  if (defaultTextEditingRoot.querySelectorAll('input').length > 0) {
+    domElementsToRemove..addAll(defaultTextEditingRoot.querySelectorAll('input'));
   }
-  if (textEditingRoot.querySelectorAll('textarea').length > 0) {
-    domElementsToRemove..addAll(textEditingRoot.querySelectorAll('textarea'));
+  if (defaultTextEditingRoot.querySelectorAll('textarea').length > 0) {
+    domElementsToRemove..addAll(defaultTextEditingRoot.querySelectorAll('textarea'));
   }
   domElementsToRemove.forEach((Node n) => n.remove());
 }
@@ -2057,7 +2059,7 @@ void checkTextAreaEditingState(
   int start,
   int end,
 ) {
-  expect(textEditingRoot.activeElement, textarea);
+  expect(defaultTextEditingRoot.activeElement, textarea);
   expect(textarea.value, text);
   expect(textarea.selectionStart, start);
   expect(textarea.selectionEnd, end);
@@ -2136,8 +2138,8 @@ Map<String, dynamic> createOneFieldValue(String hint, String uniqueId) =>
 
 /// In order to not leak test state, clean up the forms from dom if any remains.
 void clearForms() {
-  while (textEditingRoot.querySelectorAll('form').length > 0) {
-    textEditingRoot.querySelectorAll('form').last.remove();
+  while (defaultTextEditingRoot.querySelectorAll('form').length > 0) {
+    defaultTextEditingRoot.querySelectorAll('form').last.remove();
   }
   formsOnTheDom.clear();
 }


### PR DESCRIPTION
Render PlatformViews in SLOT tags. To do so:

* Wraps most of the DOM from a flutter app in the Shadow DOM of flt-glass-pane (was https://github.com/flutter/engine/pull/25483)
* Unifies the Platform View lifecycle in a PlatformViewManager class. That class keeps track of platform view factory functions, their rendered output, and the SLOTs for the Shadow DOM. 
  * Previously a PlatformView was a single DOM node, but now it has been split in two:
    * The `slot`(which flutter is able to move around within the render tree).
    * The `content` (which is always a direct child of the `flt-glass-pane` element, and contains the rendered output of a platform view factory).
* Platform messages related to platform views are now handled by a `PlatformViewMessageHandler` class, which is configured in the engine's `platform_dispatcher.dart`. Platform Messages for Platform Views are now more easily testable.
* Unused code across the engine has been removed (everything related to the old way of handling platform views in canvaskit and html renderers).

### Fixes 

* https://github.com/flutter/flutter/issues/80524

### Testing

* Deployed the Gallery App using this version of the engine: https://dit-gallery.web.app
* All existing tests pass.
* Added new tests for the new classes added.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
