### PR TITLE
Add an encoder for CharSequence in StandardMessageCodec

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
@@ -234,9 +234,9 @@ public class StandardMessageCodec implements MessageCodec<Object> {
       } else {
         throw new IllegalArgumentException("Unsupported Number type: " + value.getClass());
       }
-    } else if (value instanceof String) {
+    } else if (value instanceof CharSequence) {
       stream.write(STRING);
-      writeBytes(stream, ((String) value).getBytes(UTF8));
+      writeBytes(stream, value.toString().getBytes(UTF8));
     } else if (value instanceof byte[]) {
       stream.write(BYTE_ARRAY);
       writeBytes(stream, (byte[]) value);

--- a/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
@@ -3,6 +3,7 @@ package io.flutter.plugin.common;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import android.text.SpannableString;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import org.junit.Test;
@@ -107,5 +108,18 @@ public class StandardMessageCodecTest {
 
     float[] values = (float[]) codec.decodeMessage(message);
     assertArrayEquals(expectedValues, values, 0.01f);
+  }
+
+  @Test
+  public void itEncodesCharSequences() {
+    StandardMessageCodec codec = new StandardMessageCodec();
+
+    CharSequence cs = new SpannableString("hello world");
+
+    ByteBuffer message = codec.encodeMessage(cs);
+    message.flip();
+
+    String value = (String) codec.decodeMessage(message);
+    assertEquals(value, "hello world");
   }
 }


### PR DESCRIPTION
https://github.com/flutter/engine/pull/25373 introdued APIs that
return SpannableString, which is a CharSequence subclass that was
not previously supported by StandardMessageCodec

See https://github.com/flutter/flutter/issues/83751