### PR TITLE
Make resume dart microtasks static to avoid capturing vsync waiter

### DIFF
--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -75,7 +75,7 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
   std::unordered_map<uintptr_t, fml::closure> secondary_callbacks_;
 
   void PauseDartMicroTasks();
-  void ResumeDartMicroTasks();
+  static void ResumeDartMicroTasks(fml::TaskQueueId ui_task_queue_id);
 
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiter);
 };


### PR DESCRIPTION
This avoids the race where vsync waiter was shutdown before the tasks on
ui task runner got flushed.

Fixes: https://github.com/flutter/flutter/issues/82024
