### PR TITLE
Remove build timestamp from build_info.h.

### DIFF
--- a/shell/platform/fuchsia/runtime/dart/utils/build_info.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/build_info.h
@@ -11,7 +11,6 @@ namespace dart_utils {
 
 class BuildInfo {
  public:
-  static const char* BuildTimestamp();
   static const char* DartSdkGitRevision();
   static const char* DartSdkSemanticVersion();
   static const char* FlutterEngineGitRevision();

--- a/shell/platform/fuchsia/runtime/dart/utils/build_info_in.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/build_info_in.cc
@@ -6,10 +6,6 @@
 
 namespace dart_utils {
 
-const char* BuildInfo::BuildTimestamp() {
-  return "{{BUILD_TIMESTAMP}}";
-}
-
 const char* BuildInfo::DartSdkGitRevision() {
   return "{{DART_SDK_GIT_REVISION}}";
 }
@@ -27,8 +23,6 @@ const char* BuildInfo::FuchsiaSdkVersion() {
 }
 
 void BuildInfo::Dump(inspect::Node& node) {
-  node.CreateString("build_timestamp", BuildTimestamp(),
-                    RootInspectNode::GetInspector());
   node.CreateString("dart_sdk_git_revision", DartSdkGitRevision(),
                     RootInspectNode::GetInspector());
   node.CreateString("dart_sdk_semantic_version", DartSdkSemanticVersion(),

--- a/shell/platform/fuchsia/runtime/dart/utils/build_info_unittests.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/build_info_unittests.cc
@@ -35,7 +35,6 @@ class BuildInfoTest : public ::testing::Test {
 };
 
 TEST_F(BuildInfoTest, AllPropertiesAreDefined) {
-  EXPECT_NE(BuildInfo::BuildTimestamp(), "{{BUILD_TIMESTAMP}}");
   EXPECT_NE(BuildInfo::DartSdkGitRevision(), "{{DART_SDK_GIT_REVISION}}");
   EXPECT_NE(BuildInfo::DartSdkSemanticVersion(),
             "{{DART_SDK_SEMANTIC_VERSION}}");
@@ -53,7 +52,6 @@ TEST_F(BuildInfoTest, AllPropertiesAreDumped) {
           std::move(
               dart_utils::RootInspectNode::GetInspector()->DuplicateVmo()))
           .take_value();
-  checkProperty(root, "build_timestamp", BuildInfo::BuildTimestamp());
   checkProperty(root, "dart_sdk_git_revision", BuildInfo::DartSdkGitRevision());
   checkProperty(root, "dart_sdk_semantic_version",
                 BuildInfo::DartSdkSemanticVersion());

--- a/tools/fuchsia/make_build_info.py
+++ b/tools/fuchsia/make_build_info.py
@@ -14,10 +14,6 @@ import sys
 import json
 
 
-def GetBuildTimestamp():
-    return datetime.now().strftime('%Y-%m-%d %H:%M')
-
-
 def GetDartSdkGitRevision(buildroot):
     project_root = path.join(buildroot, 'third_party', 'dart')
     return subprocess.check_output(
@@ -66,7 +62,6 @@ def main():
     with open(args.input, 'r') as i, open(args.output, 'w') as o:
         o.write(
             i.read()
-            .replace('{{BUILD_TIMESTAMP}}', GetBuildTimestamp())
             .replace(
                 '{{DART_SDK_GIT_REVISION}}',
                 GetDartSdkGitRevision(args.buildroot))


### PR DESCRIPTION
Remove build timestamp as it is not updating correctly and it would mark
the build as dirty, triggering a rebuild.

Bug: https://fxbug.dev/73263