### PR TITLE
Fix crash when both FlutterFragmentActivity and FlutterFragment are destroyed and recreated

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -391,6 +391,12 @@ public class FlutterFragmentActivity extends FragmentActivity
    */
   private void ensureFlutterFragmentCreated() {
     if (flutterFragment == null) {
+      // If both activity and fragment have been destroyed, the activity restore may have
+      // already recreated a new instance of the fragment again via the FragmentActivity.onCreate
+      // and the FragmentManager.
+      flutterFragment = retrieveExistingFlutterFragmentIfPossible();
+    }
+    if (flutterFragment == null) {
       // No FlutterFragment exists yet. This must be the initial Activity creation. We will create
       // and add a new FlutterFragment to this Activity.
       flutterFragment = createFlutterFragment();
@@ -602,7 +608,7 @@ public class FlutterFragmentActivity extends FragmentActivity
    */
   @Override
   public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-    if (flutterFragment.isFlutterEngineInjected()) {
+    if (flutterFragment != null && flutterFragment.isFlutterEngineInjected()) {
       // If the FlutterEngine was explicitly built and injected into this FlutterActivity, the
       // builder should explicitly decide whether to automatically register plugins via the
       // FlutterEngine's construction parameter or via the AndroidManifest metadata.

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentActivityTest.java
@@ -199,6 +199,26 @@ public class FlutterFragmentActivityTest {
     assertEquals(0, activity.numberOfEnginesCreated);
   }
 
+  @Test
+  public void itHandlesNewFragmentRecreationDuringRestoreWhenActivityIsRecreated() {
+    FlutterFragmentActivityWithProvidedEngine activity =
+        spy(Robolectric.buildActivity(FlutterFragmentActivityWithProvidedEngine.class).get());
+
+    FlutterFragment fragment = mock(FlutterFragment.class);
+    // Similar to the above case, except here, it's not just the activity that was destroyed and
+    // could have its fragment restored in the fragment manager. Here, both activity and fragment
+    // are destroyed. And the fragment manager recreated the fragment on activity recreate.
+    when(activity.retrieveExistingFlutterFragmentIfPossible()).thenReturn(null, fragment);
+
+    FlutterEngine engine = mock(FlutterEngine.class);
+    when(fragment.getFlutterEngine()).thenReturn(engine);
+
+    activity.onCreate(null);
+    // The framework would have recreated a new fragment but the fragment activity wouldn't have
+    // created a new one again.
+    assertEquals(0, activity.numberOfEnginesCreated);
+  }
+
   static class FlutterFragmentActivityWithProvidedEngine extends FlutterFragmentActivity {
     int numberOfEnginesCreated = 0;
 


### PR DESCRIPTION
An awkward variation on #25770. When both the FlutterFragmentActivity and the FlutterFragment are destroyed in the background, the FlutterFragmentActivity's super may recreate the FlutterFragment before the FlutterFragmentActivity creates one. In case FlutterFragment gets reattached first, handle configuring its engine (which gets plugins registered since it's a newly created engine). 

b/186389192