### PR TITLE
Emit ViewRefFocused events in flutter_runner

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1349,6 +1349,9 @@ FILE: ../../../flutter/shell/platform/fuchsia/flutter/engine.h
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/flutter_runner_fakes.h
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/flutter_runner_product_configuration.h
+FILE: ../../../flutter/shell/platform/fuchsia/flutter/focus_delegate.cc
+FILE: ../../../flutter/shell/platform/fuchsia/flutter/focus_delegate.h
+FILE: ../../../flutter/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/fuchsia_intl.cc

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -59,6 +59,8 @@ template("runner_sources") {
       "engine.h",
       "flutter_runner_product_configuration.cc",
       "flutter_runner_product_configuration.h",
+      "focus_delegate.cc",
+      "focus_delegate.h",
       "fuchsia_external_view_embedder.cc",
       "fuchsia_external_view_embedder.h",
       "fuchsia_intl.cc",
@@ -447,6 +449,7 @@ executable("flutter_runner_unittests") {
     "accessibility_bridge_unittest.cc",
     "component_unittest.cc",
     "flutter_runner_fakes.h",
+    "focus_delegate_unittests.cc",
     "fuchsia_intl_unittest.cc",
     "keyboard_unittest.cc",
     "platform_view_unittest.cc",
@@ -471,6 +474,7 @@ executable("flutter_runner_unittests") {
   ]
 
   deps = [
+           "tests/fakes",
            ":flutter_runner_fixtures",
            ":flutter_runner_sources",
            "//build/fuchsia/pkg:sys_cpp_testing",

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -21,6 +21,7 @@
 #include "third_party/skia/include/ports/SkFontMgr_fuchsia.h"
 
 #include "../runtime/dart/utils/files.h"
+#include "focus_delegate.h"
 #include "fuchsia_intl.h"
 #include "platform_view.h"
 #include "surface.h"
@@ -99,6 +100,8 @@ Engine::Engine(Delegate& delegate,
   endpoints.set_session_listener(session_listener.Bind());
   fidl::InterfaceHandle<fuchsia::ui::views::Focuser> focuser;
   endpoints.set_view_focuser(focuser.NewRequest());
+  fidl::InterfaceHandle<fuchsia::ui::views::ViewRefFocused> view_ref_focused;
+  endpoints.set_view_ref_focused(view_ref_focused.NewRequest());
   scenic->CreateSessionT(std::move(endpoints), [] {});
 
   // Make clones of the `ViewRef` before sending it down to Scenic, since the
@@ -275,6 +278,7 @@ Engine::Engine(Delegate& delegate,
                std::move(parent_environment_service_provider),
            session_listener_request = std::move(session_listener_request),
            focuser = std::move(focuser),
+           view_ref_focused = std::move(view_ref_focused),
            on_session_listener_error_callback =
                std::move(on_session_listener_error_callback),
            on_enable_wireframe_callback =
@@ -339,7 +343,7 @@ Engine::Engine(Delegate& delegate,
                 std::move(runner_services),
                 std::move(parent_environment_service_provider),  // services
                 std::move(session_listener_request),  // session listener
-                std::move(focuser),
+                std::move(view_ref_focused), std::move(focuser),
                 // Server-side part of the fuchsia.ui.input3.KeyboardListener
                 // connection.
                 std::move(keyboard_listener_request),

--- a/shell/platform/fuchsia/flutter/focus_delegate.cc
+++ b/shell/platform/fuchsia/flutter/focus_delegate.cc
@@ -1,0 +1,94 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <ostream>
+
+#include "focus_delegate.h"
+
+namespace flutter_runner {
+
+void FocusDelegate::WatchLoop(std::function<void(bool)> callback) {
+  if (watch_loop_) {
+    FML_LOG(ERROR) << "FocusDelegate::WatchLoop() cannot be called twice.";
+    return;
+  }
+
+  watch_loop_ = [this, callback = std::move(callback)](auto focus_state) {
+    callback(is_focused_ = focus_state.focused());
+    if (next_focus_request_) {
+      CompleteCurrentFocusState(std::exchange(next_focus_request_, nullptr));
+    }
+    view_ref_focused_->Watch(watch_loop_);
+  };
+  view_ref_focused_->Watch(watch_loop_);
+}
+
+void FocusDelegate::CompleteCurrentFocusState(
+    fml::RefPtr<flutter::PlatformMessageResponse> response) {
+  std::string result(is_focused_ ? "[true]" : "[false]");
+  response->Complete(std::make_unique<fml::DataMapping>(
+      std::vector<uint8_t>(result.begin(), result.end())));
+}
+
+void FocusDelegate::CompleteNextFocusState(
+    fml::RefPtr<flutter::PlatformMessageResponse> response) {
+  if (next_focus_request_) {
+    FML_LOG(ERROR) << "An outstanding PlatformMessageResponse already exists "
+                      "for the next focus state!";
+    response->CompleteEmpty();
+  } else {
+    next_focus_request_ = std::move(response);
+  }
+}
+
+void FocusDelegate::RequestFocus(
+    rapidjson::Value request,
+    fml::RefPtr<flutter::PlatformMessageResponse> response) {
+  auto args_it = request.FindMember("args");
+  if (args_it == request.MemberEnd() || !args_it->value.IsObject()) {
+    FML_LOG(ERROR) << "No arguments found.";
+    return;
+  }
+  const auto& args = args_it->value;
+
+  auto view_ref = args.FindMember("viewRef");
+  if (!view_ref->value.IsUint64()) {
+    FML_LOG(ERROR) << "Argument 'viewRef' is not a int64";
+    return;
+  }
+
+  zx_handle_t handle = view_ref->value.GetUint64();
+  zx_handle_t out_handle;
+  zx_status_t status =
+      zx_handle_duplicate(handle, ZX_RIGHT_SAME_RIGHTS, &out_handle);
+  if (status != ZX_OK) {
+    FML_LOG(ERROR) << "Argument 'viewRef' is not valid";
+    return;
+  }
+  auto ref = fuchsia::ui::views::ViewRef({
+      .reference = zx::eventpair(out_handle),
+  });
+  focuser_->RequestFocus(
+      std::move(ref),
+      [view_ref = view_ref->value.GetUint64(), response = std::move(response)](
+          fuchsia::ui::views::Focuser_RequestFocus_Result result) {
+        if (!response.get()) {
+          return;
+        }
+        int result_code =
+            result.is_err()
+                ? static_cast<
+                      std::underlying_type_t<fuchsia::ui::views::Error>>(
+                      result.err())
+                : 0;
+
+        std::ostringstream out;
+        out << "[" << result_code << "]";
+        std::string output = out.str();
+        response->Complete(std::make_unique<fml::DataMapping>(
+            std::vector<uint8_t>(output.begin(), output.end())));
+      });
+}
+
+}  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/focus_delegate.h
+++ b/shell/platform/fuchsia/flutter/focus_delegate.h
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FOCUS_DELEGATE_H_
+#define FLUTTER_SHELL_PLATFORM_FUCHSIA_FOCUS_DELEGATE_H_
+
+#include <fuchsia/sys/cpp/fidl.h>
+#include <fuchsia/ui/views/cpp/fidl.h>
+
+#include "flutter/fml/macros.h"
+#include "flutter/lib/ui/window/platform_message.h"
+#include "third_party/rapidjson/include/rapidjson/document.h"
+
+namespace flutter_runner {
+
+class FocusDelegate {
+ public:
+  FocusDelegate(fidl::InterfaceHandle<fuchsia::ui::views::ViewRefFocused>
+                    view_ref_focused,
+                fidl::InterfaceHandle<fuchsia::ui::views::Focuser> focuser)
+      : view_ref_focused_(view_ref_focused.Bind()), focuser_(focuser.Bind()) {}
+
+  virtual ~FocusDelegate() = default;
+
+  /// Continuously watches the host viewRef for focus events, invoking a
+  /// callback each time.
+  ///
+  /// This can only be called once.
+  virtual void WatchLoop(std::function<void(bool)> callback);
+
+  /// Completes the platform message request with the FocusDelegate's most
+  /// recent focus state.
+  virtual void CompleteCurrentFocusState(
+      fml::RefPtr<flutter::PlatformMessageResponse> response);
+
+  /// Completes the platform message request with the FocusDelegate's next focus
+  /// state.
+  ///
+  /// Only one outstanding request may exist at a time. Any others will be
+  /// completed empty.
+  virtual void CompleteNextFocusState(
+      fml::RefPtr<flutter::PlatformMessageResponse> response);
+
+  /// Completes a platform message request by attempting to give focus for a
+  /// given viewRef.
+  virtual void RequestFocus(
+      rapidjson::Value request,
+      fml::RefPtr<flutter::PlatformMessageResponse> response);
+
+ private:
+  fuchsia::ui::views::ViewRefFocusedPtr view_ref_focused_;
+  fuchsia::ui::views::FocuserPtr focuser_;
+
+  std::function<void(fuchsia::ui::views::FocusState)> watch_loop_;
+  bool is_focused_;
+  fml::RefPtr<flutter::PlatformMessageResponse> next_focus_request_;
+
+  void Complete(fml::RefPtr<flutter::PlatformMessageResponse> response,
+                bool value);
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FocusDelegate);
+};
+
+}  // namespace flutter_runner
+#endif  // FLUTTER_SHELL_PLATFORM_FUCHSIA_FOCUS_DELEGATE_H_

--- a/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
+++ b/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
@@ -1,0 +1,176 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <fuchsia/ui/views/cpp/fidl.h>
+#include <gtest/gtest.h>
+#include <lib/async-loop/cpp/loop.h>
+#include <lib/async-loop/default.h>
+#include <lib/fidl/cpp/binding_set.h>
+#include <lib/ui/scenic/cpp/view_ref_pair.h>
+
+#include "focus_delegate.h"
+#include "tests/fakes/focuser.h"
+#include "tests/fakes/platform_message.h"
+#include "tests/fakes/view_ref_focused.h"
+#include "third_party/rapidjson/include/rapidjson/document.h"
+
+rapidjson::Value ParsePlatformMessage(std::string json) {
+  rapidjson::Document document;
+  document.Parse(json);
+  if (document.HasParseError() || !document.IsObject()) {
+    FML_LOG(ERROR) << "Could not parse document";
+    return rapidjson::Value();
+  }
+  return document.GetObject();
+}
+
+namespace flutter_runner::testing {
+
+class FocusDelegateTest : public ::testing::Test {
+ public:
+  std::unique_ptr<FakeViewRefFocused> vrf;
+  std::unique_ptr<FakeFocuser> focuser;
+  std::unique_ptr<FocusDelegate> focus_delegate;
+
+  void RunLoopUntilIdle() { loop_.RunUntilIdle(); }
+
+ protected:
+  FocusDelegateTest() : loop_(&kAsyncLoopConfigAttachToCurrentThread) {}
+
+  void SetUp() override {
+    vrf = std::make_unique<FakeViewRefFocused>();
+    focuser = std::make_unique<FakeFocuser>();
+    focus_delegate = std::make_unique<FocusDelegate>(
+        vrf_bindings.AddBinding(vrf.get()),
+        focuser_bindings.AddBinding(focuser.get()));
+  }
+
+  void TearDown() override {
+    vrf_bindings.CloseAll();
+    focuser_bindings.CloseAll();
+    loop_.Quit();
+    loop_.ResetQuit();
+  }
+
+ private:
+  async::Loop loop_;
+  fidl::BindingSet<ViewRefFocused> vrf_bindings;
+  fidl::BindingSet<Focuser> focuser_bindings;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(FocusDelegateTest);
+};
+
+// Tests that WatchLoop() should callback and complete PlatformMessageResponses
+// correctly, given a series of vrf invocations.
+TEST_F(FocusDelegateTest, WatchCallbackSeries) {
+  std::vector<bool> vrf_states{false, true,  true, false,
+                               true,  false, true, true};
+  std::size_t vrf_index = 0;
+  std::size_t callback_index = 0;
+  focus_delegate->WatchLoop([&](bool focus_state) {
+    // Make sure the focus state that FocusDelegate gives us is consistent with
+    // what was fired from the vrf.
+    EXPECT_EQ(vrf_states[callback_index], focus_state);
+
+    // CompleteCurrentFocusState should complete with the current (up to date)
+    // focus state.
+    auto response = FakePlatformMessageResponse::Create();
+    focus_delegate->CompleteCurrentFocusState(response);
+    response->ExpectCompleted(focus_state ? "[true]" : "[false]");
+
+    // Ensure this callback always happens in lockstep with
+    // vrf->ScheduleCallback.
+    EXPECT_EQ(vrf_index, callback_index++);
+  });
+
+  // Subsequent WatchLoop calls should not be respected.
+  focus_delegate->WatchLoop([](bool _) {
+    ADD_FAILURE() << "Subsequent WatchLoops should not be respected!";
+  });
+
+  do {
+    // Ensure the next focus state is handled correctly.
+    auto response1 = FakePlatformMessageResponse::Create();
+    focus_delegate->CompleteNextFocusState(response1);
+
+    // Since there's already an outstanding PlatformMessageResponse, this one
+    // should be completed empty.
+    auto response = FakePlatformMessageResponse::Create();
+    focus_delegate->CompleteNextFocusState(response);
+    response->ExpectCompleted("");
+
+    // Post watch events and trigger the next vrf event.
+    RunLoopUntilIdle();
+    vrf->ScheduleCallback(vrf_states[vrf_index]);
+    RunLoopUntilIdle();
+
+    // Next focus state should be completed by now.
+    response1->ExpectCompleted(vrf_states[vrf_index] ? "[true]" : "[false]");
+
+    // Check CompleteCurrentFocusState again, and increment vrf_index, since we
+    // move on to the next focus state.
+    response = FakePlatformMessageResponse::Create();
+    focus_delegate->CompleteCurrentFocusState(response);
+    response->ExpectCompleted(vrf_states[vrf_index++] ? "[true]" : "[false]");
+
+    // vrf->times_watched should always be 1 more than the amount of vrf events
+    // emitted.
+    EXPECT_EQ(vrf_index + 1, vrf->times_watched);
+  } while (vrf_index < vrf_states.size());
+}
+
+// Tests that RequestFocus() completes the platform message's response with a
+// non-error status code.
+TEST_F(FocusDelegateTest, RequestFocusTest) {
+  // This "Mock" ViewRef serves as the target for the RequestFocus operation.
+  auto mock_view_ref_pair = scenic::ViewRefPair::New();
+  // Create the platform message request.
+  std::ostringstream message;
+  message << "{"
+          << "    \"method\":\"View.requestFocus\","
+          << "    \"args\": {"
+          << "       \"viewRef\":"
+          << mock_view_ref_pair.view_ref.reference.get() << "    }"
+          << "}";
+
+  // Dispatch the plaform message request with an expected completion response.
+  auto response = FakePlatformMessageResponse::Create();
+  focus_delegate->RequestFocus(ParsePlatformMessage(message.str()), response);
+  RunLoopUntilIdle();
+
+  response->ExpectCompleted("[0]");
+  EXPECT_TRUE(focuser->request_focus_called());
+}
+
+// Tests that RequestFocus() completes the platform message's response with a
+// Error::DENIED status code.
+TEST_F(FocusDelegateTest, RequestFocusFailTest) {
+  // This "Mock" ViewRef serves as the target for the RequestFocus operation.
+  auto mock_view_ref_pair = scenic::ViewRefPair::New();
+  // We're testing the focus failure case.
+  focuser->fail_request_focus();
+  // Create the platform message request.
+  std::ostringstream message;
+  message << "{"
+          << "    \"method\":\"View.requestFocus\","
+          << "    \"args\": {"
+          << "       \"viewRef\":"
+          << mock_view_ref_pair.view_ref.reference.get() << "    }"
+          << "}";
+
+  // Dispatch the plaform message request with an expected completion response.
+  auto response = FakePlatformMessageResponse::Create();
+  focus_delegate->RequestFocus(ParsePlatformMessage(message.str()), response);
+  RunLoopUntilIdle();
+
+  response->ExpectCompleted(
+      "[" +
+      std::to_string(
+          static_cast<std::underlying_type_t<fuchsia::ui::views::Error>>(
+              fuchsia::ui::views::Error::DENIED)) +
+      "]");
+  EXPECT_TRUE(focuser->request_focus_called());
+}
+
+}  // namespace flutter_runner::testing

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -26,6 +26,7 @@
 #include "flutter/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h"
 #include "flutter/shell/platform/fuchsia/flutter/keyboard.h"
 #include "flutter/shell/platform/fuchsia/flutter/vsync_waiter.h"
+#include "focus_delegate.h"
 
 namespace flutter_runner {
 
@@ -72,6 +73,7 @@ class PlatformView final : public flutter::PlatformView,
                    parent_environment_service_provider,
                fidl::InterfaceRequest<fuchsia::ui::scenic::SessionListener>
                    session_listener_request,
+               fidl::InterfaceHandle<fuchsia::ui::views::ViewRefFocused> vrf,
                fidl::InterfaceHandle<fuchsia::ui::views::Focuser> focuser,
                fidl::InterfaceRequest<fuchsia::ui::input3::KeyboardListener>
                    keyboard_listener,
@@ -183,7 +185,7 @@ class PlatformView final : public flutter::PlatformView,
   // TODO(MI4-2490): remove once ViewRefControl is passed to Scenic and kept
   // alive there
   const fuchsia::ui::views::ViewRef view_ref_;
-  fuchsia::ui::views::FocuserPtr focuser_;
+  std::shared_ptr<FocusDelegate> focus_delegate_;
 
   // Logical size and logical->physical ratio.  These are optional to provide
   // an "unset" state during program startup, before Scenic has sent any

--- a/shell/platform/fuchsia/flutter/tests/fakes/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/tests/fakes/BUILD.gn
@@ -1,0 +1,22 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+assert(is_fuchsia)
+
+source_set("fakes") {
+  testonly = true
+
+  sources = [
+    "focuser.h",
+    "platform_message.h",
+    "view_ref_focused.h",
+  ]
+
+  deps = [
+    "//build/fuchsia/pkg:sys_cpp_testing",
+    "//flutter/lib/ui",
+    "//flutter/testing",
+    "//third_party/rapidjson",
+  ]
+}

--- a/shell/platform/fuchsia/flutter/tests/fakes/focuser.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/focuser.h
@@ -1,0 +1,41 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_TESTS_FAKES_FOCUSER_H_
+#define FLUTTER_SHELL_PLATFORM_FUCHSIA_TESTS_FAKES_FOCUSER_H_
+
+#include <fuchsia/ui/views/cpp/fidl.h>
+
+using Focuser = fuchsia::ui::views::Focuser;
+
+namespace flutter_runner::testing {
+
+class FakeFocuser : public Focuser {
+ public:
+  bool request_focus_called() const { return request_focus_called_; }
+
+  void fail_request_focus(bool fail_request = true) {
+    fail_request_focus_ = fail_request;
+  }
+
+ private:
+  void RequestFocus(fuchsia::ui::views::ViewRef view_ref,
+                    RequestFocusCallback callback) override {
+    request_focus_called_ = true;
+    auto result =
+        fail_request_focus_
+            ? fuchsia::ui::views::Focuser_RequestFocus_Result::WithErr(
+                  fuchsia::ui::views::Error::DENIED)
+            : fuchsia::ui::views::Focuser_RequestFocus_Result::WithResponse(
+                  fuchsia::ui::views::Focuser_RequestFocus_Response());
+    callback(std::move(result));
+  }
+
+  bool request_focus_called_ = false;
+  bool fail_request_focus_ = false;
+};
+
+}  // namespace flutter_runner::testing
+
+#endif  // FLUTTER_SHELL_PLATFORM_FUCHSIA_TESTS_FAKES_FOCUSER_H_

--- a/shell/platform/fuchsia/flutter/tests/fakes/platform_message.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/platform_message.h
@@ -1,0 +1,63 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_TESTS_FAKES_PLATFORM_MESSAGE_H_
+#define FLUTTER_SHELL_PLATFORM_FUCHSIA_TESTS_FAKES_PLATFORM_MESSAGE_H_
+
+#include <gtest/gtest.h>
+#include <optional>
+
+#include "flutter/lib/ui/window/platform_message.h"
+#include "third_party/rapidjson/include/rapidjson/document.h"
+
+using PlatformMessageResponse = flutter::PlatformMessageResponse;
+using PlatformMessage = flutter::PlatformMessage;
+
+namespace flutter_runner::testing {
+
+class FakePlatformMessageResponse : public PlatformMessageResponse {
+ public:
+  static fml::RefPtr<FakePlatformMessageResponse> Create() {
+    return fml::AdoptRef(new FakePlatformMessageResponse());
+  }
+
+  void ExpectCompleted(std::string expected) {
+    EXPECT_TRUE(is_complete_);
+    if (is_complete_) {
+      EXPECT_EQ(expected, response_);
+    }
+  }
+
+  std::unique_ptr<PlatformMessage> WithMessage(std::string channel,
+                                               std::string message) {
+    return std::make_unique<PlatformMessage>(
+        channel,
+        fml::MallocMapping::Copy(message.c_str(),
+                                 message.c_str() + message.size()),
+        fml::RefPtr<FakePlatformMessageResponse>(this));
+  }
+
+  void Complete(std::unique_ptr<fml::Mapping> data) override {
+    response_ =
+        std::string(data->GetMapping(), data->GetMapping() + data->GetSize());
+    FinalizeComplete();
+  };
+
+  void CompleteEmpty() override { FinalizeComplete(); };
+
+ private:
+  // Private constructors.
+  FakePlatformMessageResponse() {}
+
+  void FinalizeComplete() {
+    EXPECT_FALSE(std::exchange(is_complete_, true))
+        << "Platform message responses can only be completed once!";
+  }
+
+  std::string response_;
+};
+
+}  // namespace flutter_runner::testing
+
+#endif  // FLUTTER_SHELL_PLATFORM_FUCHSIA_TESTS_FAKES_PLATFORM_MESSAGE_H_

--- a/shell/platform/fuchsia/flutter/tests/fakes/view_ref_focused.h
+++ b/shell/platform/fuchsia/flutter/tests/fakes/view_ref_focused.h
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_TESTS_FAKES_VIEW_REF_FOCUSED_H_
+#define FLUTTER_SHELL_PLATFORM_FUCHSIA_TESTS_FAKES_VIEW_REF_FOCUSED_H_
+
+#include <fuchsia/ui/views/cpp/fidl.h>
+
+using ViewRefFocused = fuchsia::ui::views::ViewRefFocused;
+
+namespace flutter_runner::testing {
+
+class FakeViewRefFocused : public ViewRefFocused {
+ public:
+  using WatchCallback = ViewRefFocused::WatchCallback;
+  std::size_t times_watched = 0;
+
+  void Watch(WatchCallback callback) override {
+    callback_ = std::move(callback);
+    ++times_watched;
+  }
+
+  void ScheduleCallback(bool focused) {
+    fuchsia::ui::views::FocusState focus_state;
+    focus_state.set_focused(focused);
+    callback_(std::move(focus_state));
+  }
+
+ private:
+  WatchCallback callback_;
+};
+
+}  // namespace flutter_runner::testing
+
+#endif  // FLUTTER_SHELL_PLATFORM_FUCHSIA_TESTS_FAKES_VIEW_REF_FOCUSED_H_


### PR DESCRIPTION
Fulfill `HostView.getCurrentFocusState` and `HostView.getNextFocusState` platform message requests to deliver focus-related events to dart code.

Consolidate focus functionality (including `requestFocus` handling) to a new `FocusDelegate` class.

See https://cs.opensource.google/fuchsia/fuchsia/+/main:sdk/fidl/fuchsia.ui.views/view_ref_focused.fidl for details about focus state transitions and their meanings.

See https://fxbug.dev/77481.

CC: @naudzghebre 