### PR TITLE
Moved PlatformMessage's to unique_ptrs

### DIFF
--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -124,12 +124,12 @@ Dart_Handle SendPlatformMessage(Dart_Handle window,
   }
   if (Dart_IsNull(data_handle)) {
     dart_state->platform_configuration()->client()->HandlePlatformMessage(
-        fml::MakeRefCounted<PlatformMessage>(name, response));
+        std::make_unique<PlatformMessage>(name, response));
   } else {
     tonic::DartByteData data(data_handle);
     const uint8_t* buffer = static_cast<const uint8_t*>(data.data());
     dart_state->platform_configuration()->client()->HandlePlatformMessage(
-        fml::MakeRefCounted<PlatformMessage>(
+        std::make_unique<PlatformMessage>(
             name, std::vector<uint8_t>(buffer, buffer + data.length_in_bytes()),
             response));
   }
@@ -305,7 +305,7 @@ void PlatformConfiguration::UpdateAccessibilityFeatures(int32_t values) {
 }
 
 void PlatformConfiguration::DispatchPlatformMessage(
-    fml::RefPtr<PlatformMessage> message) {
+    std::unique_ptr<PlatformMessage> message) {
   std::shared_ptr<tonic::DartState> dart_state =
       dispatch_platform_message_.dart_state().lock();
   if (!dart_state) {

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -87,7 +87,8 @@ class PlatformConfigurationClient {
   /// @param[in]  message  The message from the Flutter application to send to
   ///                      the underlying platform.
   ///
-  virtual void HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) = 0;
+  virtual void HandlePlatformMessage(
+      std::unique_ptr<PlatformMessage> message) = 0;
 
   //--------------------------------------------------------------------------
   /// @brief      Returns the current collection of fonts available on the
@@ -309,7 +310,7 @@ class PlatformConfiguration final {
   /// @param[in]  message  The message sent from the embedder to the Dart
   ///                      application.
   ///
-  void DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message);
+  void DispatchPlatformMessage(std::unique_ptr<PlatformMessage> message);
 
   //----------------------------------------------------------------------------
   /// @brief      Notifies the framework that the embedder encountered an

--- a/lib/ui/window/platform_configuration_unittests.cc
+++ b/lib/ui/window/platform_configuration_unittests.cc
@@ -29,7 +29,8 @@ class DummyPlatformConfigurationClient : public PlatformConfigurationClient {
   void ScheduleFrame() override {}
   void Render(Scene* scene) override {}
   void UpdateSemantics(SemanticsUpdate* update) override {}
-  void HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) override {}
+  void HandlePlatformMessage(
+      std::unique_ptr<PlatformMessage> message) override {}
   FontCollection& GetFontCollection() override { return font_collection_; }
   void UpdateIsolateDescription(const std::string isolate_name,
                                 int64_t isolate_port) override {}

--- a/lib/ui/window/platform_message.h
+++ b/lib/ui/window/platform_message.h
@@ -14,7 +14,7 @@
 
 namespace flutter {
 
-class PlatformMessage : public fml::RefCountedThreadSafe<PlatformMessage> {
+class PlatformMessage {
  public:
   PlatformMessage(std::string channel,
                   std::vector<uint8_t> data,

--- a/lib/ui/window/platform_message.h
+++ b/lib/ui/window/platform_message.h
@@ -15,10 +15,14 @@
 namespace flutter {
 
 class PlatformMessage : public fml::RefCountedThreadSafe<PlatformMessage> {
-  FML_FRIEND_REF_COUNTED_THREAD_SAFE(PlatformMessage);
-  FML_FRIEND_MAKE_REF_COUNTED(PlatformMessage);
-
  public:
+  PlatformMessage(std::string channel,
+                  std::vector<uint8_t> data,
+                  fml::RefPtr<PlatformMessageResponse> response);
+  PlatformMessage(std::string channel,
+                  fml::RefPtr<PlatformMessageResponse> response);
+  ~PlatformMessage();
+
   const std::string& channel() const { return channel_; }
   const std::vector<uint8_t>& data() const { return data_; }
   bool hasData() { return hasData_; }
@@ -28,13 +32,6 @@ class PlatformMessage : public fml::RefCountedThreadSafe<PlatformMessage> {
   }
 
  private:
-  PlatformMessage(std::string channel,
-                  std::vector<uint8_t> data,
-                  fml::RefPtr<PlatformMessageResponse> response);
-  PlatformMessage(std::string channel,
-                  fml::RefPtr<PlatformMessageResponse> response);
-  ~PlatformMessage();
-
   std::string channel_;
   std::vector<uint8_t> data_;
   bool hasData_;

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -239,7 +239,7 @@ bool RuntimeController::NotifyIdle(int64_t deadline, size_t freed_hint) {
 }
 
 bool RuntimeController::DispatchPlatformMessage(
-    fml::RefPtr<PlatformMessage> message) {
+    std::unique_ptr<PlatformMessage> message) {
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {
     TRACE_EVENT1("flutter", "RuntimeController::DispatchPlatformMessage",
                  "mode", "basic");
@@ -320,7 +320,7 @@ void RuntimeController::UpdateSemantics(SemanticsUpdate* update) {
 
 // |PlatformConfigurationClient|
 void RuntimeController::HandlePlatformMessage(
-    fml::RefPtr<PlatformMessage> message) {
+    std::unique_ptr<PlatformMessage> message) {
   client_.HandlePlatformMessage(std::move(message));
 }
 

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -411,7 +411,8 @@ class RuntimeController : public PlatformConfigurationClient {
   /// @return     If the message was dispatched to the running root isolate.
   ///             This may fail is an isolate is not running.
   ///
-  virtual bool DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message);
+  virtual bool DispatchPlatformMessage(
+      std::unique_ptr<PlatformMessage> message);
 
   //----------------------------------------------------------------------------
   /// @brief      Dispatch the specified pointer data message to the running
@@ -655,7 +656,7 @@ class RuntimeController : public PlatformConfigurationClient {
   void UpdateSemantics(SemanticsUpdate* update) override;
 
   // |PlatformConfigurationClient|
-  void HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) override;
+  void HandlePlatformMessage(std::unique_ptr<PlatformMessage> message) override;
 
   // |PlatformConfigurationClient|
   FontCollection& GetFontCollection() override;

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -28,7 +28,8 @@ class RuntimeDelegate {
   virtual void UpdateSemantics(SemanticsNodeUpdates update,
                                CustomAccessibilityActionUpdates actions) = 0;
 
-  virtual void HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) = 0;
+  virtual void HandlePlatformMessage(
+      std::unique_ptr<PlatformMessage> message) = 0;
 
   virtual FontCollection& GetFontCollection() = 0;
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -203,13 +203,13 @@ Engine::RunStatus Engine::Run(RunConfiguration configuration) {
 
   auto service_id = runtime_controller_->GetRootIsolateServiceID();
   if (service_id.has_value()) {
-    fml::RefPtr<PlatformMessage> service_id_message =
-        fml::MakeRefCounted<flutter::PlatformMessage>(
+    std::unique_ptr<PlatformMessage> service_id_message =
+        std::make_unique<flutter::PlatformMessage>(
             kIsolateChannel,
             std::vector<uint8_t>(service_id.value().begin(),
                                  service_id.value().end()),
             nullptr);
-    HandlePlatformMessage(service_id_message);
+    HandlePlatformMessage(std::move(service_id_message));
   }
 
   return Engine::RunStatus::Success;
@@ -285,7 +285,7 @@ void Engine::SetViewportMetrics(const ViewportMetrics& metrics) {
   }
 }
 
-void Engine::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
+void Engine::DispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) {
   std::string channel = message->channel();
   if (channel == kLifecycleChannel) {
     if (HandleLifecyclePlatformMessage(message.get())) {
@@ -338,7 +338,7 @@ bool Engine::HandleLifecyclePlatformMessage(PlatformMessage* message) {
 }
 
 bool Engine::HandleNavigationPlatformMessage(
-    fml::RefPtr<PlatformMessage> message) {
+    std::unique_ptr<PlatformMessage> message) {
   const auto& data = message->data();
 
   rapidjson::Document document;
@@ -477,7 +477,7 @@ void Engine::UpdateSemantics(SemanticsNodeUpdates update,
   delegate_.OnEngineUpdateSemantics(std::move(update), std::move(actions));
 }
 
-void Engine::HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) {
+void Engine::HandlePlatformMessage(std::unique_ptr<PlatformMessage> message) {
   if (message->channel() == kAssetChannel) {
     HandleAssetPlatformMessage(std::move(message));
   } else {
@@ -520,7 +520,8 @@ void Engine::ScheduleSecondaryVsyncCallback(uintptr_t id,
   animator_->ScheduleSecondaryVsyncCallback(id, callback);
 }
 
-void Engine::HandleAssetPlatformMessage(fml::RefPtr<PlatformMessage> message) {
+void Engine::HandleAssetPlatformMessage(
+    std::unique_ptr<PlatformMessage> message) {
   fml::RefPtr<PlatformMessageResponse> response = message->response();
   if (!response) {
     return;

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -178,7 +178,7 @@ class Engine final : public RuntimeDelegate,
     ///                      the underlying platform.
     ///
     virtual void OnEngineHandlePlatformMessage(
-        fml::RefPtr<PlatformMessage> message) = 0;
+        std::unique_ptr<PlatformMessage> message) = 0;
 
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the root isolate of the
@@ -706,7 +706,7 @@ class Engine final : public RuntimeDelegate,
   /// @param[in]  message  The message sent from the embedder to the Dart
   ///                      application.
   ///
-  void DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message);
+  void DispatchPlatformMessage(std::unique_ptr<PlatformMessage> message);
 
   //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder has sent it a pointer
@@ -930,7 +930,7 @@ class Engine final : public RuntimeDelegate,
                        CustomAccessibilityActionUpdates actions) override;
 
   // |RuntimeDelegate|
-  void HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) override;
+  void HandlePlatformMessage(std::unique_ptr<PlatformMessage> message) override;
 
   // |RuntimeDelegate|
   void OnRootIsolateCreated() override;
@@ -954,13 +954,14 @@ class Engine final : public RuntimeDelegate,
 
   bool HandleLifecyclePlatformMessage(PlatformMessage* message);
 
-  bool HandleNavigationPlatformMessage(fml::RefPtr<PlatformMessage> message);
+  bool HandleNavigationPlatformMessage(
+      std::unique_ptr<PlatformMessage> message);
 
   bool HandleLocalizationPlatformMessage(PlatformMessage* message);
 
   void HandleSettingsPlatformMessage(PlatformMessage* message);
 
-  void HandleAssetPlatformMessage(fml::RefPtr<PlatformMessage> message);
+  void HandleAssetPlatformMessage(std::unique_ptr<PlatformMessage> message);
 
   bool GetAssetAsBuffer(const std::string& name, std::vector<uint8_t>* data);
 

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -25,7 +25,7 @@ class MockDelegate : public Engine::Delegate {
   MOCK_METHOD2(OnEngineUpdateSemantics,
                void(SemanticsNodeUpdates, CustomAccessibilityActionUpdates));
   MOCK_METHOD1(OnEngineHandlePlatformMessage,
-               void(fml::RefPtr<PlatformMessage>));
+               void(std::unique_ptr<PlatformMessage>));
   MOCK_METHOD0(OnPreEngineRestart, void());
   MOCK_METHOD0(OnRootIsolateCreated, void());
   MOCK_METHOD2(UpdateIsolateDescription, void(const std::string, int64_t));
@@ -49,7 +49,7 @@ class MockRuntimeDelegate : public RuntimeDelegate {
   MOCK_METHOD1(Render, void(std::unique_ptr<flutter::LayerTree>));
   MOCK_METHOD2(UpdateSemantics,
                void(SemanticsNodeUpdates, CustomAccessibilityActionUpdates));
-  MOCK_METHOD1(HandlePlatformMessage, void(fml::RefPtr<PlatformMessage>));
+  MOCK_METHOD1(HandlePlatformMessage, void(std::unique_ptr<PlatformMessage>));
   MOCK_METHOD0(GetFontCollection, FontCollection&());
   MOCK_METHOD0(OnRootIsolateCreated, void());
   MOCK_METHOD2(UpdateIsolateDescription, void(const std::string, int64_t));
@@ -65,13 +65,13 @@ class MockRuntimeController : public RuntimeController {
   MockRuntimeController(RuntimeDelegate& client, TaskRunners p_task_runners)
       : RuntimeController(client, p_task_runners) {}
   MOCK_METHOD0(IsRootIsolateRunning, bool());
-  MOCK_METHOD1(DispatchPlatformMessage, bool(fml::RefPtr<PlatformMessage>));
+  MOCK_METHOD1(DispatchPlatformMessage, bool(std::unique_ptr<PlatformMessage>));
   MOCK_METHOD3(LoadDartDeferredLibraryError,
                void(intptr_t, const std::string, bool));
   MOCK_CONST_METHOD0(GetDartVM, DartVM*());
 };
 
-fml::RefPtr<PlatformMessage> MakePlatformMessage(
+std::unique_ptr<PlatformMessage> MakePlatformMessage(
     const std::string& channel,
     const std::map<std::string, std::string>& values,
     fml::RefPtr<PlatformMessageResponse> response) {
@@ -92,7 +92,7 @@ fml::RefPtr<PlatformMessage> MakePlatformMessage(
   document.Accept(writer);
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
 
-  fml::RefPtr<PlatformMessage> message = fml::MakeRefCounted<PlatformMessage>(
+  std::unique_ptr<PlatformMessage> message = std::make_unique<PlatformMessage>(
       channel, std::vector<uint8_t>(data, data + buffer.GetSize()), response);
   return message;
 }
@@ -176,9 +176,9 @@ TEST_F(EngineTest, DispatchPlatformMessageUnknown) {
 
     fml::RefPtr<PlatformMessageResponse> response =
         fml::MakeRefCounted<MockResponse>();
-    fml::RefPtr<PlatformMessage> message =
-        fml::MakeRefCounted<PlatformMessage>("foo", response);
-    engine->DispatchPlatformMessage(message);
+    std::unique_ptr<PlatformMessage> message =
+        std::make_unique<PlatformMessage>("foo", response);
+    engine->DispatchPlatformMessage(std::move(message));
   });
 }
 
@@ -206,9 +206,9 @@ TEST_F(EngineTest, DispatchPlatformMessageInitialRoute) {
         {"method", "setInitialRoute"},
         {"args", "test_initial_route"},
     };
-    fml::RefPtr<PlatformMessage> message =
+    std::unique_ptr<PlatformMessage> message =
         MakePlatformMessage("flutter/navigation", values, response);
-    engine->DispatchPlatformMessage(message);
+    engine->DispatchPlatformMessage(std::move(message));
     EXPECT_EQ(engine->InitialRoute(), "test_initial_route");
   });
 }
@@ -239,9 +239,9 @@ TEST_F(EngineTest, DispatchPlatformMessageInitialRouteIgnored) {
         {"method", "setInitialRoute"},
         {"args", "test_initial_route"},
     };
-    fml::RefPtr<PlatformMessage> message =
+    std::unique_ptr<PlatformMessage> message =
         MakePlatformMessage("flutter/navigation", values, response);
-    engine->DispatchPlatformMessage(message);
+    engine->DispatchPlatformMessage(std::move(message));
     EXPECT_EQ(engine->InitialRoute(), "");
   });
 }

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -32,7 +32,7 @@ std::unique_ptr<VsyncWaiter> PlatformView::CreateVSyncWaiter() {
 }
 
 void PlatformView::DispatchPlatformMessage(
-    fml::RefPtr<PlatformMessage> message) {
+    std::unique_ptr<PlatformMessage> message) {
   delegate_.OnPlatformViewDispatchPlatformMessage(std::move(message));
 }
 
@@ -115,7 +115,8 @@ fml::WeakPtr<PlatformView> PlatformView::GetWeakPtr() const {
 void PlatformView::UpdateSemantics(SemanticsNodeUpdates update,
                                    CustomAccessibilityActionUpdates actions) {}
 
-void PlatformView::HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) {
+void PlatformView::HandlePlatformMessage(
+    std::unique_ptr<PlatformMessage> message) {
   if (auto response = message->response())
     response->CompleteEmpty();
 }

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -114,7 +114,7 @@ class PlatformView {
     ///                      root isolate.
     ///
     virtual void OnPlatformViewDispatchPlatformMessage(
-        fml::RefPtr<PlatformMessage> message) = 0;
+        std::unique_ptr<PlatformMessage> message) = 0;
 
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the platform view has encountered
@@ -379,7 +379,7 @@ class PlatformView {
   ///
   /// @param[in]  message  The platform message to deliver to the root isolate.
   ///
-  void DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message);
+  void DispatchPlatformMessage(std::unique_ptr<PlatformMessage> message);
 
   //----------------------------------------------------------------------------
   /// @brief      Overridden by embedders to perform actions in response to
@@ -395,7 +395,7 @@ class PlatformView {
   ///
   /// @param[in]  message  The message
   ///
-  virtual void HandlePlatformMessage(fml::RefPtr<PlatformMessage> message);
+  virtual void HandlePlatformMessage(std::unique_ptr<PlatformMessage> message);
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedders to dispatch an accessibility action to a

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -949,16 +949,16 @@ void Shell::OnPlatformViewSetViewportMetrics(const ViewportMetrics& metrics) {
 
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewDispatchPlatformMessage(
-    fml::RefPtr<PlatformMessage> message) {
+    std::unique_ptr<PlatformMessage> message) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
-  task_runners_.GetUITaskRunner()->PostTask(
-      [engine = engine_->GetWeakPtr(), message = std::move(message)] {
+  task_runners_.GetUITaskRunner()->PostTask(fml::MakeCopyable(
+      [engine = engine_->GetWeakPtr(), message = std::move(message)]() mutable {
         if (engine) {
           engine->DispatchPlatformMessage(std::move(message));
         }
-      });
+      }));
 }
 
 // |PlatformView::Delegate|
@@ -1203,7 +1203,7 @@ void Shell::OnEngineUpdateSemantics(SemanticsNodeUpdates update,
 
 // |Engine::Delegate|
 void Shell::OnEngineHandlePlatformMessage(
-    fml::RefPtr<PlatformMessage> message) {
+    std::unique_ptr<PlatformMessage> message) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
@@ -1213,14 +1213,15 @@ void Shell::OnEngineHandlePlatformMessage(
   }
 
   task_runners_.GetPlatformTaskRunner()->PostTask(
-      [view = platform_view_->GetWeakPtr(), message = std::move(message)]() {
+      fml::MakeCopyable([view = platform_view_->GetWeakPtr(),
+                         message = std::move(message)]() mutable {
         if (view) {
           view->HandlePlatformMessage(std::move(message));
         }
-      });
+      }));
 }
 
-void Shell::HandleEngineSkiaMessage(fml::RefPtr<PlatformMessage> message) {
+void Shell::HandleEngineSkiaMessage(std::unique_ptr<PlatformMessage> message) {
   const auto& data = message->data();
 
   rapidjson::Document document;
@@ -1797,12 +1798,12 @@ bool Shell::ReloadSystemFonts() {
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   document.Accept(writer);
   std::string message = buffer.GetString();
-  fml::RefPtr<PlatformMessage> fontsChangeMessage =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<PlatformMessage> fontsChangeMessage =
+      std::make_unique<flutter::PlatformMessage>(
           kSystemChannel, std::vector<uint8_t>(message.begin(), message.end()),
           nullptr);
 
-  OnPlatformViewDispatchPlatformMessage(fontsChangeMessage);
+  OnPlatformViewDispatchPlatformMessage(std::move(fontsChangeMessage));
   return true;
 }
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -476,7 +476,7 @@ class Shell final : public PlatformView::Delegate,
 
   // |PlatformView::Delegate|
   void OnPlatformViewDispatchPlatformMessage(
-      fml::RefPtr<PlatformMessage> message) override;
+      std::unique_ptr<PlatformMessage> message) override;
 
   // |PlatformView::Delegate|
   void OnPlatformViewDispatchPointerDataPacket(
@@ -547,9 +547,9 @@ class Shell final : public PlatformView::Delegate,
 
   // |Engine::Delegate|
   void OnEngineHandlePlatformMessage(
-      fml::RefPtr<PlatformMessage> message) override;
+      std::unique_ptr<PlatformMessage> message) override;
 
-  void HandleEngineSkiaMessage(fml::RefPtr<PlatformMessage> message);
+  void HandleEngineSkiaMessage(std::unique_ptr<PlatformMessage> message);
 
   // |Engine::Delegate|
   void OnPreEngineRestart() override;

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -51,7 +51,7 @@ class ShellTest : public FixtureTest {
   fml::TimePoint GetLatestFrameTargetTime(Shell* shell) const;
 
   void SendEnginePlatformMessage(Shell* shell,
-                                 fml::RefPtr<PlatformMessage> message);
+                                 std::unique_ptr<PlatformMessage> message);
 
   static void PlatformViewNotifyCreated(
       Shell* shell);  // This creates the surface

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -57,7 +57,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
                void(const ViewportMetrics& metrics));
 
   MOCK_METHOD1(OnPlatformViewDispatchPlatformMessage,
-               void(fml::RefPtr<PlatformMessage> message));
+               void(std::unique_ptr<PlatformMessage> message));
 
   MOCK_METHOD1(OnPlatformViewDispatchPointerDataPacket,
                void(std::unique_ptr<PointerDataPacket> packet));
@@ -1546,7 +1546,7 @@ TEST_F(ShellTest, SetResourceCacheSize) {
                                 "args": 10000
                               })json";
   std::vector<uint8_t> data(request_json.begin(), request_json.end());
-  auto platform_message = fml::MakeRefCounted<PlatformMessage>(
+  auto platform_message = std::make_unique<PlatformMessage>(
       "flutter/skia", std::move(data), nullptr);
   SendEnginePlatformMessage(shell.get(), std::move(platform_message));
   PumpOneFrame(shell.get());

--- a/shell/platform/android/jni/jni_mock.h
+++ b/shell/platform/android/jni/jni_mock.h
@@ -18,7 +18,8 @@ class JNIMock final : public PlatformViewAndroidJNI {
  public:
   MOCK_METHOD(void,
               FlutterViewHandlePlatformMessage,
-              (fml::RefPtr<flutter::PlatformMessage> message, int responseId),
+              (std::unique_ptr<flutter::PlatformMessage> message,
+               int responseId),
               (override));
 
   MOCK_METHOD(void,

--- a/shell/platform/android/jni/jni_mock_unittest.cc
+++ b/shell/platform/android/jni/jni_mock_unittest.cc
@@ -13,13 +13,16 @@ namespace testing {
 TEST(JNIMock, FlutterViewHandlePlatformMessage) {
   JNIMock mock;
 
-  auto message =
-      fml::MakeRefCounted<PlatformMessage>("<channel-name>", nullptr);
+  auto message = std::make_unique<PlatformMessage>("<channel-name>", nullptr);
   auto response_id = 1;
 
-  EXPECT_CALL(mock, FlutterViewHandlePlatformMessage(message, response_id));
+  EXPECT_CALL(mock,
+              FlutterViewHandlePlatformMessage(
+                  ::testing::Property(&std::unique_ptr<PlatformMessage>::get,
+                                      message.get()),
+                  response_id));
 
-  mock.FlutterViewHandlePlatformMessage(message, response_id);
+  mock.FlutterViewHandlePlatformMessage(std::move(message), response_id);
 }
 
 }  // namespace testing

--- a/shell/platform/android/jni/platform_view_android_jni.h
+++ b/shell/platform/android/jni/platform_view_android_jni.h
@@ -41,7 +41,7 @@ class PlatformViewAndroidJNI {
   /// @brief      Sends a platform message. The message may be empty.
   ///
   virtual void FlutterViewHandlePlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message,
+      std::unique_ptr<flutter::PlatformMessage> message,
       int responseId) = 0;
 
   //----------------------------------------------------------------------------

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -190,7 +190,7 @@ void PlatformViewAndroid::DispatchPlatformMessage(JNIEnv* env,
   }
 
   PlatformView::DispatchPlatformMessage(
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+      std::make_unique<flutter::PlatformMessage>(
           std::move(name), std::move(message), std::move(response)));
 }
 
@@ -204,8 +204,8 @@ void PlatformViewAndroid::DispatchEmptyPlatformMessage(JNIEnv* env,
   }
 
   PlatformView::DispatchPlatformMessage(
-      fml::MakeRefCounted<flutter::PlatformMessage>(std::move(name),
-                                                    std::move(response)));
+      std::make_unique<flutter::PlatformMessage>(std::move(name),
+                                                 std::move(response)));
 }
 
 void PlatformViewAndroid::InvokePlatformMessageResponseCallback(
@@ -243,14 +243,15 @@ void PlatformViewAndroid::InvokePlatformMessageEmptyResponseCallback(
 
 // |PlatformView|
 void PlatformViewAndroid::HandlePlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message) {
+    std::unique_ptr<flutter::PlatformMessage> message) {
   int response_id = 0;
   if (auto response = message->response()) {
     response_id = next_response_id_++;
     pending_responses_[response_id] = response;
   }
   // This call can re-enter in InvokePlatformMessageXxxResponseCallback.
-  jni_facade_->FlutterViewHandlePlatformMessage(message, response_id);
+  jni_facade_->FlutterViewHandlePlatformMessage(std::move(message),
+                                                response_id);
   message = nullptr;
 }
 

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -137,7 +137,7 @@ class PlatformViewAndroid final : public PlatformView {
 
   // |PlatformView|
   void HandlePlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message) override;
+      std::unique_ptr<flutter::PlatformMessage> message) override;
 
   // |PlatformView|
   void OnPreEngineRestart() const override;

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -1094,7 +1094,7 @@ PlatformViewAndroidJNIImpl::PlatformViewAndroidJNIImpl(
 PlatformViewAndroidJNIImpl::~PlatformViewAndroidJNIImpl() = default;
 
 void PlatformViewAndroidJNIImpl::FlutterViewHandlePlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message,
+    std::unique_ptr<flutter::PlatformMessage> message,
     int responseId) {
   JNIEnv* env = fml::jni::AttachCurrentThread();
 

--- a/shell/platform/android/platform_view_android_jni_impl.h
+++ b/shell/platform/android/platform_view_android_jni_impl.h
@@ -21,7 +21,7 @@ class PlatformViewAndroidJNIImpl final : public PlatformViewAndroidJNI {
   ~PlatformViewAndroidJNIImpl() override;
 
   void FlutterViewHandlePlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message,
+      std::unique_ptr<flutter::PlatformMessage> message,
       int responseId) override;
 
   void FlutterViewHandlePlatformMessageResponse(

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -804,12 +804,12 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
                                 callback(reply);
                               },
                               _shell->GetTaskRunners().GetPlatformTaskRunner());
-  fml::RefPtr<flutter::PlatformMessage> platformMessage =
-      (message == nil) ? fml::MakeRefCounted<flutter::PlatformMessage>(channel.UTF8String, response)
-                       : fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> platformMessage =
+      (message == nil) ? std::make_unique<flutter::PlatformMessage>(channel.UTF8String, response)
+                       : std::make_unique<flutter::PlatformMessage>(
                              channel.UTF8String, flutter::GetVectorFromNSData(message), response);
 
-  _shell->GetPlatformView()->DispatchPlatformMessage(platformMessage);
+  _shell->GetPlatformView()->DispatchPlatformMessage(std::move(platformMessage));
 }
 
 - (FlutterBinaryMessengerConnection)setMessageHandlerOnChannel:(NSString*)channel

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -22,7 +22,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDestroyed() override {}
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) override {}
   void OnPlatformViewSetViewportMetrics(const ViewportMetrics& metrics) override {}
-  void OnPlatformViewDispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) override {}
+  void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
   void OnPlatformViewDispatchKeyDataPacket(std::unique_ptr<KeyDataPacket> packet,

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -92,7 +92,7 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
   void OnPlatformViewDestroyed() override {}
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) override {}
   void OnPlatformViewSetViewportMetrics(const ViewportMetrics& metrics) override {}
-  void OnPlatformViewDispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) override {}
+  void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
   void OnPlatformViewDispatchKeyDataPacket(std::unique_ptr<KeyDataPacket> packet,

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -75,7 +75,7 @@ class MockDelegate : public PlatformView::Delegate {
   void OnPlatformViewDestroyed() override {}
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) override {}
   void OnPlatformViewSetViewportMetrics(const ViewportMetrics& metrics) override {}
-  void OnPlatformViewDispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) override {}
+  void OnPlatformViewDispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) override {}
   void OnPlatformViewDispatchPointerDataPacket(std::unique_ptr<PointerDataPacket> packet) override {
   }
   void OnPlatformViewDispatchKeyDataPacket(std::unique_ptr<KeyDataPacket> packet,

--- a/shell/platform/darwin/ios/framework/Source/platform_message_router.h
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_router.h
@@ -20,7 +20,7 @@ class PlatformMessageRouter {
   ~PlatformMessageRouter();
 
   void HandlePlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message) const;
+      std::unique_ptr<flutter::PlatformMessage> message) const;
 
   void SetMessageHandler(const std::string& channel,
                          FlutterBinaryMessageHandler handler);

--- a/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
@@ -15,7 +15,7 @@ PlatformMessageRouter::PlatformMessageRouter() = default;
 PlatformMessageRouter::~PlatformMessageRouter() = default;
 
 void PlatformMessageRouter::HandlePlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message) const {
+    std::unique_ptr<flutter::PlatformMessage> message) const {
   fml::RefPtr<flutter::PlatformMessageResponse> completer = message->response();
   auto it = message_handlers_.find(message->channel());
   if (it != message_handlers_.end()) {

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -144,7 +144,7 @@ class PlatformViewIOS final : public PlatformView {
   std::vector<std::string> platform_resolved_locale_;
 
   // |PlatformView|
-  void HandlePlatformMessage(fml::RefPtr<flutter::PlatformMessage> message) override;
+  void HandlePlatformMessage(std::unique_ptr<flutter::PlatformMessage> message) override;
 
   // |PlatformView|
   std::unique_ptr<Surface> CreateRenderingSurface() override;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -72,7 +72,7 @@ PlatformMessageRouter& PlatformViewIOS::GetPlatformMessageRouter() {
 }
 
 // |PlatformView|
-void PlatformViewIOS::HandlePlatformMessage(fml::RefPtr<flutter::PlatformMessage> message) {
+void PlatformViewIOS::HandlePlatformMessage(std::unique_ptr<flutter::PlatformMessage> message) {
   platform_message_router_.HandlePlatformMessage(std::move(message));
 }
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -730,7 +730,7 @@ InferExternalViewEmbedderFromArgs(const FlutterCompositor* compositor) {
 }
 
 struct _FlutterPlatformMessageResponseHandle {
-  fml::RefPtr<flutter::PlatformMessage> message;
+  std::unique_ptr<flutter::PlatformMessage> message;
 };
 
 struct LoadedElfDeleter {
@@ -1105,7 +1105,7 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
   if (SAFE_ACCESS(args, platform_message_callback, nullptr) != nullptr) {
     platform_message_response_callback =
         [ptr = args->platform_message_callback,
-         user_data](fml::RefPtr<flutter::PlatformMessage> message) {
+         user_data](std::unique_ptr<flutter::PlatformMessage> message) {
           auto handle = new FlutterPlatformMessageResponseHandle();
           const FlutterPlatformMessage incoming_message = {
               sizeof(FlutterPlatformMessage),  // struct_size
@@ -1636,12 +1636,12 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
     response = response_handle->message->response();
   }
 
-  fml::RefPtr<flutter::PlatformMessage> message;
+  std::unique_ptr<flutter::PlatformMessage> message;
   if (message_size == 0) {
-    message = fml::MakeRefCounted<flutter::PlatformMessage>(
+    message = std::make_unique<flutter::PlatformMessage>(
         flutter_message->channel, response);
   } else {
-    message = fml::MakeRefCounted<flutter::PlatformMessage>(
+    message = std::make_unique<flutter::PlatformMessage>(
         flutter_message->channel,
         std::vector<uint8_t>(message_data, message_data + message_size),
         response);
@@ -1680,7 +1680,7 @@ FlutterEngineResult FlutterPlatformMessageCreateResponseHandle(
 
   auto handle = new FlutterPlatformMessageResponseHandle();
 
-  handle->message = fml::MakeRefCounted<flutter::PlatformMessage>(
+  handle->message = std::make_unique<flutter::PlatformMessage>(
       "",  // The channel is empty and unused as the response handle is going
            // to referenced directly in the |FlutterEngineSendPlatformMessage|
            // with the container message discarded.
@@ -1958,7 +1958,7 @@ static bool DispatchJSONPlatformMessage(FLUTTER_API_SYMBOL(FlutterEngine)
     return false;
   }
 
-  auto platform_message = fml::MakeRefCounted<flutter::PlatformMessage>(
+  auto platform_message = std::make_unique<flutter::PlatformMessage>(
       channel_name.c_str(),                                       // channel
       std::vector<uint8_t>{message, message + buffer.GetSize()},  // message
       nullptr                                                     // response

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -144,7 +144,7 @@ bool EmbedderEngine::DispatchKeyDataPacket(
 }
 
 bool EmbedderEngine::SendPlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message) {
+    std::unique_ptr<PlatformMessage> message) {
   if (!IsValid() || !message) {
     return false;
   }
@@ -154,7 +154,7 @@ bool EmbedderEngine::SendPlatformMessage(
     return false;
   }
 
-  platform_view->DispatchPlatformMessage(message);
+  platform_view->DispatchPlatformMessage(std::move(message));
   return true;
 }
 

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -68,7 +68,7 @@ class EmbedderEngine {
   bool DispatchKeyDataPacket(std::unique_ptr<flutter::KeyDataPacket> packet,
                              KeyDataResponse callback);
 
-  bool SendPlatformMessage(fml::RefPtr<flutter::PlatformMessage> message);
+  bool SendPlatformMessage(std::unique_ptr<PlatformMessage> message);
 
   bool RegisterTexture(int64_t texture);
 

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -65,7 +65,7 @@ void PlatformViewEmbedder::UpdateSemantics(
 }
 
 void PlatformViewEmbedder::HandlePlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message) {
+    std::unique_ptr<flutter::PlatformMessage> message) {
   if (!message) {
     return;
   }

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -32,7 +32,7 @@ class PlatformViewEmbedder final : public PlatformView {
   using UpdateSemanticsCustomActionsCallback =
       std::function<void(flutter::CustomAccessibilityActionUpdates actions)>;
   using PlatformMessageResponseCallback =
-      std::function<void(fml::RefPtr<flutter::PlatformMessage>)>;
+      std::function<void(std::unique_ptr<PlatformMessage>)>;
   using ComputePlatformResolvedLocaleCallback =
       std::function<std::unique_ptr<std::vector<std::string>>(
           const std::vector<std::string>& supported_locale_data)>;
@@ -85,8 +85,7 @@ class PlatformViewEmbedder final : public PlatformView {
       flutter::CustomAccessibilityActionUpdates actions) override;
 
   // |PlatformView|
-  void HandlePlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message) override;
+  void HandlePlatformMessage(std::unique_ptr<PlatformMessage> message) override;
 
  private:
   std::shared_ptr<EmbedderExternalViewEmbedder> external_view_embedder_;

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -402,7 +402,7 @@ Engine::Engine(Delegate& delegate,
       auto message = MakeLocalizationPlatformMessage(profile);
       FML_VLOG(-1) << "Sending LocalizationPlatformMessage";
       flutter_runner_engine->shell_->GetPlatformView()->DispatchPlatformMessage(
-          message);
+          std::move(message));
     };
 
     FML_VLOG(-1) << "Requesting intl Profile";

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -50,9 +50,9 @@ void UpdateNativeThreadLabelNames(const std::string& label,
   set_thread_name(runners.GetIOTaskRunner(), label, ".io");
 }
 
-fml::RefPtr<flutter::PlatformMessage> MakeLocalizationPlatformMessage(
+std::unique_ptr<flutter::PlatformMessage> MakeLocalizationPlatformMessage(
     const fuchsia::intl::Profile& intl_profile) {
-  return fml::MakeRefCounted<flutter::PlatformMessage>(
+  return std::make_unique<flutter::PlatformMessage>(
       "flutter/localization", MakeLocalizationPlatformMessageData(intl_profile),
       nullptr);
 }

--- a/shell/platform/fuchsia/flutter/fuchsia_intl.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_intl.h
@@ -12,7 +12,7 @@ namespace flutter_runner {
 // Make a byte vector containing the JSON string used for a localization
 // PlatformMessage, using the locale list in the given Profile.
 //
-// This method does not return a `fml::RefPtr<flutter::PlatformMessage>` for
+// This method does not return a `std::unique_ptr<flutter::PlatformMessage>` for
 // testing convenience; that would require an unreasonably large set of
 // dependencies for the unit tests.
 std::vector<uint8_t> MakeLocalizationPlatformMessageData(

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -1067,8 +1067,8 @@ void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
     });
     focuser_->RequestFocus(
         std::move(ref),
-        [view_ref = view_ref->value.GetUint64(),
-         message](fuchsia::ui::views::Focuser_RequestFocus_Result result) {
+        [view_ref = view_ref->value.GetUint64(), message = std::move(message)](
+            fuchsia::ui::views::Focuser_RequestFocus_Result result) {
           if (message->response().get()) {
             int result_code =
                 result.is_err()

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -176,7 +176,7 @@ void PlatformView::DidUpdateState(
   document.Accept(writer);
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
-  DispatchPlatformMessage(fml::MakeRefCounted<flutter::PlatformMessage>(
+  DispatchPlatformMessage(std::make_unique<flutter::PlatformMessage>(
       kTextInputChannel,                                    // channel
       std::vector<uint8_t>(data, data + buffer.GetSize()),  // message
       nullptr)                                              // response
@@ -206,7 +206,7 @@ void PlatformView::OnAction(fuchsia::ui::input::InputMethodAction action) {
   document.Accept(writer);
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
-  DispatchPlatformMessage(fml::MakeRefCounted<flutter::PlatformMessage>(
+  DispatchPlatformMessage(std::make_unique<flutter::PlatformMessage>(
       kTextInputChannel,                                    // channel
       std::vector<uint8_t>(data, data + buffer.GetSize()),  // message
       nullptr)                                              // response
@@ -443,8 +443,8 @@ bool PlatformView::OnChildViewConnected(scenic::ResourceId view_holder_id) {
       << "}";
   auto call = out.str();
 
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> message =
+      std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(call.begin(), call.end()), nullptr);
   DispatchPlatformMessage(message);
@@ -467,8 +467,8 @@ bool PlatformView::OnChildViewDisconnected(scenic::ResourceId view_holder_id) {
       << "}";
   auto call = out.str();
 
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> message =
+      std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(call.begin(), call.end()), nullptr);
   DispatchPlatformMessage(message);
@@ -494,8 +494,8 @@ bool PlatformView::OnChildViewStateChanged(scenic::ResourceId view_holder_id,
       << "}";
   auto call = out.str();
 
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> message =
+      std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(call.begin(), call.end()), nullptr);
   DispatchPlatformMessage(message);
@@ -645,7 +645,7 @@ void PlatformView::OnKeyEvent(
   document.Accept(writer);
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
-  DispatchPlatformMessage(fml::MakeRefCounted<flutter::PlatformMessage>(
+  DispatchPlatformMessage(std::make_unique<flutter::PlatformMessage>(
       kKeyEventChannel,                                     // channel
       std::vector<uint8_t>(data, data + buffer.GetSize()),  // data
       nullptr)                                              // response
@@ -760,7 +760,7 @@ void PlatformView::UpdateSemantics(
 
 // Channel handler for kAccessibilityChannel
 void PlatformView::HandleAccessibilityChannelPlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message) {
+    std::unique_ptr<flutter::PlatformMessage> message) {
   FML_DCHECK(message->channel() == kAccessibilityChannel);
 
   const flutter::StandardMessageCodec& standard_message_codec =
@@ -785,7 +785,7 @@ void PlatformView::HandleAccessibilityChannelPlatformMessage(
 
 // Channel handler for kFlutterPlatformChannel
 void PlatformView::HandleFlutterPlatformChannelPlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message) {
+    std::unique_ptr<flutter::PlatformMessage> message) {
   FML_DCHECK(message->channel() == kFlutterPlatformChannel);
   const auto& data = message->data();
   rapidjson::Document document;
@@ -806,7 +806,7 @@ void PlatformView::HandleFlutterPlatformChannelPlatformMessage(
 
 // Channel handler for kTextInputChannel
 void PlatformView::HandleFlutterTextInputChannelPlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message) {
+    std::unique_ptr<flutter::PlatformMessage> message) {
   FML_DCHECK(message->channel() == kTextInputChannel);
   const auto& data = message->data();
   rapidjson::Document document;
@@ -896,7 +896,7 @@ void PlatformView::HandleFlutterTextInputChannelPlatformMessage(
 }
 
 void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message) {
+    std::unique_ptr<flutter::PlatformMessage> message) {
   FML_DCHECK(message->channel() == kFlutterPlatformViewsChannel);
   const auto& data = message->data();
   rapidjson::Document document;

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -471,7 +471,7 @@ bool PlatformView::OnChildViewDisconnected(scenic::ResourceId view_holder_id) {
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(call.begin(), call.end()), nullptr);
-  DispatchPlatformMessage(message);
+  DispatchPlatformMessage(std::move(message));
 
   return true;
 }
@@ -498,7 +498,7 @@ bool PlatformView::OnChildViewStateChanged(scenic::ResourceId view_holder_id,
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(call.begin(), call.end()), nullptr);
-  DispatchPlatformMessage(message);
+  DispatchPlatformMessage(std::move(message));
 
   return true;
 }

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -707,7 +707,7 @@ PlatformView::CreateExternalViewEmbedder() {
 
 // |flutter::PlatformView|
 void PlatformView::HandlePlatformMessage(
-    fml::RefPtr<flutter::PlatformMessage> message) {
+    std::unique_ptr<flutter::PlatformMessage> message) {
   if (!message) {
     return;
   }

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -447,7 +447,7 @@ bool PlatformView::OnChildViewConnected(scenic::ResourceId view_holder_id) {
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(call.begin(), call.end()), nullptr);
-  DispatchPlatformMessage(message);
+  DispatchPlatformMessage(std::move(message));
 
   return true;
 }

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -139,7 +139,7 @@ class PlatformView final : public flutter::PlatformView,
 
   // |flutter::PlatformView|
   void HandlePlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message) override;
+      std::unique_ptr<flutter::PlatformMessage> message) override;
 
   // |flutter::PlatformView|
   void UpdateSemantics(
@@ -150,19 +150,19 @@ class PlatformView final : public flutter::PlatformView,
   // being used, but it is necessary to handle accessibility messages
   // that are sent by Flutter when semantics is enabled.
   void HandleAccessibilityChannelPlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message);
+      std::unique_ptr<flutter::PlatformMessage> message);
 
   // Channel handler for kFlutterPlatformChannel
   void HandleFlutterPlatformChannelPlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message);
+      std::unique_ptr<flutter::PlatformMessage> message);
 
   // Channel handler for kTextInputChannel
   void HandleFlutterTextInputChannelPlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message);
+      std::unique_ptr<flutter::PlatformMessage> message);
 
   // Channel handler for kPlatformViewsChannel.
   void HandleFlutterPlatformViewsChannelPlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message);
+      std::unique_ptr<flutter::PlatformMessage> message);
 
   const std::string debug_label_;
   // TODO(MI4-2490): remove once ViewRefControl is passed to Scenic and kept
@@ -207,10 +207,10 @@ class PlatformView final : public flutter::PlatformView,
   std::unique_ptr<fuchsia::ui::input::TextInputState> last_text_state_;
 
   std::set<int> down_pointers_;
-  std::map<
-      std::string /* channel */,
-      fit::function<void(
-          fml::RefPtr<flutter::PlatformMessage> /* message */)> /* handler */>
+  std::map<std::string /* channel */,
+           fit::function<void(
+               std::unique_ptr<
+                   flutter::PlatformMessage> /* message */)> /* handler */>
       platform_message_handlers_;
   // These are the channels that aren't registered and have been notified as
   // such. Notifying via logs multiple times results in log-spam. See:

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -83,7 +83,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
   }
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchPlatformMessage(
-      fml::RefPtr<flutter::PlatformMessage> message) {
+      std::unique_ptr<flutter::PlatformMessage> message) {
     message_ = std::move(message);
   }
   // |flutter::PlatformView::Delegate|
@@ -139,7 +139,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
 
  private:
   std::unique_ptr<flutter::Surface> surface_;
-  fml::RefPtr<flutter::PlatformMessage> message_;
+  std::unique_ptr<flutter::PlatformMessage> message_;
   flutter::ViewportMetrics metrics_;
   int32_t semantics_features_ = 0;
   bool semantics_enabled_ = false;
@@ -568,8 +568,8 @@ TEST_F(PlatformViewTests, EnableWireframeTest) {
       "    }"
       "}";
 
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> message =
+      std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
@@ -628,8 +628,8 @@ TEST_F(PlatformViewTests, CreateViewTest) {
       "    }"
       "}";
 
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> message =
+      std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
@@ -678,8 +678,8 @@ TEST_F(PlatformViewTests, UpdateViewTest) {
       "    }"
       "}";
 
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> message =
+      std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
@@ -735,8 +735,8 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
       "    }"
       "}";
 
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> message =
+      std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
@@ -797,7 +797,7 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
                       << "}";
   std::string create_view_call = create_view_message.str();
   static_cast<flutter::PlatformView*>(&platform_view)
-      ->HandlePlatformMessage(fml::MakeRefCounted<flutter::PlatformMessage>(
+      ->HandlePlatformMessage(std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(create_view_call.begin(),
                                create_view_call.end()),
@@ -935,8 +935,8 @@ TEST_F(PlatformViewTests, RequestFocusTest) {
   EXPECT_CALL(*response, Complete(::testing::_))
       .WillOnce(::testing::Invoke(&data_arg, &DataArg::Complete));
 
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> message =
+      std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
   base_view->HandlePlatformMessage(message);
@@ -998,8 +998,8 @@ TEST_F(PlatformViewTests, RequestFocusFailTest) {
   EXPECT_CALL(*response, Complete(::testing::_))
       .WillOnce(::testing::Invoke(&data_arg, &DataArg::Complete));
 
-  fml::RefPtr<flutter::PlatformMessage> message =
-      fml::MakeRefCounted<flutter::PlatformMessage>(
+  std::unique_ptr<flutter::PlatformMessage> message =
+      std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
   base_view->HandlePlatformMessage(message);

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -633,7 +633,7 @@ TEST_F(PlatformViewTests, CreateViewTest) {
           "flutter/platform_views",
           std::vector<uint8_t>(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
-  base_view->HandlePlatformMessage(message);
+  base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();
 

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -573,7 +573,7 @@ TEST_F(PlatformViewTests, EnableWireframeTest) {
           "flutter/platform_views",
           std::vector<uint8_t>(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
-  base_view->HandlePlatformMessage(message);
+  base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();
 

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -683,7 +683,7 @@ TEST_F(PlatformViewTests, UpdateViewTest) {
           "flutter/platform_views",
           std::vector<uint8_t>(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
-  base_view->HandlePlatformMessage(message);
+  base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();
 
@@ -740,7 +740,7 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
           "flutter/platform_views",
           std::vector<uint8_t>(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
-  base_view->HandlePlatformMessage(message);
+  base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();
 
@@ -939,7 +939,7 @@ TEST_F(PlatformViewTests, RequestFocusTest) {
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
-  base_view->HandlePlatformMessage(message);
+  base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();
 
@@ -1002,7 +1002,7 @@ TEST_F(PlatformViewTests, RequestFocusFailTest) {
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
           std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
-  base_view->HandlePlatformMessage(message);
+  base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();
 

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -258,8 +258,8 @@ int RunTester(const flutter::Settings& settings,
                                     locale_json + std::strlen(locale_json));
   fml::RefPtr<flutter::PlatformMessageResponse> response;
   shell->GetPlatformView()->DispatchPlatformMessage(
-      fml::MakeRefCounted<flutter::PlatformMessage>("flutter/localization",
-                                                    locale_bytes, response));
+      std::make_unique<flutter::PlatformMessage>("flutter/localization",
+                                                 locale_bytes, response));
 
   std::initializer_list<fml::FileMapping::Protection> protection = {
       fml::FileMapping::Protection::kRead};


### PR DESCRIPTION
This is in preparation for our work that removes copies of messages that are passed to the embedder.  In order to safely transfer the data without a copy we need to be sure we are the only one with a copy of that data, thus the unique_ptr.

issue: https://github.com/flutter/flutter/issues/81559

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
