### PR TITLE
Skip SimpleRasterizerStatistics test on Fuchsia

### DIFF
--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -171,11 +171,12 @@ TEST_F(PerformanceOverlayLayerTest, SimpleRasterizerStatistics) {
   text_paint.setColor(SK_ColorGRAY);
   SkPoint text_position = SkPoint::Make(16.0f, 22.0f);
 
-  // TODO(https://github.com/flutter/flutter/issues/82202): Remove once the performance overlay
-  // can use Fuchsia's font manager instead of the empty default.
+  // TODO(https://github.com/flutter/flutter/issues/82202): Remove once the
+  // performance overlay can use Fuchsia's font manager instead of the empty
+  // default.
 #if defined(OS_FUCHSIA)
   GTEST_SKIP() << "Expectation requires a valid default font manager";
-#endif // OS_FUCHSIA
+#endif  // OS_FUCHSIA
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({MockCanvas::DrawCall{
                 0, MockCanvas::DrawTextData{overlay_text_data, text_paint,

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -170,6 +170,12 @@ TEST_F(PerformanceOverlayLayerTest, SimpleRasterizerStatistics) {
   SkPaint text_paint;
   text_paint.setColor(SK_ColorGRAY);
   SkPoint text_position = SkPoint::Make(16.0f, 22.0f);
+
+  // TODO(https://github.com/flutter/flutter/issues/82202): Remove once the performance overlay
+  // can use Fuchsia's font manager instead of the empty default.
+#if defined(OS_FUCHSIA)
+  GTEST_SKIP() << "Expectation requires a valid default font manager";
+#endif // OS_FUCHSIA
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({MockCanvas::DrawCall{
                 0, MockCanvas::DrawTextData{overlay_text_data, text_paint,


### PR DESCRIPTION
This removes a behavioral dependency on SkCanvas::quickReject and the empty SkTypeface that's used as a fallback when there's no real SkFontMgr installed (which is what the performance overlay uses to create its statistics SkTextBlob).

This mitigates the issue described in https://github.com/flutter/flutter/issues/82202 and unblocks changes to land in Skia, but is only a temporary solution to the larger problem of the differences between Fuchsia's font management vs. other platforms.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
