### PR TITLE
Disable ImageReleasedAfterFrame on Fuchsia

### DIFF
--- a/lib/ui/painting/image_dispose_unittests.cc
+++ b/lib/ui/painting/image_dispose_unittests.cc
@@ -40,7 +40,13 @@ class ImageDisposeTest : public ShellTest {
   sk_sp<SkImage> current_image_;
 };
 
-TEST_F(ImageDisposeTest, ImageReleasedAfterFrame) {
+TEST_F(ImageDisposeTest,
+#if defined(OS_FUCHSIA)
+       DISABLED_ImageReleasedAfterFrame
+#else
+       ImageReleasedAfterFrame
+#endif  // defined(OS_FUCHSIA)
+) {
   auto native_capture_image_and_picture = [&](Dart_NativeArguments args) {
     auto image_handle = Dart_GetNativeArgument(args, 0);
     auto native_image_handle =


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/84116.

From the linked issue, this test is planned to be removed following work from @dnfield.