### PR TITLE
Remove override; method no longer called

### DIFF
--- a/third_party/txt/src/txt/asset_font_manager.cc
+++ b/third_party/txt/src/txt/asset_font_manager.cc
@@ -70,12 +70,6 @@ SkTypeface* AssetFontManager::onMatchFamilyStyleCharacter(
   return nullptr;
 }
 
-SkTypeface* AssetFontManager::onMatchFaceStyle(const SkTypeface*,
-                                               const SkFontStyle&) const {
-  FML_DCHECK(false);
-  return nullptr;
-}
-
 sk_sp<SkTypeface> AssetFontManager::onMakeFromData(sk_sp<SkData>,
                                                    int ttcIndex) const {
   FML_DCHECK(false);

--- a/third_party/txt/src/txt/asset_font_manager.h
+++ b/third_party/txt/src/txt/asset_font_manager.h
@@ -61,10 +61,6 @@ class AssetFontManager : public SkFontMgr {
                                           SkUnichar character) const override;
 
   // |SkFontMgr|
-  SkTypeface* onMatchFaceStyle(const SkTypeface*,
-                               const SkFontStyle&) const override;
-
-  // |SkFontMgr|
   sk_sp<SkTypeface> onMakeFromData(sk_sp<SkData>, int ttcIndex) const override;
 
   // |SkFontMgr|


### PR DESCRIPTION
SkFontMgr baseclass no longer calls this virtual, so remove our override of it.
