### PR TITLE
Handle only asset-only components case

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
+++ b/shell/platform/android/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManager.java
@@ -269,15 +269,19 @@ public class PlayStoreDeferredComponentManager implements DeferredComponentManag
               "No loading unit to dynamic feature module name found. Ensure '"
                   + MAPPING_KEY
                   + "' is defined in the base module's AndroidManifest.");
-        } else {
-          for (String entry : rawMappingString.split(",")) {
-            // Split with -1 param to include empty string following trailing ":"
-            String[] splitEntry = entry.split(":", -1);
-            int loadingUnitId = Integer.parseInt(splitEntry[0]);
-            loadingUnitIdToComponentNames.put(loadingUnitId, splitEntry[1]);
-            if (splitEntry.length > 2) {
-              loadingUnitIdToSharedLibraryNames.put(loadingUnitId, splitEntry[2]);
-            }
+          return;
+        }
+        if (rawMappingString.equals("")) {
+          // Asset-only components, so no loading units to map.
+          return;
+        }
+        for (String entry : rawMappingString.split(",")) {
+          // Split with -1 param to include empty string following trailing ":"
+          String[] splitEntry = entry.split(":", -1);
+          int loadingUnitId = Integer.parseInt(splitEntry[0]);
+          loadingUnitIdToComponentNames.put(loadingUnitId, splitEntry[1]);
+          if (splitEntry.length > 2) {
+            loadingUnitIdToSharedLibraryNames.put(loadingUnitId, splitEntry[2]);
           }
         }
       }

--- a/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/deferredcomponents/PlayStoreDeferredComponentManagerTest.java
@@ -307,4 +307,14 @@ public class PlayStoreDeferredComponentManagerTest {
     assertTrue(playStoreManager.uninstallDeferredComponent(2, null));
     assertFalse(playStoreManager.uninstallDeferredComponent(3, null));
   }
+
+  @Test
+  public void assetOnlyMappingParses() throws NameNotFoundException {
+    TestFlutterJNI jni = new TestFlutterJNI();
+    Bundle bundle = new Bundle();
+    bundle.putString(PlayStoreDeferredComponentManager.MAPPING_KEY, "");
+    Context spyContext = createSpyContext(bundle);
+    TestPlayStoreDeferredComponentManager playStoreManager =
+        new TestPlayStoreDeferredComponentManager(spyContext, jni);
+  }
 }


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/82903 found that only assets-only components causes a parsing crash in the manifest mapping.

This handles the edge case of empty mapping.