### PR TITLE
Remove group() support from package:litetest

### DIFF
--- a/testing/dart/dart_test.dart
+++ b/testing/dart/dart_test.dart
@@ -9,19 +9,17 @@ import 'package:litetest/litetest.dart';
 
 /// Verifies Dart semantics governed by flags set by Flutter tooling.
 void main() {
-  group('Async', () {
-    String greeting = 'hello';
-    Future<void> changeGreeting() async {
-      greeting += ' 1';
-      await Future<void>.value(null);
-      greeting += ' 2';
-    }
-    test('execution of async method starts synchronously', () async {
-      expect(greeting, 'hello');
-      final Future<void> future = changeGreeting();
-      expect(greeting, 'hello 1');
-      await future;
-      expect(greeting, 'hello 1 2');
-    });
+  String greeting = 'hello';
+  Future<void> changeGreeting() async {
+    greeting += ' 1';
+    await Future<void>.value(null);
+    greeting += ' 2';
+  }
+  test('execution of async method starts synchronously', () async {
+    expect(greeting, 'hello');
+    final Future<void> future = changeGreeting();
+    expect(greeting, 'hello 1');
+    await future;
+    expect(greeting, 'hello 1 2');
   });
 }

--- a/testing/dart/encoding_test.dart
+++ b/testing/dart/encoding_test.dart
@@ -18,47 +18,39 @@ const Color _kBlack = Color.fromRGBO(0, 0, 0, 1.0);
 const Color _kGreen = Color.fromRGBO(0, 255, 0, 1.0);
 
 void main() {
-  group('Image.toByteData', () {
-    group('RGBA format', () {
-      test('works with simple image', () async {
-        final Image image = await Square4x4Image.image;
-        final ByteData data = await image.toByteData();
-        expect(Uint8List.view(data.buffer), Square4x4Image.bytes);
-      });
+  test('Image.toByteData RGBA format works with simple image', () async {
+    final Image image = await Square4x4Image.image;
+    final ByteData data = await image.toByteData();
+    expect(Uint8List.view(data.buffer), Square4x4Image.bytes);
+  });
 
-      test('converts grayscale images', () async {
-        final Image image = await GrayscaleImage.load();
-        final ByteData data = await image.toByteData();
-        final Uint8List bytes = data.buffer.asUint8List();
-        expect(bytes, hasLength(16));
-        expect(bytes, GrayscaleImage.bytesAsRgba);
-      });
-    });
+  test('Image.toByteData RGBA format converts grayscale images', () async {
+    final Image image = await GrayscaleImage.load();
+    final ByteData data = await image.toByteData();
+    final Uint8List bytes = data.buffer.asUint8List();
+    expect(bytes, hasLength(16));
+    expect(bytes, GrayscaleImage.bytesAsRgba);
+  });
 
-    group('Unmodified format', () {
-      test('works with simple image', () async {
-        final Image image = await Square4x4Image.image;
-        final ByteData data = await image.toByteData(format: ImageByteFormat.rawUnmodified);
-        expect(Uint8List.view(data.buffer), Square4x4Image.bytes);
-      });
+  test('Image.toByteData Unmodified format works with simple image', () async {
+    final Image image = await Square4x4Image.image;
+    final ByteData data = await image.toByteData(format: ImageByteFormat.rawUnmodified);
+    expect(Uint8List.view(data.buffer), Square4x4Image.bytes);
+  });
 
-      test('works with grayscale images', () async {
-        final Image image = await GrayscaleImage.load();
-        final ByteData data = await image.toByteData(format: ImageByteFormat.rawUnmodified);
-        final Uint8List bytes = data.buffer.asUint8List();
-        expect(bytes, hasLength(4));
-        expect(bytes, GrayscaleImage.bytesUnmodified);
-      });
-    });
+  test('Image.toByteData Unmodified format works with grayscale images', () async {
+    final Image image = await GrayscaleImage.load();
+    final ByteData data = await image.toByteData(format: ImageByteFormat.rawUnmodified);
+    final Uint8List bytes = data.buffer.asUint8List();
+    expect(bytes, hasLength(4));
+    expect(bytes, GrayscaleImage.bytesUnmodified);
+  });
 
-    group('PNG format', () {
-      test('works with simple image', () async {
-        final Image image = await Square4x4Image.image;
-        final ByteData data = await image.toByteData(format: ImageByteFormat.png);
-        final List<int> expected = await readFile('square.png');
-        expect(Uint8List.view(data.buffer), expected);
-      });
-    });
+  test('Image.toByteData PNG format works with simple image', () async {
+    final Image image = await Square4x4Image.image;
+    final ByteData data = await image.toByteData(format: ImageByteFormat.png);
+    final List<int> expected = await readFile('square.png');
+    expect(Uint8List.view(data.buffer), expected);
   });
 }
 

--- a/testing/dart/geometry_test.dart
+++ b/testing/dart/geometry_test.dart
@@ -10,296 +10,288 @@ import 'dart:ui';
 import 'package:litetest/litetest.dart';
 
 void main() {
-  group('Offset', () {
-    test('OffsetBase.>=', () {
-      expect(const Offset(0, 0) >= const Offset(0, -1), true);
-      expect(const Offset(0, 0) >= const Offset(-1, 0), true);
-      expect(const Offset(0, 0) >= const Offset(-1, -1), true);
-      expect(const Offset(0, 0) >= const Offset(0, 0), true);
-      expect(const Offset(0, 0) >= const Offset(0, double.nan), false);
-      expect(const Offset(0, 0) >= const Offset(double.nan, 0), false);
-      expect(const Offset(0, 0) >= const Offset(10, -10), false);
-    });
-
-    test('OffsetBase.<=', () {
-      expect(const Offset(0, 0) <= const Offset(0, 1), true);
-      expect(const Offset(0, 0) <= const Offset(1, 0), true);
-      expect(const Offset(0, 0) <= const Offset(0, 0), true);
-      expect(const Offset(0, 0) <= const Offset(0, double.nan), false);
-      expect(const Offset(0, 0) <= const Offset(double.nan, 0), false);
-      expect(const Offset(0, 0) <= const Offset(10, -10), false);
-    });
-
-    test('OffsetBase.>', () {
-      expect(const Offset(0, 0) > const Offset(-1, -1), true);
-      expect(const Offset(0, 0) > const Offset(0, -1), false);
-      expect(const Offset(0, 0) > const Offset(-1, 0), false);
-      expect(const Offset(0, 0) > const Offset(double.nan, -1), false);
-    });
-
-    test('OffsetBase.<', () {
-      expect(const Offset(0, 0) < const Offset(1, 1), true);
-      expect(const Offset(0, 0) < const Offset(0, 1), false);
-      expect(const Offset(0, 0) < const Offset(1, 0), false);
-      expect(const Offset(0, 0) < const Offset(double.nan, 1), false);
-    });
-
-    test('OffsetBase.==', () {
-      expect(const Offset(0, 0), equals(const Offset(0, 0)));
-      expect(const Offset(0, 0), notEquals(const Offset(1, 0)));
-      expect(const Offset(0, 0), notEquals(const Offset(0, 1)));
-    });
-
-    test('Offset.direction', () {
-      expect(const Offset(0.0, 0.0).direction, 0.0);
-      expect(const Offset(0.0, 1.0).direction, pi / 2.0);
-      expect(const Offset(0.0, -1.0).direction, -pi / 2.0);
-      expect(const Offset(1.0, 0.0).direction, 0.0);
-      expect(const Offset(1.0, 1.0).direction, pi / 4.0);
-      expect(const Offset(1.0, -1.0).direction, -pi / 4.0);
-      expect(const Offset(-1.0, 0.0).direction, pi);
-      expect(const Offset(-1.0, 1.0).direction, pi * 3.0 / 4.0);
-      expect(const Offset(-1.0, -1.0).direction, -pi * 3.0 / 4.0);
-    });
-
-    test('Offset.fromDirection', () {
-      expect(Offset.fromDirection(0.0, 0.0), const Offset(0.0, 0.0));
-      expect(Offset.fromDirection(pi / 2.0).dx, closeTo(0.0, 1e-12)); // aah, floating point math. i love you so.
-      expect(Offset.fromDirection(pi / 2.0).dy, 1.0);
-      expect(Offset.fromDirection(-pi / 2.0).dx, closeTo(0.0, 1e-12));
-      expect(Offset.fromDirection(-pi / 2.0).dy, -1.0);
-      expect(Offset.fromDirection(0.0), const Offset(1.0, 0.0));
-      expect(Offset.fromDirection(pi / 4.0).dx, closeTo(1.0 / math.sqrt(2.0), 1e-12));
-      expect(Offset.fromDirection(pi / 4.0).dy, closeTo(1.0 / math.sqrt(2.0), 1e-12));
-      expect(Offset.fromDirection(-pi / 4.0).dx, closeTo(1.0 / math.sqrt(2.0), 1e-12));
-      expect(Offset.fromDirection(-pi / 4.0).dy, closeTo(-1.0 / math.sqrt(2.0), 1e-12));
-      expect(Offset.fromDirection(pi).dx, -1.0);
-      expect(Offset.fromDirection(pi).dy, closeTo(0.0, 1e-12));
-      expect(Offset.fromDirection(pi * 3.0 / 4.0).dx, closeTo(-1.0 / math.sqrt(2.0), 1e-12));
-      expect(Offset.fromDirection(pi * 3.0 / 4.0).dy, closeTo(1.0 / math.sqrt(2.0), 1e-12));
-      expect(Offset.fromDirection(-pi * 3.0 / 4.0).dx, closeTo(-1.0 / math.sqrt(2.0), 1e-12));
-      expect(Offset.fromDirection(-pi * 3.0 / 4.0).dy, closeTo(-1.0 / math.sqrt(2.0), 1e-12));
-      expect(Offset.fromDirection(0.0, 2.0), const Offset(2.0, 0.0));
-      expect(Offset.fromDirection(pi / 6, 2.0).dx, closeTo(math.sqrt(3.0), 1e-12));
-      expect(Offset.fromDirection(pi / 6, 2.0).dy, closeTo(1.0, 1e-12));
-    });
+  test('OffsetBase.>=', () {
+    expect(const Offset(0, 0) >= const Offset(0, -1), true);
+    expect(const Offset(0, 0) >= const Offset(-1, 0), true);
+    expect(const Offset(0, 0) >= const Offset(-1, -1), true);
+    expect(const Offset(0, 0) >= const Offset(0, 0), true);
+    expect(const Offset(0, 0) >= const Offset(0, double.nan), false);
+    expect(const Offset(0, 0) >= const Offset(double.nan, 0), false);
+    expect(const Offset(0, 0) >= const Offset(10, -10), false);
   });
 
-  group('Size', () {
-    test('Size created from doubles', () {
-      const Size size = Size(5.0, 7.0);
-      expect(size.width, equals(5.0));
-      expect(size.height, equals(7.0));
-      expect(size.shortestSide, equals(5.0));
-      expect(size.longestSide, equals(7.0));
-    });
-
-    test('Size.aspectRatio', () {
-      expect(const Size(0.0, 0.0).aspectRatio, 0.0);
-      expect(const Size(-0.0, 0.0).aspectRatio, 0.0);
-      expect(const Size(0.0, -0.0).aspectRatio, 0.0);
-      expect(const Size(-0.0, -0.0).aspectRatio, 0.0);
-      expect(const Size(0.0, 1.0).aspectRatio, 0.0);
-      expect(const Size(0.0, -1.0).aspectRatio, -0.0);
-      expect(const Size(1.0, 0.0).aspectRatio, double.infinity);
-      expect(const Size(1.0, 1.0).aspectRatio, 1.0);
-      expect(const Size(1.0, -1.0).aspectRatio, -1.0);
-      expect(const Size(-1.0, 0.0).aspectRatio, -double.infinity);
-      expect(const Size(-1.0, 1.0).aspectRatio, -1.0);
-      expect(const Size(-1.0, -1.0).aspectRatio, 1.0);
-      expect(const Size(3.0, 4.0).aspectRatio, 3.0 / 4.0);
-    });
+  test('OffsetBase.<=', () {
+    expect(const Offset(0, 0) <= const Offset(0, 1), true);
+    expect(const Offset(0, 0) <= const Offset(1, 0), true);
+    expect(const Offset(0, 0) <= const Offset(0, 0), true);
+    expect(const Offset(0, 0) <= const Offset(0, double.nan), false);
+    expect(const Offset(0, 0) <= const Offset(double.nan, 0), false);
+    expect(const Offset(0, 0) <= const Offset(10, -10), false);
   });
 
-  group('Rect', () {
-    test('toString test', () {
-      const Rect r = Rect.fromLTRB(1.0, 3.0, 5.0, 7.0);
-      expect(r.toString(), 'Rect.fromLTRB(1.0, 3.0, 5.0, 7.0)');
-    });
-
-    test('Rect accessors', () {
-      const Rect r = Rect.fromLTRB(1.0, 3.0, 5.0, 7.0);
-      expect(r.left, equals(1.0));
-      expect(r.top, equals(3.0));
-      expect(r.right, equals(5.0));
-      expect(r.bottom, equals(7.0));
-    });
-
-    test('Rect.fromCenter', () {
-      Rect rect = Rect.fromCenter(center: const Offset(1.0, 3.0), width: 5.0, height: 7.0);
-      expect(rect.left, -1.5);
-      expect(rect.top, -0.5);
-      expect(rect.right, 3.5);
-      expect(rect.bottom, 6.5);
-
-      rect = Rect.fromCenter(center: const Offset(0.0, 0.0), width: 0.0, height: 0.0);
-      expect(rect.left, 0.0);
-      expect(rect.top, 0.0);
-      expect(rect.right, 0.0);
-      expect(rect.bottom, 0.0);
-
-      rect = Rect.fromCenter(center: const Offset(double.nan, 0.0), width: 0.0, height: 0.0);
-      expect(rect.left, isNaN);
-      expect(rect.top, 0.0);
-      expect(rect.right, isNaN);
-      expect(rect.bottom, 0.0);
-
-      rect = Rect.fromCenter(center: const Offset(0.0, double.nan), width: 0.0, height: 0.0);
-      expect(rect.left, 0.0);
-      expect(rect.top, isNaN);
-      expect(rect.right, 0.0);
-      expect(rect.bottom, isNaN);
-    });
-
-    test('Rect created by width and height', () {
-      const Rect r = Rect.fromLTWH(1.0, 3.0, 5.0, 7.0);
-      expect(r.left, equals(1.0));
-      expect(r.top, equals(3.0));
-      expect(r.right, equals(6.0));
-      expect(r.bottom, equals(10.0));
-      expect(r.shortestSide, equals(5.0));
-      expect(r.longestSide, equals(7.0));
-    });
-
-    test('Rect intersection', () {
-      const Rect r1 = Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
-      const Rect r2 = Rect.fromLTRB(50.0, 50.0, 200.0, 200.0);
-      final Rect r3 = r1.intersect(r2);
-      expect(r3.left, equals(50.0));
-      expect(r3.top, equals(50.0));
-      expect(r3.right, equals(100.0));
-      expect(r3.bottom, equals(100.0));
-      final Rect r4 = r2.intersect(r1);
-      expect(r4, equals(r3));
-    });
-
-    test('Rect expandToInclude overlapping rects', () {
-      const Rect r1 = Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
-      const Rect r2 = Rect.fromLTRB(50.0, 50.0, 200.0, 200.0);
-      final Rect r3 = r1.expandToInclude(r2);
-      expect(r3.left, equals(0.0));
-      expect(r3.top, equals(0.0));
-      expect(r3.right, equals(200.0));
-      expect(r3.bottom, equals(200.0));
-
-      final Rect r4 = r2.expandToInclude(r1);
-      expect(r4, equals(r3));
-    });
-
-    test('Rect expandToInclude crossing rects', () {
-      const Rect r1 = Rect.fromLTRB(50.0, 0.0, 50.0, 200.0);
-      const Rect r2 = Rect.fromLTRB(0.0, 50.0, 200.0, 50.0);
-      final Rect r3 = r1.expandToInclude(r2);
-      expect(r3.left, equals(0.0));
-      expect(r3.top, equals(0.0));
-      expect(r3.right, equals(200.0));
-      expect(r3.bottom, equals(200.0));
-
-      final Rect r4 = r2.expandToInclude(r1);
-      expect(r4, equals(r3));
-    });
+  test('OffsetBase.>', () {
+    expect(const Offset(0, 0) > const Offset(-1, -1), true);
+    expect(const Offset(0, 0) > const Offset(0, -1), false);
+    expect(const Offset(0, 0) > const Offset(-1, 0), false);
+    expect(const Offset(0, 0) > const Offset(double.nan, -1), false);
   });
 
-  group('RRect', () {
-    test('RRect.fromRectXY', () {
-      const Rect baseRect = Rect.fromLTWH(1.0, 3.0, 5.0, 7.0);
-      final RRect r = RRect.fromRectXY(baseRect, 1.0, 1.0);
-      expect(r.left, equals(1.0));
-      expect(r.top, equals(3.0));
-      expect(r.right, equals(6.0));
-      expect(r.bottom, equals(10.0));
-      expect(r.shortestSide, equals(5.0));
-      expect(r.longestSide, equals(7.0));
-    });
+  test('OffsetBase.<', () {
+    expect(const Offset(0, 0) < const Offset(1, 1), true);
+    expect(const Offset(0, 0) < const Offset(0, 1), false);
+    expect(const Offset(0, 0) < const Offset(1, 0), false);
+    expect(const Offset(0, 0) < const Offset(double.nan, 1), false);
+  });
 
-    test('RRect.contains()', () {
-      final RRect rrect = RRect.fromRectAndCorners(
-        const Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
-        topLeft: const Radius.circular(0.5),
-        topRight: const Radius.circular(0.25),
-        bottomRight: const Radius.elliptical(0.25, 0.75),
-        bottomLeft: Radius.zero,
-      );
+  test('OffsetBase.==', () {
+    expect(const Offset(0, 0), equals(const Offset(0, 0)));
+    expect(const Offset(0, 0), notEquals(const Offset(1, 0)));
+    expect(const Offset(0, 0), notEquals(const Offset(0, 1)));
+  });
 
-      expect(rrect.contains(const Offset(1.0, 1.0)), isFalse);
-      expect(rrect.contains(const Offset(1.1, 1.1)), isFalse);
-      expect(rrect.contains(const Offset(1.15, 1.15)), isTrue);
-      expect(rrect.contains(const Offset(2.0, 1.0)), isFalse);
-      expect(rrect.contains(const Offset(1.93, 1.07)), isFalse);
-      expect(rrect.contains(const Offset(1.97, 1.7)), isFalse);
-      expect(rrect.contains(const Offset(1.7, 1.97)), isTrue);
-      expect(rrect.contains(const Offset(1.0, 1.99)), isTrue);
-    });
+  test('Offset.direction', () {
+    expect(const Offset(0.0, 0.0).direction, 0.0);
+    expect(const Offset(0.0, 1.0).direction, pi / 2.0);
+    expect(const Offset(0.0, -1.0).direction, -pi / 2.0);
+    expect(const Offset(1.0, 0.0).direction, 0.0);
+    expect(const Offset(1.0, 1.0).direction, pi / 4.0);
+    expect(const Offset(1.0, -1.0).direction, -pi / 4.0);
+    expect(const Offset(-1.0, 0.0).direction, pi);
+    expect(const Offset(-1.0, 1.0).direction, pi * 3.0 / 4.0);
+    expect(const Offset(-1.0, -1.0).direction, -pi * 3.0 / 4.0);
+  });
 
-    test('RRect.contains() large radii', () {
-      final RRect rrect = RRect.fromRectAndCorners(
-        const Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
-        topLeft: const Radius.circular(5000.0),
-        topRight: const Radius.circular(2500.0),
-        bottomRight: const Radius.elliptical(2500.0, 7500.0),
-        bottomLeft: Radius.zero,
-      );
+  test('Offset.fromDirection', () {
+    expect(Offset.fromDirection(0.0, 0.0), const Offset(0.0, 0.0));
+    expect(Offset.fromDirection(pi / 2.0).dx, closeTo(0.0, 1e-12)); // aah, floating point math. i love you so.
+    expect(Offset.fromDirection(pi / 2.0).dy, 1.0);
+    expect(Offset.fromDirection(-pi / 2.0).dx, closeTo(0.0, 1e-12));
+    expect(Offset.fromDirection(-pi / 2.0).dy, -1.0);
+    expect(Offset.fromDirection(0.0), const Offset(1.0, 0.0));
+    expect(Offset.fromDirection(pi / 4.0).dx, closeTo(1.0 / math.sqrt(2.0), 1e-12));
+    expect(Offset.fromDirection(pi / 4.0).dy, closeTo(1.0 / math.sqrt(2.0), 1e-12));
+    expect(Offset.fromDirection(-pi / 4.0).dx, closeTo(1.0 / math.sqrt(2.0), 1e-12));
+    expect(Offset.fromDirection(-pi / 4.0).dy, closeTo(-1.0 / math.sqrt(2.0), 1e-12));
+    expect(Offset.fromDirection(pi).dx, -1.0);
+    expect(Offset.fromDirection(pi).dy, closeTo(0.0, 1e-12));
+    expect(Offset.fromDirection(pi * 3.0 / 4.0).dx, closeTo(-1.0 / math.sqrt(2.0), 1e-12));
+    expect(Offset.fromDirection(pi * 3.0 / 4.0).dy, closeTo(1.0 / math.sqrt(2.0), 1e-12));
+    expect(Offset.fromDirection(-pi * 3.0 / 4.0).dx, closeTo(-1.0 / math.sqrt(2.0), 1e-12));
+    expect(Offset.fromDirection(-pi * 3.0 / 4.0).dy, closeTo(-1.0 / math.sqrt(2.0), 1e-12));
+    expect(Offset.fromDirection(0.0, 2.0), const Offset(2.0, 0.0));
+    expect(Offset.fromDirection(pi / 6, 2.0).dx, closeTo(math.sqrt(3.0), 1e-12));
+    expect(Offset.fromDirection(pi / 6, 2.0).dy, closeTo(1.0, 1e-12));
+  });
 
-      expect(rrect.contains(const Offset(1.0, 1.0)), isFalse);
-      expect(rrect.contains(const Offset(1.1, 1.1)), isFalse);
-      expect(rrect.contains(const Offset(1.15, 1.15)), isTrue);
-      expect(rrect.contains(const Offset(2.0, 1.0)), isFalse);
-      expect(rrect.contains(const Offset(1.93, 1.07)), isFalse);
-      expect(rrect.contains(const Offset(1.97, 1.7)), isFalse);
-      expect(rrect.contains(const Offset(1.7, 1.97)), isTrue);
-      expect(rrect.contains(const Offset(1.0, 1.99)), isTrue);
-    });
+  test('Size created from doubles', () {
+    const Size size = Size(5.0, 7.0);
+    expect(size.width, equals(5.0));
+    expect(size.height, equals(7.0));
+    expect(size.shortestSide, equals(5.0));
+    expect(size.longestSide, equals(7.0));
+  });
 
-    test('RRect.scaleRadii() properly constrained radii should remain unchanged', () {
-      final RRect rrect = RRect.fromRectAndCorners(
-        const Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
-        topLeft: const Radius.circular(0.5),
-        topRight: const Radius.circular(0.25),
-        bottomRight: const Radius.elliptical(0.25, 0.75),
-        bottomLeft: Radius.zero,
-      ).scaleRadii();
+  test('Size.aspectRatio', () {
+    expect(const Size(0.0, 0.0).aspectRatio, 0.0);
+    expect(const Size(-0.0, 0.0).aspectRatio, 0.0);
+    expect(const Size(0.0, -0.0).aspectRatio, 0.0);
+    expect(const Size(-0.0, -0.0).aspectRatio, 0.0);
+    expect(const Size(0.0, 1.0).aspectRatio, 0.0);
+    expect(const Size(0.0, -1.0).aspectRatio, -0.0);
+    expect(const Size(1.0, 0.0).aspectRatio, double.infinity);
+    expect(const Size(1.0, 1.0).aspectRatio, 1.0);
+    expect(const Size(1.0, -1.0).aspectRatio, -1.0);
+    expect(const Size(-1.0, 0.0).aspectRatio, -double.infinity);
+    expect(const Size(-1.0, 1.0).aspectRatio, -1.0);
+    expect(const Size(-1.0, -1.0).aspectRatio, 1.0);
+    expect(const Size(3.0, 4.0).aspectRatio, 3.0 / 4.0);
+  });
 
-      // check sides
-      expect(rrect.left, 1.0);
-      expect(rrect.top, 1.0);
-      expect(rrect.right, 2.0);
-      expect(rrect.bottom, 2.0);
+  test('Rect.toString test', () {
+    const Rect r = Rect.fromLTRB(1.0, 3.0, 5.0, 7.0);
+    expect(r.toString(), 'Rect.fromLTRB(1.0, 3.0, 5.0, 7.0)');
+  });
 
-      // check corner radii
-      expect(rrect.tlRadiusX, 0.5);
-      expect(rrect.tlRadiusY, 0.5);
-      expect(rrect.trRadiusX, 0.25);
-      expect(rrect.trRadiusY, 0.25);
-      expect(rrect.blRadiusX, 0.0);
-      expect(rrect.blRadiusY, 0.0);
-      expect(rrect.brRadiusX, 0.25);
-      expect(rrect.brRadiusY, 0.75);
-    });
+  test('Rect accessors', () {
+    const Rect r = Rect.fromLTRB(1.0, 3.0, 5.0, 7.0);
+    expect(r.left, equals(1.0));
+    expect(r.top, equals(3.0));
+    expect(r.right, equals(5.0));
+    expect(r.bottom, equals(7.0));
+  });
 
-    test('RRect.scaleRadii() sum of radii that exceed side length should properly scale', () {
-      final RRect rrect = RRect.fromRectAndCorners(
-        const Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
-        topLeft: const Radius.circular(5000.0),
-        topRight: const Radius.circular(2500.0),
-        bottomRight: const Radius.elliptical(2500.0, 7500.0),
-        bottomLeft: Radius.zero,
-      ).scaleRadii();
+  test('Rect.fromCenter', () {
+    Rect rect = Rect.fromCenter(center: const Offset(1.0, 3.0), width: 5.0, height: 7.0);
+    expect(rect.left, -1.5);
+    expect(rect.top, -0.5);
+    expect(rect.right, 3.5);
+    expect(rect.bottom, 6.5);
 
-      // check sides
-      expect(rrect.left, 1.0);
-      expect(rrect.top, 1.0);
-      expect(rrect.right, 2.0);
-      expect(rrect.bottom, 2.0);
+    rect = Rect.fromCenter(center: const Offset(0.0, 0.0), width: 0.0, height: 0.0);
+    expect(rect.left, 0.0);
+    expect(rect.top, 0.0);
+    expect(rect.right, 0.0);
+    expect(rect.bottom, 0.0);
 
-      // check corner radii
-      expect(rrect.tlRadiusX, 0.5);
-      expect(rrect.tlRadiusY, 0.5);
-      expect(rrect.trRadiusX, 0.25);
-      expect(rrect.trRadiusY, 0.25);
-      expect(rrect.blRadiusX, 0.0);
-      expect(rrect.blRadiusY, 0.0);
-      expect(rrect.brRadiusX, 0.25);
-      expect(rrect.brRadiusY, 0.75);
-    });
+    rect = Rect.fromCenter(center: const Offset(double.nan, 0.0), width: 0.0, height: 0.0);
+    expect(rect.left, isNaN);
+    expect(rect.top, 0.0);
+    expect(rect.right, isNaN);
+    expect(rect.bottom, 0.0);
+
+    rect = Rect.fromCenter(center: const Offset(0.0, double.nan), width: 0.0, height: 0.0);
+    expect(rect.left, 0.0);
+    expect(rect.top, isNaN);
+    expect(rect.right, 0.0);
+    expect(rect.bottom, isNaN);
+  });
+
+  test('Rect created by width and height', () {
+    const Rect r = Rect.fromLTWH(1.0, 3.0, 5.0, 7.0);
+    expect(r.left, equals(1.0));
+    expect(r.top, equals(3.0));
+    expect(r.right, equals(6.0));
+    expect(r.bottom, equals(10.0));
+    expect(r.shortestSide, equals(5.0));
+    expect(r.longestSide, equals(7.0));
+  });
+
+  test('Rect intersection', () {
+    const Rect r1 = Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+    const Rect r2 = Rect.fromLTRB(50.0, 50.0, 200.0, 200.0);
+    final Rect r3 = r1.intersect(r2);
+    expect(r3.left, equals(50.0));
+    expect(r3.top, equals(50.0));
+    expect(r3.right, equals(100.0));
+    expect(r3.bottom, equals(100.0));
+    final Rect r4 = r2.intersect(r1);
+    expect(r4, equals(r3));
+  });
+
+  test('Rect expandToInclude overlapping rects', () {
+    const Rect r1 = Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+    const Rect r2 = Rect.fromLTRB(50.0, 50.0, 200.0, 200.0);
+    final Rect r3 = r1.expandToInclude(r2);
+    expect(r3.left, equals(0.0));
+    expect(r3.top, equals(0.0));
+    expect(r3.right, equals(200.0));
+    expect(r3.bottom, equals(200.0));
+
+    final Rect r4 = r2.expandToInclude(r1);
+    expect(r4, equals(r3));
+  });
+
+  test('Rect expandToInclude crossing rects', () {
+    const Rect r1 = Rect.fromLTRB(50.0, 0.0, 50.0, 200.0);
+    const Rect r2 = Rect.fromLTRB(0.0, 50.0, 200.0, 50.0);
+    final Rect r3 = r1.expandToInclude(r2);
+    expect(r3.left, equals(0.0));
+    expect(r3.top, equals(0.0));
+    expect(r3.right, equals(200.0));
+    expect(r3.bottom, equals(200.0));
+
+    final Rect r4 = r2.expandToInclude(r1);
+    expect(r4, equals(r3));
+  });
+
+  test('RRect.fromRectXY', () {
+    const Rect baseRect = Rect.fromLTWH(1.0, 3.0, 5.0, 7.0);
+    final RRect r = RRect.fromRectXY(baseRect, 1.0, 1.0);
+    expect(r.left, equals(1.0));
+    expect(r.top, equals(3.0));
+    expect(r.right, equals(6.0));
+    expect(r.bottom, equals(10.0));
+    expect(r.shortestSide, equals(5.0));
+    expect(r.longestSide, equals(7.0));
+  });
+
+  test('RRect.contains()', () {
+    final RRect rrect = RRect.fromRectAndCorners(
+      const Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
+      topLeft: const Radius.circular(0.5),
+      topRight: const Radius.circular(0.25),
+      bottomRight: const Radius.elliptical(0.25, 0.75),
+      bottomLeft: Radius.zero,
+    );
+
+    expect(rrect.contains(const Offset(1.0, 1.0)), isFalse);
+    expect(rrect.contains(const Offset(1.1, 1.1)), isFalse);
+    expect(rrect.contains(const Offset(1.15, 1.15)), isTrue);
+    expect(rrect.contains(const Offset(2.0, 1.0)), isFalse);
+    expect(rrect.contains(const Offset(1.93, 1.07)), isFalse);
+    expect(rrect.contains(const Offset(1.97, 1.7)), isFalse);
+    expect(rrect.contains(const Offset(1.7, 1.97)), isTrue);
+    expect(rrect.contains(const Offset(1.0, 1.99)), isTrue);
+  });
+
+  test('RRect.contains() large radii', () {
+    final RRect rrect = RRect.fromRectAndCorners(
+      const Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
+      topLeft: const Radius.circular(5000.0),
+      topRight: const Radius.circular(2500.0),
+      bottomRight: const Radius.elliptical(2500.0, 7500.0),
+      bottomLeft: Radius.zero,
+    );
+
+    expect(rrect.contains(const Offset(1.0, 1.0)), isFalse);
+    expect(rrect.contains(const Offset(1.1, 1.1)), isFalse);
+    expect(rrect.contains(const Offset(1.15, 1.15)), isTrue);
+    expect(rrect.contains(const Offset(2.0, 1.0)), isFalse);
+    expect(rrect.contains(const Offset(1.93, 1.07)), isFalse);
+    expect(rrect.contains(const Offset(1.97, 1.7)), isFalse);
+    expect(rrect.contains(const Offset(1.7, 1.97)), isTrue);
+    expect(rrect.contains(const Offset(1.0, 1.99)), isTrue);
+  });
+
+  test('RRect.scaleRadii() properly constrained radii should remain unchanged', () {
+    final RRect rrect = RRect.fromRectAndCorners(
+      const Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
+      topLeft: const Radius.circular(0.5),
+      topRight: const Radius.circular(0.25),
+      bottomRight: const Radius.elliptical(0.25, 0.75),
+      bottomLeft: Radius.zero,
+    ).scaleRadii();
+
+    // check sides
+    expect(rrect.left, 1.0);
+    expect(rrect.top, 1.0);
+    expect(rrect.right, 2.0);
+    expect(rrect.bottom, 2.0);
+
+    // check corner radii
+    expect(rrect.tlRadiusX, 0.5);
+    expect(rrect.tlRadiusY, 0.5);
+    expect(rrect.trRadiusX, 0.25);
+    expect(rrect.trRadiusY, 0.25);
+    expect(rrect.blRadiusX, 0.0);
+    expect(rrect.blRadiusY, 0.0);
+    expect(rrect.brRadiusX, 0.25);
+    expect(rrect.brRadiusY, 0.75);
+  });
+
+  test('RRect.scaleRadii() sum of radii that exceed side length should properly scale', () {
+    final RRect rrect = RRect.fromRectAndCorners(
+      const Rect.fromLTRB(1.0, 1.0, 2.0, 2.0),
+      topLeft: const Radius.circular(5000.0),
+      topRight: const Radius.circular(2500.0),
+      bottomRight: const Radius.elliptical(2500.0, 7500.0),
+      bottomLeft: Radius.zero,
+    ).scaleRadii();
+
+    // check sides
+    expect(rrect.left, 1.0);
+    expect(rrect.top, 1.0);
+    expect(rrect.right, 2.0);
+    expect(rrect.bottom, 2.0);
+
+    // check corner radii
+    expect(rrect.tlRadiusX, 0.5);
+    expect(rrect.tlRadiusY, 0.5);
+    expect(rrect.trRadiusX, 0.25);
+    expect(rrect.trRadiusY, 0.25);
+    expect(rrect.blRadiusX, 0.0);
+    expect(rrect.blRadiusY, 0.0);
+    expect(rrect.brRadiusX, 0.25);
+    expect(rrect.brRadiusY, 0.75);
   });
 }

--- a/testing/dart/text_test.dart
+++ b/testing/dart/text_test.dart
@@ -9,187 +9,187 @@ import 'dart:ui';
 
 import 'package:litetest/litetest.dart';
 
-void main() {
-  group('FontWeight.lerp', () {
-    test('works with non-null values', () {
-      expect(FontWeight.lerp(FontWeight.w400, FontWeight.w600, .5), equals(FontWeight.w500));
-    });
-
-    test('returns null if a and b are null', () {
-      expect(FontWeight.lerp(null, null, 0), isNull);
-    });
-
-    test('returns FontWeight.w400 if a is null', () {
-      expect(FontWeight.lerp(null, FontWeight.w400, 0), equals(FontWeight.w400));
-    });
-
-    test('returns FontWeight.w400 if b is null', () {
-      expect(FontWeight.lerp(FontWeight.w400, null, 1), equals(FontWeight.w400));
-    });
+void testFontWeightLerp() {
+  test('FontWeight.lerp works with non-null values', () {
+    expect(FontWeight.lerp(FontWeight.w400, FontWeight.w600, .5), equals(FontWeight.w500));
   });
 
-  group('ParagraphStyle', () {
-    final ParagraphStyle ps0 = ParagraphStyle(textDirection: TextDirection.ltr, fontSize: 14.0);
-    final ParagraphStyle ps1 = ParagraphStyle(textDirection: TextDirection.rtl, fontSize: 14.0);
-    final ParagraphStyle ps2 = ParagraphStyle(textAlign: TextAlign.center, fontWeight: FontWeight.w800, fontSize: 10.0, height: 100.0);
-    final ParagraphStyle ps3 = ParagraphStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0);
-
-    test('toString works', () {
-      expect(ps0.toString(), equals('ParagraphStyle(textAlign: unspecified, textDirection: TextDirection.ltr, fontWeight: unspecified, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 14.0, height: unspecified, ellipsis: unspecified, locale: unspecified)'));
-      expect(ps1.toString(), equals('ParagraphStyle(textAlign: unspecified, textDirection: TextDirection.rtl, fontWeight: unspecified, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 14.0, height: unspecified, ellipsis: unspecified, locale: unspecified)'));
-      expect(ps2.toString(), equals('ParagraphStyle(textAlign: TextAlign.center, textDirection: unspecified, fontWeight: FontWeight.w800, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 10.0, height: 100.0x, ellipsis: unspecified, locale: unspecified)'));
-      expect(ps3.toString(), equals('ParagraphStyle(textAlign: unspecified, textDirection: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 12.0, height: 123.0x, ellipsis: unspecified, locale: unspecified)'));
-    });
+  test('FontWeight.lerp returns null if a and b are null', () {
+    expect(FontWeight.lerp(null, null, 0), isNull);
   });
 
-  group('TextStyle', () {
-    final TextStyle ts0 = TextStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0);
-    final TextStyle ts1 = TextStyle(color: const Color(0xFF00FF00), fontWeight: FontWeight.w800, fontSize: 10.0, height: 100.0);
-    final TextStyle ts2 = TextStyle(fontFamily: 'test');
-    final TextStyle ts3 = TextStyle(fontFamily: 'foo', fontFamilyFallback: <String>['Roboto', 'test']);
-    final TextStyle ts4 = TextStyle(leadingDistribution: TextLeadingDistribution.even);
-
-    test('toString works', () {
-      expect(
-        ts0.toString(),
-        equals('TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontFamilyFallback: unspecified, fontSize: 12.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 123.0x, leadingDistribution: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
-      );
-      expect(
-        ts1.toString(),
-        equals('TextStyle(color: Color(0xff00ff00), decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: FontWeight.w800, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontFamilyFallback: unspecified, fontSize: 10.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 100.0x, leadingDistribution: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
-      );
-      expect(
-        ts2.toString(),
-        equals('TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: test, fontFamilyFallback: unspecified, fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, leadingDistribution: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
-      );
-      expect(
-        ts3.toString(),
-        equals('TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: foo, fontFamilyFallback: [Roboto, test], fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, leadingDistribution: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
-      );
-      expect(
-        ts4.toString(),
-        equals('TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontFamilyFallback: unspecified, fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, leadingDistribution: TextLeadingDistribution.even, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
-      );
-    });
+  test('FontWeight.lerp returns FontWeight.w400 if a is null', () {
+    expect(FontWeight.lerp(null, FontWeight.w400, 0), equals(FontWeight.w400));
   });
 
-  group('TextHeightBehavior', () {
-    const TextHeightBehavior behavior0 = TextHeightBehavior();
-    const TextHeightBehavior behavior1 = TextHeightBehavior(
-      applyHeightToFirstAscent: false,
-      applyHeightToLastDescent: false
+  test('FontWeight.lerp returns FontWeight.w400 if b is null', () {
+    expect(FontWeight.lerp(FontWeight.w400, null, 1), equals(FontWeight.w400));
+  });
+}
+
+void testParagraphStyle() {
+  final ParagraphStyle ps0 = ParagraphStyle(textDirection: TextDirection.ltr, fontSize: 14.0);
+  final ParagraphStyle ps1 = ParagraphStyle(textDirection: TextDirection.rtl, fontSize: 14.0);
+  final ParagraphStyle ps2 = ParagraphStyle(textAlign: TextAlign.center, fontWeight: FontWeight.w800, fontSize: 10.0, height: 100.0);
+  final ParagraphStyle ps3 = ParagraphStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0);
+
+  test('ParagraphStyle toString works', () {
+    expect(ps0.toString(), equals('ParagraphStyle(textAlign: unspecified, textDirection: TextDirection.ltr, fontWeight: unspecified, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 14.0, height: unspecified, ellipsis: unspecified, locale: unspecified)'));
+    expect(ps1.toString(), equals('ParagraphStyle(textAlign: unspecified, textDirection: TextDirection.rtl, fontWeight: unspecified, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 14.0, height: unspecified, ellipsis: unspecified, locale: unspecified)'));
+    expect(ps2.toString(), equals('ParagraphStyle(textAlign: TextAlign.center, textDirection: unspecified, fontWeight: FontWeight.w800, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 10.0, height: 100.0x, ellipsis: unspecified, locale: unspecified)'));
+    expect(ps3.toString(), equals('ParagraphStyle(textAlign: unspecified, textDirection: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, maxLines: unspecified, textHeightBehavior: unspecified, fontFamily: unspecified, fontSize: 12.0, height: 123.0x, ellipsis: unspecified, locale: unspecified)'));
+  });
+}
+
+void testTextStyle() {
+  final TextStyle ts0 = TextStyle(fontWeight: FontWeight.w700, fontSize: 12.0, height: 123.0);
+  final TextStyle ts1 = TextStyle(color: const Color(0xFF00FF00), fontWeight: FontWeight.w800, fontSize: 10.0, height: 100.0);
+  final TextStyle ts2 = TextStyle(fontFamily: 'test');
+  final TextStyle ts3 = TextStyle(fontFamily: 'foo', fontFamilyFallback: <String>['Roboto', 'test']);
+  final TextStyle ts4 = TextStyle(leadingDistribution: TextLeadingDistribution.even);
+
+  test('TextStyle toString works', () {
+    expect(
+      ts0.toString(),
+      equals('TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: FontWeight.w700, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontFamilyFallback: unspecified, fontSize: 12.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 123.0x, leadingDistribution: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
     );
-    const TextHeightBehavior behavior2 = TextHeightBehavior(
-      applyHeightToFirstAscent: false,
+    expect(
+      ts1.toString(),
+      equals('TextStyle(color: Color(0xff00ff00), decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: FontWeight.w800, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontFamilyFallback: unspecified, fontSize: 10.0, letterSpacing: unspecified, wordSpacing: unspecified, height: 100.0x, leadingDistribution: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
     );
-    const TextHeightBehavior behavior3 = TextHeightBehavior(
-      applyHeightToLastDescent: false
+    expect(
+      ts2.toString(),
+      equals('TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: test, fontFamilyFallback: unspecified, fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, leadingDistribution: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
     );
-    const TextHeightBehavior behavior4 = TextHeightBehavior(
-      applyHeightToLastDescent: false,
-      leadingDistribution: TextLeadingDistribution.even,
+    expect(
+      ts3.toString(),
+      equals('TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: foo, fontFamilyFallback: [Roboto, test], fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, leadingDistribution: unspecified, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
     );
+    expect(
+      ts4.toString(),
+      equals('TextStyle(color: unspecified, decoration: unspecified, decorationColor: unspecified, decorationStyle: unspecified, decorationThickness: unspecified, fontWeight: unspecified, fontStyle: unspecified, textBaseline: unspecified, fontFamily: unspecified, fontFamilyFallback: unspecified, fontSize: unspecified, letterSpacing: unspecified, wordSpacing: unspecified, height: unspecified, leadingDistribution: TextLeadingDistribution.even, locale: unspecified, background: unspecified, foreground: unspecified, shadows: unspecified, fontFeatures: unspecified)'),
+    );
+  });
+}
 
-    test('default constructor works', () {
-      expect(behavior0.applyHeightToFirstAscent, equals(true));
-      expect(behavior0.applyHeightToLastDescent, equals(true));
+void testTextHeightBehavior() {
+  const TextHeightBehavior behavior0 = TextHeightBehavior();
+  const TextHeightBehavior behavior1 = TextHeightBehavior(
+    applyHeightToFirstAscent: false,
+    applyHeightToLastDescent: false
+  );
+  const TextHeightBehavior behavior2 = TextHeightBehavior(
+    applyHeightToFirstAscent: false,
+  );
+  const TextHeightBehavior behavior3 = TextHeightBehavior(
+    applyHeightToLastDescent: false
+  );
+  const TextHeightBehavior behavior4 = TextHeightBehavior(
+    applyHeightToLastDescent: false,
+    leadingDistribution: TextLeadingDistribution.even,
+  );
 
-      expect(behavior1.applyHeightToFirstAscent, equals(false));
-      expect(behavior1.applyHeightToLastDescent, equals(false));
+  test('TextHeightBehavior default constructor works', () {
+    expect(behavior0.applyHeightToFirstAscent, equals(true));
+    expect(behavior0.applyHeightToLastDescent, equals(true));
 
-      expect(behavior2.applyHeightToFirstAscent, equals(false));
-      expect(behavior2.applyHeightToLastDescent, equals(true));
+    expect(behavior1.applyHeightToFirstAscent, equals(false));
+    expect(behavior1.applyHeightToLastDescent, equals(false));
 
-      expect(behavior3.applyHeightToFirstAscent, equals(true));
-      expect(behavior3.applyHeightToLastDescent, equals(false));
+    expect(behavior2.applyHeightToFirstAscent, equals(false));
+    expect(behavior2.applyHeightToLastDescent, equals(true));
 
-      expect(behavior4.applyHeightToLastDescent, equals(false));
-      expect(behavior4.leadingDistribution, equals(TextLeadingDistribution.even));
-    });
+    expect(behavior3.applyHeightToFirstAscent, equals(true));
+    expect(behavior3.applyHeightToLastDescent, equals(false));
 
-    test('toString works', () {
-      expect(behavior0.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: true, applyHeightToLastDescent: true, leadingDistribution: TextLeadingDistribution.proportional)'));
-      expect(behavior1.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: false, applyHeightToLastDescent: false, leadingDistribution: TextLeadingDistribution.proportional)'));
-      expect(behavior2.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: false, applyHeightToLastDescent: true, leadingDistribution: TextLeadingDistribution.proportional)'));
-      expect(behavior3.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: true, applyHeightToLastDescent: false, leadingDistribution: TextLeadingDistribution.proportional)'));
-      expect(behavior4.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: true, applyHeightToLastDescent: false, leadingDistribution: TextLeadingDistribution.even)'));
-    });
+    expect(behavior4.applyHeightToLastDescent, equals(false));
+    expect(behavior4.leadingDistribution, equals(TextLeadingDistribution.even));
   });
 
-  group('TextRange', () {
-    test('empty ranges are correct', () {
-      const TextRange range = TextRange(start: -1, end: -1);
-      expect(range, equals(const TextRange.collapsed(-1)));
-      expect(range, equals(TextRange.empty));
-    });
-    test('isValid works', () {
-      expect(TextRange.empty.isValid, isFalse);
-      expect(const TextRange(start: 0, end: 0).isValid, isTrue);
-      expect(const TextRange(start: 0, end: 10).isValid, isTrue);
-      expect(const TextRange(start: 10, end: 10).isValid, isTrue);
-      expect(const TextRange(start: -1, end: 10).isValid, isFalse);
-      expect(const TextRange(start: 10, end: 0).isValid, isTrue);
-      expect(const TextRange(start: 10, end: -1).isValid, isFalse);
-    });
-    test('isCollapsed works', () {
-      expect(TextRange.empty.isCollapsed, isTrue);
-      expect(const TextRange(start: 0, end: 0).isCollapsed, isTrue);
-      expect(const TextRange(start: 0, end: 10).isCollapsed, isFalse);
-      expect(const TextRange(start: 10, end: 10).isCollapsed, isTrue);
-      expect(const TextRange(start: -1, end: 10).isCollapsed, isFalse);
-      expect(const TextRange(start: 10, end: 0).isCollapsed, isFalse);
-      expect(const TextRange(start: 10, end: -1).isCollapsed, isFalse);
-    });
-    test('isNormalized works', () {
-      expect(TextRange.empty.isNormalized, isTrue);
-      expect(const TextRange(start: 0, end: 0).isNormalized, isTrue);
-      expect(const TextRange(start: 0, end: 10).isNormalized, isTrue);
-      expect(const TextRange(start: 10, end: 10).isNormalized, isTrue);
-      expect(const TextRange(start: -1, end: 10).isNormalized, isTrue);
-      expect(const TextRange(start: 10, end: 0).isNormalized, isFalse);
-      expect(const TextRange(start: 10, end: -1).isNormalized, isFalse);
-    });
-    test('textBefore works', () {
-      expect(const TextRange(start: 0, end: 0).textBefore('hello'), isEmpty);
-      expect(const TextRange(start: 1, end: 1).textBefore('hello'), equals('h'));
-      expect(const TextRange(start: 1, end: 2).textBefore('hello'), equals('h'));
-      expect(const TextRange(start: 5, end: 5).textBefore('hello'), equals('hello'));
-      expect(const TextRange(start: 0, end: 5).textBefore('hello'), isEmpty);
-    });
-    test('textAfter works', () {
-      expect(const TextRange(start: 0, end: 0).textAfter('hello'), equals('hello'));
-      expect(const TextRange(start: 1, end: 1).textAfter('hello'), equals('ello'));
-      expect(const TextRange(start: 1, end: 2).textAfter('hello'), equals('llo'));
-      expect(const TextRange(start: 5, end: 5).textAfter('hello'), isEmpty);
-      expect(const TextRange(start: 0, end: 5).textAfter('hello'), isEmpty);
-    });
-    test('textInside works', () {
-      expect(const TextRange(start: 0, end: 0).textInside('hello'), isEmpty);
-      expect(const TextRange(start: 1, end: 1).textInside('hello'), isEmpty);
-      expect(const TextRange(start: 1, end: 2).textInside('hello'), equals('e'));
-      expect(const TextRange(start: 5, end: 5).textInside('hello'), isEmpty);
-      expect(const TextRange(start: 0, end: 5).textInside('hello'), equals('hello'));
-    });
+  test('TextHeightBehavior toString works', () {
+    expect(behavior0.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: true, applyHeightToLastDescent: true, leadingDistribution: TextLeadingDistribution.proportional)'));
+    expect(behavior1.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: false, applyHeightToLastDescent: false, leadingDistribution: TextLeadingDistribution.proportional)'));
+    expect(behavior2.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: false, applyHeightToLastDescent: true, leadingDistribution: TextLeadingDistribution.proportional)'));
+    expect(behavior3.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: true, applyHeightToLastDescent: false, leadingDistribution: TextLeadingDistribution.proportional)'));
+    expect(behavior4.toString(), equals('TextHeightBehavior(applyHeightToFirstAscent: true, applyHeightToLastDescent: false, leadingDistribution: TextLeadingDistribution.even)'));
   });
+}
 
-  group('loadFontFromList', () {
-    test('will send platform message after font is loaded', () async {
-      final PlatformMessageCallback oldHandler = window.onPlatformMessage;
-      String actualName;
-      String message;
-      window.onPlatformMessage = (String name, ByteData data, PlatformMessageResponseCallback callback) {
-        actualName = name;
-        final Uint8List list = data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
-        message = utf8.decode(list);
-      };
-      final Uint8List fontData = Uint8List(0);
-      await loadFontFromList(fontData, fontFamily: 'fake');
-      window.onPlatformMessage = oldHandler;
-      expect(actualName, 'flutter/system');
-      expect(message, '{"type":"fontsChange"}');
-    });
+void testTextRange() {
+  test('TextRange empty ranges are correct', () {
+    const TextRange range = TextRange(start: -1, end: -1);
+    expect(range, equals(const TextRange.collapsed(-1)));
+    expect(range, equals(TextRange.empty));
   });
+  test('TextRange isValid works', () {
+    expect(TextRange.empty.isValid, isFalse);
+    expect(const TextRange(start: 0, end: 0).isValid, isTrue);
+    expect(const TextRange(start: 0, end: 10).isValid, isTrue);
+    expect(const TextRange(start: 10, end: 10).isValid, isTrue);
+    expect(const TextRange(start: -1, end: 10).isValid, isFalse);
+    expect(const TextRange(start: 10, end: 0).isValid, isTrue);
+    expect(const TextRange(start: 10, end: -1).isValid, isFalse);
+  });
+  test('TextRange isCollapsed works', () {
+    expect(TextRange.empty.isCollapsed, isTrue);
+    expect(const TextRange(start: 0, end: 0).isCollapsed, isTrue);
+    expect(const TextRange(start: 0, end: 10).isCollapsed, isFalse);
+    expect(const TextRange(start: 10, end: 10).isCollapsed, isTrue);
+    expect(const TextRange(start: -1, end: 10).isCollapsed, isFalse);
+    expect(const TextRange(start: 10, end: 0).isCollapsed, isFalse);
+    expect(const TextRange(start: 10, end: -1).isCollapsed, isFalse);
+  });
+  test('TextRange isNormalized works', () {
+    expect(TextRange.empty.isNormalized, isTrue);
+    expect(const TextRange(start: 0, end: 0).isNormalized, isTrue);
+    expect(const TextRange(start: 0, end: 10).isNormalized, isTrue);
+    expect(const TextRange(start: 10, end: 10).isNormalized, isTrue);
+    expect(const TextRange(start: -1, end: 10).isNormalized, isTrue);
+    expect(const TextRange(start: 10, end: 0).isNormalized, isFalse);
+    expect(const TextRange(start: 10, end: -1).isNormalized, isFalse);
+  });
+  test('TextRange textBefore works', () {
+    expect(const TextRange(start: 0, end: 0).textBefore('hello'), isEmpty);
+    expect(const TextRange(start: 1, end: 1).textBefore('hello'), equals('h'));
+    expect(const TextRange(start: 1, end: 2).textBefore('hello'), equals('h'));
+    expect(const TextRange(start: 5, end: 5).textBefore('hello'), equals('hello'));
+    expect(const TextRange(start: 0, end: 5).textBefore('hello'), isEmpty);
+  });
+  test('TextRange textAfter works', () {
+    expect(const TextRange(start: 0, end: 0).textAfter('hello'), equals('hello'));
+    expect(const TextRange(start: 1, end: 1).textAfter('hello'), equals('ello'));
+    expect(const TextRange(start: 1, end: 2).textAfter('hello'), equals('llo'));
+    expect(const TextRange(start: 5, end: 5).textAfter('hello'), isEmpty);
+    expect(const TextRange(start: 0, end: 5).textAfter('hello'), isEmpty);
+  });
+  test('TextRange textInside works', () {
+    expect(const TextRange(start: 0, end: 0).textInside('hello'), isEmpty);
+    expect(const TextRange(start: 1, end: 1).textInside('hello'), isEmpty);
+    expect(const TextRange(start: 1, end: 2).textInside('hello'), equals('e'));
+    expect(const TextRange(start: 5, end: 5).textInside('hello'), isEmpty);
+    expect(const TextRange(start: 0, end: 5).textInside('hello'), equals('hello'));
+  });
+}
 
+void testLoadFontFromList() {
+  test('loadFontFromList will send platform message after font is loaded', () async {
+    final PlatformMessageCallback oldHandler = window.onPlatformMessage;
+    String actualName;
+    String message;
+    window.onPlatformMessage = (String name, ByteData data, PlatformMessageResponseCallback callback) {
+      actualName = name;
+      final Uint8List list = data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+      message = utf8.decode(list);
+    };
+    final Uint8List fontData = Uint8List(0);
+    await loadFontFromList(fontData, fontFamily: 'fake');
+    window.onPlatformMessage = oldHandler;
+    expect(actualName, 'flutter/system');
+    expect(message, '{"type":"fontsChange"}');
+  });
+}
+
+void testFontFeatureClass() {
   test('FontFeature class', () {
     expect(const FontFeature.alternative(1), const FontFeature('aalt', 1));
     expect(const FontFeature.alternative(5), const FontFeature('aalt', 5));
@@ -230,4 +230,14 @@ void main() {
     expect(const FontFeature('FEAT', 1000).value, 1000);
     expect(const FontFeature('FEAT', 1000).toString(), "FontFeature('FEAT', 1000)");
   });
+}
+
+void main() {
+  testFontWeightLerp();
+  testParagraphStyle();
+  testTextStyle();
+  testTextHeightBehavior();
+  testTextRange();
+  testLoadFontFromList();
+  testFontFeatureClass();
 }

--- a/testing/litetest/lib/litetest.dart
+++ b/testing/litetest/lib/litetest.dart
@@ -27,11 +27,3 @@ void test(
 }) {
   _testSuite.test(name, body, skip: skip);
 }
-
-/// Describes a group of tests whose names will be prefixed with [name].
-///
-/// All calls to [group] must be made in the same event as the program's
-/// `main()` function.
-void group(String name, void Function() body) {
-  _testSuite.group(name, body);
-}

--- a/testing/litetest/test/litetest_test.dart
+++ b/testing/litetest/test/litetest_test.dart
@@ -97,57 +97,6 @@ Test "Test3": Passed
     expect(output.contains('Test "Test3": Passed'), true);
   });
 
-  test('group', () async {
-    final StringBuffer buffer = StringBuffer();
-    final TestLifecycle lifecycle = TestLifecycle();
-    final TestSuite ts = TestSuite(
-      logger: buffer,
-      lifecycle: lifecycle,
-    );
-
-    ts.group('Group', () {
-      ts.test('Test', () {
-        expect(1, equals(1));
-      });
-    });
-    final bool result = await lifecycle.result;
-
-    expect(result, true);
-    expect(buffer.toString(), equals(
-      'Test "Group Test": Started\nTest "Group Test": Passed\n',
-    ));
-  });
-
-  test('nested group', () async {
-    final StringBuffer buffer = StringBuffer();
-    final TestLifecycle lifecycle = TestLifecycle();
-    final TestSuite ts = TestSuite(
-      logger: buffer,
-      lifecycle: lifecycle,
-    );
-
-    ts.group('Outer group', () {
-      ts.group('Inner group', () {
-        ts.test('Test1', () {
-          expect(1, equals(1));
-        });
-      });
-      ts.test('Test2', () {
-        expect(1, equals(1));
-      });
-    });
-    final bool result = await lifecycle.result;
-
-    expect(result, true);
-    expect(buffer.toString(), equals('''
-Test "Outer group Inner group Test1": Started
-Test "Outer group Inner group Test1": Passed
-Test "Outer group Test2": Started
-Test "Outer group Test2": Passed
-''',
-    ));
-  });
-
   test('test fail', () async {
     final StringBuffer buffer = StringBuffer();
     final TestLifecycle lifecycle = TestLifecycle();


### PR DESCRIPTION
As discussed on https://github.com/flutter/engine/pull/26215, this PR removes `group()` from `package:litetest` along with its uses.