### PR TITLE
Provide build information to the inspect tree.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1386,6 +1386,9 @@ FILE: ../../../flutter/shell/platform/fuchsia/flutter/vulkan_surface_pool.h
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
 FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols/dart_profiler_symbols.dart
+FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/build_info.h
+FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/build_info_in.cc
+FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/build_info_unittests.cc
 FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/files.cc
 FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/files.h
 FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/handle_exception.cc

--- a/shell/platform/fuchsia/dart_runner/main.cc
+++ b/shell/platform/fuchsia/dart_runner/main.cc
@@ -14,6 +14,7 @@
 #include "flutter/fml/trace_event.h"
 #include "logging.h"
 #include "platform/utils.h"
+#include "runtime/dart/utils/build_info.h"
 #include "runtime/dart/utils/files.h"
 #include "runtime/dart/utils/root_inspect_node.h"
 #include "runtime/dart/utils/tempfs.h"
@@ -39,6 +40,8 @@ int main(int argc, const char** argv) {
   // Create our component context which is served later.
   auto context = sys::ComponentContext::Create();
   dart_utils::RootInspectNode::Initialize(context.get());
+  auto build_info = dart_utils::RootInspectNode::CreateRootChild("build_info");
+  dart_utils::BuildInfo::Dump(build_info);
 
   dart::SetDartVmNode(std::make_unique<inspect::Node>(
       dart_utils::RootInspectNode::CreateRootChild("vm")));

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -456,7 +456,7 @@ executable("flutter_runner_unittests") {
   ]
 
   # This is needed for //third_party/googletest for linking zircon symbols.
-  libs = [ "//fuchsia/sdk/$host_os/arch/$target_cpu/sysroot/lib/libzircon.so" ]
+  libs = [ "$fuchsia_sdk_path/arch/$target_cpu/sysroot/lib/libzircon.so" ]
 
   # The use of these dependencies is temporary and will be moved behind the
   # embedder API.
@@ -486,7 +486,7 @@ executable("flutter_runner_tzdata_unittests") {
   sources = [ "runner_tzdata_unittest.cc" ]
 
   # This is needed for //third_party/googletest for linking zircon symbols.
-  libs = [ "//fuchsia/sdk/$host_os/arch/$target_cpu/sysroot/lib/libzircon.so" ]
+  libs = [ "$fuchsia_sdk_path/arch/$target_cpu/sysroot/lib/libzircon.so" ]
 
   # The use of these dependencies is temporary and will be moved behind the
   # embedder API.
@@ -511,7 +511,7 @@ executable("flutter_runner_scenic_unittests") {
   sources = [ "tests/default_session_connection_unittests.cc" ]
 
   # This is needed for //third_party/googletest for linking zircon symbols.
-  libs = [ "//fuchsia/sdk/$host_os/arch/$target_cpu/sysroot/lib/libzircon.so" ]
+  libs = [ "$fuchsia_sdk_path/arch/$target_cpu/sysroot/lib/libzircon.so" ]
 
   # The use of these dependencies is temporary and will be moved behind the
   # embedder API.
@@ -846,12 +846,21 @@ fuchsia_test_archive("embedder_tests") {
   ]
 }
 
+fuchsia_test_archive("dart_utils_tests") {
+  deps = [
+    "//flutter/shell/platform/fuchsia/runtime/dart/utils:dart_utils_unittests",
+  ]
+
+  binary = "dart_utils_unittests"
+}
+
 # When adding a new dep here, please also ensure the dep is added to
 # testing/fuchsia/run_tests.sh and testing/fuchsia/test_fars
 group("tests") {
   testonly = true
 
   deps = [
+    ":dart_utils_tests",
     ":embedder_tests",
     ":flow_tests",
     ":flutter_runner_scenic_tests",

--- a/shell/platform/fuchsia/flutter/main.cc
+++ b/shell/platform/fuchsia/flutter/main.cc
@@ -12,6 +12,7 @@
 #include "loop.h"
 #include "platform/utils.h"
 #include "runner.h"
+#include "runtime/dart/utils/build_info.h"
 #include "runtime/dart/utils/root_inspect_node.h"
 #include "runtime/dart/utils/tempfs.h"
 
@@ -21,6 +22,8 @@ int main(int argc, char const* argv[]) {
   // Create our component context which is served later.
   auto context = sys::ComponentContext::Create();
   dart_utils::RootInspectNode::Initialize(context.get());
+  auto build_info = dart_utils::RootInspectNode::CreateRootChild("build_info");
+  dart_utils::BuildInfo::Dump(build_info);
 
   // We inject the 'vm' node into the dart vm so that it can add any inspect
   // data that it needs to the inspect tree.

--- a/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -14,6 +14,8 @@ config("utils_config") {
 template("make_utils") {
   source_set(target_name) {
     sources = [
+      "$target_gen_dir/build_info.cc",
+      "build_info.h",
       "files.cc",
       "files.h",
       "handle_exception.cc",
@@ -33,6 +35,7 @@ template("make_utils") {
     ]
 
     deps = invoker.deps + [
+             ":generate_build_info_cc_file",
              "$fuchsia_sdk_root/fidl:fuchsia.feedback",
              "$fuchsia_sdk_root/fidl:fuchsia.mem",
              "$fuchsia_sdk_root/pkg:async-loop",
@@ -53,8 +56,45 @@ template("make_utils") {
   }
 }
 
+action("generate_build_info_cc_file") {
+  inputs = [
+    "build_info_in.cc",
+    "//flutter/.git/logs/HEAD",
+    "//fuchsia/sdk/linux/meta/manifest.json",
+    "//third_party/dart/.git/logs/HEAD",
+  ]
+  outputs = [ "$target_gen_dir/build_info.cc" ]
+
+  script = "//flutter/tools/fuchsia/make_build_info.py"
+  args = [
+    "--input",
+    rebase_path("build_info_in.cc", root_build_dir),
+    "--output",
+    rebase_path(outputs[0], root_build_dir),
+    "--buildroot",
+    rebase_path("//", root_build_dir),
+  ]
+}
+
 make_utils("utils") {
   deps = [ "//third_party/dart/runtime/bin:elf_loader" ]
+}
+
+executable("dart_utils_unittests") {
+  testonly = true
+
+  output_name = "dart_utils_unittests"
+
+  sources = [ "build_info_unittests.cc" ]
+
+  # This is needed for //third_party/googletest for linking zircon symbols.
+  libs = [ "$fuchsia_sdk_path/arch/$target_cpu/sysroot/lib/libzircon.so" ]
+
+  deps = [
+    ":utils",
+    "$fuchsia_sdk_root/pkg:sys_inspect_cpp",
+    "//flutter/testing",
+  ]
 }
 
 make_utils("utils_product") {

--- a/shell/platform/fuchsia/runtime/dart/utils/build_info.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/build_info.h
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_BUILD_INFO_H_
+#define FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_BUILD_INFO_H_
+
+#include "root_inspect_node.h"
+
+namespace dart_utils {
+
+class BuildInfo {
+ public:
+  static const char* BuildTimestamp();
+  static const char* DartSdkGitRevision();
+  static const char* DartSdkSemanticVersion();
+  static const char* FlutterEngineGitRevision();
+  static const char* FuchsiaSdkVersion();
+
+  /// Appends the above properties to the specified node on the inspect tree for
+  /// the duration of the node's lifetime.
+  static void Dump(inspect::Node& node);
+};
+
+}  // namespace dart_utils
+
+#endif  // FLUTTER_SHELL_PLATFORM_FUCHSIA_RUNTIME_DART_UTILS_BUILD_INFO_H_

--- a/shell/platform/fuchsia/runtime/dart/utils/build_info_in.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/build_info_in.cc
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "runtime/dart/utils/build_info.h"
+
+namespace dart_utils {
+
+const char* BuildInfo::BuildTimestamp() {
+  return "{{BUILD_TIMESTAMP}}";
+}
+
+const char* BuildInfo::DartSdkGitRevision() {
+  return "{{DART_SDK_GIT_REVISION}}";
+}
+
+const char* BuildInfo::DartSdkSemanticVersion() {
+  return "{{DART_SDK_SEMANTIC_VERSION}}";
+}
+
+const char* BuildInfo::FlutterEngineGitRevision() {
+  return "{{FLUTTER_ENGINE_GIT_REVISION}}";
+}
+
+const char* BuildInfo::FuchsiaSdkVersion() {
+  return "{{FUCHSIA_SDK_VERSION}}";
+}
+
+void BuildInfo::Dump(inspect::Node& node) {
+  node.CreateString("build_timestamp", BuildTimestamp(),
+                    RootInspectNode::GetInspector());
+  node.CreateString("dart_sdk_git_revision", DartSdkGitRevision(),
+                    RootInspectNode::GetInspector());
+  node.CreateString("dart_sdk_semantic_version", DartSdkSemanticVersion(),
+                    RootInspectNode::GetInspector());
+  node.CreateString("flutter_engine_git_revision", FlutterEngineGitRevision(),
+                    RootInspectNode::GetInspector());
+  node.CreateString("fuchsia_sdk_version", FuchsiaSdkVersion(),
+                    RootInspectNode::GetInspector());
+}
+
+}  // namespace dart_utils

--- a/shell/platform/fuchsia/runtime/dart/utils/build_info_unittests.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/build_info_unittests.cc
@@ -1,0 +1,65 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "build_info.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <lib/async-loop/cpp/loop.h>
+#include <lib/async-loop/default.h>
+#include <lib/inspect/cpp/reader.h>
+
+const std::string& inspect_node_name = "build_info_unittests";
+
+void checkProperty(inspect::Hierarchy& root,
+                   const std::string& name,
+                   const std::string& expected_value) {
+  const inspect::Hierarchy* build_info = root.GetByPath({inspect_node_name});
+  EXPECT_TRUE(build_info != nullptr);
+  auto* actual_value =
+      build_info->node().get_property<inspect::StringPropertyValue>(name);
+  EXPECT_TRUE(actual_value != nullptr);
+  EXPECT_EQ(actual_value->value(), expected_value);
+}
+
+namespace dart_utils {
+
+class BuildInfoTest : public ::testing::Test {
+ public:
+  static void SetUpTestSuite() {
+    async::Loop loop(&kAsyncLoopConfigAttachToCurrentThread);
+    auto context = sys::ComponentContext::Create();
+    RootInspectNode::Initialize(context.get());
+  }
+};
+
+TEST_F(BuildInfoTest, AllPropertiesAreDefined) {
+  EXPECT_NE(BuildInfo::BuildTimestamp(), "{{BUILD_TIMESTAMP}}");
+  EXPECT_NE(BuildInfo::DartSdkGitRevision(), "{{DART_SDK_GIT_REVISION}}");
+  EXPECT_NE(BuildInfo::DartSdkSemanticVersion(),
+            "{{DART_SDK_SEMANTIC_VERSION}}");
+  EXPECT_NE(BuildInfo::FlutterEngineGitRevision(),
+            "{{FLUTTER_ENGINE_GIT_REVISION}}");
+  EXPECT_NE(BuildInfo::FuchsiaSdkVersion(), "{{FUCHSIA_SDK_VERSION}}");
+}
+
+TEST_F(BuildInfoTest, AllPropertiesAreDumped) {
+  inspect::Node node =
+      dart_utils::RootInspectNode::CreateRootChild(inspect_node_name);
+  BuildInfo::Dump(node);
+  inspect::Hierarchy root =
+      inspect::ReadFromVmo(
+          std::move(
+              dart_utils::RootInspectNode::GetInspector()->DuplicateVmo()))
+          .take_value();
+  checkProperty(root, "build_timestamp", BuildInfo::BuildTimestamp());
+  checkProperty(root, "dart_sdk_git_revision", BuildInfo::DartSdkGitRevision());
+  checkProperty(root, "dart_sdk_semantic_version",
+                BuildInfo::DartSdkSemanticVersion());
+  checkProperty(root, "flutter_engine_git_revision",
+                BuildInfo::FlutterEngineGitRevision());
+  checkProperty(root, "fuchsia_sdk_version", BuildInfo::FuchsiaSdkVersion());
+}
+
+}  // namespace dart_utils

--- a/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.cc
@@ -21,4 +21,8 @@ inspect::Node RootInspectNode::CreateRootChild(const std::string& name) {
   return inspector_->inspector()->GetRoot().CreateChild(name);
 }
 
+inspect::Inspector* RootInspectNode::GetInspector() {
+  return inspector_->inspector();
+}
+
 }  // namespace dart_utils

--- a/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/root_inspect_node.h
@@ -32,6 +32,9 @@ class RootInspectNode {
   // node with the provided |name|.
   static inspect::Node CreateRootChild(const std::string& name);
 
+  // Gets an instance to the component's inspector.
+  static inspect::Inspector* GetInspector();
+
  private:
   static std::unique_ptr<sys::ComponentInspector> inspector_;
   static std::mutex mutex_;

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -166,6 +166,15 @@ fuchsia_ctl test \
     --packages-directory packages
 echo "$(date) DONE:embedder_tests --------------------------------------"
 
+echo "$(date) START:dart_utils_tests -------------------------------------"
+fuchsia_ctl test \
+    -f dart_utils_tests-0.far  \
+    -t dart_utils_tests \
+    --identity-file $pkey \
+    --timeout-seconds $test_timeout_seconds \
+    --packages-directory packages
+echo "$(date) DONE:dart_utils_tests --------------------------------------"
+
 # TODO(gw280): Enable tests using JIT runner
 echo "$(date) START:flutter_runner_tests ----------------------------"
 fuchsia_ctl test \

--- a/testing/fuchsia/test_fars
+++ b/testing/fuchsia/test_fars
@@ -9,3 +9,4 @@ testing_tests-0.far
 txt_tests-0.far
 ui_tests-0.far
 embedder_tests-0.far
+dart_utils_tests-0.far

--- a/tools/fuchsia/gen_package.py
+++ b/tools/fuchsia/gen_package.py
@@ -3,7 +3,7 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
-""" Genrate a Fuchsia FAR Archive from an asset manifest and a signing key.
+""" Generate a Fuchsia FAR Archive from an asset manifest and a signing key.
 """
 
 import argparse

--- a/tools/fuchsia/make_build_info.py
+++ b/tools/fuchsia/make_build_info.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+''' Interpolates build environment information into a file.
+'''
+
+from argparse import ArgumentParser
+from datetime import datetime
+from os import path
+import subprocess
+import sys
+import json
+
+
+def GetBuildTimestamp():
+    return datetime.now().strftime('%Y-%m-%d %H:%M')
+
+
+def GetDartSdkGitRevision(buildroot):
+    project_root = path.join(buildroot, 'third_party', 'dart')
+    return subprocess.check_output(
+        ['git', '-C', project_root, 'rev-parse', 'HEAD']).strip()
+
+
+def GetDartSdkSemanticVersion(buildroot):
+    project_root = path.join(buildroot, 'third_party', 'dart')
+    return subprocess.check_output(
+        ['git', '-C', project_root, 'describe', '--abbrev=0']).strip()
+
+
+def GetFlutterEngineGitRevision(buildroot):
+    project_root = path.join(buildroot, 'flutter')
+    return subprocess.check_output(
+        ['git', '-C', project_root, 'rev-parse', 'HEAD']).strip()
+
+
+def GetFuchsiaSdkVersion(buildroot):
+    with open(path.join(
+        buildroot,
+        'fuchsia',
+        'sdk',
+        'linux',
+        'meta',
+        'manifest.json'),
+    'r') as fuchsia_sdk_manifest:
+        return json.load(fuchsia_sdk_manifest)['id']
+
+
+def main():
+    # Parse arguments.
+    parser = ArgumentParser()
+    parser.add_argument(
+        '--input', action='store', help='input file path', required=True)
+    parser.add_argument(
+        '--output', action='store', help='output file path', required=True)
+    parser.add_argument(
+        '--buildroot',
+        action='store',
+        help='path to the flutter engine buildroot',
+        required=True)
+    args = parser.parse_args()
+
+    # Read, interpolate, write.
+    with open(args.input, 'r') as i, open(args.output, 'w') as o:
+        o.write(
+            i.read()
+            .replace('{{BUILD_TIMESTAMP}}', GetBuildTimestamp())
+            .replace(
+                '{{DART_SDK_GIT_REVISION}}',
+                GetDartSdkGitRevision(args.buildroot))
+            .replace(
+                '{{DART_SDK_SEMANTIC_VERSION}}',
+                GetDartSdkSemanticVersion(args.buildroot))
+            .replace(
+                '{{FLUTTER_ENGINE_GIT_REVISION}}',
+                GetFlutterEngineGitRevision(args.buildroot))
+            .replace(
+                '{{FUCHSIA_SDK_VERSION}}',
+                GetFuchsiaSdkVersion(args.buildroot)))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Provide the following information to the inspect tree:
 * Build timestamp (ex: `2021-05-16 11:09`)
 * Dart sdk git revision (ex: `1e3e5efcd47edeb7ae5a69e146c8ea0559305a98`)
 * Semantic dart sdk version (ex: `2.12.0-94.0.dev`)
 * Flutter engine git revision (ex: `ff251bd558997984022bd03a719620680abf28be`)
 * Fuchsia SDK version (ex: `3.20210413.0.1`)

Tested manually with `fx iquery show flutter_jit_runner.cmx:root/build_info`.

https://fxbug.dev/73263