### PR TITLE
add flag to identify sub-trees with PlatformViewLayers and always paint them

### DIFF
--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -112,6 +112,8 @@ if (enable_unittests) {
       "testing/gl_context_switch_test.cc",
       "testing/gl_context_switch_test.h",
       "testing/layer_test.h",
+      "testing/mock_embedder.cc",
+      "testing/mock_embedder.h",
       "testing/mock_layer.cc",
       "testing/mock_layer.h",
       "testing/mock_raster_cache.cc",

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -161,6 +161,7 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
 
   context->has_platform_view = child_has_platform_view;
   context->has_texture_layer = child_has_texture_layer;
+  set_subtree_has_platform_view(child_has_platform_view);
 
 #if defined(LEGACY_FUCHSIA_EMBEDDER)
   if (child_layer_exists_below_) {

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -13,7 +13,8 @@ Layer::Layer()
     : paint_bounds_(SkRect::MakeEmpty()),
       unique_id_(NextUniqueID()),
       original_layer_id_(unique_id_),
-      needs_system_composite_(false) {}
+      needs_system_composite_(false),
+      subtree_has_platform_view_(false) {}
 
 Layer::~Layer() = default;
 

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -27,6 +27,7 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
     return;
   }
   context->has_platform_view = true;
+  set_subtree_has_platform_view(true);
   std::unique_ptr<EmbeddedViewParams> params =
       std::make_unique<EmbeddedViewParams>(matrix, size_,
                                            context->mutators_stack);

--- a/flow/layers/platform_view_layer_unittests.cc
+++ b/flow/layers/platform_view_layer_unittests.cc
@@ -56,7 +56,7 @@ TEST_F(PlatformViewLayerTest, ClippedPlatformViewPrerollsAndPaintsNothing) {
   parent_clip_layer->Add(child_clip_layer);
   child_clip_layer->Add(layer);
 
-  auto embedder = MockViewEmbedder(&mock_canvas());
+  auto embedder = MockViewEmbedder();
   preroll_context()->view_embedder = &embedder;
 
   parent_clip_layer->Preroll(preroll_context(), SkMatrix());

--- a/flow/layers/platform_view_layer_unittests.cc
+++ b/flow/layers/platform_view_layer_unittests.cc
@@ -2,9 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/flow/layers/clip_rect_layer.h"
 #include "flutter/flow/layers/platform_view_layer.h"
 
 #include "flutter/flow/testing/layer_test.h"
+#include "flutter/flow/testing/mock_embedder.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/fml/macros.h"
 #include "flutter/testing/mock_canvas.h"
@@ -32,10 +34,63 @@ TEST_F(PlatformViewLayerTest, NullViewEmbedderDoesntPrerollCompositeOrPaint) {
 #else
   EXPECT_FALSE(layer->needs_system_composite());
 #endif  // LEGACY_FUCHSIA_EMBEDDER
+  EXPECT_FALSE(layer->subtree_has_platform_view());
 
   layer->Paint(paint_context());
   EXPECT_EQ(paint_context().leaf_nodes_canvas, &mock_canvas());
   EXPECT_EQ(mock_canvas().draw_calls(), std::vector<MockCanvas::DrawCall>());
+}
+
+TEST_F(PlatformViewLayerTest, ClippedPlatformViewPrerollsAndPaintsNothing) {
+  const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
+  const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
+  const SkRect child_clip = SkRect::MakeLTRB(20.0f, 20.0f, 40.0f, 40.0f);
+  const SkRect parent_clip = SkRect::MakeLTRB(50.0f, 50.0f, 80.0f, 80.0f);
+  const int64_t view_id = 0;
+  auto layer =
+      std::make_shared<PlatformViewLayer>(layer_offset, layer_size, view_id);
+  auto child_clip_layer =
+      std::make_shared<ClipRectLayer>(child_clip, Clip::hardEdge);
+  auto parent_clip_layer =
+      std::make_shared<ClipRectLayer>(parent_clip, Clip::hardEdge);
+  parent_clip_layer->Add(child_clip_layer);
+  child_clip_layer->Add(layer);
+
+  auto embedder = MockViewEmbedder(&mock_canvas());
+  preroll_context()->view_embedder = &embedder;
+
+  parent_clip_layer->Preroll(preroll_context(), SkMatrix());
+  EXPECT_TRUE(preroll_context()->has_platform_view);
+  EXPECT_EQ(layer->paint_bounds(),
+            SkRect::MakeSize(layer_size)
+                .makeOffset(layer_offset.fX, layer_offset.fY));
+  EXPECT_TRUE(layer->needs_painting(paint_context()));
+  EXPECT_TRUE(child_clip_layer->needs_painting(paint_context()));
+  EXPECT_TRUE(parent_clip_layer->needs_painting(paint_context()));
+#if defined(LEGACY_FUCHSIA_EMBEDDER)
+  EXPECT_TRUE(layer->needs_system_composite());
+#else
+  EXPECT_FALSE(layer->needs_system_composite());
+#endif  // LEGACY_FUCHSIA_EMBEDDER
+  EXPECT_TRUE(layer->subtree_has_platform_view());
+  EXPECT_TRUE(child_clip_layer->subtree_has_platform_view());
+  EXPECT_TRUE(parent_clip_layer->subtree_has_platform_view());
+
+  parent_clip_layer->Paint(paint_context());
+  EXPECT_EQ(paint_context().leaf_nodes_canvas, &mock_canvas());
+  EXPECT_EQ(
+      mock_canvas().draw_calls(),
+      std::vector(
+          {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
+           MockCanvas::DrawCall{
+               1, MockCanvas::ClipRectData{parent_clip, SkClipOp::kIntersect,
+                                           MockCanvas::kHard_ClipEdgeStyle}},
+           MockCanvas::DrawCall{1, MockCanvas::SaveData{2}},
+           MockCanvas::DrawCall{
+               2, MockCanvas::ClipRectData{child_clip, SkClipOp::kIntersect,
+                                           MockCanvas::kHard_ClipEdgeStyle}},
+           MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
+           MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 }  // namespace testing

--- a/flow/testing/mock_embedder.cc
+++ b/flow/testing/mock_embedder.cc
@@ -20,13 +20,11 @@ void MockViewEmbedder::BeginFrame(
     SkISize frame_size,
     GrDirectContext* context,
     double device_pixel_ratio,
-    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
-}
+    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {}
 
 void MockViewEmbedder::PrerollCompositeEmbeddedView(
     int view_id,
-    std::unique_ptr<EmbeddedViewParams> params) {
-}
+    std::unique_ptr<EmbeddedViewParams> params) {}
 
 std::vector<SkCanvas*> MockViewEmbedder::GetCurrentCanvases() {
   return std::vector<SkCanvas*>({root_canvas_});

--- a/flow/testing/mock_embedder.cc
+++ b/flow/testing/mock_embedder.cc
@@ -7,31 +7,38 @@
 namespace flutter {
 namespace testing {
 
-MockViewEmbedder::MockViewEmbedder(SkCanvas* root_canvas)
-    : root_canvas_(root_canvas) {}
+MockViewEmbedder::MockViewEmbedder() = default;
 
+MockViewEmbedder::~MockViewEmbedder() = default;
+
+// |ExternalViewEmbedder|
 SkCanvas* MockViewEmbedder::GetRootCanvas() {
-  return root_canvas_;
+  return nullptr;
 }
 
+// |ExternalViewEmbedder|
 void MockViewEmbedder::CancelFrame() {}
 
+// |ExternalViewEmbedder|
 void MockViewEmbedder::BeginFrame(
     SkISize frame_size,
     GrDirectContext* context,
     double device_pixel_ratio,
     fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {}
 
+// |ExternalViewEmbedder|
 void MockViewEmbedder::PrerollCompositeEmbeddedView(
     int view_id,
     std::unique_ptr<EmbeddedViewParams> params) {}
 
+// |ExternalViewEmbedder|
 std::vector<SkCanvas*> MockViewEmbedder::GetCurrentCanvases() {
-  return std::vector<SkCanvas*>({root_canvas_});
+  return std::vector<SkCanvas*>({});
 }
 
+// |ExternalViewEmbedder|
 SkCanvas* MockViewEmbedder::CompositeEmbeddedView(int view_id) {
-  return root_canvas_;
+  return nullptr;
 }
 
 }  // namespace testing

--- a/flow/testing/mock_embedder.cc
+++ b/flow/testing/mock_embedder.cc
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/testing/mock_embedder.h"
+
+namespace flutter {
+namespace testing {
+
+MockViewEmbedder::MockViewEmbedder(SkCanvas* root_canvas)
+    : root_canvas_(root_canvas) {}
+
+SkCanvas* MockViewEmbedder::GetRootCanvas() {
+  return root_canvas_;
+}
+
+void MockViewEmbedder::CancelFrame() {}
+
+void MockViewEmbedder::BeginFrame(
+    SkISize frame_size,
+    GrDirectContext* context,
+    double device_pixel_ratio,
+    fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
+}
+
+void MockViewEmbedder::PrerollCompositeEmbeddedView(
+    int view_id,
+    std::unique_ptr<EmbeddedViewParams> params) {
+}
+
+std::vector<SkCanvas*> MockViewEmbedder::GetCurrentCanvases() {
+  return std::vector<SkCanvas*>({root_canvas_});
+}
+
+SkCanvas* MockViewEmbedder::CompositeEmbeddedView(int view_id) {
+  return root_canvas_;
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/flow/testing/mock_embedder.h
+++ b/flow/testing/mock_embedder.h
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLOW_TESTING_MOCK_EMBEDDER_H_
+#define FLOW_TESTING_MOCK_EMBEDDER_H_
+
+#include "flutter/flow/embedded_views.h"
+
+namespace flutter {
+namespace testing {
+
+class MockViewEmbedder : public ExternalViewEmbedder {
+ public:
+  MockViewEmbedder(SkCanvas* root_canvas);
+
+  ~MockViewEmbedder() = default;
+
+  SkCanvas* GetRootCanvas() override;
+
+  void CancelFrame() override;
+
+  void BeginFrame(
+      SkISize frame_size,
+      GrDirectContext* context,
+      double device_pixel_ratio,
+      fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
+
+  void PrerollCompositeEmbeddedView(
+      int view_id,
+      std::unique_ptr<EmbeddedViewParams> params) override;
+
+  std::vector<SkCanvas*> GetCurrentCanvases() override;
+
+  SkCanvas* CompositeEmbeddedView(int view_id) override;
+
+ private:
+  SkCanvas* root_canvas_;
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLOW_TESTING_MOCK_EMBEDDER_H_

--- a/flow/testing/mock_embedder.h
+++ b/flow/testing/mock_embedder.h
@@ -12,30 +12,33 @@ namespace testing {
 
 class MockViewEmbedder : public ExternalViewEmbedder {
  public:
-  MockViewEmbedder(SkCanvas* root_canvas);
+  MockViewEmbedder();
 
-  ~MockViewEmbedder() = default;
+  ~MockViewEmbedder();
 
+  // |ExternalViewEmbedder|
   SkCanvas* GetRootCanvas() override;
 
+  // |ExternalViewEmbedder|
   void CancelFrame() override;
 
+  // |ExternalViewEmbedder|
   void BeginFrame(
       SkISize frame_size,
       GrDirectContext* context,
       double device_pixel_ratio,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override;
 
+  // |ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(
       int view_id,
       std::unique_ptr<EmbeddedViewParams> params) override;
 
+  // |ExternalViewEmbedder|
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
+  // |ExternalViewEmbedder|
   SkCanvas* CompositeEmbeddedView(int view_id) override;
-
- private:
-  SkCanvas* root_canvas_;
 };
 
 }  // namespace testing


### PR DESCRIPTION
This is a more targeted workaround for https://github.com/flutter/flutter/issues/76097

The only down-sides to this workaround is that we will always paint down to a PlatformViewLayer even if it is not visible on the screen. This should have very little impact on performance as the rendering should not result in any work done (in particular, we won't paint leaf nodes like PictureLayer in these subtrees, only the intervening containers and the PVL itself).

This fix is only needed for the iOS embedder, but it will take effect on all platforms as the impact should be negligible. I've filed an issue against the iOS embedder to try to fix the underlying problem there. See https://github.com/flutter/flutter/issues/81419