### PR TITLE
[web canvaskit] fix SkiaObjectBox instrumentation

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -351,16 +351,16 @@ class SkiaObjectBox<R extends StackTraceDebugger, T extends Object>
       R debugReferrer, T initialValue, this._resurrector) {
     assert(!browserSupportsFinalizationRegistry);
     _initialize(debugReferrer, initialValue);
-    SkiaObjects.manageExpensive(this);
-  }
-
-  void _initialize(R debugReferrer, T initialValue) {
-    _update(initialValue);
     if (Instrumentation.enabled) {
       Instrumentation.instance.incrementCounter(
         '${_skDeletable?.constructor.name} created',
       );
     }
+    SkiaObjects.manageExpensive(this);
+  }
+
+  void _initialize(R debugReferrer, T initialValue) {
+    _update(initialValue);
     if (assertionsEnabled) {
       debugReferrers.add(debugReferrer);
     }

--- a/lib/web_ui/test/engine/profiler_test.dart
+++ b/lib/web_ui/test/engine/profiler_test.dart
@@ -3,20 +3,34 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
+import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js' as js;
 import 'dart:js_util' as js_util;
 
+import 'package:quiver/testing/async.dart';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart';
+
+import '../spy.dart';
 
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
 
 void testMain() {
+  group('$Profiler', () {
+    _profilerTests();
+  });
+
+  group('$Instrumentation', () {
+    _instrumentationTests();
+  });
+}
+
+void _profilerTests() {
   setUp(() {
     Profiler.isBenchmarkMode = true;
     Profiler.ensureInitialized();
@@ -70,6 +84,52 @@ void testMain() {
       () => jsOnBenchmark('string'),
       throwsA(isA<TypeError>()),
     );
+  });
+}
+
+void _instrumentationTests() {
+  setUp(() {
+    Instrumentation.enabled = false;
+  });
+
+  tearDown(() {
+    Instrumentation.enabled = false;
+  });
+
+  test('when disabled throws instead of initializing', () {
+    expect(() => Instrumentation.instance, throwsStateError);
+  });
+
+  test('when disabled throws instead of incrementing counter', () {
+    Instrumentation.enabled = true;
+    final Instrumentation instrumentation = Instrumentation.instance;
+    Instrumentation.enabled = false;
+    expect(() => instrumentation.incrementCounter('test'), throwsStateError);
+  });
+
+  test('when enabled increments counter', () {
+    final ZoneSpy spy = ZoneSpy();
+    spy.run(() {
+      Instrumentation.enabled = true;
+      final Instrumentation instrumentation = Instrumentation.instance;
+      expect(instrumentation.debugPrintTimer, isNull);
+      instrumentation.incrementCounter('foo');
+      expect(instrumentation.debugPrintTimer, isNotNull);
+      instrumentation.incrementCounter('foo');
+      instrumentation.incrementCounter('bar');
+      expect(spy.printLog, isEmpty);
+
+      expect(instrumentation.debugPrintTimer, isNotNull);
+      spy.fakeAsync.elapse(const Duration(seconds: 2));
+      expect(instrumentation.debugPrintTimer, isNull);
+      expect(spy.printLog, hasLength(1));
+      expect(
+        spy.printLog.single,
+        'Engine counters:\n'
+        '  bar: 1\n'
+        '  foo: 2\n',
+      );
+    });
   });
 }
 

--- a/lib/web_ui/test/engine/profiler_test.dart
+++ b/lib/web_ui/test/engine/profiler_test.dart
@@ -3,12 +3,10 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
-import 'dart:async';
 import 'dart:html' as html;
 import 'dart:js' as js;
 import 'dart:js_util' as js_util;
 
-import 'package:quiver/testing/async.dart';
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';


### PR DESCRIPTION
Fixes instrumentation in `SkiaObjectBox` where it would duplicate records for object creation both in "created" and "registered" category. After this change we log either "created" (when FinalizerRegistry is not available) or "registered" (otherwise), but not both.

Before:

```
Engine counters:
  Picture created: 732
  Picture deleted: 170
  Picture registered: 732
```

After (with FinalizerRegistry):

```
Engine counters:
  Picture deleted: 170
  Picture registered: 732
```

Or (without FinalizerRegistry):

```
Engine counters:
  Picture created: 732
  Picture deleted: 170
```
