### PR TITLE
[uwptool] Move Launch, Uninstall to AppStore class

### DIFF
--- a/shell/platform/windows/uwptool_commands.h
+++ b/shell/platform/windows/uwptool_commands.h
@@ -73,7 +73,11 @@ class UninstallCommand : public Command {
   int Run(const std::vector<std::string>& args) const override;
 };
 
-// Command that launches the specified application package.
+// Launches the app installed on the system with the specified package.
+//
+// Returns -1 if no matching app, or multiple matching apps are found, or if
+// the app fails to launch. Otherwise, the process ID of the launched app is
+// returned.
 class LaunchCommand : public Command {
  public:
   LaunchCommand()

--- a/shell/platform/windows/uwptool_utils.cc
+++ b/shell/platform/windows/uwptool_utils.cc
@@ -20,58 +20,6 @@
 
 namespace flutter {
 
-Application::Application(const std::wstring_view package_name,
-                         const std::wstring_view package_family,
-                         const std::wstring_view package_full_name)
-    : package_name_(package_name),
-      package_family_(package_family),
-      package_full_name_(package_full_name) {}
-
-int Application::Launch(const std::wstring_view args) {
-  // Create the ApplicationActivationManager.
-  winrt::com_ptr<IApplicationActivationManager> activation_manager;
-  HRESULT hresult = ::CoCreateInstance(
-      CLSID_ApplicationActivationManager, nullptr, CLSCTX_INPROC_SERVER,
-      IID_IApplicationActivationManager, activation_manager.put_void());
-  if (FAILED(hresult)) {
-    return -1;
-  }
-
-  // Launch the application.
-  DWORD process_id;
-  ACTIVATEOPTIONS options = AO_NONE;
-  std::wstring app_user_model_id = package_family_ + L"!App";
-  hresult = activation_manager->ActivateApplication(
-      app_user_model_id.data(), args.data(), options, &process_id);
-  if (FAILED(hresult)) {
-    return -1;
-  }
-  return process_id;
-}
-
-bool Application::Uninstall() {
-  using winrt::Windows::Foundation::AsyncStatus;
-  using winrt::Windows::Management::Deployment::PackageManager;
-  using winrt::Windows::Management::Deployment::RemovalOptions;
-
-  PackageManager package_manager;
-  auto operation = package_manager.RemovePackageAsync(
-      package_full_name_, RemovalOptions::RemoveForAllUsers);
-  operation.get();
-
-  if (operation.Status() == AsyncStatus::Completed) {
-    return true;
-  } else if (operation.Status() == AsyncStatus::Canceled) {
-    return false;
-  } else if (operation.Status() == AsyncStatus::Error) {
-    auto result = operation.GetResults();
-    std::wcerr << L"error: uninstall failed for package " << package_full_name_
-               << L" with error: " << result.ErrorText().c_str() << std::endl;
-    return false;
-  }
-  return false;
-}
-
 std::vector<Application> ApplicationStore::GetApps() const {
   using winrt::Windows::ApplicationModel::Package;
   using winrt::Windows::Management::Deployment::PackageManager;
@@ -112,7 +60,7 @@ std::vector<Application> ApplicationStore::GetApps(
   return apps;
 }
 
-bool ApplicationStore::InstallApp(
+bool ApplicationStore::Install(
     const std::wstring_view package_uri,
     const std::vector<std::wstring>& dependency_uris) {
   using winrt::Windows::Foundation::AsyncStatus;
@@ -143,6 +91,68 @@ bool ApplicationStore::InstallApp(
   }
 
   return false;
+}
+
+bool ApplicationStore::Uninstall(const std::wstring_view package_family) {
+  bool success = true;
+  for (const Application& app : GetApps(package_family)) {
+    if (Uninstall(app.GetPackageFullName())) {
+      std::wcerr << L"Uninstalled application " << app.GetPackageFullName()
+                 << std::endl;
+    } else {
+      std::wcerr << L"error: Failed to uninstall application "
+                 << app.GetPackageFullName() << std::endl;
+      success = false;
+    }
+  }
+  return success;
+}
+
+bool ApplicationStore::UninstallPackage(
+    const std::wstring_view package_full_name) {
+  using winrt::Windows::Foundation::AsyncStatus;
+  using winrt::Windows::Management::Deployment::PackageManager;
+  using winrt::Windows::Management::Deployment::RemovalOptions;
+
+  PackageManager package_manager;
+  auto operation = package_manager.RemovePackageAsync(
+      package_full_name, RemovalOptions::RemoveForAllUsers);
+  operation.get();
+
+  if (operation.Status() == AsyncStatus::Completed) {
+    return true;
+  } else if (operation.Status() == AsyncStatus::Canceled) {
+    return false;
+  } else if (operation.Status() == AsyncStatus::Error) {
+    auto result = operation.GetResults();
+    std::wcerr << L"error: uninstall failed for package " << package_full_name
+               << L" with error: " << result.ErrorText().c_str() << std::endl;
+    return false;
+  }
+  return false;
+}
+
+int ApplicationStore::Launch(const std::wstring_view package_family,
+                             const std::wstring_view args) {
+  // Create the ApplicationActivationManager.
+  winrt::com_ptr<IApplicationActivationManager> activation_manager;
+  HRESULT hresult = ::CoCreateInstance(
+      CLSID_ApplicationActivationManager, nullptr, CLSCTX_INPROC_SERVER,
+      IID_IApplicationActivationManager, activation_manager.put_void());
+  if (FAILED(hresult)) {
+    return -1;
+  }
+
+  // Launch the application.
+  DWORD process_id;
+  ACTIVATEOPTIONS options = AO_NONE;
+  std::wstring app_user_model_id = std::wstring(package_family) + L"!App";
+  hresult = activation_manager->ActivateApplication(
+      app_user_model_id.data(), args.data(), options, &process_id);
+  if (FAILED(hresult)) {
+    return -1;
+  }
+  return process_id;
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/uwptool_utils.h
+++ b/shell/platform/windows/uwptool_utils.h
@@ -14,9 +14,13 @@ namespace flutter {
 // A UWP application.
 class Application {
  public:
-  explicit Application(const std::wstring_view package_name,
-                       const std::wstring_view package_family,
-                       const std::wstring_view package_full_name);
+  Application(const std::wstring_view package_name,
+              const std::wstring_view package_family,
+              const std::wstring_view package_full_name)
+      : package_name_(package_name),
+        package_family_(package_family),
+        package_full_name_(package_full_name) {}
+
   Application(const Application& other) = default;
   Application& operator=(const Application& other) = default;
 
@@ -38,16 +42,6 @@ class Application {
   // includes a particular version of the package on the computer. It encodes
   // package name, publisher, architecture and version information.
   std::wstring GetPackageFullName() const { return package_full_name_; }
-
-  // Launches the application with the specified list of launch arguments.
-  //
-  // Returns the process ID on success, or -1 on failure.
-  int Launch(const std::wstring_view args);
-
-  // Uninstalls the application.
-  //
-  // Returns true on success.
-  bool Uninstall();
 
  private:
   std::wstring package_name_;
@@ -75,8 +69,25 @@ class ApplicationStore {
   //
   // Installs the application located at package_uri with the specified
   // dependencies.
-  bool InstallApp(const std::wstring_view package_uri,
-                  const std::vector<std::wstring>& dependency_uris);
+  bool Install(const std::wstring_view package_uri,
+               const std::vector<std::wstring>& dependency_uris);
+
+  // Uninstalls all application packages in the specified package family.
+  //
+  // Returns true on success.
+  bool Uninstall(const std::wstring_view package_family);
+
+  // Launches the application with the specified list of launch arguments.
+  //
+  // Returns the process ID on success, or -1 on failure.
+  int Launch(const std::wstring_view package_family,
+             const std::wstring_view args);
+
+ private:
+  // Uninstalls the specified application package.
+  //
+  // Returns true on success.
+  bool UninstallPackage(const std::wstring_view package_full_name);
 };
 
 }  // namespace flutter


### PR DESCRIPTION
This refactoring moves the Application Launch and Uninstall methods to
the ApplicationStore class. This simplifies writing tests for Command
classes since the Application class is now a plain old data class, and
ApplicationStore can be replaced with a fake implementation for hermetic
testing, while I'll do in a follow-up patch.

This is a refactoring that introduces no changes to existing functionality.
Functionality is covered by existing tests.

Issue: flutter/flutter#83072

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
