### PR TITLE
Add Float32List support to the Linux standard message codec

### DIFF
--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -63,8 +63,8 @@ class CustomEncodableValue {
   ~CustomEncodableValue() = default;
 
   // Allow implicit conversion to std::any to allow direct use of any_cast.
-  operator std::any&() { return value_; }
-  operator const std::any&() const { return value_; }
+  operator std::any &() { return value_; }
+  operator const std::any &() const { return value_; }
 
 #if defined(FLUTTER_ENABLE_RTTI) && FLUTTER_ENABLE_RTTI
   // Passthrough to std::any's type().

--- a/shell/platform/linux/fl_standard_message_codec_test.cc
+++ b/shell/platform/linux/fl_standard_message_codec_test.cc
@@ -526,6 +526,58 @@ TEST(FlStandardMessageCodecTest, DecodeInt64ListShortData2) {
       FL_MESSAGE_CODEC_ERROR, FL_MESSAGE_CODEC_ERROR_OUT_OF_DATA);
 }
 
+TEST(FlStandardMessageCodecTest, EncodeFloat32ListEmpty) {
+  g_autoptr(FlValue) value = fl_value_new_float32_list(nullptr, 0);
+  g_autofree gchar* hex_string = encode_message(value);
+  EXPECT_STREQ(hex_string, "0e000000");
+}
+
+TEST(FlStandardMessageCodecTest, EncodeFloat32List) {
+  float data[] = {0.0f, -0.5f, 0.25f, -0.125f, 0.00625f};
+  g_autoptr(FlValue) value = fl_value_new_float32_list(data, 5);
+  g_autofree gchar* hex_string = encode_message(value);
+  EXPECT_STREQ(hex_string, "0e05000000000000000000bf0000803e000000becdcccc3b");
+}
+
+TEST(FlStandardMessageCodecTest, DecodeFloat32ListEmpty) {
+  g_autoptr(FlValue) value = decode_message("0e000000");
+  ASSERT_EQ(fl_value_get_type(value), FL_VALUE_TYPE_FLOAT32_LIST);
+  EXPECT_EQ(fl_value_get_length(value), static_cast<size_t>(0));
+}
+
+TEST(FlStandardMessageCodecTest, DecodeFloat32List) {
+  g_autoptr(FlValue) value =
+      decode_message("0e05000000000000000000bf0000803e000000becdcccc3b");
+  ASSERT_EQ(fl_value_get_type(value), FL_VALUE_TYPE_FLOAT32_LIST);
+  const float* data = fl_value_get_float32_list(value);
+  EXPECT_FLOAT_EQ(data[0], 0.0f);
+  EXPECT_FLOAT_EQ(data[1], -0.5f);
+  EXPECT_FLOAT_EQ(data[2], 0.25f);
+  EXPECT_FLOAT_EQ(data[3], -0.125f);
+  EXPECT_FLOAT_EQ(data[4], 0.00625f);
+}
+
+TEST(FlStandardMessageCodecTest, DecodeFloat32ListNoData) {
+  decode_error_value("0e", FL_MESSAGE_CODEC_ERROR,
+                     FL_MESSAGE_CODEC_ERROR_OUT_OF_DATA);
+}
+
+TEST(FlStandardMessageCodecTest, DecodeFloat32ListLengthNoData) {
+  decode_error_value("0e050000", FL_MESSAGE_CODEC_ERROR,
+                     FL_MESSAGE_CODEC_ERROR_OUT_OF_DATA);
+}
+
+TEST(FlStandardMessageCodecTest, DecodeFloat32ListShortData1) {
+  decode_error_value("0e05000000", FL_MESSAGE_CODEC_ERROR,
+                     FL_MESSAGE_CODEC_ERROR_OUT_OF_DATA);
+}
+
+TEST(FlStandardMessageCodecTest, DecodeFloat32ListShortData2) {
+  decode_error_value("0e05000000000000000000bf0000803e000000becdcccc",
+                     FL_MESSAGE_CODEC_ERROR,
+                     FL_MESSAGE_CODEC_ERROR_OUT_OF_DATA);
+}
+
 TEST(FlStandardMessageCodecTest, EncodeFloatListEmpty) {
   g_autoptr(FlValue) value = fl_value_new_float_list(nullptr, 0);
   g_autofree gchar* hex_string = encode_message(value);
@@ -1006,7 +1058,7 @@ TEST(FlStandardMessageCodecTest, EncodeDecodeLargeMap) {
 }
 
 TEST(FlStandardMessageCodecTest, DecodeUnknownType) {
-  decode_error_value("0e", FL_MESSAGE_CODEC_ERROR,
+  decode_error_value("0f", FL_MESSAGE_CODEC_ERROR,
                      FL_MESSAGE_CODEC_ERROR_UNSUPPORTED_TYPE);
 }
 

--- a/shell/platform/linux/public/flutter_linux/fl_value.h
+++ b/shell/platform/linux/public/flutter_linux/fl_value.h
@@ -30,6 +30,7 @@ G_BEGIN_DECLS
  * - #FL_VALUE_TYPE_UINT8_LIST: Uint8List
  * - #FL_VALUE_TYPE_INT32_LIST: Int32List
  * - #FL_VALUE_TYPE_INT64_LIST: Int64List
+ * - #FL_VALUE_TYPE_FLOAT32_LIST: Float32List
  * - #FL_VALUE_TYPE_FLOAT_LIST: Float64List
  * - #FL_VALUE_TYPE_LIST: List<dynamic>
  * - #FL_VALUE_TYPE_MAP: Map<dynamic>
@@ -51,6 +52,7 @@ typedef struct _FlValue FlValue;
  * @FL_VALUE_TYPE_FLOAT_LIST: An ordered list of floating point numbers.
  * @FL_VALUE_TYPE_LIST: An ordered list of #FlValue objects.
  * @FL_VALUE_TYPE_MAP: A map of #FlValue objects keyed by #FlValue object.
+ * @FL_VALUE_TYPE_FLOAT32_LIST: An ordered list of 32bit floating point numbers.
  *
  * Types of #FlValue.
  */
@@ -66,6 +68,7 @@ typedef enum {
   FL_VALUE_TYPE_FLOAT_LIST,
   FL_VALUE_TYPE_LIST,
   FL_VALUE_TYPE_MAP,
+  FL_VALUE_TYPE_FLOAT32_LIST,
 } FlValueType;
 
 /**
@@ -180,6 +183,18 @@ FlValue* fl_value_new_int32_list(const int32_t* value, size_t value_length);
  * Returns: a new #FlValue.
  */
 FlValue* fl_value_new_int64_list(const int64_t* value, size_t value_length);
+
+/**
+ * fl_value_new_float32_list:
+ * @value: an array of floating point numbers.
+ * @value_length: number of elements in @value.
+ *
+ * Creates an ordered list containing 32 bit floating point numbers.
+ * The equivalent Dart type is a Float32List.
+ *
+ * Returns: a new #FlValue.
+ */
+FlValue* fl_value_new_float32_list(const float* value, size_t value_length);
 
 /**
  * fl_value_new_float_list:
@@ -435,7 +450,8 @@ const gchar* fl_value_get_string(FlValue* value);
  * fl_value_get_length:
  * @value: an #FlValue of type #FL_VALUE_TYPE_UINT8_LIST,
  * #FL_VALUE_TYPE_INT32_LIST, #FL_VALUE_TYPE_INT64_LIST,
- * #FL_VALUE_TYPE_FLOAT_LIST, #FL_VALUE_TYPE_LIST or #FL_VALUE_TYPE_MAP.
+ * #FL_VALUE_TYPE_FLOAT32_LIST, #FL_VALUE_TYPE_FLOAT_LIST, #FL_VALUE_TYPE_LIST
+ * or #FL_VALUE_TYPE_MAP.
  *
  * Gets the number of elements @value contains. This is only valid for list
  * and map types. Calling this with other types is a programming error.
@@ -479,6 +495,18 @@ const int32_t* fl_value_get_int32_list(FlValue* value);
  * Returns: an array of 64 bit integers.
  */
 const int64_t* fl_value_get_int64_list(FlValue* value);
+
+/**
+ * fl_value_get_float32_list:
+ * @value: an #FlValue of type #FL_VALUE_TYPE_FLOAT32_LIST.
+ *
+ * Gets the array of floating point numbers @value contains. The data
+ * contains fl_get_length() elements. Calling this with an #FlValue that is
+ * not of type #FL_VALUE_TYPE_FLOAT32_LIST is a programming error.
+ *
+ * Returns: an array of floating point numbers.
+ */
+const float* fl_value_get_float32_list(FlValue* value);
 
 /**
  * fl_value_get_float_list:


### PR DESCRIPTION
It adds support that was missing from flutter/engine#26386 and is part of the fix for flutter/flutter#72613

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
