### PR TITLE
Re-enable non-smooth scrolling.

### DIFF
--- a/shell/platform/linux/fl_view.cc
+++ b/shell/platform/linux/fl_view.cc
@@ -485,14 +485,14 @@ static gboolean event_box_scroll_event(GtkWidget* widget,
   if (event->direction == GDK_SCROLL_SMOOTH) {
     scroll_delta_x = event->delta_x;
     scroll_delta_y = event->delta_y;
-  } else {
-    // We currently skip non-smooth scroll events due to the X11 events being
-    // delivered directly to the FlView X window and bypassing the GtkWindow
-    // handling.
-    // This causes both smooth and non-smooth events to be received (i.e.
-    // duplication).
-    // https://github.com/flutter/flutter/issues/73823
-    return FALSE;
+  } else if (event->direction == GDK_SCROLL_UP) {
+    scroll_delta_y = -1;
+  } else if (event->direction == GDK_SCROLL_DOWN) {
+    scroll_delta_y = 1;
+  } else if (event->direction == GDK_SCROLL_LEFT) {
+    scroll_delta_x = -1;
+  } else if (event->direction == GDK_SCROLL_RIGHT) {
+    scroll_delta_x = 1;
   }
 
   // The multiplier is taken from the Chromium source


### PR DESCRIPTION
Since f94cf140c5 events are now handled in a GtkEventBox and the duplicate
scroll events no longer occur.

Fixes https://github.com/flutter/flutter/issues/73823

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
