### PR TITLE
Fix create_arm_gen_snapshot target

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -197,27 +197,29 @@ bin_to_linkable("platform_strong_dill_linkable") {
   executable = false
 }
 
-action("create_arm_gen_snapshot") {
-  output_dir = "$root_out_dir/clang_x64"
-  script = "//flutter/sky/tools/create_macos_gen_snapshots.py"
-  visibility = [ ":*" ]
-  deps = [ "//third_party/dart/runtime/bin:gen_snapshot(//build/toolchain/$host_os:clang_x64)" ]
-  args = [
-    "--dst",
-    rebase_path(output_dir),
-  ]
-  if (target_cpu == "arm") {
-    args += [
-      "--armv7-out-dir",
-      rebase_path("$root_out_dir"),
+if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
+  action("create_arm_gen_snapshot") {
+    output_dir = "$root_out_dir/clang_x64"
+    script = "//flutter/sky/tools/create_macos_gen_snapshots.py"
+    visibility = [ ":*" ]
+    deps = [ "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)" ]
+    args = [
+      "--dst",
+      rebase_path(output_dir),
     ]
-    outputs = [ "$output_dir/gen_snapshot_armv7" ]
-  } else {
-    args += [
-      "--arm64-out-dir",
-      rebase_path("$root_out_dir"),
-    ]
-    outputs = [ "$output_dir/gen_snapshot_arm64" ]
+    if (target_cpu == "arm") {
+      args += [
+        "--armv7-out-dir",
+        rebase_path("$root_out_dir"),
+      ]
+      outputs = [ "$output_dir/gen_snapshot_armv7" ]
+    } else {
+      args += [
+        "--arm64-out-dir",
+        rebase_path("$root_out_dir"),
+      ]
+      outputs = [ "$output_dir/gen_snapshot_arm64" ]
+    }
   }
 }
 
@@ -229,7 +231,7 @@ source_set("snapshot") {
     ":vm_snapshot_data_linkable",
     ":vm_snapshot_instructions_linkable",
   ]
-  if (host_os == "macos" && (target_cpu == "arm" || target_cpu == "arm64")) {
+  if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]
   }
 

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -201,7 +201,7 @@ action("create_arm_gen_snapshot") {
   output_dir = "$root_out_dir/clang_x64"
   script = "//flutter/sky/tools/create_macos_gen_snapshots.py"
   visibility = [ ":*" ]
-  deps = [ "//third_party/dart/runtime/bin:gen_snapshot" ]
+  deps = [ "//third_party/dart/runtime/bin:gen_snapshot(//build/toolchain/$host_os:clang_x64)" ]
   args = [
     "--dst",
     rebase_path(output_dir),


### PR DESCRIPTION
It should depend on the `gen_snapshot` target produced by the host toolchain and not with a target toolchain. Depending on the wrong `gen_snapshot` means we will not re-execute `create_arm_gen_snapshot` sometimes when it is actually necessary.

