### PR TITLE
Fixes handleNavigationMessage in order

### DIFF
--- a/lib/web_ui/lib/src/engine/navigation/history.dart
+++ b/lib/web_ui/lib/src/engine/navigation/history.dart
@@ -187,7 +187,6 @@ class MultiEntriesBrowserHistory extends BrowserHistory {
     }
     _isDisposed = true;
     _unsubscribe();
-
     // Restores the html browser history.
     assert(_hasSerialCount(currentState));
     int backCount = _currentSerialCount;

--- a/lib/web_ui/lib/src/engine/navigation/history.dart
+++ b/lib/web_ui/lib/src/engine/navigation/history.dart
@@ -187,6 +187,7 @@ class MultiEntriesBrowserHistory extends BrowserHistory {
     }
     _isDisposed = true;
     _unsubscribe();
+
     // Restores the html browser history.
     assert(_hasSerialCount(currentState));
     int backCount = _currentSerialCount;

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -124,11 +124,9 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     bool result = false;
     try {
       result = await callback();
-    } catch (err) {
+    } finally {
       completer.complete();
-      rethrow;
     }
-    completer.complete();
     return result;
   }
 

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -4,6 +4,8 @@
 
 part of engine;
 
+typedef _HandleMessageCallBack = Future<bool> Function();
+
 /// When set to true, all platform messages will be printed to the console.
 const bool /*!*/ _debugPrintPlatformMessages = false;
 
@@ -112,32 +114,52 @@ class EngineFlutterWindow extends ui.SingletonFlutterWindow {
     _customUrlStrategy = null;
   }
 
-  Future<bool> handleNavigationMessage(ByteData? data) async {
-    final MethodCall decoded = JSONMethodCodec().decodeMethodCall(data);
-    final Map<String, dynamic>? arguments = decoded.arguments;
-    switch (decoded.method) {
-      case 'selectMultiEntryHistory':
-        await _useMultiEntryBrowserHistory();
-        return true;
-      case 'selectSingleEntryHistory':
-        await _useSingleEntryBrowserHistory();
-        return true;
-      // the following cases assert that arguments are not null
-      case 'routeUpdated': // deprecated
-        assert(arguments != null);
-        await _useSingleEntryBrowserHistory();
-        browserHistory.setRouteName(arguments!['routeName']);
-        return true;
-      case 'routeInformationUpdated':
-        assert(arguments != null);
-        browserHistory.setRouteName(
-          arguments!['location'],
-          state: arguments['state'],
-          replace: arguments['replace'] ?? false,
-        );
-        return true;
+  Future<void> _endOfTheLine = Future<void>.value(null);
+
+  Future<bool> _waitInTheLine(_HandleMessageCallBack callback) async {
+    final Future<void> currentPosition = _endOfTheLine;
+    final Completer<void> completer = Completer<void>();
+    _endOfTheLine = completer.future;
+    await currentPosition;
+    bool result = false;
+    try {
+      result = await callback();
+    } catch (err) {
+      completer.complete();
+      rethrow;
     }
-    return false;
+    completer.complete();
+    return result;
+  }
+
+  Future<bool> handleNavigationMessage(ByteData? data) async {
+    return _waitInTheLine(() async {
+      final MethodCall decoded = JSONMethodCodec().decodeMethodCall(data);
+      final Map<String, dynamic>? arguments = decoded.arguments;
+      switch (decoded.method) {
+        case 'selectMultiEntryHistory':
+          await _useMultiEntryBrowserHistory();
+          return true;
+        case 'selectSingleEntryHistory':
+          await _useSingleEntryBrowserHistory();
+          return true;
+        // the following cases assert that arguments are not null
+        case 'routeUpdated': // deprecated
+          assert(arguments != null);
+          await _useSingleEntryBrowserHistory();
+          browserHistory.setRouteName(arguments!['routeName']);
+          return true;
+        case 'routeInformationUpdated':
+          assert(arguments != null);
+          browserHistory.setRouteName(
+            arguments!['location'],
+            state: arguments['state'],
+            replace: arguments['replace'] ?? false,
+          );
+          return true;
+      }
+      return false;
+    });
   }
 
   @override


### PR DESCRIPTION
The issue is the navigator will send selectSingleEntryHistory method call and routeInformationUpdated method call back to back. The engine executes them in the same time and leaves the browser in a bad state. This pr fixes it so that the window.dart will execute the method call in the order it receives.

fixes https://github.com/flutter/flutter/issues/82237

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
