### PR TITLE
Formatting cleanup for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,25 +20,30 @@ contributing guide.
 
 The Flutter engine follows Google style for the languages it uses:
 - [C++](https://google.github.io/styleguide/cppguide.html)
-  - **Note**: The Linux embedding generally follows idiomatic GObject-based C style.
-    Use of C++ is discouraged in that embedding to avoid creating hybrid code that
-    feels unfamiliar to either developers used to working with GObject or C++ developers.
-    For example, do not use STL collections or std::string. Exceptions:
+  - **Note**: The Linux embedding generally follows idiomatic GObject-based C
+    style. Use of C++ is discouraged in that embedding to avoid creating hybrid
+    code that feels unfamiliar to either developers used to working with
+    `GObject` or C++ developers. For example, do not use STL collections or
+    `std::string`. Exceptions:
       - C-style casts are forbidden; use C++ casts.
       - Use `nullptr` rather than `NULL`.
       - Avoid `#define`; for internal constants use `static constexpr` instead.
-- [Objective-C](https://google.github.io/styleguide/objcguide.html) (including
-  [Objective-C++](https://google.github.io/styleguide/objcguide.html#objective-c))
-- [Java](https://google.github.io/styleguide/javaguide.html)
+- [Objective-C][objc_style] (including [Objective-C++][objcc_style])
+- [Java][java_style]
 
-C/C++ and Objective-C/C++ files are formatted with `clang-format`, and GN files with `gn format`.
+C/C++ and Objective-C/C++ files are formatted with `clang-format`, and GN files
+with `gn format`.
 
 [build_status]: https://cirrus-ci.com/github/flutter/engine
 [code_of_conduct]: https://github.com/flutter/flutter/blob/master/CODE_OF_CONDUCT.md
 [contrib_guide]: https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md
 [engine_dev_setup]: https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment
+[objc_style]: https://google.github.io/styleguide/objcguide.html
+[objcc_style]: https://google.github.io/styleguide/objcguide.html#objective-c
+[java_style]: https://google.github.io/styleguide/javaguide.html
 
 
 ### Fuchsia Contributions from Googlers
 
-Googlers contributing to Fuchsia should follow the additional steps at: go/flutter-fuchsia-pr-policy.
+Googlers contributing to Fuchsia should follow the additional steps at:
+go/flutter-fuchsia-pr-policy.


### PR DESCRIPTION
Re-wrap to 80 columns and use references for style guide links.

Unofficially, this is more about triggering a build than cleaning up.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
