### PR TITLE
[web] use isTrue/isFalse in all tests

### DIFF
--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -39,12 +39,12 @@ void testMain() {
 
     setUp(() {
       expect(notoDownloadQueue.downloader.debugActiveDownloadCount, 0);
-      expect(notoDownloadQueue.isPending, false);
+      expect(notoDownloadQueue.isPending, isFalse);
     });
 
     tearDown(() {
       expect(notoDownloadQueue.downloader.debugActiveDownloadCount, 0);
-      expect(notoDownloadQueue.isPending, false);
+      expect(notoDownloadQueue.isPending, isFalse);
     });
 
     test('renders using non-recording canvas if weak refs are supported',

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -705,8 +705,8 @@ void _pathTests() {
 
   test('contains', () {
     final SkPath testPath = _testClosedSkPath();
-    expect(testPath.contains(15, 15), true);
-    expect(testPath.contains(100, 100), false);
+    expect(testPath.contains(15, 15), isTrue);
+    expect(testPath.contains(100, 100), isFalse);
   });
 
   test('cubicTo', () {
@@ -777,8 +777,8 @@ void _pathTests() {
   });
 
   test('isEmpty', () {
-    expect(SkPath().isEmpty(), true);
-    expect(_testClosedSkPath().isEmpty(), false);
+    expect(SkPath().isEmpty(), isTrue);
+    expect(_testClosedSkPath().isEmpty(), isFalse);
   });
 
   test('copy', () {
@@ -802,7 +802,7 @@ void _pathTests() {
     expect(measure1.getPosTan(5), Float32List.fromList(<double>[15, 10, 1, 0]));
     expect(
         measure1.getPosTan(15), Float32List.fromList(<double>[20, 15, 0, 1]));
-    expect(measure1.isClosed(), true);
+    expect(measure1.isClosed(), isTrue);
 
     // Starting with a box path:
     //
@@ -1341,7 +1341,7 @@ void _paragraphTests() {
     paragraph.layout(55);
     expect(paragraph.getAlphabeticBaseline(),
         within<double>(distance: 0.5, from: 20.7));
-    expect(paragraph.didExceedMaxLines(), false);
+    expect(paragraph.didExceedMaxLines(), isFalse);
     expect(paragraph.getHeight(), 25);
     expect(paragraph.getIdeographicBaseline(),
         within<double>(distance: 0.5, from: 25));
@@ -1359,7 +1359,7 @@ void _paragraphTests() {
     final SkLineMetrics lineMetrics = paragraph.getLineMetrics().single;
     expect(lineMetrics.ascent, within<double>(distance: 0.5, from: 20.7));
     expect(lineMetrics.descent, within<double>(distance: 0.2, from: 4.3));
-    expect(lineMetrics.isHardBreak, true);
+    expect(lineMetrics.isHardBreak, isTrue);
     expect(lineMetrics.baseline, within<double>(distance: 0.5, from: 20.7));
     expect(lineMetrics.height, 25);
     expect(lineMetrics.left, 2.5);

--- a/lib/web_ui/test/canvaskit/image_test.dart
+++ b/lib/web_ui/test/canvaskit/image_test.dart
@@ -29,9 +29,9 @@ void testMain() {
 
     test('CkAnimatedImage can be explicitly disposed of', () {
       final CkAnimatedImage image = CkAnimatedImage.decodeFromBytes(kTransparentImage, 'test');
-      expect(image.debugDisposed, false);
+      expect(image.debugDisposed, isFalse);
       image.dispose();
-      expect(image.debugDisposed, true);
+      expect(image.debugDisposed, isTrue);
 
       // Disallow usage after disposal
       expect(() => image.frameCount, throwsAssertionError);
@@ -86,11 +86,11 @@ void testMain() {
           canvasKit.MakeAnimatedImageFromEncoded(kTransparentImage)
               .makeImageAtCurrentFrame();
       final CkImage image = CkImage(skImage);
-      expect(image.debugDisposed, false);
-      expect(image.box.isDeletedPermanently, false);
+      expect(image.debugDisposed, isFalse);
+      expect(image.box.isDeletedPermanently, isFalse);
       image.dispose();
-      expect(image.debugDisposed, true);
-      expect(image.box.isDeletedPermanently, true);
+      expect(image.debugDisposed, isTrue);
+      expect(image.box.isDeletedPermanently, isTrue);
 
       // Disallow double-dispose.
       expect(() => image.dispose(), throwsAssertionError);
@@ -110,23 +110,23 @@ void testMain() {
       expect(box.refCount, 2);
       expect(box.debugGetStackTraces().length, 2);
 
-      expect(image.isCloneOf(clone), true);
-      expect(box.isDeletedPermanently, false);
+      expect(image.isCloneOf(clone), isTrue);
+      expect(box.isDeletedPermanently, isFalse);
 
       testCollector.collectNow();
-      expect(skImage.isDeleted(), false);
+      expect(skImage.isDeleted(), isFalse);
       image.dispose();
       expect(box.refCount, 1);
-      expect(box.isDeletedPermanently, false);
+      expect(box.isDeletedPermanently, isFalse);
 
       testCollector.collectNow();
-      expect(skImage.isDeleted(), false);
+      expect(skImage.isDeleted(), isFalse);
       clone.dispose();
       expect(box.refCount, 0);
-      expect(box.isDeletedPermanently, true);
+      expect(box.isDeletedPermanently, isTrue);
 
       testCollector.collectNow();
-      expect(skImage.isDeleted(), true);
+      expect(skImage.isDeleted(), isTrue);
       expect(box.debugGetStackTraces().length, 0);
       testCollector.collectNow();
     });

--- a/lib/web_ui/test/canvaskit/path_test.dart
+++ b/lib/web_ui/test/canvaskit/path_test.dart
@@ -19,7 +19,7 @@ void testMain() {
     setUpCanvasKitTest();
 
     test('Using CanvasKit', () {
-      expect(useCanvasKit, true);
+      expect(useCanvasKit, isTrue);
     });
 
     test(CkPathMetrics, () {
@@ -40,7 +40,7 @@ void testMain() {
       expect(tangent2.position, ui.Offset(10, 5));
       expect(tangent2.vector, ui.Offset(0, 1));
 
-      expect(metric.isClosed, true);
+      expect(metric.isClosed, isTrue);
 
       path.addOval(ui.Rect.fromLTRB(10, 10, 100, 100));
       expect(path.computeMetrics().length, 2);
@@ -56,16 +56,16 @@ void testMain() {
       final ui.PathMetrics metrics2 = path.computeMetrics();
       final Iterator<ui.PathMetric> iter1 = metrics1.iterator;
       final Iterator<ui.PathMetric> iter2 = metrics2.iterator;
-      expect(iter1.moveNext(), true);
-      expect(iter2.moveNext(), true);
+      expect(iter1.moveNext(), isTrue);
+      expect(iter2.moveNext(), isTrue);
       expect(iter1.current, isNotNull);
       expect(iter2.current, isNotNull);
-      expect(iter1.moveNext(), true);
-      expect(iter2.moveNext(), true);
+      expect(iter1.moveNext(), isTrue);
+      expect(iter2.moveNext(), isTrue);
       expect(iter1.current, isNotNull);
       expect(iter2.current, isNotNull);
-      expect(iter1.moveNext(), false);
-      expect(iter2.moveNext(), false);
+      expect(iter1.moveNext(), isFalse);
+      expect(iter2.moveNext(), isFalse);
       expect(() => iter1.current, throwsRangeError);
       expect(() => iter2.current, throwsRangeError);
     });
@@ -106,9 +106,9 @@ void testMain() {
       final ui.PathMetrics metrics = path.computeMetrics();
       final CkContourMeasureIter iterator = metrics.iterator as CkContourMeasureIter;
 
-      expect(iterator.moveNext(), true);
+      expect(iterator.moveNext(), isTrue);
       expect(iterator.current.contourIndex, 0);
-      expect(iterator.moveNext(), true);
+      expect(iterator.moveNext(), isTrue);
       expect(iterator.current.contourIndex, 1);
 
       // Delete iterator in the middle of iteration
@@ -116,9 +116,9 @@ void testMain() {
       iterator.rawSkiaObject = null;
 
       // Check that the iterator can continue from the last position.
-      expect(iterator.moveNext(), true);
+      expect(iterator.moveNext(), isTrue);
       expect(iterator.current.contourIndex, 2);
-      expect(iterator.moveNext(), false);
+      expect(iterator.moveNext(), isFalse);
     });
 
     test('Resurrect CkContourMeasure', () {
@@ -132,12 +132,12 @@ void testMain() {
       final ui.PathMetrics metrics = path.computeMetrics();
       final CkContourMeasureIter iterator = metrics.iterator as CkContourMeasureIter;
 
-      expect(iterator.moveNext(), true);
+      expect(iterator.moveNext(), isTrue);
       final CkContourMeasure measure0 = iterator.current as CkContourMeasure;
       expect(measure0.contourIndex, 0);
       expect(measure0.extractPath(0, 15).getBounds(), ui.Rect.fromLTRB(0, 0, 10, 5));
 
-      expect(iterator.moveNext(), true);
+      expect(iterator.moveNext(), isTrue);
       final CkContourMeasure measure1 = iterator.current as CkContourMeasure;
       expect(measure1.contourIndex, 1);
       expect(measure1.extractPath(0, 15).getBounds(), ui.Rect.fromLTRB(20, 20, 30, 25));

--- a/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
+++ b/lib/web_ui/test/canvaskit/skia_objects_cache_test.dart
@@ -122,7 +122,7 @@ void _tests() {
 
         expect(original.box.debugGetStackTraces().length, 1);
         expect(original.box.refCount, 1);
-        expect(original.box.isDeletedPermanently, false);
+        expect(original.box.isDeletedPermanently, isFalse);
 
         final TestBoxWrapper clone = original.clone();
         expect(clone.box, same(original.box));
@@ -130,7 +130,7 @@ void _tests() {
         expect(clone.box.refCount, 2);
         expect(original.box.debugGetStackTraces().length, 2);
         expect(original.box.refCount, 2);
-        expect(original.box.isDeletedPermanently, false);
+        expect(original.box.isDeletedPermanently, isFalse);
 
         original.dispose();
 
@@ -154,7 +154,7 @@ void _tests() {
         expect(clone.box.refCount, 0);
         expect(original.box.debugGetStackTraces().length, 0);
         expect(original.box.refCount, 0);
-        expect(original.box.isDeletedPermanently, true);
+        expect(original.box.isDeletedPermanently, isTrue);
 
         testCollector.collectNow();
         expect(TestSkDeletable.deleteCount, 1);
@@ -186,18 +186,18 @@ void _tests() {
         object.box.didDelete();
         expect(TestSkDeletable.deleteCount, i + 1);
         expect(TestBoxWrapper.resurrectCount, i);
-        expect(object.box.isDeletedTemporarily, true);
-        expect(object.box.isDeletedPermanently, false);
+        expect(object.box.isDeletedTemporarily, isTrue);
+        expect(object.box.isDeletedPermanently, isFalse);
 
         expect(object.box.skiaObject, isNotNull);
         expect(TestSkDeletable.deleteCount, i + 1);
         expect(TestBoxWrapper.resurrectCount, i + 1);
-        expect(object.box.isDeletedTemporarily, false);
-        expect(object.box.isDeletedPermanently, false);
+        expect(object.box.isDeletedTemporarily, isFalse);
+        expect(object.box.isDeletedPermanently, isFalse);
       }
 
       object.dispose();
-      expect(object.box.isDeletedPermanently, true);
+      expect(object.box.isDeletedPermanently, isTrue);
     });
 
     test('Can dispose temporarily deleted object', () async {
@@ -211,11 +211,11 @@ void _tests() {
       object.box.didDelete();
       expect(TestSkDeletable.deleteCount, 1);
       expect(TestBoxWrapper.resurrectCount, 0);
-      expect(object.box.isDeletedTemporarily, true);
-      expect(object.box.isDeletedPermanently, false);
+      expect(object.box.isDeletedTemporarily, isTrue);
+      expect(object.box.isDeletedPermanently, isFalse);
 
       object.dispose();
-      expect(object.box.isDeletedPermanently, true);
+      expect(object.box.isDeletedPermanently, isTrue);
     });
   });
 

--- a/lib/web_ui/test/channel_buffers_test.dart
+++ b/lib/web_ui/test/channel_buffers_test.dart
@@ -90,7 +90,7 @@ void testMain() {
       didCall = true;
       return Future<void>.value();
     });
-    expect(didCall, equals(false));
+    expect(didCall, isFalse);
   });
 
   test('drain when empty', () async {
@@ -101,7 +101,7 @@ void testMain() {
       didCall = true;
       return Future<void>.value();
     });
-    expect(didCall, equals(false));
+    expect(didCall, isFalse);
   });
 
   test('overflow', () async {
@@ -174,9 +174,9 @@ void testMain() {
     _resize(buffers, channel, 100);
     buffers.push(channel, one, oneCallback);
     buffers.push(channel, two, twoCallback);
-    expect(didCallCallback, equals(false));
+    expect(didCallCallback, isFalse);
     _resize(buffers, channel, 1);
-    expect(didCallCallback, equals(true));
+    expect(didCallCallback, isTrue);
   });
 
   test('overflow calls callback', () async {
@@ -195,7 +195,7 @@ void testMain() {
     _resize(buffers, channel, 1);
     buffers.push(channel, one, oneCallback);
     buffers.push(channel, two, twoCallback);
-    expect(didCallCallback, equals(true));
+    expect(didCallCallback, isTrue);
   });
 
   test('handle garbage', () async {

--- a/lib/web_ui/test/clipboard_test.dart
+++ b/lib/web_ui/test/clipboard_test.dart
@@ -49,7 +49,7 @@ void testMain() async {
           }),
           callback);
 
-      expect(await completer.future, true);
+      expect(await completer.future, isTrue);
     });
 
     test('set data error', () async {

--- a/lib/web_ui/test/dom_renderer_test.dart
+++ b/lib/web_ui/test/dom_renderer_test.dart
@@ -99,7 +99,7 @@ void testMain() {
       ..name = 'viewport'
       ..content = 'foo=bar';
     html.document.head!.append(existingMeta);
-    expect(existingMeta.isConnected, true);
+    expect(existingMeta.isConnected, isTrue);
 
     final DomRenderer renderer = DomRenderer();
     renderer.reset();

--- a/lib/web_ui/test/engine/frame_reference_test.dart
+++ b/lib/web_ui/test/engine/frame_reference_test.dart
@@ -68,8 +68,8 @@ void testMain() {
       expect(_evictedItems.length, 0);
       cache.reuse('item2');
       cache.commitFrame();
-      expect(_evictedItems.contains(testItem1), true);
-      expect(_evictedItems.contains(testItem2), false);
+      expect(_evictedItems.contains(testItem1), isTrue);
+      expect(_evictedItems.contains(testItem2), isFalse);
     });
   });
 }

--- a/lib/web_ui/test/engine/image/html_image_codec_test.dart
+++ b/lib/web_ui/test/engine/image/html_image_codec_test.dart
@@ -67,9 +67,9 @@ void testMain() async {
       final HtmlCodec codec = HtmlCodec('sample_image1.png');
       final ui.FrameInfo frameInfo = await codec.getNextFrame();
       expect(frameInfo.image, isNotNull);
-      expect(frameInfo.image.debugDisposed, false);
+      expect(frameInfo.image.debugDisposed, isFalse);
       frameInfo.image.dispose();
-      expect(frameInfo.image.debugDisposed, true);
+      expect(frameInfo.image.debugDisposed, isTrue);
     });
     test('provides image loading progress', () async {
       StringBuffer buffer = new StringBuffer();

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -544,7 +544,7 @@ void testMain() {
       expect(packets.single.data, hasLength(2));
 
       expect(packets.single.data[0].change, equals(ui.PointerChange.add));
-      expect(packets.single.data[0].synthesized, equals(true));
+      expect(packets.single.data[0].synthesized, isTrue);
       expect(packets.single.data[1].change, equals(ui.PointerChange.hover));
     },
   );
@@ -570,7 +570,7 @@ void testMain() {
       // An add will be synthesized.
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
       packets.clear();
 
@@ -636,7 +636,7 @@ void testMain() {
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
       expect(packets[0].data[0].pointerIdentifier, equals(0));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].physicalX, equals(10.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(10.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(0.0));
@@ -646,7 +646,7 @@ void testMain() {
       expect(
           packets[0].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
       expect(packets[0].data[1].pointerIdentifier, equals(0));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].physicalX, equals(10.0 * dpi));
       expect(packets[0].data[1].physicalY, equals(10.0 * dpi));
       expect(packets[0].data[1].physicalDeltaX, equals(0.0));
@@ -656,7 +656,7 @@ void testMain() {
       expect(packets[1].data, hasLength(2));
       expect(packets[1].data[0].change, equals(ui.PointerChange.hover));
       expect(packets[1].data[0].pointerIdentifier, equals(0));
-      expect(packets[1].data[0].synthesized, equals(true));
+      expect(packets[1].data[0].synthesized, isTrue);
       expect(packets[1].data[0].physicalX, equals(20.0 * dpi));
       expect(packets[1].data[0].physicalY, equals(50.0 * dpi));
       expect(packets[1].data[0].physicalDeltaX, equals(10.0 * dpi));
@@ -666,7 +666,7 @@ void testMain() {
       expect(
           packets[1].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
       expect(packets[1].data[1].pointerIdentifier, equals(0));
-      expect(packets[1].data[1].synthesized, equals(false));
+      expect(packets[1].data[1].synthesized, isFalse);
       expect(packets[1].data[1].physicalX, equals(20.0 * dpi));
       expect(packets[1].data[1].physicalY, equals(50.0 * dpi));
       expect(packets[1].data[1].physicalDeltaX, equals(0.0));
@@ -677,7 +677,7 @@ void testMain() {
       expect(packets[2].data[0].change, equals(ui.PointerChange.down));
       expect(packets[2].data[0].signalKind, equals(ui.PointerSignalKind.none));
       expect(packets[2].data[0].pointerIdentifier, equals(1));
-      expect(packets[2].data[0].synthesized, equals(false));
+      expect(packets[2].data[0].synthesized, isFalse);
       expect(packets[2].data[0].physicalX, equals(20.0 * dpi));
       expect(packets[2].data[0].physicalY, equals(50.0 * dpi));
       expect(packets[2].data[0].physicalDeltaX, equals(0.0));
@@ -687,7 +687,7 @@ void testMain() {
       expect(packets[3].data, hasLength(2));
       expect(packets[3].data[0].change, equals(ui.PointerChange.move));
       expect(packets[3].data[0].pointerIdentifier, equals(1));
-      expect(packets[3].data[0].synthesized, equals(true));
+      expect(packets[3].data[0].synthesized, isTrue);
       expect(packets[3].data[0].physicalX, equals(30.0 * dpi));
       expect(packets[3].data[0].physicalY, equals(60.0 * dpi));
       expect(packets[3].data[0].physicalDeltaX, equals(10.0 * dpi));
@@ -697,7 +697,7 @@ void testMain() {
       expect(
           packets[3].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
       expect(packets[3].data[1].pointerIdentifier, equals(1));
-      expect(packets[3].data[1].synthesized, equals(false));
+      expect(packets[3].data[1].synthesized, isFalse);
       expect(packets[3].data[1].physicalX, equals(30.0 * dpi));
       expect(packets[3].data[1].physicalY, equals(60.0 * dpi));
       expect(packets[3].data[1].physicalDeltaX, equals(0.0));
@@ -726,7 +726,7 @@ void testMain() {
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
       expect(packets[0].data[0].pointerIdentifier, equals(0));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].physicalX, equals(10.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(10.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(0.0));
@@ -734,7 +734,7 @@ void testMain() {
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.hover));
       expect(packets[0].data[1].pointerIdentifier, equals(0));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].physicalX, equals(10.0 * dpi));
       expect(packets[0].data[1].physicalY, equals(10.0 * dpi));
       expect(packets[0].data[1].physicalDeltaX, equals(0.0));
@@ -749,7 +749,7 @@ void testMain() {
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.hover));
       expect(packets[0].data[0].pointerIdentifier, equals(0));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(10.0 * dpi));
@@ -764,7 +764,7 @@ void testMain() {
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.down));
       expect(packets[0].data[0].pointerIdentifier, equals(1));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(0.0));
@@ -779,7 +779,7 @@ void testMain() {
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
       expect(packets[0].data[0].pointerIdentifier, equals(1));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(40.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(30.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(20.0 * dpi));
@@ -794,7 +794,7 @@ void testMain() {
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
       expect(packets[0].data[0].pointerIdentifier, equals(1));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(40.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(30.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(0.0));
@@ -809,7 +809,7 @@ void testMain() {
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.hover));
       expect(packets[0].data[0].pointerIdentifier, equals(1));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(10.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(-20.0 * dpi));
@@ -824,7 +824,7 @@ void testMain() {
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.down));
       expect(packets[0].data[0].pointerIdentifier, equals(2));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(10.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(0.0));
@@ -856,12 +856,12 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].physicalX, equals(10 * dpi));
       expect(packets[0].data[0].physicalY, equals(11 * dpi));
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.hover));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].physicalX, equals(10 * dpi));
       expect(packets[0].data[1].physicalY, equals(11 * dpi));
       expect(packets[0].data[1].buttons, equals(0));
@@ -876,7 +876,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(10 * dpi));
       expect(packets[0].data[0].physicalY, equals(11 * dpi));
       expect(packets[0].data[0].buttons, equals(1));
@@ -891,7 +891,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20 * dpi));
       expect(packets[0].data[0].physicalY, equals(21 * dpi));
       expect(packets[0].data[0].buttons, equals(1));
@@ -905,7 +905,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20 * dpi));
       expect(packets[0].data[0].physicalY, equals(21 * dpi));
       expect(packets[0].data[0].buttons, equals(0));
@@ -921,7 +921,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20 * dpi));
       expect(packets[0].data[0].physicalY, equals(21 * dpi));
       expect(packets[0].data[0].buttons, equals(2));
@@ -936,7 +936,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(30 * dpi));
       expect(packets[0].data[0].physicalY, equals(31 * dpi));
       expect(packets[0].data[0].buttons, equals(2));
@@ -950,7 +950,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(30 * dpi));
       expect(packets[0].data[0].physicalY, equals(31 * dpi));
       expect(packets[0].data[0].buttons, equals(0));
@@ -966,7 +966,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(30 * dpi));
       expect(packets[0].data[0].physicalY, equals(31 * dpi));
       expect(packets[0].data[0].buttons, equals(4));
@@ -981,7 +981,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(40 * dpi));
       expect(packets[0].data[0].physicalY, equals(41 * dpi));
       expect(packets[0].data[0].buttons, equals(4));
@@ -995,7 +995,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(40 * dpi));
       expect(packets[0].data[0].physicalY, equals(41 * dpi));
       expect(packets[0].data[0].buttons, equals(0));
