### PR TITLE
Update NDK from r21 to r22

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -98,7 +98,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'da131f62020132fa0df9008ad5951bb8ac591746',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'd98091760f05b3bec95868d94c27d36d6e0cf8f1',
 
    # Fuchsia compatibility
    #
@@ -455,7 +455,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/ndk/${{platform}}',
-        'version': 'version:r21.0.6113669'
+        'version': 'version:r22.0.7026061'
        }
      ],
      'condition': 'download_android_deps',


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/73818.

Buildroot PR: https://github.com/flutter/buildroot/pull/470

Smoke tested with Flutter Gallery against arm64 and x64 at API 30.

Used the r22 version that was pushed to CIPD in Jan -- we could possibly push a more recent revision.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.