### PR TITLE
Updates the objectc docs script to use env variables.

### DIFF
--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -23,11 +23,11 @@ if [[ -z $LUCI_CI ]]
       then
         echo "Error: Argument specifying output directory required."
         exit 1
-      else
+    else
         OUTPUT_DIR=$1
     fi
-  else 
-    OUTPUT_DIR="$LUCI_WORKDIR/objectc_docs"
+else 
+  OUTPUT_DIR="$LUCI_WORKDIR/objectc_docs"
 fi
 
 

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -17,15 +17,13 @@ fi
 # to pass an output directory as the first parameter.
 OUTPUT_DIR=""
 
-if [[ -z $LUCI_CI ]]
-  then
-    if [[ $# -eq 0 ]]
-      then
-        echo "Error: Argument specifying output directory required."
-        exit 1
-    else
-        OUTPUT_DIR=$1
-    fi
+if [[ -z $LUCI_CI ]]; then
+  if [[ $# -eq 0 ]]; then
+    echo "Error: Argument specifying output directory required."
+    exit 1
+  else
+    OUTPUT_DIR=$1
+  fi
 else 
   OUTPUT_DIR="$LUCI_WORKDIR/objectc_docs"
 fi

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -23,7 +23,7 @@ if [[ -z $LUCI_CI ]]
       then
         echo "Error: Argument specifying output directory required."
         exit 1
-    else
+  else
       OUTPUT_DIR=$1
     fi
 else 

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -5,6 +5,8 @@
 
 # Generates objc docs for Flutter iOS libraries.
 
+set -e
+
 FLUTTER_UMBRELLA_HEADER=$(find ../out -maxdepth 4 -type f -name Flutter.h | grep 'ios_' | head -n 1)
 if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
   then
@@ -17,12 +19,12 @@ fi
 # to pass an output directory as the first parameter.
 OUTPUT_DIR=""
 
-if [[ -z $LUCI_CI ]]; then
+if [[ -z "$LUCI_CI" ]]; then
   if [[ $# -eq 0 ]]; then
     echo "Error: Argument specifying output directory required."
     exit 1
   else
-    OUTPUT_DIR=$1
+    OUTPUT_DIR="$1"
   fi
 else
   OUTPUT_DIR="$LUCI_WORKDIR/objectc_docs"

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -24,10 +24,9 @@ if [[ -z $LUCI_CI ]]; then
   else
     OUTPUT_DIR=$1
   fi
-else 
+else
   OUTPUT_DIR="$LUCI_WORKDIR/objectc_docs"
 fi
-
 
 # If GEM_HOME is set, prefer using its copy of jazzy.
 # LUCI will put jazzy here instead of on the path.

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -23,13 +23,12 @@ if [[ -z $LUCI_CI ]]
       then
         echo "Error: Argument specifying output directory required."
         exit 1
-  else
-      OUTPUT_DIR=$1
+      else
+        OUTPUT_DIR=$1
     fi
-else 
-  OUTPUT_DIR="$LUCI_WORKDIR/objectc_docs"
+  else 
+    OUTPUT_DIR="$LUCI_WORKDIR/objectc_docs"
 fi
-
 
 
 # If GEM_HOME is set, prefer using its copy of jazzy.

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -12,11 +12,25 @@ if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
       exit 1
 fi
 
-if [[ $# -eq 0 ]]
+
+# If the script is running from within LUCI we use the LUCI_WORKDIR, if not we force the caller of the script
+# to pass an output directory as the first parameter.
+OUTPUT_DIR=""
+
+if [[ -z $LUCI_CI ]]
   then
-      echo "Error: Argument specifying output directory required."
-      exit 1
+    if [[ $# -eq 0 ]]
+      then
+        echo "Error: Argument specifying output directory required."
+        exit 1
+    else
+      OUTPUT_DIR=$1
+    fi
+else 
+  OUTPUT_DIR="$LUCI_WORKDIR/objectc_docs"
 fi
+
+
 
 # If GEM_HOME is set, prefer using its copy of jazzy.
 # LUCI will put jazzy here instead of on the path.
@@ -39,7 +53,7 @@ jazzy \
   --xcodebuild-arguments --objc,"$FLUTTER_UMBRELLA_HEADER",--,-x,objective-c,-isysroot,"$(xcrun --show-sdk-path --sdk iphonesimulator)",-I,"$(pwd)"\
   --module Flutter\
   --root-url https://api.flutter.dev/objc/\
-  --output "$1"
+  --output "$OUTPUT_DIR"
 
 EXPECTED_CLASSES="FlutterAppDelegate.html
 FlutterBasicMessageChannel.html
@@ -62,7 +76,7 @@ FlutterStandardTypedData.html
 FlutterStandardWriter.html
 FlutterViewController.html"
 
-ACTUAL_CLASSES=$(ls "$1/Classes" | sort)
+ACTUAL_CLASSES=$(ls "$OUTPUT_DIR/Classes" | sort)
 
 if [[ $EXPECTED_CLASSES != $ACTUAL_CLASSES ]]; then
   echo "Expected classes did not match actual classes"


### PR DESCRIPTION
This is in preparation to split the recipes into builder/tester. Adding
the env variable support will allow us to call different scripts from
configurations and coordinate artifacts location between generator steps
and archiving steps.

Bug: https://github.com/flutter/flutter/issues/84300

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
