### PR TITLE
[iOS TextInputPlugin] fix autofill assert

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -925,6 +925,9 @@ FLUTTER_ASSERT_ARC
 
 - (void)testInitialActiveViewCantAccessTextInputDelegate {
   textInputPlugin.activeView.textInputDelegate = engine;
+  // Before the framework sends the first text input configuration,
+  // the dummy "activeView" we use should never have access to
+  // its textInputDelegate.
   XCTAssertNil(textInputPlugin.activeView.textInputDelegate);
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -80,6 +80,9 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)tearDown {
+  for (FlutterTextInputView* autofillView in textInputPlugin.autofillContext.allValues) {
+    autofillView.textInputDelegate = nil;
+  }
   [textInputPlugin.autofillContext removeAllObjects];
   [textInputPlugin cleanUpViewHierarchy:YES clearText:YES delayRemoval:NO];
   [[[[textInputPlugin textInputView] superview] subviews]
@@ -894,6 +897,35 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(self.installedInputViews.count, 2);
 
   [self commitAutofillContextAndVerify];
+}
+
+- (void)testDecommissionedViewAreNotReusedByAutofill {
+  // Regression test for https://github.com/flutter/flutter/issues/84407.
+  NSMutableDictionary* configuration = self.mutableTemplateCopy;
+  [configuration setValue:@{
+    @"uniqueIdentifier" : @"field1",
+    @"hints" : @[ UITextContentTypePassword ],
+    @"editingValue" : @{@"text" : @""}
+  }
+                   forKey:@"autofill"];
+  [configuration setValue:@[ [configuration copy] ] forKey:@"fields"];
+
+  [self setClientId:123 configuration:configuration];
+
+  [self setTextInputHide];
+  UIView* previousActiveView = textInputPlugin.activeView;
+
+  [self setClientId:124 configuration:configuration];
+
+  // Make sure the autofillable view is reused.
+  XCTAssertEqual(previousActiveView, textInputPlugin.activeView);
+  XCTAssertNotNil(previousActiveView);
+  // Does not crash.
+}
+
+- (void)testInitialActiveViewCantAccessTextInputDelegate {
+  textInputPlugin.activeView.textInputDelegate = engine;
+  XCTAssertNil(textInputPlugin.activeView.textInputDelegate);
 }
 
 #pragma mark - Accessibility - Tests


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/84407.

In `hideTextInput` when we remove the active view from the view hierarchy, there's still a chance that at a later point we reuse the view. 
Additionally, this addresses some additional edge cases when the view is hidden by `hideTextInput` (mostly just to make the test to pass).

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
