### PR TITLE
Fix race with engine destruction in `Shell`

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -427,8 +427,8 @@ Shell::~Shell() {
 
   fml::TaskRunner::RunNowOrPostTask(
       task_runners_.GetUITaskRunner(),
-      fml::MakeCopyable([engine = std::move(engine_), &ui_latch]() mutable {
-        engine.reset();
+      fml::MakeCopyable([this, &ui_latch]() mutable {
+        engine_.reset();
         ui_latch.Signal();
       }));
   ui_latch.Wait();


### PR DESCRIPTION
When `Shell`'s dtor gets invoked, `engine_` can still
be active, calling `std::move(engine_)` within the lambda
capture args can then cause `engine_` to be nulled out while
still in use. This causes code like this to fail:

```
if (engine_) {
  // at this point `engine_` could be `std::move`d.
  engine_->DoSomething();
}

```

Fixes: https://github.com/flutter/flutter/issues/83221
