### PR TITLE
[vm_service] Add vm service port to inspect.

### DIFF
--- a/shell/platform/fuchsia/flutter/main.cc
+++ b/shell/platform/fuchsia/flutter/main.cc
@@ -24,8 +24,11 @@ int main(int argc, char const* argv[]) {
 
   // We inject the 'vm' node into the dart vm so that it can add any inspect
   // data that it needs to the inspect tree.
-  dart::SetDartVmNode(std::make_unique<inspect::Node>(
-      dart_utils::RootInspectNode::CreateRootChild("vm")));
+  auto vm_node = std::make_unique<inspect::Node>(dart_utils::RootInspectNode::CreateRootChild("vm"));
+  vm_node->CreateString(
+    dart_utils::VMServiceObject::kPortDirName, dart_utils::VMServiceObject::kPortDir,
+    dart_utils::RootInspectNode::GetInspector());
+  dart::SetDartVmNode(std::move(vm_node));
 
   std::unique_ptr<trace::TraceProviderWithFdio> provider;
   {

--- a/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.cc
@@ -21,4 +21,9 @@ inspect::Node RootInspectNode::CreateRootChild(const std::string& name) {
   return inspector_->inspector()->GetRoot().CreateChild(name);
 }
 
+inspect::Inspector* RootInspectNode::GetInspector() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return inspector_->inspector();
+}
+
 }  // namespace dart_utils

--- a/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h
@@ -25,12 +25,15 @@ class RootInspectNode {
 
  public:
   // Initializes the underlying component inspector. Must be invoked at least
-  // once before calling CreateRootChild().
+  // once before calling CreateRootChild() or GetInspector().
   static void Initialize(sys::ComponentContext* context);
 
   // Creates an inspect node which is a child of the component's root inspect
   // node with the provided |name|.
   static inspect::Node CreateRootChild(const std::string& name);
+
+  // Exposes the underlying component inspector.
+  static inspect::Inspector* GetInspector();
 
  private:
   static std::unique_ptr<sys::ComponentInspector> inspector_;


### PR DESCRIPTION
The vm service port is currently being written to a file and later read by tools that need to access the vm service. This usually requires a complicated find command that can timeout in tests. Instead we should publish the port to inspect. 

fxb/75455
