### PR TITLE
web: improve engine dev cycle on Windows

### DIFF
--- a/lib/web_ui/dev/felt.bat
+++ b/lib/web_ui/dev/felt.bat
@@ -5,6 +5,13 @@
 @ECHO OFF
 SETLOCAL
 
+:: Make sure gclient and ninja exist. Otherwise felt won't work.
+FOR /F "tokens=1-2 delims=:" %%a in ('where gclient') DO SET GCLIENT_PATH=%%b
+IF %GCLIENT_PATH%==[] (ECHO "ERROR: gclient is not in your PATH")
+
+FOR /F "tokens=1-2 delims=:" %%a in ('where ninja') DO SET NINJA_PATH=%%b
+IF %NINJA_PATH%==[] (ECHO "ERROR: ninja is not in your PATH")
+
 :: Starting from this script's path, walk up to engine source directory.
 SET SCRIPT_DIR=%~dp0
 FOR %%a IN ("%SCRIPT_DIR:~0,-1%") DO SET TMP=%%~dpa
@@ -25,9 +32,26 @@ SET FELT_PATH=%DEV_DIR%\felt.dart
 SET DART_TOOL_DIR=%WEB_UI_DIR%\.dart_tool
 SET SNAPSHOT_PATH=%DART_TOOL_DIR%\felt.snapshot
 
