### PR TITLE
Revert "Sped up the objc standard message codec (#25998)"

### DIFF
--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
@@ -6,17 +6,6 @@
 
 #pragma mark - Codec for basic message channel
 
-static const UInt8 kZeroBuffer[8] = {0, 0, 0, 0, 0, 0, 0, 0};
-// Classes are cached in static variables to avoid the extra method calls in a
-// highly traffic'd recursive function.
-static const Class kNSNumberClass = [NSNumber class];
-static const id kNSNull = [NSNull null];
-static const Class kNSStringClass = [NSString class];
-static const Class kNSDataClass = [NSData class];
-static const Class kNSArrayClass = [NSArray class];
-static const Class kNSDictionaryClass = [NSDictionary class];
-static const Class kFlutterStandardTypedDataClass = [FlutterStandardTypedData class];
-
 @implementation FlutterStandardMessageCodec {
   FlutterStandardReaderWriter* _readerWriter;
 }
@@ -232,141 +221,114 @@ using namespace flutter;
   [super dealloc];
 }
 
-static void WriteByte(CFMutableDataRef data, UInt8 value) {
-  CFDataAppendBytes(data, &value, 1);
+- (void)writeByte:(UInt8)value {
+  [_data appendBytes:&value length:1];
 }
 
-static void WriteBytes(CFMutableDataRef data, const void* bytes, NSUInteger length) {
-  CFDataAppendBytes(data, (const UInt8*)bytes, length);
+- (void)writeBytes:(const void*)bytes length:(NSUInteger)length {
+  [_data appendBytes:bytes length:length];
 }
 
-static void WriteData(CFMutableDataRef destination, NSData* source) {
-  CFDataAppendBytes(destination, (const UInt8*)source.bytes, source.length);
+- (void)writeData:(NSData*)data {
+  [_data appendData:data];
 }
 
-static void WriteSize(CFMutableDataRef data, UInt32 size) {
+- (void)writeSize:(UInt32)size {
   if (size < 254) {
-    WriteByte(data, (UInt8)size);
+    [self writeByte:(UInt8)size];
   } else if (size <= 0xffff) {
-    WriteByte(data, 254);
+    [self writeByte:254];
     UInt16 value = (UInt16)size;
-    WriteBytes(data, &value, 2);
+    [self writeBytes:&value length:2];
   } else {
-    WriteByte(data, 255);
-    WriteBytes(data, &size, 4);
+    [self writeByte:255];
+    [self writeBytes:&size length:4];
   }
 }
 
-static void WriteAlignment(CFMutableDataRef data, UInt8 alignment) {
-  NSCAssert(alignment <= 8, @"Alignment larger than kZeroBuffer.");
-  UInt8 mod = CFDataGetLength(data) % alignment;
+- (void)writeAlignment:(UInt8)alignment {
+  UInt8 mod = _data.length % alignment;
   if (mod) {
-    WriteBytes(data, kZeroBuffer, alignment - mod);
+    for (int i = 0; i < (alignment - mod); i++) {
+      [self writeByte:0];
+    }
   }
 }
 
-static void WriteUTF8(CFMutableDataRef data, NSString* value) {
+- (void)writeUTF8:(NSString*)value {
   UInt32 length = [value lengthOfBytesUsingEncoding:NSUTF8StringEncoding];
-  WriteSize(data, length);
-  WriteBytes(data, value.UTF8String, length);
+  [self writeSize:length];
+  [self writeBytes:value.UTF8String length:length];
 }
 
-static void WriteValue(CFMutableDataRef data, id value) {
-  if (value == nil || value == kNSNull) {
-    WriteByte(data, FlutterStandardFieldNil);
-  } else if ([value isKindOfClass:kNSNumberClass]) {
+- (void)writeValue:(id)value {
+  if (value == nil || value == [NSNull null]) {
+    [self writeByte:FlutterStandardFieldNil];
+  } else if ([value isKindOfClass:[NSNumber class]]) {
     CFNumberRef number = (CFNumberRef)value;
     BOOL success = NO;
     if (CFGetTypeID(number) == CFBooleanGetTypeID()) {
       BOOL b = CFBooleanGetValue((CFBooleanRef)number);
-      WriteByte(data, (b ? FlutterStandardFieldTrue : FlutterStandardFieldFalse));
+      [self writeByte:(b ? FlutterStandardFieldTrue : FlutterStandardFieldFalse)];
       success = YES;
     } else if (CFNumberIsFloatType(number)) {
       Float64 f;
       success = CFNumberGetValue(number, kCFNumberFloat64Type, &f);
       if (success) {
-        WriteByte(data, FlutterStandardFieldFloat64);
-        WriteAlignment(data, 8);
-        WriteBytes(data, (UInt8*)&f, 8);
+        [self writeByte:FlutterStandardFieldFloat64];
+        [self writeAlignment:8];
+        [self writeBytes:(UInt8*)&f length:8];
       }
     } else if (CFNumberGetByteSize(number) <= 4) {
       SInt32 n;
       success = CFNumberGetValue(number, kCFNumberSInt32Type, &n);
       if (success) {
-        WriteByte(data, FlutterStandardFieldInt32);
-        WriteBytes(data, (UInt8*)&n, 4);
+        [self writeByte:FlutterStandardFieldInt32];
+        [self writeBytes:(UInt8*)&n length:4];
       }
     } else if (CFNumberGetByteSize(number) <= 8) {
       SInt64 n;
       success = CFNumberGetValue(number, kCFNumberSInt64Type, &n);
       if (success) {
-        WriteByte(data, FlutterStandardFieldInt64);
-        WriteBytes(data, (UInt8*)&n, 8);
+        [self writeByte:FlutterStandardFieldInt64];
+        [self writeBytes:(UInt8*)&n length:8];
       }
     }
     if (!success) {
       NSLog(@"Unsupported value: %@ of number type %ld", value, CFNumberGetType(number));
-      NSCAssert(NO, @"Unsupported value for standard codec.");
+      NSAssert(NO, @"Unsupported value for standard codec");
     }
-  } else if ([value isKindOfClass:kNSStringClass]) {
+  } else if ([value isKindOfClass:[NSString class]]) {
     NSString* string = value;
-    WriteByte(data, FlutterStandardFieldString);
-    WriteUTF8(data, string);
-  } else if ([value isKindOfClass:kFlutterStandardTypedDataClass]) {
+    [self writeByte:FlutterStandardFieldString];
+    [self writeUTF8:string];
+  } else if ([value isKindOfClass:[FlutterStandardTypedData class]]) {
     FlutterStandardTypedData* typedData = value;
-    WriteByte(data, FlutterStandardFieldForDataType(typedData.type));
-    WriteSize(data, typedData.elementCount);
-    WriteAlignment(data, typedData.elementSize);
-    WriteData(data, typedData.data);
-  } else if ([value isKindOfClass:kNSDataClass]) {
-    WriteValue(data, [FlutterStandardTypedData typedDataWithBytes:value]);
-  } else if ([value isKindOfClass:kNSArrayClass]) {
+    [self writeByte:FlutterStandardFieldForDataType(typedData.type)];
+    [self writeSize:typedData.elementCount];
+    [self writeAlignment:typedData.elementSize];
+    [self writeData:typedData.data];
+  } else if ([value isKindOfClass:[NSData class]]) {
+    [self writeValue:[FlutterStandardTypedData typedDataWithBytes:value]];
+  } else if ([value isKindOfClass:[NSArray class]]) {
     NSArray* array = value;
-    WriteByte(data, FlutterStandardFieldList);
-    WriteSize(data, array.count);
+    [self writeByte:FlutterStandardFieldList];
+    [self writeSize:array.count];
     for (id object in array) {
-      WriteValue(data, object);
+      [self writeValue:object];
     }
-  } else if ([value isKindOfClass:kNSDictionaryClass]) {
+  } else if ([value isKindOfClass:[NSDictionary class]]) {
     NSDictionary* dict = value;
-    WriteByte(data, FlutterStandardFieldMap);
-    WriteSize(data, dict.count);
+    [self writeByte:FlutterStandardFieldMap];
+    [self writeSize:dict.count];
     for (id key in dict) {
-      WriteValue(data, key);
-      WriteValue(data, [dict objectForKey:key]);
+      [self writeValue:key];
+      [self writeValue:[dict objectForKey:key]];
     }
   } else {
     NSLog(@"Unsupported value: %@ of type %@", value, [value class]);
-    NSCAssert(NO, @"Unsupported value for standard codec.");
+    NSAssert(NO, @"Unsupported value for standard codec");
   }
-}
-
-- (void)writeByte:(UInt8)value {
-  WriteByte((__bridge CFMutableDataRef)_data, value);
-}
-
-- (void)writeBytes:(const void*)bytes length:(NSUInteger)length {
-  WriteBytes((__bridge CFMutableDataRef)_data, bytes, length);
-}
-
-- (void)writeData:(NSData*)data {
-  WriteData((__bridge CFMutableDataRef)_data, data);
-}
-
-- (void)writeSize:(UInt32)size {
-  WriteSize((__bridge CFMutableDataRef)_data, size);
-}
-
-- (void)writeAlignment:(UInt8)alignment {
-  WriteAlignment((__bridge CFMutableDataRef)_data, alignment);
-}
-
-- (void)writeUTF8:(NSString*)value {
-  WriteUTF8((__bridge CFMutableDataRef)_data, value);
-}
-
-- (void)writeValue:(id)value {
-  WriteValue((__bridge CFMutableDataRef)_data, value);
 }
 @end
 
@@ -488,7 +450,7 @@ static void WriteValue(CFMutableDataRef data, id value) {
       NSMutableArray* array = [NSMutableArray arrayWithCapacity:length];
       for (UInt32 i = 0; i < length; i++) {
         id value = [self readValue];
-        [array addObject:(value == nil ? kNSNull : value)];
+        [array addObject:(value == nil ? [NSNull null] : value)];
       }
       return array;
     }
@@ -498,7 +460,8 @@ static void WriteValue(CFMutableDataRef data, id value) {
       for (UInt32 i = 0; i < size; i++) {
         id key = [self readValue];
         id val = [self readValue];
-        [dict setObject:(val == nil ? kNSNull : val) forKey:(key == nil ? kNSNull : key)];
+        [dict setObject:(val == nil ? [NSNull null] : val)
+                 forKey:(key == nil ? [NSNull null] : key)];
       }
       return dict;
     }


### PR DESCRIPTION
This appears to have triggered reproducible failures in channels_integration_test_ios:

    [   +4 ms] 00:01 [32m+0[0m: channel suite step through[0m
    [+3744 ms] Unsupported value: Sun Mar 11 07:16:42 2018 of type __NSTaggedDate
    [        ] *** Assertion failure in void WriteValue(CFMutableDataRef, id)(), FlutterStandardCodec.mm:340
    [   +2 ms] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Unsupported value for standard codec.'
    [        ] *** First throw call stack:
    [        ] (0x19d5bd9d8 0x1b1940b54 0x19d4cc50c 0x19e815238 0x1050031ec 0x104823f80 0x105003aac 0x1050009bc 0x104824e9c 0x105000b4c 0x104d0cc98 0x10501b398 0x104fb3c94 0x104fb72c4 0x19d53e3e0 0x19d53dfe4 0x19d53d4c4 0x19d537850 0x19d536ba0 0x1b429c598 0x19fe282f4 0x19fe2d874 0x1048257fc 0x19d215568)
    [        ] libc++abi.dylib: terminating with uncaught exception of type NSException
    [  +65 ms] Process 541 stopped
    [        ] * thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    [        ]     frame #0: 0x00000001c93e584c libsystem_kernel.dylib`__pthread_kill + 8
    [        ] libsystem_kernel.dylib`__pthread_kill:
    [        ] -> 0x1c93e584c <+8>:  b.lo   0x1c93e5868               ; <+36>
    [        ]    0x1c93e5850 <+12>: stp    x29, x30, [sp, #-0x10]!
    [        ]    0x1c93e5854 <+16>: mov    x29, sp
    [        ]    0x1c93e5858 <+20>: bl     0x1c93c2f5c               ; cerror_nocancel
    [        ] Target 0: (Runner) stopped.

Example builds:
* https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_ios%20channels_integration_test_ios/828/overview
* https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_ios%20channels_integration_test_ios/829/overview
* https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_ios%20channels_integration_test_ios/830/overview
* https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_ios%20channels_integration_test_ios/831/overview

Example Log:
* https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8847377106855056784/+/u/run_channels_integration_test_ios/stdout

This reverts commit 99021da09058bf7cf0a6743d4bef293450cd0714.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
