### PR TITLE
[tools/gn] Add mac as target_os and mac_cpu

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -39,6 +39,9 @@ def get_out_dir(args):
     if args.ios_cpu != 'arm64':
         target_dir.append(args.ios_cpu)
 
+    if args.mac_cpu != 'x64':
+      target_dir.append(args.mac_cpu)
+
     if args.simulator_cpu != 'x64':
         target_dir.append(args.simulator_cpu)
 
@@ -183,6 +186,8 @@ def to_gn_args(args):
             gn_args['target_cpu'] = args.simulator_cpu
         else:
             gn_args['target_cpu'] = args.ios_cpu
+    elif args.target_os == 'mac':
+      gn_args['target_cpu'] = args.mac_cpu
     elif args.target_os == 'linux':
       gn_args['target_cpu'] = args.linux_cpu
     elif args.target_os == 'fuchsia':
@@ -350,11 +355,13 @@ def parse_args(args):
   parser.add_argument('--full-dart-debug', default=False, action='store_true', help='Implies --dart-debug ' +
       'and also disables optimizations in the Dart VM making it easier to step through VM code in the debugger.')
 
-  parser.add_argument('--target-os', type=str, choices=['android', 'ios', 'linux', 'fuchsia', 'win', 'winuwp'])
+  parser.add_argument('--target-os', type=str, choices=['android', 'ios', 'mac', 'linux', 'fuchsia', 'win', 'winuwp'])
   parser.add_argument('--android', dest='target_os', action='store_const', const='android')
   parser.add_argument('--android-cpu', type=str, choices=['arm', 'x64', 'x86', 'arm64'], default='arm')
   parser.add_argument('--ios', dest='target_os', action='store_const', const='ios')
   parser.add_argument('--ios-cpu', type=str, choices=['arm', 'arm64'], default='arm64')
+  parser.add_argument('--mac', dest='target_os', action='store_const', const='mac')
+  parser.add_argument('--mac-cpu', type=str, choices=['x64', 'arm64'], default='x64')
   parser.add_argument('--simulator', action='store_true', default=False)
   parser.add_argument('--linux', dest='target_os', action='store_const', const='linux')
   parser.add_argument('--fuchsia', dest='target_os', action='store_const', const='fuchsia')


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/69221

This allows creating build folders for macOS cross compilation.

`gn --mac` will create `mac_*` folder for x64 builds
`gn --mac --mac-cpu=arm64` will create `mac_*_arm64` folder for arm64 builds

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
