### PR TITLE
ImageFilterLayer should not contribute to readback region

### DIFF
--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -35,13 +35,6 @@ void ImageFilterLayer::Diff(DiffContext* context, const Layer* old_layer) {
         filter->filterBounds(screen_bounds.roundOut(), SkMatrix::I(),
                              SkImageFilter::kForward_MapDirection);
     context->AddLayerBounds(inverse.mapRect(SkRect::Make(filter_bounds)));
-
-    // Technically, there is no readback with ImageFilterLayer, but we can't
-    // clip the filter (because it may sample out of clip rect) so if any part
-    // of layer is repainted the whole layer needs to be.
-    // TODO(knopp) There is a room for optimization here - this doesn't need to
-    // be done if we know for sure that we're using raster cache
-    context->AddReadbackRegion(filter_bounds);
   }
 
   context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -376,13 +376,14 @@ TEST_F(ImageFilterLayerDiffTest, ImageFilterLayer) {
   damage = DiffLayerTree(l3, l2);
   EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(130, 130, 140, 140));
 
-  // path intersecting ImageFilterLayer, should trigger ImageFilterLayer repaint
+  // path intersecting ImageFilterLayer, shouldn't trigger entire
+  // ImageFilterLayer repaint
   MockLayerTree l4;
   l4.root()->Add(scale);
   auto path2 = SkPath().addRect(SkRect::MakeLTRB(130, 130, 141, 141));
   l4.root()->Add(std::make_shared<MockLayer>(path2));
   damage = DiffLayerTree(l4, l3);
-  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(130, 130, 280, 280));
+  EXPECT_EQ(damage.frame_damage, SkIRect::MakeLTRB(130, 130, 141, 141));
 }
 
 #endif


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/83380

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
