### PR TITLE
fuchsia: Improve checking/logging for composition

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
@@ -35,6 +35,8 @@ VulkanSurfacePool::VulkanSurfacePool(vulkan::VulkanProvider& vulkan_provider,
     : vulkan_provider_(vulkan_provider),
       context_(std::move(context)),
       scenic_session_(scenic_session) {
+  FML_CHECK(context_ != nullptr);
+
   zx_status_t status = fdio_service_connect(
       "/svc/fuchsia.sysmem.Allocator",
       sysmem_allocator_.NewRequest().TakeChannel().release());
@@ -50,12 +52,13 @@ std::unique_ptr<VulkanSurface> VulkanSurfacePool::AcquireSurface(
   auto surface = GetCachedOrCreateSurface(size);
 
   if (surface == nullptr) {
-    FML_DLOG(ERROR) << "Could not acquire surface";
+    FML_LOG(ERROR) << "VulkanSurfaceProducer: Could not acquire surface";
     return nullptr;
   }
 
   if (!surface->FlushSessionAcquireAndReleaseEvents()) {
-    FML_DLOG(ERROR) << "Could not flush acquire/release events for buffer.";
+    FML_LOG(ERROR) << "VulkanSurfaceProducer: Could not flush acquire/release "
+                      "events for buffer.";
     return nullptr;
   }
 
@@ -117,6 +120,7 @@ std::unique_ptr<VulkanSurface> VulkanSurfacePool::CreateSurface(
       vulkan_provider_, sysmem_allocator_, context_, scenic_session_, size,
       buffer_id_++);
   if (!surface->IsValid()) {
+    FML_LOG(ERROR) << "VulkanSurfaceProducer: Created surface is invalid";
     return nullptr;
   }
   trace_surfaces_created_++;
@@ -189,7 +193,8 @@ void VulkanSurfacePool::AgeAndCollectOldBuffers() {
     if (new_surface != nullptr) {
       available_surfaces_.push_back(std::move(new_surface));
     } else {
-      FML_DLOG(ERROR) << "Failed to create a new shrunk surface";
+      FML_LOG(ERROR)
+          << "VulkanSurfaceProducer: Failed to create a new shrunk surface";
     }
   }
 
@@ -216,7 +221,8 @@ void VulkanSurfacePool::ShrinkToFit() {
     if (surface != nullptr) {
       available_surfaces_.push_back(std::move(surface));
     } else {
-      FML_DLOG(ERROR) << "Failed to create resized surface";
+      FML_LOG(ERROR)
+          << "VulkanSurfaceProducer: Failed to create resized surface";
     }
   }
 


### PR DESCRIPTION
Convert a hard crash when accessing a map into a log in order to help us investigate better what is going on during the crash (suspected OOM).

Also convert any array-lookup-related and vulkan/sysmem-failure-related DCHECKs to CHECKs.  These are serious error conditions so we always want to crash immediately in those cases to avoid undefined behavior.

Tests: Ran fuchsia.git integration tests, ran internal tests, manual testing using workstation
Bug: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=76614