### PR TITLE
Add support for native callbacks to the macOS embedder test harness

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1160,6 +1160,8 @@ FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterEmbed
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTest.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterExternalTextureGL.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FlutterExternalTextureGL.mm

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -176,6 +176,8 @@ executable("flutter_desktop_darwin_unittests") {
     "framework/Source/FlutterEmbedderExternalTextureUnittests.mm",
     "framework/Source/FlutterEmbedderKeyResponderUnittests.mm",
     "framework/Source/FlutterEngineTest.mm",
+    "framework/Source/FlutterEngineTestUtils.h",
+    "framework/Source/FlutterEngineTestUtils.mm",
     "framework/Source/FlutterGLCompositorUnittests.mm",
     "framework/Source/FlutterKeyboardManagerUnittests.mm",
     "framework/Source/FlutterMetalCompositorUnittests.mm",

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h
@@ -31,6 +31,11 @@
 @property(nonatomic, readonly) std::vector<std::string> switches;
 
 /**
+ * The callback invoked by the engine in root isolate scope.
+ */
+@property(nonatomic, nullable) void (*rootIsolateCreateCallback)(void* _Nullable);
+
+/**
  * Instead of looking up the assets and ICU data path in the application bundle, this initializer
  * allows callers to create a Dart project with custom locations specified for the both.
  */

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -235,6 +235,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FlutterEngi
   flutterArguments.shutdown_dart_vm_when_done = true;
   flutterArguments.dart_entrypoint_argc = dartEntrypointArgs.size();
   flutterArguments.dart_entrypoint_argv = dartEntrypointArgs.data();
+  flutterArguments.root_isolate_create_callback = _project.rootIsolateCreateCallback;
 
   static size_t sTaskRunnerIdentifiers = 0;
   const FlutterTaskRunnerDescription cocoa_task_runner_description = {

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h
@@ -1,0 +1,34 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
+
+#include "flutter/testing/test_dart_native_resolver.h"
+#include "gtest/gtest.h"
+
+namespace flutter::testing {
+
+class FlutterEngineTest : public ::testing::Test {
+ public:
+  FlutterEngineTest();
+
+  FlutterEngine* GetFlutterEngine() { return engine_; };
+
+  void SetUp() override;
+  void TearDown() override;
+
+  void AddNativeCallback(const char* name, Dart_NativeFunction function);
+
+  static void IsolateCreateCallback(void* user_data);
+
+ private:
+  inline static std::shared_ptr<TestDartNativeResolver> native_resolver_;
+
+  FlutterDartProject* project_;
+  FlutterEngine* engine_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FlutterEngineTest);
+};
+
+}  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.mm
@@ -1,0 +1,41 @@
+
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngineTestUtils.h"
+#import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
+
+#include "flutter/testing/testing.h"
+
+namespace flutter::testing {
+
+FlutterEngineTest::FlutterEngineTest() = default;
+
+void FlutterEngineTest::SetUp() {
+  native_resolver_ = std::make_shared<TestDartNativeResolver>();
+  NSString* fixtures = @(testing::GetFixturesPath());
+  project_ = [[FlutterDartProject alloc]
+      initWithAssetsPath:fixtures
+             ICUDataPath:[fixtures stringByAppendingString:@"/icudtl.dat"]];
+  project_.rootIsolateCreateCallback = FlutterEngineTest::IsolateCreateCallback;
+  engine_ = [[FlutterEngine alloc] initWithName:@"test"
+                                        project:project_
+                         allowHeadlessExecution:true];
+}
+
+void FlutterEngineTest::TearDown() {
+  [engine_ shutDownEngine];
+  engine_ = nil;
+  native_resolver_.reset();
+}
+
+void FlutterEngineTest::IsolateCreateCallback(void* user_data) {
+  native_resolver_->SetNativeResolverForIsolate();
+}
+
+void FlutterEngineTest::AddNativeCallback(const char* name, Dart_NativeFunction function) {
+  native_resolver_->AddNativeCallback({name}, function);
+}
+
+}  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
+++ b/shell/platform/darwin/macos/framework/Source/fixtures/flutter_desktop_test.dart
@@ -28,3 +28,10 @@ void can_composite_platform_views() {
   };
   PlatformDispatcher.instance.scheduleFrame();
 }
+
+void signalNativeTest() native 'SignalNativeTest';
+
+@pragma('vm:entry-point')
+void native_callback() {
+  signalNativeTest();
+}


### PR DESCRIPTION
Reland of https://github.com/flutter/engine/pull/26623 without erroneous `FlutterEngineTestContext.mm` file.

That file was accidentally included in the last PR which didn't break any pre/post-submits due to it not being built, but its presence caused test failures later on after rolling. This PR is the same as the previous one but without that file.