### PR TITLE
Clean up Dart scripts in ci/

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -413,11 +413,17 @@ deps = {
   'src/third_party/pkg/googleapis':
   Var('github_git') + '/google/googleapis.dart.git' + '@' + '07f01b7aa6985e4cafd0fd4b98724841bc9e85a1', # various
 
+  'src/third_party/pkg/isolate':
+  Var('github_git') + '/dart-lang/isolate.git' + '@' + 'ca133acb5af3a60a026fa2aab12b81e60048b3be', # 2.0.3
+
   'src/third_party/pkg/platform':
   Var('github_git') + '/google/platform.dart.git' + '@' + 'f63fd0bc3021354a0687dc935962c9acc003f47e', # 3.0.1
 
   'src/third_party/pkg/process':
   Var('github_git') + '/google/process.dart.git' + '@' + '0c9aeac86dcc4e3a6cf760b76fed507107e244d5', # 4.2.1
+
+  'src/third_party/pkg/process_runner':
+  Var('github_git') + '/google/process_runner.git' + '@' + 'd632ea0bfd814d779fcc53a361ed33eaf3620a0b', # 4.0.1
 
   'src/third_party/pkg/vector_math':
   Var('github_git') + '/google/vector_math.dart.git' + '@' + 'v2.1.0',

--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -64,6 +64,12 @@ analyze \
   --options "$FLUTTER_DIR/analysis_options.yaml" \
   "$SRC_DIR/out/host_debug_unopt/gen/sky/bindings/dart_ui/ui.dart"
 
+echo "Analyzing ci/"
+analyze \
+  --packages="$FLUTTER_DIR/ci/.dart_tool/package_config.json" \
+  --options "$FLUTTER_DIR/analysis_options.yaml" \
+  "$FLUTTER_DIR/ci"
+
 echo "Analyzing flutter_frontend_server..."
 analyze \
   --packages="$FLUTTER_DIR/flutter_frontend_server/.dart_tool/package_config.json" \

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -344,7 +344,7 @@ class ClangFormatChecker extends FormatChecker {
     if (failures.isEmpty) {
       return true;
     }
-    return await applyPatch(failures);
+    return applyPatch(failures);
   }
 
   Future<String> _getClangFormatVersion() async {
@@ -373,7 +373,7 @@ class ClangFormatChecker extends FormatChecker {
       message('Using ${await _getClangFormatVersion()}');
     }
     final List<WorkerJob> clangJobs = <WorkerJob>[];
-    for (String file in files) {
+    for (final String file in files) {
       if (file.trim().isEmpty) {
         continue;
       }
@@ -475,7 +475,7 @@ class JavaFormatChecker extends FormatChecker {
     if (failures.isEmpty) {
       return true;
     }
-    return await applyPatch(failures);
+    return applyPatch(failures);
   }
 
   Future<String> _getJavaVersion() async {
@@ -509,7 +509,7 @@ class JavaFormatChecker extends FormatChecker {
     if (verbose) {
       message('Using $javaFormatVersion with Java $javaVersion');
     }
-    for (String file in files) {
+    for (final String file in files) {
       if (file.trim().isEmpty) {
         continue;
       }
@@ -696,7 +696,7 @@ class WhitespaceFormatChecker extends FormatChecker {
   Future<bool> fixFormatting() async {
     final List<File> failures = await _getWhitespaceFailures();
     if (failures.isNotEmpty) {
-      for (File file in failures) {
+      for (final File file in failures) {
         stderr.writeln('Fixing $file');
         String contents = file.readAsStringSync();
         contents = contents.replaceAll(trailingWsRegEx, '');

--- a/ci/bin/lint.dart
+++ b/ci/bin/lint.dart
@@ -136,11 +136,11 @@ Future<LintAction> getLintAction(File file) async {
   }
 
   // Check for FlUTTER_NOLINT at top of file.
-  final RegExp exp = RegExp('\/\/\\s*FLUTTER_NOLINT(: $issueUrlPrefix/\\d+)?');
+  final RegExp exp = RegExp(r'//\s*FLUTTER_NOLINT(: $issueUrlPrefix/\d+)?');
   final Stream<String> lines = file.openRead()
     .transform(utf8.decoder)
     .transform(const LineSplitter());
-  await for (String line in lines) {
+  await for (final String line in lines) {
     final RegExpMatch? match = exp.firstMatch(line);
     if (match != null) {
       return match.group(1) != null
@@ -174,7 +174,7 @@ void _usage(ArgParser parser, {int exitCode = 1}) {
 
 bool verbose = false;
 
-void main(List<String> arguments) async {
+Future<void> main(List<String> arguments) async {
   final ArgParser parser = ArgParser();
   parser.addFlag('help', help: 'Print help.');
   parser.addFlag('lint-all',
@@ -262,7 +262,7 @@ void main(List<String> arguments) async {
   }
 
   final List<WorkerJob> jobs = <WorkerJob>[];
-  for (Command command in changedFileBuildCommands) {
+  for (final Command command in changedFileBuildCommands) {
     final String relativePath = path.relative(command.file.path, from: repoPath.parent.path);
     final LintAction action = await getLintAction(command.file);
     switch (action) {

--- a/ci/format.bat
+++ b/ci/format.bat
@@ -22,7 +22,6 @@ SET repo_dir=%SRC_DIR%\flutter
 SET ci_dir=%repo_dir%\flutter\ci
 SET dart_sdk_path=%SRC_DIR%\third_party\dart\tools\sdks\dart-sdk
 SET dart=%dart_sdk_path%\bin\dart.exe
-SET pub=%dart_sdk_path%\bin\pub.bat
 
 cd "%ci_dir%"
 
@@ -30,4 +29,4 @@ REM Do not use the CALL command in the next line to execute Dart. CALL causes
 REM Windows to re-read the line from disk after the CALL command has finished
 REM regardless of the ampersand chain.
 REM TODO(gspencergoog): Remove --no-sound-null-safety once isolate package is null-safe.
-"%pub%" get & "%dart%" --no-sound-null-safety --disable-dart-dev bin\format.dart %* & exit /B !ERRORLEVEL!
+"%dart%" --no-sound-null-safety --disable-dart-dev bin\format.dart %* & exit /B !ERRORLEVEL!

--- a/ci/format.sh
+++ b/ci/format.sh
@@ -32,11 +32,10 @@ SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
 SRC_DIR="$(cd "$SCRIPT_DIR/../.."; pwd -P)"
 DART_SDK_DIR="${SRC_DIR}/third_party/dart/tools/sdks/dart-sdk"
 DART="${DART_SDK_DIR}/bin/dart"
-PUB="${DART_SDK_DIR}/bin/pub"
 
 # TODO(gspencergoog): Remove --no-sound-null-safety once isolate package is null-safe.
 cd "$SCRIPT_DIR"
-"$PUB" get && "$DART" \
+"$DART" \
   --disable-dart-dev \
   --no-sound-null-safety \
   bin/format.dart \

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 8e5901632fdea212b4f49528f19c5f74
+Signature: 0cdf6cc7db53edb79b6010ee16d5ec19
 

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -31,7 +31,6 @@ SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
 SRC_DIR="$(cd "$SCRIPT_DIR/../.."; pwd -P)"
 DART_BIN="${SRC_DIR}/third_party/dart/tools/sdks/dart-sdk/bin"
 DART="${DART_BIN}/dart"
-PUB="${DART_BIN}/pub"
 
 COMPILE_COMMANDS="$SRC_DIR/out/host_debug/compile_commands.json"
 if [ ! -f "$COMPILE_COMMANDS" ]; then
@@ -39,7 +38,7 @@ if [ ! -f "$COMPILE_COMMANDS" ]; then
 fi
 
 cd "$SCRIPT_DIR"
-"$PUB" get && "$DART" \
+"$DART" \
   --disable-dart-dev \
   bin/lint.dart \
   --compile-commands="$COMPILE_COMMANDS" \

--- a/ci/pubspec.yaml
+++ b/ci/pubspec.yaml
@@ -3,13 +3,44 @@
 # found in the LICENSE file.
 
 name: ci_scripts
-
-dependencies:
-  args: ^2.0.0
-  meta: ^1.3.0
-  path: ^1.8.0
-  isolate: ^2.0.3
-  process_runner: ^4.0.0
-
+publish_to: none
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
+
+# Do not add any dependencies that require more than what is provided in
+# //third_party/pkg, //third_party/dart/pkg, or
+# //third_party/dart/third_party/pkg. In particular, package:test is not usable
+# here.
+
+# If you do add packages here, make sure you can run `pub get --offline`, and
+# check the .packages and .package_config to make sure all the paths are
+# relative to this directory into //third_party/dart
+
+dependencies:
+  args: any
+  meta: any
+  path: any
+  isolate: any
+  process_runner: any
+
+dependency_overrides:
+  args:
+    path: ../../third_party/dart/third_party/pkg/args
+  async:
+    path: ../../third_party/dart/third_party/pkg/async
+  collection:
+    path: ../../third_party/dart/third_party/pkg/collection
+  file:
+    path: ../../third_party/pkg/file/packages/file
+  isolate:
+    path: ../../third_party/pkg/isolate
+  meta:
+    path: ../../third_party/dart/pkg/meta
+  path:
+    path: ../../third_party/dart/third_party/pkg/path
+  platform:
+    path: ../../third_party/pkg/platform
+  process:
+    path: ../../third_party/pkg/process
+  process_runner:
+    path: ../../third_party/pkg/process_runner

--- a/testing/symbols/pubspec.yaml
+++ b/testing/symbols/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=2.11.0 <3.0.0'
 
 # Do not add any dependencies that require more than what is provided in
-# //third_party.pkg, //third_party/dart/pkg, or
+# //third_party/pkg, //third_party/dart/pkg, or
 # //third_party/dart/third_party/pkg. In particular, package:test is not usable
 # here.
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1670,8 +1670,10 @@ class _RepositoryPkgDirectory extends _RepositoryDirectory {
       && entry.name != 'flutter_packages'
       && entry.name != 'gcloud'
       && entry.name != 'googleapis'
+      && entry.name != 'isolate'
       && entry.name != 'platform'
       && entry.name != 'process'
+      && entry.name != 'process_runner'
       && entry.name != 'vector_math';
   }
 

--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 
 ALL_PACKAGES = [
+  os.path.join("src", "flutter", "ci"),
   os.path.join("src", "flutter", "flutter_frontend_server"),
   os.path.join("src", "flutter", "testing", "benchmark"),
   os.path.join("src", "flutter", "testing", "litetest"),


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/82134

Includes the dependencies of the format and lint Dart scripts in the DEPS file.

Also includes these scripts in the analyzer CI and makes them analyzer clean.