### PR TITLE
Clean up testing/benchmark

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -398,8 +398,20 @@ deps = {
   'src/third_party/pkg/archive':
   Var('github_git') + '/brendan-duncan/archive.git' + '@' + '3.1.2',
 
+  'src/third_party/pkg/equatable':
+  Var('github_git') + '/felangel/equatable.git' + '@' + '0ba67c72db8bed75877fc1caafa74112ee0bd921', # 2.0.2
+
   'src/third_party/pkg/file':
   Var('github_git') + '/google/file.dart.git' + '@' + '427bb20ccc852425d67f2880da2a9b4707c266b4', # 6.1.0
+
+  'src/third_party/pkg/flutter_packages':
+  Var('github_git') + '/flutter/packages.git' + '@' + '5617d089f26dd52da3bf05c9fa4620ef11a7419b', # various
+
+  'src/third_party/pkg/gcloud':
+  Var('github_git') + '/dart-lang/gcloud.git' + '@' + '92a33a9d95ea94a4354b052a28b98088d660e0e7', # 0.8.0-dev
+
+  'src/third_party/pkg/googleapis':
+  Var('github_git') + '/google/googleapis.dart.git' + '@' + '07f01b7aa6985e4cafd0fd4b98724841bc9e85a1', # various
 
   'src/third_party/pkg/platform':
   Var('github_git') + '/google/platform.dart.git' + '@' + 'f63fd0bc3021354a0687dc935962c9acc003f47e', # 3.0.1

--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -82,6 +82,12 @@ analyze \
   --options "$FLUTTER_DIR/analysis_options.yaml" \
   "$FLUTTER_DIR/testing/litetest"
 
+echo "Analyzing testing/benchmark"
+analyze \
+  --packages="$FLUTTER_DIR/testing/benchmark/.dart_tool/package_config.json" \
+  --options "$FLUTTER_DIR/analysis_options.yaml" \
+  "$FLUTTER_DIR/testing/benchmark"
+
 echo "Analyzing testing/smoke_test_failure"
 analyze \
   --packages="$FLUTTER_DIR/testing/smoke_test_failure/.dart_tool/package_config.json" \

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: a62660b42e470ade57e05b076bff1222
+Signature: 8e5901632fdea212b4f49528f19c5f74
 

--- a/testing/benchmark/pubspec.yaml
+++ b/testing/benchmark/pubspec.yaml
@@ -1,13 +1,72 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
 name: flutter_engine_benchmark
-
-dependencies:
-  git: any
-
-  metrics_center: 0.0.9
-
-dev_dependencies:
-  test: any
-  pedantic: ^1.8.0
-
+publish_to: none
 environment:
   sdk: ">=2.2.2 <3.0.0"
+
+# Do not add any dependencies that require more than what is provided in
+# //third_party/pkg, //third_party/dart/pkg, or
+# //third_party/dart/third_party/pkg. In particular, package:test is not usable
+# here.
+
+# If you do add packages here, make sure you can run `pub get --offline`, and
+# check the .packages and .package_config to make sure all the paths are
+# relative to this directory into //third_party/dart
+
+dependencies:
+  metrics_center: any
+  path: any
+
+dev_dependencies:
+  litetest: any
+
+dependency_overrides:
+  _discoveryapis_commons:
+    path: ../../../third_party/pkg/googleapis/discoveryapis_commons
+  async_helper:
+    path: ../../../third_party/dart/pkg/async_helper
+  async:
+    path: ../../../third_party/dart/third_party/pkg/async
+  charcode:
+    path: ../../../third_party/dart/third_party/pkg/charcode
+  collection:
+    path: ../../../third_party/dart/third_party/pkg/collection
+  convert:
+    path: ../../../third_party/dart/third_party/pkg/convert
+  crypto :
+    path: ../../../third_party/dart/third_party/pkg/crypto
+  equatable:
+    path: ../../../third_party/pkg/equatable
+  expect:
+    path: ../../../third_party/dart/pkg/expect
+  gcloud:
+    path: ../../../third_party/pkg/gcloud
+  googleapis:
+    path: ../../../third_party/pkg/googleapis/generated/googleapis
+  googleapis_auth:
+    path: ../../../third_party/pkg/googleapis/googleapis_auth
+  http:
+    path: ../../../third_party/dart/third_party/pkg/http
+  http_parser:
+    path: ../../../third_party/dart/third_party/pkg/http_parser
+  litetest:
+    path: ../litetest
+  meta:
+    path: ../../../third_party/dart/pkg/meta
+  metrics_center:
+    path: ../../../third_party/pkg/flutter_packages/packages/metrics_center
+  path:
+    path: ../../../third_party/dart/third_party/pkg/path
+  pedantic:
+    path: ../../../third_party/dart/third_party/pkg/pedantic
+  source_span:
+    path: ../../../third_party/dart/third_party/pkg/source_span
+  string_scanner:
+    path: ../../../third_party/dart/third_party/pkg/string_scanner
+  term_glyph:
+    path: ../../../third_party/dart/third_party/pkg/term_glyph
+  typed_data:
+    path: ../../../third_party/dart/third_party/pkg/typed_data

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -520,6 +520,21 @@ def RunLitetestTests(build_dir):
       cwd=test_dir)
 
 