@@ -1024,10 +1024,10 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(1));
       packets.clear();
 
@@ -1039,7 +1039,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(5));
       packets.clear();
 
@@ -1051,7 +1051,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(4));
       packets.clear();
 
@@ -1062,7 +1062,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(0));
       packets.clear();
     },
@@ -1094,12 +1094,12 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].physicalX, equals(10 * dpi));
       expect(packets[0].data[0].physicalY, equals(11 * dpi));
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].physicalX, equals(10 * dpi));
       expect(packets[0].data[1].physicalY, equals(11 * dpi));
       expect(packets[0].data[1].buttons, equals(2));
@@ -1114,7 +1114,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20 * dpi));
       expect(packets[0].data[0].physicalY, equals(21 * dpi));
       expect(packets[0].data[0].buttons, equals(2));
@@ -1129,7 +1129,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20 * dpi));
       expect(packets[0].data[0].physicalY, equals(21 * dpi));
       expect(packets[0].data[0].buttons, equals(2));
@@ -1143,7 +1143,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(20 * dpi));
       expect(packets[0].data[0].physicalY, equals(21 * dpi));
       expect(packets[0].data[0].buttons, equals(0));
@@ -1178,10 +1178,10 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(2));
       packets.clear();
 
@@ -1195,7 +1195,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(3));
       packets.clear();
 
