### PR TITLE
Deeplink URI fragment on Android and iOS

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -405,11 +405,14 @@ import java.util.Arrays;
     if (host.shouldHandleDeeplinking()) {
       Uri data = intent.getData();
       if (data != null && !data.getPath().isEmpty()) {
-        String pathAndQuery = data.getPath();
+        String pathAndQueryAndFragment = data.getPath();
         if (data.getQuery() != null && !data.getQuery().isEmpty()) {
-          pathAndQuery += "?" + data.getQuery();
+          pathAndQueryAndFragment += "?" + data.getQuery();
         }
-        return pathAndQuery;
+        if (data.getFragment() != null && !data.getFragment().isEmpty()) {
+          pathAndQueryAndFragment += "#" + data.getFragment();
+        }
+        return pathAndQueryAndFragment;
       }
     }
     return null;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -405,14 +405,14 @@ import java.util.Arrays;
     if (host.shouldHandleDeeplinking()) {
       Uri data = intent.getData();
       if (data != null && !data.getPath().isEmpty()) {
-        String pathAndQueryAndFragment = data.getPath();
+        String fullRoute = data.getPath();
         if (data.getQuery() != null && !data.getQuery().isEmpty()) {
-          pathAndQueryAndFragment += "?" + data.getQuery();
+          fullRoute += "?" + data.getQuery();
         }
         if (data.getFragment() != null && !data.getFragment().isEmpty()) {
-          pathAndQueryAndFragment += "#" + data.getFragment();
+          fullRoute += "#" + data.getFragment();
         }
-        return pathAndQueryAndFragment;
+        return fullRoute;
       }
     }
     return null;

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -433,7 +433,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void
       itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinking() {
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
-    intent.setData(Uri.parse("http://myApp/custom/route?query=test"));
+    intent.setData(Uri.parse("http://myApp/custom/route?query=test#fragment"));
 
     ActivityController<FlutterActivity> activityController =
         Robolectric.buildActivity(FlutterActivity.class, intent);
@@ -453,7 +453,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // Verify that the navigation channel was given the initial route message.
     verify(mockFlutterEngine.getNavigationChannel(), times(1))
-        .setInitialRoute("/custom/route?query=test");
+        .setInitialRoute("/custom/route?query=test#fragment");
   }
 
   @Test
@@ -518,13 +518,14 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onAttach(RuntimeEnvironment.application);
 
     Intent mockIntent = mock(Intent.class);
-    when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route?query=test"));
+    when(mockIntent.getData())
+        .thenReturn(Uri.parse("http://myApp/custom/route?query=test#fragment"));
     // Emulate the host and call the method that we expect to be forwarded.
     delegate.onNewIntent(mockIntent);
 
     // Verify that the navigation channel was given the push route message.
     verify(mockFlutterEngine.getNavigationChannel(), times(1))
-        .pushRoute("/custom/route?query=test");
+        .pushRoute("/custom/route?query=test#fragment");
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -433,6 +433,33 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void
       itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinking() {
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    intent.setData(Uri.parse("http://myApp/custom/route?query=test"));
+
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    when(mockHost.getActivity()).thenReturn(flutterActivity);
+    when(mockHost.getInitialRoute()).thenReturn(null);
+    when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is set up in onAttach().
+    delegate.onAttach(RuntimeEnvironment.application);
+    // Emulate app start.
+    delegate.onStart();
+
+    // Verify that the navigation channel was given the initial route message.
+    verify(mockFlutterEngine.getNavigationChannel(), times(1))
+        .setInitialRoute("/custom/route?query=test");
+  }
+
+  @Test
+  public void
+      itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinkingWithQueryParameterAndFragment() {
+    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
     intent.setData(Uri.parse("http://myApp/custom/route?query=test#fragment"));
 
     ActivityController<FlutterActivity> activityController =
@@ -454,6 +481,33 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Verify that the navigation channel was given the initial route message.
     verify(mockFlutterEngine.getNavigationChannel(), times(1))
         .setInitialRoute("/custom/route?query=test#fragment");
+  }
+
+  @Test
+  public void
+      itSendsInitialRouteFromIntentOnStartIfNoInitialRouteFromActivityAndShouldHandleDeeplinkingWithFragmentNoQueryParameter() {
+    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    intent.setData(Uri.parse("http://myApp/custom/route#fragment"));
+
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    when(mockHost.getActivity()).thenReturn(flutterActivity);
+    when(mockHost.getInitialRoute()).thenReturn(null);
+    when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is set up in onAttach().
+    delegate.onAttach(RuntimeEnvironment.application);
+    // Emulate app start.
+    delegate.onStart();
+
+    // Verify that the navigation channel was given the initial route message.
+    verify(mockFlutterEngine.getNavigationChannel(), times(1))
+        .setInitialRoute("/custom/route#fragment");
   }
 
   @Test
