### PR TITLE
Canonicalize runner debug symbol path for fuchsia.

### DIFF
--- a/tools/fuchsia/fuchsia_debug_symbols.gni
+++ b/tools/fuchsia/fuchsia_debug_symbols.gni
@@ -23,6 +23,46 @@ template("_copy_debug_symbols") {
 
     sources = [ binary_path ]
 
+    _dest_base = "${root_out_dir}/.build-id"
+
+    args = [
+      "--executable-name",
+      target_name,
+      "--executable-path",
+      rebase_path(binary_path),
+      "--destination-base",
+      rebase_path(_dest_base),
+      "--read-elf",
+      rebase_path("//buildtools/${host_os}-${host_cpu}/clang/bin/llvm-readelf"),
+    ]
+
+    if (unstripped) {
+      args += [ "--unstripped" ]
+    }
+
+    outputs = [ "${_dest_base}/.${target_name}_success" ]
+
+    if (!defined(deps)) {
+      deps = []
+    }
+    deps += [ ":${target_name}_soft_transition" ]
+  }
+
+  # TODO(fxbug.dev/76223): Soft transition recipes/engine.py to used
+  # canonicalized debug symbol name and then remove.
+  action(target_name + "_soft_transition") {
+    forward_variables_from(invoker,
+                           [
+                             "deps",
+                             "unstripped",
+                             "binary_path",
+                             "testonly",
+                           ])
+
+    script = "//flutter/tools/fuchsia/copy_debug_symbols.py"
+
+    sources = [ binary_path ]
+
     _dest_base = "${root_out_dir}/flutter-debug-symbols-${flutter_runtime_mode}-${target_os}-${target_cpu}"
 
     args = [


### PR DESCRIPTION
This will make it simpler to add debug symbols using `symbol-index`: `./fuchsia/sdk/linux/tools/symbol-index add out/fuchsia_debug_x64/.build-id out/fuchsia_debug_x64`.

This helps implement https://fxbug.dev/76223.

CC: @naudzghebre 