-:: Set revision from using git in Flutter directory.
-CD %FLUTTER_DIR%
-FOR /F "tokens=1 delims=:" %%a in ('git rev-parse HEAD') DO SET REVISION=%%a
+SET needsHostDebugUnoptRebuild=0
+for %%x in (%*) do (
+  if ["%%~x"]==["--clean"] (
+    ECHO Clean rebuild requested
+    SET needsHostDebugUnoptRebuild=1
+  )
+)
+
+IF NOT EXIST %OUT_DIR% (SET needsHostDebugUnoptRebuild=1)
+IF NOT EXIST %HOST_DEBUG_UNOPT_DIR% (SET needsHostDebugUnoptRebuild=1)
+
+IF %needsHostDebugUnoptRebuild%==1 (
+  ECHO Building host_debug_unopt
+  :: Delete old snapshot, if any, because the new Dart SDK may invalidate it.
+  IF EXIST "%SNAPSHOT_PATH%" (
+    del %SNAPSHOT_PATH%
+  )
+  CALL gclient sync -D
+  CALL python %GN% --unoptimized --full-dart-sdk
+  CALL ninja -C %HOST_DEBUG_UNOPT_DIR%)
 
 cd %WEB_UI_DIR%
 IF NOT EXIST "%SNAPSHOT_PATH%" (

--- a/lib/web_ui/dev/felt.bat
+++ b/lib/web_ui/dev/felt.bat
@@ -1,0 +1,45 @@
+:: felt: a command-line utility for Windows for building and testing
+:: Flutter web engine.
+:: FELT stands for Flutter Engine Local Tester.
+
+@ECHO OFF
+SETLOCAL
+
+:: Starting from this script's path, walk up to engine source directory.
+SET SCRIPT_DIR=%~dp0
+FOR %%a IN ("%SCRIPT_DIR:~0,-1%") DO SET TMP=%%~dpa
+FOR %%a IN ("%TMP:~0,-1%") DO SET TMP=%%~dpa
+FOR %%a IN ("%TMP:~0,-1%") DO SET TMP=%%~dpa
+FOR %%a IN ("%TMP:~0,-1%") DO SET ENGINE_SRC_DIR=%%~dpa
+
+SET ENGINE_SRC_DIR=%ENGINE_SRC_DIR:~0,-1%
+SET OUT_DIR=%ENGINE_SRC_DIR%\out
+SET HOST_DEBUG_UNOPT_DIR=%OUT_DIR%\host_debug_unopt
+SET DART_SDK_DIR=%HOST_DEBUG_UNOPT_DIR%\dart-sdk
+SET DART_BIN=%DART_SDK_DIR%\bin\dart
+SET PUB_BIN=%DART_SDK_DIR%\bin\pub
+SET FLUTTER_DIR=%ENGINE_SRC_DIR%\flutter
+SET WEB_UI_DIR=%FLUTTER_DIR%\lib\web_ui
+SET DEV_DIR=%WEB_UI_DIR%\dev
+SET FELT_PATH=%DEV_DIR%\felt.dart
+SET DART_TOOL_DIR=%WEB_UI_DIR%\.dart_tool
+SET SNAPSHOT_PATH=%DART_TOOL_DIR%\felt.snapshot
+
+:: Set revision from using git in Flutter directory.
+CD %FLUTTER_DIR%
+FOR /F "tokens=1 delims=:" %%a in ('git rev-parse HEAD') DO SET REVISION=%%a
+
+cd %WEB_UI_DIR%
+IF NOT EXIST "%SNAPSHOT_PATH%" (
+  ECHO Precompiling felt snapshot
+  CALL %PUB_BIN% get
+  %DART_BIN% --snapshot="%SNAPSHOT_PATH%" --packages="%WEB_UI_DIR%\.packages" %FELT_PATH%
+)
+
+IF %1==test (
+  %DART_SDK_DIR%\bin\dart --packages="%WEB_UI_DIR%\.packages" "%SNAPSHOT_PATH%" %* --browser=chrome
+) ELSE (
+  %DART_SDK_DIR%\bin\dart --packages="%WEB_UI_DIR%\.packages" "%SNAPSHOT_PATH%" %*
+)
+
+EXIT /B %ERRORLEVEL%

--- a/lib/web_ui/dev/felt.dart
+++ b/lib/web_ui/dev/felt.dart
@@ -25,7 +25,10 @@ CommandRunner runner = CommandRunner<bool>(
   ..addCommand(TestCommand())
   ..addCommand(BuildCommand());
 
-void main(List<String> args) async {
+void main(List<String> rawArgs) async {
+  // Remove --clean from the list as that's processed by the wrapper script.
+  final List<String> args = rawArgs.where((arg) => arg != '--clean').toList();
+
   if (args.isEmpty) {
     // The felt tool was invoked with no arguments. Print usage.
     runner.printUsage();

--- a/lib/web_ui/dev/felt_windows.bat
+++ b/lib/web_ui/dev/felt_windows.bat
@@ -1,3 +1,4 @@
+:: TODO(yjbanov): migrate LUCI to felt.bat and delete this file.
 :: felt_windows: a command-line utility for Windows for building and testing
 :: Flutter web engine.
 :: FELT stands for Flutter Engine Local Tester.

--- a/lib/web_ui/dev/felt_windows.bat
+++ b/lib/web_ui/dev/felt_windows.bat
@@ -38,13 +38,6 @@ SET SNAPSHOT_PATH="%DART_TOOL_DIR%felt.snapshot"
 CD %FLUTTER_DIR%
 FOR /F "tokens=1 delims=:" %%a in ('git rev-parse HEAD') DO SET REVISION=%%a
 
-:: Uncomment for debugging the values.
-:: ECHO "FELT_DIR:%FELT_DIR%"
-:: ECHO "WEB_UI_DIR:%WEB_UI_DIR%"
-:: ECHO "FLUTTER_DIR:%FLUTTER_DIR%"
-:: ECHO "ENGINE_SRC_DIR:%ENGINE_SRC_DIR%"
-:: ECHO "REVISION:%REVISION%"
-
 SET orTempValue=1
 IF NOT EXIST %OUT_DIR% (SET orTempValue=0)
 IF NOT EXIST %HOST_DEBUG_UNOPT_DIR% (SET orTempValue=0)

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -294,13 +294,6 @@ class TestCommand extends Command<bool> with ArgUtils {
   Future<bool> runUnitTests() async {
     _copyTestFontsIntoWebUi();
     await _buildHostPage();
-    if (io.Platform.isWindows) {
-      // On Dart 2.7 or greater, it gives an error for not
-      // recognized "pub" version and asks for "pub" get.
-      // See: https://github.com/dart-lang/sdk/issues/39738
-      await _runPubGet();
-    }
-
     await _prepare();
     await _buildTargets();
 
@@ -636,21 +629,6 @@ class TestCommand extends Command<bool> with ArgUtils {
     }
   }
 
-  Future<void> _runPubGet() async {
-    final int exitCode = await runProcess(
-      environment.pubExecutable,
-      <String>[
-        'get',
-      ],
-      workingDirectory: environment.webUiRootDir.path,
-    );
-
-    if (exitCode != 0) {
-      throw ToolException(
-          'Failed to run pub get. Exited with exit code $exitCode');
-    }
-  }
-
   Future<void> _buildHostPage() async {
     final String hostDartPath = path.join('lib', 'static', 'host.dart');
     final io.File hostDartFile = io.File(path.join(
@@ -758,7 +736,7 @@ class TestCommand extends Command<bool> with ArgUtils {
       '-DFLUTTER_WEB_AUTO_DETECT=false',
       '-DFLUTTER_WEB_USE_SKIA=${input.forCanvasKit}',
 
-      '-O2',
+      '-O0',
       '-o',
       targetFileName, // target path.
       '${input.path.relativeToWebUi}', // current path.

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -736,7 +736,7 @@ class TestCommand extends Command<bool> with ArgUtils {
       '-DFLUTTER_WEB_AUTO_DETECT=false',
       '-DFLUTTER_WEB_USE_SKIA=${input.forCanvasKit}',
 
-      '-O0',
+      '-O2',
       '-o',
       targetFileName, // target path.
       '${input.path.relativeToWebUi}', // current path.


### PR DESCRIPTION
- Add `felt.bat` that snapshots `felt.dart` (removes ~10 seconds per command invocation)
- Remove no longer necessary extra `pub get` in the test runner (removes ~5 seconds per `felt test` invocation)
- Build tests with `-O0` for less aggressive inlining (improves stack traces)
