### PR TITLE
Reclaim paragraph memory more aggressively

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -209,7 +209,7 @@ class CkCanvas {
       offset.dx,
       offset.dy,
     );
-    paragraph.dispose();
+    paragraph.release();
   }
 
   void drawPath(CkPath path, CkPaint paint) {
@@ -1089,7 +1089,7 @@ class CkDrawParagraphCommand extends CkPaintCommand {
       offset.dx,
       offset.dy,
     );
-    paragraph.dispose();
+    paragraph.release();
   }
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -209,7 +209,7 @@ class CkCanvas {
       offset.dx,
       offset.dy,
     );
-    paragraph.release();
+    paragraph.markUsed();
   }
 
   void drawPath(CkPath path, CkPaint paint) {
@@ -1089,7 +1089,7 @@ class CkDrawParagraphCommand extends CkPaintCommand {
       offset.dx,
       offset.dy,
     );
-    paragraph.release();
+    paragraph.markUsed();
   }
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -209,6 +209,7 @@ class CkCanvas {
       offset.dx,
       offset.dy,
     );
+    paragraph.dispose();
   }
 
   void drawPath(CkPath path, CkPaint paint) {
@@ -1088,6 +1089,7 @@ class CkDrawParagraphCommand extends CkPaintCommand {
       offset.dx,
       offset.dy,
     );
+    paragraph.dispose();
   }
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -1786,7 +1786,7 @@ class SkParagraph {
     SkRectHeightStyle heightStyle,
     SkRectWidthStyle widthStyle,
   );
