### PR TITLE
fuchsia: Fix bad syntax in viewStateConnected msg

### DIFF
--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -487,9 +487,9 @@ bool PlatformView::OnChildViewStateChanged(scenic::ResourceId view_holder_id,
   out << "{"
       << "\"method\":\"View.viewStateChanged\","
       << "\"args\":{"
-      << "  \"viewId\":" << view_id_mapping->second  // ViewHolderToken handle
-      << "  \"is_rendering\":" << is_rendering       // IsViewRendering
-      << "  \"state\":" << is_rendering              // IsViewRendering
+      << "  \"viewId\":" << view_id_mapping->second << ","  // ViewHolderToken
+      << "  \"is_rendering\":" << is_rendering << ","       // IsViewRendering
+      << "  \"state\":" << is_rendering                     // IsViewRendering
       << "  }"
       << "}";
   auto call = out.str();

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -876,9 +876,9 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
       << "{"
       << "\"method\":\"View.viewStateChanged\","
       << "\"args\":{"
-      << "  \"viewId\":" << kViewId     // ViewHolderToken handle
-      << "  \"is_rendering\":" << true  // IsViewRendering
-      << "  \"state\":" << true         // IsViewRendering
+      << "  \"viewId\":" << kViewId << ","     // ViewHolderToken
+      << "  \"is_rendering\":" << true << ","  // IsViewRendering
+      << "  \"state\":" << true                // IsViewRendering
       << "  }"
       << "}";
   EXPECT_EQ(view_state_changed_expected_out.str(),


### PR DESCRIPTION
The platform message for viewStateChanged has a JSON syntax error, introduced in https://github.com/flutter/engine/pull/25343. 
The dart code therefore can't parse this message and just reports an error.  This causes a lot of annoying logspam and means the viewStateChanged event doesn't work properly.

Follow-on fix for: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=71337