### PR TITLE
Use path dependencies for testing/symbols

### DIFF
--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -104,6 +104,12 @@ analyze \
   --options "$FLUTTER_DIR/analysis_options.yaml" \
   "$FLUTTER_DIR/testing/scenario_app"
 
+echo "Analyzing testing/symbols..."
+analyze \
+  --packages="$FLUTTER_DIR/testing/symbols/.dart_tool/package_config.json" \
+  --options "$FLUTTER_DIR/analysis_options.yaml" \
+  "$FLUTTER_DIR/testing/symbols"
+
 # Check that dart libraries conform.
 echo "Checking web_ui api conformance..."
 (cd "$FLUTTER_DIR/web_sdk"; pub get)

--- a/testing/symbols/pubspec.yaml
+++ b/testing/symbols/pubspec.yaml
@@ -1,6 +1,24 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: verify_exported
+publish_to: none
 environment:
   sdk: '>=2.11.0 <3.0.0'
+
+# Do not add any dependencies that require more than what is provided in
+# //third_party.pkg, //third_party/dart/pkg, or
+# //third_party/dart/third_party/pkg. In particular, package:test is not usable
+# here.
+
+# If you do add packages here, make sure you can run `pub get --offline`, and
+# check the .packages and .package_config to make sure all the paths are
+# relative to this directory into //third_party/dart
+
 dependencies:
-  path: 1.6.2
-  collection: 1.14.11
+  path: any
+
+dependency_overrides:
+  path:
+    path: ../../../third_party/dart/third_party/pkg/path

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -18,6 +18,7 @@ ALL_PACKAGES = [
   os.path.join("src", "flutter", "flutter_frontend_server"),
   os.path.join("src", "flutter", "testing", "litetest"),
   os.path.join("src", "flutter", "testing", "smoke_test_failure"),
+  os.path.join("src", "flutter", "testing", "symbols"),
   os.path.join("src", "flutter", "tools", "android_lint"),
   os.path.join("src", "flutter", "tools", "const_finder"),
   os.path.join("src", "flutter", "tools", "licenses"),


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/82134

This also adds analysis of `testing/symbols` to the CI script, and cleans up lints.