### PR TITLE
test: Use upstream googletest

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -107,9 +107,6 @@ deps = {
   'src/third_party/benchmark':
    Var('fuchsia_git') + '/third_party/benchmark' + '@' + 'a779ffce872b4c811beef482e18bd0b63626aa42',
 
-  'src/third_party/googletest':
-   Var('fuchsia_git') + '/third_party/googletest' + '@' + '3fef9015bfe7617d57806cd7c73a653b28559fae',
-
   'src/third_party/rapidjson':
    Var('fuchsia_git') + '/third_party/rapidjson' + '@' + 'ef3564c5c8824989393b87df25355baf35ff544b',
 
@@ -138,6 +135,9 @@ deps = {
 
   'src/third_party/khronos':
    Var('chromium_git') + '/chromium/src/third_party/khronos.git' + '@' + '7122230e90547962e0f0c627f62eeed3c701f275',
+
+  'src/third_party/googletest':
+   Var('github_git') + '/google/googletest' + '@' + 'f5e592d8ee5ffb1d9af5be7f715ce3576b8bf9c4',
 
   'src/third_party/boringssl':
    Var('github_git') + '/dart-lang/boringssl_gen.git' + '@' + Var('dart_boringssl_gen_rev'),


### PR DESCRIPTION
7 months ago, the fuchsia toolchain team turned down the repository at https://fuchsia.googlesource.com/third_party/googletest and we did not notice.

Fuchsia is now using the upstream version of googletest and it is now carrying changes that new versions of the Fuchsia SDK depend on.  This began blocking Fuchsia SDK rolls, which is what brought it to the Flutter-on-Fuchsia team's attention.