### PR TITLE
Remove autoninja calls from the analyze script.

### DIFF
--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -106,7 +106,6 @@ analyze \
   "$FLUTTER_DIR/testing/smoke_test_failure"
 
 echo "Analyzing testing/dart..."
-"$FLUTTER_DIR/tools/gn" --unoptimized
 (cd "$FLUTTER_DIR/testing/dart" && "$PUB" get --offline)
 analyze \
   --packages="$FLUTTER_DIR/testing/dart/.dart_tool/package_config.json" \

--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -59,7 +59,6 @@ function analyze() (
 )
 
 echo "Analyzing dart:ui library..."
-autoninja -C "$SRC_DIR/out/host_debug_unopt" generate_dart_ui
 analyze \
   --options "$FLUTTER_DIR/analysis_options.yaml" \
   "$SRC_DIR/out/host_debug_unopt/gen/sky/bindings/dart_ui/ui.dart"
@@ -108,7 +107,6 @@ analyze \
 
 echo "Analyzing testing/dart..."
 "$FLUTTER_DIR/tools/gn" --unoptimized
-autoninja -C "$SRC_DIR/out/host_debug_unopt" sky_engine sky_services
 (cd "$FLUTTER_DIR/testing/dart" && "$PUB" get --offline)
 analyze \
   --packages="$FLUTTER_DIR/testing/dart/.dart_tool/package_config.json" \

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -294,7 +294,7 @@ def EnsureJavaTestsAreBuilt(android_out_dir):
 
 def EnsureIosTestsAreBuilt(ios_out_dir):
   """Builds the engine variant and the test dylib containing the XCTests"""
-  tmp_out_dir = os.path.exists(out_dir, ios_out_dir)
+  tmp_out_dir = os.path.join(out_dir, ios_out_dir)
   assert os.path.exists(tmp_out_dir), "%s doesn't exist. Run GN to generate the directory first" % ios_out_dir
 
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -311,12 +311,12 @@ def EnsureDebugUnoptSkyPackagesAreBuilt():
 
 def EnsureJavaTestsAreBuilt(android_out_dir):
   """Builds the engine variant and the test jar containing the JUnit tests"""
-  ninja_command = [
-    'autoninja',
-    '-C',
-    android_out_dir,
-    'flutter/shell/platform/android:robolectric_tests'
-  ]
+  #ninja_command = [
+  #  'autoninja',
+  #  '-C',
+  #  android_out_dir,
+  #  'flutter/shell/platform/android:robolectric_tests'
+  #]
 
   # Attempt running Ninja if the out directory exists.
   # We don't want to blow away any custom GN args the caller may have already set.
@@ -327,15 +327,15 @@ def EnsureJavaTestsAreBuilt(android_out_dir):
   assert android_out_dir != "out/android_debug_unopt", "%s doesn't exist. Run GN to generate the directory first" % android_out_dir
 
   # Otherwise prepare the directory first, then build the test.
-  gn_command = [
-    os.path.join(buildroot_dir, 'flutter', 'tools', 'gn'),
-    '--android',
-    '--unoptimized',
-    '--runtime-mode=debug',
-    '--no-lto',
-  ]
-  RunCmd(gn_command, cwd=buildroot_dir)
-  RunCmd(ninja_command, cwd=buildroot_dir)
+  #gn_command = [
+  #  os.path.join(buildroot_dir, 'flutter', 'tools', 'gn'),
+  #  '--android',
+  #  '--unoptimized',
+  #  '--runtime-mode=debug',
+  #  '--no-lto',
+  #]
+  #RunCmd(gn_command, cwd=buildroot_dir)
+  #RunCmd(ninja_command, cwd=buildroot_dir)
 
 
 def EnsureIosTestsAreBuilt(ios_out_dir):

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -320,9 +320,9 @@ def EnsureJavaTestsAreBuilt(android_out_dir):
 
   # Attempt running Ninja if the out directory exists.
   # We don't want to blow away any custom GN args the caller may have already set.
