### PR TITLE
Add Handle.replace(int rights).

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
@@ -42,6 +42,8 @@ class Handle extends NativeFieldWrapperClass2 {
       native 'Handle_AsyncWait';
 
   Handle duplicate(int rights) native 'Handle_Duplicate';
+
+  Handle replace(int rights) native 'Handle_Replace';
 }
 
 @pragma('vm:entry-point')

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.cc
@@ -115,6 +115,19 @@ Dart_Handle Handle::Duplicate(uint32_t rights) {
   return ToDart(Create(out_handle));
 }
 
+Dart_Handle Handle::Replace(uint32_t rights) {
+  if (!is_valid()) {
+    return ToDart(Create(ZX_HANDLE_INVALID));
+  }
+
+  zx_handle_t out_handle;
+  zx_status_t status = zx_handle_replace(ReleaseHandle(), rights, &out_handle);
+  if (status != ZX_OK) {
+    return ToDart(Create(ZX_HANDLE_INVALID));
+  }
+  return ToDart(Create(out_handle));
+}
+
 void Handle::ScheduleCallback(tonic::DartPersistentValue callback,
                               zx_status_t status,
                               const zx_packet_signal_t* signal) {
@@ -155,7 +168,8 @@ void Handle::ScheduleCallback(tonic::DartPersistentValue callback,
   V(Handle, is_valid)       \
   V(Handle, Close)          \
   V(Handle, AsyncWait)      \
-  V(Handle, Duplicate)
+  V(Handle, Duplicate)      \
+  V(Handle, Replace)
 
 // clang-format: on
 

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.h
@@ -67,6 +67,8 @@ class Handle : public fml::RefCountedThreadSafe<Handle>,
 
   Dart_Handle Duplicate(uint32_t rights);
 
+  Dart_Handle Replace(uint32_t rights);
+
   void ScheduleCallback(tonic::DartPersistentValue callback,
                         zx_status_t status,
                         const zx_packet_signal_t* signal);

--- a/shell/platform/fuchsia/dart-pkg/zircon/test/handle_test.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/test/handle_test.dart
@@ -2,38 +2,153 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:test/test.dart';
 import 'package:zircon/zircon.dart';
 
+/// Helper method to turn a [String] into a [ByteData] containing the
+/// text of the string encoded as UTF-8.
+ByteData utf8Bytes(final String text) {
+  return ByteData.view(Uint8List.fromList(utf8.encode(text)).buffer);
+}
+
 void main() {
-  test('create and duplicate handle', () {
-    final HandlePairResult pair = System.eventpairCreate();
-    expect(pair.status, equals(ZX.OK));
-    expect(pair.first.isValid, isTrue);
-    expect(pair.second.isValid, isTrue);
+  group('duplicated handle', () {
+    test('create and duplicate handles', () {
+      final HandlePairResult pair = System.eventpairCreate();
+      expect(pair.status, equals(ZX.OK));
+      expect(pair.first.isValid, isTrue);
+      expect(pair.second.isValid, isTrue);
 
-    final Handle duplicate = pair.first.duplicate(ZX.RIGHT_SAME_RIGHTS);
-    expect(duplicate.isValid, isTrue);
+      final Handle duplicate = pair.first.duplicate(ZX.RIGHT_SAME_RIGHTS);
+      expect(duplicate.isValid, isTrue);
 
-    final Handle failedDuplicate = pair.first.duplicate(-1);
-    expect(failedDuplicate.isValid, isFalse);
+      final Handle failedDuplicate = pair.first.duplicate(-1);
+      expect(failedDuplicate.isValid, isFalse);
+    });
+
+    test('failure invalid rights', () {
+      final HandleResult vmo = System.vmoCreate(0);
+      expect(vmo.status, equals(ZX.OK));
+      final Handle failedDuplicate = vmo.handle.duplicate(-1);
+      expect(failedDuplicate.isValid, isFalse);
+      expect(vmo.handle.isValid, isTrue);
+    });
+
+    test('failure invalid handle', () {
+      final Handle handle = Handle.invalid();
+      final Handle duplicate = handle.duplicate(ZX.RIGHT_SAME_RIGHTS);
+      expect(duplicate.isValid, isFalse);
+    });
+
+    test('duplicated handle should have same koid', () {
+      final HandlePairResult pair = System.eventpairCreate();
+      expect(pair.status, equals(ZX.OK));
+      expect(pair.first.isValid, isTrue);
+      expect(pair.second.isValid, isTrue);
+
+      final Handle duplicate = pair.first.duplicate(ZX.RIGHT_SAME_RIGHTS);
+      expect(duplicate.isValid, isTrue);
+
+      expect(pair.first.koid, duplicate.koid);
+    });
+
+    test('reduced rights', () {
+      // Set up handle.
+      final HandleResult vmo = System.vmoCreate(2);
+      expect(vmo.status, equals(ZX.OK));
+
+      // Duplicate the first handle.
+      final Handle duplicate = vmo.handle.duplicate(ZX.RIGHTS_BASIC);
+      expect(duplicate.isValid, isTrue);
+
+      // Write bytes to the original handle.
+      final ByteData data1 = utf8Bytes('a');
+      final int status1 = System.vmoWrite(vmo.handle, 0, data1);
+      expect(status1, equals(ZX.OK));
+
+      // Write bytes to the duplicated handle.
+      final ByteData data2 = utf8Bytes('b');
+      final int status2 = System.vmoWrite(duplicate, 1, data2);
+      expect(status2, equals(ZX.ERR_ACCESS_DENIED));
+
+      // Read bytes.
+      final ReadResult readResult = System.vmoRead(vmo.handle, 0, 2);
+      expect(readResult.status, equals(ZX.OK));
+      expect(readResult.numBytes, equals(2));
+      expect(readResult.bytes.lengthInBytes, equals(2));
+      expect(readResult.bytesAsUTF8String(), equals('a\x00'));
+    });
   });
 
-  test('failure invalid handle', () {
-    final Handle handle = Handle.invalid();
-    final Handle duplicate = handle.duplicate(ZX.RIGHT_SAME_RIGHTS);
-    expect(duplicate.isValid, isFalse);
-  });
+  group('replaced handle', () {
+    test('create and replace handles', () {
+      final HandlePairResult pair = System.eventpairCreate();
+      expect(pair.status, equals(ZX.OK));
+      expect(pair.first.isValid, isTrue);
+      expect(pair.second.isValid, isTrue);
 
-  test('handle and its duplicate have same koid', () {
-    final HandlePairResult pair = System.eventpairCreate();
-    expect(pair.status, equals(ZX.OK));
-    expect(pair.first.isValid, isTrue);
-    expect(pair.second.isValid, isTrue);
+      final Handle replaced = pair.first.replace(ZX.RIGHT_SAME_RIGHTS);
+      expect(replaced.isValid, isTrue);
+      expect(pair.first.isValid, isFalse);
+    });
 
-    final Handle duplicate = pair.first.duplicate(ZX.RIGHT_SAME_RIGHTS);
-    expect(duplicate.isValid, isTrue);
+    test('failure invalid rights', () {
+      final HandleResult vmo = System.vmoCreate(0);
+      expect(vmo.status, equals(ZX.OK));
+      final Handle failedDuplicate = vmo.handle.replace(-1);
+      expect(failedDuplicate.isValid, isFalse);
+      expect(vmo.handle.isValid, isFalse);
+    });
 
-    expect(pair.first.koid, duplicate.koid);
+    test('failure invalid handle', () {
+      final Handle handle = Handle.invalid();
+      final Handle replaced = handle.replace(ZX.RIGHT_SAME_RIGHTS);
+      expect(handle.isValid, isFalse);
+      expect(replaced.isValid, isFalse);
+    });
+
+    test('transferred handle should have same koid', () {
+      final HandlePairResult pair = System.eventpairCreate();
+      expect(pair.status, equals(ZX.OK));
+      expect(pair.first.isValid, isTrue);
+      expect(pair.second.isValid, isTrue);
+
+      final int koid = pair.first.koid;
+      final Handle replaced = pair.first.replace(ZX.RIGHT_SAME_RIGHTS);
+      expect(replaced.isValid, isTrue);
+
+      expect(koid, replaced.koid);
+    });
+
+    test('reduced rights', () {
+      // Set up handle.
+      final HandleResult vmo = System.vmoCreate(2);
+      expect(vmo.status, equals(ZX.OK));
+
+      // Replace the first handle.
+      final Handle duplicate =
+          vmo.handle.replace(ZX.RIGHTS_BASIC | ZX.RIGHT_READ);
+      expect(duplicate.isValid, isTrue);
+
+      // Write bytes to the original handle.
+      final ByteData data1 = utf8Bytes('a');
+      final int status1 = System.vmoWrite(vmo.handle, 0, data1);
+      expect(status1, equals(ZX.ERR_BAD_HANDLE));
+
+      // Write bytes to the duplicated handle.
+      final ByteData data2 = utf8Bytes('b');
+      final int status2 = System.vmoWrite(duplicate, 1, data2);
+      expect(status2, equals(ZX.ERR_ACCESS_DENIED));
+
+      // Read bytes.
+      final ReadResult readResult = System.vmoRead(duplicate, 0, 2);
+      expect(readResult.status, equals(ZX.OK));
+      expect(readResult.numBytes, equals(2));
+      expect(readResult.bytes.lengthInBytes, equals(2));
+      expect(readResult.bytesAsUTF8String(), equals('\x00\x00'));
+    });
   });
 }


### PR DESCRIPTION
Add support for zx_handle_replace.

This is related to https://fxbug.dev/68600.

I've tested the updated handle_test in fuchsia.git locally.
Handle.duplicate is tested more rigorously now.

CC: @naudzghebre 