### PR TITLE
Set exitcode to 0 on successful uwptool launch

### DIFF
--- a/shell/platform/windows/uwptool_main.cc
+++ b/shell/platform/windows/uwptool_main.cc
@@ -33,12 +33,7 @@ void PrintInstalledApps() {
 // returned.
 int LaunchApp(const std::wstring_view app_id, const std::wstring_view args) {
   flutter::Application app(app_id);
-  DWORD process_id = app.Launch(args);
-  if (process_id == -1) {
-    std::wcerr << L"Failed to launch app " << app.GetPackageId() << std::endl;
-    return 1;
-  }
-  return 0;
+  return app.Launch(args);
 }
 
 // Prints the command usage to stderr.
@@ -82,8 +77,20 @@ int main(int argc, char** argv) {
         app_args << " ";
       }
     }
-    return LaunchApp(flutter::Utf16FromUtf8(package_id),
-                     flutter::Utf16FromUtf8(app_args.str()));
+    int process_id = LaunchApp(flutter::Utf16FromUtf8(package_id),
+                               flutter::Utf16FromUtf8(app_args.str()));
+    if (process_id == -1) {
+      std::cerr << "error: Failed to launch app with package ID " << package_id
+                << std::endl;
+      return 1;
+    }
+
+    // Write an informative message for the user to stderr.
+    std::cerr << "Launched app with package_id " << package_id
+              << ". PID: " << std::endl;
+    // Write the PID to stdout. The flutter tool reads this value in.
+    std::cout << process_id << std::endl;
+    return 0;
   }
 
   std::cerr << "Unknown command: " << command << std::endl;

--- a/shell/platform/windows/uwptool_utils.h
+++ b/shell/platform/windows/uwptool_utils.h
@@ -23,6 +23,8 @@ class Application {
   std::wstring GetPackageId() const { return package_id_; }
 
   // Launches the application with the specified list of launch arguments.
+  //
+  // Returns the process ID on success, or -1 on failure.
   int Launch(const std::wstring_view args);
 
  private:


### PR DESCRIPTION
Also adds some user-friendly messages to stderr to aid with any
debugging, and emits the PID to stdout.

Part of https://github.com/flutter/flutter/issues/81756

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
