### PR TITLE
fuchsia: Fix multi-views fallout

### DIFF
--- a/flow/view_holder.cc
+++ b/flow/view_holder.cc
@@ -74,7 +74,7 @@ void ViewHolder::Destroy(zx_koid_t id, ViewIdCallback on_view_destroyed) {
   auto binding = bindings->find(id);
   FML_DCHECK(binding != bindings->end());
 
-  if (binding->second->view_holder_) {
+  if (binding->second->view_holder_ && on_view_destroyed) {
     on_view_destroyed(binding->second->view_holder_->id());
   }
   bindings->erase(id);

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -483,13 +483,14 @@ bool PlatformView::OnChildViewStateChanged(scenic::ResourceId view_holder_id,
     return false;
   }
 
+  const std::string is_rendering_str = is_rendering ? "true" : "false";
   std::ostringstream out;
   out << "{"
       << "\"method\":\"View.viewStateChanged\","
       << "\"args\":{"
       << "  \"viewId\":" << view_id_mapping->second << ","  // ViewHolderToken
-      << "  \"is_rendering\":" << is_rendering << ","       // IsViewRendering
-      << "  \"state\":" << is_rendering                     // IsViewRendering
+      << "  \"is_rendering\":" << is_rendering_str << ","   // IsViewRendering
+      << "  \"state\":" << is_rendering_str                 // IsViewRendering
       << "  }"
       << "}";
   auto call = out.str();

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -877,9 +877,9 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
       << "{"
       << "\"method\":\"View.viewStateChanged\","
       << "\"args\":{"
-      << "  \"viewId\":" << kViewId << ","     // ViewHolderToken
-      << "  \"is_rendering\":" << true << ","  // IsViewRendering
-      << "  \"state\":" << true                // IsViewRendering
+      << "  \"viewId\":" << kViewId << ","  // ViewHolderToken
+      << "  \"is_rendering\":true,"         // IsViewRendering
+      << "  \"state\":true"                 // IsViewRendering
       << "  }"
       << "}";
   EXPECT_EQ(view_state_changed_expected_out.str(),


### PR DESCRIPTION
Unfortunately https://github.com/flutter/engine/pull/25343 introduced a few regressions (crashes) on internal Fuchsia builds.  The integration tests running in fuchsia.git would have caught these.

This CL fixes both issues.

Fixes: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=76134
Fixes: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=76162
Tests: platform_view_unittests updated, manually ran fuchsia.git integration tests