### PR TITLE
Allow Flutter focus to interop with Android view hierarchies 

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -38,28 +38,25 @@ public class FlutterMutatorView extends FrameLayout {
   public FlutterMutatorView(
       @NonNull Context context,
       float screenDensity,
-      @Nullable AndroidTouchProcessor androidTouchProcessor,
-      @Nullable OnFocusChangeListener focusListener) {
+      @Nullable AndroidTouchProcessor androidTouchProcessor) {
     super(context, null);
     this.screenDensity = screenDensity;
     this.androidTouchProcessor = androidTouchProcessor;
-
-    if (focusListener != null) {
-      final View mutatorView = this;
-      this.getViewTreeObserver()
-          .addOnGlobalFocusChangeListener(
-              new ViewTreeObserver.OnGlobalFocusChangeListener() {
-                @Override
-                public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-                  focusListener.onFocusChange(mutatorView, childHasFocus(mutatorView));
-                }
-              });
-    }
   }
 
-  /** Returns true if the current view or any descendant view has focus. */
+  /** Initialize the FlutterMutatorView. */
+  public FlutterMutatorView(@NonNull Context context) {
+    this(context, 1, /* androidTouchProcessor=*/ null);
+  }
+
+  /**
+   * Determines if the current view or any descendant view has focus.
+   *
+   * @param root the root view.
+   * @return true if the current view or any descendant view has focus.
+   */
   @VisibleForTesting
