### PR TITLE
Add back inexpensive framework tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,6 +30,25 @@ task:
     mv $CIRRUS_WORKING_DIR flutter
     gclient sync
   matrix:
+    - name: build_and_test_linux_unopt_debug
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      test_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/testing/run_tests.sh host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+      analyze_framework_script: |
+        cd $FRAMEWORK_PATH/flutter
+        rm -rf bin/cache/pkg/sky_engine
+        mkdir -p bin/cache/pkg/
+        cp -r $ENGINE_PATH/src/out/host_debug_unopt/gen/dart-pkg/sky_engine bin/cache/pkg/
+        bin/flutter update-packages --local-engine=host_debug_unopt
+        bin/flutter analyze --flutter-repo --local-engine=host_debug_unopt
     # TODO(fujino): remove this once ci/licenses.sh is run on LUCI
     - name: licenses_check
       build_script: |


### PR DESCRIPTION
Some of the tests that https://github.com/flutter/engine/pull/26377 deleted are relatively inexpensive. This PR adds them back.