### PR TITLE
[web] Fix incorrect physical size due to visualviewport api on iOS

### DIFF
--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -480,11 +480,11 @@ flt-glass-pane * {
     setElementAttribute(_sceneHostElement!, 'aria-hidden', 'true');
 
     if (html.window.visualViewport == null && isWebKit) {
-      // Safari sometimes gives us bogus innerWidth/innerHeight values when the
-      // page loads. When it changes the values to correct ones it does not
-      // notify of the change via `onResize`. As a workaround, we set up a
-      // temporary periodic timer that polls innerWidth and triggers the
-      // resizeListener so that the framework can react to the change.
+      // Older Safari versions sometimes give us bogus innerWidth/innerHeight
+      // values when the page loads. When it changes the values to correct ones
+      // it does not notify of the change via `onResize`. As a workaround, we
+      // set up a temporary periodic timer that polls innerWidth and triggers
+      // the resizeListener so that the framework can react to the change.
       //
       // Safari 13 has implemented visualViewport API so it doesn't need this
       // timer.
@@ -606,12 +606,12 @@ flt-glass-pane * {
   void _metricsDidChange(html.Event? event) {
     updateSemanticsScreenProperties();
     if (isMobile && !window.isRotation() && textEditing.isEditing) {
-      window.computeOnScreenKeyboardInsets();
+      window.computeOnScreenKeyboardInsets(true);
       EnginePlatformDispatcher.instance.invokeOnMetricsChanged();
     } else {
       window._computePhysicalSize();
       // When physical size changes this value has to be recalculated.
-      window.computeOnScreenKeyboardInsets();
+      window.computeOnScreenKeyboardInsets(false);
       EnginePlatformDispatcher.instance.invokeOnMetricsChanged();
     }
   }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -181,6 +181,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
       double windowInnerWidth;
       double windowInnerHeight;
       final html.VisualViewport? viewport = html.window.visualViewport;
+
       if (viewport != null) {
         if (browserEngine == BrowserEngine.webkit &&
             operatingSystem == OperatingSystem.iOs) {
@@ -216,7 +217,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     final html.VisualViewport? viewport = html.window.visualViewport;
     if (viewport != null) {
       if (browserEngine == BrowserEngine.webkit &&
-          operatingSystem == OperatingSystem.iOs && isEditingOnMobile) {
+          operatingSystem == OperatingSystem.iOs && !isEditingOnMobile) {
         windowInnerHeight = html.document.documentElement!.clientHeight! * devicePixelRatio;
       } else {
         windowInnerHeight = viewport.height!.toDouble() * devicePixelRatio;

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -218,7 +218,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     if (viewport != null) {
       if (browserEngine == BrowserEngine.webkit &&
           operatingSystem == OperatingSystem.iOs && !isEditingOnMobile) {
-        windowInnerHeight = html.document.documentElement!.clientHeight! * devicePixelRatio;
+        windowInnerHeight = html.document.documentElement!.clientHeight * devicePixelRatio;
       } else {
         windowInnerHeight = viewport.height!.toDouble() * devicePixelRatio;
       }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -183,8 +183,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
       final html.VisualViewport? viewport = html.window.visualViewport;
 
       if (viewport != null) {
-        if (browserEngine == BrowserEngine.webkit &&
-            operatingSystem == OperatingSystem.iOs) {
+        if (operatingSystem == OperatingSystem.iOs) {
           /// Chrome on iOS reports incorrect viewport.height when app
           /// starts in portrait orientation and the phone is rotated to
           /// landscape.
@@ -216,8 +215,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     double windowInnerHeight;
     final html.VisualViewport? viewport = html.window.visualViewport;
     if (viewport != null) {
-      if (browserEngine == BrowserEngine.webkit &&
-          operatingSystem == OperatingSystem.iOs && !isEditingOnMobile) {
+      if (operatingSystem == OperatingSystem.iOs && !isEditingOnMobile) {
         windowInnerHeight = html.document.documentElement!.clientHeight * devicePixelRatio;
       } else {
         windowInnerHeight = viewport.height!.toDouble() * devicePixelRatio;


### PR DESCRIPTION
Fixed Chrome on iOS reporting incorrect visualviewport height when application is launched in portrait and then phone is rotated.

https://github.com/flutter/flutter/issues/81430

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
