### PR TITLE
Cloned frame timings have same frame number

### DIFF
--- a/flow/frame_timings.cc
+++ b/flow/frame_timings.cc
@@ -24,6 +24,10 @@ FrameTimingsRecorder::FrameTimingsRecorder()
     : frame_number_(frame_number_gen_++),
       frame_number_trace_arg_val_(ToString(frame_number_)) {}
 
+FrameTimingsRecorder::FrameTimingsRecorder(uint64_t frame_number)
+    : frame_number_(frame_number),
+      frame_number_trace_arg_val_(ToString(frame_number_)) {}
+
 FrameTimingsRecorder::~FrameTimingsRecorder() = default;
 
 fml::TimePoint FrameTimingsRecorder::GetVsyncStartTime() const {
@@ -117,7 +121,7 @@ std::unique_ptr<FrameTimingsRecorder> FrameTimingsRecorder::CloneUntil(
     State state) {
   std::scoped_lock state_lock(state_mutex_);
   std::unique_ptr<FrameTimingsRecorder> recorder =
-      std::make_unique<FrameTimingsRecorder>();
+      std::make_unique<FrameTimingsRecorder>(frame_number_);
   recorder->state_ = state;
 
   if (state >= State::kVsync) {

--- a/flow/frame_timings.h
+++ b/flow/frame_timings.h
@@ -39,6 +39,9 @@ class FrameTimingsRecorder {
   /// Default constructor, initializes the recorder with State::kUninitialized.
   FrameTimingsRecorder();
 
+  /// Constructor with a pre-populated frame number.
+  FrameTimingsRecorder(uint64_t frame_number);
+
   ~FrameTimingsRecorder();
 
   /// Timestamp of the vsync signal.

--- a/flow/frame_timings_recorder_unittests.cc
+++ b/flow/frame_timings_recorder_unittests.cc
@@ -95,14 +95,14 @@ TEST(FrameTimingsRecorderTest, RecordersHaveUniqueFrameNumbers) {
   ASSERT_TRUE(recorder2->GetFrameNumber() > recorder1->GetFrameNumber());
 }
 
-TEST(FrameTimingsRecorderTest, ClonedHasUniqueFrameNumber) {
+TEST(FrameTimingsRecorderTest, ClonedHasSameFrameNumber) {
   auto recorder = std::make_unique<FrameTimingsRecorder>();
 
   const auto now = fml::TimePoint::Now();
   recorder->RecordVsync(now, now);
 
   auto cloned = recorder->CloneUntil(FrameTimingsRecorder::State::kVsync);
-  ASSERT_NE(recorder->GetFrameNumber(), cloned->GetFrameNumber());
+  ASSERT_EQ(recorder->GetFrameNumber(), cloned->GetFrameNumber());
 }
 
 TEST(FrameTimingsRecorderTest, FrameNumberTraceArgIsValid) {


### PR DESCRIPTION
We clone a frame timings recorder before rasterization
is finished in-case the frame gets resubmitted due to
platform views resulting in a frame being resubmitted.
This lead to frame timings incrementing by 2 each time,
when they are cloned, this fixes that problem.
