### PR TITLE
Fix Typo in create_sdk_cipd_package.sh

### DIFF
--- a/tools/create_sdk_cipd_package.sh
+++ b/tools/create_sdk_cipd_package.sh
@@ -3,7 +3,7 @@
 # This script requires depot_tools to be on path.
 
 print_usage () {
-  echo "Usage: create_ndk_cipd_package.sh <PACKAGE_TYPE> <PATH_TO_ASSETS> <PLATFORM_NAME> <VERSION_TAG>"
+  echo "Usage: create_sdk_cipd_package.sh <PACKAGE_TYPE> <PATH_TO_ASSETS> <PLATFORM_NAME> <VERSION_TAG>"
   echo "  where:"
   echo "    - PACKAGE_TYPE is one of build-tools, platform-tools, platforms, or tools"
   echo "    - PATH_TO_ASSETS is the path to the unzipped asset folder"


### PR DESCRIPTION
Minor fix: Should be `sdk` instead of `ndk` in this file in the help printout.
