### PR TITLE
** fix Galaxy A7, Galaxy s3 Android 4.4.4 os .IllegalStateException: maxImages (3) has already been acquired, call #close before acquiring more.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -172,12 +172,16 @@ public class FlutterImageView extends View implements RenderSurface {
     // or some special Android devices so the calls to `invalidate()` queued up
     // until the device produces a new frame.
     // 3. While the engine will also stop producing frames, there is a race condition.
-    final Image newImage = imageReader.acquireLatestImage();
-    if (newImage != null) {
-      // Only close current image after acquiring valid new image
-      closeCurrentImage();
-      currentImage = newImage;
-      invalidate();
+    try {
+      final Image newImage = imageReader.acquireLatestImage();
+      if (newImage != null) {
+        // Only close current image after acquiring valid new image
+        closeCurrentImage();
+        currentImage = newImage;
+        invalidate();
+      }
+    }catch (IllegalStateException illegalStateException){
+        //fix Galaxy A7, Galaxy s3 Android 4.4.4 os IllegalStateException.
     }
     return newImage != null;
   }


### PR DESCRIPTION
exception:  java.lang.IllegalStateException: maxImages (3) has already been acquired, call #close before acquiring more.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
