### PR TITLE
Docs, debugDisposed for ImmutableBuffer

### DIFF
--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -51,11 +51,13 @@ Future<void> createSingleFrameCodec() async {
   );
   final Codec codec = await descriptor.instantiateCodec();
   _validateCodec(codec);
-  await codec.getNextFrame();
+  final FrameInfo info = await codec.getNextFrame();
+  info.image.dispose();
   _validateCodec(codec);
   codec.dispose();
   descriptor.dispose();
   buffer.dispose();
+  assert(buffer.debugDisposed);
   _finish();
 }
 void _validateCodec(Codec codec) native 'ValidateCodec';

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2055,12 +2055,10 @@ Future<Codec> instantiateImageCodec(
     }
   }
   buffer.dispose();
-  final Future<Codec> codec = descriptor.instantiateCodec(
+  return descriptor.instantiateCodec(
     targetWidth: targetWidth,
     targetHeight: targetHeight,
   );
-  descriptor.dispose();
-  return codec;
 }
 
 /// Loads a single image frame from a byte array into an [Image] object.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -5178,6 +5178,9 @@ class Shadow {
 }
 
 /// A handle to a read-only byte buffer that is managed by the engine.
+///
+/// The create of this object is responsible for calling [dispose] when it is
+/// no longer needed. However,
 class ImmutableBuffer extends NativeFieldWrapperClass2 {
   ImmutableBuffer._(this.length);
 
@@ -5194,9 +5197,39 @@ class ImmutableBuffer extends NativeFieldWrapperClass2 {
   /// The length, in bytes, of the underlying data.
   final int length;
 
+  bool _debugDisposed = false;
+
+  /// Whether [dispose] has been called.
+  ///
+  /// This must only be used when asserts are enabled. Otherwise, it will throw.
+  bool get debugDisposed {
+    late bool disposed;
+    assert(() {
+      disposed = _debugDisposed;
+      return true;
+    }());
+    return disposed;
+  }
+
   /// Release the resources used by this object. The object is no longer usable
   /// after this method is called.
-  void dispose() native 'ImmutableBuffer_dispose';
+  ///
+  /// The underlying memory allocated by this object will be retained beyond
+  /// this call if it is still needed by another object that has not been
+  /// disposed. For example, an [ImageDescriptor] that has not been disposed
+  /// may still retain a reference to the memory from this buffer even if it
+  /// has been disposed. Freeing that memory requires disposing all resources
+  /// that may still hold it.
+  void dispose() {
+    assert(() {
+      assert(!_debugDisposed);
+      _debugDisposed = true;
+      return true;
+    }());
+    _dispose();
+  }
+
+  void _dispose() native 'ImmutableBuffer_dispose';
 }
 
 /// A descriptor of data that can be turned into an [Image] via a [Codec].

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -5191,8 +5191,8 @@ class Shadow {
 
 /// A handle to a read-only byte buffer that is managed by the engine.
 ///
-/// The create of this object is responsible for calling [dispose] when it is
-/// no longer needed. However,
+/// The creator of this object is responsible for calling [dispose] when it is
+/// no longer needed.
 class ImmutableBuffer extends NativeFieldWrapperClass2 {
   ImmutableBuffer._(this.length);
 

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -712,6 +712,15 @@ class ImmutableBuffer {
 
   Uint8List? _list;
   final int length;
+
+  bool get debugDisposed {
+    late bool disposed;
+    assert(() {
+      disposed = _list == null;
+      return true;
+    }());
+    return disposed;
+  }
   void dispose() => _list = null;
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/83764
Fixes https://github.com/flutter/flutter/issues/83910

Adds `debugDisposed` to `ImmutableBuffer`, and updates a test that exercises disposed to make sure it works as intended. Updates docs. Adds a missing dispose to existing test.

Ideally, something like https://github.com/flutter/flutter/issues/83274 would help us with this, although we'd need some way to deterministically be sure that GC has run and finished for that to work.

/cc @zathras