### PR TITLE
Fix a leak of the resource EGL context on Android

### DIFF
--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -92,7 +92,9 @@ bool AndroidSurfaceGL::ResourceContextMakeCurrent() {
 
 bool AndroidSurfaceGL::ResourceContextClearCurrent() {
   FML_DCHECK(IsValid());
-  return GLContextPtr()->ClearCurrent();
+  EGLBoolean result = eglMakeCurrent(eglGetCurrentDisplay(), EGL_NO_SURFACE,
+                                     EGL_NO_SURFACE, EGL_NO_CONTEXT);
+  return result == EGL_TRUE;
 }
 
 bool AndroidSurfaceGL::SetNativeWindow(


### PR DESCRIPTION
ResourceContextClearCurrent had been calling AndroidContextGL::ClearCurrent
using the primary context.  However, AndroidContextGL::ClearCurrent
does nothing if the thread's current EGL context does not match the
expected context.
This was an attempt to avoid overwriting other EGL contexts that might
be used on the platform thread (see https://github.com/flutter/flutter/issues/19566).
But the IO thread is owned by Flutter, and its context should always be
cleared.

Fixes https://github.com/flutter/flutter/issues/84702
