### PR TITLE
[web] Allow some more nulls in platform_dispatcher.

### DIFF
--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -727,12 +727,12 @@ $_glassPaneTagName * {
   /// defer to the operating system default.
   ///
   /// See w3c screen api: https://www.w3.org/TR/screen-orientation/
-  Future<bool> setPreferredOrientation(List<dynamic>? orientations) {
+  Future<bool> setPreferredOrientation(List<dynamic> orientations) {
     final html.Screen screen = html.window.screen!;
     if (!_unsafeIsNull(screen)) {
       final html.ScreenOrientation? screenOrientation = screen.orientation;
       if (!_unsafeIsNull(screenOrientation)) {
-        if (orientations!.isEmpty) {
+        if (orientations.isEmpty) {
           screenOrientation!.unlock();
           return Future.value(true);
         } else {
@@ -760,7 +760,7 @@ $_glassPaneTagName * {
   }
 
   // Converts device orientation to w3c OrientationLockType enum.
-  static String? _deviceOrientationToLockType(String deviceOrientation) {
+  static String? _deviceOrientationToLockType(String? deviceOrientation) {
     switch (deviceOrientation) {
       case 'DeviceOrientation.portraitUp':
         return orientationLockTypePortraitPrimary;

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -397,8 +397,9 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
             return;
           case 'SystemChrome.setApplicationSwitcherDescription':
             final Map<String, Object> arguments = decoded.arguments;
+            // TODO: Find more appropriate defaults? Or noop when values are null?
             final String label = arguments['label'] as String? ?? '';
-            final int primaryColor = arguments['primaryColor'] as int? ?? 0;
+            final int primaryColor = arguments['primaryColor'] as int? ?? 0xFF000000;
             domRenderer.setTitle(label);
             domRenderer.setThemeColor(ui.Color(primaryColor));
             _replyToPlatformMessage(

--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -396,9 +396,11 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
                 callback, codec.encodeSuccessEnvelope(true));
             return;
           case 'SystemChrome.setApplicationSwitcherDescription':
-            final Map<String, dynamic> arguments = decoded.arguments;
-            domRenderer.setTitle(arguments['label']);
-            domRenderer.setThemeColor(ui.Color(arguments['primaryColor']));
+            final Map<String, Object> arguments = decoded.arguments;
+            final String label = arguments['label'] as String? ?? '';
+            final int primaryColor = arguments['primaryColor'] as int? ?? 0;
+            domRenderer.setTitle(label);
+            domRenderer.setThemeColor(ui.Color(primaryColor));
             _replyToPlatformMessage(
                 callback, codec.encodeSuccessEnvelope(true));
             return;

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -301,9 +301,8 @@ void testMain() {
   test('setPreferredOrientation responds even if browser doesn\'t support api', () async {
     final html.Screen screen = html.window.screen;
     js_util.setProperty(screen, 'orientation', null);
-    bool responded = false;
 
-    final Completer<void> completer = Completer<void>();
+    final Completer<bool> completer = Completer<bool>();
     final ByteData inputData = JSONMethodCodec().encodeMethodCall(MethodCall(
         'SystemChrome.setPreferredOrientations',
         <dynamic>[]));
@@ -312,12 +311,11 @@ void testMain() {
       'flutter/platform',
           inputData,
           (outputData) {
-        responded = true;
-        completer.complete();
+        completer.complete(true);
       },
     );
-    await completer.future;
-    expect(responded, isTrue);
+
+    expect(await completer.future, isTrue);
   });
 
   test('SingletonFlutterWindow implements locale, locales, and locale change notifications', () async {

--- a/lib/web_ui/test/title_test.dart
+++ b/lib/web_ui/test/title_test.dart
@@ -49,5 +49,39 @@ void testMain() {
 
       expect(document.title, 'Different title');
     });
+
+    test('supports null title and primaryColor', () {
+      // Run the unit test without emulating Flutter tester environment.
+      ui.debugEmulateFlutterTesterEnvironment = false;
+
+      // TODO(yjbanov): https://github.com/flutter/flutter/issues/39159
+      document.title = 'Something Else';
+      expect(document.title, 'Something Else');
+
+      ui.window.sendPlatformMessage(
+          'flutter/platform',
+          codec.encodeMethodCall(const MethodCall(
+              'SystemChrome.setApplicationSwitcherDescription',
+              <String, dynamic>{
+                'label': null,
+                'primaryColor': null,
+              })),
+          null);
+
+      expect(document.title, '');
+
+      document.title = 'Something Else';
+      expect(document.title, 'Something Else');
+
+      ui.window.sendPlatformMessage(
+          'flutter/platform',
+          codec.encodeMethodCall(const MethodCall(
+              'SystemChrome.setApplicationSwitcherDescription',
+              <String, dynamic>{
+              })),
+          null);
+
+      expect(document.title, '');
+    });
   });
 }


### PR DESCRIPTION
* Allow nulls in setApplicationSwitcherDescription
* Tighten setPreferredOrientation types.

Fixes https://github.com/flutter/flutter/issues/83351

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
