### PR TITLE
Switch PlatformMessages to hold data in Mappings

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -170,6 +170,7 @@ FILE: ../../../flutter/fml/macros.h
 FILE: ../../../flutter/fml/make_copyable.h
 FILE: ../../../flutter/fml/mapping.cc
 FILE: ../../../flutter/fml/mapping.h
+FILE: ../../../flutter/fml/mapping_unittests.cc
 FILE: ../../../flutter/fml/memory/ref_counted.h
 FILE: ../../../flutter/fml/memory/ref_counted_internal.h
 FILE: ../../../flutter/fml/memory/ref_counted_unittest.cc

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -252,6 +252,7 @@ if (enable_unittests) {
       "file_unittest.cc",
       "hash_combine_unittests.cc",
       "logging_unittests.cc",
+      "mapping_unittests.cc",
       "memory/ref_counted_unittest.cc",
       "memory/task_runner_checker_unittest.cc",
       "memory/weak_ptr_unittest.cc",

--- a/fml/mapping.cc
+++ b/fml/mapping.cc
@@ -104,7 +104,7 @@ const uint8_t* NonOwnedMapping::GetMapping() const {
 // MallocMapping
 MallocMapping::MallocMapping() : data_(nullptr), size_(0) {}
 
-MallocMapping::MallocMapping(const uint8_t* data, size_t size)
+MallocMapping::MallocMapping(uint8_t* data, size_t size)
     : data_(data), size_(size) {}
 
 MallocMapping::MallocMapping(fml::MallocMapping&& mapping)
@@ -114,15 +114,14 @@ MallocMapping::MallocMapping(fml::MallocMapping&& mapping)
 }
 
 MallocMapping::~MallocMapping() {
-  if (data_) {
-    free(const_cast<uint8_t*>(data_));
-    data_ = nullptr;
-  }
+  free(data_);
+  data_ = nullptr;
 }
 
 MallocMapping MallocMapping::Copy(const void* begin, size_t length) {
   auto result =
       MallocMapping(reinterpret_cast<uint8_t*>(malloc(length)), length);
+  FML_CHECK(result.GetMapping() != nullptr);
   memcpy(const_cast<uint8_t*>(result.GetMapping()), begin, length);
   return result;
 }
@@ -135,8 +134,8 @@ const uint8_t* MallocMapping::GetMapping() const {
   return data_;
 }
 
-const uint8_t* MallocMapping::Release() {
-  const uint8_t* result = data_;
+uint8_t* MallocMapping::Release() {
+  uint8_t* result = data_;
   data_ = nullptr;
   size_ = 0;
   return result;

--- a/fml/mapping.cc
+++ b/fml/mapping.cc
@@ -120,6 +120,13 @@ MallocMapping::~MallocMapping() {
   }
 }
 
+MallocMapping MallocMapping::Copy(const void* begin, size_t length) {
+  auto result =
+      MallocMapping(reinterpret_cast<uint8_t*>(malloc(length)), length);
+  memcpy(const_cast<uint8_t*>(result.GetMapping()), begin, length);
+  return result;
+}
+
 size_t MallocMapping::GetSize() const {
   return size_;
 }

--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -130,7 +130,11 @@ class MallocMapping final : public Mapping {
  public:
   MallocMapping();
 
-  MallocMapping(const uint8_t* data, size_t size);
+  /// Creates a MallocMapping for a region of memory (without copying it).
+  /// The function will `abort()` if the malloc fails.
+  /// @param data The starting address of the mapping.
+  /// @param size The size of the mapping in bytes.
+  MallocMapping(uint8_t* data, size_t size);
 
   MallocMapping(fml::MallocMapping&& mapping);
 
@@ -141,10 +145,15 @@ class MallocMapping final : public Mapping {
   /// for `uint8_t` and `char`.
   template <typename T>
   static MallocMapping Copy(const T* begin, const T* end) {
+    FML_DCHECK(end > begin);
     size_t length = end - begin;
     return Copy(begin, length);
   }
 
+  /// Copies a region of memory into a MallocMapping.
+  /// The function will `abort()` if the malloc fails.
+  /// @param begin The starting address of where we will copy.
+  /// @param length The length of the region to copy in bytes.
   static MallocMapping Copy(const void* begin, size_t length);
 
   // |Mapping|
@@ -154,10 +163,11 @@ class MallocMapping final : public Mapping {
   const uint8_t* GetMapping() const override;
 
   /// Removes ownership of the data buffer.
-  const uint8_t* Release();
+  /// After this is called; the mapping will point to nullptr.
+  [[nodiscard]] uint8_t* Release();
 
  private:
-  const uint8_t* data_;
+  uint8_t* data_;
   size_t size_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(MallocMapping);

--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -142,11 +142,10 @@ class MallocMapping final : public Mapping {
   template <typename T>
   static MallocMapping Copy(const T* begin, const T* end) {
     size_t length = end - begin;
-    auto result =
-        MallocMapping(reinterpret_cast<uint8_t*>(malloc(length)), length);
-    memcpy(const_cast<uint8_t*>(result.GetMapping()), begin, length);
-    return result;
+    return Copy(begin, length);
   }
+
+  static MallocMapping Copy(const void* begin, size_t length);
 
   // |Mapping|
   size_t GetSize() const override;

--- a/fml/mapping_unittests.cc
+++ b/fml/mapping_unittests.cc
@@ -1,0 +1,55 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/mapping.h"
+#include "flutter/testing/testing.h"
+
+namespace fml {
+
+TEST(MallocMapping, EmptyContructor) {
+  MallocMapping mapping;
+  ASSERT_EQ(nullptr, mapping.GetMapping());
+  ASSERT_EQ(0u, mapping.GetSize());
+}
+
+TEST(MallocMapping, NotEmptyContructor) {
+  size_t length = 10;
+  MallocMapping mapping(reinterpret_cast<uint8_t*>(malloc(length)), length);
+  ASSERT_NE(nullptr, mapping.GetMapping());
+  ASSERT_EQ(length, mapping.GetSize());
+}
+
+TEST(MallocMapping, MoveConstructor) {
+  size_t length = 10;
+  MallocMapping mapping(reinterpret_cast<uint8_t*>(malloc(length)), length);
+  MallocMapping moved = std::move(mapping);
+
+  ASSERT_EQ(nullptr, mapping.GetMapping());
+  ASSERT_EQ(0u, mapping.GetSize());
+  ASSERT_NE(nullptr, moved.GetMapping());
+  ASSERT_EQ(length, moved.GetSize());
+}
+
+TEST(MallocMapping, Copy) {
+  size_t length = 10;
+  MallocMapping mapping(reinterpret_cast<uint8_t*>(malloc(length)), length);
+  memset(const_cast<uint8_t*>(mapping.GetMapping()), 0xac, mapping.GetSize());
+  MallocMapping copied =
+      MallocMapping::Copy(mapping.GetMapping(), mapping.GetSize());
+
+  ASSERT_NE(mapping.GetMapping(), copied.GetMapping());
+  ASSERT_EQ(mapping.GetSize(), copied.GetSize());
+  ASSERT_EQ(
+      0, memcmp(mapping.GetMapping(), copied.GetMapping(), mapping.GetSize()));
+}
+
+TEST(MallocMapping, Release) {
+  size_t length = 10;
+  MallocMapping mapping(reinterpret_cast<uint8_t*>(malloc(length)), length);
+  free(const_cast<uint8_t*>(mapping.Release()));
+  ASSERT_EQ(nullptr, mapping.GetMapping());
+  ASSERT_EQ(0u, mapping.GetSize());
+}
+
+}  // namespace fml

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -130,8 +130,7 @@ Dart_Handle SendPlatformMessage(Dart_Handle window,
     const uint8_t* buffer = static_cast<const uint8_t*>(data.data());
     dart_state->platform_configuration()->client()->HandlePlatformMessage(
         std::make_unique<PlatformMessage>(
-            name,
-            fml::MallocMapping::Copy(buffer, buffer + data.length_in_bytes()),
+            name, fml::MallocMapping::Copy(buffer, data.length_in_bytes()),
             response));
   }
 

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -131,7 +131,7 @@ Dart_Handle SendPlatformMessage(Dart_Handle window,
     dart_state->platform_configuration()->client()->HandlePlatformMessage(
         std::make_unique<PlatformMessage>(
             name,
-            fml::NonOwnedMapping::Copy(buffer, buffer + data.length_in_bytes()),
+            fml::MallocMapping::Copy(buffer, buffer + data.length_in_bytes()),
             response));
   }
 
@@ -339,7 +339,7 @@ void PlatformConfiguration::DispatchPlatformMessage(
 
 void PlatformConfiguration::DispatchSemanticsAction(int32_t id,
                                                     SemanticsAction action,
-                                                    fml::NonOwnedMapping args) {
+                                                    fml::MallocMapping args) {
   std::shared_ptr<tonic::DartState> dart_state =
       dispatch_semantics_action_.dart_state().lock();
   if (!dart_state) {

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -130,7 +130,8 @@ Dart_Handle SendPlatformMessage(Dart_Handle window,
     const uint8_t* buffer = static_cast<const uint8_t*>(data.data());
     dart_state->platform_configuration()->client()->HandlePlatformMessage(
         std::make_unique<PlatformMessage>(
-            name, std::vector<uint8_t>(buffer, buffer + data.length_in_bytes()),
+            name,
+            fml::NonOwnedMapping::Copy(buffer, buffer + data.length_in_bytes()),
             response));
   }
 
@@ -190,8 +191,8 @@ void _RespondToKeyData(Dart_NativeArguments args) {
   tonic::DartCallStatic(&RespondToKeyData, args);
 }
 
-Dart_Handle ToByteData(const std::vector<uint8_t>& buffer) {
-  return tonic::DartByteData::Create(buffer.data(), buffer.size());
+Dart_Handle ToByteData(const fml::Mapping& buffer) {
+  return tonic::DartByteData::Create(buffer.GetMapping(), buffer.GetSize());
 }
 
 }  // namespace
@@ -338,7 +339,7 @@ void PlatformConfiguration::DispatchPlatformMessage(
 
 void PlatformConfiguration::DispatchSemanticsAction(int32_t id,
                                                     SemanticsAction action,
-                                                    std::vector<uint8_t> args) {
+                                                    fml::NonOwnedMapping args) {
   std::shared_ptr<tonic::DartState> dart_state =
       dispatch_semantics_action_.dart_state().lock();
   if (!dart_state) {
@@ -346,7 +347,8 @@ void PlatformConfiguration::DispatchSemanticsAction(int32_t id,
   }
   tonic::DartState::Scope scope(dart_state);
 
-  Dart_Handle args_handle = (args.empty()) ? Dart_Null() : ToByteData(args);
+  Dart_Handle args_handle =
+      (args.GetSize() <= 0) ? Dart_Null() : ToByteData(args);
 
   if (Dart_IsError(args_handle)) {
     return;

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -325,7 +325,7 @@ class PlatformConfiguration final {
   ///
   void DispatchSemanticsAction(int32_t id,
                                SemanticsAction action,
-                               fml::NonOwnedMapping args);
+                               fml::MallocMapping args);
 
   //----------------------------------------------------------------------------
   /// @brief      Registers a callback to be invoked when the framework has

--- a/lib/ui/window/platform_configuration.h
+++ b/lib/ui/window/platform_configuration.h
@@ -325,7 +325,7 @@ class PlatformConfiguration final {
   ///
   void DispatchSemanticsAction(int32_t id,
                                SemanticsAction action,
-                               std::vector<uint8_t> args);
+                               fml::NonOwnedMapping args);
 
   //----------------------------------------------------------------------------
   /// @brief      Registers a callback to be invoked when the framework has

--- a/lib/ui/window/platform_message.cc
+++ b/lib/ui/window/platform_message.cc
@@ -9,7 +9,7 @@
 namespace flutter {
 
 PlatformMessage::PlatformMessage(std::string channel,
-                                 fml::NonOwnedMapping data,
+                                 fml::MallocMapping data,
                                  fml::RefPtr<PlatformMessageResponse> response)
     : channel_(std::move(channel)),
       data_(std::move(data)),

--- a/lib/ui/window/platform_message.cc
+++ b/lib/ui/window/platform_message.cc
@@ -9,7 +9,7 @@
 namespace flutter {
 
 PlatformMessage::PlatformMessage(std::string channel,
-                                 std::vector<uint8_t> data,
+                                 fml::NonOwnedMapping data,
                                  fml::RefPtr<PlatformMessageResponse> response)
     : channel_(std::move(channel)),
       data_(std::move(data)),

--- a/lib/ui/window/platform_message.h
+++ b/lib/ui/window/platform_message.h
@@ -17,23 +17,25 @@ namespace flutter {
 class PlatformMessage {
  public:
   PlatformMessage(std::string channel,
-                  std::vector<uint8_t> data,
+                  fml::NonOwnedMapping data,
                   fml::RefPtr<PlatformMessageResponse> response);
   PlatformMessage(std::string channel,
                   fml::RefPtr<PlatformMessageResponse> response);
   ~PlatformMessage();
 
   const std::string& channel() const { return channel_; }
-  const std::vector<uint8_t>& data() const { return data_; }
+  const fml::NonOwnedMapping& data() const { return data_; }
   bool hasData() { return hasData_; }
 
   const fml::RefPtr<PlatformMessageResponse>& response() const {
     return response_;
   }
 
+  fml::NonOwnedMapping releaseData() { return std::move(data_); }
+
  private:
   std::string channel_;
-  std::vector<uint8_t> data_;
+  fml::NonOwnedMapping data_;
   bool hasData_;
   fml::RefPtr<PlatformMessageResponse> response_;
 };

--- a/lib/ui/window/platform_message.h
+++ b/lib/ui/window/platform_message.h
@@ -17,25 +17,25 @@ namespace flutter {
 class PlatformMessage {
  public:
   PlatformMessage(std::string channel,
-                  fml::NonOwnedMapping data,
+                  fml::MallocMapping data,
                   fml::RefPtr<PlatformMessageResponse> response);
   PlatformMessage(std::string channel,
                   fml::RefPtr<PlatformMessageResponse> response);
   ~PlatformMessage();
 
   const std::string& channel() const { return channel_; }
-  const fml::NonOwnedMapping& data() const { return data_; }
+  const fml::MallocMapping& data() const { return data_; }
   bool hasData() { return hasData_; }
 
   const fml::RefPtr<PlatformMessageResponse>& response() const {
     return response_;
   }
 
-  fml::NonOwnedMapping releaseData() { return std::move(data_); }
+  fml::MallocMapping releaseData() { return std::move(data_); }
 
  private:
   std::string channel_;
-  fml::NonOwnedMapping data_;
+  fml::MallocMapping data_;
   bool hasData_;
   fml::RefPtr<PlatformMessageResponse> response_;
 };

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -278,7 +278,7 @@ bool RuntimeController::DispatchKeyDataPacket(const KeyDataPacket& packet,
 
 bool RuntimeController::DispatchSemanticsAction(int32_t id,
                                                 SemanticsAction action,
-                                                std::vector<uint8_t> args) {
+                                                fml::NonOwnedMapping args) {
   TRACE_EVENT1("flutter", "RuntimeController::DispatchSemanticsAction", "mode",
                "basic");
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -278,7 +278,7 @@ bool RuntimeController::DispatchKeyDataPacket(const KeyDataPacket& packet,
 
 bool RuntimeController::DispatchSemanticsAction(int32_t id,
                                                 SemanticsAction action,
-                                                fml::NonOwnedMapping args) {
+                                                fml::MallocMapping args) {
   TRACE_EVENT1("flutter", "RuntimeController::DispatchSemanticsAction", "mode",
                "basic");
   if (auto* platform_configuration = GetPlatformConfigurationIfAvailable()) {

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -453,7 +453,7 @@ class RuntimeController : public PlatformConfigurationClient {
   ///
   bool DispatchSemanticsAction(int32_t id,
                                SemanticsAction action,
-                               fml::NonOwnedMapping args);
+                               fml::MallocMapping args);
 
   //----------------------------------------------------------------------------
   /// @brief      Gets the main port identifier of the root isolate.

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -453,7 +453,7 @@ class RuntimeController : public PlatformConfigurationClient {
   ///
   bool DispatchSemanticsAction(int32_t id,
                                SemanticsAction action,
-                               std::vector<uint8_t> args);
+                               fml::NonOwnedMapping args);
 
   //----------------------------------------------------------------------------
   /// @brief      Gets the main port identifier of the root isolate.

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -38,7 +38,7 @@ static constexpr char kIsolateChannel[] = "flutter/isolate";
 
 namespace {
 fml::MallocMapping MakeMapping(const std::string& str) {
-  return fml::MallocMapping::Copy(str.c_str(), str.c_str() + str.length());
+  return fml::MallocMapping::Copy(str.c_str(), str.length());
 }
 }  // namespace
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/common/engine.h"
 
+#include <cstring>
 #include <memory>
 #include <string>
 #include <utility>
@@ -34,6 +35,12 @@ static constexpr char kNavigationChannel[] = "flutter/navigation";
 static constexpr char kLocalizationChannel[] = "flutter/localization";
 static constexpr char kSettingsChannel[] = "flutter/settings";
 static constexpr char kIsolateChannel[] = "flutter/isolate";
+
+namespace {
+fml::NonOwnedMapping MakeMapping(const std::string& str) {
+  return fml::NonOwnedMapping::Copy(str.c_str(), str.c_str() + str.length());
+}
+}  // namespace
 
 Engine::Engine(
     Delegate& delegate,
@@ -205,10 +212,7 @@ Engine::RunStatus Engine::Run(RunConfiguration configuration) {
   if (service_id.has_value()) {
     std::unique_ptr<PlatformMessage> service_id_message =
         std::make_unique<flutter::PlatformMessage>(
-            kIsolateChannel,
-            std::vector<uint8_t>(service_id.value().begin(),
-                                 service_id.value().end()),
-            nullptr);
+            kIsolateChannel, MakeMapping(service_id.value()), nullptr);
     HandlePlatformMessage(std::move(service_id_message));
   }
 
@@ -326,7 +330,8 @@ void Engine::DispatchPlatformMessage(std::unique_ptr<PlatformMessage> message) {
 
 bool Engine::HandleLifecyclePlatformMessage(PlatformMessage* message) {
   const auto& data = message->data();
-  std::string state(reinterpret_cast<const char*>(data.data()), data.size());
+  std::string state(reinterpret_cast<const char*>(data.GetMapping()),
+                    data.GetSize());
   if (state == "AppLifecycleState.paused" ||
       state == "AppLifecycleState.detached") {
     activity_running_ = false;
@@ -353,7 +358,8 @@ bool Engine::HandleNavigationPlatformMessage(
   const auto& data = message->data();
 
   rapidjson::Document document;
-  document.Parse(reinterpret_cast<const char*>(data.data()), data.size());
+  document.Parse(reinterpret_cast<const char*>(data.GetMapping()),
+                 data.GetSize());
   if (document.HasParseError() || !document.IsObject()) {
     return false;
   }
@@ -371,7 +377,8 @@ bool Engine::HandleLocalizationPlatformMessage(PlatformMessage* message) {
   const auto& data = message->data();
 
   rapidjson::Document document;
-  document.Parse(reinterpret_cast<const char*>(data.data()), data.size());
+  document.Parse(reinterpret_cast<const char*>(data.GetMapping()),
+                 data.GetSize());
   if (document.HasParseError() || !document.IsObject()) {
     return false;
   }
@@ -411,7 +418,8 @@ bool Engine::HandleLocalizationPlatformMessage(PlatformMessage* message) {
 
 void Engine::HandleSettingsPlatformMessage(PlatformMessage* message) {
   const auto& data = message->data();
-  std::string jsonData(reinterpret_cast<const char*>(data.data()), data.size());
+  std::string jsonData(reinterpret_cast<const char*>(data.GetMapping()),
+                       data.GetSize());
   if (runtime_controller_->SetUserSettingsData(std::move(jsonData)) &&
       have_surface_) {
     ScheduleFrame();
@@ -436,7 +444,7 @@ void Engine::DispatchKeyDataPacket(std::unique_ptr<KeyDataPacket> packet,
 
 void Engine::DispatchSemanticsAction(int id,
                                      SemanticsAction action,
-                                     std::vector<uint8_t> args) {
+                                     fml::NonOwnedMapping args) {
   runtime_controller_->DispatchSemanticsAction(id, action, std::move(args));
 }
 
@@ -538,8 +546,8 @@ void Engine::HandleAssetPlatformMessage(
     return;
   }
   const auto& data = message->data();
-  std::string asset_name(reinterpret_cast<const char*>(data.data()),
-                         data.size());
+  std::string asset_name(reinterpret_cast<const char*>(data.GetMapping()),
+                         data.GetSize());
 
   if (asset_manager_) {
     std::unique_ptr<fml::Mapping> asset_mapping =

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -37,8 +37,8 @@ static constexpr char kSettingsChannel[] = "flutter/settings";
 static constexpr char kIsolateChannel[] = "flutter/isolate";
 
 namespace {
-fml::NonOwnedMapping MakeMapping(const std::string& str) {
-  return fml::NonOwnedMapping::Copy(str.c_str(), str.c_str() + str.length());
+fml::MallocMapping MakeMapping(const std::string& str) {
+  return fml::MallocMapping::Copy(str.c_str(), str.c_str() + str.length());
 }
 }  // namespace
 
@@ -444,7 +444,7 @@ void Engine::DispatchKeyDataPacket(std::unique_ptr<KeyDataPacket> packet,
 
 void Engine::DispatchSemanticsAction(int id,
                                      SemanticsAction action,
-                                     fml::NonOwnedMapping args) {
+                                     fml::MallocMapping args) {
   runtime_controller_->DispatchSemanticsAction(id, action, std::move(args));
 }
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -763,7 +763,7 @@ class Engine final : public RuntimeDelegate,
   ///
   void DispatchSemanticsAction(int id,
                                SemanticsAction action,
-                               fml::NonOwnedMapping args);
+                               fml::MallocMapping args);
 
   //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder has expressed an opinion

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -763,7 +763,7 @@ class Engine final : public RuntimeDelegate,
   ///
   void DispatchSemanticsAction(int id,
                                SemanticsAction action,
-                               std::vector<uint8_t> args);
+                               fml::NonOwnedMapping args);
 
   //----------------------------------------------------------------------------
   /// @brief      Notifies the engine that the embedder has expressed an opinion

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -96,7 +96,8 @@ std::unique_ptr<PlatformMessage> MakePlatformMessage(
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
 
   std::unique_ptr<PlatformMessage> message = std::make_unique<PlatformMessage>(
-      channel, std::vector<uint8_t>(data, data + buffer.GetSize()), response);
+      channel, fml::NonOwnedMapping::Copy(data, data + buffer.GetSize()),
+      response);
   return message;
 }
 

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -96,7 +96,7 @@ std::unique_ptr<PlatformMessage> MakePlatformMessage(
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
 
   std::unique_ptr<PlatformMessage> message = std::make_unique<PlatformMessage>(
-      channel, fml::NonOwnedMapping::Copy(data, data + buffer.GetSize()),
+      channel, fml::MallocMapping::Copy(data, data + buffer.GetSize()),
       response);
   return message;
 }

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -96,8 +96,7 @@ std::unique_ptr<PlatformMessage> MakePlatformMessage(
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
 
   std::unique_ptr<PlatformMessage> message = std::make_unique<PlatformMessage>(
-      channel, fml::MallocMapping::Copy(data, data + buffer.GetSize()),
-      response);
+      channel, fml::MallocMapping::Copy(data, buffer.GetSize()), response);
   return message;
 }
 

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -50,7 +50,7 @@ void PlatformView::DispatchKeyDataPacket(std::unique_ptr<KeyDataPacket> packet,
 
 void PlatformView::DispatchSemanticsAction(int32_t id,
                                            SemanticsAction action,
-                                           std::vector<uint8_t> args) {
+                                           fml::NonOwnedMapping args) {
   delegate_.OnPlatformViewDispatchSemanticsAction(id, action, std::move(args));
 }
 

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -50,7 +50,7 @@ void PlatformView::DispatchKeyDataPacket(std::unique_ptr<KeyDataPacket> packet,
 
 void PlatformView::DispatchSemanticsAction(int32_t id,
                                            SemanticsAction action,
-                                           fml::NonOwnedMapping args) {
+                                           fml::MallocMapping args) {
   delegate_.OnPlatformViewDispatchSemanticsAction(id, action, std::move(args));
 }
 

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -157,7 +157,7 @@ class PlatformView {
     virtual void OnPlatformViewDispatchSemanticsAction(
         int32_t id,
         SemanticsAction action,
-        fml::NonOwnedMapping args) = 0;
+        fml::MallocMapping args) = 0;
 
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the embedder has expressed an
@@ -408,7 +408,7 @@ class PlatformView {
   ///
   void DispatchSemanticsAction(int32_t id,
                                SemanticsAction action,
-                               fml::NonOwnedMapping args);
+                               fml::MallocMapping args);
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedder to notify the running isolate hosted by the

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -157,7 +157,7 @@ class PlatformView {
     virtual void OnPlatformViewDispatchSemanticsAction(
         int32_t id,
         SemanticsAction action,
-        std::vector<uint8_t> args) = 0;
+        fml::NonOwnedMapping args) = 0;
 
     //--------------------------------------------------------------------------
     /// @brief      Notifies the delegate that the embedder has expressed an
@@ -408,7 +408,7 @@ class PlatformView {
   ///
   void DispatchSemanticsAction(int32_t id,
                                SemanticsAction action,
-                               std::vector<uint8_t> args);
+                               fml::NonOwnedMapping args);
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedder to notify the running isolate hosted by the

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -998,7 +998,7 @@ void Shell::OnPlatformViewDispatchKeyDataPacket(
 // |PlatformView::Delegate|
 void Shell::OnPlatformViewDispatchSemanticsAction(int32_t id,
                                                   SemanticsAction action,
-                                                  fml::NonOwnedMapping args) {
+                                                  fml::MallocMapping args) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
@@ -1809,8 +1809,8 @@ bool Shell::ReloadSystemFonts() {
   std::unique_ptr<PlatformMessage> fontsChangeMessage =
       std::make_unique<flutter::PlatformMessage>(
           kSystemChannel,
-          fml::NonOwnedMapping::Copy(message.c_str(),
-                                     message.c_str() + message.length()),
+          fml::MallocMapping::Copy(message.c_str(),
+                                   message.c_str() + message.length()),
           nullptr);
 
   OnPlatformViewDispatchPlatformMessage(std::move(fontsChangeMessage));

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1809,9 +1809,7 @@ bool Shell::ReloadSystemFonts() {
   std::unique_ptr<PlatformMessage> fontsChangeMessage =
       std::make_unique<flutter::PlatformMessage>(
           kSystemChannel,
-          fml::MallocMapping::Copy(message.c_str(),
-                                   message.c_str() + message.length()),
-          nullptr);
+          fml::MallocMapping::Copy(message.c_str(), message.length()), nullptr);
 
   OnPlatformViewDispatchPlatformMessage(std::move(fontsChangeMessage));
   return true;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -496,7 +496,7 @@ class Shell final : public PlatformView::Delegate,
   void OnPlatformViewDispatchSemanticsAction(
       int32_t id,
       SemanticsAction action,
-      std::vector<uint8_t> args) override;
+      fml::NonOwnedMapping args) override;
 
   // |PlatformView::Delegate|
   void OnPlatformViewSetSemanticsEnabled(bool enabled) override;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -493,10 +493,9 @@ class Shell final : public PlatformView::Delegate,
       std::function<void(bool /* handled */)> callback) override;
 
   // |PlatformView::Delegate|
-  void OnPlatformViewDispatchSemanticsAction(
-      int32_t id,
-      SemanticsAction action,
-      fml::NonOwnedMapping args) override;
+  void OnPlatformViewDispatchSemanticsAction(int32_t id,
+                                             SemanticsAction action,
+                                             fml::MallocMapping args) override;
 
   // |PlatformView::Delegate|
   void OnPlatformViewSetSemanticsEnabled(bool enabled) override;

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -69,7 +69,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   MOCK_METHOD3(OnPlatformViewDispatchSemanticsAction,
                void(int32_t id,
                     SemanticsAction action,
-                    std::vector<uint8_t> args));
+                    fml::NonOwnedMapping args));
 
   MOCK_METHOD1(OnPlatformViewSetSemanticsEnabled, void(bool enabled));
 
@@ -1489,7 +1489,8 @@ TEST_F(ShellTest, SetResourceCacheSize) {
                                 "method": "Skia.setResourceCacheMaxBytes",
                                 "args": 10000
                               })json";
-  std::vector<uint8_t> data(request_json.begin(), request_json.end());
+  auto data = fml::NonOwnedMapping::Copy(
+      request_json.c_str(), request_json.c_str() + request_json.length());
   auto platform_message = std::make_unique<PlatformMessage>(
       "flutter/skia", std::move(data), nullptr);
   SendEnginePlatformMessage(shell.get(), std::move(platform_message));

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -69,7 +69,7 @@ class MockPlatformViewDelegate : public PlatformView::Delegate {
   MOCK_METHOD3(OnPlatformViewDispatchSemanticsAction,
                void(int32_t id,
                     SemanticsAction action,
-                    fml::NonOwnedMapping args));
+                    fml::MallocMapping args));
 
   MOCK_METHOD1(OnPlatformViewSetSemanticsEnabled, void(bool enabled));
 
@@ -1489,7 +1489,7 @@ TEST_F(ShellTest, SetResourceCacheSize) {
                                 "method": "Skia.setResourceCacheMaxBytes",
                                 "args": 10000
                               })json";
-  auto data = fml::NonOwnedMapping::Copy(
+  auto data = fml::MallocMapping::Copy(
       request_json.c_str(), request_json.c_str() + request_json.length());
   auto platform_message = std::make_unique<PlatformMessage>(
       "flutter/skia", std::move(data), nullptr);
@@ -1812,10 +1812,7 @@ TEST_F(ShellTest, CanConvertToAndFromMappings) {
       buffer, buffer_size, MemsetPatternOp::kMemsetPatternOpSetBuffer));
 
   std::unique_ptr<fml::Mapping> mapping =
-      std::make_unique<fml::NonOwnedMapping>(
-          buffer, buffer_size, [](const uint8_t* buffer, size_t size) {
-            ::free(const_cast<uint8_t*>(buffer));
-          });
+      std::make_unique<fml::MallocMapping>(buffer, buffer_size);
 
   ASSERT_EQ(mapping->GetSize(), buffer_size);
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1489,8 +1489,8 @@ TEST_F(ShellTest, SetResourceCacheSize) {
                                 "method": "Skia.setResourceCacheMaxBytes",
                                 "args": 10000
                               })json";
-  auto data = fml::MallocMapping::Copy(
-      request_json.c_str(), request_json.c_str() + request_json.length());
+  auto data =
+      fml::MallocMapping::Copy(request_json.c_str(), request_json.length());
   auto platform_message = std::make_unique<PlatformMessage>(
       "flutter/skia", std::move(data), nullptr);
   SendEnginePlatformMessage(shell.get(), std::move(platform_message));

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -180,7 +180,7 @@ void PlatformViewAndroid::DispatchPlatformMessage(JNIEnv* env,
                                                   jint response_id) {
   uint8_t* message_data =
       static_cast<uint8_t*>(env->GetDirectBufferAddress(java_message_data));
-  fml::NonOwnedMapping message = fml::NonOwnedMapping::Copy(
+  fml::MallocMapping message = fml::MallocMapping::Copy(
       message_data, message_data + java_message_position);
 
   fml::RefPtr<flutter::PlatformMessageResponse> response;
@@ -268,13 +268,13 @@ void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,
   if (env->IsSameObject(args, NULL)) {
     PlatformView::DispatchSemanticsAction(
         id, static_cast<flutter::SemanticsAction>(action),
-        fml::NonOwnedMapping());
+        fml::MallocMapping());
     return;
   }
 
   uint8_t* args_data = static_cast<uint8_t*>(env->GetDirectBufferAddress(args));
   auto args_vector =
-      fml::NonOwnedMapping::Copy(args_data, args_data + args_position);
+      fml::MallocMapping::Copy(args_data, args_data + args_position);
 
   PlatformView::DispatchSemanticsAction(
       id, static_cast<flutter::SemanticsAction>(action),

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -180,8 +180,8 @@ void PlatformViewAndroid::DispatchPlatformMessage(JNIEnv* env,
                                                   jint response_id) {
   uint8_t* message_data =
       static_cast<uint8_t*>(env->GetDirectBufferAddress(java_message_data));
-  std::vector<uint8_t> message =
-      std::vector<uint8_t>(message_data, message_data + java_message_position);
+  fml::NonOwnedMapping message = fml::NonOwnedMapping::Copy(
+      message_data, message_data + java_message_position);
 
   fml::RefPtr<flutter::PlatformMessageResponse> response;
   if (response_id) {
@@ -266,15 +266,15 @@ void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,
                                                   jobject args,
                                                   jint args_position) {
   if (env->IsSameObject(args, NULL)) {
-    std::vector<uint8_t> args_vector;
     PlatformView::DispatchSemanticsAction(
-        id, static_cast<flutter::SemanticsAction>(action), args_vector);
+        id, static_cast<flutter::SemanticsAction>(action),
+        fml::NonOwnedMapping());
     return;
   }
 
   uint8_t* args_data = static_cast<uint8_t*>(env->GetDirectBufferAddress(args));
-  std::vector<uint8_t> args_vector =
-      std::vector<uint8_t>(args_data, args_data + args_position);
+  auto args_vector =
+      fml::NonOwnedMapping::Copy(args_data, args_data + args_position);
 
   PlatformView::DispatchSemanticsAction(
       id, static_cast<flutter::SemanticsAction>(action),

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -180,8 +180,8 @@ void PlatformViewAndroid::DispatchPlatformMessage(JNIEnv* env,
                                                   jint response_id) {
   uint8_t* message_data =
       static_cast<uint8_t*>(env->GetDirectBufferAddress(java_message_data));
-  fml::MallocMapping message = fml::MallocMapping::Copy(
-      message_data, message_data + java_message_position);
+  fml::MallocMapping message =
+      fml::MallocMapping::Copy(message_data, java_message_position);
 
   fml::RefPtr<flutter::PlatformMessageResponse> response;
   if (response_id) {
@@ -273,8 +273,7 @@ void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,
   }
 
   uint8_t* args_data = static_cast<uint8_t*>(env->GetDirectBufferAddress(args));
-  auto args_vector =
-      fml::MallocMapping::Copy(args_data, args_data + args_position);
+  auto args_vector = fml::MallocMapping::Copy(args_data, args_position);
 
   PlatformView::DispatchSemanticsAction(
       id, static_cast<flutter::SemanticsAction>(action),

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -1108,10 +1108,10 @@ void PlatformViewAndroidJNIImpl::FlutterViewHandlePlatformMessage(
 
   if (message->hasData()) {
     fml::jni::ScopedJavaLocalRef<jbyteArray> message_array(
-        env, env->NewByteArray(message->data().size()));
+        env, env->NewByteArray(message->data().GetSize()));
     env->SetByteArrayRegion(
-        message_array.obj(), 0, message->data().size(),
-        reinterpret_cast<const jbyte*>(message->data().data()));
+        message_array.obj(), 0, message->data().GetSize(),
+        reinterpret_cast<const jbyte*>(message->data().GetMapping()));
     env->CallVoidMethod(java_object.obj(), g_handle_platform_message_method,
                         java_channel.obj(), message_array.obj(), responseId);
   } else {

--- a/shell/platform/common/BUILD.gn
+++ b/shell/platform/common/BUILD.gn
@@ -83,6 +83,7 @@ source_set("common_cpp_accessibility") {
       [ "//flutter/third_party/accessibility:accessibility_config" ]
 
   public_deps = [
+    "//flutter/fml:fml",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/third_party/accessibility",
   ]

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -539,8 +539,8 @@ gfx::RectF AccessibilityBridge::RelativeToGlobalBounds(const ui::AXNode* node,
 void AccessibilityBridge::DispatchAccessibilityAction(
     AccessibilityNodeId target,
     FlutterSemanticsAction action,
-    std::vector<uint8_t> data) {
-  delegate_->DispatchAccessibilityAction(target, action, data);
+    fml::NonOwnedMapping data) {
+  delegate_->DispatchAccessibilityAction(target, action, std::move(data));
 }
 
 }  // namespace flutter

--- a/shell/platform/common/accessibility_bridge.cc
+++ b/shell/platform/common/accessibility_bridge.cc
@@ -539,7 +539,7 @@ gfx::RectF AccessibilityBridge::RelativeToGlobalBounds(const ui::AXNode* node,
 void AccessibilityBridge::DispatchAccessibilityAction(
     AccessibilityNodeId target,
     FlutterSemanticsAction action,
-    fml::NonOwnedMapping data) {
+    fml::MallocMapping data) {
   delegate_->DispatchAccessibilityAction(target, action, std::move(data));
 }
 

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -89,7 +89,7 @@ class AccessibilityBridge
     ///                                 action.
     virtual void DispatchAccessibilityAction(AccessibilityNodeId target,
                                              FlutterSemanticsAction action,
-                                             fml::NonOwnedMapping data) = 0;
+                                             fml::MallocMapping data) = 0;
 
     //---------------------------------------------------------------------------
     /// @brief      Creates a platform specific FlutterPlatformNodeDelegate.
@@ -277,7 +277,7 @@ class AccessibilityBridge
   // |FlutterPlatformNodeDelegate::OwnerBridge|
   void DispatchAccessibilityAction(AccessibilityNodeId target,
                                    FlutterSemanticsAction action,
-                                   fml::NonOwnedMapping data) override;
+                                   fml::MallocMapping data) override;
 
   // |FlutterPlatformNodeDelegate::OwnerBridge|
   gfx::RectF RelativeToGlobalBounds(const ui::AXNode* node,

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -7,6 +7,7 @@
 
 #include <unordered_map>
 
+#include "flutter/fml/mapping.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 
 #include "flutter/third_party/accessibility/ax/ax_event_generator.h"
@@ -86,10 +87,9 @@ class AccessibilityBridge
     /// @param[in]  action              The generated flutter semantics action.
     /// @param[in]  data                Additional data associated with the
     ///                                 action.
-    virtual void DispatchAccessibilityAction(
-        AccessibilityNodeId target,
-        FlutterSemanticsAction action,
-        const std::vector<uint8_t>& data) = 0;
+    virtual void DispatchAccessibilityAction(AccessibilityNodeId target,
+                                             FlutterSemanticsAction action,
+                                             fml::NonOwnedMapping data) = 0;
 
     //---------------------------------------------------------------------------
     /// @brief      Creates a platform specific FlutterPlatformNodeDelegate.
@@ -277,7 +277,7 @@ class AccessibilityBridge
   // |FlutterPlatformNodeDelegate::OwnerBridge|
   void DispatchAccessibilityAction(AccessibilityNodeId target,
                                    FlutterSemanticsAction action,
-                                   std::vector<uint8_t> data) override;
+                                   fml::NonOwnedMapping data) override;
 
   // |FlutterPlatformNodeDelegate::OwnerBridge|
   gfx::RectF RelativeToGlobalBounds(const ui::AXNode* node,

--- a/shell/platform/common/flutter_platform_node_delegate.h
+++ b/shell/platform/common/flutter_platform_node_delegate.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_COMMON_FLUTTER_PLATFORM_NODE_DELEGATE_H_
 #define FLUTTER_SHELL_PLATFORM_COMMON_FLUTTER_PLATFORM_NODE_DELEGATE_H_
 
+#include "flutter/fml/mapping.h"
 #include "flutter/shell/platform/embedder/embedder.h"
-
 #include "flutter/third_party/accessibility/ax/ax_event_generator.h"
 #include "flutter/third_party/accessibility/ax/platform/ax_platform_node_delegate_base.h"
 
@@ -57,7 +57,7 @@ class FlutterPlatformNodeDelegate : public ui::AXPlatformNodeDelegateBase {
     ///                                 action.
     virtual void DispatchAccessibilityAction(AccessibilityNodeId target,
                                              FlutterSemanticsAction action,
-                                             std::vector<uint8_t> data) = 0;
+                                             fml::NonOwnedMapping data) = 0;
 
     //---------------------------------------------------------------------------
     /// @brief      Get the native accessibility node with the given id.

--- a/shell/platform/common/flutter_platform_node_delegate.h
+++ b/shell/platform/common/flutter_platform_node_delegate.h
@@ -57,7 +57,7 @@ class FlutterPlatformNodeDelegate : public ui::AXPlatformNodeDelegateBase {
     ///                                 action.
     virtual void DispatchAccessibilityAction(AccessibilityNodeId target,
                                              FlutterSemanticsAction action,
-                                             fml::NonOwnedMapping data) = 0;
+                                             fml::MallocMapping data) = 0;
 
     //---------------------------------------------------------------------------
     /// @brief      Get the native accessibility node with the given id.

--- a/shell/platform/common/test_accessibility_bridge.cc
+++ b/shell/platform/common/test_accessibility_bridge.cc
@@ -19,7 +19,7 @@ void TestAccessibilityBridgeDelegate::OnAccessibilityEvent(
 void TestAccessibilityBridgeDelegate::DispatchAccessibilityAction(
     AccessibilityNodeId target,
     FlutterSemanticsAction action,
-    const std::vector<uint8_t>& data) {
+    fml::NonOwnedMapping data) {
   performed_actions.push_back(action);
 }
 

--- a/shell/platform/common/test_accessibility_bridge.cc
+++ b/shell/platform/common/test_accessibility_bridge.cc
@@ -19,7 +19,7 @@ void TestAccessibilityBridgeDelegate::OnAccessibilityEvent(
 void TestAccessibilityBridgeDelegate::DispatchAccessibilityAction(
     AccessibilityNodeId target,
     FlutterSemanticsAction action,
-    fml::NonOwnedMapping data) {
+    fml::MallocMapping data) {
   performed_actions.push_back(action);
 }
 

--- a/shell/platform/common/test_accessibility_bridge.h
+++ b/shell/platform/common/test_accessibility_bridge.h
@@ -18,7 +18,7 @@ class TestAccessibilityBridgeDelegate
       ui::AXEventGenerator::TargetedEvent targeted_event) override;
   void DispatchAccessibilityAction(AccessibilityNodeId target,
                                    FlutterSemanticsAction action,
-                                   fml::NonOwnedMapping data) override;
+                                   fml::MallocMapping data) override;
   std::unique_ptr<FlutterPlatformNodeDelegate>
   CreateFlutterPlatformNodeDelegate();
 

--- a/shell/platform/common/test_accessibility_bridge.h
+++ b/shell/platform/common/test_accessibility_bridge.h
@@ -18,7 +18,7 @@ class TestAccessibilityBridgeDelegate
       ui::AXEventGenerator::TargetedEvent targeted_event) override;
   void DispatchAccessibilityAction(AccessibilityNodeId target,
                                    FlutterSemanticsAction action,
-                                   const std::vector<uint8_t>& data) override;
+                                   fml::NonOwnedMapping data) override;
   std::unique_ptr<FlutterPlatformNodeDelegate>
   CreateFlutterPlatformNodeDelegate();
 

--- a/shell/platform/darwin/common/buffer_conversions.h
+++ b/shell/platform/darwin/common/buffer_conversions.h
@@ -13,9 +13,9 @@
 
 namespace flutter {
 
-fml::NonOwnedMapping CopyNSDataToMapping(NSData* data);
+fml::MallocMapping CopyNSDataToMapping(NSData* data);
 
-NSData* CopyMappingToNSData(fml::NonOwnedMapping buffer);
+NSData* CopyMappingToNSData(fml::MallocMapping buffer);
 
 std::unique_ptr<fml::Mapping> CopyNSDataToMappingPtr(NSData* data);
 

--- a/shell/platform/darwin/common/buffer_conversions.h
+++ b/shell/platform/darwin/common/buffer_conversions.h
@@ -13,13 +13,13 @@
 
 namespace flutter {
 
-std::vector<uint8_t> GetVectorFromNSData(NSData* data);
+fml::NonOwnedMapping CopyNSDataToMapping(NSData* data);
 
-NSData* GetNSDataFromVector(const std::vector<uint8_t>& buffer);
+NSData* CopyMappingToNSData(fml::NonOwnedMapping buffer);
 
-std::unique_ptr<fml::Mapping> GetMappingFromNSData(NSData* data);
+std::unique_ptr<fml::Mapping> CopyNSDataToMappingPtr(NSData* data);
 
-NSData* GetNSDataFromMapping(std::unique_ptr<fml::Mapping> mapping);
+NSData* CopyMappingPtrToNSData(std::unique_ptr<fml::Mapping> mapping);
 
 }  // namespace flutter
 

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -6,18 +6,18 @@
 
 namespace flutter {
 
-fml::NonOwnedMapping CopyNSDataToMapping(NSData* data) {
+fml::MallocMapping CopyNSDataToMapping(NSData* data) {
   const uint8_t* bytes = static_cast<const uint8_t*>(data.bytes);
-  return fml::NonOwnedMapping::Copy(bytes, bytes + data.length);
+  return fml::MallocMapping::Copy(bytes, bytes + data.length);
 }
 
-NSData* CopyMappingToNSData(fml::NonOwnedMapping buffer) {
+NSData* CopyMappingToNSData(fml::MallocMapping buffer) {
   return [NSData dataWithBytes:const_cast<uint8_t*>(buffer.GetMapping()) length:buffer.GetSize()];
 }
 
 std::unique_ptr<fml::Mapping> CopyNSDataToMappingPtr(NSData* data) {
   auto mapping = CopyNSDataToMapping(data);
-  return std::make_unique<fml::NonOwnedMapping>(std::move(mapping));
+  return std::make_unique<fml::MallocMapping>(std::move(mapping));
 }
 
 NSData* CopyMappingPtrToNSData(std::unique_ptr<fml::Mapping> mapping) {

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -8,7 +8,7 @@ namespace flutter {
 
 fml::MallocMapping CopyNSDataToMapping(NSData* data) {
   const uint8_t* bytes = static_cast<const uint8_t*>(data.bytes);
-  return fml::MallocMapping::Copy(bytes, bytes + data.length);
+  return fml::MallocMapping::Copy(bytes, data.length);
 }
 
 NSData* CopyMappingToNSData(fml::MallocMapping buffer) {

--- a/shell/platform/darwin/common/buffer_conversions.mm
+++ b/shell/platform/darwin/common/buffer_conversions.mm
@@ -6,20 +6,21 @@
 
 namespace flutter {
 
-std::vector<uint8_t> GetVectorFromNSData(NSData* data) {
-  const uint8_t* bytes = reinterpret_cast<const uint8_t*>(data.bytes);
-  return std::vector<uint8_t>(bytes, bytes + data.length);
+fml::NonOwnedMapping CopyNSDataToMapping(NSData* data) {
+  const uint8_t* bytes = static_cast<const uint8_t*>(data.bytes);
+  return fml::NonOwnedMapping::Copy(bytes, bytes + data.length);
 }
 
-NSData* GetNSDataFromVector(const std::vector<uint8_t>& buffer) {
-  return [NSData dataWithBytes:buffer.data() length:buffer.size()];
+NSData* CopyMappingToNSData(fml::NonOwnedMapping buffer) {
+  return [NSData dataWithBytes:const_cast<uint8_t*>(buffer.GetMapping()) length:buffer.GetSize()];
 }
 
-std::unique_ptr<fml::Mapping> GetMappingFromNSData(NSData* data) {
-  return std::make_unique<fml::DataMapping>(GetVectorFromNSData(data));
+std::unique_ptr<fml::Mapping> CopyNSDataToMappingPtr(NSData* data) {
+  auto mapping = CopyNSDataToMapping(data);
+  return std::make_unique<fml::NonOwnedMapping>(std::move(mapping));
 }
 
-NSData* GetNSDataFromMapping(std::unique_ptr<fml::Mapping> mapping) {
+NSData* CopyMappingPtrToNSData(std::unique_ptr<fml::Mapping> mapping) {
   return [NSData dataWithBytes:mapping->GetMapping() length:mapping->GetSize()];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -807,7 +807,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   std::unique_ptr<flutter::PlatformMessage> platformMessage =
       (message == nil) ? std::make_unique<flutter::PlatformMessage>(channel.UTF8String, response)
                        : std::make_unique<flutter::PlatformMessage>(
-                             channel.UTF8String, flutter::GetVectorFromNSData(message), response);
+                             channel.UTF8String, flutter::CopyNSDataToMapping(message), response);
 
   _shell->GetPlatformView()->DispatchPlatformMessage(std::move(platformMessage));
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEnginePlatformViewTest.mm
@@ -29,7 +29,7 @@ class MockDelegate : public PlatformView::Delegate {
                                            std::function<void(bool)> callback) override {}
   void OnPlatformViewDispatchSemanticsAction(int32_t id,
                                              SemanticsAction action,
-                                             std::vector<uint8_t> args) override {}
+                                             fml::MallocMapping args) override {}
   void OnPlatformViewSetSemanticsEnabled(bool enabled) override {}
   void OnPlatformViewSetAccessibilityFeatures(int32_t flags) override {}
   void OnPlatformViewRegisterTexture(std::shared_ptr<Texture> texture) override {}

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -99,7 +99,7 @@ class FlutterPlatformViewsTestMockPlatformViewDelegate : public PlatformView::De
                                            std::function<void(bool)> callback) override {}
   void OnPlatformViewDispatchSemanticsAction(int32_t id,
                                              SemanticsAction action,
-                                             std::vector<uint8_t> args) override {}
+                                             fml::MallocMapping args) override {}
   void OnPlatformViewSetSemanticsEnabled(bool enabled) override {}
   void OnPlatformViewSetAccessibilityFeatures(int32_t flags) override {}
   void OnPlatformViewRegisterTexture(std::shared_ptr<Texture> texture) override {}

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -308,8 +308,9 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   args.push_back(action_id >> 8);
   args.push_back(action_id >> 16);
   args.push_back(action_id >> 24);
-  [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kCustomAction,
-                                         std::move(args));
+  [self bridge]->DispatchSemanticsAction(
+      [self uid], flutter::SemanticsAction::kCustomAction,
+      fml::NonOwnedMapping::Copy(args.data(), args.data() + args.size() * sizeof(uint8_t)));
   return YES;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -310,7 +310,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   args.push_back(action_id >> 24);
   [self bridge]->DispatchSemanticsAction(
       [self uid], flutter::SemanticsAction::kCustomAction,
-      fml::NonOwnedMapping::Copy(args.data(), args.data() + args.size() * sizeof(uint8_t)));
+      fml::MallocMapping::Copy(args.data(), args.data() + args.size() * sizeof(uint8_t)));
   return YES;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -310,7 +310,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   args.push_back(action_id >> 24);
   [self bridge]->DispatchSemanticsAction(
       [self uid], flutter::SemanticsAction::kCustomAction,
-      fml::MallocMapping::Copy(args.data(), args.data() + args.size() * sizeof(uint8_t)));
+      fml::MallocMapping::Copy(args.data(), args.size() * sizeof(uint8_t)));
   return YES;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -33,7 +33,7 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   }
   void DispatchSemanticsAction(int32_t id,
                                SemanticsAction action,
-                               std::vector<uint8_t> args) override {
+                               fml::MallocMapping args) override {
     SemanticsActionObservation observation(id, action);
     observations.push_back(observation);
   }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -60,7 +60,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   void DispatchSemanticsAction(int32_t id, flutter::SemanticsAction action) override;
   void DispatchSemanticsAction(int32_t id,
                                flutter::SemanticsAction action,
-                               fml::NonOwnedMapping args) override;
+                               fml::MallocMapping args) override;
   void AccessibilityObjectDidBecomeFocused(int32_t id) override;
   void AccessibilityObjectDidLoseFocus(int32_t id) override;
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -60,7 +60,7 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   void DispatchSemanticsAction(int32_t id, flutter::SemanticsAction action) override;
   void DispatchSemanticsAction(int32_t id,
                                flutter::SemanticsAction action,
-                               std::vector<uint8_t> args) override;
+                               fml::NonOwnedMapping args) override;
   void AccessibilityObjectDidBecomeFocused(int32_t id) override;
   void AccessibilityObjectDidLoseFocus(int32_t id) override;
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -233,7 +233,7 @@ void AccessibilityBridge::DispatchSemanticsAction(int32_t uid, flutter::Semantic
 
 void AccessibilityBridge::DispatchSemanticsAction(int32_t uid,
                                                   flutter::SemanticsAction action,
-                                                  fml::NonOwnedMapping args) {
+                                                  fml::MallocMapping args) {
   platform_view_->DispatchSemanticsAction(uid, action, std::move(args));
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -233,7 +233,7 @@ void AccessibilityBridge::DispatchSemanticsAction(int32_t uid, flutter::Semantic
 
 void AccessibilityBridge::DispatchSemanticsAction(int32_t uid,
                                                   flutter::SemanticsAction action,
-                                                  std::vector<uint8_t> args) {
+                                                  fml::NonOwnedMapping args) {
   platform_view_->DispatchSemanticsAction(uid, action, std::move(args));
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 
+#import "flutter/fml/mapping.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 
 @class UIView;
@@ -24,7 +25,7 @@ class AccessibilityBridgeIos {
   virtual void DispatchSemanticsAction(int32_t id, flutter::SemanticsAction action) = 0;
   virtual void DispatchSemanticsAction(int32_t id,
                                        flutter::SemanticsAction action,
-                                       std::vector<uint8_t> args) = 0;
+                                       fml::NonOwnedMapping args) = 0;
   /**
    * A callback that is called when a SemanticObject receives focus.
    *

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
@@ -25,7 +25,7 @@ class AccessibilityBridgeIos {
   virtual void DispatchSemanticsAction(int32_t id, flutter::SemanticsAction action) = 0;
   virtual void DispatchSemanticsAction(int32_t id,
                                        flutter::SemanticsAction action,
-                                       fml::NonOwnedMapping args) = 0;
+                                       fml::MallocMapping args) = 0;
   /**
    * A callback that is called when a SemanticObject receives focus.
    *

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -82,7 +82,7 @@ class MockDelegate : public PlatformView::Delegate {
                                            std::function<void(bool)> callback) override {}
   void OnPlatformViewDispatchSemanticsAction(int32_t id,
                                              SemanticsAction action,
-                                             std::vector<uint8_t> args) override {}
+                                             fml::MallocMapping args) override {}
   void OnPlatformViewSetSemanticsEnabled(bool enabled) override {}
   void OnPlatformViewSetAccessibilityFeatures(int32_t flags) override {}
   void OnPlatformViewRegisterTexture(std::shared_ptr<Texture> texture) override {}

--- a/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
@@ -17,7 +17,7 @@ PlatformMessageResponseDarwin::~PlatformMessageResponseDarwin() = default;
 void PlatformMessageResponseDarwin::Complete(std::unique_ptr<fml::Mapping> data) {
   fml::RefPtr<PlatformMessageResponseDarwin> self(this);
   platform_task_runner_->PostTask(fml::MakeCopyable([self, data = std::move(data)]() mutable {
-    self->callback_.get()(GetNSDataFromMapping(std::move(data)));
+    self->callback_.get()(CopyMappingPtrToNSData(std::move(data)));
   }));
 }
 

--- a/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
@@ -22,12 +22,12 @@ void PlatformMessageRouter::HandlePlatformMessage(
     FlutterBinaryMessageHandler handler = it->second;
     NSData* data = nil;
     if (message->hasData()) {
-      data = GetNSDataFromVector(message->data());
+      data = CopyMappingToNSData(message->releaseData());
     }
     handler(data, ^(NSData* reply) {
       if (completer) {
         if (reply) {
-          completer->Complete(GetMappingFromNSData(reply));
+          completer->Complete(CopyNSDataToMappingPtr(reply));
         } else {
           completer->CompleteEmpty();
         }

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h
@@ -30,7 +30,7 @@ class AccessibilityBridgeMacDelegate : public AccessibilityBridge::Accessibility
   // |AccessibilityBridge::AccessibilityBridgeDelegate|
   void DispatchAccessibilityAction(AccessibilityNodeId target,
                                    FlutterSemanticsAction action,
-                                   fml::NonOwnedMapping data) override;
+                                   fml::MallocMapping data) override;
 
   // |AccessibilityBridge::AccessibilityBridgeDelegate|
   std::unique_ptr<FlutterPlatformNodeDelegate> CreateFlutterPlatformNodeDelegate() override;

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.h
@@ -30,7 +30,7 @@ class AccessibilityBridgeMacDelegate : public AccessibilityBridge::Accessibility
   // |AccessibilityBridge::AccessibilityBridgeDelegate|
   void DispatchAccessibilityAction(AccessibilityNodeId target,
                                    FlutterSemanticsAction action,
-                                   const std::vector<uint8_t>& data) override;
+                                   fml::NonOwnedMapping data) override;
 
   // |AccessibilityBridge::AccessibilityBridgeDelegate|
   std::unique_ptr<FlutterPlatformNodeDelegate> CreateFlutterPlatformNodeDelegate() override;

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -339,7 +339,7 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
 
 void AccessibilityBridgeMacDelegate::DispatchAccessibilityAction(ui::AXNode::AXID target,
                                                                  FlutterSemanticsAction action,
-                                                                 fml::NonOwnedMapping data) {
+                                                                 fml::MallocMapping data) {
   NSCAssert(flutter_engine_, @"Flutter engine should not be deallocated");
   NSCAssert(flutter_engine_.viewController.viewLoaded && flutter_engine_.viewController.view.window,
             @"The accessibility bridge should not receive accessibility actions if the flutter view"

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -339,12 +339,12 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
 
 void AccessibilityBridgeMacDelegate::DispatchAccessibilityAction(ui::AXNode::AXID target,
                                                                  FlutterSemanticsAction action,
-                                                                 const std::vector<uint8_t>& data) {
+                                                                 fml::NonOwnedMapping data) {
   NSCAssert(flutter_engine_, @"Flutter engine should not be deallocated");
   NSCAssert(flutter_engine_.viewController.viewLoaded && flutter_engine_.viewController.view.window,
             @"The accessibility bridge should not receive accessibility actions if the flutter view"
             @"is not loaded or attached to a NSWindow.");
-  [flutter_engine_ dispatchSemanticsAction:action toTarget:target withData:data];
+  [flutter_engine_ dispatchSemanticsAction:action toTarget:target withData:std::move(data)];
 }
 
 std::unique_ptr<FlutterPlatformNodeDelegate>

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -465,7 +465,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
 
 - (void)dispatchSemanticsAction:(FlutterSemanticsAction)action
                        toTarget:(uint16_t)target
-                       withData:(fml::NonOwnedMapping)data {
+                       withData:(fml::MallocMapping)data {
   _embedderAPI.DispatchSemanticsAction(_engine, target, action, data.GetMapping(), data.GetSize());
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -465,8 +465,8 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
 
 - (void)dispatchSemanticsAction:(FlutterSemanticsAction)action
                        toTarget:(uint16_t)target
-                       withData:(const std::vector<uint8_t>&)data {
-  _embedderAPI.DispatchSemanticsAction(_engine, target, action, data.data(), data.size());
+                       withData:(fml::NonOwnedMapping)data {
+  _embedderAPI.DispatchSemanticsAction(_engine, target, action, data.GetMapping(), data.GetSize());
 }
 
 #pragma mark - Private methods

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -77,6 +77,6 @@
  */
 - (void)dispatchSemanticsAction:(FlutterSemanticsAction)action
                        toTarget:(uint16_t)target
-                       withData:(const std::vector<uint8_t>&)data;
+                       withData:(fml::NonOwnedMapping)data;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
@@ -77,6 +77,6 @@
  */
 - (void)dispatchSemanticsAction:(FlutterSemanticsAction)action
                        toTarget:(uint16_t)target
-                       withData:(fml::NonOwnedMapping)data;
+                       withData:(fml::MallocMapping)data;
 
 @end

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1637,8 +1637,7 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
   } else {
     message = std::make_unique<flutter::PlatformMessage>(
         flutter_message->channel,
-        fml::MallocMapping::Copy(message_data, message_data + message_size),
-        response);
+        fml::MallocMapping::Copy(message_data, message_size), response);
   }
 
   return reinterpret_cast<flutter::EmbedderEngine*>(engine)
@@ -1829,7 +1828,7 @@ FlutterEngineResult FlutterEngineDispatchSemanticsAction(
   if (!reinterpret_cast<flutter::EmbedderEngine*>(engine)
            ->DispatchSemanticsAction(
                id, engine_action,
-               fml::MallocMapping::Copy(data, data + data_length))) {
+               fml::MallocMapping::Copy(data, data_length))) {
     return LOG_EMBEDDER_ERROR(kInternalInconsistency,
                               "Could not dispatch semantics action.");
   }
@@ -1955,8 +1954,8 @@ static bool DispatchJSONPlatformMessage(FLUTTER_API_SYMBOL(FlutterEngine)
   auto platform_message = std::make_unique<flutter::PlatformMessage>(
       channel_name.c_str(),  // channel
       fml::MallocMapping::Copy(message,
-                               message + buffer.GetSize()),  // message
-      nullptr                                                // response
+                               buffer.GetSize()),  // message
+      nullptr                                      // response
   );
 
   return reinterpret_cast<flutter::EmbedderEngine*>(engine)

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1637,7 +1637,7 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
   } else {
     message = std::make_unique<flutter::PlatformMessage>(
         flutter_message->channel,
-        fml::NonOwnedMapping::Copy(message_data, message_data + message_size),
+        fml::MallocMapping::Copy(message_data, message_data + message_size),
         response);
   }
 
@@ -1829,7 +1829,7 @@ FlutterEngineResult FlutterEngineDispatchSemanticsAction(
   if (!reinterpret_cast<flutter::EmbedderEngine*>(engine)
            ->DispatchSemanticsAction(
                id, engine_action,
-               fml::NonOwnedMapping::Copy(data, data + data_length))) {
+               fml::MallocMapping::Copy(data, data + data_length))) {
     return LOG_EMBEDDER_ERROR(kInternalInconsistency,
                               "Could not dispatch semantics action.");
   }
@@ -1954,9 +1954,9 @@ static bool DispatchJSONPlatformMessage(FLUTTER_API_SYMBOL(FlutterEngine)
 
   auto platform_message = std::make_unique<flutter::PlatformMessage>(
       channel_name.c_str(),  // channel
-      fml::NonOwnedMapping::Copy(message,
-                                 message + buffer.GetSize()),  // message
-      nullptr                                                  // response
+      fml::MallocMapping::Copy(message,
+                               message + buffer.GetSize()),  // message
+      nullptr                                                // response
   );
 
   return reinterpret_cast<flutter::EmbedderEngine*>(engine)

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -210,7 +210,7 @@ bool EmbedderEngine::SetAccessibilityFeatures(int32_t flags) {
 
 bool EmbedderEngine::DispatchSemanticsAction(int id,
                                              flutter::SemanticsAction action,
-                                             std::vector<uint8_t> args) {
+                                             fml::NonOwnedMapping args) {
   if (!IsValid()) {
     return false;
   }

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -210,7 +210,7 @@ bool EmbedderEngine::SetAccessibilityFeatures(int32_t flags) {
 
 bool EmbedderEngine::DispatchSemanticsAction(int id,
                                              flutter::SemanticsAction action,
-                                             fml::NonOwnedMapping args) {
+                                             fml::MallocMapping args) {
   if (!IsValid()) {
     return false;
   }

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -82,7 +82,7 @@ class EmbedderEngine {
 
   bool DispatchSemanticsAction(int id,
                                flutter::SemanticsAction action,
-                               std::vector<uint8_t> args);
+                               fml::NonOwnedMapping args);
 
   bool OnVsyncEvent(intptr_t baton,
                     fml::TimePoint frame_start_time,

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -82,7 +82,7 @@ class EmbedderEngine {
 
   bool DispatchSemanticsAction(int id,
                                flutter::SemanticsAction action,
-                               fml::NonOwnedMapping args);
+                               fml::MallocMapping args);
 
   bool OnVsyncEvent(intptr_t baton,
                     fml::TimePoint frame_start_time,

--- a/shell/platform/fuchsia/flutter/fuchsia_intl.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_intl.cc
@@ -66,7 +66,7 @@ fml::MallocMapping MakeLocalizationPlatformMessageData(
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   document.Accept(writer);
   auto data = reinterpret_cast<const uint8_t*>(buffer.GetString());
-  return fml::MallocMapping::Copy(data, data + buffer.GetSize());
+  return fml::MallocMapping::Copy(data, buffer.GetSize());
 }
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/fuchsia_intl.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_intl.cc
@@ -27,7 +27,7 @@ namespace flutter_runner {
 
 using fuchsia::intl::Profile;
 
-std::vector<uint8_t> MakeLocalizationPlatformMessageData(
+fml::MallocMapping MakeLocalizationPlatformMessageData(
     const Profile& intl_profile) {
   rapidjson::Document document;
   auto& allocator = document.GetAllocator();
@@ -66,7 +66,7 @@ std::vector<uint8_t> MakeLocalizationPlatformMessageData(
   rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
   document.Accept(writer);
   auto data = reinterpret_cast<const uint8_t*>(buffer.GetString());
-  return std::vector<uint8_t>(data, data + buffer.GetSize());
+  return fml::MallocMapping::Copy(data, data + buffer.GetSize());
 }
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/fuchsia_intl.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_intl.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FUCHSIA_INTL_H_
 
 #include <fuchsia/intl/cpp/fidl.h>
+#include "flutter/fml/mapping.h"
 
 namespace flutter_runner {
 
@@ -15,7 +16,7 @@ namespace flutter_runner {
 // This method does not return a `std::unique_ptr<flutter::PlatformMessage>` for
 // testing convenience; that would require an unreasonably large set of
 // dependencies for the unit tests.
-std::vector<uint8_t> MakeLocalizationPlatformMessageData(
+fml::MallocMapping MakeLocalizationPlatformMessageData(
     const fuchsia::intl::Profile& intl_profile);
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/fuchsia_intl_unittest.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_intl_unittest.cc
@@ -34,7 +34,8 @@ TEST_F(FuchsiaIntlTest, MakeLocalizationPlatformMessageData_SimpleLocale) {
   const std::string expected =
       R"({"method":"setLocale","args":["en","US","",""]})";
   const auto actual = MakeLocalizationPlatformMessageData(profile);
-  ASSERT_EQ(expected, std::string(actual.begin(), actual.end()));
+  ASSERT_EQ(expected, std::string(actual.GetMapping(),
+                                  actual.GetMapping() + actual.GetSize()));
 }
 
 TEST_F(FuchsiaIntlTest, MakeLocalizationPlatformMessageData_OneLocale) {
@@ -48,7 +49,8 @@ TEST_F(FuchsiaIntlTest, MakeLocalizationPlatformMessageData_OneLocale) {
   const std::string expected =
       R"({"method":"setLocale","args":["en","US","",""]})";
   const auto actual = MakeLocalizationPlatformMessageData(profile);
-  ASSERT_EQ(expected, std::string(actual.begin(), actual.end()));
+  ASSERT_EQ(expected, std::string(actual.GetMapping(),
+                                  actual.GetMapping() + actual.GetSize()));
 }
 
 TEST_F(FuchsiaIntlTest, MakeLocalizationPlatformMessageData_MultipleLocales) {
@@ -65,7 +67,8 @@ TEST_F(FuchsiaIntlTest, MakeLocalizationPlatformMessageData_MultipleLocales) {
       R"({"method":"setLocale","args":["en","US","","","sl","IT","Latn","nedis",)"
       R"("zh","","Hans","","sr","CS","Cyrl",""]})";
   const auto actual = MakeLocalizationPlatformMessageData(profile);
-  ASSERT_EQ(expected, std::string(actual.begin(), actual.end()));
+  ASSERT_EQ(expected, std::string(actual.GetMapping(),
+                                  actual.GetMapping() + actual.GetSize()));
 }
 
 }  // namespace

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -177,9 +177,9 @@ void PlatformView::DidUpdateState(
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
   DispatchPlatformMessage(std::make_unique<flutter::PlatformMessage>(
-      kTextInputChannel,                                        // channel
-      fml::MallocMapping::Copy(data, data + buffer.GetSize()),  // message
-      nullptr)                                                  // response
+      kTextInputChannel,                                 // channel
+      fml::MallocMapping::Copy(data, buffer.GetSize()),  // message
+      nullptr)                                           // response
   );
   last_text_state_ =
       std::make_unique<fuchsia::ui::input::TextInputState>(state);
@@ -207,9 +207,9 @@ void PlatformView::OnAction(fuchsia::ui::input::InputMethodAction action) {
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
   DispatchPlatformMessage(std::make_unique<flutter::PlatformMessage>(
-      kTextInputChannel,                                        // channel
-      fml::MallocMapping::Copy(data, data + buffer.GetSize()),  // message
-      nullptr)                                                  // response
+      kTextInputChannel,                                 // channel
+      fml::MallocMapping::Copy(data, buffer.GetSize()),  // message
+      nullptr)                                           // response
   );
 }
 
@@ -446,8 +446,7 @@ bool PlatformView::OnChildViewConnected(scenic::ResourceId view_holder_id) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          fml::MallocMapping::Copy(call.c_str(), call.c_str() + call.size()),
-          nullptr);
+          fml::MallocMapping::Copy(call.c_str(), call.size()), nullptr);
   DispatchPlatformMessage(std::move(message));
 
   return true;
@@ -471,8 +470,7 @@ bool PlatformView::OnChildViewDisconnected(scenic::ResourceId view_holder_id) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          fml::MallocMapping::Copy(call.c_str(), call.c_str() + call.size()),
-          nullptr);
+          fml::MallocMapping::Copy(call.c_str(), call.size()), nullptr);
   DispatchPlatformMessage(std::move(message));
 
   return true;
@@ -499,8 +497,7 @@ bool PlatformView::OnChildViewStateChanged(scenic::ResourceId view_holder_id,
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          fml::MallocMapping::Copy(call.c_str(), call.c_str() + call.size()),
-          nullptr);
+          fml::MallocMapping::Copy(call.c_str(), call.size()), nullptr);
   DispatchPlatformMessage(std::move(message));
 
   return true;
@@ -649,9 +646,9 @@ void PlatformView::OnKeyEvent(
 
   const uint8_t* data = reinterpret_cast<const uint8_t*>(buffer.GetString());
   DispatchPlatformMessage(std::make_unique<flutter::PlatformMessage>(
-      kKeyEventChannel,                                         // channel
-      fml::MallocMapping::Copy(data, data + buffer.GetSize()),  // data
-      nullptr)                                                  // response
+      kKeyEventChannel,                                  // channel
+      fml::MallocMapping::Copy(data, buffer.GetSize()),  // data
+      nullptr)                                           // response
   );
   callback(fuchsia::ui::input3::KeyEventStatus::HANDLED);
 }

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -575,8 +575,7 @@ TEST_F(PlatformViewTests, EnableWireframeTest) {
 
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
-          "flutter/platform_views",
-          fml::MallocMapping::Copy(txt, txt + sizeof(txt)),
+          "flutter/platform_views", fml::MallocMapping::Copy(txt, sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
   base_view->HandlePlatformMessage(std::move(message));
 
@@ -635,8 +634,7 @@ TEST_F(PlatformViewTests, CreateViewTest) {
 
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
-          "flutter/platform_views",
-          fml::MallocMapping::Copy(txt, txt + sizeof(txt)),
+          "flutter/platform_views", fml::MallocMapping::Copy(txt, sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
   base_view->HandlePlatformMessage(std::move(message));
 
@@ -686,8 +684,7 @@ TEST_F(PlatformViewTests, UpdateViewTest) {
 
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
-          "flutter/platform_views",
-          fml::MallocMapping::Copy(txt, txt + sizeof(txt)),
+          "flutter/platform_views", fml::MallocMapping::Copy(txt, sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
   base_view->HandlePlatformMessage(std::move(message));
 
@@ -743,8 +740,7 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
 
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
-          "flutter/platform_views",
-          fml::MallocMapping::Copy(txt, txt + sizeof(txt)),
+          "flutter/platform_views", fml::MallocMapping::Copy(txt, sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
   base_view->HandlePlatformMessage(std::move(message));
 
@@ -805,9 +801,8 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
   static_cast<flutter::PlatformView*>(&platform_view)
       ->HandlePlatformMessage(std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          fml::MallocMapping::Copy(
-              create_view_call.c_str(),
-              create_view_call.c_str() + create_view_call.size()),
+          fml::MallocMapping::Copy(create_view_call.c_str(),
+                                   create_view_call.size()),
           fml::RefPtr<flutter::PlatformMessageResponse>()));
   RunLoopUntilIdle();
 
@@ -942,7 +937,7 @@ TEST_F(PlatformViewTests, RequestFocusTest) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          fml::MallocMapping::Copy(buff, buff + sizeof(buff)), response);
+          fml::MallocMapping::Copy(buff, sizeof(buff)), response);
   base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();
@@ -1004,7 +999,7 @@ TEST_F(PlatformViewTests, RequestFocusFailTest) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          fml::MallocMapping::Copy(buff, buff + sizeof(buff)), response);
+          fml::MallocMapping::Copy(buff, sizeof(buff)), response);
   base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -31,6 +31,11 @@
 namespace flutter_runner::testing {
 namespace {
 
+std::string ToString(const fml::Mapping& mapping) {
+  return std::string(mapping.GetMapping(),
+                     mapping.GetMapping() + mapping.GetSize());
+}
+
 class MockExternalViewEmbedder : public flutter::ExternalViewEmbedder {
  public:
   SkCanvas* GetRootCanvas() override { return nullptr; }
@@ -96,7 +101,7 @@ class MockPlatformViewDelegate : public flutter::PlatformView::Delegate {
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewDispatchSemanticsAction(int32_t id,
                                              flutter::SemanticsAction action,
-                                             std::vector<uint8_t> args) {}
+                                             fml::MallocMapping args) {}
   // |flutter::PlatformView::Delegate|
   void OnPlatformViewSetSemanticsEnabled(bool enabled) {
     semantics_enabled_ = enabled;
@@ -571,7 +576,7 @@ TEST_F(PlatformViewTests, EnableWireframeTest) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          std::vector<uint8_t>(txt, txt + sizeof(txt)),
+          fml::MallocMapping::Copy(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
   base_view->HandlePlatformMessage(std::move(message));
 
@@ -631,7 +636,7 @@ TEST_F(PlatformViewTests, CreateViewTest) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          std::vector<uint8_t>(txt, txt + sizeof(txt)),
+          fml::MallocMapping::Copy(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
   base_view->HandlePlatformMessage(std::move(message));
 
@@ -682,7 +687,7 @@ TEST_F(PlatformViewTests, UpdateViewTest) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          std::vector<uint8_t>(txt, txt + sizeof(txt)),
+          fml::MallocMapping::Copy(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
   base_view->HandlePlatformMessage(std::move(message));
 
@@ -739,7 +744,7 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          std::vector<uint8_t>(txt, txt + sizeof(txt)),
+          fml::MallocMapping::Copy(txt, txt + sizeof(txt)),
           fml::RefPtr<flutter::PlatformMessageResponse>());
   base_view->HandlePlatformMessage(std::move(message));
 
@@ -800,8 +805,9 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
   static_cast<flutter::PlatformView*>(&platform_view)
       ->HandlePlatformMessage(std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          std::vector<uint8_t>(create_view_call.begin(),
-                               create_view_call.end()),
+          fml::MallocMapping::Copy(
+              create_view_call.c_str(),
+              create_view_call.c_str() + create_view_call.size()),
           fml::RefPtr<flutter::PlatformMessageResponse>()));
   RunLoopUntilIdle();
 
@@ -827,8 +833,7 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
       << "  }"
       << "}";
   EXPECT_EQ(view_connected_expected_out.str(),
-            std::string(view_connected_msg->data().begin(),
-                        view_connected_msg->data().end()));
+            ToString(view_connected_msg->data()));
 
   // ViewDisconnected event.
   delegate.Reset();
@@ -852,8 +857,7 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
       << "  }"
       << "}";
   EXPECT_EQ(view_disconnected_expected_out.str(),
-            std::string(view_disconnected_msg->data().begin(),
-                        view_disconnected_msg->data().end()));
+            ToString(view_disconnected_msg->data()));
 
   // ViewStateChanged event.
   delegate.Reset();
@@ -883,8 +887,7 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
       << "  }"
       << "}";
   EXPECT_EQ(view_state_changed_expected_out.str(),
-            std::string(view_state_changed_msg->data().begin(),
-                        view_state_changed_msg->data().end()));
+            ToString(view_state_changed_msg->data()));
 }
 
 // This test makes sure that the PlatformView forwards messages on the
@@ -939,14 +942,13 @@ TEST_F(PlatformViewTests, RequestFocusTest) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
+          fml::MallocMapping::Copy(buff, buff + sizeof(buff)), response);
   base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();
 
   EXPECT_TRUE(mock_focuser.request_focus_called());
-  auto result = std::string((const char*)data_arg.data->GetMapping(),
-                            data_arg.data->GetSize());
+  auto result = ToString(*data_arg.data);
   EXPECT_EQ(std::string("[0]"), result);
 }
 
@@ -1002,14 +1004,13 @@ TEST_F(PlatformViewTests, RequestFocusFailTest) {
   std::unique_ptr<flutter::PlatformMessage> message =
       std::make_unique<flutter::PlatformMessage>(
           "flutter/platform_views",
-          std::vector<uint8_t>(buff, buff + sizeof(buff)), response);
+          fml::MallocMapping::Copy(buff, buff + sizeof(buff)), response);
   base_view->HandlePlatformMessage(std::move(message));
 
   RunLoopUntilIdle();
 
   EXPECT_TRUE(mock_focuser.request_focus_called());
-  auto result = std::string((const char*)data_arg.data->GetMapping(),
-                            data_arg.data->GetSize());
+  auto result = ToString(*data_arg.data);
   std::ostringstream out;
   out << "["
       << static_cast<std::underlying_type_t<fuchsia::ui::views::Error>>(
@@ -1094,8 +1095,8 @@ TEST_F(PlatformViewTests, OnKeyEvent) {
           key_event_status = status;
         });
     RunLoopUntilIdle();
-    const std::vector<uint8_t> data = delegate.message()->data();
-    const std::string message = std::string(data.begin(), data.end());
+    const fml::MallocMapping data = delegate.message()->releaseData();
+    const std::string message = ToString(data);
 
     EXPECT_EQ(event.expected_platform_message, message);
     EXPECT_EQ(key_event_status, event.expected_key_event_status);

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -254,12 +254,12 @@ int RunTester(const flutter::Settings& settings,
   const char* locale_json =
       "{\"method\":\"setLocale\",\"args\":[\"en\",\"US\",\"\",\"\",\"zh\","
       "\"CN\",\"\",\"\"]}";
-  std::vector<uint8_t> locale_bytes(locale_json,
-                                    locale_json + std::strlen(locale_json));
+  auto locale_bytes = fml::NonOwnedMapping::Copy(
+      locale_json, locale_json + std::strlen(locale_json));
   fml::RefPtr<flutter::PlatformMessageResponse> response;
   shell->GetPlatformView()->DispatchPlatformMessage(
-      std::make_unique<flutter::PlatformMessage>("flutter/localization",
-                                                 locale_bytes, response));
+      std::make_unique<flutter::PlatformMessage>(
+          "flutter/localization", std::move(locale_bytes), response));
 
   std::initializer_list<fml::FileMapping::Protection> protection = {
       fml::FileMapping::Protection::kRead};

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -254,7 +254,7 @@ int RunTester(const flutter::Settings& settings,
   const char* locale_json =
       "{\"method\":\"setLocale\",\"args\":[\"en\",\"US\",\"\",\"\",\"zh\","
       "\"CN\",\"\",\"\"]}";
-  auto locale_bytes = fml::NonOwnedMapping::Copy(
+  auto locale_bytes = fml::MallocMapping::Copy(
       locale_json, locale_json + std::strlen(locale_json));
   fml::RefPtr<flutter::PlatformMessageResponse> response;
   shell->GetPlatformView()->DispatchPlatformMessage(


### PR DESCRIPTION
Switch PlatformMessages to having their data in std::vector to fml::Mapping so that we can steal ownership of the data and have more efficient allocation / deallocation of the data.

On iOS this had about a 20% increase in performance tests for 14k binary platform messages.  The savings seem to come from the removal of the `~std::vector<uint8_t>` calls.

**Do not merge this until the performance tests are running.**
This PR depends on https://github.com/flutter/engine/pull/25860
Next PR: https://github.com/flutter/engine/pull/25988
Issue: https://github.com/flutter/flutter/issues/81559

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
