### PR TITLE
reland output json manifest file in fuchsia_archive

### DIFF
--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -94,6 +94,7 @@ template("fuchsia_archive") {
     testonly = pkg_testonly
   }
 
+  manifest_json_file = "${root_out_dir}/${target_name}_package_manifest.json"
   action(target_name) {
     script = "//flutter/tools/fuchsia/gen_package.py"
     deps = pkg_dir_deps + [
@@ -116,8 +117,11 @@ template("fuchsia_archive") {
       rebase_path("//flutter/tools/fuchsia/development.key"),
       "--far-name",
       target_name,
+      "--manifest-json-file",
+      rebase_path(manifest_json_file, root_build_dir),
     ]
     outputs = [
+      manifest_json_file,
       "${far_base_dir}.manifest",
       "$root_out_dir/${target_name}-0.far",
     ]

--- a/tools/fuchsia/gen_package.py
+++ b/tools/fuchsia/gen_package.py
@@ -62,6 +62,8 @@ def main():
   parser.add_argument(
       '--manifest-file', dest='manifest_file', action='store', required=False)
   parser.add_argument(
+      '--manifest-json-file', dest='manifest_json_file', action='store', required=True)
+  parser.add_argument(
       '--far-name', dest='far_name', action='store', required=False)
 
   args = parser.parse_args()
@@ -89,6 +91,8 @@ def main():
       args.pm_bin,
       '-o',
       output_dir,
+      '-n',
+      args.far_name,
       '-k',
       args.signing_key,
       '-m',
@@ -98,8 +102,9 @@ def main():
   # Build and then archive the package
   # Use check_output so if anything goes wrong we get the output.
   try:
+
     pm_commands = [
-        ['build'],
+        ['build', '--output-package-manifest', args.manifest_json_file],
         ['archive', '--output='+ os.path.join(os.path.dirname(output_dir), args.far_name + "-0")],
     ]
     for pm_command in pm_commands:


### PR DESCRIPTION
Reland outputs a json version of the package manifest.

This patch is in preparation for incremental package serving from the engine repo.

fxbug.dev/76633
Previous attempt to land this patch was failing because I was generating the package manifest in the package's directory.