### PR TITLE
Handle EINTR during epoll_wait in MessageLoopLinux

### DIFF
--- a/fml/platform/linux/message_loop_linux.cc
+++ b/fml/platform/linux/message_loop_linux.cc
@@ -53,6 +53,12 @@ void MessageLoopLinux::Run() {
     int epoll_result = FML_HANDLE_EINTR(
         ::epoll_wait(epoll_fd_.get(), &event, 1, -1 /* timeout */));
 
+    // epoll_wait can be interrupted by signal handler before the timeout
+    // expires
+    if (epoll_result == -1 && errno == EINTR) {
+      continue;
+    }
+
     // Errors are fatal.
     if (event.events & (EPOLLERR | EPOLLHUP)) {
       running_ = false;


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/82226

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
