### PR TITLE
Implement smooth resizing for Linux

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1480,6 +1480,8 @@ FILE: ../../../flutter/shell/platform/linux/fl_standard_method_codec.cc
 FILE: ../../../flutter/shell/platform/linux/fl_standard_method_codec_test.cc
 FILE: ../../../flutter/shell/platform/linux/fl_string_codec.cc
 FILE: ../../../flutter/shell/platform/linux/fl_string_codec_test.cc
+FILE: ../../../flutter/shell/platform/linux/fl_task_runner.cc
+FILE: ../../../flutter/shell/platform/linux/fl_task_runner.h
 FILE: ../../../flutter/shell/platform/linux/fl_text_input_plugin.cc
 FILE: ../../../flutter/shell/platform/linux/fl_text_input_plugin.h
 FILE: ../../../flutter/shell/platform/linux/fl_value.cc

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -114,6 +114,8 @@ source_set("flutter_linux_sources") {
     "fl_standard_message_codec.cc",
     "fl_standard_method_codec.cc",
     "fl_string_codec.cc",
+    "fl_task_runner.cc",
+    "fl_task_runner.h",
     "fl_text_input_plugin.cc",
     "fl_value.cc",
     "fl_view.cc",

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -58,13 +58,6 @@ G_DEFINE_TYPE_WITH_CODE(
     G_IMPLEMENT_INTERFACE(fl_plugin_registry_get_type(),
                           fl_engine_plugin_registry_iface_init))
 
-// Subclass of GSource that integrates Flutter tasks into the GLib main loop.
-typedef struct {
-  GSource parent;
-  FlEngine* engine;
-  FlutterTask task;
-} FlutterSource;
-
 // Parse a locale into its components.
 static void parse_locale(const gchar* locale,
                          gchar** language,

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -674,5 +674,6 @@ FlTaskRunner* fl_engine_get_task_runner(FlEngine* self) {
 }
 
 void fl_engine_execute_task(FlEngine* self, FlutterTask* task) {
+  g_return_if_fail(FL_IS_ENGINE(self));
   self->embedder_api.RunTask(self->engine, task);
 }

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -301,8 +301,6 @@ static void fl_engine_dispose(GObject* object) {
   g_clear_object(&self->renderer);
   g_clear_object(&self->binary_messenger);
   g_clear_object(&self->settings_plugin);
-
-  fl_task_runner_stop(self->task_runner);
   g_clear_object(&self->task_runner);
 
   if (self->platform_message_handler_destroy_notify) {

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -350,15 +350,10 @@ G_MODULE_EXPORT FlEngine* fl_engine_new_headless(FlDartProject* project) {
   return fl_engine_new(project, FL_RENDERER(renderer));
 }
 
-static void fl_engine_execute_task(FlutterTask task, gpointer user_data) {
-  FlEngine* self = FL_ENGINE(user_data);
-  self->embedder_api.RunTask(self->engine, &task);
-}
-
 gboolean fl_engine_start(FlEngine* self, GError** error) {
   g_return_val_if_fail(FL_IS_ENGINE(self), FALSE);
 
-  self->task_runner = fl_task_runner_new(fl_engine_execute_task, self);
+  self->task_runner = fl_task_runner_new(self);
 
   FlutterRendererConfig config = {};
   config.type = kOpenGL;
@@ -676,4 +671,8 @@ G_MODULE_EXPORT FlBinaryMessenger* fl_engine_get_binary_messenger(
 FlTaskRunner* fl_engine_get_task_runner(FlEngine* self) {
   g_return_val_if_fail(FL_IS_ENGINE(self), nullptr);
   return self->task_runner;
+}
+
+void fl_engine_execute_task(FlEngine* self, FlutterTask* task) {
+  self->embedder_api.RunTask(self->engine, task);
 }

--- a/shell/platform/linux/fl_engine.cc
+++ b/shell/platform/linux/fl_engine.cc
@@ -365,6 +365,8 @@ static void fl_engine_execute_task(FlutterTask task, gpointer user_data) {
 gboolean fl_engine_start(FlEngine* self, GError** error) {
   g_return_val_if_fail(FL_IS_ENGINE(self), FALSE);
 
+  self->task_runner = fl_task_runner_new(fl_engine_execute_task, self);
+
   FlutterRendererConfig config = {};
   config.type = kOpenGL;
   config.open_gl.struct_size = sizeof(FlutterOpenGLRendererConfig);
@@ -456,8 +458,6 @@ gboolean fl_engine_start(FlEngine* self, GError** error) {
 
   self->settings_plugin = fl_settings_plugin_new(self->binary_messenger);
   fl_settings_plugin_start(self->settings_plugin);
-
-  self->task_runner = fl_task_runner_new(fl_engine_execute_task, self);
 
   result = self->embedder_api.UpdateSemanticsEnabled(self->engine, TRUE);
   if (result != kSuccess)

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -236,6 +236,15 @@ GBytes* fl_engine_send_platform_message_finish(FlEngine* engine,
  */
 FlTaskRunner* fl_engine_get_task_runner(FlEngine* engine);
 
+/**
+ * fl_engine_execute_task:
+ * @engine: an #FlEngine.
+ * @task: a #FlutterTask to execute.
+ *
+ * Executes given Flutter task.
+ */
+void fl_engine_execute_task(FlEngine* engine, FlutterTask* task);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_ENGINE_PRIVATE_H_

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -227,6 +227,13 @@ GBytes* fl_engine_send_platform_message_finish(FlEngine* engine,
                                                GAsyncResult* result,
                                                GError** error);
 
+/**
+ * fl_engine_get_task_runner:
+ * @engine: an #FlEngine.
+ * @result: a #FlTaskRunner.
+ *
+ * Returns: task runner responsible for scheduling Flutter tasks.
+ */
 FlTaskRunner* fl_engine_get_task_runner(FlEngine* engine);
 
 G_END_DECLS

--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -9,6 +9,7 @@
 
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_renderer.h"
+#include "flutter/shell/platform/linux/fl_task_runner.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_dart_project.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
 
@@ -225,6 +226,8 @@ void fl_engine_send_platform_message(FlEngine* engine,
 GBytes* fl_engine_send_platform_message_finish(FlEngine* engine,
                                                GAsyncResult* result,
                                                GError** error);
+
+FlTaskRunner* fl_engine_get_task_runner(FlEngine* engine);
 
 G_END_DECLS
 

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -9,11 +9,23 @@
 
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/fl_backing_store_provider.h"
+#include "flutter/shell/platform/linux/fl_engine_private.h"
 
 G_DEFINE_QUARK(fl_renderer_error_quark, fl_renderer_error)
 
 typedef struct {
   FlView* view;
+
+  // target dimension for resizing
+  int target_width;
+  int target_height;
+
+  // whether the renderer waits for frame render
+  bool blocking_main_thread;
+
+  // true if frame was completed; resizing is not synchronized until first frame
+  // was rendered
+  bool had_first_frame;
 
   GdkGLContext* main_context;
   GdkGLContext* resource_context;
@@ -21,7 +33,26 @@ typedef struct {
 
 G_DEFINE_TYPE_WITH_PRIVATE(FlRenderer, fl_renderer, G_TYPE_OBJECT)
 
-static void fl_renderer_class_init(FlRendererClass* klass) {}
+static void fl_renderer_unblock_main_thread(FlRenderer* self) {
+  FlRendererPrivate* priv = reinterpret_cast<FlRendererPrivate*>(
+      fl_renderer_get_instance_private(self));
+  if (priv->blocking_main_thread) {
+    priv->blocking_main_thread = false;
+
+    FlTaskRunner* runner =
+        fl_engine_get_task_runner(fl_view_get_engine(priv->view));
+    fl_task_runner_release_main_thread(runner);
+  }
+}
+
+static void fl_renderer_dispose(GObject* self) {
+  fl_renderer_unblock_main_thread(FL_RENDERER(self));
+  G_OBJECT_CLASS(fl_renderer_parent_class)->dispose(self);
+}
+
+static void fl_renderer_class_init(FlRendererClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = fl_renderer_dispose;
+}
 
 static void fl_renderer_init(FlRenderer* self) {}
 
@@ -109,9 +140,42 @@ gboolean fl_renderer_collect_backing_store(
                                                             backing_store);
 }
 
+void fl_renderer_wait_for_frame(FlRenderer* self,
+                                int target_width,
+                                int target_height) {
+  FlRendererPrivate* priv = reinterpret_cast<FlRendererPrivate*>(
+      fl_renderer_get_instance_private(self));
+
+  priv->target_width = target_width;
+  priv->target_height = target_height;
+
+  if (priv->had_first_frame && !priv->blocking_main_thread) {
+    priv->blocking_main_thread = true;
+    FlTaskRunner* runner =
+        fl_engine_get_task_runner(fl_view_get_engine(priv->view));
+    fl_task_runner_block_main_thread(runner);
+  }
+}
+
 gboolean fl_renderer_present_layers(FlRenderer* self,
                                     const FlutterLayer** layers,
                                     size_t layers_count) {
+  FlRendererPrivate* priv = reinterpret_cast<FlRendererPrivate*>(
+      fl_renderer_get_instance_private(self));
+
+  // ignore incoming frame with wrong dimensions in trivial case with just one
+  // layer
+  if (priv->blocking_main_thread && layers_count == 1 &&
+      layers[0]->offset.x == 0 && layers[0]->offset.y == 0 &&
+      (layers[0]->size.width != priv->target_width ||
+       layers[0]->size.height != priv->target_height)) {
+    return true;
+  }
+
+  priv->had_first_frame = true;
+
+  fl_renderer_unblock_main_thread(self);
+
   return FL_RENDERER_GET_CLASS(self)->present_layers(self, layers,
                                                      layers_count);
 }

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -249,7 +249,7 @@ gboolean fl_renderer_present_layers(FlRenderer* renderer,
  * @target_height: height of frame being waited for
  *
  * Holds the thread until frame with requested dimensions is presented.
- * While waiting for frame flutter platform and raster tasks are being
+ * While waiting for frame Flutter platform and raster tasks are being
  * processed.
  */
 void fl_renderer_wait_for_frame(FlRenderer* renderer,

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -243,7 +243,7 @@ gboolean fl_renderer_present_layers(FlRenderer* renderer,
                                     size_t layers_count);
 
 /**
- * fl_renderer_wait_for_frame
+ * fl_renderer_wait_for_frame:
  * @renderer: an #FlRenderer.
  * @target_width: width of frame being waited for
  * @target_height: height of frame being waited for

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -242,6 +242,20 @@ gboolean fl_renderer_present_layers(FlRenderer* renderer,
                                     const FlutterLayer** layers,
                                     size_t layers_count);
 
+/**
+ * fl_renderer_wait_for_frame
+ * @renderer: an #FlRenderer.
+ * @target_width: width of frame being waited for
+ * @target_height: height of frame being waited for
+ *
+ * Holds the thread until frame with requested dimensions is presented.
+ * While waiting for frame flutter platform and raster tasks are being
+ * processed.
+ */
+void fl_renderer_wait_for_frame(FlRenderer* renderer,
+                                int target_width,
+                                int target_height);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_H_

--- a/shell/platform/linux/fl_task_runner.cc
+++ b/shell/platform/linux/fl_task_runner.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "flutter/shell/platform/linux/fl_task_runner.h"
 
 static constexpr int kMicrosecondsPerNanosecond = 1000;

--- a/shell/platform/linux/fl_task_runner.cc
+++ b/shell/platform/linux/fl_task_runner.cc
@@ -196,6 +196,9 @@ void fl_task_runner_block_main_thread(FlTaskRunner* self) {
     fl_task_runner_process_expired_tasks_locked(self);
   }
 
+  // Tasks might have changed in the meanwhile, reschedule timeout
+  fl_task_runner_tasks_did_change_locked(self);
+
   g_object_unref(self);
 }
 

--- a/shell/platform/linux/fl_task_runner.cc
+++ b/shell/platform/linux/fl_task_runner.cc
@@ -66,7 +66,7 @@ static void fl_task_runner_process_expired_tasks_locked(FlTaskRunner* self) {
 static void fl_task_runner_tasks_did_change_locked(FlTaskRunner* self);
 
 // Invoked from a timeout source. Removes and executes expired tasks
-// and rechedules timeout if needed.
+// and reschedules timeout if needed.
 static gboolean fl_task_runner_on_expired_timeout(gpointer data) {
   FlTaskRunner* self = FL_TASK_RUNNER(data);
 

--- a/shell/platform/linux/fl_task_runner.cc
+++ b/shell/platform/linux/fl_task_runner.cc
@@ -1,0 +1,205 @@
+#include "flutter/shell/platform/linux/fl_task_runner.h"
+
+static constexpr int kMicrosecondsPerNanosecond = 1000;
+static constexpr int kMillisecondsPerMicrosecond = 1000;
+
+struct _FlTaskRunner {
+  GObject parent_instance;
+
+  FlTaskExecutor executor;
+  gpointer executor_user_data;
+
+  GMutex mutex;
+  GCond cond;
+
+  guint timeout_source_id;
+  GList /*<FlTaskRunnerTask>*/* pending_tasks;
+  gboolean blocking_main_thread;
+
+  gboolean stopped;
+};
+
+typedef struct _FlTaskRunnerTask {
+  // absolute time of task (based on g_get_monotonic_time)
+  gint64 task_time_micros;
+  FlutterTask task;
+} FlTaskRunnerTask;
+
+G_DEFINE_TYPE(FlTaskRunner, fl_task_runner, G_TYPE_OBJECT)
+
+static void fl_task_runner_dispose(GObject* object);
+
+static void fl_task_runner_class_init(FlTaskRunnerClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = fl_task_runner_dispose;
+}
+
+static void fl_task_runner_init(FlTaskRunner* self) {
+  g_mutex_init(&self->mutex);
+  g_cond_init(&self->cond);
+}
+
+void fl_task_runner_dispose(GObject* object) {
+  FlTaskRunner* self = FL_TASK_RUNNER(object);
+
+  // this should never happen because the task runner is retained while blocking
+  // main thread
+  g_assert(!self->blocking_main_thread);
+
+  g_mutex_clear(&self->mutex);
+  g_cond_clear(&self->cond);
+
+  g_list_free_full(self->pending_tasks, g_free);
+  if (self->timeout_source_id != 0) {
+    g_source_remove(self->timeout_source_id);
+  }
+
+  G_OBJECT_CLASS(fl_task_runner_parent_class)->dispose(object);
+}
+
+FlTaskRunner* fl_task_runner_new(FlTaskExecutor executor,
+                                 gpointer executor_user_data) {
+  FlTaskRunner* res =
+      FL_TASK_RUNNER(g_object_new(fl_task_runner_get_type(), nullptr));
+  res->executor = executor;
+  res->executor_user_data = executor_user_data;
+  return res;
+}
+
+// Removes expired tasks from the task queue and executes them.
+// The execution is performed with mutex unlocked.
+static void fl_task_runner_process_expired_tasks_locked(FlTaskRunner* self) {
+  GList* expired_tasks = nullptr;
+
+  gint64 current_time = g_get_monotonic_time();
+
+  GList* l = self->pending_tasks;
+  while (l != nullptr) {
+    FlTaskRunnerTask* task = static_cast<FlTaskRunnerTask*>(l->data);
+    if (task->task_time_micros <= current_time) {
+      GList* link = l;
+      l = l->next;
+      self->pending_tasks = g_list_remove_link(self->pending_tasks, link);
+      expired_tasks = g_list_concat(expired_tasks, link);
+    } else {
+      l = l->next;
+    }
+  }
+
+  g_mutex_unlock(&self->mutex);
+
+  l = expired_tasks;
+  while (l != nullptr && !self->stopped) {
+    FlTaskRunnerTask* task = static_cast<FlTaskRunnerTask*>(l->data);
+    self->executor(task->task, self->executor_user_data);
+    l = l->next;
+  }
+
+  g_list_free_full(expired_tasks, g_free);
+
+  g_mutex_lock(&self->mutex);
+}
+
+static void fl_task_runner_tasks_did_change_locked(FlTaskRunner* self);
+
+// Invoked from a timeout source. Removes and executes expired tasks
+// and rechedules timeout if needed.
+static gboolean fl_task_runner_on_expired_timeout(gpointer data) {
+  FlTaskRunner* self = FL_TASK_RUNNER(data);
+
+  g_autoptr(GMutexLocker) locker = g_mutex_locker_new(&self->mutex);
+  (void)locker;  // unused variable
+
+  g_object_ref(self);
+
+  self->timeout_source_id = 0;
+  fl_task_runner_process_expired_tasks_locked(self);
+
+  // reschedule timeout
+  fl_task_runner_tasks_did_change_locked(self);
+
+  g_object_unref(self);
+
+  return FALSE;
+}
+
+// Returns the absolute time of next expired task (in microseconds, based on
+// g_get_monotonic_time). If no task is scheduled returns G_MAXINT64.
+static gint64 fl_task_runner_next_task_expiration_time_locked(
+    FlTaskRunner* self) {
+  gint64 min_time = G_MAXINT64;
+  GList* l = self->pending_tasks;
+  while (l != nullptr) {
+    FlTaskRunnerTask* task = static_cast<FlTaskRunnerTask*>(l->data);
+    min_time = MIN(min_time, task->task_time_micros);
+    l = l->next;
+  }
+  return min_time;
+}
+
+static void fl_task_runner_tasks_did_change_locked(FlTaskRunner* self) {
+  if (self->blocking_main_thread) {
+    // Wake up blocked thread
+    g_cond_signal(&self->cond);
+  } else {
+    // Reschedule timeout
+    if (self->timeout_source_id != 0) {
+      g_source_remove(self->timeout_source_id);
+      self->timeout_source_id = 0;
+    }
+    gint64 min_time = fl_task_runner_next_task_expiration_time_locked(self);
+    if (min_time != G_MAXINT64) {
+      gint64 remaining = MAX(min_time - g_get_monotonic_time(), 0);
+      self->timeout_source_id =
+          g_timeout_add(remaining / kMillisecondsPerMicrosecond + 1,
+                        fl_task_runner_on_expired_timeout, self);
+    }
+  }
+}
+
+void fl_task_runner_stop(FlTaskRunner* self) {
+  // No locking necessary, stop is only set and read on main thread
+  self->stopped = true;
+}
+
+void fl_task_runner_post_task(FlTaskRunner* self,
+                              FlutterTask task,
+                              uint64_t target_time_nanos) {
+  g_autoptr(GMutexLocker) locker = g_mutex_locker_new(&self->mutex);
+  (void)locker;  // unused variable
+
+  FlTaskRunnerTask* runner_task = g_new0(FlTaskRunnerTask, 1);
+  runner_task->task = task;
+  runner_task->task_time_micros =
+      target_time_nanos / kMicrosecondsPerNanosecond;
+
+  self->pending_tasks = g_list_append(self->pending_tasks, runner_task);
+  fl_task_runner_tasks_did_change_locked(self);
+}
+
+void fl_task_runner_block_main_thread(FlTaskRunner* self) {
+  g_autoptr(GMutexLocker) locker = g_mutex_locker_new(&self->mutex);
+  (void)locker;  // unused variable
+
+  g_return_if_fail(self->blocking_main_thread == FALSE);
+
+  g_object_ref(self);
+
+  self->blocking_main_thread = true;
+  while (self->blocking_main_thread) {
+    g_cond_wait_until(&self->cond, &self->mutex,
+                      fl_task_runner_next_task_expiration_time_locked(self));
+    fl_task_runner_process_expired_tasks_locked(self);
+  }
+
+  g_object_unref(self);
+}
+
+void fl_task_runner_release_main_thread(FlTaskRunner* self) {
+  g_autoptr(GMutexLocker) locker = g_mutex_locker_new(&self->mutex);
+  (void)locker;  // unused variable
+
+  g_return_if_fail(self->blocking_main_thread == TRUE);
+
+  self->blocking_main_thread = FALSE;
+  g_cond_signal(&self->cond);
+}

--- a/shell/platform/linux/fl_task_runner.h
+++ b/shell/platform/linux/fl_task_runner.h
@@ -8,12 +8,11 @@
 #include <glib-object.h>
 
 #include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
 
 G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE(FlTaskRunner, fl_task_runner, FL, TASK_RUNNER, GObject);
-
-typedef void (*FlTaskExecutor)(FlutterTask task, gpointer user_data);
 
 /**
  * fl_task_runner_new:
@@ -24,8 +23,7 @@ typedef void (*FlTaskExecutor)(FlutterTask task, gpointer user_data);
  *
  * Returns: an #FlTaskRunner.
  */
-FlTaskRunner* fl_task_runner_new(FlTaskExecutor executor,
-                                 gpointer executor_user_data);
+FlTaskRunner* fl_task_runner_new(FlEngine* engine);
 
 /**
  * fl_task_runner_post_task:

--- a/shell/platform/linux/fl_task_runner.h
+++ b/shell/platform/linux/fl_task_runner.h
@@ -16,8 +16,7 @@ G_DECLARE_FINAL_TYPE(FlTaskRunner, fl_task_runner, FL, TASK_RUNNER, GObject);
 
 /**
  * fl_task_runner_new:
- * @executor: Function responsible for executing Flutter tasks.
- * @executor_user_data: user data for executor.
+ * @engine: the #FlEngine owning the task runner.
  *
  * Creates new task runner instance.
  *

--- a/shell/platform/linux/fl_task_runner.h
+++ b/shell/platform/linux/fl_task_runner.h
@@ -45,7 +45,7 @@ void fl_task_runner_post_task(FlTaskRunner* task_runner,
  * @task_runner: an #FlTaskRunner.
  *
  * Requests stop. After this method completes no more tasks will be executed
- * on the task runner. Remaining scheduled tasks will be invoked.
+ * by the task runner. Remaining scheduled tasks will be ignored.
  * Must be invoked on main thread.
  */
 void fl_task_runner_stop(FlTaskRunner* task_runner);

--- a/shell/platform/linux/fl_task_runner.h
+++ b/shell/platform/linux/fl_task_runner.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/shell/platform/linux/fl_task_runner.h
+++ b/shell/platform/linux/fl_task_runner.h
@@ -38,16 +38,6 @@ void fl_task_runner_post_task(FlTaskRunner* task_runner,
                               uint64_t target_time_nanos);
 
 /**
- * fl_task_runner_stop:
- * @task_runner: an #FlTaskRunner.
- *
- * Requests stop. After this method completes no more tasks will be executed
- * by the task runner. Remaining scheduled tasks will be ignored.
- * Must be invoked on main thread.
- */
-void fl_task_runner_stop(FlTaskRunner* task_runner);
-
-/**
  * fl_task_runner_block_main_thread:
  * @task_runner: an #FlTaskRunner.
  *

--- a/shell/platform/linux/fl_task_runner.h
+++ b/shell/platform/linux/fl_task_runner.h
@@ -16,8 +16,8 @@ G_DECLARE_FINAL_TYPE(FlTaskRunner, fl_task_runner, FL, TASK_RUNNER, GObject);
 typedef void (*FlTaskExecutor)(FlutterTask task, gpointer user_data);
 
 /**
- * fl_task_runner_new
- * @executor: Function responsible for executing fluter tasks.
+ * fl_task_runner_new:
+ * @executor: Function responsible for executing Flutter tasks.
  * @executor_user_data: user data for executor.
  *
  * Creates new task runner instance.
@@ -28,12 +28,12 @@ FlTaskRunner* fl_task_runner_new(FlTaskExecutor executor,
                                  gpointer executor_user_data);
 
 /**
- * fl_task_runner_post_task
+ * fl_task_runner_post_task:
  * @task_runner: an #FlTaskRunner.
- * @task: flutter task being scheduled
+ * @task: Flutter task being scheduled
  * @target_time_nanos: absolute time in nanoseconds
  *
- * Posts a flutter task to be executed on main thread. This function is thread
+ * Posts a Flutter task to be executed on main thread. This function is thread
  * safe and may be called from any thread.
  */
 void fl_task_runner_post_task(FlTaskRunner* task_runner,
@@ -41,7 +41,7 @@ void fl_task_runner_post_task(FlTaskRunner* task_runner,
                               uint64_t target_time_nanos);
 
 /**
- * fl_task_runner_stop
+ * fl_task_runner_stop:
  * @task_runner: an #FlTaskRunner.
  *
  * Requests stop. After this method completes no more tasks will be executed
@@ -51,7 +51,7 @@ void fl_task_runner_post_task(FlTaskRunner* task_runner,
 void fl_task_runner_stop(FlTaskRunner* task_runner);
 
 /**
- * fl_task_runner_block_main_thread
+ * fl_task_runner_block_main_thread:
  * @task_runner: an #FlTaskRunner.
  *
  * Blocks main thread until fl_task_runner_release_main_thread is called.
@@ -62,7 +62,7 @@ void fl_task_runner_stop(FlTaskRunner* task_runner);
 void fl_task_runner_block_main_thread(FlTaskRunner* task_runner);
 
 /**
- * fl_task_runner_release_main_thread
+ * fl_task_runner_release_main_thread:
  * @task_runner: an #FlTaskRunner.
  *
  * Unblocks main thread. This will resume normal processing of main loop.

--- a/shell/platform/linux/fl_task_runner.h
+++ b/shell/platform/linux/fl_task_runner.h
@@ -1,0 +1,75 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_LINUX_FL_TASK_RUNNER_H_
+#define FLUTTER_SHELL_PLATFORM_LINUX_FL_TASK_RUNNER_H_
+
+#include <glib-object.h>
+
+#include "flutter/shell/platform/embedder/embedder.h"
+
+G_BEGIN_DECLS
+
+G_DECLARE_FINAL_TYPE(FlTaskRunner, fl_task_runner, FL, TASK_RUNNER, GObject);
+
+typedef void (*FlTaskExecutor)(FlutterTask task, gpointer user_data);
+
+/**
+ * fl_task_runner_new
+ * @executor: Function responsible for executing fluter tasks.
+ * @executor_user_data: user data for executor.
+ *
+ * Creates new task runner instance.
+ *
+ * Returns: an #FlTaskRunner.
+ */
+FlTaskRunner* fl_task_runner_new(FlTaskExecutor executor,
+                                 gpointer executor_user_data);
+
+/**
+ * fl_task_runner_post_task
+ * @task_runner: an #FlTaskRunner.
+ * @task: flutter task being scheduled
+ * @target_time_nanos: absolute time in nanoseconds
+ *
+ * Posts a flutter task to be executed on main thread. This function is thread
+ * safe and may be called from any thread.
+ */
+void fl_task_runner_post_task(FlTaskRunner* task_runner,
+                              FlutterTask task,
+                              uint64_t target_time_nanos);
+
+/**
+ * fl_task_runner_stop
+ * @task_runner: an #FlTaskRunner.
+ *
+ * Requests stop. After this method completes no more tasks will be executed
+ * on the task runner. Remaining scheduled tasks will be invoked.
+ * Must be invoked on main thread.
+ */
+void fl_task_runner_stop(FlTaskRunner* task_runner);
+
+/**
+ * fl_task_runner_block_main_thread
+ * @task_runner: an #FlTaskRunner.
+ *
+ * Blocks main thread until fl_task_runner_release_main_thread is called.
+ * While main thread is blocked tasks posted to #FlTaskRunner are executed as
+ * usual.
+ * Must be invoked on main thread.
+ */
+void fl_task_runner_block_main_thread(FlTaskRunner* task_runner);
+
+/**
+ * fl_task_runner_release_main_thread
+ * @task_runner: an #FlTaskRunner.
+ *
+ * Unblocks main thread. This will resume normal processing of main loop.
+ * Can be invoked from any thread.
+ */
+void fl_task_runner_release_main_thread(FlTaskRunner* self);
+
+G_END_DECLS
+
+#endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_TASK_RUNNER_H_

--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -137,6 +137,9 @@ static void fl_view_geometry_changed(FlView* self) {
   fl_engine_send_window_metrics_event(
       self->engine, allocation.width * scale_factor,
       allocation.height * scale_factor, scale_factor);
+
+  fl_renderer_wait_for_frame(self->renderer, allocation.width * scale_factor,
+                             allocation.height * scale_factor);
 }
 
 // Implements FlPluginRegistry::get_registrar_for_plugin.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/81677

Conceptually this is similar to what macOS and Windows embedder are doing (blocking the platform thread in resize event until frame of proper size is presented). The difference here is that on Linux the platform and raster thread are merged, so the implementation must ensure that flutter tasks are processed normally while waiting for the frame (otherwise raster thread would be blocked and not produce any frame). This is done in `fl_task_runner.cc`.

My initial prototype was simply running a nested `GMainLoop` within the resize event handler, but this caused problems with wayland where some events were prematurely processed while resize callback was still in progress. `FlTaskRunner` solves this by only processing flutter tasks.

Tested with X11 and Wayland.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
