### PR TITLE
Fix crash when loading empty unit mapping

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -268,7 +268,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
               "No loading unit to dynamic feature module name found. Ensure '"
                   + MAPPING_KEY
                   + "' is defined in the base module's AndroidManifest.");
-        } else if (!rawStringMapping.isBlank()){
+        } else if (!rawStringMapping.isBlank()) {
           for (String entry : rawMappingString.split(",")) {
             // Split with -1 param to include empty string following trailing ":"
             String[] splitEntry = entry.split(":", -1);

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -268,7 +268,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
               "No loading unit to dynamic feature module name found. Ensure '"
                   + MAPPING_KEY
                   + "' is defined in the base module's AndroidManifest.");
-        } else if (!rawStringMapping.isBlank()) {
+        } else if (!rawMappingString.isEmpty()) {
           for (String entry : rawMappingString.split(",")) {
             // Split with -1 param to include empty string following trailing ":"
             String[] splitEntry = entry.split(":", -1);

--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -45,7 +45,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
   private static final String TAG = "PlayStoreDeferredComponentManager";
 
   public static final String MAPPING_KEY =
-      DeferredComponentManager.class.getName() + ".loadingUnitMapping";
+      "io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager.loadingUnitMapping";
 
   private @NonNull SplitInstallManager splitInstallManager;
   private @Nullable FlutterJNI flutterJNI;
@@ -257,7 +257,6 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
   // string, indicating it is included in the base module and no dynamic
   // feature modules need to be downloaded.
   private void initLoadingUnitMappingToComponentNames() {
-    String mappingKey = DeferredComponentManager.class.getName() + ".loadingUnitMapping";
     ApplicationInfo applicationInfo = getApplicationInfo();
     if (applicationInfo != null) {
       Bundle metaData = applicationInfo.metaData;
@@ -269,7 +268,7 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
               "No loading unit to dynamic feature module name found. Ensure '"
                   + MAPPING_KEY
                   + "' is defined in the base module's AndroidManifest.");
-        } else {
+        } else if (!rawStringMapping.isBlank()){
           for (String entry : rawMappingString.split(",")) {
             // Split with -1 param to include empty string following trailing ":"
             String[] splitEntry = entry.split(":", -1);

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -307,4 +307,14 @@ public class PlayStoreDeferredComponentManagerTest {
     assertTrue(playStoreManager.uninstallDeferredComponent(2, null));
     assertFalse(playStoreManager.uninstallDeferredComponent(3, null));
   }
+
+  @Test
+  public void loadingUnitMappingEmptyPasses() throws NameNotFoundException {
+    TestFlutterJNI jni = new TestFlutterJNI();
+    Bundle bundle = new Bundle();
+    bundle.putString(PlayStoreDeferredComponentManager.MAPPING_KEY, "");
+    Context spyContext = createSpyContext(bundle);
+    TestPlayStoreDeferredComponentManager playStoreManager =
+            new TestPlayStoreDeferredComponentManager(spyContext, jni);
+  }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -315,6 +315,6 @@ public class PlayStoreDeferredComponentManagerTest {
     bundle.putString(PlayStoreDeferredComponentManager.MAPPING_KEY, "");
     Context spyContext = createSpyContext(bundle);
     TestPlayStoreDeferredComponentManager playStoreManager =
-            new TestPlayStoreDeferredComponentManager(spyContext, jni);
+        new TestPlayStoreDeferredComponentManager(spyContext, jni);
   }
 }


### PR DESCRIPTION
When loading unit mapping from the android manifest, we can come across a case where only asset deferred components are present. In this case, the value is an empty string. Currently the code did not handle this case and threw a runtime exception. This PR fixes that. 

Fixes https://github.com/flutter/flutter/issues/82903

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
