### PR TITLE
Disable hidden symbols on unoptimized builds in order to improve test backtraces

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -98,7 +98,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'd86d028552a050f25fb25bf9163f7df0cee9f9a4',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'ef50dec1f85ee435e967505f460d2c0ce6fde58e',
 
    # Fuchsia compatibility
    #

--- a/tools/gn
+++ b/tools/gn
@@ -294,6 +294,9 @@ def to_gn_args(args):
     # even with -fPIC everywhere.
     # gn_args['enable_profiling'] = args.runtime_mode != 'release' and args.android_cpu != 'x86'
 
+    # Make symbols visible in order to enable symbolization of unit test crash backtraces on Linux
+    gn_args['disable_hidden_visibility'] = args.target_os == 'linux' and args.unoptimized
+
     if args.arm_float_abi:
       gn_args['arm_float_abi'] = args.arm_float_abi
 


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/83286
