### PR TITLE
Delete framework test from Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,30 +30,6 @@ task:
     mv $CIRRUS_WORKING_DIR flutter
     gclient sync
   matrix:
-    # The following test depends on Flutter framework repo. It may fail if the
-    # framework repo is currently broken.
-    - name: build_and_test_linux_unopt_debug
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      test_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/testing/run_tests.sh host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-      analyze_framework_script: |
-        cd $FRAMEWORK_PATH/flutter
-        rm -rf bin/cache/pkg/sky_engine
-        mkdir -p bin/cache/pkg/
-        cp -r $ENGINE_PATH/src/out/host_debug_unopt/gen/dart-pkg/sky_engine bin/cache/pkg/
-        bin/flutter update-packages --local-engine=host_debug_unopt
-        bin/flutter analyze --flutter-repo --local-engine=host_debug_unopt
-      test_framework_script: |
-        cd $FRAMEWORK_PATH/flutter/packages/flutter
-        ../../bin/flutter test --local-engine=host_debug_unopt --null-assertions --sound-null-safety
     # TODO(fujino): remove this once ci/licenses.sh is run on LUCI
     - name: licenses_check
       build_script: |


### PR DESCRIPTION
This test routinely times out and is ignored. It's being moved to LUCI and will need to be sharded more.

https://github.com/flutter/flutter/issues/72391?
