### PR TITLE
Simplify build and test host_debug_unopt on cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,10 +36,7 @@ task:
       compile_host_script: |
         cd $ENGINE_PATH/src
         ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      test_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/testing/run_tests.sh host_debug_unopt
+        ninja -C out/host_debug_unopt -j 20
       fetch_framework_script: |
         mkdir -p $FRAMEWORK_PATH
         cd $FRAMEWORK_PATH

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,7 +36,7 @@ task:
       compile_host_script: |
         cd $ENGINE_PATH/src
         ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt -j 20
+        ninja -C out/host_debug_unopt
       fetch_framework_script: |
         mkdir -p $FRAMEWORK_PATH
         cd $FRAMEWORK_PATH


### PR DESCRIPTION
- Build with `-j 20` (2/3rds of available cores, since comments indicate cores are needed for other things too during execution)
- Remove the engine unittests that are covered on LUCI builds and this task has been timing out lately.

Helps with https://github.com/flutter/flutter/issues/72391