-  if os.path.exists(android_out_dir):
-    RunCmd(ninja_command, cwd=buildroot_dir)
-    return
+  #if os.path.exists(android_out_dir):
+  #  RunCmd(ninja_command, cwd=buildroot_dir)
+  #  return
 
   assert android_out_dir != "out/android_debug_unopt", "%s doesn't exist. Run GN to generate the directory first" % android_out_dir
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -283,90 +283,19 @@ def RunDartTest(build_dir, test_packages, dart_file, verbose_dart_snapshot, mult
 
 def EnsureDebugUnoptSkyPackagesAreBuilt():
   variant_out_dir = os.path.join(out_dir, 'host_debug_unopt')
-
-  #ninja_command = [
-  #  'ninja',
-  #  '-C',
-  #  variant_out_dir,
-  #  'flutter/sky/packages'
-  #]
-
-  # Attempt running Ninja if the out directory exists.
-  # We don't want to blow away any custom GN args the caller may have already set.
-  #if os.path.exists(variant_out_dir):
-  #  RunCmd(ninja_command, cwd=buildroot_dir)
-  #  return
-
-  #gn_command = [
-  #  os.path.join(buildroot_dir, 'flutter', 'tools', 'gn'),
-  #  '--runtime-mode',
-  #  'debug',
-  #  '--unopt',
-  #  '--no-lto',
-  #]
-
-  #RunCmd(gn_command, cwd=buildroot_dir)
-  #RunCmd(ninja_command, cwd=buildroot_dir)
   assert os.path.exists(variant_out_dir), "%s doesn't exist. Run GN to generate the directory first" % variant_out_dir
 
 
 def EnsureJavaTestsAreBuilt(android_out_dir):
   """Builds the engine variant and the test jar containing the JUnit tests"""
-  #ninja_command = [
-  #  'autoninja',
-  #  '-C',
-  #  android_out_dir,
-  #  'flutter/shell/platform/android:robolectric_tests'
-  #]
-
-  # Attempt running Ninja if the out directory exists.
-  # We don't want to blow away any custom GN args the caller may have already set.
-  #if os.path.exists(android_out_dir):
-  #  RunCmd(ninja_command, cwd=buildroot_dir)
-  #  return
-
-  assert android_out_dir != "out/android_debug_unopt", "%s doesn't exist. Run GN to generate the directory first" % android_out_dir
-
-  # Otherwise prepare the directory first, then build the test.
-  #gn_command = [
-  #  os.path.join(buildroot_dir, 'flutter', 'tools', 'gn'),
-  #  '--android',
-  #  '--unoptimized',
-  #  '--runtime-mode=debug',
-  #  '--no-lto',
-  #]
-  #RunCmd(gn_command, cwd=buildroot_dir)
-  #RunCmd(ninja_command, cwd=buildroot_dir)
+  tmp_out_dir = os.path.join(out_dir, android_out_dir)
+  assert os.path.exists(tmp_out_dir), "%s doesn't exist. Run GN to generate the directory first" % android_out_dir
 
 
 def EnsureIosTestsAreBuilt(ios_out_dir):
   """Builds the engine variant and the test dylib containing the XCTests"""
-  #ninja_command = [
-  #  'autoninja',
-  #  '-C',
-  #  ios_out_dir,
-  #  'ios_test_flutter'
-  #]
-
-  # Attempt running Ninja if the out directory exists.
-  # We don't want to blow away any custom GN args the caller may have already set.
-  #if os.path.exists(ios_out_dir):
-  #  RunCmd(ninja_command, cwd=buildroot_dir)
-  #  return
-
-  assert ios_out_dir != "out/ios_debug_sim_unopt", "%s doesn't exist. Run GN to generate the directory first" % ios_out_dir
-
-  # Otherwise prepare the directory first, then build the test.
-  #gn_command = [
-  #  os.path.join(buildroot_dir, 'flutter', 'tools', 'gn'),
-  #  '--ios',
-  #  '--unoptimized',
-  #  '--runtime-mode=debug',
-  #  '--no-lto',
-  #  '--simulator'
-  #]
-  #RunCmd(gn_command, cwd=buildroot_dir)
-  #RunCmd(ninja_command, cwd=buildroot_dir)
+  tmp_out_dir = os.path.exists(out_dir, ios_out_dir)
+  assert os.path.exists(tmp_out_dir), "%s doesn't exist. Run GN to generate the directory first" % ios_out_dir
 
 
 def AssertExpectedJavaVersion():

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -307,7 +307,7 @@ def EnsureDebugUnoptSkyPackagesAreBuilt():
 
   #RunCmd(gn_command, cwd=buildroot_dir)
   #RunCmd(ninja_command, cwd=buildroot_dir)
-  assert android_out_dir != "out/host_debug_unopt", "%s doesn't exist. Run GN to generate the directory first" % variant_out_dir
+  assert os.path.exists(variant_out_dir), "%s doesn't exist. Run GN to generate the directory first" % variant_out_dir
 
 
 def EnsureJavaTestsAreBuilt(android_out_dir):

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -284,29 +284,30 @@ def RunDartTest(build_dir, test_packages, dart_file, verbose_dart_snapshot, mult
 def EnsureDebugUnoptSkyPackagesAreBuilt():
   variant_out_dir = os.path.join(out_dir, 'host_debug_unopt')
 
-  ninja_command = [
-    'ninja',
-    '-C',
-    variant_out_dir,
-    'flutter/sky/packages'
-  ]
+  #ninja_command = [
+  #  'ninja',
+  #  '-C',
+  #  variant_out_dir,
+  #  'flutter/sky/packages'
+  #]
 
   # Attempt running Ninja if the out directory exists.
   # We don't want to blow away any custom GN args the caller may have already set.
-  if os.path.exists(variant_out_dir):
-    RunCmd(ninja_command, cwd=buildroot_dir)
-    return
+  #if os.path.exists(variant_out_dir):
+  #  RunCmd(ninja_command, cwd=buildroot_dir)
+  #  return
 
-  gn_command = [
-    os.path.join(buildroot_dir, 'flutter', 'tools', 'gn'),
-    '--runtime-mode',
-    'debug',
-    '--unopt',
-    '--no-lto',
-  ]
+  #gn_command = [
+  #  os.path.join(buildroot_dir, 'flutter', 'tools', 'gn'),
+  #  '--runtime-mode',
+  #  'debug',
+  #  '--unopt',
+  #  '--no-lto',
+  #]
 
-  RunCmd(gn_command, cwd=buildroot_dir)
-  RunCmd(ninja_command, cwd=buildroot_dir)
+  #RunCmd(gn_command, cwd=buildroot_dir)
+  #RunCmd(ninja_command, cwd=buildroot_dir)
+  assert android_out_dir != "out/host_debug_unopt", "%s doesn't exist. Run GN to generate the directory first" % variant_out_dir
 
 
 def EnsureJavaTestsAreBuilt(android_out_dir):
@@ -340,32 +341,32 @@ def EnsureJavaTestsAreBuilt(android_out_dir):
 
 def EnsureIosTestsAreBuilt(ios_out_dir):
   """Builds the engine variant and the test dylib containing the XCTests"""
-  ninja_command = [
-    'autoninja',
-    '-C',
-    ios_out_dir,
-    'ios_test_flutter'
-  ]
+  #ninja_command = [
+  #  'autoninja',
+  #  '-C',
+  #  ios_out_dir,
+  #  'ios_test_flutter'
+  #]
 
   # Attempt running Ninja if the out directory exists.
   # We don't want to blow away any custom GN args the caller may have already set.
-  if os.path.exists(ios_out_dir):
-    RunCmd(ninja_command, cwd=buildroot_dir)
-    return
+  #if os.path.exists(ios_out_dir):
+  #  RunCmd(ninja_command, cwd=buildroot_dir)
+  #  return
 
   assert ios_out_dir != "out/ios_debug_sim_unopt", "%s doesn't exist. Run GN to generate the directory first" % ios_out_dir
 
   # Otherwise prepare the directory first, then build the test.
-  gn_command = [
-    os.path.join(buildroot_dir, 'flutter', 'tools', 'gn'),
-    '--ios',
-    '--unoptimized',
-    '--runtime-mode=debug',
-    '--no-lto',
-    '--simulator'
-  ]
-  RunCmd(gn_command, cwd=buildroot_dir)
-  RunCmd(ninja_command, cwd=buildroot_dir)
+  #gn_command = [
+  #  os.path.join(buildroot_dir, 'flutter', 'tools', 'gn'),
+  #  '--ios',
+  #  '--unoptimized',
+  #  '--runtime-mode=debug',
+  #  '--no-lto',
+  #  '--simulator'
+  #]
+  #RunCmd(gn_command, cwd=buildroot_dir)
+  #RunCmd(ninja_command, cwd=buildroot_dir)
 
 
 def AssertExpectedJavaVersion():


### PR DESCRIPTION
Calling autoninja from this script is preventing the roll of new depot
tools that requires autoninja to run from inside a goma context.

Bug: https://github.com/flutter/flutter/issues/84618

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
