### PR TITLE
Disable Skia reduceOpsTaskSplitting

### DIFF
--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -39,6 +39,10 @@ sk_sp<GrDirectContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
   // ES2 shading language when the ES3 external image extension is missing.
   options.fPreferExternalImagesOverES3 = true;
 
+  // Enabling this flag can increase VRAM consumption. Turn it off until
+  // further notice.
+  options.fReduceOpsTaskSplitting = GrContextOptions::Enable::kNo;
+
 #if !OS_FUCHSIA
   if (auto context = GrDirectContext::MakeGL(gl_interface, options)) {
     // Do not cache textures created by the image decoder.  These textures

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -119,6 +119,7 @@ bool ShellTestPlatformViewVulkan::OffScreenSurface::CreateSkiaGrContext() {
   }
   PersistentCache::MarkStrategySet();
   options.fPersistentCache = PersistentCache::GetCacheForProcess();
+  options.fReduceOpsTaskSplitting = GrContextOptions::Enable::kNo;
 
   sk_sp<GrDirectContext> context =
       GrDirectContext::MakeVulkan(backend_context, options);

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -61,6 +61,9 @@ sk_sp<GrDirectContext> GPUSurfaceGL::MakeGLContext(
   // TODO(goderbauer): remove option when skbug.com/7523 is fixed.
   // A similar work-around is also used in shell/common/io_manager.cc.
   options.fDisableGpuYUVConversion = true;
+
+  options.fReduceOpsTaskSplitting = GrContextOptions::Enable::kNo;
+
   auto context = GrDirectContext::MakeGL(delegate->GetGLInterface(), options);
 
   if (!context) {

--- a/shell/platform/darwin/graphics/FlutterDarwinContextMetal.mm
+++ b/shell/platform/darwin/graphics/FlutterDarwinContextMetal.mm
@@ -18,6 +18,7 @@ static GrContextOptions CreateMetalGrContextOptions() {
   }
   flutter::PersistentCache::MarkStrategySet();
   options.fPersistentCache = flutter::PersistentCache::GetCacheForProcess();
+  options.fReduceOpsTaskSplitting = GrContextOptions::Enable::kNo;
   return options;
 }
 

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -137,8 +137,10 @@ bool VulkanSurfaceProducer::Initialize(scenic::Session* scenic_session) {
                      backend_context.fPhysicalDevice, 0, nullptr,
                      countof(device_extensions), device_extensions);
   backend_context.fVkExtensions = &vk_extensions;
+  GrContextOptions options;
+  options.fReduceOpsTaskSplitting = GrContextOptions::Enable::kNo;
 
-  context_ = GrDirectContext::MakeVulkan(backend_context);
+  context_ = GrDirectContext::MakeVulkan(backend_context, options);
 
   if (context_ == nullptr) {
     FML_LOG(ERROR)

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -119,7 +119,10 @@ bool VulkanWindow::CreateSkiaGrContext() {
     return false;
   }
 
-  sk_sp<GrDirectContext> context = GrDirectContext::MakeVulkan(backend_context);
+  GrContextOptions options;
+  options.fReduceOpsTaskSplitting = GrContextOptions::Enable::kNo;
+  sk_sp<GrDirectContext> context =
+      GrDirectContext::MakeVulkan(backend_context, options);
 
   if (context == nullptr) {
     return false;


### PR DESCRIPTION
This option will be the default in Skia soon. Per discussion in #26067, let’s be explicit about disabling it for the time being, and we can revisit the flag in the future if desirable.