### PR TITLE
Issues/80711 reland

### DIFF
--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -44,11 +44,16 @@ enum class SemanticsAction : int32_t {
   kSetText = 1 << 21,
 };
 
-const int kScrollableSemanticsActions =
-    static_cast<int32_t>(SemanticsAction::kScrollLeft) |
-    static_cast<int32_t>(SemanticsAction::kScrollRight) |
+const int kVerticalScrollSemanticsActions =
     static_cast<int32_t>(SemanticsAction::kScrollUp) |
     static_cast<int32_t>(SemanticsAction::kScrollDown);
+
+const int kHorizontalScrollSemanticsActions =
+    static_cast<int32_t>(SemanticsAction::kScrollLeft) |
+    static_cast<int32_t>(SemanticsAction::kScrollRight);
+
+const int kScrollableSemanticsActions =
+    kVerticalScrollSemanticsActions | kHorizontalScrollSemanticsActions;
 
 /// C/C++ representation of `SemanticsFlags` defined in
 /// `lib/ui/semantics.dart`.

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
@@ -31,7 +31,7 @@ constexpr int32_t kRootNodeId = 0;
  * The parent of this node in the node tree. Will be nil for the root node and
  * during transient state changes.
  */
-@property(nonatomic, readonly) SemanticsObject* parent;
+@property(nonatomic, assign) SemanticsObject* parent;
 
 /**
  * The accessibility bridge that this semantics object is attached to. This
@@ -93,6 +93,14 @@ constexpr int32_t kRootNodeId = 0;
 - (NSString*)routeName;
 
 - (BOOL)onCustomAccessibilityAction:(FlutterCustomAccessibilityAction*)action;
+
+/**
+ * Called after accessibility bridge finishes a semantics update.
+ *
+ * Subclasses can override this method if they contain states that can only be
+ * updated once every node in the accessibility tree has finished updating.
+ */
+- (void)accessibilityBridgeDidFinishUpdate;
 
 #pragma mark - Designated initializers
 
@@ -156,6 +164,18 @@ constexpr int32_t kRootNodeId = 0;
 /// The semantics object for switch buttons. This class creates an UISwitch to interact with the
 /// iOS.
 @interface FlutterSwitchSemanticsObject : SemanticsObject
+
+@end
+
+/// The semantics object for scrollable. This class creates an UIScrollView to interact with the
+/// iOS.
+@interface FlutterScrollableSemanticsObject : UIScrollView
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
+- (instancetype)initWithCoder:(NSCoder*)coder NS_UNAVAILABLE;
+- (instancetype)initWithSemanticsObject:(SemanticsObject*)semanticsObject NS_DESIGNATED_INITIALIZER;
+- (void)accessibilityBridgeDidFinishUpdate;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
@@ -13,6 +13,8 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h"
 
 constexpr int32_t kRootNodeId = 0;
+// This can be arbitrary number as long as it is bigger than 0.
+constexpr float kScrollExtentMaxForInf = 1000;
 
 @class FlutterCustomAccessibilityAction;
 @class FlutterPlatformViewSemanticsContainer;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -9,6 +9,8 @@
 
 namespace {
 
+constexpr float kScrollExtentMaxForInf = 1000;
+
 flutter::SemanticsAction GetSemanticsActionForScrollDirection(
     UIAccessibilityScrollDirection direction) {
   // To describe the vertical scroll direction, UIAccessibilityScrollDirection uses the
@@ -198,7 +200,6 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
     self.isAccessibilityElement = YES;
   } else {
     self.isAccessibilityElement = NO;
-    ;
   }
 }
 
