### PR TITLE
Use the image generator registry & protocol for resolving image decoders.

### DIFF
--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -550,10 +550,9 @@ TEST(ImageDecoderTest,
   ASSERT_TRUE(gif_generator);
   ASSERT_TRUE(webp_generator);
 
-  // Both fixtures have a loop count of 2 which should lead to the repeat count
-  // of 1
-  ASSERT_EQ(gif_generator->GetRepetitionCount(), 1);
-  ASSERT_EQ(webp_generator->GetRepetitionCount(), 1);
+  // Both fixtures have a loop count of 2.
+  ASSERT_EQ(gif_generator->GetPlayCount(), static_cast<unsigned int>(2));
+  ASSERT_EQ(webp_generator->GetPlayCount(), static_cast<unsigned int>(2));
 }
 
 TEST(ImageDecoderTest, VerifySimpleDecoding) {

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -204,10 +204,9 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
     ASSERT_TRUE(data);
     ASSERT_GE(data->size(), 0u);
 
-    auto dart_state = UIDartState::Current();
-    auto registry = dart_state->GetImageGeneratorRegistry();
+    ImageGeneratorRegistry registry;
     std::unique_ptr<ImageGenerator> generator =
-        registry->CreateCompatibleGenerator(data);
+        registry.CreateCompatibleGenerator(data);
     ASSERT_TRUE(generator);
 
     auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
@@ -262,10 +261,9 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
     ASSERT_TRUE(data);
     ASSERT_GE(data->size(), 0u);
 
-    auto dart_state = UIDartState::Current();
-    auto registry = dart_state->GetImageGeneratorRegistry();
+    ImageGeneratorRegistry registry;
     std::unique_ptr<ImageGenerator> generator =
-        registry->CreateCompatibleGenerator(data);
+        registry.CreateCompatibleGenerator(data);
     ASSERT_TRUE(generator);
 
     auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
@@ -322,10 +320,9 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
     ASSERT_TRUE(data);
     ASSERT_GE(data->size(), 0u);
 
-    auto dart_state = UIDartState::Current();
-    auto registry = dart_state->GetImageGeneratorRegistry();
+    ImageGeneratorRegistry registry;
     std::unique_ptr<ImageGenerator> generator =
-        registry->CreateCompatibleGenerator(data);
+        registry.CreateCompatibleGenerator(data);
     ASSERT_TRUE(generator);
 
     auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
@@ -398,10 +395,9 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
       ASSERT_TRUE(data);
       ASSERT_GE(data->size(), 0u);
 
-      auto dart_state = UIDartState::Current();
-      auto registry = dart_state->GetImageGeneratorRegistry();
+      ImageGeneratorRegistry registry;
       std::unique_ptr<ImageGenerator> generator =
-          registry->CreateCompatibleGenerator(data);
+          registry.CreateCompatibleGenerator(data);
       ASSERT_TRUE(generator);
 
       auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
@@ -546,11 +542,10 @@ TEST(ImageDecoderTest,
   ASSERT_TRUE(gif_mapping);
   ASSERT_TRUE(webp_mapping);
 
-  auto dart_state = UIDartState::Current();
-  auto registry = dart_state->GetImageGeneratorRegistry();
+  ImageGeneratorRegistry registry;
 
-  auto gif_generator = registry->CreateCompatibleGenerator(gif_mapping);
-  auto webp_generator = registry->CreateCompatibleGenerator(webp_mapping);
+  auto gif_generator = registry.CreateCompatibleGenerator(gif_mapping);
+  auto webp_generator = registry.CreateCompatibleGenerator(webp_mapping);
 
   ASSERT_TRUE(gif_generator);
   ASSERT_TRUE(webp_generator);
@@ -567,10 +562,9 @@ TEST(ImageDecoderTest, VerifySimpleDecoding) {
   ASSERT_TRUE(image != nullptr);
   ASSERT_EQ(SkISize::Make(600, 200), image->dimensions());
 
-  auto dart_state = UIDartState::Current();
-  auto registry = dart_state->GetImageGeneratorRegistry();
+  ImageGeneratorRegistry registry;
   std::unique_ptr<ImageGenerator> generator =
-      registry->CreateCompatibleGenerator(data);
+      registry.CreateCompatibleGenerator(data);
   ASSERT_TRUE(generator);
 
   auto descriptor = fml::MakeRefCounted<ImageDescriptor>(std::move(data),
@@ -585,10 +579,9 @@ TEST(ImageDecoderTest, VerifySimpleDecoding) {
 TEST(ImageDecoderTest, VerifySubpixelDecodingPreservesExifOrientation) {
   auto data = OpenFixtureAsSkData("Horizontal.jpg");
 
-  auto dart_state = UIDartState::Current();
-  auto registry = dart_state->GetImageGeneratorRegistry();
+  ImageGeneratorRegistry registry;
   std::unique_ptr<ImageGenerator> generator =
-      registry->CreateCompatibleGenerator(data);
+      registry.CreateCompatibleGenerator(data);
   ASSERT_TRUE(generator);
   auto descriptor =
       fml::MakeRefCounted<ImageDescriptor>(data, std::move(generator));
@@ -638,10 +631,9 @@ TEST_F(ImageDecoderFixtureTest,
 
   ASSERT_TRUE(gif_mapping);
 
-  auto dart_state = UIDartState::Current();
-  auto registry = dart_state->GetImageGeneratorRegistry();
+  ImageGeneratorRegistry registry;
   std::unique_ptr<ImageGenerator> gif_generator =
-      registry->CreateCompatibleGenerator(gif_mapping);
+      registry.CreateCompatibleGenerator(gif_mapping);
   ASSERT_TRUE(gif_generator);
 
   TaskRunners runners(GetCurrentTestName(),         // label

--- a/lib/ui/painting/image_descriptor.cc
+++ b/lib/ui/painting/image_descriptor.cc
@@ -33,10 +33,8 @@ void ImageDescriptor::RegisterNatives(tonic::DartLibraryNatives* natives) {
 }
 
 const SkImageInfo ImageDescriptor::CreateImageInfo() const {
-  if (generator_) {
-    return generator_->GetInfo();
-  }
-  return SkImageInfo::MakeUnknown();
+  FML_DCHECK(generator_);
+  return generator_->GetInfo();
 }
 
 ImageDescriptor::ImageDescriptor(sk_sp<SkData> buffer,
@@ -78,7 +76,9 @@ void ImageDescriptor::initEncoded(Dart_NativeArguments args) {
 
   if (!registry) {
     Dart_SetReturnValue(
-        args, tonic::ToDart("Image generator registry not available"));
+        args, tonic::ToDart("Failed to access the internal image decoder "
+                            "registry on this isolate. Please file a bug on "
+                            "https://github.com/flutter/flutter/issues."));
     return;
   }
 

--- a/lib/ui/painting/image_descriptor.cc
+++ b/lib/ui/painting/image_descriptor.cc
@@ -50,7 +50,7 @@ ImageDescriptor::ImageDescriptor(sk_sp<SkData> buffer,
 ImageDescriptor::ImageDescriptor(sk_sp<SkData> buffer,
                                  std::unique_ptr<ImageGenerator> generator)
     : buffer_(std::move(buffer)),
-      generator_(nullptr),
+      generator_(std::move(generator)),
       image_info_(CreateImageInfo()),
       row_bytes_(std::nullopt) {}
 
@@ -128,7 +128,7 @@ void ImageDescriptor::instantiateCodec(Dart_Handle codec_handle,
                                        int target_width,
                                        int target_height) {
   fml::RefPtr<Codec> ui_codec;
-  if (generator_->GetFrameCount() == 1) {
+  if (!generator_ || generator_->GetFrameCount() == 1) {
     ui_codec = fml::MakeRefCounted<SingleFrameCodec>(
         static_cast<fml::RefPtr<ImageDescriptor>>(this), target_width,
         target_height);

--- a/lib/ui/painting/image_descriptor.cc
+++ b/lib/ui/painting/image_descriptor.cc
@@ -7,26 +7,11 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/trace_event.h"
-#include "flutter/lib/ui/painting/codec.h"
-#include "flutter/lib/ui/painting/image_decoder.h"
 #include "flutter/lib/ui/painting/multi_frame_codec.h"
 #include "flutter/lib/ui/painting/single_frame_codec.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/logging/dart_invoke.h"
-
-#ifdef OS_MACOSX
-#include "third_party/skia/include/ports/SkImageGeneratorCG.h"
-#define PLATFORM_IMAGE_GENERATOR(data) \
-  SkImageGeneratorCG::MakeFromEncodedCG(data)
-#elif OS_WIN
-#include "third_party/skia/include/ports/SkImageGeneratorWIC.h"
-#define PLATFORM_IMAGE_GENERATOR(data) \
-  SkImageGeneratorWIC::MakeFromEncodedWIC(data)
-#else
-#define PLATFORM_IMAGE_GENERATOR(data) \
-  std::unique_ptr<SkImageGenerator>(nullptr)
-#endif
 
 namespace flutter {
 
@@ -49,10 +34,7 @@ void ImageDescriptor::RegisterNatives(tonic::DartLibraryNatives* natives) {
 
 const SkImageInfo ImageDescriptor::CreateImageInfo() const {
   if (generator_) {
-    return generator_->getInfo();
-  }
-  if (platform_image_generator_) {
-    return platform_image_generator_->getInfo();
+    return generator_->GetInfo();
   }
   return SkImageInfo::MakeUnknown();
 }
@@ -62,26 +44,13 @@ ImageDescriptor::ImageDescriptor(sk_sp<SkData> buffer,
                                  std::optional<size_t> row_bytes)
     : buffer_(std::move(buffer)),
       generator_(nullptr),
-      platform_image_generator_(nullptr),
       image_info_(std::move(image_info)),
       row_bytes_(row_bytes) {}
 
 ImageDescriptor::ImageDescriptor(sk_sp<SkData> buffer,
-                                 std::unique_ptr<SkCodec> codec)
-    : buffer_(std::move(buffer)),
-      generator_(std::shared_ptr<SkCodecImageGenerator>(
-          static_cast<SkCodecImageGenerator*>(
-              SkCodecImageGenerator::MakeFromCodec(std::move(codec))
-                  .release()))),
-      platform_image_generator_(nullptr),
-      image_info_(CreateImageInfo()),
-      row_bytes_(std::nullopt) {}
-
-ImageDescriptor::ImageDescriptor(sk_sp<SkData> buffer,
-                                 std::unique_ptr<SkImageGenerator> generator)
+                                 std::unique_ptr<ImageGenerator> generator)
     : buffer_(std::move(buffer)),
       generator_(nullptr),
-      platform_image_generator_(std::move(generator)),
       image_info_(CreateImageInfo()),
       row_bytes_(std::nullopt) {}
 
@@ -103,26 +72,27 @@ void ImageDescriptor::initEncoded(Dart_NativeArguments args) {
     return;
   }
 
-  // This call will succeed if Skia has a built-in codec for this.
-  // If it fails, we will check if the platform knows how to decode this image.
-  std::unique_ptr<SkCodec> codec =
-      SkCodec::MakeFromData(immutable_buffer->data());
-  fml::RefPtr<ImageDescriptor> descriptor;
-  if (!codec) {
-    std::unique_ptr<SkImageGenerator> generator =
-        PLATFORM_IMAGE_GENERATOR(immutable_buffer->data());
-    if (!generator) {
-      // We don't have a Skia codec for this image, and the platform doesn't
-      // know how to decode it.
-      Dart_SetReturnValue(args, tonic::ToDart("Invalid image data"));
-      return;
-    }
-    descriptor = fml::MakeRefCounted<ImageDescriptor>(immutable_buffer->data(),
-                                                      std::move(generator));
-  } else {
-    descriptor = fml::MakeRefCounted<ImageDescriptor>(immutable_buffer->data(),
-                                                      std::move(codec));
+  // This has to be valid because this method is called from Dart.
+  auto dart_state = UIDartState::Current();
+  auto registry = dart_state->GetImageGeneratorRegistry();
+
+  if (!registry) {
+    Dart_SetReturnValue(
+        args, tonic::ToDart("Image generator registry not available"));
+    return;
   }
+
+  std::unique_ptr<ImageGenerator> generator =
+      registry->CreateCompatibleGenerator(immutable_buffer->data());
+
+  if (!generator) {
+    // No compatible image decoder was found.
+    Dart_SetReturnValue(args, tonic::ToDart("Invalid image data"));
+    return;
+  }
+
+  auto descriptor = fml::MakeRefCounted<ImageDescriptor>(
+      immutable_buffer->data(), std::move(generator));
 
   FML_DCHECK(descriptor);
 
@@ -158,7 +128,7 @@ void ImageDescriptor::instantiateCodec(Dart_Handle codec_handle,
                                        int target_width,
                                        int target_height) {
   fml::RefPtr<Codec> ui_codec;
-  if (!generator_ || generator_->getFrameCount() == 1) {
+  if (generator_->GetFrameCount() == 1) {
     ui_codec = fml::MakeRefCounted<SingleFrameCodec>(
         static_cast<fml::RefPtr<ImageDescriptor>>(this), target_width,
         target_height);
@@ -186,12 +156,9 @@ sk_sp<SkImage> ImageDescriptor::image() const {
 }
 
 bool ImageDescriptor::get_pixels(const SkPixmap& pixmap) const {
-  if (generator_) {
-    return generator_->getPixels(pixmap.info(), pixmap.writable_addr(),
-                                 pixmap.rowBytes());
-  }
-  FML_DCHECK(platform_image_generator_);
-  return platform_image_generator_->getPixels(pixmap);
+  FML_DCHECK(generator_);
+  return generator_->GetPixels(pixmap.info(), pixmap.writable_addr(),
+                               pixmap.rowBytes());
 }
 
 }  // namespace flutter

--- a/lib/ui/painting/image_descriptor.h
+++ b/lib/ui/painting/image_descriptor.h
@@ -11,6 +11,7 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/lib/ui/dart_wrapper.h"
+#include "flutter/lib/ui/painting/image_generator_registry.h"
 #include "flutter/lib/ui/painting/immutable_buffer.h"
 #include "third_party/skia/include/codec/SkCodec.h"
 #include "third_party/skia/include/core/SkImageGenerator.h"
@@ -20,13 +21,13 @@
 
 namespace flutter {
 
-/// Creates an image descriptor for encoded or decoded image data, describing
-/// the width, height, and bytes per pixel for that image.
-///
-/// This class will hold a reference on the underlying image data, and in the
-/// case of compressed data, an SkCodec and SkImageGenerator for the data.
-/// The Codec initialization actually happens in initEncoded, making
-/// initstantiateCodec a lightweight operation.
+/// @brief  Creates an image descriptor for encoded or decoded image data,
+///         describing the width, height, and bytes per pixel for that image.
+///         This class will hold a reference on the underlying image data, and
+///         in the case of compressed data, an `ImageGenerator` for the data.
+///         The Codec initialization actually happens in initEncoded, making
+///         `initstantiateCodec` a lightweight operation.
+/// @see    `ImageGenerator`
 class ImageDescriptor : public RefCountedDartWrappable<ImageDescriptor> {
  public:
   ~ImageDescriptor() override = default;
@@ -37,15 +38,16 @@ class ImageDescriptor : public RefCountedDartWrappable<ImageDescriptor> {
     kBGRA8888,
   };
 
-  /// Asynchronously initlializes an ImageDescriptor for an encoded image, as
-  /// long as the format is supported by Skia.
-  ///
-  /// Calling this method will result in creating an SkCodec and
-  /// SkImageGenerator to read EXIF corrected dimensions from the image data.
+  /// @brief  Asynchronously initlializes an ImageDescriptor for an encoded
+  ///         image, as long as the format is recognized by an encoder installed
+  ///         in the `ImageGeneratorRegistry`. Calling this method will create
+  ///         an `ImageGenerator` and read EXIF corrected dimensions from the
+  ///         image data.
+  /// @see    `ImageGeneratorRegistry`
   static void initEncoded(Dart_NativeArguments args);
 
-  /// Synchronously initializes an ImageDescriptor for decompressed image data
-  /// as specified by the PixelFormat.
+  /// @brief  Synchronously initializes an `ImageDescriptor` for decompressed
+  ///         image data as specified by the `PixelFormat`.
   static void initRaw(Dart_Handle descriptor_handle,
                       fml::RefPtr<ImmutableBuffer> data,
                       int width,
@@ -53,60 +55,60 @@ class ImageDescriptor : public RefCountedDartWrappable<ImageDescriptor> {
                       int row_bytes,
                       PixelFormat pixel_format);
 
-  /// Associates a flutter::Codec object with the dart.ui Codec handle.
+  /// @brief  Associates a flutter::Codec object with the dart.ui Codec handle.
   void instantiateCodec(Dart_Handle codec, int target_width, int target_height);
 
-  /// The width of this image, EXIF oriented if applicable.
+  /// @brief  The width of this image, EXIF oriented if applicable.
   int width() const { return image_info_.width(); }
 
-  /// The height of this image. EXIF oriented if applicable.
+  /// @brief  The height of this image. EXIF oriented if applicable.
   int height() const { return image_info_.height(); }
 
-  /// The bytes per pixel of the image.
+  /// @brief  The bytes per pixel of the image.
   int bytesPerPixel() const { return image_info_.bytesPerPixel(); }
 
-  /// The byte length of the first row of the image.
-  ///
-  /// Defaults to width() * 4.
+  /// @brief  The byte length of the first row of the image.
+  ///         Defaults to width() * 4.
   int row_bytes() const {
     return row_bytes_.value_or(
         static_cast<size_t>(image_info_.width() * image_info_.bytesPerPixel()));
   }
 
-  /// Whether the given target_width or target_height differ from width() and
-  /// height() respectively.
+  /// @brief  Whether the given `target_width` or `target_height` differ from
+  ///         `width()` and `height()` respectively.
   bool should_resize(int target_width, int target_height) const {
     return target_width != width() || target_height != height();
   }
 
-  /// The underlying buffer for this image.
+  /// @brief  The underlying buffer for this image.
   sk_sp<SkData> data() const { return buffer_; }
 
   sk_sp<SkImage> image() const;
 
-  /// Whether this descriptor represents compressed (encoded) data or not.
-  bool is_compressed() const { return generator_ || platform_image_generator_; }
+  /// @brief  Whether this descriptor represents compressed (encoded) data or
+  ///         not.
+  bool is_compressed() const { return !!generator_; }
 
-  /// The orientation corrected image info for this image.
+  /// @brief  The orientation corrected image info for this image.
   const SkImageInfo& image_info() const { return image_info_; }
 
-  /// Gets the scaled dimensions of this image, if backed by a codec that can
-  /// perform efficient subpixel scaling.
+  /// @brief  Gets the scaled dimensions of this image, if backed by an
+  ///         `ImageGenerator` that can perform efficient subpixel scaling.
+  /// @see    `ImageGenerator::GetScaledDimensions`
   SkISize get_scaled_dimensions(float scale) {
     if (generator_) {
-      return generator_->getScaledDimensions(scale);
+      return generator_->GetScaledDimensions(scale);
     }
     return image_info_.dimensions();
   }
 
-  /// Gets pixels for this image transformed based on the EXIF orientation tag,
-  /// if applicable.
+  /// @brief  Gets pixels for this image transformed based on the EXIF
+  ///         orientation tag, if applicable.
   bool get_pixels(const SkPixmap& pixmap) const;
 
   void dispose() {
     ClearDartWrapper();
     generator_.reset();
-    platform_image_generator_.reset();
   }
 
   size_t GetAllocationSize() const override {
@@ -119,13 +121,11 @@ class ImageDescriptor : public RefCountedDartWrappable<ImageDescriptor> {
   ImageDescriptor(sk_sp<SkData> buffer,
                   const SkImageInfo& image_info,
                   std::optional<size_t> row_bytes);
-  ImageDescriptor(sk_sp<SkData> buffer, std::unique_ptr<SkCodec> codec);
   ImageDescriptor(sk_sp<SkData> buffer,
-                  std::unique_ptr<SkImageGenerator> generator);
+                  std::unique_ptr<ImageGenerator> generator);
 
   sk_sp<SkData> buffer_;
-  std::shared_ptr<SkCodecImageGenerator> generator_;
-  std::unique_ptr<SkImageGenerator> platform_image_generator_;
+  std::shared_ptr<ImageGenerator> generator_;
   const SkImageInfo image_info_;
   std::optional<size_t> row_bytes_;
 

--- a/lib/ui/painting/image_generator.cc
+++ b/lib/ui/painting/image_generator.cc
@@ -22,8 +22,8 @@ unsigned int BuiltinSkiaImageGenerator::GetFrameCount() const {
   return 1;
 }
 
-int BuiltinSkiaImageGenerator::GetRepetitionCount() const {
-  return 0;
+unsigned int BuiltinSkiaImageGenerator::GetPlayCount() const {
+  return 1;
 }
 
 const ImageGenerator::FrameInfo BuiltinSkiaImageGenerator::GetFrameInfo(
@@ -75,8 +75,9 @@ unsigned int BuiltinSkiaCodecImageGenerator::GetFrameCount() const {
   return codec_generator_->getFrameCount();
 }
 
-int BuiltinSkiaCodecImageGenerator::GetRepetitionCount() const {
-  return codec_generator_->getRepetitionCount();
+unsigned int BuiltinSkiaCodecImageGenerator::GetPlayCount() const {
+  auto repetition_count = codec_generator_->getRepetitionCount();
+  return repetition_count < 0 ? kInfinitePlayCount : repetition_count + 1;
 }
 
 const ImageGenerator::FrameInfo BuiltinSkiaCodecImageGenerator::GetFrameInfo(

--- a/lib/ui/painting/image_generator.cc
+++ b/lib/ui/painting/image_generator.cc
@@ -22,6 +22,10 @@ unsigned int BuiltinSkiaImageGenerator::GetFrameCount() const {
   return 1;
 }
 
+int BuiltinSkiaImageGenerator::GetRepetitionCount() const {
+  return 0;
+}
+
 const ImageGenerator::FrameInfo BuiltinSkiaImageGenerator::GetFrameInfo(
     unsigned int frame_index) const {
   return {.required_frame = std::nullopt,
@@ -69,6 +73,10 @@ const SkImageInfo& BuiltinSkiaCodecImageGenerator::GetInfo() const {
 
 unsigned int BuiltinSkiaCodecImageGenerator::GetFrameCount() const {
   return codec_generator_->getFrameCount();
+}
+
+int BuiltinSkiaCodecImageGenerator::GetRepetitionCount() const {
+  return codec_generator_->getRepetitionCount();
 }
 
 const ImageGenerator::FrameInfo BuiltinSkiaCodecImageGenerator::GetFrameInfo(

--- a/lib/ui/painting/image_generator.h
+++ b/lib/ui/painting/image_generator.h
@@ -21,6 +21,10 @@ namespace flutter {
 /// @see    `ImageGenerator::GetScaledDimensions`
 class ImageGenerator {
  public:
+  /// Frame count value to denote infinite looping.
+  const static unsigned int kInfinitePlayCount =
+      std::numeric_limits<unsigned int>::max();
+
   /// @brief  Info about a single frame in the context of a multi-frame image,
   ///         useful for animation and blending.
   struct FrameInfo {
@@ -54,14 +58,13 @@ class ImageGenerator {
   ///          always be 1 for single-frame images.
   virtual unsigned int GetFrameCount() const = 0;
 
-  /// @brief  Return the number of times to repeat, if this image is animated.
-  ///         This number does not include the first play through of each frame.
-  ///         For example, a repetition count of 4 means that each frame is
-  ///         played 5 timesand then the animation stops.
-  /// @return The number of times to repeat (not counting the first play
-  ///         through). For still (non-animated) image decoders, 0 is returned.
-  ///         For animated images that should repeat forever, -1 is returned.
-  virtual int GetRepetitionCount() const = 0;
+  /// @brief  The number of times an animated image should play through before
+  ///         playback stops.
+  /// @return If this image is animated, the number of times the animation
+  ///         should play through is returned, otherwise it'll just return 1.
+  ///         If the animation should loop forever, `kInfinitePlayCount` is
+  ///         returned.
+  virtual unsigned int GetPlayCount() const = 0;
 
   /// @brief      Get information about a single frame in the context of a
   ///             multi-frame image, useful for animation and frame blending.
@@ -132,7 +135,7 @@ class BuiltinSkiaImageGenerator : public ImageGenerator {
   unsigned int GetFrameCount() const override;
 
   // |ImageGenerator|
-  int GetRepetitionCount() const override;
+  unsigned int GetPlayCount() const override;
 
   // |ImageGenerator|
   const ImageGenerator::FrameInfo GetFrameInfo(
@@ -172,7 +175,7 @@ class BuiltinSkiaCodecImageGenerator : public ImageGenerator {
   unsigned int GetFrameCount() const override;
 
   // |ImageGenerator|
-  int GetRepetitionCount() const override;
+  unsigned int GetPlayCount() const override;
 
   // |ImageGenerator|
   const ImageGenerator::FrameInfo GetFrameInfo(

--- a/lib/ui/painting/image_generator.h
+++ b/lib/ui/painting/image_generator.h
@@ -5,9 +5,10 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_IMAGE_GENERATOR_H_
 #define FLUTTER_LIB_UI_PAINTING_IMAGE_GENERATOR_H_
 
+#include <optional>
 #include "flutter/fml/macros.h"
-#include "flutter/lib/ui/painting/codec.h"
 #include "third_party/skia/include/core/SkImageInfo.h"
+#include "third_party/skia/src/codec/SkCodecImageGenerator.h"
 
 namespace flutter {
 
@@ -52,6 +53,15 @@ class ImageGenerator {
   /// @return  The number of frames that the encoded image stores. This will
   ///          always be 1 for single-frame images.
   virtual unsigned int GetFrameCount() const = 0;
+
+  /// @brief  Return the number of times to repeat, if this image is animated.
+  ///         This number does not include the first play through of each frame.
+  ///         For example, a repetition count of 4 means that each frame is
+  ///         played 5 timesand then the animation stops.
+  /// @return The number of times to repeat (not counting the first play
+  ///         through). For still (non-animated) image decoders, 0 is returned.
+  ///         For animated images that should repeat forever, -1 is returned.
+  virtual int GetRepetitionCount() const = 0;
 
   /// @brief      Get information about a single frame in the context of a
   ///             multi-frame image, useful for animation and frame blending.
@@ -122,6 +132,9 @@ class BuiltinSkiaImageGenerator : public ImageGenerator {
   unsigned int GetFrameCount() const override;
 
   // |ImageGenerator|
+  int GetRepetitionCount() const override;
+
+  // |ImageGenerator|
   const ImageGenerator::FrameInfo GetFrameInfo(
       unsigned int frame_index) const override;
 
@@ -157,6 +170,9 @@ class BuiltinSkiaCodecImageGenerator : public ImageGenerator {
 
   // |ImageGenerator|
   unsigned int GetFrameCount() const override;
+
+  // |ImageGenerator|
+  int GetRepetitionCount() const override;
 
   // |ImageGenerator|
   const ImageGenerator::FrameInfo GetFrameInfo(

--- a/lib/ui/painting/image_generator_registry.cc
+++ b/lib/ui/painting/image_generator_registry.cc
@@ -54,6 +54,15 @@ void ImageGeneratorRegistry::AddFactory(ImageGeneratorFactory factory,
 
 std::unique_ptr<ImageGenerator>
 ImageGeneratorRegistry::CreateCompatibleGenerator(sk_sp<SkData> buffer) {
+  if (!image_generator_factories_.size()) {
+    FML_LOG(WARNING)
+        << "There are currently no image decoders installed. If you're writing "
+           "your own platform embedding, you can register new image decoders "
+           "via `ImageGeneratorRegistry::AddFactory` on the "
+           "`ImageGeneratorRegistry` provided by the engine. Otherwise, please "
+           "file a bug on https://github.com/flutter/flutter/issues.";
+  }
+
   for (auto& factory : image_generator_factories_) {
     std::unique_ptr<ImageGenerator> result = factory.callback(buffer);
     if (result) {

--- a/lib/ui/painting/image_generator_registry_unittests.cc
+++ b/lib/ui/painting/image_generator_registry_unittests.cc
@@ -58,6 +58,8 @@ class FakeImageGenerator : public ImageGenerator {
 
   unsigned int GetFrameCount() const { return 1; }
 
+  int GetRepetitionCount() const { return 0; }
+
   const ImageGenerator::FrameInfo GetFrameInfo(unsigned int frame_index) const {
     return {std::nullopt, 0, SkCodecAnimation::DisposalMethod::kKeep};
   }

--- a/lib/ui/painting/image_generator_registry_unittests.cc
+++ b/lib/ui/painting/image_generator_registry_unittests.cc
@@ -58,7 +58,7 @@ class FakeImageGenerator : public ImageGenerator {
 
   unsigned int GetFrameCount() const { return 1; }
 
-  int GetRepetitionCount() const { return 0; }
+  unsigned int GetPlayCount() const { return 1; }
 
   const ImageGenerator::FrameInfo GetFrameInfo(unsigned int frame_index) const {
     return {std::nullopt, 0, SkCodecAnimation::DisposalMethod::kKeep};

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -20,7 +20,10 @@ MultiFrameCodec::~MultiFrameCodec() = default;
 MultiFrameCodec::State::State(std::shared_ptr<ImageGenerator> generator)
     : generator_(std::move(generator)),
       frameCount_(generator_->GetFrameCount()),
-      repetitionCount_(generator_->GetRepetitionCount()),
+      repetitionCount_(generator_->GetPlayCount() ==
+                               ImageGenerator::kInfinitePlayCount
+                           ? -1
+                           : generator_->GetPlayCount() - 1),
       nextFrameIndex_(0) {}
 
 static void InvokeNextFrameCallback(

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -12,16 +12,15 @@
 
 namespace flutter {
 
-MultiFrameCodec::MultiFrameCodec(
-    std::shared_ptr<SkCodecImageGenerator> generator)
+MultiFrameCodec::MultiFrameCodec(std::shared_ptr<ImageGenerator> generator)
     : state_(new State(std::move(generator))) {}
 
 MultiFrameCodec::~MultiFrameCodec() = default;
 
-MultiFrameCodec::State::State(std::shared_ptr<SkCodecImageGenerator> generator)
+MultiFrameCodec::State::State(std::shared_ptr<ImageGenerator> generator)
     : generator_(std::move(generator)),
-      frameCount_(generator_->getFrameCount()),
-      repetitionCount_(generator_->getRepetitionCount()),
+      frameCount_(generator_->GetFrameCount()),
+      repetitionCount_(generator_->GetRepetitionCount()),
       nextFrameIndex_(0) {}
 
 static void InvokeNextFrameCallback(
@@ -76,18 +75,20 @@ static bool CopyToBitmap(SkBitmap* dst,
 sk_sp<SkImage> MultiFrameCodec::State::GetNextFrameImage(
     fml::WeakPtr<GrDirectContext> resourceContext) {
   SkBitmap bitmap = SkBitmap();
-  SkImageInfo info = generator_->getInfo().makeColorType(kN32_SkColorType);
+  SkImageInfo info = generator_->GetInfo().makeColorType(kN32_SkColorType);
   if (info.alphaType() == kUnpremul_SkAlphaType) {
     SkImageInfo updated = info.makeAlphaType(kPremul_SkAlphaType);
     info = updated;
   }
   bitmap.allocPixels(info);
 
-  SkCodec::Options options;
-  options.fFrameIndex = nextFrameIndex_;
-  SkCodec::FrameInfo frameInfo{0};
-  generator_->getFrameInfo(nextFrameIndex_, &frameInfo);
-  const int requiredFrameIndex = frameInfo.fRequiredFrame;
+  ImageGenerator::FrameInfo frameInfo =
+      generator_->GetFrameInfo(nextFrameIndex_);
+
+  const int requiredFrameIndex =
+      frameInfo.required_frame.value_or(SkCodec::kNoFrame);
+  std::optional<unsigned int> prior_frame_index = std::nullopt;
+
   if (requiredFrameIndex != SkCodec::kNoFrame) {
     if (lastRequiredFrame_ == nullptr) {
       FML_LOG(ERROR) << "Frame " << nextFrameIndex_ << " depends on frame "
@@ -103,18 +104,18 @@ sk_sp<SkImage> MultiFrameCodec::State::GetNextFrameImage(
     if (lastRequiredFrame_->getPixels() &&
         CopyToBitmap(&bitmap, lastRequiredFrame_->colorType(),
                      *lastRequiredFrame_)) {
-      options.fPriorFrame = requiredFrameIndex;
+      prior_frame_index = requiredFrameIndex;
     }
   }
 
-  if (!generator_->getPixels(info, bitmap.getPixels(), bitmap.rowBytes(),
-                             &options)) {
+  if (!generator_->GetPixels(info, bitmap.getPixels(), bitmap.rowBytes(),
+                             nextFrameIndex_, requiredFrameIndex)) {
     FML_LOG(ERROR) << "Could not getPixels for frame " << nextFrameIndex_;
     return nullptr;
   }
 
   // Hold onto this if we need it to decode future frames.
-  if (frameInfo.fDisposalMethod == SkCodecAnimation::DisposalMethod::kKeep) {
+  if (frameInfo.disposal_method == SkCodecAnimation::DisposalMethod::kKeep) {
     lastRequiredFrame_ = std::make_unique<SkBitmap>(bitmap);
     lastRequiredFrameIndex_ = nextFrameIndex_;
   }
@@ -144,9 +145,8 @@ void MultiFrameCodec::State::GetNextFrameAndInvokeCallback(
   if (skImage) {
     image = CanvasImage::Create();
     image->set_image({skImage, std::move(unref_queue)});
-    SkCodec::FrameInfo skFrameInfo{0};
-    generator_->getFrameInfo(nextFrameIndex_, &skFrameInfo);
-    duration = skFrameInfo.fDuration;
+    ImageGenerator::FrameInfo frameInfo = generator_->GetFrameInfo(nextFrameIndex_);
+    duration = frameInfo.duration;
   }
   nextFrameIndex_ = (nextFrameIndex_ + 1) % frameCount_;
 

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -145,7 +145,8 @@ void MultiFrameCodec::State::GetNextFrameAndInvokeCallback(
   if (skImage) {
     image = CanvasImage::Create();
     image->set_image({skImage, std::move(unref_queue)});
-    ImageGenerator::FrameInfo frameInfo = generator_->GetFrameInfo(nextFrameIndex_);
+    ImageGenerator::FrameInfo frameInfo =
+        generator_->GetFrameInfo(nextFrameIndex_);
     duration = frameInfo.duration;
   }
   nextFrameIndex_ = (nextFrameIndex_ + 1) % frameCount_;

--- a/lib/ui/painting/multi_frame_codec.h
+++ b/lib/ui/painting/multi_frame_codec.h
@@ -7,13 +7,13 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/lib/ui/painting/codec.h"
-#include "third_party/skia/src/codec/SkCodecImageGenerator.h"
+#include "flutter/lib/ui/painting/image_generator.h"
 
 namespace flutter {
 
 class MultiFrameCodec : public Codec {
  public:
-  MultiFrameCodec(std::shared_ptr<SkCodecImageGenerator> generator);
+  MultiFrameCodec(std::shared_ptr<ImageGenerator> generator);
 
   ~MultiFrameCodec() override;
 
@@ -37,9 +37,9 @@ class MultiFrameCodec : public Codec {
   // shares it with the IO task runner's decoding work, and sets the live_
   // member to false when it is destructed.
   struct State {
-    State(std::shared_ptr<SkCodecImageGenerator> generator);
+    State(std::shared_ptr<ImageGenerator> generator);
 
-    const std::shared_ptr<SkCodecImageGenerator> generator_;
+    const std::shared_ptr<ImageGenerator> generator_;
     const int frameCount_;
     const int repetitionCount_;
 

--- a/lib/ui/painting/single_frame_codec.cc
+++ b/lib/ui/painting/single_frame_codec.cc
@@ -52,7 +52,10 @@ Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
   auto decoder = dart_state->GetImageDecoder();
 
   if (!decoder) {
-    return tonic::ToDart("Image decoder not available.");
+    return tonic::ToDart(
+        "Failed to access the internal image decoder "
+        "registry on this isolate. Please file a bug on "
+        "https://github.com/flutter/flutter/issues.");
   }
 
   // The SingleFrameCodec must be deleted on the UI thread.  Allocate a RefPtr


### PR DESCRIPTION
Use the image generator registry to resolve image decoders.

This is a continuation of flutter/flutter#17356 and flutter/flutter#82603.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
