### PR TITLE
Ensure that AutoIsolateShutdown drops its reference to the DartIsolate on the intended task runner

### DIFF
--- a/testing/dart_isolate_runner.cc
+++ b/testing/dart_isolate_runner.cc
@@ -17,11 +17,11 @@ AutoIsolateShutdown::~AutoIsolateShutdown() {
     Shutdown();
   }
   fml::AutoResetWaitableEvent latch;
-  fml::TaskRunner::RunNowOrPostTask(runner_,
-                                    [isolate = std::move(isolate_), &latch]() {
-                                      // Delete isolate on thread.
-                                      latch.Signal();
-                                    });
+  fml::TaskRunner::RunNowOrPostTask(runner_, [this, &latch]() {
+    // Delete isolate on thread.
+    isolate_.reset();
+    latch.Signal();
+  });
   latch.Wait();
 }
 


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/80964
