### PR TITLE
Ensure stdout and stderr from failed test runs are reported from `run_tests.py`.

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -46,7 +46,18 @@ def RunCmd(cmd, forbidden_output=[], **kwargs):
 
   if process.returncode != 0:
     PrintDivider('!')
-    raise Exception('Command "%s" exited with code %d' % (command_string, process.returncode))
+
+    print('Failed Command:\n\n%s\n\nExit Code: %d\n' % (command_string, process.returncode))
+
+    if stdout:
+      print('STDOUT: \n%s' % stdout)
+
+    if stderr:
+      print('STDERR: \n%s' % stderr)
+
+    PrintDivider('!')
+
+    raise Exception('Command "%s" exited with code %d.' % (command_string, process.returncode))
 
   if stdout or stderr:
     print(stdout)


### PR DESCRIPTION
We print stdout and stderr only from successful test or benchmark runs. Because
of the raised exception, a non-zero exit code would gobble up output from these
runs. This is actually the situation where this information would be most
useful. Print all the information we have before raising the exception.