@@ -518,6 +572,26 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onAttach(RuntimeEnvironment.application);
 
     Intent mockIntent = mock(Intent.class);
+    when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route?query=test"));
+    // Emulate the host and call the method that we expect to be forwarded.
+    delegate.onNewIntent(mockIntent);
+
+    // Verify that the navigation channel was given the push route message.
+    verify(mockFlutterEngine.getNavigationChannel(), times(1))
+        .pushRoute("/custom/route?query=test");
+  }
+
+  @Test
+  public void itSendsPushRouteMessageWhenOnNewIntentWithQueryParameterAndFragment() {
+    when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is set up in onAttach().
+    delegate.onAttach(RuntimeEnvironment.application);
+
+    Intent mockIntent = mock(Intent.class);
     when(mockIntent.getData())
         .thenReturn(Uri.parse("http://myApp/custom/route?query=test#fragment"));
     // Emulate the host and call the method that we expect to be forwarded.
@@ -526,6 +600,25 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Verify that the navigation channel was given the push route message.
     verify(mockFlutterEngine.getNavigationChannel(), times(1))
         .pushRoute("/custom/route?query=test#fragment");
+  }
+
+  @Test
+  public void itSendsPushRouteMessageWhenOnNewIntentWithFragmentNoQueryParameter() {
+    when(mockHost.shouldHandleDeeplinking()).thenReturn(true);
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is set up in onAttach().
+    delegate.onAttach(RuntimeEnvironment.application);
+
+    Intent mockIntent = mock(Intent.class);
+    when(mockIntent.getData()).thenReturn(Uri.parse("http://myApp/custom/route#fragment"));
+    // Emulate the host and call the method that we expect to be forwarded.
+    delegate.onNewIntent(mockIntent);
+
+    // Verify that the navigation channel was given the push route message.
+    verify(mockFlutterEngine.getNavigationChannel(), times(1)).pushRoute("/custom/route#fragment");
   }
 
   @Test

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -159,18 +159,15 @@ static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
                        FML_LOG(ERROR)
                            << "Timeout waiting for the first frame when launching an URL.";
                      } else {
-                       NSString* pathAndQueryAndFragment = url.path;
+                       NSString* fullRoute = url.path;
                        if ([url.query length] != 0) {
-                         pathAndQueryAndFragment = [NSString
-                             stringWithFormat:@"%@?%@", pathAndQueryAndFragment, url.query];
+                         fullRoute = [NSString stringWithFormat:@"%@?%@", fullRoute, url.query];
                        }
                        if ([url.fragment length] != 0) {
-                         pathAndQueryAndFragment = [NSString
-                             stringWithFormat:@"%@#%@", pathAndQueryAndFragment, url.fragment];
+                         fullRoute = [NSString stringWithFormat:@"%@#%@", fullRoute, url.fragment];
                        }
-                       [flutterViewController.engine.navigationChannel
-                           invokeMethod:@"pushRoute"
-                              arguments:pathAndQueryAndFragment];
+                       [flutterViewController.engine.navigationChannel invokeMethod:@"pushRoute"
+                                                                          arguments:fullRoute];
                      }
                    }];
       return YES;

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -159,13 +159,18 @@ static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
                        FML_LOG(ERROR)
                            << "Timeout waiting for the first frame when launching an URL.";
                      } else {
-                       NSString* pathAndQuery = url.path;
+                       NSString* pathAndQueryAndFragment = url.path;
                        if ([url.query length] != 0) {
-                         pathAndQuery =
-                             [NSString stringWithFormat:@"%@?%@", pathAndQuery, url.query];
+                         pathAndQueryAndFragment = [NSString
+                             stringWithFormat:@"%@?%@", pathAndQueryAndFragment, url.query];
                        }
-                       [flutterViewController.engine.navigationChannel invokeMethod:@"pushRoute"
-                                                                          arguments:pathAndQuery];
+                       if ([url.fragment length] != 0) {
+                         pathAndQueryAndFragment = [NSString
+                             stringWithFormat:@"%@#%@", pathAndQueryAndFragment, url.fragment];
+                       }
+                       [flutterViewController.engine.navigationChannel
+                           invokeMethod:@"pushRoute"
+                              arguments:pathAndQueryAndFragment];
                      }
                    }];
       return YES;

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -30,7 +30,7 @@ FLUTTER_ASSERT_ARC
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };
-  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
+  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test#fragment"];
   NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
   BOOL result = [appDelegate application:[UIApplication sharedApplication]
                                  openURL:url
@@ -39,7 +39,8 @@ FLUTTER_ASSERT_ARC
                            return @{@"FlutterDeepLinkingEnabled" : @(YES)};
                          }];
   XCTAssertTrue(result);
