### PR TITLE
Cache Handle.koid().

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/handle.cc
@@ -60,6 +60,7 @@ zx_handle_t Handle::ReleaseHandle() {
 
   zx_handle_t handle = handle_;
   handle_ = ZX_HANDLE_INVALID;
+  cached_koid_ = std::nullopt;
   while (waiters_.size()) {
     // HandleWaiter::Cancel calls Handle::ReleaseWaiter which removes the
     // HandleWaiter from waiters_.

--- a/shell/platform/fuchsia/dart-pkg/zircon/test/handle_test.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/test/handle_test.dart
@@ -153,4 +153,16 @@ void main() {
       expect(readResult.bytesAsUTF8String(), equals('\x00\x00'));
     });
   });
+
+  test('cache koid and invalidate', () {
+    final HandleResult vmo = System.vmoCreate(0);
+    expect(vmo.status, equals(ZX.OK));
+    int originalKoid = vmo.handle.koid;
+    expect(originalKoid, isNot(equals(ZX.KOID_INVALID)));
+    // Cached koid should be same value.
+    expect(originalKoid, equals(vmo.handle.koid));
+    vmo.handle.close();
+    // koid should be invalidated.
+    expect(vmo.handle.koid, equals(ZX.KOID_INVALID));
+  });
 }


### PR DESCRIPTION
Additionally add tests to ensure that the koid is properly cache-invalidated.

See https://fxbug.dev/73390.

CC: @naudzghebre, @chaselatta 