### PR TITLE
iOS: add support for TextInputType.none

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -253,6 +253,13 @@ static UITextContentType ToUITextContentType(NSArray<NSString*>* hints) {
   return hints[0];
 }
 
+static BOOL isKeyboardEnabled(NSDictionary* type) {
+  NSString* inputType = type[@"name"];
+  if ([inputType isEqualToString:@"TextInputType.none"])
+    return NO;
+  return YES;
+}
+
 // Retrieves the autofillId from an input field's configuration. Returns
 // nil if the field is nil and the input field is not a password field.
 static NSString* autofillIdFromDictionary(NSDictionary* dictionary) {
@@ -508,6 +515,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 @property(nonatomic, assign) CGRect markedRect;
 @property(nonatomic) BOOL isVisibleToAutofill;
 @property(nonatomic, assign) BOOL accessibilityEnabled;
+@property(nonatomic, assign) BOOL keyboardEnabled;
 
 - (void)setEditableTransform:(NSArray*)matrix;
 @end
@@ -549,6 +557,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
     _enablesReturnKeyAutomatically = NO;
     _keyboardAppearance = UIKeyboardAppearanceDefault;
     _keyboardType = UIKeyboardTypeDefault;
+    _keyboardEnabled = YES;
     _returnKeyType = UIReturnKeyDone;
     _secureTextEntry = NO;
     _accessibilityEnabled = NO;
@@ -580,6 +589,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 
   self.secureTextEntry = [configuration[kSecureTextEntry] boolValue];
   self.keyboardType = ToUIKeyboardType(inputType);
+  self.keyboardEnabled = isKeyboardEnabled(inputType);
   self.returnKeyType = ToUIReturnKeyType(configuration[kInputAction]);
   self.autocapitalizationType = ToUITextAutoCapitalizationType(configuration);
 
@@ -1451,6 +1461,10 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 }
 
 - (void)showTextInput {
+  if (!_activeView.keyboardEnabled) {
+    [self hideTextInput];
+    return;
+  }
   _activeView.textInputDelegate = _textInputDelegate;
   [self addToInputParentViewIfNeeded:_activeView];
   // Adds a delay to prevent the text view from receiving accessibility

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -191,7 +191,8 @@ FLUTTER_ASSERT_ARC
 
   FlutterTextInputView* inputView = inputFields[0];
 
-  // Verify keyboardType is set to the value specified in config.
+  // Verify keyboardType and keyboardEnabled are set as appropriate for the input
+  // type specified in config.
   XCTAssertEqual(inputView.keyboardType, UIKeyboardTypeURL);
   XCTAssertEqual(inputView.keyboardEnabled, YES);
 }
@@ -206,7 +207,8 @@ FLUTTER_ASSERT_ARC
 
   FlutterTextInputView* inputView = inputFields[0];
 
-  // Verify keyboardType is set to the value specified in config.
+  // Verify keyboardType and keyboardEnabled are set as appropriate for the input
+  // type specified in config.
   XCTAssertEqual(inputView.keyboardType, UIKeyboardTypeDefault);
   XCTAssertEqual(inputView.keyboardEnabled, NO);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -14,6 +14,7 @@ FLUTTER_ASSERT_ARC
 
 @interface FlutterTextInputView ()
 @property(nonatomic, copy) NSString* autofillId;
+@property(nonatomic, assign) BOOL keyboardEnabled;
 
 - (void)setEditableTransform:(NSArray*)matrix;
 - (void)setTextInputState:(NSDictionary*)state;
@@ -192,6 +193,22 @@ FLUTTER_ASSERT_ARC
 
   // Verify keyboardType is set to the value specified in config.
   XCTAssertEqual(inputView.keyboardType, UIKeyboardTypeURL);
+  XCTAssertEqual(inputView.keyboardEnabled, YES);
+}
+
+- (void)testKeyboardDisabled {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [config setValue:@{@"name" : @"TextInputType.none"} forKey:@"inputType"];
+  [self setClientId:123 configuration:config];
+
+  // Find all the FlutterTextInputViews we created.
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+
+  FlutterTextInputView* inputView = inputFields[0];
+
+  // Verify keyboardType is set to the value specified in config.
+  XCTAssertEqual(inputView.keyboardType, UIKeyboardTypeDefault);
+  XCTAssertEqual(inputView.keyboardEnabled, NO);
 }
 
 - (void)testAutocorrectionPromptRectAppears {


### PR DESCRIPTION
`TextInputType.none` makes it possible to disable the virtual keyboard for certain TextFields, and lays the foundations for custom in-app virtual keyboards (flutter/flutter#76072).

Ref: flutter/flutter#83567

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
