### PR TITLE
Add Float32List support to StandardMessageCodec

### DIFF
--- a/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
@@ -1,5 +1,6 @@
 package io.flutter.plugin.common;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.nio.ByteBuffer;
@@ -28,6 +29,7 @@ public class StandardMessageCodecTest {
   private static final byte DOUBLE_ARRAY = 11;
   private static final byte LIST = 12;
   private static final byte MAP = 13;
+  private static final byte FLOAT_ARRAY = 14;
 
   @Test
   public void itEncodesNullLiterals() {
@@ -92,5 +94,18 @@ public class StandardMessageCodecTest {
     expected.put(new byte[] {LIST, 2, TRUE, FALSE});
     expected.flip();
     assertEquals(expected, message);
+  }
+
+  @Test
+  public void itEncodesFloatArrays() {
+    StandardMessageCodec codec = new StandardMessageCodec();
+
+    float[] expectedValues = new float[] {1.0f, 2.2f, 5.3f};
+
+    ByteBuffer message = codec.encodeMessage(expectedValues);
+    message.flip();
+
+    float[] values = (float[]) codec.decodeMessage(message);
+    assertArrayEquals(expectedValues, values, 0.01f);
   }
 }

--- a/shell/platform/common/client_wrapper/encodable_value_unittests.cc
+++ b/shell/platform/common/client_wrapper/encodable_value_unittests.cc
@@ -217,6 +217,9 @@ TEST(EncodableValueTest, Comparison) {
       EncodableValue(
           EncodableMap{{EncodableValue(), EncodableValue(1.0)},
                        {EncodableValue("key"), EncodableValue("value")}}),
+      // FloatList
+      EncodableValue(std::vector<float>{0, 1}),
+      EncodableValue(std::vector<float>{0, 100}),
   };
 
   for (size_t i = 0; i < values.size(); ++i) {

--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -110,6 +110,7 @@ using EncodableValueVariant = std::variant<std::monostate,
                                            std::vector<double>,
                                            EncodableList,
                                            EncodableMap,
+                                           std::vector<float>,
                                            CustomEncodableValue>;
 }  // namespace internal
 
@@ -158,6 +159,7 @@ using EncodableValueVariant = std::variant<std::monostate,
 // std::vector<double>  -> Float64List
 // EncodableList        -> List
 // EncodableMap         -> Map
+// std::vector<float>   -> Float32List
 class EncodableValue : public internal::EncodableValueVariant {
  public:
   // Rely on std::variant for most of the constructors/operators.

--- a/shell/platform/common/client_wrapper/standard_codec.cc
+++ b/shell/platform/common/client_wrapper/standard_codec.cc
@@ -41,6 +41,7 @@ enum class EncodedType {
   kFloat64List,
   kList,
   kMap,
+  kFloat32List,
 };
 
 // Returns the encoded type that should be written when serializing |value|.
@@ -70,6 +71,8 @@ EncodedType EncodedTypeForValue(const EncodableValue& value) {
       return EncodedType::kList;
     case 11:
       return EncodedType::kMap;
+    case 12:
+      return EncodedType::kFloat32List;
   }
   assert(false);
   return EncodedType::kNull;
@@ -150,7 +153,11 @@ void StandardCodecSerializer::WriteValue(const EncodableValue& value,
       }
       break;
     }
-    case 12:
+    case 12: {
+      WriteVector(std::get<std::vector<float>>(value), stream);
+      break;
+    }
+    case 13:
       std::cerr
           << "Unhandled custom type in StandardCodecSerializer::WriteValue. "
           << "Custom types require codec extensions." << std::endl;
@@ -209,6 +216,9 @@ EncodableValue StandardCodecSerializer::ReadValueOfType(
         map_value.emplace(std::move(key), std::move(value));
       }
       return EncodableValue(map_value);
+    }
+    case EncodedType::kFloat32List: {
+      return ReadVector<float>(stream);
     }
   }
   std::cerr << "Unknown type in StandardCodecSerializer::ReadValueOfType: "

--- a/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
+++ b/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
@@ -175,6 +175,13 @@ TEST(StandardMessageCodec, CanEncodeAndDecodeInt64Array) {
   CheckEncodeDecode(value, bytes);
 }
 
