### PR TITLE
Fixes BUILD.gn if is_fuchsia (legacy embedder) and is_debug

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -21,16 +21,18 @@ config("config") {
     }
   }
 
+  defines = []
+
   # This define is transitional and will be removed after the embedder API
   # transition is complete.
   #
   # TODO(bugs.fuchsia.dev/54041): Remove when no longer necessary.
   if (is_fuchsia && flutter_enable_legacy_fuchsia_embedder) {
-    defines = [ "LEGACY_FUCHSIA_EMBEDDER" ]
+    defines += [ "LEGACY_FUCHSIA_EMBEDDER" ]
   }
 
   if (is_debug) {
-    defines = [ "FLUTTER_ENABLE_DIFF_CONTEXT" ]
+    defines += [ "FLUTTER_ENABLE_DIFF_CONTEXT" ]
   }
 }
 


### PR DESCRIPTION
Current recommended build methods may not trigger this issue, but
while trying different options, building flutter for the first time, I
noticed a build error because `defines` was assigned twice.

If building with both options is ever supported, I think this
fixes the error.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