@@ -1207,7 +1207,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(2));
       packets.clear();
 
@@ -1218,7 +1218,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(0));
       packets.clear();
     },
@@ -1251,10 +1251,10 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(2));
       packets.clear();
 
@@ -1266,10 +1266,10 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(0));
       expect(packets[0].data[1].change, equals(ui.PointerChange.hover));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(0));
       packets.clear();
     },
@@ -1302,10 +1302,10 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.hover));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(0));
       packets.clear();
     },
@@ -1339,10 +1339,10 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(2));
       packets.clear();
 
@@ -1356,13 +1356,13 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(3));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].buttons, equals(2));
       expect(packets[0].data[1].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(0));
       expect(packets[0].data[2].change, equals(ui.PointerChange.hover));
-      expect(packets[0].data[2].synthesized, equals(false));
+      expect(packets[0].data[2].synthesized, isFalse);
       expect(packets[0].data[2].buttons, equals(0));
       packets.clear();
     },
@@ -1402,10 +1402,10 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(2));
       packets.clear();
 
@@ -1419,7 +1419,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(3));
       packets.clear();
 
@@ -1431,7 +1431,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(0));
       packets.clear();
     },
@@ -1465,9 +1465,9 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(2));
       packets.clear();
 
@@ -1483,15 +1483,15 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(3));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].buttons, equals(2));
       expect(packets[0].data[0].physicalX, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(20.0 * dpi));
       expect(packets[0].data[1].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(0));
       expect(packets[0].data[2].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[2].synthesized, equals(false));
+      expect(packets[0].data[2].synthesized, isFalse);
       expect(packets[0].data[2].buttons, equals(2));
       packets.clear();
 
@@ -1504,7 +1504,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(0));
       packets.clear();
     },
@@ -1540,9 +1540,9 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(2));
       packets.clear();
 
@@ -1555,7 +1555,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(0));
       packets.clear();
 
@@ -1571,10 +1571,10 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.hover));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].buttons, equals(0));
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(2));
       packets.clear();
 
@@ -1587,7 +1587,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].buttons, equals(0));
       packets.clear();
     },
@@ -1626,9 +1626,9 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(2));
       packets.clear();
 
@@ -1654,10 +1654,10 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.hover));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].buttons, equals(0));
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(2));
       packets.clear();
     },
@@ -1692,9 +1692,9 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].buttons, equals(1));
       expect(packets[0].data[1].physicalX, equals(5.0 * dpi));
       expect(packets[0].data[1].physicalY, equals(100.0 * dpi));