+TEST(StandradMessageCodec, CanEncodeAndDecodeFloat32Array) {
+  std::vector<uint8_t> bytes = {0x0e, 0x02, 0x00, 0x00, 0xd8, 0x0f,
+                                0x49, 0x40, 0x00, 0x00, 0x7a, 0x44};
+  EncodableValue value(std::vector<float>{3.1415920257568359375f, 1000.0f});
+  CheckEncodeDecode(value, bytes);
+}
+
 TEST(StandardMessageCodec, CanEncodeAndDecodeFloat64Array) {
   std::vector<uint8_t> bytes = {0x0b, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                                 0x18, 0x2d, 0x44, 0x54, 0xfb, 0x21, 0x09, 0x40,

--- a/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h
@@ -282,6 +282,7 @@ typedef NS_ENUM(NSInteger, FlutterStandardDataType) {
   FlutterStandardDataTypeUInt8,
   FlutterStandardDataTypeInt32,
   FlutterStandardDataTypeInt64,
+  FlutterStandardDataTypeFloat32,
   FlutterStandardDataTypeFloat64,
 };
 
@@ -318,6 +319,14 @@ FLUTTER_DARWIN_EXPORT
  * @param data the byte data. The length must be divisible by 8.
  */
 + (instancetype)typedDataWithInt64:(NSData*)data;
+
+/**
+ * Creates a `FlutterStandardTypedData` which interprets the specified data
+ * as 32-bit floats.
+ *
+ * @param data the byte data. The length must be divisible by 8.
+ */
++ (instancetype)typedDataWithFloat32:(NSData*)data;
 
 /**
  * Creates a `FlutterStandardTypedData` which interprets the specified data

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
@@ -162,6 +162,10 @@ using namespace flutter;
   return [FlutterStandardTypedData typedDataWithData:data type:FlutterStandardDataTypeInt64];
 }
 
++ (instancetype)typedDataWithFloat32:(NSData*)data {
+  return [FlutterStandardTypedData typedDataWithData:data type:FlutterStandardDataTypeFloat32];
+}
+
 + (instancetype)typedDataWithFloat64:(NSData*)data {
   return [FlutterStandardTypedData typedDataWithData:data type:FlutterStandardDataTypeFloat64];
 }
@@ -443,6 +447,7 @@ using namespace flutter;
     case FlutterStandardFieldUInt8Data:
     case FlutterStandardFieldInt32Data:
     case FlutterStandardFieldInt64Data:
+    case FlutterStandardFieldFloat32Data:
     case FlutterStandardFieldFloat64Data:
       return [self readTypedDataOfType:FlutterStandardDataTypeForField(field)];
     case FlutterStandardFieldList: {

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodec_Internal.h
@@ -16,22 +16,47 @@ typedef NS_ENUM(NSInteger, FlutterStandardField) {
   FlutterStandardFieldIntHex,
   FlutterStandardFieldFloat64,
   FlutterStandardFieldString,
-  // The following must match the corresponding order from `FlutterStandardDataType`.
   FlutterStandardFieldUInt8Data,
   FlutterStandardFieldInt32Data,
   FlutterStandardFieldInt64Data,
   FlutterStandardFieldFloat64Data,
   FlutterStandardFieldList,
   FlutterStandardFieldMap,
+  FlutterStandardFieldFloat32Data,
 };
 
 namespace flutter {
 FlutterStandardField FlutterStandardFieldForDataType(FlutterStandardDataType type) {
-  return (FlutterStandardField)(type + FlutterStandardFieldUInt8Data);
+  switch (type) {
+    case FlutterStandardDataTypeUInt8:
+      return FlutterStandardFieldUInt8Data;
+    case FlutterStandardDataTypeInt32:
+      return FlutterStandardFieldInt32Data;
+    case FlutterStandardDataTypeInt64:
+      return FlutterStandardFieldInt64Data;
+    case FlutterStandardDataTypeFloat32:
+      return FlutterStandardFieldFloat32Data;
+    case FlutterStandardDataTypeFloat64:
+      return FlutterStandardFieldFloat64Data;
+  }
 }
 FlutterStandardDataType FlutterStandardDataTypeForField(FlutterStandardField field) {
-  return (FlutterStandardDataType)(field - FlutterStandardFieldUInt8Data);
+  switch (field) {
+    case FlutterStandardFieldUInt8Data:
+      return FlutterStandardDataTypeUInt8;
+    case FlutterStandardFieldInt32Data:
+      return FlutterStandardDataTypeInt32;
+    case FlutterStandardFieldInt64Data:
+      return FlutterStandardDataTypeInt64;
+    case FlutterStandardFieldFloat32Data:
+      return FlutterStandardDataTypeFloat32;
+    case FlutterStandardFieldFloat64Data:
+      return FlutterStandardDataTypeFloat64;
+    default:
+      return FlutterStandardDataTypeUInt8;
+  }
 }
+
 UInt8 elementSizeForFlutterStandardDataType(FlutterStandardDataType type) {
   switch (type) {
     case FlutterStandardDataTypeUInt8:
@@ -40,6 +65,8 @@ UInt8 elementSizeForFlutterStandardDataType(FlutterStandardDataType type) {
       return 4;
     case FlutterStandardDataTypeInt64:
       return 8;
+    case FlutterStandardDataTypeFloat32:
+      return 4;
     case FlutterStandardDataTypeFloat64:
       return 8;
   }

--- a/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
+++ b/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
@@ -176,6 +176,13 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeInt64Array) {
   checkEncodeDecode(value);
 }
 
+TEST(FlutterStandardCodec, CanEncodeAndDecodeFloat32Array) {
+  uint8_t bytes[8] = {0xd8, 0x0f, 0x49, 0x40, 0x00, 0x00, 0x7a, 0x44};
+  NSData* data = [NSData dataWithBytes:bytes length:8];
+  FlutterStandardTypedData* value = [FlutterStandardTypedData typedDataWithFloat32:data];
+  checkEncodeDecode(value);
+}
+
 TEST(FlutterStandardCodec, CanEncodeAndDecodeFloat64Array) {
   uint8_t bytes[16] = {0xBA, 0x5E, 0xBA, 0x11, 0xff, 0xff, 0xff, 0xff,
                        0xBA, 0x5E, 0xBA, 0x11, 0xff, 0xff, 0xff, 0xff};


### PR DESCRIPTION
Adding Float32List support to Android, iOS and C++ implementations of StandardMessageCodec. These are the engine changes needed to support flutter/flutter#72613

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.