-  public boolean childHasFocus(@Nullable View root) {
+  public static boolean childHasFocus(@Nullable View root) {
     if (root == null) {
       return false;
     }
@@ -77,9 +74,24 @@ public class FlutterMutatorView extends FrameLayout {
     return false;
   }
 
-  /** Initialize the FlutterMutatorView. */
-  public FlutterMutatorView(@NonNull Context context) {
-    this(context, 1, /* androidTouchProcessor=*/ null, /*onFocusChangeListener=*/ null);
+  /**
+   * Adds a focus change listener that notifies when the current view or any of its descendant views
+   * have received focus.
+   *
+   * @param focusListener The focus listener.
+   */
+  public void addOnFocusChangeListener(@NonNull OnFocusChangeListener focusListener) {
+    final View mutatorView = this;
+    final ViewTreeObserver observer = this.getViewTreeObserver();
+    if (observer.isAlive()) {
+      observer.addOnGlobalFocusChangeListener(
+          new ViewTreeObserver.OnGlobalFocusChangeListener() {
+            @Override
+            public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+              focusListener.onFocusChange(mutatorView, childHasFocus(mutatorView));
+            }
+          });
+    }
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -44,15 +44,17 @@ public class FlutterMutatorView extends FrameLayout {
     this.screenDensity = screenDensity;
     this.androidTouchProcessor = androidTouchProcessor;
 
-    final View mutatorView = this;
-    this.getViewTreeObserver()
-        .addOnGlobalFocusChangeListener(
-            new ViewTreeObserver.OnGlobalFocusChangeListener() {
-              @Override
-              public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-                focusListener.onFocusChange(mutatorView, childHasFocus(mutatorView));
-              }
-            });
+    if (focusListener != null) {
+      final View mutatorView = this;
+      this.getViewTreeObserver()
+          .addOnGlobalFocusChangeListener(
+              new ViewTreeObserver.OnGlobalFocusChangeListener() {
+                @Override
+                public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+                  focusListener.onFocusChange(mutatorView, childHasFocus(mutatorView));
+                }
+              });
+    }
   }
 
   /** Returns true if the current view or any descendant view has focus. */

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -52,8 +52,8 @@ public class FlutterMutatorView extends FrameLayout {
   /**
    * Determines if the current view or any descendant view has focus.
    *
-   * @param root the root view.
-   * @return true if the current view or any descendant view has focus.
+   * @param root The root view.
+   * @return True if the current view or any descendant view has focus.
    */
   @VisibleForTesting
   public static boolean childHasFocus(@Nullable View root) {

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -85,7 +85,8 @@ public class TextInputChannel {
               try {
                 final JSONObject arguments = (JSONObject) args;
                 final int platformViewId = arguments.getInt("platformViewId");
-                final boolean usesVirtualDisplay = arguments.getBoolean("usesVirtualDisplay");
+                final boolean usesVirtualDisplay =
+                    arguments.optBoolean("usesVirtualDisplay", false);
                 textInputMethodHandler.setPlatformViewClient(platformViewId, usesVirtualDisplay);
                 result.success(null);
               } catch (JSONException exception) {

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -368,7 +368,8 @@ public class TextInputChannel {
      * different client is set.
      *
      * @param id the ID of the platform view to be set as a text input client.
-     * @param usesVirtualDisplay Whether the platform view uses a virtual display.
+     * @param usesVirtualDisplay True if the platform view uses a virtual display, false if it uses
+     *     hybrid composition.
      */
     void setPlatformViewClient(int id, boolean usesVirtualDisplay);
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -82,8 +82,15 @@ public class TextInputChannel {
               result.success(null);
               break;
             case "TextInput.setPlatformViewClient":
-              final int id = (int) args;
-              textInputMethodHandler.setPlatformViewClient(id);
+              try {
+                final JSONObject arguments = (JSONObject) args;
+                final int platformViewId = arguments.getInt("platformViewId");
+                final boolean usesVirtualDisplay = arguments.getBoolean("usesVirtualDisplay");
+                textInputMethodHandler.setPlatformViewClient(platformViewId, usesVirtualDisplay);
+                result.success(null);
+              } catch (JSONException exception) {
+                result.error("error", exception.getMessage(), null);
+              }
               break;
             case "TextInput.setEditingState":
               try {
@@ -360,8 +367,9 @@ public class TextInputChannel {
      * different client is set.
      *
      * @param id the ID of the platform view to be set as a text input client.
+     * @param usesVirtualDisplay Whether the platform view uses a virtual display.
      */
-    void setPlatformViewClient(int id);
+    void setPlatformViewClient(int id, boolean usesVirtualDisplay);
 
     /**
      * Sets the size and the transform matrix of the current text input client.

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -377,6 +377,13 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
   private void hideTextInput(View view) {
     notifyViewExited();
     if (inputTarget.type != InputTarget.Type.HC_PLATFORM_VIEW) {
+      // Note: When a virtual display is used, there's a race condition may lead to us hiding
+      // the keyboard here just after a platform view has shown it.
+      // This can only potentially happen when switching focus from a Flutter text field to a
+      // platform
+      // view's text
+      // field(by text field here I mean anything that keeps the keyboard open).
+      // See: https://github.com/flutter/flutter/issues/34169
       mImm.hideSoftInputFromWindow(view.getApplicationWindowToken(), 0);
     }
   }

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -550,10 +550,10 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       // framework.
       FRAMEWORK_CLIENT,
       // InputConnection is managed by an embedded platform view that is backed by a virtual
-      // display.
+      // display (VD).
       VD_PLATFORM_VIEW,
       // InputConnection is managed by an embedded platform view that is embeded in the Android view
-      // hierarchy.
+      // hierarchy, and uses hybrid composition (HC).
       HC_PLATFORM_VIEW,
     }
 

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -102,7 +102,11 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
 
           @Override
           public void hide() {
-            hideTextInput(mView);
+            if (inputTarget.type == InputTarget.Type.HC_PLATFORM_VIEW) {
+              notifyViewExited();
+            } else {
+              hideTextInput(mView);
+            }
           }
 
           @Override
@@ -376,16 +380,13 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
 
   private void hideTextInput(View view) {
     notifyViewExited();
-    if (inputTarget.type != InputTarget.Type.HC_PLATFORM_VIEW) {
-      // Note: When a virtual display is used, there's a race condition may lead to us hiding
-      // the keyboard here just after a platform view has shown it.
-      // This can only potentially happen when switching focus from a Flutter text field to a
-      // platform
-      // view's text
-      // field(by text field here I mean anything that keeps the keyboard open).
-      // See: https://github.com/flutter/flutter/issues/34169
-      mImm.hideSoftInputFromWindow(view.getApplicationWindowToken(), 0);
-    }
+    // Note: when a virtual display is used, a race condition may lead to us hiding the keyboard
+    // here just after a platform view has shown it.
+    // This can only potentially happen when switching focus from a Flutter text field to a platform
+    // view's text
+    // field(by text field here I mean anything that keeps the keyboard open).
+    // See: https://github.com/flutter/flutter/issues/34169
+    mImm.hideSoftInputFromWindow(view.getApplicationWindowToken(), 0);
   }
 
   @VisibleForTesting
@@ -416,8 +417,7 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       // We need to make sure that the Flutter view is focused so that no imm operations get short
       // circuited.
       // Not asking for focus here specifically manifested in a but on API 28 devices where the
-      // platform view's
-      // request to show a keyboard was ignored.
+      // platform view's request to show a keyboard was ignored.
       mView.requestFocus();
       inputTarget = new InputTarget(InputTarget.Type.VD_PLATFORM_VIEW, platformViewId);
       mImm.restartInput(mView);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -736,16 +736,16 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     }
     final FlutterMutatorView parentView =
         new FlutterMutatorView(
-            context,
-            context.getResources().getDisplayMetrics().density,
-            androidTouchProcessor,
-            (view, hasFocus) -> {
-              if (hasFocus) {
-                platformViewsChannel.invokeViewFocused(viewId);
-              } else {
-                textInputPlugin.clearPlatformViewClient(viewId);
-              }
-            });
+            context, context.getResources().getDisplayMetrics().density, androidTouchProcessor);
+
+    parentView.addOnFocusChangeListener(
+        (view, hasFocus) -> {
+          if (hasFocus) {
+            platformViewsChannel.invokeViewFocused(viewId);
+          } else {
+            textInputPlugin.clearPlatformViewClient(viewId);
+          }
+        });
 
     platformViewParent.put(viewId, parentView);
     parentView.addView(platformView.getView());

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -337,6 +337,11 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
 
         @Override
         public void clearFocus(int viewId) {
+          final PlatformView platformView = platformViews.get(viewId);
+          if (platformView != null) {
+            platformView.getView().clearFocus();
+            return;
+          }
           ensureValidAndroidVersion(Build.VERSION_CODES.KITKAT_WATCH);
           View view = vdControllers.get(viewId).getView();
           view.clearFocus();
@@ -731,7 +736,17 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     }
     final FlutterMutatorView parentView =
         new FlutterMutatorView(
-            context, context.getResources().getDisplayMetrics().density, androidTouchProcessor);
+            context,
+            context.getResources().getDisplayMetrics().density,
+            androidTouchProcessor,
+            (view, hasFocus) -> {
+              if (hasFocus) {
+                platformViewsChannel.invokeViewFocused(viewId);
+              } else {
+                textInputPlugin.clearPlatformViewClient(viewId);
+              }
+            });
+
     platformViewParent.put(viewId, parentView);
     parentView.addView(platformView.getView());
     ((FlutterView) flutterView).addView(parentView);

--- a/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -1,10 +1,14 @@
 package io.flutter.embedding.engine.mutatorsstack;
 
+import static android.view.View.OnFocusChangeListener;
 import static junit.framework.TestCase.*;
 import static org.mockito.Mockito.*;
 
 import android.graphics.Matrix;
 import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewTreeObserver;
 import io.flutter.embedding.android.AndroidTouchProcessor;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,7 +25,7 @@ public class FlutterMutatorViewTest {
   public void canDragViews() {
     final AndroidTouchProcessor touchProcessor = mock(AndroidTouchProcessor.class);
     final FlutterMutatorView view =
-        new FlutterMutatorView(RuntimeEnvironment.systemContext, 1.0f, touchProcessor, null);
+        new FlutterMutatorView(RuntimeEnvironment.systemContext, 1.0f, touchProcessor);
     final FlutterMutatorsStack mutatorStack = mock(FlutterMutatorsStack.class);
 
     assertTrue(view.onInterceptTouchEvent(mock(MotionEvent.class)));
@@ -75,5 +79,106 @@ public class FlutterMutatorViewTest {
       screenMatrix.postTranslate(7, 8);
       assertTrue(matrixCaptor.getValue().equals(screenMatrix));
     }
+  }
+
+  @Test
+  public void childHasFocus_rootHasFocus() {
+    final View rootView = mock(View.class);
+    when(rootView.hasFocus()).thenReturn(true);
+    assertTrue(FlutterMutatorView.childHasFocus(rootView));
+  }
+
+  @Test
+  public void childHasFocus_rootDoesNotHaveFocus() {
+    final View rootView = mock(View.class);
+    when(rootView.hasFocus()).thenReturn(false);
+    assertFalse(FlutterMutatorView.childHasFocus(rootView));
+  }
+
+  @Test
+  public void childHasFocus_rootIsNull() {
+    assertFalse(FlutterMutatorView.childHasFocus(null));
+  }
+
+  @Test
+  public void childHasFocus_childHasFocus() {
+    final View childView = mock(View.class);
+    when(childView.hasFocus()).thenReturn(true);
+
+    final ViewGroup rootView = mock(ViewGroup.class);
+    when(rootView.getChildCount()).thenReturn(1);
+    when(rootView.getChildAt(0)).thenReturn(childView);
+
+    assertTrue(FlutterMutatorView.childHasFocus(rootView));
+  }
+
+  @Test
+  public void childHasFocus_childDoesNotHaveFocus() {
+    final View childView = mock(View.class);
+    when(childView.hasFocus()).thenReturn(false);
+
+    final ViewGroup rootView = mock(ViewGroup.class);
+    when(rootView.getChildCount()).thenReturn(1);
+    when(rootView.getChildAt(0)).thenReturn(childView);
+
+    assertFalse(FlutterMutatorView.childHasFocus(rootView));
+  }
+
+  @Test
+  public void focusChangeListener_hasFocus() {
+    final ViewTreeObserver viewTreeObserver = mock(ViewTreeObserver.class);
+    when(viewTreeObserver.isAlive()).thenReturn(true);
+
+    final FlutterMutatorView view =
+        new FlutterMutatorView(RuntimeEnvironment.systemContext) {
+          @Override
+          public ViewTreeObserver getViewTreeObserver() {
+            return viewTreeObserver;
+          }
+
+          @Override
+          public boolean hasFocus() {
+            return true;
+          }
+        };
+
+    final OnFocusChangeListener focusListener = mock(OnFocusChangeListener.class);
+    view.addOnFocusChangeListener(focusListener);
+
+    final ArgumentCaptor<ViewTreeObserver.OnGlobalFocusChangeListener> focusListenerCaptor =
+        ArgumentCaptor.forClass(ViewTreeObserver.OnGlobalFocusChangeListener.class);
+    verify(viewTreeObserver).addOnGlobalFocusChangeListener(focusListenerCaptor.capture());
+
+    focusListenerCaptor.getValue().onGlobalFocusChanged(null, null);
+    verify(focusListener).onFocusChange(view, true);
+  }
+
+  @Test
+  public void focusChangeListener_doesNotHaveFocus() {
+    final ViewTreeObserver viewTreeObserver = mock(ViewTreeObserver.class);
+    when(viewTreeObserver.isAlive()).thenReturn(true);
+
+    final FlutterMutatorView view =
+        new FlutterMutatorView(RuntimeEnvironment.systemContext) {
+          @Override
+          public ViewTreeObserver getViewTreeObserver() {
+            return viewTreeObserver;
+          }
+
+          @Override
+          public boolean hasFocus() {
+            return false;
+          }
+        };
+
+    final OnFocusChangeListener focusListener = mock(OnFocusChangeListener.class);
+    view.addOnFocusChangeListener(focusListener);
+
+    final ArgumentCaptor<ViewTreeObserver.OnGlobalFocusChangeListener> focusListenerCaptor =
+        ArgumentCaptor.forClass(ViewTreeObserver.OnGlobalFocusChangeListener.class);
+    verify(viewTreeObserver).addOnGlobalFocusChangeListener(focusListenerCaptor.capture());
+
+    focusListenerCaptor.getValue().onGlobalFocusChanged(null, null);
+    verify(focusListener).onFocusChange(view, false);
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -181,4 +181,18 @@ public class FlutterMutatorViewTest {
     focusListenerCaptor.getValue().onGlobalFocusChanged(null, null);
     verify(focusListener).onFocusChange(view, false);
   }
+
+  @Test
+  public void focusChangeListener_viewTreeObserverIsAliveFalseDoesNotThrow() {
+    final FlutterMutatorView view =
+        new FlutterMutatorView(RuntimeEnvironment.systemContext) {
+          @Override
+          public ViewTreeObserver getViewTreeObserver() {
+            final ViewTreeObserver viewTreeObserver = mock(ViewTreeObserver.class);
+            when(viewTreeObserver.isAlive()).thenReturn(false);
+            return viewTreeObserver;
+          }
+        };
+    view.addOnFocusChangeListener(mock(OnFocusChangeListener.class));
+  }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -21,7 +21,7 @@ public class FlutterMutatorViewTest {
   public void canDragViews() {
     final AndroidTouchProcessor touchProcessor = mock(AndroidTouchProcessor.class);
     final FlutterMutatorView view =
-        new FlutterMutatorView(RuntimeEnvironment.systemContext, 1.0f, touchProcessor);
+        new FlutterMutatorView(RuntimeEnvironment.systemContext, 1.0f, touchProcessor, null);
     final FlutterMutatorsStack mutatorStack = mock(FlutterMutatorsStack.class);
 
     assertTrue(view.onInterceptTouchEvent(mock(MotionEvent.class)));


### PR DESCRIPTION
When platform views are used in the Flutter widget tree, the keyboard may be dismissed or shown incorrectly.

The issue was present in hybrid composition too. When HC is used, this issue can be solved by checking 
if any descendant view of the current platform view has been focused.

Fixes https://github.com/flutter/flutter/issues/81029
Fixes https://github.com/flutter/flutter/issues/34169 for HC.

This PR will also close https://github.com/flutter/flutter/issues/34169 since using HC is the solution.


https://user-images.githubusercontent.com/1410613/120903241-dbcb6280-c5f9-11eb-9a78-94c9c697b24c.mp4



<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
