### PR TITLE
Initialize EventChannel state

### DIFF
--- a/shell/platform/common/client_wrapper/include/flutter/event_channel.h
+++ b/shell/platform/common/client_wrapper/include/flutter/event_channel.h
@@ -37,7 +37,10 @@ class EventChannel {
   EventChannel(BinaryMessenger* messenger,
                const std::string& name,
                const MethodCodec<T>* codec)
-      : messenger_(messenger), name_(name), codec_(codec) {}
+      : messenger_(messenger),
+        name_(name),
+        codec_(codec),
+        is_listening_(false) {}
   ~EventChannel() = default;
 
   // Prevent copying.

--- a/shell/platform/common/client_wrapper/include/flutter/event_channel.h
+++ b/shell/platform/common/client_wrapper/include/flutter/event_channel.h
@@ -37,10 +37,7 @@ class EventChannel {
   EventChannel(BinaryMessenger* messenger,
                const std::string& name,
                const MethodCodec<T>* codec)
-      : messenger_(messenger),
-        name_(name),
-        codec_(codec),
-        is_listening_(false) {}
+      : messenger_(messenger), name_(name), codec_(codec) {}
   ~EventChannel() = default;
 
   // Prevent copying.
@@ -168,7 +165,7 @@ class EventChannel {
   BinaryMessenger* messenger_;
   const std::string name_;
   const MethodCodec<T>* codec_;
-  bool is_listening_;
+  bool is_listening_ = false;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
OnCancel was fired randomly on event channel registration because of uninitialized `is_listening_` variable.

Wrong call: [event_channel.h:85](https://github.com/flutter/engine/blob/2118a1bb4bf0686795279b24e3a5bb84ccdd4fd3/shell/platform/common/client_wrapper/include/flutter/event_channel.h#L85)

This PR fixes: flutter/flutter#84632

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
