### PR TITLE
[web] Ensure handleNavigationMessage can receive null arguments.

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -113,7 +113,7 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
 
   Future<bool> handleNavigationMessage(ByteData? data) async {
     final MethodCall decoded = JSONMethodCodec().decodeMethodCall(data);
-    final Map<String, dynamic> arguments = decoded.arguments;
+    final Map<String, dynamic>? arguments = decoded.arguments;
     switch (decoded.method) {
       case 'selectMultiEntryHistory':
         await _useMultiEntryBrowserHistory();
@@ -123,12 +123,12 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
         return true;
       case 'routeUpdated': // deprecated
         await _useSingleEntryBrowserHistory();
-        browserHistory.setRouteName(arguments['routeName']);
+        browserHistory.setRouteName(arguments?['routeName']);
         return true;
       case 'routeInformationUpdated':
         browserHistory.setRouteName(
-          arguments['location'],
-          state: arguments['state'],
+          arguments?['location'],
+          state: arguments?['state'],
         );
         return true;
     }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -121,14 +121,17 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
       case 'selectSingleEntryHistory':
         await _useSingleEntryBrowserHistory();
         return true;
+      // the following cases assert that arguments are not null
       case 'routeUpdated': // deprecated
+        assert(arguments != null);
         await _useSingleEntryBrowserHistory();
-        browserHistory.setRouteName(arguments?['routeName']);
+        browserHistory.setRouteName(arguments!['routeName']);
         return true;
       case 'routeInformationUpdated':
+        assert(arguments != null);
         browserHistory.setRouteName(
-          arguments?['location'],
-          state: arguments?['state'],
+          arguments!['location'],
+          state: arguments['state'],
         );
         return true;
     }

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -82,7 +82,7 @@ void testMain() {
     ), useSingle: false);
     expect(window.browserHistory, isA<MultiEntriesBrowserHistory>());
 
-    Future<void> check<T>(String method, dynamic arguments) async {
+    Future<void> check<T>(String method, Object? arguments) async {
       callback = Completer<void>();
       window.sendPlatformMessage(
         'flutter/navigation',

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -105,6 +105,27 @@ void testMain() {
     await check<MultiEntriesBrowserHistory>('routeInformationUpdated', <String, dynamic>{'location': '/bar'}); // does not change mode
   });
 
+  test('handleNavigationMessage throws for route update methods called with null arguments',
+      () async {
+    expect(() async {
+      await window.handleNavigationMessage(
+        JSONMethodCodec().encodeMethodCall(MethodCall(
+          'routeUpdated',
+          null, // boom
+        ))
+      );
+    }, throwsAssertionError);
+
+    expect(() async {
+      await window.handleNavigationMessage(
+        JSONMethodCodec().encodeMethodCall(MethodCall(
+          'routeInformationUpdated',
+          null, // boom
+        ))
+      );
+    }, throwsAssertionError);
+  });
+
   test('should not throw when using nav1 and nav2 together',
       () async {
     await window.debugInitializeHistory(TestUrlStrategy.fromEntry(

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -82,7 +82,7 @@ void testMain() {
     ), useSingle: false);
     expect(window.browserHistory, isA<MultiEntriesBrowserHistory>());
 
-    Future<void> check<T>(String method, Map<String, Object?> arguments) async {
+    Future<void> check<T>(String method, dynamic arguments) async {
       callback = Completer<void>();
       window.sendPlatformMessage(
         'flutter/navigation',
@@ -93,6 +93,10 @@ void testMain() {
       expect(window.browserHistory, isA<T>());
     }
 
+    // These may be initialized as `null`
+    // See https://github.com/flutter/flutter/issues/83158#issuecomment-847483010
+    await check<SingleEntryBrowserHistory>('selectSingleEntryHistory', null); // -> single
+    await check<MultiEntriesBrowserHistory>('selectMultiEntryHistory', null); // -> multi
     await check<SingleEntryBrowserHistory>('selectSingleEntryHistory', <String, dynamic>{}); // -> single
     await check<MultiEntriesBrowserHistory>('selectMultiEntryHistory', <String, dynamic>{}); // -> multi
     await check<SingleEntryBrowserHistory>('routeUpdated', <String, dynamic>{'routeName': '/bar'}); // -> single


### PR DESCRIPTION
In a recent update to `handleNavigationMessage` some extra messages were added that don't require any arguments. From the framework side, those messages are sent without arguments (OK), but the engine was never modified to accept `null` arguments, so it fails with:

```
Error: Expected a value of type 'Map<String, dynamic>', but got one of type 'Null'
...
    at _engine.EngineSingletonFlutterWindow.new.handleNavigationMessage 
...
    at _engine.EnginePlatformDispatcher.__.sendPlatformMessage 
...
    at OptionalMethodChannel.invokeMethod
...
    at Function.selectSingleEntryHistory (framework)
```

Since that unhandled exception bubbles up to the browser, web apps in `master` display a red error message, which may break all web integration tests like so:

```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
The following TypeErrorImpl was thrown running a test:
Expected a value of type 'Map<String, dynamic>', but got one of type 'Null'

When the exception was thrown, this was the stack:
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 251:49      throw_
dart-sdk/lib/_internal/js_dev_runtime/private/ddc_runtime/errors.dart 84:3        castError
...
lib/_engine/engine/window.dart 116:32                                             handleNavigationMessage
...
packages/flutter/src/services/system_channels.dart.js 1007:20                     invokeMethod
packages/flutter/src/services/system_navigator.dart.js 26:56                      selectSingleEntryHistory
packages/flutter/src/widgets/inherited_model.dart.js 25905:42                     initState
```

Fixes https://github.com/flutter/flutter/issues/83158

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
