### PR TITLE
[Android TextInput] clean up nested batch edits in closeConnection()

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -433,9 +433,7 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       // to reset their internal states.
       mRestartInputPending = composingChanged(mLastKnownFrameworkTextEditingState, state);
       if (mRestartInputPending) {
-        Log.w(
-            TAG,
-            "Changing the content within the the composing region may cause the input method to behave strangely, and is therefore discouraged. See https://github.com/flutter/flutter/issues/78827 for more details");
+        Log.i(TAG, "Composing region changed by the framework. Restarting the IME");
       }
     }
 

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -433,7 +433,7 @@ public class TextInputPlugin implements ListenableEditingState.EditingStateWatch
       // to reset their internal states.
       mRestartInputPending = composingChanged(mLastKnownFrameworkTextEditingState, state);
       if (mRestartInputPending) {
-        Log.i(TAG, "Composing region changed by the framework. Restarting the IME");
+        Log.i(TAG, "Composing region changed by the framework. Restarting the input method.");
       }
     }
 

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -1163,6 +1163,19 @@ public class InputConnectionAdaptorTest {
     assertFalse(didConsume);
   }
 
+  @Test
+  public void testCleanUpBatchEndsOnCloseConnection() {
+    final ListenableEditingState editable = sampleEditable(0, 0);
+    InputConnectionAdaptor adaptor = spy(sampleInputConnectionAdaptor(editable));
+    for (int i = 0; i < 5; i++) {
+      adaptor.beginBatchEdit();
+    }
+    adaptor.endBatchEdit();
+    verify(adaptor, times(1)).endBatchEdit();
+    adaptor.closeConnection();
+    verify(adaptor, times(4)).endBatchEdit();
+  }
+
   private static final String SAMPLE_TEXT =
       "Lorem ipsum dolor sit amet," + "\nconsectetur adipiscing elit.";
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/83213.
Maybe fixes https://github.com/flutter/flutter/issues/80938

We restart the IME when the framework changes the composing region. When this happens during a batch edit the old connection doesn't get to call `endBatchEdit` so we need to clean that up. Currently if that happens the framework will never be updated (as the batch edit count is always going to be > 0).

Per Android API docs:
> `public abstract void closeConnection ()`
Editor authors: You can clear all the nested batch edit right now and you no longer need to handle subsequent callbacks on this connection, including beginBatchEdit()}. Note that although the system tries to call this method whenever possible, there may be a chance that this method is not called in some exceptional situations.


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
