### PR TITLE
deflake more shell unittests

### DIFF
--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -25,6 +25,7 @@ void reportTimingsMain() {
       }
     }
     nativeReportTimingsCallback(timestamps);
+    PlatformDispatcher.instance.onReportTimings = (List<FrameTiming> timings) {};
   };
 }
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -534,8 +534,7 @@ static void CheckFrameTimings(const std::vector<FrameTiming>& timings,
   }
 }
 
-// TODO(43192): This test is disable because of flakiness.
-TEST_F(ShellTest, DISABLED_ReportTimingsIsCalled) {
+TEST_F(ShellTest, ReportTimingsIsCalled) {
   fml::TimePoint start = fml::TimePoint::Now();
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);
@@ -551,6 +550,7 @@ TEST_F(ShellTest, DISABLED_ReportTimingsIsCalled) {
   auto nativeTimingCallback = [&reportLatch,
                                &timestamps](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
+    ASSERT_EQ(timestamps.size(), 0ul);
     timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
         args, 0, exception);
     reportLatch.Signal();
@@ -1277,6 +1277,7 @@ TEST_F(ShellTest, ReportTimingsIsCalledImmediatelyAfterTheFirstFrame) {
   auto nativeTimingCallback = [&reportLatch,
                                &timestamps](Dart_NativeArguments args) {
     Dart_Handle exception = nullptr;
+    ASSERT_EQ(timestamps.size(), 0ul);
     timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
         args, 0, exception);
     reportLatch.Signal();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/81580
Fixes https://github.com/flutter/flutter/issues/43192

I was able to reproduce flakes locally on this about 25-33% of the time without this change, as long as I used `cpulimit` to limit the execution. In those cases, we were getting a second report timings callback after the first, which was throwing off test expectations. This way we only get a single initial call.