@@ -223,17 +224,28 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // private methods
 
 - (CGSize)contentSizeInternal {
-  CGRect result;
   const SkRect& rect = _semanticsObject.node.rect;
+  float x, y, width, height;
+  float scrollExtentMax = _semanticsObject.node.scrollExtentMax == INFINITY
+                              ? kScrollExtentMaxForInf + _semanticsObject.node.scrollPosition
+                              : _semanticsObject.node.scrollExtentMax;
   if (_semanticsObject.node.actions & flutter::kVerticalScrollSemanticsActions) {
-    result = CGRectMake(rect.x(), rect.y(), rect.width(),
-                        rect.height() + _semanticsObject.node.scrollExtentMax);
+    x = rect.x();
+    y = rect.y();
+    width = rect.width();
+    height = rect.height() + scrollExtentMax;
   } else if (_semanticsObject.node.actions & flutter::kHorizontalScrollSemanticsActions) {
-    result = CGRectMake(rect.x(), rect.y(), rect.width() + _semanticsObject.node.scrollExtentMax,
-                        rect.height());
+    x = rect.x();
+    y = rect.y();
+    width = rect.width() + scrollExtentMax;
+    height = rect.height();
   } else {
-    result = CGRectMake(rect.x(), rect.y(), rect.width(), rect.height());
+    x = rect.x();
+    y = rect.y();
+    width = rect.width();
+    height = rect.height();
   }
+  CGRect result = CGRectMake(x, y, width, height);
   return ConvertRectToGlobal(_semanticsObject, result).size;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -9,8 +9,6 @@
 
 namespace {
 
-constexpr float kScrollExtentMaxForInf = 1000;
-
 flutter::SemanticsAction GetSemanticsActionForScrollDirection(
     UIAccessibilityScrollDirection direction) {
   // To describe the vertical scroll direction, UIAccessibilityScrollDirection uses the
@@ -224,28 +222,18 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // private methods
 
 - (CGSize)contentSizeInternal {
+  CGRect result;
   const SkRect& rect = _semanticsObject.node.rect;
-  float x, y, width, height;
-  float scrollExtentMax = _semanticsObject.node.scrollExtentMax == INFINITY
-                              ? kScrollExtentMaxForInf + _semanticsObject.node.scrollPosition
-                              : _semanticsObject.node.scrollExtentMax;
+  float scrollExtentMax = isfinite(_semanticsObject.node.scrollExtentMax)
+                              ? _semanticsObject.node.scrollExtentMax
+                              : kScrollExtentMaxForInf + _semanticsObject.node.scrollPosition;
   if (_semanticsObject.node.actions & flutter::kVerticalScrollSemanticsActions) {
-    x = rect.x();
-    y = rect.y();
-    width = rect.width();
-    height = rect.height() + scrollExtentMax;
+    result = CGRectMake(rect.x(), rect.y(), rect.width(), rect.height() + scrollExtentMax);
   } else if (_semanticsObject.node.actions & flutter::kHorizontalScrollSemanticsActions) {
-    x = rect.x();
-    y = rect.y();
-    width = rect.width() + scrollExtentMax;
-    height = rect.height();
+    result = CGRectMake(rect.x(), rect.y(), rect.width() + scrollExtentMax, rect.height());
   } else {
-    x = rect.x();
-    y = rect.y();
-    width = rect.width();
-    height = rect.height();
+    result = CGRectMake(rect.x(), rect.y(), rect.width(), rect.height());
   }
-  CGRect result = CGRectMake(x, y, width, height);
   return ConvertRectToGlobal(_semanticsObject, result).size;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -10,6 +10,8 @@
 
 FLUTTER_ASSERT_ARC
 
+const CGRect kScreenSize = CGRectMake(0, 0, 600, 800);
+
 namespace flutter {
 namespace {
 
@@ -24,7 +26,11 @@ class SemanticsActionObservation {
 
 class MockAccessibilityBridge : public AccessibilityBridgeIos {
  public:
-  MockAccessibilityBridge() : observations({}) { view_ = [[UIView alloc] init]; }
+  MockAccessibilityBridge() : observations({}) {
+    view_ = [[UIView alloc] initWithFrame:kScreenSize];
+    window_ = [[UIWindow alloc] initWithFrame:kScreenSize];
+    [window_ addSubview:view_];
+  }
   UIView* view() const override { return view_; }
   UIView<UITextInput>* textInputView() override { return nil; }
   void DispatchSemanticsAction(int32_t id, SemanticsAction action) override {
@@ -46,6 +52,7 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
 
  private:
   UIView* view_;
+  UIWindow* window_;
 };
 }  // namespace
 }  // namespace flutter
@@ -158,6 +165,105 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
   FlutterSemanticsObject* object = [[FlutterSemanticsObject alloc] initWithBridge:bridge uid:0];
   [object setSemanticsNode:&node];
   XCTAssertEqual([object accessibilityTraits], UIAccessibilityTraitButton);
+}
+
+- (void)testVerticalFlutterScrollableSemanticsObject {
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+
+  float transformScale = 0.5f;
+  float screenScale = [[bridge->view() window] screen].scale;
+  float effectivelyScale = transformScale / screenScale;
+  float x = 10;
+  float y = 10;
+  float w = 100;
+  float h = 200;
+  float scrollExtentMax = 500.0;
+  float scrollPosition = 150.0;
+
+  flutter::SemanticsNode node;
+  node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kHasImplicitScrolling);
+  node.actions = flutter::kVerticalScrollSemanticsActions;
+  node.rect = SkRect::MakeXYWH(x, y, w, h);
+  node.scrollExtentMax = scrollExtentMax;
+  node.scrollPosition = scrollPosition;
+  node.transform = {
+      transformScale, 0, 0, 0, 0, transformScale, 0, 0, 0, 0, transformScale, 0, 0, 0, 0, 1.0};
+  FlutterSemanticsObject* delegate = [[FlutterSemanticsObject alloc] initWithBridge:bridge uid:0];
+  FlutterScrollableSemanticsObject* scrollable =
+      [[FlutterScrollableSemanticsObject alloc] initWithSemanticsObject:delegate];
+  SemanticsObject* scrollable_object = static_cast<SemanticsObject*>(scrollable);
+  [scrollable_object setSemanticsNode:&node];
+  [scrollable_object accessibilityBridgeDidFinishUpdate];
+  XCTAssertTrue(
+      CGRectEqualToRect(scrollable.frame, CGRectMake(x * effectivelyScale, y * effectivelyScale,
+                                                     w * effectivelyScale, h * effectivelyScale)));
+  XCTAssertTrue(CGSizeEqualToSize(
+      scrollable.contentSize,
+      CGSizeMake(w * effectivelyScale, (h + scrollExtentMax) * effectivelyScale)));
+  XCTAssertTrue(CGPointEqualToPoint(scrollable.contentOffset,
+                                    CGPointMake(0, scrollPosition * effectivelyScale)));
+}
+
+- (void)testHorizontalFlutterScrollableSemanticsObject {
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+
+  float transformScale = 0.5f;
+  float screenScale = [[bridge->view() window] screen].scale;
+  float effectivelyScale = transformScale / screenScale;
+  float x = 10;
+  float y = 10;
+  float w = 100;
+  float h = 200;
+  float scrollExtentMax = 500.0;
+  float scrollPosition = 150.0;
+
+  flutter::SemanticsNode node;
+  node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kHasImplicitScrolling);
+  node.actions = flutter::kHorizontalScrollSemanticsActions;
+  node.rect = SkRect::MakeXYWH(x, y, w, h);
+  node.scrollExtentMax = scrollExtentMax;
+  node.scrollPosition = scrollPosition;
+  node.transform = {
+      transformScale, 0, 0, 0, 0, transformScale, 0, 0, 0, 0, transformScale, 0, 0, 0, 0, 1.0};
+  FlutterSemanticsObject* delegate = [[FlutterSemanticsObject alloc] initWithBridge:bridge uid:0];
+  FlutterScrollableSemanticsObject* scrollable =
+      [[FlutterScrollableSemanticsObject alloc] initWithSemanticsObject:delegate];
+  SemanticsObject* scrollable_object = static_cast<SemanticsObject*>(scrollable);
+  [scrollable_object setSemanticsNode:&node];
+  [scrollable_object accessibilityBridgeDidFinishUpdate];
+  XCTAssertTrue(
+      CGRectEqualToRect(scrollable.frame, CGRectMake(x * effectivelyScale, y * effectivelyScale,
+                                                     w * effectivelyScale, h * effectivelyScale)));
+  XCTAssertTrue(CGSizeEqualToSize(
+      scrollable.contentSize,
+      CGSizeMake((w + scrollExtentMax) * effectivelyScale, h * effectivelyScale)));
+  XCTAssertTrue(CGPointEqualToPoint(scrollable.contentOffset,
+                                    CGPointMake(scrollPosition * effectivelyScale, 0)));
+}
+
+- (void)testFlutterScrollableSemanticsObjectIsNotHittestable {
+  fml::WeakPtrFactory<flutter::AccessibilityBridgeIos> factory(
+      new flutter::MockAccessibilityBridge());
+  fml::WeakPtr<flutter::AccessibilityBridgeIos> bridge = factory.GetWeakPtr();
+
+  flutter::SemanticsNode node;
+  node.flags = static_cast<int32_t>(flutter::SemanticsFlags::kHasImplicitScrolling);
+  node.actions = flutter::kHorizontalScrollSemanticsActions;
+  node.rect = SkRect::MakeXYWH(0, 0, 100, 200);
+  node.scrollExtentMax = 100.0;
+  node.scrollPosition = 0.0;
+
+  FlutterSemanticsObject* delegate = [[FlutterSemanticsObject alloc] initWithBridge:bridge uid:0];
+  FlutterScrollableSemanticsObject* scrollable =
+      [[FlutterScrollableSemanticsObject alloc] initWithSemanticsObject:delegate];
+  SemanticsObject* scrollable_object = static_cast<SemanticsObject*>(scrollable);
+  [scrollable_object setSemanticsNode:&node];
+  [scrollable_object accessibilityBridgeDidFinishUpdate];
+  XCTAssertEqual([scrollable hitTest:CGPointMake(10, 10) withEvent:nil], nil);
 }
 
 - (void)testSemanticsObjectBuildsAttributedString {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
@@ -279,7 +279,8 @@ class MockAccessibilityBridge : public AccessibilityBridgeIos {
                                                      w * effectivelyScale, h * effectivelyScale)));
   XCTAssertTrue(CGSizeEqualToSize(
       scrollable.contentSize,
-      CGSizeMake(w * effectivelyScale, (h + 1000 + scrollPosition) * effectivelyScale)));
+      CGSizeMake(w * effectivelyScale,
+                 (h + kScrollExtentMaxForInf + scrollPosition) * effectivelyScale)));
   XCTAssertTrue(CGPointEqualToPoint(scrollable.contentOffset,
                                     CGPointMake(0, scrollPosition * effectivelyScale)));
 }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -200,10 +200,15 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     view_controller_.view.accessibilityElements = nil;
   }
 
