### PR TITLE
A11y inspect

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -21,6 +21,7 @@
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
 #include "flutter/shell/common/shell.h"
+#include "flutter/shell/platform/fuchsia/flutter/accessibility_bridge.h"
 
 #include "default_session_connection.h"
 #include "flutter_runner_product_configuration.h"
@@ -83,6 +84,7 @@ class Engine final {
 
   std::unique_ptr<IsolateConfigurator> isolate_configurator_;
   std::unique_ptr<flutter::Shell> shell_;
+  std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
 
   fuchsia::intl::PropertyProviderPtr intl_property_provider_;
 

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -72,6 +72,8 @@ PlatformView::PlatformView(
     OnUpdateView on_update_view_callback,
     OnDestroyView on_destroy_view_callback,
     OnCreateSurface on_create_surface_callback,
+    OnSemanticsNodeUpdate on_semantics_node_update_callback,
+    OnRequestAnnounce on_request_announce_callback,
     std::shared_ptr<flutter::ExternalViewEmbedder> external_view_embedder,
     AwaitVsyncCallback await_vsync_callback,
     AwaitVsyncForSecondaryCallbackCallback
@@ -88,6 +90,9 @@ PlatformView::PlatformView(
       on_update_view_callback_(std::move(on_update_view_callback)),
       on_destroy_view_callback_(std::move(on_destroy_view_callback)),
       on_create_surface_callback_(std::move(on_create_surface_callback)),
+      on_semantics_node_update_callback_(
+          std::move(on_semantics_node_update_callback)),
+      on_request_announce_callback_(std::move(on_request_announce_callback)),
       external_view_embedder_(external_view_embedder),
       ime_client_(this),
       keyboard_listener_binding_(this, std::move(keyboard_listener_request)),
@@ -113,11 +118,6 @@ PlatformView::PlatformView(
 
   // Finally! Register the native platform message handlers.
   RegisterPlatformMessageHandlers();
-
-  fuchsia::ui::views::ViewRef accessibility_view_ref;
-  view_ref_.Clone(&accessibility_view_ref);
-  accessibility_bridge_ = std::make_unique<AccessibilityBridge>(
-      *this, runner_services, std::move(accessibility_view_ref));
 }
 
 PlatformView::~PlatformView() = default;
@@ -734,7 +734,6 @@ void PlatformView::HandlePlatformMessage(
 }
 
 // |flutter::PlatformView|
-// |flutter_runner::AccessibilityBridge::Delegate|
 void PlatformView::SetSemanticsEnabled(bool enabled) {
   flutter::PlatformView::SetSemanticsEnabled(enabled);
   if (enabled) {
@@ -746,20 +745,13 @@ void PlatformView::SetSemanticsEnabled(bool enabled) {
 }
 
 // |flutter::PlatformView|
-// |flutter_runner::AccessibilityBridge::Delegate|
-void PlatformView::DispatchSemanticsAction(int32_t node_id,
-                                           flutter::SemanticsAction action) {
-  flutter::PlatformView::DispatchSemanticsAction(node_id, action, {});
-}
-
-// |flutter::PlatformView|
 void PlatformView::UpdateSemantics(
     flutter::SemanticsNodeUpdates update,
     flutter::CustomAccessibilityActionUpdates actions) {
   const float pixel_ratio =
       view_pixel_ratio_.has_value() ? *view_pixel_ratio_ : 0.f;
 
-  accessibility_bridge_->AddSemanticsNodeUpdate(update, pixel_ratio);
+  on_semantics_node_update_callback_(update, pixel_ratio);
 }
 
 // Channel handler for kAccessibilityChannel
@@ -782,7 +774,7 @@ void PlatformView::HandleAccessibilityChannelPlatformMessage(
     std::string text =
         std::get<std::string>(data_map.at(flutter::EncodableValue("message")));
 
-    accessibility_bridge_->RequestAnnounce(text);
+    on_request_announce_callback_(text);
   }
 
   message->response()->CompleteEmpty();

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -268,8 +268,10 @@ class PlatformViewBuilder {
         std::move(on_create_view_callback_),
         std::move(on_update_view_callback_),
         std::move(on_destroy_view_callback_),
-        std::move(on_create_surface_callback_), view_embedder_, [](auto...) {},
-        [](auto...) {});
+        std::move(on_create_surface_callback_),
+        std::move(on_semantics_node_update_callback_),
+        std::move(on_request_announce_callback_), view_embedder_,
+        [](auto...) {}, [](auto...) {});
   }
 
  private:
@@ -298,6 +300,8 @@ class PlatformViewBuilder {
   OnUpdateView on_update_view_callback_{nullptr};
   OnDestroyView on_destroy_view_callback_{nullptr};
   OnCreateSurface on_create_surface_callback_{nullptr};
+  OnSemanticsNodeUpdate on_semantics_node_update_callback_{nullptr};
+  OnRequestAnnounce on_request_announce_callback_{nullptr};
   std::shared_ptr<flutter::ExternalViewEmbedder> view_embedder_{nullptr};
   fml::TimeDelta vsync_offset_{fml::TimeDelta::Zero()};
 };


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*
This change adds inspect data to the a11y bridge, which can be requested via  the command line. 

Inspect nodes are lazy computed, meaning that they are only processed when invoked, so no extra space is used during normal use.


*List which issues are fixed by this PR. You must list at least one issue.*
fxbug.dev/75100

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
