### PR TITLE
fuchsia: Fix View create vs render race

### DIFF
--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -218,16 +218,18 @@ void SceneUpdateContext::UpdateView(int64_t view_id,
 }
 
 void SceneUpdateContext::CreateView(int64_t view_id,
-                                    ViewHolder::ViewIdCallback on_view_created,
+                                    ViewCallback on_view_created,
+                                    ViewHolder::ViewIdCallback on_view_bound,
                                     bool hit_testable,
                                     bool focusable) {
   FML_LOG(INFO) << "CreateView for view holder: " << view_id;
   zx_handle_t handle = (zx_handle_t)view_id;
-  flutter::ViewHolder::Create(handle, std::move(on_view_created),
+  flutter::ViewHolder::Create(handle, std::move(on_view_bound),
                               scenic::ToViewHolderToken(zx::eventpair(handle)));
+  on_view_created();
+
   auto* view_holder = ViewHolder::FromId(view_id);
   FML_DCHECK(view_holder);
-
   view_holder->set_hit_testable(hit_testable);
   view_holder->set_focusable(focusable);
 }

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -120,6 +120,8 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
     std::vector<Layer*> layers;
   };
 
+  using ViewCallback = std::function<void()>;
+
   SceneUpdateContext(std::string debug_label,
                      fuchsia::ui::views::ViewToken view_token,
                      scenic::ViewRefPair view_ref_pair,
@@ -170,7 +172,8 @@ class SceneUpdateContext : public flutter::ExternalViewEmbedder {
 
   // View manipulation.
   void CreateView(int64_t view_id,
-                  ViewHolder::ViewIdCallback on_view_created,
+                  ViewCallback on_view_created,
+                  ViewHolder::ViewIdCallback on_view_bound,
                   bool hit_testable,
                   bool focusable);
   void DestroyView(int64_t view_id,

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -109,6 +109,7 @@ class Engine final {
 
   void DebugWireframeSettingsChanged(bool enabled);
   void CreateView(int64_t view_id,
+                  ViewCallback on_view_created,
                   ViewIdCallback on_view_bound,
                   bool hit_testable,
                   bool focusable);

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.cc
@@ -508,6 +508,7 @@ void FuchsiaExternalViewEmbedder::EnableWireframe(bool enable) {
 }
 
 void FuchsiaExternalViewEmbedder::CreateView(int64_t view_id,
+                                             ViewCallback on_view_created,
                                              ViewIdCallback on_view_bound) {
   FML_CHECK(scenic_views_.find(view_id) == scenic_views_.end());
 
@@ -519,6 +520,7 @@ void FuchsiaExternalViewEmbedder::CreateView(int64_t view_id,
           scenic::ToViewHolderToken(zx::eventpair((zx_handle_t)view_id)),
           "Flutter::PlatformView"),
   };
+  on_view_created();
   on_view_bound(new_view.view_holder.id());
 
   new_view.opacity_node.SetLabel("flutter::PlatformView::OpacityMutator");

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
@@ -32,6 +32,7 @@
 
 namespace flutter_runner {
 
+using ViewCallback = std::function<void()>;
 using ViewIdCallback = std::function<void(scenic::ResourceId)>;
 
 // This class orchestrates interaction with the Scenic compositor on Fuchsia. It
@@ -93,7 +94,9 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
   // |SetViewProperties| doesn't manipulate the view directly -- it sets pending
   // properties for the next |UpdateView| call.
   void EnableWireframe(bool enable);
-  void CreateView(int64_t view_id, ViewIdCallback on_view_bound);
+  void CreateView(int64_t view_id,
+                  ViewCallback on_view_created,
+                  ViewIdCallback on_view_bound);
   void DestroyView(int64_t view_id, ViewIdCallback on_view_unbound);
   void SetViewProperties(int64_t view_id,
                          const SkRect& occlusion_hint,

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -30,7 +30,8 @@
 namespace flutter_runner {
 
 using OnEnableWireframe = fit::function<void(bool)>;
-using OnCreateView = fit::function<void(int64_t, ViewIdCallback, bool, bool)>;
+using OnCreateView =
+    fit::function<void(int64_t, ViewCallback, ViewIdCallback, bool, bool)>;
 using OnUpdateView = fit::function<void(int64_t, SkRect, bool, bool)>;
 using OnDestroyView = fit::function<void(int64_t, ViewIdCallback)>;
 using OnCreateSurface = fit::function<std::unique_ptr<flutter::Surface>()>;

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -607,9 +607,11 @@ TEST_F(PlatformViewTests, CreateViewTest) {
   bool create_view_called = false;
   auto CreateViewCallback = [&create_view_called](
                                 int64_t view_id,
+                                flutter_runner::ViewCallback on_view_created,
                                 flutter_runner::ViewIdCallback on_view_bound,
                                 bool hit_testable, bool focusable) {
     create_view_called = true;
+    on_view_created();
     on_view_bound(0);
   };
 
@@ -843,9 +845,11 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
       );
 
   auto on_create_view = [kViewId](int64_t view_id,
+                                  flutter_runner::ViewCallback on_view_created,
                                   flutter_runner::ViewIdCallback on_view_bound,
                                   bool hit_testable, bool focusable) {
     ASSERT_EQ(view_id, kViewId);
+    on_view_created();
     on_view_bound(kViewHolderId);
   };
 


### PR DESCRIPTION
When creating a platform view on Fuchsia, currently it is possible for the raster thread to process the PlatformViewLayer() for that View before underlying process of View creation on the raster thread is complete.

This leads to a failure when rendering the first frame that contains the child View.  This shows up a lot in Fuchsia E2E tests.  It seems we don't see this in practice in a "real" flutter app, since subsequent frames after the first will look correct -- only the E2E tests are simple enough to draw only one frame and then stop.

With this fix, I am able to run the E2E test hundreds of times without failure. :)

Test: Ran workstation, ran internal tests, ran fx test flutter-embedder-test x100