### PR TITLE
Remove unused parameter in flutter application info loader

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
@@ -9,7 +9,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.XmlResourceParser;
 import android.os.Bundle;
-import android.security.NetworkSecurityPolicy;
 import androidx.annotation.NonNull;
 import java.io.IOException;
 import org.json.JSONArray;
@@ -146,12 +145,6 @@ public final class ApplicationInfoLoader {
   @NonNull
   public static FlutterApplicationInfo load(@NonNull Context applicationContext) {
     ApplicationInfo appInfo = getApplicationInfo(applicationContext);
-    // Prior to API 23, cleartext traffic is allowed.
-    boolean clearTextPermitted = true;
-    if (android.os.Build.VERSION.SDK_INT >= 23) {
-      clearTextPermitted = NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted();
-    }
-
     return new FlutterApplicationInfo(
         getString(appInfo.metaData, PUBLIC_AOT_SHARED_LIBRARY_NAME),
         getString(appInfo.metaData, PUBLIC_VM_SNAPSHOT_DATA_KEY),
@@ -159,7 +152,6 @@ public final class ApplicationInfoLoader {
         getString(appInfo.metaData, PUBLIC_FLUTTER_ASSETS_DIR_KEY),
         getNetworkPolicy(appInfo, applicationContext),
         appInfo.nativeLibraryDir,
-        clearTextPermitted,
         getBoolean(appInfo.metaData, PUBLIC_AUTOMATICALLY_REGISTER_PLUGINS_METADATA_KEY, true));
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterApplicationInfo.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterApplicationInfo.java
@@ -17,7 +17,6 @@ public final class FlutterApplicationInfo {
   public final String flutterAssetsDir;
   public final String domainNetworkPolicy;
   public final String nativeLibraryDir;
-  public final boolean clearTextPermitted;
   final boolean automaticallyRegisterPlugins;
 
   public FlutterApplicationInfo(
@@ -27,7 +26,6 @@ public final class FlutterApplicationInfo {
       String flutterAssetsDir,
       String domainNetworkPolicy,
       String nativeLibraryDir,
-      boolean clearTextPermitted,
       boolean automaticallyRegisterPlugins) {
     this.aotSharedLibraryName =
         aotSharedLibraryName == null ? DEFAULT_AOT_SHARED_LIBRARY_NAME : aotSharedLibraryName;
@@ -38,7 +36,6 @@ public final class FlutterApplicationInfo {
         flutterAssetsDir == null ? DEFAULT_FLUTTER_ASSETS_DIR : flutterAssetsDir;
     this.nativeLibraryDir = nativeLibraryDir;
     this.domainNetworkPolicy = domainNetworkPolicy == null ? "" : domainNetworkPolicy;
-    this.clearTextPermitted = clearTextPermitted;
     this.automaticallyRegisterPlugins = automaticallyRegisterPlugins;
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/ApplicationInfoLoaderTest.java
@@ -19,7 +19,6 @@ import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.content.res.XmlResourceParser;
 import android.os.Bundle;
-import android.security.NetworkSecurityPolicy;
 import java.io.StringReader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,8 +26,6 @@ import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.Implementation;
-import org.robolectric.annotation.Implements;
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserFactory;
 
@@ -46,23 +43,6 @@ public class ApplicationInfoLoaderTest {
     assertEquals("flutter_assets", info.flutterAssetsDir);
     assertEquals("", info.domainNetworkPolicy);
     assertNull(info.nativeLibraryDir);
-    assertEquals(true, info.clearTextPermitted);
-  }
-
-  @Config(shadows = {ApplicationInfoLoaderTest.ShadowNetworkSecurityPolicy.class})
-  @Test
-  public void itVotesAgainstClearTextIfSecurityPolicySaysSo() {
-    FlutterApplicationInfo info = ApplicationInfoLoader.load(RuntimeEnvironment.application);
-    assertNotNull(info);
-    assertEquals(false, info.clearTextPermitted);
-  }
-
-  @Implements(NetworkSecurityPolicy.class)
-  public static class ShadowNetworkSecurityPolicy {
-    @Implementation
-    public boolean isCleartextTrafficPermitted() {
-      return false;
-    }
   }
 
   private Context generateMockContext(Bundle metadata, String networkPolicyXml) throws Exception {


### PR DESCRIPTION
Internal issue: b/187271871

This PR is mostly a cleaner revert of #25299 After that PR was submitted there is still a call 

```
NetworkSecurityPolicy.getInstance().isCleartextTrafficPermitted()
```

inside `ApplicationInfoLoader.java` which results in calling the underlying xml parsing via the NetworkSecurityPolicy. This results in additional I/O contention in the main thread. 

Since #25299 is anyways currently turned off as a feature `--disallow-insecure-connections`, maybe this can be reverted as well until we can get some other way of passing this info across.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
* Updated the tests

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