+def RunBenchmarkTests(build_dir):
+  test_dir = os.path.join(buildroot_dir, 'flutter', 'testing', 'benchmark')
+  dart_tests = glob.glob('%s/test/*_test.dart' % test_dir)
+  for dart_test_file in dart_tests:
+    opts = [
+      '--disable-dart-dev',
+      dart_test_file]
+    RunEngineExecutable(
+      build_dir,
+      os.path.join('dart-sdk', 'bin', 'dart'),
+      None,
+      flags=opts,
+      cwd=test_dir)
+
+
 def main():
   parser = argparse.ArgumentParser()
 
@@ -560,10 +575,10 @@ def main():
     assert not IsWindows(), "Dart tests can't be run on windows. https://github.com/flutter/flutter/issues/36301."
     dart_filter = args.dart_filter.split(',') if args.dart_filter else None
     RunDartSmokeTest(build_dir, args.verbose_dart_snapshot)
+    RunLitetestTests(build_dir)
     RunDartTests(build_dir, dart_filter, args.verbose_dart_snapshot)
     RunConstFinderTests(build_dir)
     RunFrontEndServerTests(build_dir)
-    RunLitetestTests(build_dir)
 
   if 'java' in types:
     assert not IsWindows(), "Android engine files can't be compiled on Windows."
@@ -579,6 +594,7 @@ def main():
 
   # https://github.com/flutter/flutter/issues/36300
   if 'benchmarks' in types and not IsWindows():
+    RunBenchmarkTests(build_dir)
     RunEngineBenchmarks(build_dir, engine_filter)
 
   if ('engine' in types or 'font-subset' in types) and args.variant != 'host_release':

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1665,13 +1665,14 @@ class _RepositoryPkgDirectory extends _RepositoryDirectory {
   @override
   bool shouldRecurse(fs.IoNode entry) {
     return entry.name != 'archive'  // contains nothing that ends up in the binary executable
+      && entry.name != 'equatable'
       && entry.name != 'file'
-      && entry.name != 'image'
-      && entry.name != 'petitparser'
+      && entry.name != 'flutter_packages'
+      && entry.name != 'gcloud'
+      && entry.name != 'googleapis'
       && entry.name != 'platform'
       && entry.name != 'process'
-      && entry.name != 'vector_math'
-      && entry.name != 'xml';
+      && entry.name != 'vector_math';
   }
 
   @override

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -16,6 +16,7 @@ import sys
 
 ALL_PACKAGES = [
   os.path.join("src", "flutter", "flutter_frontend_server"),
+  os.path.join("src", "flutter", "testing", "benchmark"),
   os.path.join("src", "flutter", "testing", "litetest"),
   os.path.join("src", "flutter", "testing", "smoke_test_failure"),
   os.path.join("src", "flutter", "testing", "symbols"),


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/82134

This PR also refactors the Dart script to be unit testable, adds tests for it, adds analysis to the CI script, and makes it analyzer clean.

I filed https://github.com/flutter/flutter/issues/83100 for removing the dependence of `metrics_center` on `package:equatable`.