-  external List<Float32List> getRectsForPlaceholders();
+  external List<dynamic> getRectsForPlaceholders();
   external SkTextPosition getGlyphPositionAtCoordinate(
     double x,
     double y,

--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -125,6 +125,10 @@ class SynchronousSkiaObjectCache {
   /// [maximumSize], then the least recently used objects are evicted and
   /// deleted.
   void add(SkiaObject object) {
+    assert(
+      !_itemMap.containsKey(object),
+      'Cannot add object. Object is already in the cache: $object',
+    );
     _itemQueue.addFirst(object);
     _itemMap[object] = _itemQueue.firstEntry()!;
     _enforceCacheLimit();
@@ -379,13 +383,13 @@ class SkiaObjectBox<R extends StackTraceDebugger, T extends Object>
 
   /// If asserts are enabled, the [StackTrace]s representing when a reference
   /// was created.
-  List<StackTrace>? debugGetStackTraces() {
+  List<StackTrace> debugGetStackTraces() {
     if (assertionsEnabled) {
       return debugReferrers
           .map<StackTrace>((R referrer) => referrer.debugStackTrace)
           .toList();
     }
-    return null;
+    throw UnsupportedError('');
   }
 
   /// The Skia object whose lifecycle is being managed.

--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -87,6 +87,81 @@ class SkiaObjectCache {
   }
 }
 
+/// Like [SkiaObjectCache] but enforces the [maximumSize] of the cache
+/// synchronously instead of waiting until a post-frame callback.
+class SynchronousSkiaObjectCache {
+  /// This cache will never exceed this limit, even temporarily.
+  final int maximumSize;
+
+  /// A doubly linked list of the objects in the cache.
+  ///
+  /// This makes it fast to move a recently used object to the front.
+  final DoubleLinkedQueue<SkiaObject> _itemQueue;
+
+  /// A map of objects to their associated node in the [_itemQueue].
+  ///
+  /// This makes it fast to find the node in the queue when we need to
+  /// move the object to the front of the queue.
+  final Map<SkiaObject, DoubleLinkedQueueEntry<SkiaObject>> _itemMap;
+
+  SynchronousSkiaObjectCache(this.maximumSize)
+      : _itemQueue = DoubleLinkedQueue<SkiaObject>(),
+        _itemMap = <SkiaObject, DoubleLinkedQueueEntry<SkiaObject>>{};
+
+  /// The number of objects in the cache.
+  int get length => _itemQueue.length;
+
+  /// Whether or not [object] is in the cache.
+  ///
+  /// This is only for testing.
+  @visibleForTesting
+  bool debugContains(SkiaObject object) {
+    return _itemMap.containsKey(object);
+  }
+
+  /// Adds [object] to the cache.
+  ///
+  /// If adding [object] causes the total size of the cache to exceed
+  /// [maximumSize], then the least recently used objects are evicted and
+  /// deleted.
+  void add(SkiaObject object) {
+    _itemQueue.addFirst(object);
+    _itemMap[object] = _itemQueue.firstEntry()!;
+    _enforceCacheLimit();
+  }
+
+  /// Marks the [object] as most recently used.
+  ///
+  /// If [object] is in the cache returns true. If the object is not in
+  /// the cache, for example, because it was never added or because it was
+  /// evicted as a result of the app reaching the cache limit, returns false.
+  bool markUsed(SkiaObject object) {
+    final DoubleLinkedQueueEntry<SkiaObject>? item = _itemMap[object];
+
+    if (item == null) {
+      return false;
+    }
+
+    item.remove();
+    _itemQueue.addFirst(object);
+    _itemMap[object] = _itemQueue.firstEntry()!;
+    return true;
+  }
+
+  /// Ensures the cache does not exceed [maximumSize], evicting objects if
+  /// necessary.
+  ///
+  /// Calls `delete` and `didDelete` on objects evicted from the cache.
+  void _enforceCacheLimit() {
+    while (_itemQueue.length > maximumSize) {
+      final SkiaObject oldObject = _itemQueue.removeLast();
+      _itemMap.remove(oldObject);
+      oldObject.delete();
+      oldObject.didDelete();
+    }
+  }
+}
+
 /// An object backed by a JavaScript object mapped onto a Skia C++ object in the
 /// WebAssembly heap.
 ///

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -635,14 +635,14 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
   //                https://github.com/flutter/flutter/issues/81224
   static SynchronousSkiaObjectCache _paragraphCache = SynchronousSkiaObjectCache(500);
 
-  /// Marks this paragraph as eligible for GC.
+  /// Marks this paragraph as having been used this frame.
   ///
   /// Puts this paragraph in a [SynchronousSkiaObjectCache], which will delete it
-  /// if there memory pressure to do so. This protects our memory usage from
+  /// if there's memory pressure to do so. This protects our memory usage from
   /// blowing up if within a single frame the framework needs to layout a lot of
   /// paragraphs. One common use-case is `ListView.builder`, which needs to layout
   /// more of its content than it actually renders to compute the scroll position.
-  void release() {
+  void markUsed() {
     // If the paragraph is already in the cache, just mark it as most recently
     // used. Otherwise, add to cache.
     if (!_paragraphCache.markUsed(this)) {
@@ -708,7 +708,7 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
     }
 
     final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
-    final List<Float32List> skRects = paragraph.getRectsForRange(
+    final List<List<double>> skRects = paragraph.getRectsForRange(
       start,
       end,
       toSkRectHeightStyle(boxHeightStyle),
@@ -718,7 +718,7 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
     return skRectsToTextBoxes(skRects);
   }
 
-  List<ui.TextBox> skRectsToTextBoxes(List<Float32List> skRects) {
+  List<ui.TextBox> skRectsToTextBoxes(List<dynamic> skRects) {
     List<ui.TextBox> result = <ui.TextBox>[];
 
     for (int i = 0; i < skRects.length; i++) {
@@ -762,7 +762,7 @@ class CkParagraph extends SkiaObject<SkParagraph> implements ui.Paragraph {
 
     // See class-level and _paragraphCache doc comments for why we're releasing
     // the paragraph immediately after layout.
-    release();
+    markUsed();
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -524,15 +524,14 @@ SkFontStyle toSkFontStyle(ui.FontWeight? fontWeight, ui.FontStyle? fontStyle) {
   return style;
 }
 
-class CkParagraph extends ManagedSkiaObject<SkParagraph>
-    implements ui.Paragraph {
+class CkParagraph implements ui.Paragraph {
   CkParagraph(
-      this._initialParagraph, this._paragraphStyle, this._paragraphCommands);
+      this._skParagraph, this._paragraphStyle, this._paragraphCommands);
 
   /// The result of calling `build()` on the JS CkParagraphBuilder.
   ///
   /// This may be invalidated later.
-  final SkParagraph _initialParagraph;
+  SkParagraph? _skParagraph;
 
   /// The paragraph style used to build this paragraph.
   ///
@@ -552,75 +551,104 @@ class CkParagraph extends ManagedSkiaObject<SkParagraph>
   /// is deleted.
   ui.ParagraphConstraints? _lastLayoutConstraints;
 
-  @override
-  SkParagraph createDefault() => _initialParagraph;
+  SkParagraph get skiaObject => _ensureInitialized(_lastLayoutConstraints!);
 
-  @override
-  SkParagraph resurrect() {
-    final builder = CkParagraphBuilder(_paragraphStyle);
-    for (_ParagraphCommand command in _paragraphCommands) {
-      switch (command.type) {
-        case _ParagraphCommandType.addText:
-          builder.addText(command.text!);
-          break;
-        case _ParagraphCommandType.pop:
-          builder.pop();
-          break;
-        case _ParagraphCommandType.pushStyle:
-          builder.pushStyle(command.style!);
-          break;
-        case _ParagraphCommandType.addPlaceholder:
-          builder._addPlaceholder(command.placeholderStyle!);
-          break;
+  SkParagraph _ensureInitialized(ui.ParagraphConstraints constraints) {
+    SkParagraph? paragraph = _skParagraph;
+
+    // Paragraph objects are immutable. It's OK to skip initialization and reuse
+    // existing object.
+    bool didRebuildSkiaObject = false;
+    if (paragraph == null) {
+      final builder = CkParagraphBuilder(_paragraphStyle);
+      for (_ParagraphCommand command in _paragraphCommands) {
+        switch (command.type) {
+          case _ParagraphCommandType.addText:
+            builder.addText(command.text!);
+            break;
+          case _ParagraphCommandType.pop:
+            builder.pop();
+            break;
+          case _ParagraphCommandType.pushStyle:
+            builder.pushStyle(command.style!);
+            break;
+          case _ParagraphCommandType.addPlaceholder:
+            builder._addPlaceholder(command.placeholderStyle!);
+            break;
+        }
+      }
+      paragraph = builder._buildSkParagraph();
+      _skParagraph = paragraph;
+      didRebuildSkiaObject = true;
+    }
+
+    final bool constraintsChanged = _lastLayoutConstraints != constraints;
+    if (didRebuildSkiaObject || constraintsChanged) {
+      _lastLayoutConstraints = constraints;
+      // TODO(het): CanvasKit throws an exception when laid out with
+      // a font that wasn't registered.
+      try {
+        paragraph.layout(constraints.width);
+        _alphabeticBaseline = paragraph.getAlphabeticBaseline();
+        _didExceedMaxLines = paragraph.didExceedMaxLines();
+        _height = paragraph.getHeight();
+        _ideographicBaseline = paragraph.getIdeographicBaseline();
+        _longestLine = paragraph.getLongestLine();
+        _maxIntrinsicWidth = paragraph.getMaxIntrinsicWidth();
+        _minIntrinsicWidth = paragraph.getMinIntrinsicWidth();
+        _width = paragraph.getMaxWidth();
+        _boxesForPlaceholders = skRectsToTextBoxes(paragraph.getRectsForPlaceholders());
+      } catch (e) {
+        printWarning('CanvasKit threw an exception while laying '
+            'out the paragraph. The font was "${_paragraphStyle._fontFamily}". '
+            'Exception:\n$e');
+        rethrow;
       }
     }
 
-    final SkParagraph result = builder._buildCkParagraph();
-    if (_lastLayoutConstraints != null) {
-      // We need to set the Skia object early so layout works.
-      rawSkiaObject = result;
-      this.layout(_lastLayoutConstraints!);
-    }
-    return result;
+    return paragraph;
+  }
+
+  void dispose() {
+    _skParagraph!.delete();
+    _skParagraph = null;
   }
 
   @override
-  void delete() {
-    rawSkiaObject?.delete();
-  }
+  double get alphabeticBaseline => _alphabeticBaseline;
+  double _alphabeticBaseline = 0;
 
   @override
-  bool get isResurrectionExpensive => true;
+  bool get didExceedMaxLines => _didExceedMaxLines;
+  bool _didExceedMaxLines = false;
 
   @override
-  double get alphabeticBaseline => skiaObject.getAlphabeticBaseline();
+  double get height => _height;
+  double _height = 0;
 
   @override
-  bool get didExceedMaxLines => skiaObject.didExceedMaxLines();
+  double get ideographicBaseline => _ideographicBaseline;
+  double _ideographicBaseline = 0;
 
   @override
-  double get height => skiaObject.getHeight();
+  double get longestLine => _longestLine;
+  double _longestLine = 0;
 
   @override
-  double get ideographicBaseline => skiaObject.getIdeographicBaseline();
+  double get maxIntrinsicWidth => _maxIntrinsicWidth;
+  double _maxIntrinsicWidth = 0;
 
   @override
-  double get longestLine => skiaObject.getLongestLine();
+  double get minIntrinsicWidth => _minIntrinsicWidth;
+  double _minIntrinsicWidth = 0;
 
   @override
-  double get maxIntrinsicWidth => skiaObject.getMaxIntrinsicWidth();
+  double get width => _width;
+  double _width = 0;
 
   @override
-  double get minIntrinsicWidth => skiaObject.getMinIntrinsicWidth();
-
-  @override
-  double get width => skiaObject.getMaxWidth();
-
-  @override
-  List<ui.TextBox> getBoxesForPlaceholders() {
-    List<List<double>> skRects = skiaObject.getRectsForPlaceholders();
-    return skRectsToTextBoxes(skRects);
-  }
+  List<ui.TextBox> getBoxesForPlaceholders() => _boxesForPlaceholders!;
+  List<ui.TextBox>? _boxesForPlaceholders;
 
   @override
   List<ui.TextBox> getBoxesForRange(
@@ -633,7 +661,8 @@ class CkParagraph extends ManagedSkiaObject<SkParagraph>
       return const <ui.TextBox>[];
     }
 
-    List<List<double>> skRects = skiaObject.getRectsForRange(
+    final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
+    final List<Float32List> skRects = paragraph.getRectsForRange(
       start,
       end,
       toSkRectHeightStyle(boxHeightStyle),
@@ -643,7 +672,7 @@ class CkParagraph extends ManagedSkiaObject<SkParagraph>
     return skRectsToTextBoxes(skRects);
   }
 
-  List<ui.TextBox> skRectsToTextBoxes(List<List<double>> skRects) {
+  List<ui.TextBox> skRectsToTextBoxes(List<Float32List> skRects) {
     List<ui.TextBox> result = <ui.TextBox>[];
 
     for (int i = 0; i < skRects.length; i++) {
@@ -662,8 +691,9 @@ class CkParagraph extends ManagedSkiaObject<SkParagraph>
 
   @override
   ui.TextPosition getPositionForOffset(ui.Offset offset) {
+    final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
     final SkTextPosition positionWithAffinity =
-        skiaObject.getGlyphPositionAtCoordinate(
+        paragraph.getGlyphPositionAtCoordinate(
       offset.dx,
       offset.dy,
     );
@@ -672,29 +702,24 @@ class CkParagraph extends ManagedSkiaObject<SkParagraph>
 
   @override
   ui.TextRange getWordBoundary(ui.TextPosition position) {
-    final SkTextRange skRange = skiaObject.getWordBoundary(position.offset);
+    final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
+    final SkTextRange skRange = paragraph.getWordBoundary(position.offset);
     return ui.TextRange(start: skRange.start, end: skRange.end);
   }
 
   @override
   void layout(ui.ParagraphConstraints constraints) {
-    _lastLayoutConstraints = constraints;
-
-    // TODO(het): CanvasKit throws an exception when laid out with
-    // a font that wasn't registered.
-    try {
-      skiaObject.layout(constraints.width);
-    } catch (e) {
-      printWarning('CanvasKit threw an exception while laying '
-          'out the paragraph. The font was "${_paragraphStyle._fontFamily}". '
-          'Exception:\n$e');
-      rethrow;
+    if (_lastLayoutConstraints == constraints) {
+      return;
     }
+    _ensureInitialized(constraints);
+    dispose();
   }
 
   @override
   ui.TextRange getLineBoundary(ui.TextPosition position) {
-    final List<SkLineMetrics> metrics = skiaObject.getLineMetrics();
+    final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
+    final List<SkLineMetrics> metrics = paragraph.getLineMetrics();
     final int offset = position.offset;
     for (final SkLineMetrics metric in metrics) {
       if (offset >= metric.startIndex && offset <= metric.endIndex) {
@@ -706,7 +731,8 @@ class CkParagraph extends ManagedSkiaObject<SkParagraph>
 
   @override
   List<ui.LineMetrics> computeLineMetrics() {
-    final List<SkLineMetrics> skLineMetrics = skiaObject.getLineMetrics();
+    final SkParagraph paragraph = _ensureInitialized(_lastLayoutConstraints!);
+    final List<SkLineMetrics> skLineMetrics = paragraph.getLineMetrics();
     final List<ui.LineMetrics> result = <ui.LineMetrics>[];
     for (final SkLineMetrics metric in skLineMetrics) {
       result.add(CkLineMetrics._(metric));
@@ -997,15 +1023,14 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
     _commands.add(_ParagraphCommand.addText(text));
     _paragraphBuilder.addText(text);
   }
-
   @override
   CkParagraph build() {
-    final builtParagraph = _buildCkParagraph();
+    final builtParagraph = _buildSkParagraph();
     return CkParagraph(builtParagraph, _style, _commands);
   }
 
   /// Builds the CkParagraph with the builder and deletes the builder.
-  SkParagraph _buildCkParagraph() {
+  SkParagraph _buildSkParagraph() {
     final SkParagraph result = _paragraphBuilder.build();
     _paragraphBuilder.delete();
     return result;


### PR DESCRIPTION
Put `CkParagraph` objects into a separate synchronous cache, which reclaims memory synchronously. This significantly reduces paragraph memory usage for very long `ListView`s and other cases where lots of paragraphs are laid out but not rendered. It does not fully cover the use-case where we both lay out and render tons of paragraphs (it fixes the memory issue but not the performance issue). For that we need https://github.com/flutter/flutter/issues/81224.

Some benchmark numbers:

`text_canvas_kit_color_grid`: before 420MB, after 153MB
Layout and render 10000 paragraphs: before 1GB, after 200MB
[sample 1, 60 seconds](https://github.com/flutter/flutter/issues/66614#issue-708581477) (by @slavap): before 600MB, after 168MB
[sample 2, 100 tab switches](https://github.com/flutter/flutter/issues/66614#issuecomment-844733715) (by @asjqkkkk): before 422MB, after 253MB

Fixes https://github.com/flutter/flutter/issues/66614
