### PR TITLE
Added more descriptive error to StandardMessageCodec for types that override toString

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
@@ -288,7 +288,8 @@ public class StandardMessageCodec implements MessageCodec<Object> {
         writeFloat(stream, f);
       }
     } else {
-      throw new IllegalArgumentException("Unsupported value: " + value);
+      throw new IllegalArgumentException(
+          "Unsupported value: '" + value + "' of type '" + value.getClass() + "'");
     }
   }
 

--- a/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/common/StandardMessageCodecTest.java
@@ -2,6 +2,8 @@ package io.flutter.plugin.common;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import android.text.SpannableString;
 import java.nio.ByteBuffer;
@@ -121,5 +123,25 @@ public class StandardMessageCodecTest {
 
     String value = (String) codec.decodeMessage(message);
     assertEquals(value, "hello world");
+  }
+
+  private static class NotEncodable {
+    @Override
+    public String toString() {
+      return "not encodable";
+    }
+  }
+
+  @Test
+  public void errorHasType() {
+    StandardMessageCodec codec = new StandardMessageCodec();
+    NotEncodable notEncodable = new NotEncodable();
+    Exception exception =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              codec.encodeMessage(notEncodable);
+            });
+    assertTrue(exception.getMessage().contains("NotEncodable"));
   }
 }


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/83751

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
