### PR TITLE
Fix Fragment not transparent in Texture render mode

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -279,6 +279,8 @@ import java.util.Arrays;
     } else {
       FlutterTextureView flutterTextureView = new FlutterTextureView(host.getActivity());
 
+      flutterTextureView.setOpaque(host.getTransparencyMode() == TransparencyMode.opaque);
+
       // Allow our host to customize FlutterSurfaceView, if desired.
       host.onFlutterTextureViewCreated(flutterTextureView);
 


### PR DESCRIPTION
When the render mode was set to RenderMode.texture,
the engine did not check, whether the texture view should
be transparent, so it was always opaque. This commit fixes
this behavior.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
