### PR TITLE
Remove counter from eintr wrapper

### DIFF
--- a/fml/eintr_wrapper.h
+++ b/fml/eintr_wrapper.h
@@ -17,8 +17,6 @@
 
 #else
 
-#if defined(NDEBUG)
-
 #define FML_HANDLE_EINTR(x)                                 \
   ({                                                        \
     decltype(x) eintr_wrapper_result;                       \
@@ -27,21 +25,6 @@
     } while (eintr_wrapper_result == -1 && errno == EINTR); \
     eintr_wrapper_result;                                   \
   })
-
-#else
-
-#define FML_HANDLE_EINTR(x)                                  \
-  ({                                                         \
-    int eintr_wrapper_counter = 0;                           \
-    decltype(x) eintr_wrapper_result;                        \
-    do {                                                     \
-      eintr_wrapper_result = (x);                            \
-    } while (eintr_wrapper_result == -1 && errno == EINTR && \
-             eintr_wrapper_counter++ < 100);                 \
-    eintr_wrapper_result;                                    \
-  })
-
-#endif  // NDEBUG
 
 #define FML_IGNORE_EINTR(x)                               \
   ({                                                      \


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/82226

On linux/lldb there are sometimes  spurious EINTR errors
when starting an isolate (without an apparent reason).
This results in threads being prematurely terminated.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
