### PR TITLE
Use string_view inputs for conversion functions

### DIFF
--- a/shell/platform/windows/string_conversion.cc
+++ b/shell/platform/windows/string_conversion.cc
@@ -8,7 +8,7 @@
 
 namespace flutter {
 
-std::string Utf8FromUtf16(const std::wstring& utf16_string) {
+std::string Utf8FromUtf16(const std::wstring_view utf16_string) {
   if (utf16_string.empty()) {
     return std::string();
   }
@@ -30,7 +30,7 @@ std::string Utf8FromUtf16(const std::wstring& utf16_string) {
   return utf8_string;
 }
 
-std::wstring Utf16FromUtf8(const std::string& utf8_string) {
+std::wstring Utf16FromUtf8(const std::string_view utf8_string) {
   if (utf8_string.empty()) {
     return std::wstring();
   }

--- a/shell/platform/windows/string_conversion.h
+++ b/shell/platform/windows/string_conversion.h
@@ -11,11 +11,11 @@ namespace flutter {
 
 // Converts a string from UTF-16 to UTF-8. Returns an empty string if the
 // input is not valid UTF-16.
-std::string Utf8FromUtf16(const std::wstring& utf16_string);
+std::string Utf8FromUtf16(const std::wstring_view utf16_string);
 
 // Converts a string from UTF-8 to UTF-16. Returns an empty string if the
 // input is not valid UTF-8.
-std::wstring Utf16FromUtf8(const std::string& utf8_string);
+std::wstring Utf16FromUtf8(const std::string_view utf8_string);
 
 }  // namespace flutter
 


### PR DESCRIPTION
This offers a small improvement in performance in cases where the input
is a raw char* or wchar_t* string due to not having to perform an
implicit conversion to std::string/std::wstring.

Code cleanup covered by existing tests, which already use raw C strings.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
