### PR TITLE
Use -rdynamic when building test executables in order to improve backtraces

### DIFF
--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -6,6 +6,12 @@ import("//flutter/common/config.gni")
 import("//flutter/shell/config.gni")
 import("testing.gni")
 
+config("dynamic_symbols") {
+  if (is_clang && is_linux) {
+    ldflags = [ "-rdynamic" ]
+  }
+}
+
 source_set("testing_lib") {
   testonly = true
 
@@ -37,6 +43,7 @@ source_set("testing") {
   ]
 
   public_deps = [ ":testing_lib" ]
+  public_configs = [ ":dynamic_symbols" ]
 }
 
 source_set("dart") {


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/83286