### PR TITLE
fuchsia: Only send different ViewProperties

### DIFF
--- a/flow/view_holder.h
+++ b/flow/view_holder.h
@@ -83,6 +83,7 @@ class ViewHolder {
   fuchsia::ui::gfx::HitTestBehavior hit_test_behavior_ =
       fuchsia::ui::gfx::HitTestBehavior::kDefault;
   fuchsia::ui::gfx::ViewProperties view_properties_;
+  bool view_properties_changed_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ViewHolder);
 };


### PR DESCRIPTION
Only send ViewProperties when they actually change, and send -1000 for the "depth" each time.

This fixes black screens on workstation.

Fixes: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=76358