### PR TITLE
Fix pub_get_offline.py undefined variables

### DIFF
--- a/tools/pub_get_offline.py
+++ b/tools/pub_get_offline.py
@@ -32,7 +32,7 @@ def FetchPackage(pub, package):
     subprocess.check_output(pub, cwd=package, stderr=subprocess.STDOUT)
   except subprocess.CalledProcessError as err:
     print("'%s' failed in '%s' with status %d:\n%s" %
-          (' '.join(cmd), cwd, err.returncode, err.output))
+          (' '.join(pub), package, err.returncode, err.output))
     return 1
   return 0
 


### PR DESCRIPTION
`cmd` and `cwd` are not defined, hiding the real error message.

Log: https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket.appspot.com/8845647420396218640/+/u/gclient_runhooks/stdout