### PR TITLE
Add support for zx_channel_write_etc and zx_channel_read_etc.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1266,11 +1266,14 @@ FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/fuchsia/lib/fuchsia.dart
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.cc
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/fuchsia/sdk_ext/fuchsia.h
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
+FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_disposition.dart
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_waiter.dart
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/lib/zircon.dart
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.cc
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h
+FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.cc
+FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.h
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_waiter.cc
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_waiter.h
 FILE: ../../../flutter/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/natives.cc

--- a/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
@@ -14,6 +14,8 @@ source_set("zircon") {
   sources = [
     "sdk_ext/handle.cc",
     "sdk_ext/handle.h",
+    "sdk_ext/handle_disposition.cc",
+    "sdk_ext/handle_disposition.h",
     "sdk_ext/handle_waiter.cc",
     "sdk_ext/handle_waiter.h",
     "sdk_ext/natives.cc",

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_disposition.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_disposition.dart
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of zircon;
+
+// ignore_for_file: native_function_body_in_non_sdk_code
+// ignore_for_file: public_member_api_docs
+
+@pragma('vm:entry-point')
+class HandleDisposition extends NativeFieldWrapperClass2 {
+  @pragma('vm:entry-point')
+  HandleDisposition(int operation, Handle handle, int type, int rights) {
+    _constructor(operation, handle, type, rights);
+  }
+
+  void _constructor(int operation, Handle handle, int type, int rights)
+      native 'HandleDisposition_constructor';
+
+  int get operation native 'HandleDisposition_operation';
+  Handle get handle native 'HandleDisposition_handle';
+  int get type native 'HandleDisposition_type';
+  int get rights native 'HandleDisposition_rights';
+  int get result native 'HandleDisposition_result';
+
+  @override
+  String toString() =>
+      'HandleDisposition(operation=$operation, handle=$handle, type=$type, rights=$rights, result=$result)';
+}

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
@@ -99,6 +99,49 @@ class ReadResult extends _Result {
 }
 
 @pragma('vm:entry-point')
+class HandleInfo {
+  final Handle handle;
+  final int type;
+  final int rights;
+
+  @pragma('vm:entry-point')
+  const HandleInfo(this.handle, this.type, this.rights);
+
+  @override
+  String toString() =>
+      'HandleInfo(handle=$handle, type=$type, rights=$rights)';
+}
+
+@pragma('vm:entry-point')
+class ReadEtcResult extends _Result {
+  final ByteData? _bytes;
+  final int? _numBytes;
+  final List<HandleInfo>? _handleInfos;
+
+  ByteData get bytes => _bytes!;
+  int get numBytes => _numBytes!;
+  List<HandleInfo> get handleInfos => _handleInfos!;
+
+  @pragma('vm:entry-point')
+  const ReadEtcResult(final int status, [this._bytes, this._numBytes, this._handleInfos])
+      : super(status);
+
+  /// Returns the bytes as a Uint8List. If status != OK this will throw
+  /// an exception.
+  Uint8List bytesAsUint8List() {
+    return _bytes!.buffer.asUint8List(_bytes!.offsetInBytes, _numBytes!);
+  }
+
+  /// Returns the bytes as a String. If status != OK this will throw
+  /// an exception.
+  String bytesAsUTF8String() => utf8.decode(bytesAsUint8List());
+
+  @override
+  String toString() =>
+      'ReadEtcResult(status=$status, bytes=$_bytes, numBytes=$_numBytes, handleInfos=$_handleInfos)';
+}
+
+@pragma('vm:entry-point')
 class WriteResult extends _Result {
   final int? _numBytes;
   int get numBytes => _numBytes!;
@@ -161,8 +204,12 @@ class System extends NativeFieldWrapperClass2 {
     native 'System_ConnectToService';
   static int channelWrite(Handle channel, ByteData data, List<Handle> handles)
       native 'System_ChannelWrite';
+  static int channelWriteEtc(Handle channel, ByteData data, List<HandleDisposition> handleDispositions)
+      native 'System_ChannelWriteEtc';
   static ReadResult channelQueryAndRead(Handle channel)
       native 'System_ChannelQueryAndRead';
+  static ReadEtcResult channelQueryAndReadEtc(Handle channel)
+      native 'System_ChannelQueryAndReadEtc';
 
   // Eventpair operations.
   static HandlePairResult eventpairCreate([int options = 0])

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/zircon.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/zircon.dart
@@ -9,5 +9,6 @@ import 'dart:nativewrappers';
 import 'dart:typed_data';
 
 part 'src/handle.dart';
+part 'src/handle_disposition.dart';
 part 'src/handle_waiter.dart';
 part 'src/system.dart';

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.cc
@@ -1,0 +1,60 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "handle_disposition.h"
+
+#include <algorithm>
+
+#include "third_party/tonic/dart_binding_macros.h"
+#include "third_party/tonic/dart_class_library.h"
+
+using tonic::ToDart;
+
+namespace zircon {
+namespace dart {
+
+IMPLEMENT_WRAPPERTYPEINFO(zircon, HandleDisposition);
+
+void HandleDisposition_constructor(Dart_NativeArguments args) {
+  DartCallConstructor(&HandleDisposition::create, args);
+}
+
+fml::RefPtr<HandleDisposition> HandleDisposition::create(
+    zx_handle_op_t operation,
+    fml::RefPtr<dart::Handle> handle,
+    zx_obj_type_t type,
+    zx_rights_t rights) {
+  return fml::MakeRefCounted<HandleDisposition>(operation, handle, type, rights,
+                                                ZX_OK);
+}
+
+// clang-format: off
+
+#define FOR_EACH_STATIC_BINDING(V) V(HandleDisposition, create)
+
+#define FOR_EACH_BINDING(V)       \
+  V(HandleDisposition, operation) \
+  V(HandleDisposition, handle)    \
+  V(HandleDisposition, type)      \
+  V(HandleDisposition, rights)    \
+  V(HandleDisposition, result)
+
+// clang-format: on
+
+// Tonic is missing a comma.
+#define DART_REGISTER_NATIVE_STATIC_(CLASS, METHOD) \
+  DART_REGISTER_NATIVE_STATIC(CLASS, METHOD),
+
+FOR_EACH_STATIC_BINDING(DART_NATIVE_CALLBACK_STATIC)
+FOR_EACH_BINDING(DART_NATIVE_NO_UI_CHECK_CALLBACK)
+
+void HandleDisposition::RegisterNatives(tonic::DartLibraryNatives* natives) {
+  natives->Register({{"HandleDisposition_constructor",
+                      HandleDisposition_constructor, 5, true},
+                     FOR_EACH_STATIC_BINDING(DART_REGISTER_NATIVE_STATIC_)
+                         FOR_EACH_BINDING(DART_REGISTER_NATIVE)});
+}
+
+}  // namespace dart
+}  // namespace zircon

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.h
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle_disposition.h
@@ -1,0 +1,71 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_SDK_EXT_HANDLE_DISPOSITION_H_
+#define FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_SDK_EXT_HANDLE_DISPOSITION_H_
+
+#include <zircon/syscalls.h>
+
+#include <vector>
+
+#include "flutter/fml/memory/ref_counted.h"
+#include "handle.h"
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "third_party/tonic/dart_library_natives.h"
+#include "third_party/tonic/dart_wrappable.h"
+
+namespace zircon {
+namespace dart {
+/**
+ * HandleDisposition is the native peer of a Dart object (HandleDisposition
+ * in dart:zircon) that holds a Handle and additional properties.
+ */
+class HandleDisposition : public fml::RefCountedThreadSafe<HandleDisposition>,
+                          public tonic::DartWrappable {
+  DEFINE_WRAPPERTYPEINFO();
+  FML_FRIEND_REF_COUNTED_THREAD_SAFE(HandleDisposition);
+  FML_FRIEND_MAKE_REF_COUNTED(HandleDisposition);
+
+ public:
+  static void RegisterNatives(tonic::DartLibraryNatives* natives);
+
+  static fml::RefPtr<HandleDisposition> create(zx_handle_op_t operation,
+                                               fml::RefPtr<dart::Handle> handle,
+                                               zx_obj_type_t type,
+                                               zx_rights_t rights);
+
+  zx_handle_op_t operation() const { return operation_; }
+  fml::RefPtr<dart::Handle> handle() const { return handle_; }
+  zx_obj_type_t type() const { return type_; }
+  zx_rights_t rights() const { return rights_; }
+  zx_status_t result() const { return result_; }
+  void set_result(zx_status_t result) { result_ = result; }
+
+ private:
+  explicit HandleDisposition(zx_handle_op_t operation,
+                             fml::RefPtr<dart::Handle> handle,
+                             zx_obj_type_t type,
+                             zx_rights_t rights,
+                             zx_status_t result)
+      : operation_(operation),
+        handle_(handle),
+        type_(type),
+        rights_(rights),
+        result_(result) {}
+
+  void RetainDartWrappableReference() const override { AddRef(); }
+
+  void ReleaseDartWrappableReference() const override { Release(); }
+
+  zx_handle_op_t operation_;
+  fml::RefPtr<dart::Handle> handle_;
+  zx_obj_type_t type_;
+  zx_rights_t rights_;
+  zx_status_t result_;
+};
+
+}  // namespace dart
+}  // namespace zircon
+
+#endif  // FLUTTER_SHELL_PLATFORM_FUCHSIA_DART_PKG_ZIRCON_SDK_EXT_HANDLE_DISPOSITION_H_

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/natives.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/natives.cc
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "handle.h"
+#include "handle_disposition.h"
 #include "handle_waiter.h"
 #include "system.h"
 #include "third_party/dart/runtime/include/dart_api.h"
@@ -32,6 +33,7 @@ static tonic::DartLibraryNatives* g_natives;
 
 tonic::DartLibraryNatives* InitNatives() {
   tonic::DartLibraryNatives* natives = new tonic::DartLibraryNatives();
+  HandleDisposition::RegisterNatives(natives);
   HandleWaiter::RegisterNatives(natives);
   Handle::RegisterNatives(natives);
   System::RegisterNatives(natives);

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
@@ -8,6 +8,7 @@
 #include <zircon/syscalls.h>
 
 #include "handle.h"
+#include "handle_disposition.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/dart_library_natives.h"
 #include "third_party/tonic/dart_wrappable.h"
@@ -37,8 +38,13 @@ class System : public fml::RefCountedThreadSafe<System>,
   static zx_status_t ChannelWrite(fml::RefPtr<Handle> channel,
                                   const tonic::DartByteData& data,
                                   std::vector<Handle*> handles);
+  static zx_status_t ChannelWriteEtc(
+      fml::RefPtr<Handle> channel,
+      const tonic::DartByteData& data,
+      std::vector<HandleDisposition*> handle_dispositions);
   // TODO(ianloic): Add ChannelRead
   static Dart_Handle ChannelQueryAndRead(fml::RefPtr<Handle> channel);
+  static Dart_Handle ChannelQueryAndReadEtc(fml::RefPtr<Handle> channel);
 
   static Dart_Handle EventpairCreate(uint32_t options);
 

--- a/shell/platform/fuchsia/dart-pkg/zircon/test/handle_disposition_test.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/test/handle_disposition_test.dart
@@ -1,0 +1,18 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:zircon/zircon.dart';
+
+void main() {
+  test('store the disposition arguments correctly', () {
+    final Handle handle = System.channelCreate().first;
+    final HandleDisposition disposition = HandleDisposition(1, handle, 2, 3);
+    expect(disposition.operation, equals(1));
+    expect(disposition.handle, equals(handle));
+    expect(disposition.type, equals(2));
+    expect(disposition.rights, equals(3));
+    expect(disposition.result, equals(ZX.OK));
+  });
+}


### PR DESCRIPTION
Add support for System.channelWriteEtc and System.channelQueryAndReadEtc.

These use the zx_channel_write_etc and zx_channel_read_etc syscalls, which implements the majority of https://fxbug.dev/68600.

Also add HandleDisposition, HandleInfoResult, and ReadEtcResult classes to dart:zircon's API surface.

I've added tests to channel_test and handle_disposition_test, and ran them locally.

Relevant bugs: https://fxbug.dev/68600


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
