### PR TITLE
Fix gradient stop out of range error

### DIFF
--- a/lib/web_ui/lib/src/engine/html/shaders/shader.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/shader.dart
@@ -387,8 +387,9 @@ void _addColorStopsToCanvasGradient(html.CanvasGradient gradient,
     gradient.addColorStop(1 - offset, colorToCssString(colors[1])!);
   } else {
     for (int i = 0; i < colors.length; i++) {
+      final double colorStop = colorStops[i].clamp(0.0, 1.0);
       gradient.addColorStop(
-          colorStops[i] * scale + offset, colorToCssString(colors[i])!);
+          colorStop * scale + offset, colorToCssString(colors[i])!);
     }
   }
   if (isDecal) {

--- a/lib/web_ui/test/golden_tests/engine/gradient_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/gradient_golden_test.dart
@@ -345,6 +345,42 @@ void testMain() async {
     await _checkScreenshot(canvas, 'linear_gradient_rect_shifted');
   });
 
+  /// Regression test for https://github.com/flutter/flutter/issues/82748.
+  test('Paints gradient with gradient stop outside range', () async {
+    final RecordingCanvas canvas =
+    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+    canvas.save();
+
+    final Paint borderPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1
+      ..color = Color(0xFF000000);
+
+    List<Color> colors = <Color>[
+      Color(0xFF000000),
+      Color(0xFFFF3C38)];
+    List<double> stops = <double>[0.0, 10.0];
+
+    EngineGradient linearGradient = GradientLinear(Offset(50, 50),
+        Offset(200,130),
+        colors, stops, TileMode.clamp,
+        Matrix4.identity().storage);
+
+    const double kBoxWidth = 150;
+    const double kBoxHeight = 80;
+    // Gradient with default center.
+    Rect rectBounds = Rect.fromLTWH(10, 20, kBoxWidth, kBoxHeight);
+    canvas.drawRect(rectBounds,
+        Paint()..shader = engineLinearGradientToShader(linearGradient, rectBounds));
+    canvas.drawRect(rectBounds, borderPaint);
+    canvas.restore();
+
+    final EngineCanvas engineCanvas = BitmapCanvas(screenRect,
+        RenderStrategy());
+    canvas.endRecording();
+    canvas.apply(engineCanvas, screenRect);
+  });
+
   test('Paints clamped, rotated and shifted linear gradient', () async {
     final RecordingCanvas canvas =
     RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));


### PR DESCRIPTION
Native and canvaskit renderer clamps gradient stops but html renderer backend passes color stop values to CanvasGradient that throws error when out of range. This PR clamps value before passing to platform.

Fixes
https://github.com/flutter/flutter/issues/82748

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
