### PR TITLE
Web: add support for TextInputType.none

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -25,11 +25,16 @@ abstract class EngineInputType {
         return url;
       case 'TextInputType.multiline':
         return multiline;
+      case 'TextInputType.none':
+        return none;
       case 'TextInputType.text':
       default:
         return text;
     }
   }
+
+  /// No text input.
+  static const NoTextInputType none = NoTextInputType();
 
   /// Single-line text input type.
   static const TextInputType text = TextInputType();
@@ -76,10 +81,19 @@ abstract class EngineInputType {
     // Only apply `inputmode` in mobile browsers so that the right virtual
     // keyboard shows up.
     if (operatingSystem == OperatingSystem.iOs ||
-        operatingSystem == OperatingSystem.android) {
+        operatingSystem == OperatingSystem.android ||
+        inputmodeAttribute == EngineInputType.none.inputmodeAttribute) {
       domElement.setAttribute('inputmode', inputmodeAttribute!);
     }
   }
+}
+
+/// No text input.
+class NoTextInputType extends EngineInputType {
+  const NoTextInputType();
+
+  @override
+  final String inputmodeAttribute = 'none';
 }
 
 /// Single-line text input type.

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -862,6 +862,10 @@ abstract class DefaultTextEditingStrategy implements TextEditingStrategy {
       activeDomElement.setAttribute('type', 'password');
     }
 
+    if (config.inputType == EngineInputType.none) {
+      activeDomElement.setAttribute('inputmode', 'none');
+    }
+
     config.autofill?.applyToDomElement(activeDomElement, focusedElement: true);
 
     final String autocorrectValue = config.autocorrect ? 'on' : 'off';

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -1571,6 +1571,9 @@ void testMain() {
       showKeyboard(inputType: 'url');
       expect(getEditingInputMode(), 'url');
 
+      showKeyboard(inputType: 'none');
+      expect(getEditingInputMode(), 'none');
+
       hideKeyboard();
     });
 
@@ -1602,6 +1605,9 @@ void testMain() {
 
         showKeyboard(inputType: 'url');
         expect(getEditingInputMode(), 'url');
+
+        showKeyboard(inputType: 'none');
+        expect(getEditingInputMode(), 'none');
 
         hideKeyboard();
       }


### PR DESCRIPTION
`TextInputType.none` makes it possible to disable the virtual keyboard for certain TextFields, and lays the foundations for custom in-app virtual keyboards (flutter/flutter#76072).

Ref: flutter/flutter#83567

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
