### PR TITLE
Remove layer trees from pipeline when destroying Animator

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -49,7 +49,10 @@ Animator::Animator(Delegate& delegate,
       weak_factory_(this) {
 }
 
-Animator::~Animator() = default;
+Animator::~Animator() {
+  // Remove all queued layer trees to ensure that Skia objects are unreffed.
+  layer_tree_pipeline_->Clear();
+}
 
 void Animator::Stop() {
   paused_ = true;

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -701,9 +701,12 @@ TEST_F(ShellTest,
   auto end_frame_callback =
       [&](bool should_resubmit_frame,
           fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) {
-        ASSERT_TRUE(raster_thread_merger.get() != nullptr);
-        ASSERT_TRUE(should_resubmit_frame);
-        end_frame_called = true;
+        // The asserts below are only valid until DestroyShell is called
+        if (!end_frame_called) {
+          ASSERT_TRUE(raster_thread_merger.get() != nullptr);
+          ASSERT_TRUE(should_resubmit_frame);
+          end_frame_called = true;
+        }
         end_frame_latch.Signal();
       };
   auto external_view_embedder = std::make_shared<ShellTestExternalViewEmbedder>(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/82353

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
