### PR TITLE
Get licenses check deps from gclient rather than pub

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -394,10 +394,14 @@ deps = {
    'src/third_party/abseil-cpp':
    Var('chromium_git') + '/chromium/src/third_party/abseil-cpp.git' + '@' + '2d8c1340f0350828f1287c4eaeebefcf317bcfc9',
 
-  'src/third_party/pkg/when':
-   Var('dart_git') + '/when.git' + '@' + '0.2.0',
+   # Dart packages
+  'src/third_party/pkg/archive':
+  Var('github_git') + '/brendan-duncan/archive.git' + '@' + '3.1.2',
 
-   'src/third_party/android_tools/ndk': {
+  'src/third_party/pkg/when':
+  Var('dart_git') + '/when.git' + '@' + '0.2.0',
+
+  'src/third_party/android_tools/ndk': {
      'packages': [
        {
         'package': 'flutter/android/ndk/${{platform}}',

--- a/ci/licenses.sh
+++ b/ci/licenses.sh
@@ -62,7 +62,6 @@ dart --version
 # Runs in a subshell.
 function collect_licenses() (
   cd "$SRC_DIR/flutter/tools/licenses"
-  pub get
   dart --enable-asserts lib/main.dart         \
     --src ../../..                            \
     --out ../../../out/license_script_output  \

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: d165688a88dd53153d8e32bd26d3fa6d
+Signature: dd0af3be798528c3303ec68043c4785c
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1663,6 +1663,11 @@ class _RepositoryPkgDirectory extends _RepositoryDirectory {
   _RepositoryPkgDirectory(_RepositoryDirectory parent, fs.Directory io) : super(parent, io);
 
   @override
+  bool shouldRecurse(fs.IoNode entry) {
+    return entry.name != 'archive';  // contains nothing that ends up in the binary executable
+  }
+
+  @override
   _RepositoryDirectory createSubdirectory(fs.Directory entry) {
     if (entry.name == 'when')
       return _RepositoryPkgWhenDirectory(this, entry);

--- a/tools/licenses/pubspec.yaml
+++ b/tools/licenses/pubspec.yaml
@@ -1,10 +1,40 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: licenses
+publish_to: none
 environment:
   sdk: '>=2.8.0 <3.0.0'
 
+# Do not add any dependencies that require more than what is provided in
+# //third_party.pkg, //third_party/dart/pkg, or
+# //third_party/dart/third_party/pkg. In particular, package:test is not usable
+# here.
+
+# If you do add packages here, make sure you can run `pub get --offline`, and
+# check the .packages and .package_config to make sure all the paths are
+# relative to this directory into //third_party/dart
+
 dependencies:
-  archive: ^2.0.4
-  args: 1.5.0
-  crypto: ^2.0.2+1
-  meta: ^1.1.6
-  path: ^1.3.0
+  archive: any
+  args: any
+  crypto: any
+  meta: any
+  path: any
+
+dependency_overrides:
+  archive:
+    path: ../../../third_party/pkg/archive
+  args:
+    path: ../../../third_party/dart/third_party/pkg/args
+  collection:
+    path: ../../../third_party/dart/third_party/pkg/collection
+  crypto:
+    path: ../../../third_party/dart/third_party/pkg/crypto
+  meta:
+    path: ../../../third_party/dart/pkg/meta
+  path:
+    path: ../../../third_party/dart/third_party/pkg/path
+  typed_data:
+    path: ../../../third_party/dart/third_party/pkg/typed_data

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -17,6 +17,7 @@ import sys
 ALL_PACKAGES = [
   os.path.join("src", "flutter", "flutter_frontend_server"),
   os.path.join("src", "flutter", "tools", "const_finder"),
+  os.path.join("src", "flutter", "tools", "licenses"),
 ]
 
 


### PR DESCRIPTION
Instead of using pub to get the dependencies of the license check script, this PR explicitly points the script's pubspec.yaml file at the dependencies it needs it needs that are already populated in the source tree by `gclient sync`. To accomplish this, it adds a checkout of the `archive` package from github to the DEPS file.

Related https://github.com/flutter/flutter/issues/82134