### PR TITLE
Fix incorrectly inserting Float32List in the wrong location in encodable_value

### DIFF
--- a/shell/platform/common/client_wrapper/encodable_value_unittests.cc
+++ b/shell/platform/common/client_wrapper/encodable_value_unittests.cc
@@ -283,4 +283,51 @@ TEST(EncodableValueTest, DeepCopy) {
   EXPECT_EQ(std::get<std::string>(innermost_map[EncodableValue("a")]), "b");
 }
 
+// Simple class for testing custom encodable values
+class TestCustomValue {
+ public:
+  TestCustomValue() : x_(0), y_(0) {}
+  TestCustomValue(int x, int y) : x_(x), y_(y) {}
+  ~TestCustomValue() = default;
+
+  int x() const { return x_; }
+  int y() const { return y_; }
+
+ private:
+  int x_;
+  int y_;
+};
+
+TEST(EncodableValueTest, TypeIndexesCorrect) {
+  // Null
+  EXPECT_EQ(EncodableValue().index(), 0u);
+  // Bool
+  EXPECT_EQ(EncodableValue(true).index(), 1u);
+  // Int32
+  EXPECT_EQ(EncodableValue(100).index(), 2u);
+  // Int64
+  EXPECT_EQ(EncodableValue(INT64_C(100)).index(), 3u);
+  // Double
+  EXPECT_EQ(EncodableValue(7.0).index(), 4u);
+  // String
+  EXPECT_EQ(EncodableValue("one").index(), 5u);
+  // ByteList
+  EXPECT_EQ(EncodableValue(std::vector<uint8_t>()).index(), 6u);
+  // IntList
+  EXPECT_EQ(EncodableValue(std::vector<int32_t>()).index(), 7u);
+  // LongList
+  EXPECT_EQ(EncodableValue(std::vector<int64_t>()).index(), 8u);
+  // DoubleList
+  EXPECT_EQ(EncodableValue(std::vector<double>()).index(), 9u);
+  // List
+  EXPECT_EQ(EncodableValue(EncodableList()).index(), 10u);
+  // Map
+  EXPECT_EQ(EncodableValue(EncodableMap()).index(), 11u);
+  // Custom type
+  TestCustomValue customValue;
+  EXPECT_EQ(((EncodableValue)CustomEncodableValue(customValue)).index(), 12u);
+  // FloatList
+  EXPECT_EQ(EncodableValue(std::vector<float>()).index(), 13u);
+}  // namespace flutter
+
 }  // namespace flutter

--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -110,8 +110,8 @@ using EncodableValueVariant = std::variant<std::monostate,
                                            std::vector<double>,
                                            EncodableList,
                                            EncodableMap,
-                                           std::vector<float>,
-                                           CustomEncodableValue>;
+                                           CustomEncodableValue,
+                                           std::vector<float>>;
 }  // namespace internal
 
 // An object that can contain any value or collection type supported by
@@ -156,10 +156,10 @@ using EncodableValueVariant = std::variant<std::monostate,
 // std::vector<uint8_t> -> Uint8List
 // std::vector<int32_t> -> Int32List
 // std::vector<int64_t> -> Int64List
+// std::vector<float>   -> Float32List
 // std::vector<double>  -> Float64List
 // EncodableList        -> List
 // EncodableMap         -> Map
-// std::vector<float>   -> Float32List
 class EncodableValue : public internal::EncodableValueVariant {
  public:
   // Rely on std::variant for most of the constructors/operators.

--- a/shell/platform/common/client_wrapper/standard_codec.cc
+++ b/shell/platform/common/client_wrapper/standard_codec.cc
@@ -71,7 +71,7 @@ EncodedType EncodedTypeForValue(const EncodableValue& value) {
       return EncodedType::kList;
     case 11:
       return EncodedType::kMap;
-    case 12:
+    case 13:
       return EncodedType::kFloat32List;
   }
   assert(false);
@@ -153,15 +153,15 @@ void StandardCodecSerializer::WriteValue(const EncodableValue& value,
       }
       break;
     }
-    case 12: {
-      WriteVector(std::get<std::vector<float>>(value), stream);
-      break;
-    }
-    case 13:
+    case 12:
       std::cerr
           << "Unhandled custom type in StandardCodecSerializer::WriteValue. "
           << "Custom types require codec extensions." << std::endl;
       break;
+    case 13: {
+      WriteVector(std::get<std::vector<float>>(value), stream);
+      break;
+    }
   }
 }
 

--- a/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
+++ b/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
@@ -175,7 +175,7 @@ TEST(StandardMessageCodec, CanEncodeAndDecodeInt64Array) {
   CheckEncodeDecode(value, bytes);
 }
 
-TEST(StandradMessageCodec, CanEncodeAndDecodeFloat32Array) {
+TEST(StandardMessageCodec, CanEncodeAndDecodeFloat32Array) {
   std::vector<uint8_t> bytes = {0x0e, 0x02, 0x00, 0x00, 0xd8, 0x0f,
                                 0x49, 0x40, 0x00, 0x00, 0x7a, 0x44};
   EncodableValue value(std::vector<float>{3.1415920257568359375f, 1000.0f});


### PR DESCRIPTION
This is to address an issue introduced in flutter/engine#26386 and part of the fix for flutter/flutter#72613

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
