### PR TITLE
Fixes iOS refuses to accept semantics rect update if UISwitch is not …

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
@@ -149,11 +149,10 @@ constexpr int32_t kRootNodeId = 0;
 
 @end
 
-/// A proxy class for SemanticsObject and UISwitch.  For most Accessibility and
-/// SemanticsObject methods it delegates to the semantics object, otherwise it
-/// sends messages to the UISwitch.
-@interface FlutterSwitchSemanticsObject : UISwitch
-- (instancetype)initWithSemanticsObject:(SemanticsObject*)semanticsObject;
+/// The semantics object for switch buttons. This class creates an UISwitch to interact with the
+/// iOS.
+@interface FlutterSwitchSemanticsObject : SemanticsObject
+
 @end
 
 /**

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -37,96 +37,53 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }  // namespace
 
 @implementation FlutterSwitchSemanticsObject {
-  SemanticsObject* _semanticsObject;
+  UISwitch* _nativeSwitch;
 }
 
-- (instancetype)initWithSemanticsObject:(SemanticsObject*)semanticsObject {
-  self = [super init];
+- (instancetype)initWithBridge:(fml::WeakPtr<flutter::AccessibilityBridgeIos>)bridge
+                           uid:(int32_t)uid {
+  self = [super initWithBridge:bridge uid:uid];
   if (self) {
-    _semanticsObject = [semanticsObject retain];
+    _nativeSwitch = [[[UISwitch alloc] init] retain];
   }
   return self;
 }
 
 - (void)dealloc {
-  [_semanticsObject release];
+  [_nativeSwitch release];
   [super dealloc];
 }
 
 - (NSMethodSignature*)methodSignatureForSelector:(SEL)sel {
   NSMethodSignature* result = [super methodSignatureForSelector:sel];
   if (!result) {
-    result = [_semanticsObject methodSignatureForSelector:sel];
+    result = [_nativeSwitch methodSignatureForSelector:sel];
   }
   return result;
 }
 
 - (void)forwardInvocation:(NSInvocation*)anInvocation {
-  [anInvocation setTarget:_semanticsObject];
+  [anInvocation setTarget:_nativeSwitch];
   [anInvocation invoke];
 }
 
-// The following methods are explicitly forwarded to the wrapped SemanticsObject because the
-// forwarding logic above doesn't apply to them since they are also implemented in the UISwitch
-// class, the base class.
-
-- (CGRect)accessibilityFrame {
-  return [_semanticsObject accessibilityFrame];
-}
-
-- (id)accessibilityContainer {
-  return [_semanticsObject accessibilityContainer];
-}
-
-- (NSString*)accessibilityLabel {
-  return [_semanticsObject accessibilityLabel];
-}
-
-- (NSString*)accessibilityHint {
-  return [_semanticsObject accessibilityHint];
-}
-
 - (NSString*)accessibilityValue {
-  if ([_semanticsObject node].HasFlag(flutter::SemanticsFlags::kIsToggled) ||
-      [_semanticsObject node].HasFlag(flutter::SemanticsFlags::kIsChecked)) {
-    self.on = YES;
+  if ([self node].HasFlag(flutter::SemanticsFlags::kIsToggled) ||
+      [self node].HasFlag(flutter::SemanticsFlags::kIsChecked)) {
+    _nativeSwitch.on = YES;
   } else {
-    self.on = NO;
+    _nativeSwitch.on = NO;
   }
 
-  if (![_semanticsObject isAccessibilityBridgeAlive]) {
+  if (![self isAccessibilityBridgeAlive]) {
     return nil;
   } else {
-    return [super accessibilityValue];
+    return _nativeSwitch.accessibilityValue;
   }
 }
 
-- (BOOL)accessibilityActivate {
-  return [_semanticsObject accessibilityActivate];
-}
-
-- (void)accessibilityIncrement {
-  [_semanticsObject accessibilityIncrement];
-}
-
-- (void)accessibilityDecrement {
-  [_semanticsObject accessibilityDecrement];
-}
-
-- (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
-  return [_semanticsObject accessibilityScroll:direction];
-}
-
-- (BOOL)accessibilityPerformEscape {
-  return [_semanticsObject accessibilityPerformEscape];
-}
-
-- (void)accessibilityElementDidBecomeFocused {
-  [_semanticsObject accessibilityElementDidBecomeFocused];
-}
-
-- (void)accessibilityElementDidLoseFocus {
-  [_semanticsObject accessibilityElementDidLoseFocus];
+- (UIAccessibilityTraits)accessibilityTraits {
+  return _nativeSwitch.accessibilityTraits;
 }
 
 @end  // FlutterSwitchSemanticsObject

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -254,9 +254,10 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
 
 - (void)testFlutterSwitchSemanticsObjectMatchesUISwitch {
   fml::WeakPtrFactory<flutter::MockAccessibilityBridge> factory(
-    new flutter::MockAccessibilityBridge());
+      new flutter::MockAccessibilityBridge());
   fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
-  FlutterSwitchSemanticsObject* object = [[FlutterSwitchSemanticsObject alloc] initWithBridge:bridge uid:1];
+  FlutterSwitchSemanticsObject* object = [[FlutterSwitchSemanticsObject alloc] initWithBridge:bridge
+                                                                                          uid:1];
 
   // Handle initial setting of node with header.
   flutter::SemanticsNode node;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -252,35 +252,35 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   XCTAssertNil(weakObject);
 }
 
-- (void)testFlutterSwitchSemanticsObjectForwardsCalls {
-  SemanticsObject* mockSemanticsObject = OCMClassMock([SemanticsObject class]);
-  FlutterSwitchSemanticsObject* switchObj =
-      [[FlutterSwitchSemanticsObject alloc] initWithSemanticsObject:mockSemanticsObject];
-  OCMStub([mockSemanticsObject accessibilityActivate]).andReturn(YES);
-  OCMStub([mockSemanticsObject accessibilityScroll:UIAccessibilityScrollDirectionRight])
-      .andReturn(NO);
-  OCMStub([mockSemanticsObject accessibilityPerformEscape]).andReturn(YES);
+- (void)testFlutterSwitchSemanticsObjectMatchesUISwitch {
+  fml::WeakPtrFactory<flutter::MockAccessibilityBridge> factory(
+    new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::MockAccessibilityBridge> bridge = factory.GetWeakPtr();
+  FlutterSwitchSemanticsObject* object = [[FlutterSwitchSemanticsObject alloc] initWithBridge:bridge uid:1];
 
-  XCTAssertTrue([switchObj accessibilityActivate]);
-  OCMVerify([mockSemanticsObject accessibilityActivate]);
+  // Handle initial setting of node with header.
+  flutter::SemanticsNode node;
+  node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kHasToggledState) |
+               static_cast<int32_t>(flutter::SemanticsFlags::kIsToggled);
+  node.label = "foo";
+  [object setSemanticsNode:&node];
+  // Create ab real UISwitch to compare the FlutterSwitchSemanticsObject with.
+  UISwitch* nativeSwitch = [[UISwitch alloc] init];
+  nativeSwitch.on = YES;
 
-  [switchObj accessibilityIncrement];
-  OCMVerify([mockSemanticsObject accessibilityIncrement]);
+  XCTAssertEqual(object.accessibilityTraits, nativeSwitch.accessibilityTraits);
+  XCTAssertEqual(object.accessibilityValue, nativeSwitch.accessibilityValue);
 
-  [switchObj accessibilityDecrement];
-  OCMVerify([mockSemanticsObject accessibilityDecrement]);
+  // Set the toggled to false;
+  flutter::SemanticsNode update;
+  update.flags = static_cast<int32_t>(flutter::SemanticsFlags::kHasToggledState);
+  update.label = "foo";
+  [object setSemanticsNode:&update];
 
-  XCTAssertFalse([switchObj accessibilityScroll:UIAccessibilityScrollDirectionRight]);
-  OCMVerify([mockSemanticsObject accessibilityScroll:UIAccessibilityScrollDirectionRight]);
+  nativeSwitch.on = NO;
 
-  XCTAssertTrue([switchObj accessibilityPerformEscape]);
-  OCMVerify([mockSemanticsObject accessibilityPerformEscape]);
-
-  [switchObj accessibilityElementDidBecomeFocused];
-  OCMVerify([mockSemanticsObject accessibilityElementDidBecomeFocused]);
-
-  [switchObj accessibilityElementDidLoseFocus];
-  OCMVerify([mockSemanticsObject accessibilityElementDidLoseFocus]);
+  XCTAssertEqual(object.accessibilityTraits, nativeSwitch.accessibilityTraits);
+  XCTAssertEqual(object.accessibilityValue, nativeSwitch.accessibilityValue);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -257,10 +257,7 @@ static SemanticsObject* CreateObject(const flutter::SemanticsNode& node,
     return [[[TextInputSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
   } else if (node.HasFlag(flutter::SemanticsFlags::kHasToggledState) ||
              node.HasFlag(flutter::SemanticsFlags::kHasCheckedState)) {
-    SemanticsObject* delegateObject =
-        [[[FlutterSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
-    return (SemanticsObject*)[[[FlutterSwitchSemanticsObject alloc]
-        initWithSemanticsObject:delegateObject] autorelease];
+    return [[[FlutterSwitchSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
   } else {
     return [[[FlutterSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
   }


### PR DESCRIPTION
…in the view

The issue:

We create a UISwitch to represent the semantics object for radiobutton or checkbox. We attaches it directly in the accessibility tree but not in the actual view hierarchy. When the screen rotates, iOS seems to do some snapshot operation and is not happy about the UISwitch for not being in the actual view hierarchy and refuses to accept any update to the accessibilityframe

The fix:

Don't expose the UISwitch to the iOS, but make SemanticsObject to delegate some of the accessibility selector to a hidden UISwitch, so that the iOS still think the semanticsObject is a UISwitch but won't complain about the UISwitch is not in the view hierarchy

fixes https://github.com/flutter/flutter/issues/82952

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