-  NSMutableArray<NSNumber*>* doomed_uids = [NSMutableArray arrayWithArray:[objects_.get() allKeys]];
-  if (root)
+  NSMutableArray<NSNumber*>* doomed_uids = [NSMutableArray arrayWithArray:[objects_ allKeys]];
+  if (root) {
     VisitObjectsRecursivelyAndRemove(root, doomed_uids);
+  }
   [objects_ removeObjectsForKeys:doomed_uids];
+
+  for (SemanticsObject* object in [objects_ allValues]) {
+    [object accessibilityBridgeDidFinishUpdate];
+  }
 
   if (!ios_delegate_->IsFlutterViewControllerPresentingModalViewController(view_controller_)) {
     layoutChanged = layoutChanged || [doomed_uids count] > 0;
@@ -258,6 +263,11 @@ static SemanticsObject* CreateObject(const flutter::SemanticsNode& node,
   } else if (node.HasFlag(flutter::SemanticsFlags::kHasToggledState) ||
              node.HasFlag(flutter::SemanticsFlags::kHasCheckedState)) {
     return [[[FlutterSwitchSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
+  } else if (node.HasFlag(flutter::SemanticsFlags::kHasImplicitScrolling)) {
+    SemanticsObject* delegateObject =
+        [[[FlutterSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
+    return (SemanticsObject*)[[[FlutterScrollableSemanticsObject alloc]
+        initWithSemanticsObject:delegateObject] autorelease];
   } else {
     return [[[FlutterSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
   }


### PR DESCRIPTION
Previous pr was reverted due to a internal test failure

the issue was the flutterscrollablesemanticsobject does not handle the case where scrollextent can be infinity. The fix is in the second commit.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
