### PR TITLE
Revert "Fix a11y placeholder on desktop; auto-enable engine semantics…

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -1471,18 +1471,7 @@ class EngineSemanticsOwner {
   /// Updates the semantics tree from data in the [uiUpdate].
   void updateSemantics(ui.SemanticsUpdate uiUpdate) {
     if (!_semanticsEnabled) {
-      if (ui.debugEmulateFlutterTesterEnvironment) {
-        // Running Flutter widget tests in a fake environment. Don't enable
-        // engine semantics. Test semantics trees violate invariants in ways
-        // production implementation isn't built to handle. For example, tests
-        // routinely reset semantics node IDs, which is messing up the update
-        // process.
-        return;
-      } else {
-        // Running a real app. Auto-enable engine semantics.
-        semanticsHelper.dispose(); // placeholder no longer needed
-        semanticsEnabled = true;
-      }
+      return;
     }
 
     final SemanticsUpdate update = uiUpdate as SemanticsUpdate;

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -88,60 +88,23 @@ void _testEngineSemanticsOwner() {
     expect(semantics().mode, AccessibilityMode.unknown);
   });
 
-  test('placeholder enables semantics', () async {
+  test('auto-enables semantics', () async {
     domRenderer.reset(); // triggers `autoEnableOnTap` to be called
     expect(semantics().semanticsEnabled, false);
 
     // Synthesize a click on the placeholder.
     final html.Element placeholder =
         html.document.querySelectorAll('flt-semantics-placeholder').single;
-    expect(placeholder.isConnected, true);
     final html.Rectangle<num> rect = placeholder.getBoundingClientRect();
     placeholder.dispatchEvent(html.MouseEvent(
       'click',
       clientX: (rect.left + (rect.right - rect.left) / 2).floor(),
       clientY: (rect.top + (rect.bottom - rect.top) / 2).floor(),
     ));
-
-    // On mobile semantics is not enabled synchronously. This is because the
-    // placeholder receives pointer events in non-accessibility mode too, and
-    // therefore we wait to see if any subsequent pointer events are issued
-    // indicating that this is not a request to enable accessibility.
-    if (isMobile) {
-      while (!semantics().semanticsEnabled) {
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-      }
+    while (!semantics().semanticsEnabled) {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
     }
     expect(semantics().semanticsEnabled, true);
-
-    // The placeholder should be removed
-    if (isMobile) {
-      // On mobile the placeholder is not removed synchronously. Instead it is
-      // removed upon the next DOM event. Otherwise Safari swallows pointerup.
-      expect(placeholder.isConnected, true);
-      placeholder.click();
-      await Future<void>.delayed(Duration.zero);
-    }
-    expect(placeholder.isConnected, false);
-  });
-
-  test('auto-enables semantics', () async {
-    domRenderer.reset(); // triggers `autoEnableOnTap` to be called
-    expect(semantics().semanticsEnabled, false);
-
-    final html.Element placeholder =
-        html.document.querySelectorAll('flt-semantics-placeholder').single;
-    expect(placeholder.isConnected, true);
-
-    // Sending a semantics update should auto-enable engine semantics.
-    final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
-    updateNode(builder, id: 0);
-    semantics().updateSemantics(builder.build());
-
-    expect(semantics().semanticsEnabled, true);
-
-    // The placeholder should be removed
-    expect(placeholder.isConnected, false);
   });
 
   void renderLabel(String label) {


### PR DESCRIPTION
… (#25830)"

It broke an integration test on the framework side.

This reverts commit aa2672ff5db20f382a834e7e4c1511e05a247b39.
