### PR TITLE
[web] migrate more felt code to null safety

### DIFF
--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -17,9 +17,10 @@ class BuildCommand extends Command<bool> with ArgUtils {
     argParser
       ..addFlag(
         'watch',
+        defaultsTo: false,
         abbr: 'w',
         help: 'Run the build in watch mode so it rebuilds whenever a change'
-            'is made.',
+            'is made. Disabled by default.',
       );
   }
 
@@ -29,7 +30,7 @@ class BuildCommand extends Command<bool> with ArgUtils {
   @override
   String get description => 'Build the Flutter web engine.';
 
-  bool get isWatchMode => boolArg('watch') ?? false;
+  bool get isWatchMode => boolArg('watch')!;
 
   @override
   FutureOr<bool> run() async {

--- a/lib/web_ui/dev/clean.dart
+++ b/lib/web_ui/dev/clean.dart
@@ -17,21 +17,21 @@ class CleanCommand extends Command<bool> with ArgUtils {
       ..addFlag(
         'flutter',
         defaultsTo: true,
-        help: 'Cleans up the .dart_tool directory under engine/src/flutter.',
+        help: 'Cleans up the .dart_tool directory under engine/src/flutter. Enabled by default.',
       )
       ..addFlag(
         'ninja',
         defaultsTo: false,
-        help: 'Also clean up the engine out directory with ninja output.',
+        help: 'Also clean up the engine out directory with ninja output. Disabled by default.',
       );
   }
 
   @override
   String get name => 'clean';
 
-  bool get _alsoCleanNinja => boolArg('ninja') ?? false;
+  bool get _alsoCleanNinja => boolArg('ninja')!;
 
-  bool get _alsoCleanFlutterRepo => boolArg('flutter') ?? true;
+  bool get _alsoCleanFlutterRepo => boolArg('flutter')!;
 
   @override
   String get description => 'Deletes build caches and artifacts.';

--- a/lib/web_ui/dev/common.dart
+++ b/lib/web_ui/dev/common.dart
@@ -18,23 +18,22 @@ const double kMaxDiffRateFailure = 0.28 / 100; // 0.28%
 
 abstract class PlatformBinding {
   static PlatformBinding get instance {
-    PlatformBinding? binding = _instance;
-    if (binding == null) {
-      if (io.Platform.isLinux) {
-        binding = _LinuxBinding();
-      } else if (io.Platform.isMacOS) {
-        binding = _MacBinding();
-      } else if (io.Platform.isWindows) {
-        binding = _WindowsBinding();
-      } else {
-        throw '${io.Platform.operatingSystem} is not supported';
-      }
-      _instance = binding;
-    }
-    return binding;
+    return _instance ??= _createInstance();
   }
-
   static PlatformBinding? _instance;
+
+  static PlatformBinding _createInstance() {
+    if (io.Platform.isLinux) {
+      return _LinuxBinding();
+    }
+    if (io.Platform.isMacOS) {
+      return _MacBinding();
+    }
+    if (io.Platform.isWindows) {
+      return _WindowsBinding();
+    }
+    throw '${io.Platform.operatingSystem} is not supported';
+  }
 
   int getChromeBuild(YamlMap chromeLock);
   String getChromeDownloadUrl(String version);

--- a/lib/web_ui/dev/create_simulator.dart
+++ b/lib/web_ui/dev/create_simulator.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 import 'dart:async';
 
 import 'package:args/command_runner.dart';
@@ -35,8 +34,8 @@ class CreateSimulatorCommand extends Command<bool> with ArgUtils {
 
   @override
   FutureOr<bool> run() async {
-    IosSafariArgParser.instance.parseOptions(argResults);
-    final String simulatorType = argResults['type'] as String;
+    IosSafariArgParser.instance.parseOptions(argResults!);
+    final String simulatorType = argResults!['type'] as String;
     if (simulatorType.toUpperCase() != 'IOS') {
       throw Exception('Currently the only iOS Simulators are supported');
     }

--- a/lib/web_ui/dev/driver_manager.dart
+++ b/lib/web_ui/dev/driver_manager.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 import 'dart:io' as io;
 
 import 'package:path/path.dart' as pathlib;
@@ -29,7 +28,7 @@ class ChromeDriverManager extends DriverManager {
   /// Initialized to the current first to avoid the `Non-nullable` error.
   // TODO: https://github.com/flutter/flutter/issues/53179. Local integration
   // tests are still using the system Chrome.
-  io.Directory _browserDriverDirWithVersion;
+  late final io.Directory _browserDriverDirWithVersion;
 
   ChromeDriverManager(String browser) : super(browser) {
     final io.File lockFile = io.File(pathlib.join(

--- a/lib/web_ui/dev/edge.dart
+++ b/lib/web_ui/dev/edge.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 import 'dart:async';
 import 'dart:io';
 
@@ -21,14 +20,11 @@ class Edge extends Browser {
   @override
   final name = 'Edge';
 
-  static String version;
-
   /// Starts a new instance of Safari open to the given [url], which may be a
   /// [Uri] or a [String].
   factory Edge(Uri url, {bool debug = false}) {
-    version = EdgeArgParser.instance.version;
+    final String version = EdgeArgParser.instance.version;
 
-    assert(version != null);
     return Edge._(() async {
       // TODO(nurhan): Configure info log for LUCI.
       final BrowserInstallation installation = await getEdgeInstallation(

--- a/lib/web_ui/dev/edge_installation.dart
+++ b/lib/web_ui/dev/edge_installation.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 import 'dart:async';
 import 'dart:io' as io;
 
@@ -19,7 +18,7 @@ class EdgeArgParser extends BrowserArgParser {
   /// The [EdgeArgParser] singleton.
   static EdgeArgParser get instance => _singletonInstance;
 
-  String _version;
+  late String _version;
 
   EdgeArgParser._();
 
@@ -56,7 +55,7 @@ class EdgeArgParser extends BrowserArgParser {
 // from the beta channel.
 Future<BrowserInstallation> getEdgeInstallation(
   String requestedVersion, {
-  StringSink infoLog,
+  StringSink? infoLog,
 }) async {
   // For now these tests are aimed to run only on Windows machines local or on LUCI/CI.
   // In the future we can investigate to run them on Android or on MacOS.
@@ -127,7 +126,7 @@ class EdgeLauncher {
             BrowserLock.instance.configuration['edge']['launcher_version'] as String;
 
   /// Install the launcher if it does not exist in this system.
-  void install() async {
+  Future<void> install() async {
     // Checks if the  `MicrosoftEdgeLauncher` executable exists.
     if (isInstalled) {
       return;

--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 import 'dart:async';
 import 'dart:io';
 
@@ -30,14 +29,10 @@ class Firefox extends Browser {
   @override
   final Future<Uri> remoteDebuggerUrl;
 
-  static String version;
-
   /// Starts a new instance of Firefox open to the given [url], which may be a
   /// [Uri] or a [String].
   factory Firefox(Uri url, {bool debug = false}) {
-    version = FirefoxArgParser.instance.version;
-
-    assert(version != null);
+    final String version = FirefoxArgParser.instance.version;
     var remoteDebuggerCompleter = Completer<Uri>.sync();
     return Firefox._(() async {
       final BrowserInstallation installation = await getOrInstallFirefox(

--- a/lib/web_ui/dev/firefox_installer.dart
+++ b/lib/web_ui/dev/firefox_installer.dart
@@ -1,12 +1,11 @@
 // Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-// @dart = 2.6
+
 import 'dart:io' as io;
 
 import 'package:args/args.dart';
 import 'package:http/http.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
 
@@ -20,7 +19,7 @@ class FirefoxArgParser extends BrowserArgParser {
   /// The [FirefoxArgParser] singleton.
   static FirefoxArgParser get instance => _singletonInstance;
 
-  String _version;
+  late final String _version;
 
   FirefoxArgParser._();
 
@@ -64,7 +63,7 @@ class FirefoxArgParser extends BrowserArgParser {
 /// https://download-installer.cdn.mozilla.net/pub/firefox/releases/
 Future<BrowserInstallation> getOrInstallFirefox(
   String requestedVersion, {
-  StringSink infoLog,
+  StringSink? infoLog,
 }) async {
   // These tests are aimed to run only on the Linux containers in Cirrus.
   // Therefore Firefox installation is implemented only for Linux now.
@@ -82,7 +81,7 @@ Future<BrowserInstallation> getOrInstallFirefox(
     );
   }
 
-  FirefoxInstaller installer;
+  FirefoxInstaller? installer;
   try {
     installer = requestedVersion == 'latest'
         ? await FirefoxInstaller.latest()
@@ -94,11 +93,11 @@ Future<BrowserInstallation> getOrInstallFirefox(
     } else {
       infoLog.writeln('Installing Firefox version: ${installer.version}');
       await installer.install();
-      final BrowserInstallation installation = installer.getInstallation();
+      final BrowserInstallation installation = installer.getInstallation()!;
       infoLog.writeln(
           'Installations complete. To launch it run ${installation.executable}');
     }
-    return installer.getInstallation();
+    return installer.getInstallation()!;
   } finally {
     installer?.close();
   }
@@ -107,7 +106,7 @@ Future<BrowserInstallation> getOrInstallFirefox(
 /// Manages the installation of a particular [version] of Firefox.
 class FirefoxInstaller {
   factory FirefoxInstaller({
-    @required String version,
+    required String version,
   }) {
     if (version == 'system') {
       throw BrowserInstallerException(
@@ -138,9 +137,9 @@ class FirefoxInstaller {
   }
 
   FirefoxInstaller._({
-    @required this.version,
-    @required this.firefoxInstallationDir,
-    @required this.versionDir,
+    required this.version,
+    required this.firefoxInstallationDir,
+    required this.versionDir,
   });
 
   /// Firefox version managed by this installer.
@@ -159,7 +158,7 @@ class FirefoxInstaller {
     return versionDir.existsSync();
   }
 
-  BrowserInstallation getInstallation() {
+  BrowserInstallation? getInstallation() {
     if (!isInstalled) {
       return null;
     }
@@ -262,7 +261,7 @@ class FirefoxInstaller {
     }
 
     List<String> processOutput = (mountResult.stdout as String).split('\n');
-    String volumePath = _volumeFromMountResult(processOutput);
+    final String? volumePath = _volumeFromMountResult(processOutput);
     if (volumePath == null) {
       throw BrowserInstallerException(
           'Failed to parse mount dmg result ${processOutput.join('\n')}.\n'
@@ -273,7 +272,7 @@ class FirefoxInstaller {
 
   // Parses volume from mount result.
   // Output is of form: {devicename} /Volumes/{name}.
-  String _volumeFromMountResult(List<String> lines) {
+  String? _volumeFromMountResult(List<String> lines) {
     for (String line in lines) {
       int pos = line.indexOf('/Volumes');
       if (pos != -1) {
@@ -326,8 +325,8 @@ Future<String> fetchLatestFirefoxVersionLinux() async {
   // We will parse the HttpHeaders to find the redirect location.
   final io.HttpClientResponse response = await request.close();
 
-  final String location = response.headers.value('location');
-  final String version = forFirefoxVersion.stringMatch(location);
+  final String location = response.headers.value('location')!;
+  final String version = forFirefoxVersion.stringMatch(location)!;
 
   return version.substring(version.lastIndexOf('-') + 1);
 }
@@ -341,13 +340,13 @@ Future<String> fetchLatestFirefoxVersionMacOS() async {
   // We will parse the HttpHeaders to find the redirect location.
   final io.HttpClientResponse response = await request.close();
 
-  final String location = response.headers.value('location');
-  final String version = forFirefoxVersion.stringMatch(location);
+  final String location = response.headers.value('location')!;
+  final String version = forFirefoxVersion.stringMatch(location)!;
   return version.substring(version.lastIndexOf('/') + 1);
 }
 
 Future<BrowserInstallation> getInstaller({String requestedVersion = 'latest'}) async {
-  FirefoxInstaller installer;
+  FirefoxInstaller? installer;
   try {
     installer = requestedVersion == 'latest'
         ? await FirefoxInstaller.latest()
@@ -359,11 +358,11 @@ Future<BrowserInstallation> getInstaller({String requestedVersion = 'latest'}) a
     } else {
       print('Installing Firefox version: ${installer.version}');
       await installer.install();
-      final BrowserInstallation installation = installer.getInstallation();
+      final BrowserInstallation installation = installer.getInstallation()!;
       print(
           'Installations complete. To launch it run ${installation.executable}');
     }
-    return installer.getInstallation();
+    return installer.getInstallation()!;
   } finally {
     installer?.close();
   }

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
-
 import 'dart:io' as io;
 import 'package:args/args.dart';
 import 'package:path/path.dart' as pathlib;
@@ -182,8 +180,8 @@ class IntegrationTestsManager {
     final Set<String> renderingBackends = _getRenderingBackends();
     for (String renderingBackend in renderingBackends) {
       for (String mode in buildModes) {
-        if (!blockedTestsListsMapForModes[mode].contains(target) &&
-            !blockedTestsListsMapForRenderBackends[renderingBackend]
+        if (!blockedTestsListsMapForModes[mode]!.contains(target) &&
+            !blockedTestsListsMapForRenderBackends[renderingBackend]!
                 .contains(target)) {
           final bool result = await _runTestsInMode(directory, target,
               mode: mode, webRenderer: renderingBackend);
@@ -268,7 +266,7 @@ class IntegrationTestsManager {
     // Whether the project has the pubspec.yaml file.
     bool pubSpecFound = false;
     // The test directory 'test_driver'.
-    io.Directory testDirectory;
+    io.Directory? testDirectory;
 
     for (io.FileSystemEntity e in entities) {
       // The tests should be under this directories.
@@ -508,7 +506,7 @@ class IntegrationTestsArgumentParser {
 
   /// If target name is provided integration tests can run that one test
   /// instead of running all the tests.
-  String testTarget;
+  late final String testTarget;
 
   /// The build mode to run the integration tests.
   ///
@@ -517,13 +515,13 @@ class IntegrationTestsArgumentParser {
   ///
   /// In order to skip a test for one of the modes, add the test to the
   /// `blockedTestsListsMapForModes` list for the relevant compile mode.
-  String buildMode;
+  late final String buildMode;
 
   /// Whether to use html, canvaskit or auto for web renderer.
   ///
   /// If not set all backends will be used one after another for integration
   /// tests. If set only the provided option will be used.
-  String webRenderer;
+  late final String webRenderer;
 
   void populateOptions(ArgParser argParser) {
     argParser

--- a/lib/web_ui/dev/safari.dart
+++ b/lib/web_ui/dev/safari.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 import 'dart:async';
 import 'dart:io';
 
@@ -21,16 +20,11 @@ class Safari extends Browser {
   @override
   final name = 'Safari';
 
-  static String version;
-
-  static bool isMobileBrowser;
-
   /// Starts a new instance of Safari open to the given [url], which may be a
   /// [Uri] or a [String].
   factory Safari(Uri url, {bool debug = false}) {
-    version = SafariArgParser.instance.version;
-    isMobileBrowser = SafariArgParser.instance.isMobileBrowser;
-    assert(version != null);
+    final String version = SafariArgParser.instance.version;
+    final bool isMobileBrowser = SafariArgParser.instance.isMobileBrowser;
     return Safari._(() async {
       if (isMobileBrowser) {
         // iOS-Safari

--- a/lib/web_ui/dev/supported_browsers.dart
+++ b/lib/web_ui/dev/supported_browsers.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.6
 import 'package:test_api/src/backend/runtime.dart';
 
 import 'browser.dart';

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -28,9 +28,9 @@ dev_dependencies:
     git:
       url: git://github.com/flutter/web_installers.git
       path: packages/simulators/
-      ref: 4a9643e55e9bd127f4e4e3cb20e562ed5d5b9aa7
+      ref: 4a7b0a2c84b8993bf4d19030218de38c18838c26
   web_driver_installer:
     git:
       url: git://github.com/flutter/web_installers.git
       path: packages/web_drivers/
-      ref: 946111ae3248132e3773bf5c5327bcbbefa0c5f2
+      ref: 4a7b0a2c84b8993bf4d19030218de38c18838c26


### PR DESCRIPTION
Migrate more of the felt code to null safety. Includes everything under `dev/` except `test_platform.dart`, `test_runner.dart`, and `felt.dart`. `test_platform.dart` and `test_runner.dart` are big and it's better to migrate them in individual PRs. `felt.dart` depends on `test_runner.dart`.