### PR TITLE
[web] Resolve OS as iOs for iDevice Safari requesting desktop version of app.

### DIFF
--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -131,7 +131,7 @@ enum OperatingSystem {
 }
 
 /// Lazily initialized current operating system.
-late final OperatingSystem _operatingSystem = _detectOperatingSystem();
+late final OperatingSystem _operatingSystem = detectOperatingSystem();
 
 /// Returns the [OperatingSystem] the current browsers works on.
 ///
@@ -149,11 +149,23 @@ OperatingSystem get operatingSystem {
 /// This is intended to be used for testing and debugging only.
 OperatingSystem? debugOperatingSystemOverride;
 
-OperatingSystem _detectOperatingSystem() {
-  final String platform = html.window.navigator.platform!;
-  final String userAgent = html.window.navigator.userAgent;
+@visibleForTesting
+OperatingSystem detectOperatingSystem({
+  @visibleForTesting String? overridePlatform,
+  @visibleForTesting String? overrideUserAgent,
+  @visibleForTesting int? overrideMaxTouchPoints,
+}) {
+  final String platform = overridePlatform ?? html.window.navigator.platform!;
+  final String userAgent = overrideUserAgent ?? html.window.navigator.userAgent;
 
   if (platform.startsWith('Mac')) {
+    // iDevices requesting a "desktop site" spoof their UA so it looks like a Mac.
+    // This checks if we're in a touch device, or on a real mac.
+    final int maxTouchPoints =
+        overrideMaxTouchPoints ?? html.window.navigator.maxTouchPoints ?? 0;
+    if (maxTouchPoints > 2) {
+      return OperatingSystem.iOs;
+    }
     return OperatingSystem.macOs;
   } else if (platform.toLowerCase().contains('iphone') ||
       platform.toLowerCase().contains('ipad') ||

--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -151,9 +151,9 @@ OperatingSystem? debugOperatingSystemOverride;
 
 @visibleForTesting
 OperatingSystem detectOperatingSystem({
-  @visibleForTesting String? overridePlatform,
-  @visibleForTesting String? overrideUserAgent,
-  @visibleForTesting int? overrideMaxTouchPoints,
+  String? overridePlatform,
+  String? overrideUserAgent,
+  int? overrideMaxTouchPoints,
 }) {
   final String platform = overridePlatform ?? html.window.navigator.platform!;
   final String userAgent = overrideUserAgent ?? html.window.navigator.userAgent;

--- a/lib/web_ui/test/browser_detect_test.dart
+++ b/lib/web_ui/test/browser_detect_test.dart
@@ -11,38 +11,154 @@ void main() {
 }
 
 void testMain() {
-  test('Should detect Blink', () {
-    // Chrome Version 89.0.4389.90 (Official Build) (x86_64) / MacOS
-    BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
-        'Google Inc.',
-        'mozilla/5.0 (macintosh; intel mac os x 11_2_3) applewebkit/537.36 '
-        '(khtml, like gecko) chrome/89.0.4389.90 safari/537.36');
-    expect(browserEngine, BrowserEngine.blink);
+  group('detectBrowserEngineByVendorAgent', () {
+    test('Should detect Blink', () {
+      // Chrome Version 89.0.4389.90 (Official Build) (x86_64) / MacOS
+      BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
+          'Google Inc.',
+          'mozilla/5.0 (macintosh; intel mac os x 11_2_3) applewebkit/537.36 '
+              '(khtml, like gecko) chrome/89.0.4389.90 safari/537.36');
+      expect(browserEngine, BrowserEngine.blink);
+    });
+
+    test('Should detect Firefox', () {
+      // 85.0.2 (64-bit) / MacOS
+      BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
+          '',
+          'mozilla/5.0 (macintosh; intel mac os x 10.16; rv:85.0) '
+              'gecko/20100101 firefox/85.0');
+      expect(browserEngine, BrowserEngine.firefox);
+    });
+
+    test('Should detect Safari', () {
+      BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
+          'Apple Computer, Inc.',
+          'mozilla/5.0 (macintosh; intel mac os x 10_15_6) applewebkit/605.1.15 '
+              '(khtml, like gecko) version/14.0.3 safari/605.1.15');
+      expect(browserEngine, BrowserEngine.webkit);
+    });
+
+    test('Should detect Samsung browser', () {
+      // Samsung 13.2.1.70 on Galaxy Tab S6.
+      BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
+          'Google Inc.',
+          'mozilla/5.0 (x11; linux x86_64) applewebkit/537.36 (khtml, like gecko)'
+              ' samsungbrowser/13.2 chrome/83.0.4103.106 safari/537.36');
+      expect(browserEngine, BrowserEngine.samsung);
+    });
   });
 
-  test('Should detect Firefox', () {
-    // 85.0.2 (64-bit) / MacOS
-    BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
-        '',
-        'mozilla/5.0 (macintosh; intel mac os x 10.16; rv:85.0) '
-        'gecko/20100101 firefox/85.0');
-    expect(browserEngine, BrowserEngine.firefox);
-  });
+  group('detectOperatingSystem', () {
+    void expectOs(
+      OperatingSystem expectedOs, {
+      String platform = 'any',
+      String ua = 'any',
+      int touchPoints = 0,
+    }) {
+      expect(
+          detectOperatingSystem(
+            overridePlatform: platform,
+            overrideUserAgent: ua,
+            overrideMaxTouchPoints: touchPoints,
+          ),
+          expectedOs);
+    }
 
-  test('Should detect Safari', () {
-    BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
-      'Apple Computer, Inc.',
-      'mozilla/5.0 (macintosh; intel mac os x 10_15_6) applewebkit/605.1.15 '
-      '(khtml, like gecko) version/14.0.3 safari/605.1.15');
-    expect(browserEngine, BrowserEngine.webkit);
-  });
+    test('Determine unknown for weird values of platform/ua', () {
+      expectOs(OperatingSystem.unknown);
+    });
 
-  test('Should detect Samsung browser', () {
-    // Samsung 13.2.1.70 on Galaxy Tab S6.
-    BrowserEngine browserEngine = detectBrowserEngineByVendorAgent(
-        'Google Inc.',
-        'mozilla/5.0 (x11; linux x86_64) applewebkit/537.36 (khtml, like gecko)'
-        ' samsungbrowser/13.2 chrome/83.0.4103.106 safari/537.36');
-    expect(browserEngine, BrowserEngine.samsung);
+    test('Determine MacOS if platform starts by Mac', () {
+      expectOs(
+        OperatingSystem.macOs,
+        platform: 'MacIntel',
+      );
+      expectOs(
+        OperatingSystem.macOs,
+        platform: 'MacAnythingElse',
+      );
+    });
+
+    test('Determine iOS if platform contains iPhone/iPad/iPod', () {
+      expectOs(
+        OperatingSystem.iOs,
+        platform: 'iPhone',
+      );
+      expectOs(
+        OperatingSystem.iOs,
+        platform: 'iPhone Simulator',
+      );
+      expectOs(
+        OperatingSystem.iOs,
+        platform: 'iPad',
+      );
+      expectOs(
+        OperatingSystem.iOs,
+        platform: 'iPad Simulator',
+      );
+      expectOs(
+        OperatingSystem.iOs,
+        platform: 'iPod',
+      );
+      expectOs(
+        OperatingSystem.iOs,
+        platform: 'iPod Simulator',
+      );
+    });
+
+    // See https://github.com/flutter/flutter/issues/81918
+    test('Tell apart MacOS from iOS requesting a desktop site.', () {
+      expectOs(
+        OperatingSystem.macOs,
+        platform: 'MacARM',
+      );
+
+      expectOs(
+        OperatingSystem.iOs,
+        platform: 'MacARM',
+        touchPoints: 5,
+      );
+    });
+
+    test('Determine Android if user agent contains Android', () {
+      expectOs(
+        OperatingSystem.android,
+        ua: 'Mozilla/5.0 (Linux; U; Android 2.2) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1',
+      );
+    });
+
+    test('Determine Linux if the platform begins with Linux', () {
+      expectOs(
+        OperatingSystem.linux,
+        platform: 'Linux',
+      );
+      expectOs(
+        OperatingSystem.linux,
+        platform: 'Linux armv8l',
+      );
+      expectOs(
+        OperatingSystem.linux,
+        platform: 'Linux x86_64',
+      );
+    });
+
+    test('Determine Windows if the platform begins with Win', () {
+      expectOs(
+        OperatingSystem.windows,
+        platform: 'Windows',
+      );
+      expectOs(
+        OperatingSystem.windows,
+        platform: 'Win32',
+      );
+      expectOs(
+        OperatingSystem.windows,
+        platform: 'Win16',
+      );
+      expectOs(
+        OperatingSystem.windows,
+        platform: 'WinCE',
+      );
+    });
   });
 }


### PR DESCRIPTION
This PR tweaks the OS detection code in Flutter web, so iDevices requesting flutter apps in "desktop mode" (spoofing their navigator attributes) are still correctly identified as iDevices, and not confused with "Macs".

I've also added tests for the OS detection code.

Fixes https://github.com/flutter/flutter/issues/81918

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
