### PR TITLE
Fix compilation error on clang-12

### DIFF
--- a/shell/platform/linux/fl_key_event_plugin.cc
+++ b/shell/platform/linux/fl_key_event_plugin.cc
@@ -66,7 +66,7 @@ static void fl_key_event_pair_dispose(GObject* object) {
   g_return_if_fail(FL_IS_KEY_EVENT_PAIR(object));
 
   FlKeyEventPair* self = FL_KEY_EVENT_PAIR(object);
-  g_clear_pointer(&self->event, gdk_event_free);
+  g_clear_pointer(reinterpret_cast<GdkEvent**>(&self->event), gdk_event_free);
   G_OBJECT_CLASS(fl_key_event_pair_parent_class)->dispose(object);
 }
 


### PR DESCRIPTION
Fixes the following compilation error:

 ../../flutter/shell/platform/linux/fl_key_event_plugin.cc:69:3:
  error: cannot initialize a parameter of type 'GdkEvent *' (aka '_GdkEvent *')
  with an lvalue of type 'typename std::remove_reference<decltype(*(&self->event))>::type' (aka '_GdkEventKey *')

  g_clear_pointer(&self->event, gdk_event_free);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /usr/include/glib-2.0/glib/gmem.h:127:18: note: expanded from macro 'g_clear_pointer'
      (destroy) (_ptr);                                  \
                 ^~~~
 /usr/include/gtk-3.0/gdk/gdkevents.h:1467:41: note: passing argument to parameter 'event' here
void      gdk_event_free                (GdkEvent       *event);
                                                         ^
1 error generated.

when using clang-12:

 $ clang++ --version
 clang version 12.0.0 (Fedora 12.0.0-0.3.rc1.fc34)
 Target: x86_64-unknown-linux-gnu
 Thread model: posix
 InstalledDir: /usr/bin

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>
