### PR TITLE
[fuchsia] Remove now unsed wrapper for zx_clock_get

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
@@ -190,7 +190,6 @@ class System extends NativeFieldWrapperClass2 {
 
   // Time operations.
   static int clockGetMonotonic() native 'System_ClockGetMonotonic';
-  static int clockGet(int clockId) native 'System_ClockGet';
 
   // TODO(edcoyne): Remove this, it is required to safely do an API transition across repos.
   static int reboot() { return -2; /*ZX_ERR_NOT_SUPPORTED*/ }

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
@@ -463,12 +463,6 @@ uint64_t System::ClockGetMonotonic() {
   return zx_clock_get_monotonic();
 }
 
-uint64_t System::ClockGet(uint32_t clock_id) {
-  zx_time_t result = 0;
-  zx_clock_get(clock_id, &result);
-  return result;
-}
-
 // clang-format: off
 
 #define FOR_EACH_STATIC_BINDING(V) \
@@ -488,8 +482,7 @@ uint64_t System::ClockGet(uint32_t clock_id) {
   V(System, VmoRead)               \
   V(System, VmoWrite)              \
   V(System, VmoMap)                \
-  V(System, ClockGetMonotonic)     \
-  V(System, ClockGet)
+  V(System, ClockGetMonotonic)
 
 // clang-format: on
 

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
@@ -63,8 +63,6 @@ class System : public fml::RefCountedThreadSafe<System>,
 
   static uint64_t ClockGetMonotonic();
 
-  static uint64_t ClockGet(uint32_t clock_id);
-
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
   static zx_status_t ConnectToService(std::string path,


### PR DESCRIPTION
All existing usages of zx_clock_get were moved to zx_clock_get_monotonic
in February so I believe its now safe to just skip to the last step and
delete the original call rather than keeping it around throwing an
exception (happy to head down the deprecated+exception route if
reviewers prefer though).

Bug: flutter/flutter#72321

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
