### PR TITLE
Use a comma-separated args string for UWP

### DIFF
--- a/shell/platform/windows/uwptool_main.cc
+++ b/shell/platform/windows/uwptool_main.cc
@@ -69,12 +69,12 @@ int main(int argc, char** argv) {
     // Get the package ID.
     std::string package_id = args[1];
 
-    // Concatenate the remaining args, space-separated.
+    // Concatenate the remaining args, comma-separated.
     std::ostringstream app_args;
     for (int i = 2; i < args.size(); ++i) {
       app_args << args[i];
       if (i < args.size() - 1) {
-        app_args << " ";
+        app_args << ",";
       }
     }
     int process_id = LaunchApp(flutter::Utf16FromUtf8(package_id),


### PR DESCRIPTION
UWP apps get a single arguments string on launch rather than an array.
The current implementation splits that args string on commas. This
updates the UWP launch args generation to match.

Part of https://github.com/flutter/flutter/issues/81756
Part of https://github.com/flutter/flutter/issues/82085

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
