### PR TITLE
[metal] Remove invalid texture error message

### DIFF
--- a/shell/platform/embedder/embedder_external_texture_metal.mm
+++ b/shell/platform/embedder/embedder_external_texture_metal.mm
@@ -56,8 +56,6 @@ sk_sp<SkImage> EmbedderExternalTextureMetal::ResolveTexture(int64_t texture_id,
       external_texture_callback_(texture_id, size.width(), size.height());
 
   if (!texture) {
-    FML_LOG(ERROR) << "External texture callback for ID " << texture_id
-                   << " did not return a valid texture.";
     return nullptr;
   }
 


### PR DESCRIPTION
Silence error message on invalid texture to be in line with other embedders.

Fixes https://github.com/flutter/flutter/issues/84855

As this is a rather cosmetic change I am not sure if we really need a test for this.

/cc @iskakaushik 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.