-  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
+  OCMVerify([navigationChannel invokeMethod:@"pushRoute"
+                                  arguments:@"/custom/route?query=test#fragment"]);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -30,6 +30,29 @@ FLUTTER_ASSERT_ARC
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };
+  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
+  NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
+  BOOL result = [appDelegate application:[UIApplication sharedApplication]
+                                 openURL:url
+                                 options:options
+                         infoPlistGetter:^NSDictionary*() {
+                           return @{@"FlutterDeepLinkingEnabled" : @(YES)};
+                         }];
+  XCTAssertTrue(result);
+  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
+}
+
+- (void)skip_testLaunchUrlWithQueryParameterAndFragment {
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
+  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
+  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
+  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
+  OCMStub([viewController engine]).andReturn(engine);
+  OCMStub([engine waitForFirstFrame:3.0 callback:([OCMArg invokeBlockWithArgs:@(NO), nil])]);
+  appDelegate.rootFlutterViewControllerGetter = ^{
+    return viewController;
+  };
   NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test#fragment"];
   NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
   BOOL result = [appDelegate application:[UIApplication sharedApplication]
@@ -41,6 +64,29 @@ FLUTTER_ASSERT_ARC
   XCTAssertTrue(result);
   OCMVerify([navigationChannel invokeMethod:@"pushRoute"
                                   arguments:@"/custom/route?query=test#fragment"]);
+}
+
+- (void)skip_testLaunchUrlWithFragmentNoQueryParameter {
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
+  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
+  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
+  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
+  OCMStub([viewController engine]).andReturn(engine);
+  OCMStub([engine waitForFirstFrame:3.0 callback:([OCMArg invokeBlockWithArgs:@(NO), nil])]);
+  appDelegate.rootFlutterViewControllerGetter = ^{
+    return viewController;
+  };
+  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route#fragment"];
+  NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
+  BOOL result = [appDelegate application:[UIApplication sharedApplication]
+                                 openURL:url
+                                 options:options
+                         infoPlistGetter:^NSDictionary*() {
+                           return @{@"FlutterDeepLinkingEnabled" : @(YES)};
+                         }];
+  XCTAssertTrue(result);
+  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route#fragment"]);
 }
 
 @end


### PR DESCRIPTION
Currently the URI fragment of a deeplink is ignored. This adds the URI fragment to the URI send to Flutter as well.

Fixes https://github.com/flutter/flutter/issues/80666.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
