### PR TITLE
Fix frame request tracing

### DIFF
--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -104,6 +104,7 @@ class Animator final {
   std::shared_ptr<VsyncWaiter> waiter_;
 
   std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder_;
+  uint64_t frame_request_number_ = 1;
   int64_t dart_frame_deadline_;
   fml::RefPtr<LayerTreePipeline> layer_tree_pipeline_;
   fml::Semaphore pending_frame_semaphore_;


### PR DESCRIPTION
Frame request related async trace events should have a distinct
identifier unrelated to the frame number as frame number isn't available
when frame request pending begins.
