### PR TITLE
fix mobile a11y placeholder

### DIFF
--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
+// @dart = 2.12
 import 'dart:html' as html;
 
 import 'package:test/bootstrap/browser.dart';
@@ -17,43 +17,42 @@ void main() {
 
 void testMain() {
   group('$DesktopSemanticsEnabler', () {
-    DesktopSemanticsEnabler desktopSemanticsEnabler;
-    html.Element _placeholder;
+    late DesktopSemanticsEnabler desktopSemanticsEnabler;
+    late html.Element? _placeholder;
 
     setUp(() {
+      EngineSemanticsOwner.instance.semanticsEnabled = false;
       desktopSemanticsEnabler = DesktopSemanticsEnabler();
+      _placeholder = desktopSemanticsEnabler.prepareAccessibilityPlaceholder();
+      html.document.body!.append(_placeholder!);
     });
 
     tearDown(() {
-      if (_placeholder != null) {
-        _placeholder.remove();
-      }
+      expect(_placeholder, isNotNull,
+          reason: 'Expected the test to create a placeholder');
+      _placeholder!.remove();
+      EngineSemanticsOwner.instance.semanticsEnabled = false;
     });
 
     test('prepare accesibility placeholder', () async {
-      _placeholder = desktopSemanticsEnabler.prepareAccessibilityPlaceholder();
+      expect(_placeholder!.getAttribute('role'), 'button');
+      expect(_placeholder!.getAttribute('aria-live'), 'true');
+      expect(_placeholder!.getAttribute('tabindex'), '0');
 
-      expect(_placeholder.getAttribute('role'), 'button');
-      expect(_placeholder.getAttribute('aria-live'), 'true');
-      expect(_placeholder.getAttribute('tabindex'), '0');
-
-      html.document.body.append(_placeholder);
+      html.document.body!.append(_placeholder!);
 
       expect(html.document.getElementsByTagName('flt-semantics-placeholder'),
           isNotEmpty);
 
-      expect(_placeholder.getBoundingClientRect().height, 1);
-      expect(_placeholder.getBoundingClientRect().width, 1);
-      expect(_placeholder.getBoundingClientRect().top, -1);
-      expect(_placeholder.getBoundingClientRect().left, -1);
-    },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
+      expect(_placeholder!.getBoundingClientRect().height, 1);
+      expect(_placeholder!.getBoundingClientRect().width, 1);
+      expect(_placeholder!.getBoundingClientRect().top, -1);
+      expect(_placeholder!.getBoundingClientRect().left, -1);
+    });
 
     test('Not relevant events should be forwarded to the framework', () async {
-      // Prework. Attach the placeholder to dom.
-      _placeholder = desktopSemanticsEnabler.prepareAccessibilityPlaceholder();
-      html.document.body.append(_placeholder);
+      // Attach the placeholder to dom.
+      html.document.body!.append(_placeholder!);
 
       html.Event event = html.MouseEvent('mousemove');
       bool shouldForwardToFramework =
@@ -74,12 +73,8 @@ void testMain() {
     test(
         'Relevants events targeting placeholder should not be forwarded to the framework',
         () async {
-      // Prework. Attach the placeholder to dom.
-      _placeholder = desktopSemanticsEnabler.prepareAccessibilityPlaceholder();
-      html.document.body.append(_placeholder);
-
       html.Event event = html.MouseEvent('mousedown');
-      _placeholder.dispatchEvent(event);
+      _placeholder!.dispatchEvent(event);
 
       bool shouldForwardToFramework =
           desktopSemanticsEnabler.tryEnableSemantics(event);
@@ -88,61 +83,89 @@ void testMain() {
     });
 
     test('disposes of the placeholder', () {
-      _placeholder = desktopSemanticsEnabler.prepareAccessibilityPlaceholder();
-      html.document.body.append(_placeholder);
+      html.document.body!.append(_placeholder!);
 
-      expect(_placeholder.isConnected, isTrue);
+      expect(_placeholder!.isConnected, isTrue);
       desktopSemanticsEnabler.dispose();
-      expect(_placeholder.isConnected, isFalse);
+      expect(_placeholder!.isConnected, isFalse);
     });
-  });
+  }, skip: isMobile);
 
-  group('$MobileSemanticsEnabler', () {
-    MobileSemanticsEnabler mobileSemanticsEnabler;
-    html.Element _placeholder;
+  group(
+    '$MobileSemanticsEnabler',
+    () {
+      late MobileSemanticsEnabler mobileSemanticsEnabler;
+      html.Element? _placeholder;
 
-    setUp(() {
-      mobileSemanticsEnabler = MobileSemanticsEnabler();
-    });
+      setUp(() {
+        EngineSemanticsOwner.instance.semanticsEnabled = false;
+        mobileSemanticsEnabler = MobileSemanticsEnabler();
+        _placeholder = mobileSemanticsEnabler.prepareAccessibilityPlaceholder();
+        html.document.body!.append(_placeholder!);
+      });
 
-    tearDown(() {
-      if (_placeholder != null) {
-        _placeholder.remove();
-      }
-    });
+      tearDown(() {
+        _placeholder!.remove();
+        EngineSemanticsOwner.instance.semanticsEnabled = false;
+      });
 
-    test('prepare accesibility placeholder', () async {
-      _placeholder = mobileSemanticsEnabler.prepareAccessibilityPlaceholder();
+      test('prepare accesibility placeholder', () async {
+        expect(_placeholder!.getAttribute('role'), 'button');
 
-      expect(_placeholder.getAttribute('role'), 'button');
+        // Placeholder should cover all the screen on a mobile device.
+        final num bodyHeight = html.window.innerHeight!;
+        final num bodyWidht = html.window.innerWidth!;
 
-      html.document.body.append(_placeholder);
+        expect(_placeholder!.getBoundingClientRect().height, bodyHeight);
+        expect(_placeholder!.getBoundingClientRect().width, bodyWidht);
+      });
 
-      // Placeholder should cover all the screen on a mobile device.
-      final num bodyHeight = html.window.innerHeight;
-      final num bodyWidht = html.window.innerWidth;
+      test('Non-relevant events should be forwarded to the framework',
+          () async {
+        html.Event event;
+        if (_defaultSupportDetector.hasPointerEvents) {
+          event = html.PointerEvent('pointermove');
+        } else if (_defaultSupportDetector.hasTouchEvents) {
+          event = html.TouchEvent('touchcancel');
+        } else {
+          event = html.MouseEvent('mousemove');
+        }
 
-      expect(_placeholder.getBoundingClientRect().height, bodyHeight);
-      expect(_placeholder.getBoundingClientRect().width, bodyWidht);
+        bool shouldForwardToFramework =
+            mobileSemanticsEnabler.tryEnableSemantics(event);
+
+        expect(shouldForwardToFramework, true);
+      });
+
+      test('Enables semantics when receiving a relevant event', () {
+        expect(mobileSemanticsEnabler.semanticsActivationTimer, isNull);
+
+        // Send a click off center
+        _placeholder!.dispatchEvent(html.MouseEvent(
+          'click',
+          clientX: 0,
+          clientY: 0,
+        ));
+        expect(mobileSemanticsEnabler.semanticsActivationTimer, isNull);
+
+        // Send a click at center
+        final html.Rectangle<num> activatingElementRect =
+            _placeholder!.getBoundingClientRect();
+        final int midX = (activatingElementRect.left +
+                (activatingElementRect.right - activatingElementRect.left) / 2)
+            .toInt();
+        final int midY = (activatingElementRect.top +
+                (activatingElementRect.bottom - activatingElementRect.top) / 2)
+            .toInt();
+        _placeholder!.dispatchEvent(html.MouseEvent(
+          'click',
+          clientX: midX,
+          clientY: midY,
+        ));
+        expect(mobileSemanticsEnabler.semanticsActivationTimer, isNotNull);
+      });
     },
-        // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
-
-    test('Not relevant events should be forwarded to the framework', () async {
-      html.Event event;
-      if (_defaultSupportDetector.hasPointerEvents) {
-        event = html.PointerEvent('pointermove');
-      } else if (_defaultSupportDetector.hasTouchEvents) {
-        event = html.TouchEvent('touchcancel');
-      } else {
-        event = html.MouseEvent('mousemove');
-      }
-
-      bool shouldForwardToFramework =
-          mobileSemanticsEnabler.tryEnableSemantics(event);
-
-      expect(shouldForwardToFramework, true);
-    });
-  },  // Run the `MobileSemanticsEnabler` only on mobile browsers.
-      skip: isDesktop);
+    // We can run `MobileSemanticsEnabler` tests in mobile browsers and in desktop Chrome.
+    skip: isDesktop && browserEngine != BrowserEngine.blink,
+  );
 }

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -98,25 +98,13 @@ void _testEngineSemanticsOwner() {
       clientY: (rect.top + (rect.bottom - rect.top) / 2).floor(),
     ));
 
-    // On mobile semantics is not enabled synchronously. This is because the
-    // placeholder receives pointer events in non-accessibility mode too, and
-    // therefore we wait to see if any subsequent pointer events are issued
-    // indicating that this is not a request to enable accessibility.
+    // On mobile semantics is enabled asynchronously.
     if (isMobile) {
-      while (!semantics().semanticsEnabled) {
+      while (placeholder.isConnected) {
         await Future<void>.delayed(const Duration(milliseconds: 50));
       }
     }
     expect(semantics().semanticsEnabled, true);
-
-    // The placeholder should be removed
-    if (isMobile) {
-      // On mobile the placeholder is not removed synchronously. Instead it is
-      // removed upon the next DOM event. Otherwise Safari swallows pointerup.
-      expect(placeholder.isConnected, true);
-      placeholder.click();
-      await Future<void>.delayed(Duration.zero);
-    }
     expect(placeholder.isConnected, false);
   });
 


### PR DESCRIPTION
Chrome+TalkBack seem to have changed the DOM events that are sent when the a11y placeholder is tapped on. Instead of a single "click" we see a pair of pointer-up/down, which was messing with our gesture disambiguation logic.

This PR adopts the same approach we use on Safari, i.e. look for taps that happen exactly in the middle of the placeholder.

This PR also fixes the issue with the placeholder lingering after it is activated. We used to wait for the next user-initiated event before removing it to prevent Safari from swallowing DOM events. After this change the placeholder is removed either upon a user-initiated event or upon `semanticsActivationTimer` firing, whichever comes first.

Fixes https://github.com/flutter/flutter/issues/82717
