### PR TITLE
Return a maximum nanoseconds value in FlutterDesktopEngineProcessMessages

### DIFF
--- a/shell/platform/windows/flutter_windows_win32.cc
+++ b/shell/platform/windows/flutter_windows_win32.cc
@@ -67,7 +67,7 @@ bool FlutterDesktopViewControllerHandleTopLevelWindowProc(
 }
 
 uint64_t FlutterDesktopEngineProcessMessages(FlutterDesktopEngineRef engine) {
-  return std::numeric_limits<uint64_t>::max();
+  return std::chrono::nanoseconds::max().count();
 }
 
 void FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate(


### PR DESCRIPTION
This had been returning the maximum uint64_t, which is converted to
a signed -1 value when constructing a std::chrono::nanoseconds.
