### PR TITLE
Clean up upload_metrics.sh

### DIFF
--- a/testing/benchmark/upload_metrics.sh
+++ b/testing/benchmark/upload_metrics.sh
@@ -3,14 +3,44 @@
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
-#
-# This script is expected to run from $ENGINE_PATH/src/flutter/testing/benchmark
-# it is currently used only by automation to collect and upload metrics.
+
+# This script is currently used only by automation to collect and upload
+# metrics.
 
 set -ex
 
-pub get
-dart bin/parse_and_send.dart ../../../out/host_release/txt_benchmarks.json
-dart bin/parse_and_send.dart ../../../out/host_release/fml_benchmarks.json
-dart bin/parse_and_send.dart ../../../out/host_release/shell_benchmarks.json
-dart bin/parse_and_send.dart ../../../out/host_release/ui_benchmarks.json
+# Needed because if it is set, cd may print the path it changed to.
+unset CDPATH
+
+# On Mac OS, readlink -f doesn't work, so follow_links traverses the path one
+# link at a time, and then cds into the link destination and find out where it
+# ends up.
+#
+# The function is enclosed in a subshell to avoid changing the working directory
+# of the caller.
+function follow_links() (
+  cd -P "$(dirname -- "$1")"
+  file="$PWD/$(basename -- "$1")"
+  while [[ -h "$file" ]]; do
+    cd -P "$(dirname -- "$file")"
+    file="$(readlink -- "$file")"
+    cd -P "$(dirname -- "$file")"
+    file="$PWD/$(basename -- "$file")"
+  done
+  echo "$file"
+)
+
+SCRIPT_DIR=$(follow_links "$(dirname -- "${BASH_SOURCE[0]}")")
+SRC_DIR="$(cd "$SCRIPT_DIR/../../.."; pwd -P)"
+DART_SDK_DIR="${SRC_DIR}/third_party/dart/tools/sdks/dart-sdk"
+DART="${DART_SDK_DIR}/bin/dart"
+
+cd "$SCRIPT_DIR"
+"$DART" --disable-dart-dev bin/parse_and_send.dart \
+  ../../../out/host_release/txt_benchmarks.json
+"$DART" --disable-dart-dev bin/parse_and_send.dart \
+  ../../../out/host_release/fml_benchmarks.json
+"$DART" --disable-dart-dev bin/parse_and_send.dart \
+  ../../../out/host_release/shell_benchmarks.json
+"$DART" --disable-dart-dev bin/parse_and_send.dart \
+  ../../../out/host_release/ui_benchmarks.json


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/82134.

Follow up on https://github.com/flutter/engine/pull/26313.

This PR removes the `pub get` from `upload_metrics.sh` and adopts patterns from other shell scripts.