### PR TITLE
MacOS: Do not send key event if modifiers flags haven't changed

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -54,7 +54,7 @@
         type = @"keydown";
       } else {
         // ignore duplicate modifiers; This can happen in situations like switching
-        // between application window when MacOS only sends the up event to new window.
+        // between application windows when MacOS only sends the up event to new window.
         return;
       }
       break;

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -50,8 +50,12 @@
     case NSEventTypeFlagsChanged:
       if (event.modifierFlags < _previouslyPressedFlags) {
         type = @"keyup";
-      } else {
+      } else if (event.modifierFlags > _previouslyPressedFlags) {
         type = @"keydown";
+      } else {
+        // ignore duplicate modifiers; This can happen in situations like switching
+        // between application window when MacOS only sends the up event to new window.
+        return;
       }
       break;
     default:

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
@@ -170,6 +170,16 @@ TEST(FlutterChannelKeyResponderUnittests, BasicKeyEvent) {
 
   [messages removeAllObjects];
   [responses removeAllObjects];
+
+  // RShift up again, should be ignored and not produce a keydown event.
+  next_response = false;
+  [responder handleEvent:keyEvent(NSEventTypeFlagsChanged, 0x100, @"", @"", FALSE, 60)
+                callback:^(BOOL handled) {
+                  [responses addObject:@(handled)];
+                }];
+
+  EXPECT_EQ([messages count], 0u);
+  EXPECT_EQ([responses count], 0u);
 }
 
 TEST(FlutterChannelKeyResponderUnittests, EmptyResponseIsTakenAsHandled) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/77535

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