@@ -1847,7 +1847,7 @@ void testMain() {
       data = _allPointerData(packets);
       expect(data, hasLength(4));
       expect(data[0].change, equals(ui.PointerChange.add));
-      expect(data[0].synthesized, equals(true));
+      expect(data[0].synthesized, isTrue);
       expect(data[0].device, equals(2));
       expect(data[0].physicalX, equals(100 * dpi));
       expect(data[0].physicalY, equals(101 * dpi));
@@ -1861,7 +1861,7 @@ void testMain() {
       expect(data[1].physicalDeltaY, equals(0));
 
       expect(data[2].change, equals(ui.PointerChange.add));
-      expect(data[2].synthesized, equals(true));
+      expect(data[2].synthesized, isTrue);
       expect(data[2].device, equals(3));
       expect(data[2].physicalX, equals(200 * dpi));
       expect(data[2].physicalY, equals(201 * dpi));
@@ -1975,7 +1975,7 @@ void testMain() {
       data = _allPointerData(packets);
       expect(data, hasLength(4));
       expect(data[0].change, equals(ui.PointerChange.add));
-      expect(data[0].synthesized, equals(true));
+      expect(data[0].synthesized, isTrue);
       expect(data[0].device, equals(3));
       expect(data[0].physicalX, equals(500 * dpi));
       expect(data[0].physicalY, equals(501 * dpi));
@@ -1989,7 +1989,7 @@ void testMain() {
       expect(data[1].physicalDeltaY, equals(0));
 
       expect(data[2].change, equals(ui.PointerChange.add));
-      expect(data[2].synthesized, equals(true));
+      expect(data[2].synthesized, isTrue);
       expect(data[2].device, equals(2));
       expect(data[2].physicalX, equals(600 * dpi));
       expect(data[2].physicalY, equals(601 * dpi));
@@ -2071,7 +2071,7 @@ void testMain() {
       // An add will be synthesized.
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].device, equals(1));
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
       expect(packets[0].data[1].device, equals(1));
@@ -2084,7 +2084,7 @@ void testMain() {
       expect(packets, hasLength(1));
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].device, equals(2));
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
       expect(packets[0].data[1].device, equals(2));
@@ -2122,7 +2122,7 @@ void testMain() {
       expect(packets.single.data, hasLength(2));
 
       expect(packets.single.data[0].change, equals(ui.PointerChange.add));
-      expect(packets.single.data[0].synthesized, equals(true));
+      expect(packets.single.data[0].synthesized, isTrue);
       expect(packets.single.data[1].change, equals(ui.PointerChange.down));
       packets.clear();
 
@@ -2168,7 +2168,7 @@ void testMain() {
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
       expect(packets[0].data[0].pointerIdentifier, equals(1));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].physicalX, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(0.0));
@@ -2176,7 +2176,7 @@ void testMain() {
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
       expect(packets[0].data[1].pointerIdentifier, equals(1));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].physicalX, equals(20.0 * dpi));
       expect(packets[0].data[1].physicalY, equals(20.0 * dpi));
       expect(packets[0].data[1].physicalDeltaX, equals(0.0));
@@ -2190,7 +2190,7 @@ void testMain() {
       expect(packets[0].data, hasLength(1));
       expect(packets[0].data[0].change, equals(ui.PointerChange.move));
       expect(packets[0].data[0].pointerIdentifier, equals(1));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(40.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(30.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(20.0 * dpi));
@@ -2204,7 +2204,7 @@ void testMain() {
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.up));
       expect(packets[0].data[0].pointerIdentifier, equals(1));
-      expect(packets[0].data[0].synthesized, equals(false));
+      expect(packets[0].data[0].synthesized, isFalse);
       expect(packets[0].data[0].physicalX, equals(40.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(30.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(0.0));
@@ -2212,7 +2212,7 @@ void testMain() {
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.remove));
       expect(packets[0].data[1].pointerIdentifier, equals(1));
-      expect(packets[0].data[1].synthesized, equals(true));
+      expect(packets[0].data[1].synthesized, isTrue);
       expect(packets[0].data[1].physicalX, equals(40.0 * dpi));
       expect(packets[0].data[1].physicalY, equals(30.0 * dpi));
       expect(packets[0].data[1].physicalDeltaX, equals(0.0));
@@ -2226,7 +2226,7 @@ void testMain() {
       expect(packets[0].data, hasLength(2));
       expect(packets[0].data[0].change, equals(ui.PointerChange.add));
       expect(packets[0].data[0].pointerIdentifier, equals(2));
-      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].synthesized, isTrue);
       expect(packets[0].data[0].physicalX, equals(20.0 * dpi));
       expect(packets[0].data[0].physicalY, equals(10.0 * dpi));
       expect(packets[0].data[0].physicalDeltaX, equals(0.0));
@@ -2234,7 +2234,7 @@ void testMain() {
 
       expect(packets[0].data[1].change, equals(ui.PointerChange.down));
       expect(packets[0].data[1].pointerIdentifier, equals(2));
-      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].synthesized, isFalse);
       expect(packets[0].data[1].physicalX, equals(20.0 * dpi));
       expect(packets[0].data[1].physicalY, equals(10.0 * dpi));
       expect(packets[0].data[1].physicalDeltaX, equals(0.0));

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -140,36 +140,36 @@ void testMain() {
 
     expect(underTest.debugPaintCommands, hasLength(10));
     final PaintDrawRect outsideLeft = underTest.debugPaintCommands[0];
-    expect(outsideLeft.isClippedOut, false);
+    expect(outsideLeft.isClippedOut, isFalse);
     expect(outsideLeft.leftBound, 0);
     expect(outsideLeft.topBound, 20);
     expect(outsideLeft.rightBound, 10);
     expect(outsideLeft.bottomBound, 30);
 
     final PaintDrawRect outsideAbove = underTest.debugPaintCommands[1];
-    expect(outsideAbove.isClippedOut, false);
+    expect(outsideAbove.isClippedOut, isFalse);
 
     final PaintDrawRect visible = underTest.debugPaintCommands[2];
-    expect(visible.isClippedOut, false);
+    expect(visible.isClippedOut, isFalse);
 
     final PaintDrawRect zeroSize = underTest.debugPaintCommands[3];
-    expect(zeroSize.isClippedOut, true);
+    expect(zeroSize.isClippedOut, isTrue);
 
     expect(underTest.debugPaintCommands[4], isA<PaintSave>());
 
     final PaintClipRect clip = underTest.debugPaintCommands[5];
-    expect(clip.isClippedOut, false);
+    expect(clip.isClippedOut, isFalse);
 
     final PaintDrawRect clippedOut = underTest.debugPaintCommands[6];
-    expect(clippedOut.isClippedOut, true);
+    expect(clippedOut.isClippedOut, isTrue);
 
     expect(underTest.debugPaintCommands[7], isA<PaintRestore>());
 
     final PaintDrawRect outsideRight = underTest.debugPaintCommands[8];
-    expect(outsideRight.isClippedOut, false);
+    expect(outsideRight.isClippedOut, isFalse);
 
     final PaintDrawRect outsideBelow = underTest.debugPaintCommands[9];
-    expect(outsideBelow.isClippedOut, false);
+    expect(outsideBelow.isClippedOut, isFalse);
 
     // Give it the entire screen so everything paints.
     underTest.apply(mockCanvas, screenRect);

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -57,7 +57,7 @@ void testMain() {
       bool shouldForwardToFramework =
           desktopSemanticsEnabler.tryEnableSemantics(event);
 
-      expect(shouldForwardToFramework, true);
+      expect(shouldForwardToFramework, isTrue);
 
       // Pointer events are not defined in webkit.
       if (browserEngine != BrowserEngine.webkit) {
@@ -65,7 +65,7 @@ void testMain() {
         shouldForwardToFramework =
             desktopSemanticsEnabler.tryEnableSemantics(event);
 
-        expect(shouldForwardToFramework, true);
+        expect(shouldForwardToFramework, isTrue);
       }
     });
 
@@ -78,7 +78,7 @@ void testMain() {
       bool shouldForwardToFramework =
           desktopSemanticsEnabler.tryEnableSemantics(event);
 
-      expect(shouldForwardToFramework, false);
+      expect(shouldForwardToFramework, isFalse);
     });
 
     test('disposes of the placeholder', () {
@@ -133,7 +133,7 @@ void testMain() {
         bool shouldForwardToFramework =
             mobileSemanticsEnabler.tryEnableSemantics(event);
 
-        expect(shouldForwardToFramework, true);
+        expect(shouldForwardToFramework, isTrue);
       });
 
       test('Enables semantics when receiving a relevant event', () {

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -75,7 +75,7 @@ void _testEngineSemanticsOwner() {
   });
 
   test('semantics is off by default', () {
-    expect(semantics().semanticsEnabled, false);
+    expect(semantics().semanticsEnabled, isFalse);
   });
 
   test('default mode is "unknown"', () {
@@ -84,13 +84,13 @@ void _testEngineSemanticsOwner() {
 
   test('placeholder enables semantics', () async {
     domRenderer.reset(); // triggers `autoEnableOnTap` to be called
-    expect(semantics().semanticsEnabled, false);
+    expect(semantics().semanticsEnabled, isFalse);
 
     // Synthesize a click on the placeholder.
     final html.Element placeholder =
         appShadowRoot.querySelector('flt-semantics-placeholder');
 
-    expect(placeholder.isConnected, true);
+    expect(placeholder.isConnected, isTrue);
 
     final html.Rectangle<num> rect = placeholder.getBoundingClientRect();
     placeholder.dispatchEvent(html.MouseEvent(
@@ -105,28 +105,28 @@ void _testEngineSemanticsOwner() {
         await Future<void>.delayed(const Duration(milliseconds: 50));
       }
     }
-    expect(semantics().semanticsEnabled, true);
-    expect(placeholder.isConnected, false);
+    expect(semantics().semanticsEnabled, isTrue);
+    expect(placeholder.isConnected, isFalse);
   });
 
   test('auto-enables semantics', () async {
     domRenderer.reset(); // triggers `autoEnableOnTap` to be called
-    expect(semantics().semanticsEnabled, false);
+    expect(semantics().semanticsEnabled, isFalse);
 
     final html.Element placeholder =
         appShadowRoot.querySelector('flt-semantics-placeholder');
 
-    expect(placeholder.isConnected, true);
+    expect(placeholder.isConnected, isTrue);
 
     // Sending a semantics update should auto-enable engine semantics.
     final ui.SemanticsUpdateBuilder builder = ui.SemanticsUpdateBuilder();
     updateNode(builder, id: 0);
     semantics().updateSemantics(builder.build());
 
-    expect(semantics().semanticsEnabled, true);
+    expect(semantics().semanticsEnabled, isTrue);
 
     // The placeholder should be removed
-    expect(placeholder.isConnected, false);
+    expect(placeholder.isConnected, isFalse);
   });
 
   void renderLabel(String label) {
@@ -211,7 +211,7 @@ void _testEngineSemanticsOwner() {
 
   test('accepts standalone browser gestures', () {
     semantics().semanticsEnabled = true;
-    expect(semantics().shouldAcceptBrowserGesture('click'), true);
+    expect(semantics().shouldAcceptBrowserGesture('click'), isTrue);
     semantics().semanticsEnabled = false;
   });
 
@@ -220,13 +220,13 @@ void _testEngineSemanticsOwner() {
       semantics()
         ..debugOverrideTimestampFunction(fakeAsync.getClock(_testTime).now)
         ..semanticsEnabled = true;
-      expect(semantics().shouldAcceptBrowserGesture('click'), true);
+      expect(semantics().shouldAcceptBrowserGesture('click'), isTrue);
       semantics().receiveGlobalEvent(html.Event('pointermove'));
-      expect(semantics().shouldAcceptBrowserGesture('click'), false);
+      expect(semantics().shouldAcceptBrowserGesture('click'), isFalse);
 
       // After 1 second of inactivity a browser gestures counts as standalone.
       fakeAsync.elapse(const Duration(seconds: 1));
-      expect(semantics().shouldAcceptBrowserGesture('click'), true);
+      expect(semantics().shouldAcceptBrowserGesture('click'), isTrue);
       semantics().semanticsEnabled = false;
     });
   });

--- a/lib/web_ui/test/engine/surface/path/path_winding_test.dart
+++ b/lib/web_ui/test/engine/surface/path/path_winding_test.dart
@@ -18,38 +18,38 @@ void testMain() {
   group('Convexity', () {
     test('Empty path should be convex', () {
       final SurfacePath path = SurfacePath();
-      expect(path.isConvex, true);
+      expect(path.isConvex, isTrue);
     });
 
     test('Circle should be convex', () {
       final SurfacePath path = SurfacePath();
       path.addOval(Rect.fromLTRB(0, 0, 20, 20));
-      expect(path.isConvex, true);
+      expect(path.isConvex, isTrue);
       // 2nd circle.
       path.addOval(Rect.fromLTRB(0, 0, 20, 20));
-      expect(path.isConvex, false);
+      expect(path.isConvex, isFalse);
     });
 
     test('addRect should be convex', () {
       SurfacePath path = SurfacePath();
       path.addRect(Rect.fromLTRB(0, 0, 20, 20));
-      assert(path.isConvex, true);
+      expect(path.isConvex, isTrue);
 
       path = SurfacePath();
       path.addRectWithDirection(
           Rect.fromLTRB(0, 0, 20, 20), SPathDirection.kCW, 0);
-      assert(path.isConvex, true);
+      expect(path.isConvex, isTrue);
 
       path = SurfacePath();
       path.addRectWithDirection(
           Rect.fromLTRB(0, 0, 20, 20), SPathDirection.kCCW, 0);
-      assert(path.isConvex, true);
+      expect(path.isConvex, isTrue);
     });
 
     test('Quad should be convex', () {
       final SurfacePath path = SurfacePath();
       path.quadraticBezierTo(100, 100, 50, 50);
-      expect(path.isConvex, true);
+      expect(path.isConvex, isTrue);
     });
 
     test('moveto/lineto convexity', () {
@@ -434,9 +434,9 @@ void testMain() {
       path.quadraticBezierTo(0.0, 200.0, 0.0, 100.0);
       path.quadraticBezierTo(0.0, 0.0, 100.0, 0.0);
       path.close();
-      expect(path.contains(Offset(100, 20)), true);
-      expect(path.contains(Offset(100, 120)), true);
-      expect(path.contains(Offset(100, -10)), false);
+      expect(path.contains(Offset(100, 20)), isTrue);
+      expect(path.contains(Offset(100, 120)), isTrue);
+      expect(path.contains(Offset(100, -10)), isFalse);
     });
   });
 }

--- a/lib/web_ui/test/engine/surface/scene_builder_test.dart
+++ b/lib/web_ui/test/engine/surface/scene_builder_test.dart
@@ -612,8 +612,8 @@ void testMain() {
     html.CanvasElement canvas2 = contentAfterScale.querySelector('canvas');
     // Although we are drawing same picture, due to scaling the new canvas
     // should have fewer pixels.
-    expect(canvas2.width < unscaledWidth, true);
-    expect(canvas2.height < unscaledHeight, true);
+    expect(canvas2.width < unscaledWidth, isTrue);
+    expect(canvas2.height < unscaledHeight, isTrue);
   });
 
   test('Canvas should allocate more pixels when zoomed in', () async {
@@ -644,8 +644,8 @@ void testMain() {
     html.CanvasElement canvas2 = contentAfterScale.querySelector('canvas');
     // Although we are drawing same picture, due to scaling the new canvas
     // should have more pixels.
-    expect(canvas2.width > unscaledWidth, true);
-    expect(canvas2.height > unscaledHeight, true);
+    expect(canvas2.width > unscaledWidth, isTrue);
+    expect(canvas2.height > unscaledHeight, isTrue);
   });
 
   test('Should recycle canvas once', () async {

--- a/lib/web_ui/test/engine/surface/surface_test.dart
+++ b/lib/web_ui/test/engine/surface/surface_test.dart
@@ -44,12 +44,12 @@ void testMain() {
 
       expect(opacityLayer, isNotNull);
       expect(opacityLayer.rootElement, isNull);
-      expect(opacityLayer.isCreated, true);
+      expect(opacityLayer.isCreated, isTrue);
 
       builder.build();
 
       expect(opacityLayer.rootElement.tagName.toLowerCase(), 'flt-opacity');
-      expect(opacityLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
     });
 
     test('is released', () {
@@ -57,10 +57,10 @@ void testMain() {
       final PersistedOpacity opacityLayer = builder1.pushOpacity(100);
       builder1.pop();
       builder1.build();
-      expect(opacityLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
 
       SceneBuilder().build();
-      expect(opacityLayer.isReleased, true);
+      expect(opacityLayer.isReleased, isTrue);
       expect(opacityLayer.rootElement, isNull);
     });
 
@@ -72,12 +72,12 @@ void testMain() {
       builder1.pop();
       builder1.pop();
       builder1.build();
-      expect(opacityLayer.isActive, true);
-      expect(transformLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
+      expect(transformLayer.isActive, isTrue);
 
       SceneBuilder().build();
-      expect(opacityLayer.isReleased, true);
-      expect(transformLayer.isReleased, true);
+      expect(opacityLayer.isReleased, isTrue);
+      expect(transformLayer.isReleased, isTrue);
       expect(opacityLayer.rootElement, isNull);
       expect(transformLayer.rootElement, isNull);
     });
@@ -87,21 +87,21 @@ void testMain() {
       final PersistedOpacity opacityLayer1 = builder1.pushOpacity(100);
       builder1.pop();
       builder1.build();
-      expect(opacityLayer1.isActive, true);
+      expect(opacityLayer1.isActive, isTrue);
       final html.Element element = opacityLayer1.rootElement;
 
       final SceneBuilder builder2 = SceneBuilder();
       final PersistedOpacity opacityLayer2 =
           builder2.pushOpacity(200, oldLayer: opacityLayer1);
-      expect(opacityLayer1.isPendingUpdate, true);
-      expect(opacityLayer2.isCreated, true);
+      expect(opacityLayer1.isPendingUpdate, isTrue);
+      expect(opacityLayer2.isCreated, isTrue);
       expect(opacityLayer2.oldLayer, same(opacityLayer1));
       builder2.pop();
 
       builder2.build();
-      expect(opacityLayer1.isReleased, true);
+      expect(opacityLayer1.isReleased, isTrue);
       expect(opacityLayer1.rootElement, isNull);
-      expect(opacityLayer2.isActive, true);
+      expect(opacityLayer2.isActive, isTrue);
       expect(
           opacityLayer2.rootElement, element); // adopts old surface's element
       expect(opacityLayer2.oldLayer, isNull);
@@ -113,12 +113,12 @@ void testMain() {
       final PersistedOpacity opacityLayer1 = builder1.pushOpacity(100);
       builder1.pop();
       builder1.build();
-      expect(opacityLayer1.isActive, true);
+      expect(opacityLayer1.isActive, isTrue);
       final html.Element element = opacityLayer1.rootElement;
 
       // Release it
       SceneBuilder().build();
-      expect(opacityLayer1.isReleased, true);
+      expect(opacityLayer1.isReleased, isTrue);
       expect(opacityLayer1.rootElement, isNull);
 
       // Attempt to update it
@@ -126,12 +126,12 @@ void testMain() {
       final PersistedOpacity opacityLayer2 =
           builder2.pushOpacity(200, oldLayer: opacityLayer1);
       builder2.pop();
-      expect(opacityLayer1.isReleased, true);
-      expect(opacityLayer2.isCreated, true);
+      expect(opacityLayer1.isReleased, isTrue);
+      expect(opacityLayer2.isCreated, isTrue);
 
       builder2.build();
-      expect(opacityLayer1.isReleased, true);
-      expect(opacityLayer2.isActive, true);
+      expect(opacityLayer1.isReleased, isTrue);
+      expect(opacityLayer2.isActive, isTrue);
       expect(opacityLayer2.rootElement, isNot(equals(element)));
     });
 
@@ -189,12 +189,12 @@ void testMain() {
       builder2.pop();
       builder2.pop();
 
-      expect(c1.isPendingUpdate, true);
-      expect(c2.isCreated, true);
+      expect(c1.isPendingUpdate, isTrue);
+      expect(c2.isCreated, isTrue);
       builder2.build();
       expect(logger.log, <String>['build', 'createElement', 'apply', 'retain']);
-      expect(c1.isReleased, true);
-      expect(c2.isActive, true);
+      expect(c1.isReleased, isTrue);
+      expect(c2.isActive, isTrue);
 
       expect(a2.rootElement, elementA);
       expect(b1.rootElement, isNull);
@@ -213,17 +213,17 @@ void testMain() {
       final PersistedOpacity opacityLayer = builder1.pushOpacity(100);
       builder1.pop();
       builder1.build();
-      expect(opacityLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
       final html.Element element = opacityLayer.rootElement;
 
       final SceneBuilder builder2 = SceneBuilder();
 
-      expect(opacityLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
       builder2.addRetained(opacityLayer);
-      expect(opacityLayer.isPendingRetention, true);
+      expect(opacityLayer.isPendingRetention, isTrue);
 
       builder2.build();
-      expect(opacityLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
       expect(opacityLayer.rootElement, element);
     });
 
@@ -234,22 +234,22 @@ void testMain() {
       builder1.debugAddSurface(logger);
       builder1.pop();
       builder1.build();
-      expect(opacityLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
       expect(logger.log, <String>['build', 'createElement', 'apply']);
       final html.Element element = opacityLayer.rootElement;
 
       SceneBuilder().build();
-      expect(opacityLayer.isReleased, true);
+      expect(opacityLayer.isReleased, isTrue);
       expect(opacityLayer.rootElement, isNull);
       expect(logger.log, <String>['build', 'createElement', 'apply', 'discard']);
 
       final SceneBuilder builder2 = SceneBuilder();
       builder2.addRetained(opacityLayer);
-      expect(opacityLayer.isCreated, true); // revived
+      expect(opacityLayer.isCreated, isTrue); // revived
       expect(logger.log, <String>['build', 'createElement', 'apply', 'discard', 'revive']);
 
       builder2.build();
-      expect(opacityLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
       expect(opacityLayer.rootElement, isNot(equals(element)));
     });
 
@@ -261,8 +261,8 @@ void testMain() {
       builder1.pop();
       builder1.pop();
       builder1.build();
-      expect(opacityLayer.isActive, true);
-      expect(transformLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
+      expect(transformLayer.isActive, isTrue);
       final html.Element opacityElement = opacityLayer.rootElement;
       final html.Element transformElement = transformLayer.rootElement;
 
@@ -270,12 +270,12 @@ void testMain() {
 
       final SceneBuilder builder2 = SceneBuilder();
       builder2.addRetained(opacityLayer);
-      expect(opacityLayer.isCreated, true); // revived
-      expect(transformLayer.isCreated, true); // revived
+      expect(opacityLayer.isCreated, isTrue); // revived
+      expect(transformLayer.isCreated, isTrue); // revived
 
       builder2.build();
-      expect(opacityLayer.isActive, true);
-      expect(transformLayer.isActive, true);
+      expect(opacityLayer.isActive, isTrue);
+      expect(transformLayer.isActive, isTrue);
       expect(opacityLayer.rootElement, isNot(equals(opacityElement)));
       expect(transformLayer.rootElement, isNot(equals(transformElement)));
     });
@@ -346,19 +346,19 @@ void testMain() {
       final PersistedOpacity opacityLayer1 = builder1.pushOpacity(100);
       builder1.pop();
       builder1.build();
-      expect(opacityLayer1.isActive, true);
+      expect(opacityLayer1.isActive, isTrue);
       final html.Element element = opacityLayer1.rootElement;
 
       final SceneBuilder builder2 = SceneBuilder();
       final PersistedOpacity opacityLayer2 = builder2.pushOpacity(200);
-      expect(opacityLayer1.isActive, true);
-      expect(opacityLayer2.isCreated, true);
+      expect(opacityLayer1.isActive, isTrue);
+      expect(opacityLayer2.isCreated, isTrue);
       builder2.pop();
 
       builder2.build();
-      expect(opacityLayer1.isReleased, true);
+      expect(opacityLayer1.isReleased, isTrue);
       expect(opacityLayer1.rootElement, isNull);
-      expect(opacityLayer2.isActive, true);
+      expect(opacityLayer2.isActive, isTrue);
       expect(
           opacityLayer2.rootElement, element); // adopts old surface's element
     });

--- a/lib/web_ui/test/engine/ulps_test.dart
+++ b/lib/web_ui/test/engine/ulps_test.dart
@@ -57,37 +57,37 @@ void testMain() {
       final double a = 1.1;
       int aBits = floatAs2sCompliment(a);
       double b = twosComplimentAsFloat(aBits + 1);
-      expect(almostEqualUlps(a, b), true);
+      expect(almostEqualUlps(a, b), isTrue);
       b = twosComplimentAsFloat(aBits + 15);
-      expect(almostEqualUlps(a, b), true);
+      expect(almostEqualUlps(a, b), isTrue);
       b = twosComplimentAsFloat(aBits + 16);
-      expect(almostEqualUlps(a, b), false);
+      expect(almostEqualUlps(a, b), isFalse);
 
       // Test between variant of equalUlps.
       b = twosComplimentAsFloat(aBits + 1);
-      expect(almostBequalUlps(a, b), true);
+      expect(almostBequalUlps(a, b), isTrue);
       b = twosComplimentAsFloat(aBits + 1);
-      expect(almostBequalUlps(a, b), true);
+      expect(almostBequalUlps(a, b), isTrue);
       b = twosComplimentAsFloat(aBits + 2);
-      expect(almostBequalUlps(a, b), false);
+      expect(almostBequalUlps(a, b), isFalse);
     });
 
     test('Should compare 2 coordinates based on ulps', () {
       double a = 1.1;
       int aBits = floatAs2sCompliment(a);
       double b = twosComplimentAsFloat(aBits + 1);
-      expect(approximatelyEqual(5.0, a, 5.0, b), true);
+      expect(approximatelyEqual(5.0, a, 5.0, b), isTrue);
       b = twosComplimentAsFloat(aBits + 16);
-      expect(approximatelyEqual(5.0, a, 5.0, b), true);
+      expect(approximatelyEqual(5.0, a, 5.0, b), isTrue);
 
       // Increase magnitude which should start checking with ulps rather than
       // fltEpsilon.
       a = 3000000.1;
       aBits = floatAs2sCompliment(a);
       b = twosComplimentAsFloat(aBits + 1);
-      expect(approximatelyEqual(5.0, a, 5.0, b), true);
+      expect(approximatelyEqual(5.0, a, 5.0, b), isTrue);
       b = twosComplimentAsFloat(aBits + 16);
-      expect(approximatelyEqual(5.0, a, 5.0, b), false);
+      expect(approximatelyEqual(5.0, a, 5.0, b), isFalse);
     });
   });
 }

--- a/lib/web_ui/test/engine/web_experiments_test.dart
+++ b/lib/web_ui/test/engine/web_experiments_test.dart
@@ -33,13 +33,13 @@ void testMain() {
   test('can turn on/off web experiments', () {
     WebExperiments.instance!.updateExperiment('useCanvasText', true);
     WebExperiments.instance!.updateExperiment('useCanvasRichText', true);
-    expect(WebExperiments.instance!.useCanvasText, true);
-    expect(WebExperiments.instance!.useCanvasRichText, true);
+    expect(WebExperiments.instance!.useCanvasText, isTrue);
+    expect(WebExperiments.instance!.useCanvasRichText, isTrue);
 
     WebExperiments.instance!.updateExperiment('useCanvasText', false);
     WebExperiments.instance!.updateExperiment('useCanvasRichText', false);
-    expect(WebExperiments.instance!.useCanvasText, false);
-    expect(WebExperiments.instance!.useCanvasRichText, false);
+    expect(WebExperiments.instance!.useCanvasText, isFalse);
+    expect(WebExperiments.instance!.useCanvasRichText, isFalse);
 
     WebExperiments.instance!.updateExperiment('useCanvasText', null);
     WebExperiments.instance!.updateExperiment('useCanvasRichText', null);
@@ -80,8 +80,8 @@ void testMain() {
 
     expect(() => jsUpdateExperiment('useCanvasText', true), returnsNormally);
     expect(() => jsUpdateExperiment('useCanvasRichText', true), returnsNormally);
-    expect(WebExperiments.instance!.useCanvasText, true);
-    expect(WebExperiments.instance!.useCanvasRichText, true);
+    expect(WebExperiments.instance!.useCanvasText, isTrue);
+    expect(WebExperiments.instance!.useCanvasRichText, isTrue);
 
     expect(() => jsUpdateExperiment('useCanvasText', null), returnsNormally);
     expect(() => jsUpdateExperiment('useCanvasRichText', null), returnsNormally);

--- a/lib/web_ui/test/engine/window_test.dart
+++ b/lib/web_ui/test/engine/window_test.dart
@@ -317,7 +317,7 @@ void testMain() {
       },
     );
     await completer.future;
-    expect(responded, true);
+    expect(responded, isTrue);
   });
 
   test('SingletonFlutterWindow implements locale, locales, and locale change notifications', () async {

--- a/lib/web_ui/test/golden_tests/engine/canvas_reuse_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_reuse_test.dart
@@ -85,7 +85,7 @@ void testMain() async {
     final html.CanvasElement canvas2 = html.document.querySelector('canvas') as html.CanvasElement;
     // ZIndex should have been cleared since we have image element preceding
     // canvas.
-    expect(canvas.style.zIndex != '-1', true);
+    expect(canvas.style.zIndex != '-1', isTrue);
     expect(canvas2.id, kTestId);
     await matchGoldenFile('bitmap_canvas_reuse_zindex.png', region: region);
   });

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -842,7 +842,7 @@ void _testCullRectComputation() {
         final RecordingCanvas canvas = recorder.beginRecording(outerClip);
         canvas.drawParagraph(paragraph, const Offset(8.5, 8.5));
         final Picture picture = recorder.endRecording();
-        expect(canvas.renderStrategy.hasArbitraryPaint, false);
+        expect(canvas.renderStrategy.hasArbitraryPaint, isFalse);
 
         builder.addPicture(
           Offset.zero,
@@ -856,7 +856,7 @@ void _testCullRectComputation() {
         final RecordingCanvas canvas = recorder.beginRecording(innerClip);
         canvas.drawParagraph(paragraph, Offset(8.5, 8.5 + innerClip.top));
         final Picture picture = recorder.endRecording();
-        expect(canvas.renderStrategy.hasArbitraryPaint, false);
+        expect(canvas.renderStrategy.hasArbitraryPaint, isFalse);
 
         builder.addPicture(
           Offset.zero,

--- a/lib/web_ui/test/keyboard_converter_test.dart
+++ b/lib/web_ui/test/keyboard_converter_test.dart
@@ -64,7 +64,7 @@ void testMain() {
       logical: kLogicalKeyA,
       character: 'a',
     );
-    expect(preventedDefault, true);
+    expect(preventedDefault, isTrue);
     preventedDefault = false;
 
     converter.handleEvent(keyRepeatedDownEvent('KeyA', 'a')
@@ -78,7 +78,7 @@ void testMain() {
       logical: kLogicalKeyA,
       character: 'a',
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
 
     converter.handleEvent(keyRepeatedDownEvent('KeyA', 'a')
       ..timeStamp = 1500
@@ -91,7 +91,7 @@ void testMain() {
       logical: kLogicalKeyA,
       character: 'a',
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
 
     converter.handleEvent(keyUpEvent('KeyA', 'a')
       ..timeStamp = 2000.5
@@ -104,7 +104,7 @@ void testMain() {
       logical: kLogicalKeyA,
       character: null,
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
   });
 
   test('Release modifier during a repeated sequence', () {
@@ -126,7 +126,7 @@ void testMain() {
       logical: kLogicalShiftLeft,
       character: null,
     );
-    expect(preventedDefault, true);
+    expect(preventedDefault, isTrue);
     preventedDefault = false;
 
     converter.handleEvent(keyDownEvent('KeyA', 'A', kShift)
@@ -138,7 +138,7 @@ void testMain() {
       logical: kLogicalKeyA,
       character: 'A',
     );
-    expect(preventedDefault, true);
+    expect(preventedDefault, isTrue);
     preventedDefault = false;
 
     converter.handleEvent(keyRepeatedDownEvent('KeyA', 'A', kShift)
@@ -150,7 +150,7 @@ void testMain() {
       logical: kLogicalKeyA,
       character: 'A',
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
 
     converter.handleEvent(keyUpEvent('ShiftLeft', 'Shift', 0, kLocationLeft)
       ..onPreventDefault = onPreventDefault
@@ -161,7 +161,7 @@ void testMain() {
       logical: kLogicalShiftLeft,
       character: null,
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
 
     converter.handleEvent(keyRepeatedDownEvent('KeyA', 'a')
       ..onPreventDefault = onPreventDefault
@@ -172,7 +172,7 @@ void testMain() {
       logical: kLogicalKeyA,
       character: 'a',
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
 
     converter.handleEvent(keyRepeatedDownEvent('KeyA', 'a')
       ..onPreventDefault = onPreventDefault
@@ -183,7 +183,7 @@ void testMain() {
       logical: kLogicalKeyA,
       character: 'a',
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
 
     converter.handleEvent(keyUpEvent('KeyA', 'a'));
     expectKeyData(keyDataList.last,
@@ -192,7 +192,7 @@ void testMain() {
       logical: kLogicalKeyA,
       character: null,
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
   });
 
   test('Distinguish between left and right modifiers', () {
@@ -361,7 +361,7 @@ void testMain() {
     converter.handleEvent(keyDownEvent('ShiftLeft', 'Shift', kShift, kLocationLeft)
       ..onPreventDefault = onPreventDefault
     );
-    expect(preventedDefault, true);
+    expect(preventedDefault, isTrue);
     preventedDefault = false;
     // A KeyUp of ShiftLeft is missed due to loss of focus.
 
@@ -370,7 +370,7 @@ void testMain() {
       ..onPreventDefault = onPreventDefault
     );
     expect(keyDataList, isEmpty);
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
 
     converter.handleEvent(keyUpEvent('ShiftLeft', 'Shift', 0, kLocationLeft)
       ..onPreventDefault = onPreventDefault
@@ -382,7 +382,7 @@ void testMain() {
       logical: kLogicalShiftLeft,
       character: null,
     );
-    expect(preventedDefault, true);
+    expect(preventedDefault, isTrue);
   });
 
   test('Duplicate ups are skipped', () {
@@ -399,7 +399,7 @@ void testMain() {
       ..onPreventDefault = onPreventDefault
     );
     expect(keyDataList, isEmpty);
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
   });
 
   test('Conflict from multiple keyboards do not crash', () {
@@ -460,7 +460,7 @@ void testMain() {
       logical: kLogicalCapsLock,
       character: null,
     );
-    expect(preventedDefault, true);
+    expect(preventedDefault, isTrue);
     keyDataList.clear();
     preventedDefault = false;
 
@@ -473,7 +473,7 @@ void testMain() {
       character: null,
       synthesized: true,
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
     keyDataList.clear();
 
     converter.handleEvent(keyUpEvent('CapsLock', 'CapsLock')
@@ -486,7 +486,7 @@ void testMain() {
       logical: kLogicalCapsLock,
       character: null,
     );
-    expect(preventedDefault, true);
+    expect(preventedDefault, isTrue);
     keyDataList.clear();
     preventedDefault = false;
 
@@ -499,7 +499,7 @@ void testMain() {
       character: null,
       synthesized: true,
     );
-    expect(preventedDefault, false);
+    expect(preventedDefault, isFalse);
     keyDataList.clear();
 
     // Another key down works

--- a/lib/web_ui/test/lerp_test.dart
+++ b/lib/web_ui/test/lerp_test.dart
@@ -153,9 +153,9 @@ void expectAssertion(Function callback) {
     try {
       callback();
     } catch (e) {
-      expect(e is AssertionError, true);
+      expect(e is AssertionError, isTrue);
       threw = true;
     }
-    expect(threw, true);
+    expect(threw, isTrue);
   }
 }

--- a/lib/web_ui/test/path_test.dart
+++ b/lib/web_ui/test/path_test.dart
@@ -21,7 +21,7 @@ void testMain() {
   group('Path', () {
     test('Should have no subpaths when created', () {
       final SurfacePath path = SurfacePath();
-      expect(path.isEmpty, true);
+      expect(path.isEmpty, isTrue);
     });
 
     test('LineTo should add command', () {
@@ -375,10 +375,10 @@ void testMain() {
       path.lineTo(110, 190);
       path.lineTo(50, 190);
       path.close();
-      expect(path.contains(Offset(80, 190)), true);
-      expect(path.contains(Offset(110, 80)), true);
-      expect(path.contains(Offset(110, 190)), true);
-      expect(path.contains(Offset(110, 191)), false);
+      expect(path.contains(Offset(80, 190)), isTrue);
+      expect(path.contains(Offset(110, 80)), isTrue);
+      expect(path.contains(Offset(110, 190)), isTrue);
+      expect(path.contains(Offset(110, 191)), isFalse);
     });
 
     test('Should not contain top-left of beveled border', () {
@@ -392,7 +392,7 @@ void testMain() {
       path.lineTo(15, 40);
       path.lineTo(10, 35);
       path.close();
-      expect(path.contains(Offset(10, 20)), false);
+      expect(path.contains(Offset(10, 20)), isFalse);
     });
 
     test('Computes contains for cubic curves', () {
@@ -406,8 +406,8 @@ void testMain() {
       path.lineTo(15, 40);
       path.cubicTo(10, 40, 10,  40, 10, 35);
       path.close();
-      expect(path.contains(Offset(10, 20)), false);
-      expect(path.contains(Offset(30, 40)), false);
+      expect(path.contains(Offset(10, 20)), isFalse);
+      expect(path.contains(Offset(30, 40)), isFalse);
     });
 
     // Regression test for https://github.com/flutter/flutter/issues/44470
@@ -476,20 +476,20 @@ void testMain() {
     test('Should be able to construct from empty path', () {
       final SurfacePath path = SurfacePath();
       final SurfacePath? path2 = SurfacePath.from(path);
-      assert(path2 != null, true);
+      expect(path2, isNotNull);
     });
   });
 
   group('PathRef', () {
     test('Should return empty when created', () {
       final PathRef pathRef = PathRef();
-      expect(pathRef.isEmpty, true);
+      expect(pathRef.isEmpty, isTrue);
     });
 
     test('Should return non-empty when mutated', () {
       final PathRef pathRef = PathRef();
       pathRef.growForVerb(SPath.kMoveVerb, 0);
-      expect(pathRef.isEmpty, false);
+      expect(pathRef.isEmpty, isFalse);
     });
   });
   group('PathRefIterator', () {

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -37,7 +37,7 @@ void testMain() async {
             browserEngine == BrowserEngine.webkit));
 
     test('loads Blehm font from buffer', () async {
-      expect(_containsFontFamily('Blehm'), false);
+      expect(_containsFontFamily('Blehm'), isFalse);
 
       final html.HttpRequest response = await html.HttpRequest.request(
           _testFontUrl,
@@ -45,7 +45,7 @@ void testMain() async {
       await ui.loadFontFromList(Uint8List.view(response.response),
           fontFamily: 'Blehm');
 
-      expect(_containsFontFamily('Blehm'), true);
+      expect(_containsFontFamily('Blehm'), isTrue);
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/56702
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
@@ -78,7 +78,7 @@ void testMain() async {
           fontFamily: 'Blehm');
 
       // Verifies the font is loaded, and the cache is cleaned.
-      expect(_containsFontFamily('Blehm'), true);
+      expect(_containsFontFamily('Blehm'), isTrue);
       expect(TextMeasurementService.rulerManager.rulers.length, 0);
       expect(Spanometer.rulers.length, 0);
     },

--- a/lib/web_ui/test/text/measurement_test.dart
+++ b/lib/web_ui/test/text/measurement_test.dart
@@ -267,7 +267,7 @@ void testMain()  async {
             instance.measure(build(ahemStyle, '12345'), constraints);
 
         // Should fit on a single line.
-        expect(result.isSingleLine, true);
+        expect(result.isSingleLine, isTrue);
         expect(result.alphabeticBaseline, 8);
         expect(result.maxIntrinsicWidth, 50);
         expect(result.minIntrinsicWidth, 50);
@@ -288,7 +288,7 @@ void testMain()  async {
 
         // The long text doesn't fit in 70px of width, so it needs to wrap.
         result = instance.measure(build(ahemStyle, 'foo bar baz'), constraints);
-        expect(result.isSingleLine, false);
+        expect(result.isSingleLine, isFalse);
         expect(result.alphabeticBaseline, 8);
         expect(result.maxIntrinsicWidth, 110);
         expect(result.minIntrinsicWidth, 30);
@@ -314,7 +314,7 @@ void testMain()  async {
 
         // The long text doesn't fit in 50px of width, so it needs to wrap.
         result = instance.measure(build(ahemStyle, '1234567890'), constraints);
-        expect(result.isSingleLine, false);
+        expect(result.isSingleLine, isFalse);
         expect(result.alphabeticBaseline, 8);
         expect(result.maxIntrinsicWidth, 100);
         expect(result.minIntrinsicWidth, 100);
@@ -334,7 +334,7 @@ void testMain()  async {
         // The first word is force-broken twice.
         result =
             instance.measure(build(ahemStyle, 'abcdefghijk lm'), constraints);
-        expect(result.isSingleLine, false);
+        expect(result.isSingleLine, isFalse);
         expect(result.alphabeticBaseline, 8);
         expect(result.maxIntrinsicWidth, 140);
         expect(result.minIntrinsicWidth, 110);
@@ -357,7 +357,7 @@ void testMain()  async {
         const ui.ParagraphConstraints narrowConstraints =
             ui.ParagraphConstraints(width: 8);
         result = instance.measure(build(ahemStyle, 'AA'), narrowConstraints);
-        expect(result.isSingleLine, false);
+        expect(result.isSingleLine, isFalse);
         expect(result.alphabeticBaseline, 8);
         expect(result.maxIntrinsicWidth, 20);
         expect(result.minIntrinsicWidth, 20);
@@ -376,7 +376,7 @@ void testMain()  async {
 
         // Extremely narrow constraints with new line in the middle.
         result = instance.measure(build(ahemStyle, 'AA\nA'), narrowConstraints);
-        expect(result.isSingleLine, false);
+        expect(result.isSingleLine, isFalse);
         expect(result.alphabeticBaseline, 8);
         expect(result.maxIntrinsicWidth, 20);
         expect(result.minIntrinsicWidth, 20);
@@ -396,7 +396,7 @@ void testMain()  async {
 
         // Extremely narrow constraints with new line in the end.
         result = instance.measure(build(ahemStyle, 'AAA\n'), narrowConstraints);
-        expect(result.isSingleLine, false);
+        expect(result.isSingleLine, isFalse);
         expect(result.alphabeticBaseline, 8);
         expect(result.maxIntrinsicWidth, 30);
         expect(result.minIntrinsicWidth, 30);
@@ -425,7 +425,7 @@ void testMain()  async {
             instance.measure(build(ahemStyle, '12\n34'), constraints);
 
         // Text containing newlines should always be drawn in multi-line mode.
-        expect(result.isSingleLine, false);
+        expect(result.isSingleLine, isFalse);
         expect(result.maxIntrinsicWidth, 20);
         expect(result.minIntrinsicWidth, 20);
         expect(result.width, 50);
@@ -506,7 +506,7 @@ void testMain()  async {
         final MeasurementResult result =
             instance.measure(paragraph, infiniteConstraints);
 
-        expect(result.isSingleLine, false);
+        expect(result.isSingleLine, isFalse);
         expect(result.maxIntrinsicWidth, 70);
         expect(result.minIntrinsicWidth, 30);
         expect(result.width, double.infinity);

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -746,7 +746,7 @@ void testMain() {
       sendFrameworkMessage(codec.encodeMethodCall(finishAutofillContext));
 
       // `submit` action is called on form.
-      await expectLater(await submittedForm.future, true);
+      await expectLater(await submittedForm.future, isTrue);
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
         skip: browserEngine == BrowserEngine.edge);
@@ -802,7 +802,7 @@ void testMain() {
       expect(spy.messages[0].methodName, 'TextInputClient.onConnectionClosed');
 
       // `submit` action is called on form.
-      await expectLater(await submittedForm.future, true);
+      await expectLater(await submittedForm.future, isTrue);
       // Form element is removed from DOM.
       expect(defaultTextEditingRoot.querySelectorAll('form'), hasLength(0));
       expect(formsOnTheDom, hasLength(0));
@@ -1980,8 +1980,8 @@ void testMain() {
 
       EditingState editingState3 = EditingState.fromDomElement(input);
 
-      expect(editingState1 == editingState2, true);
-      expect(editingState1 != editingState3, true);
+      expect(editingState1 == editingState2, isTrue);
+      expect(editingState1 != editingState3, isTrue);
     });
   });
 }


### PR DESCRIPTION
Use `isTrue` and `isFalse` instead of `true`/`false`/`equals(true)`/`equals(false)` in all tests.

Bonus: also fix accidental usages of `assert` instead of `expect` in a couple of tests.