### PR TITLE
Provide the isolate cleanup callback to Dart_CreateIsolateInGroup

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -261,7 +261,9 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
           /*shutdown_callback=*/
           reinterpret_cast<Dart_IsolateShutdownCallback>(
               DartIsolate::SpawnIsolateShutdownCallback),
-          /*cleanup_callback=*/nullptr,
+          /*cleanup_callback=*/
+          reinterpret_cast<Dart_IsolateCleanupCallback>(
+              DartIsolateCleanupCallback),
           /*child_isolate_data=*/isolate_data,
           /*error=*/error);
     };


### PR DESCRIPTION
This API is used by spawned engines and does not use the cleanup callback
specified in the Dart_InitializeParams.

See https://github.com/flutter/flutter/issues/77304