### PR TITLE
[canvaskit] Fix bug where empty scene doesn't overwrite contentful scene

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: bdf2f896cec4fa1589c277a5fbb2c73622924375
+revision: f7a59e1cd4dc3800ded4b3df6f3823ac379df40a

--- a/lib/web_ui/lib/src/engine/canvaskit/rasterizer.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/rasterizer.dart
@@ -32,6 +32,8 @@ class Rasterizer {
           SurfaceFactory.instance.baseSurface.acquireFrame(layerTree.frameSize);
       HtmlViewEmbedder.instance.frameSize = layerTree.frameSize;
       final CkCanvas canvas = frame.skiaCanvas;
+      // Clear the canvas before trying to draw to it again.
+      canvas.clear(ui.Color(0x00000000));
       final Frame compositorFrame =
           context.acquireFrame(canvas, HtmlViewEmbedder.instance);
 

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -781,6 +781,31 @@ void testMain() {
             'საბეჭდი და ტიპოგრაფიული ინდუსტრიის უშინაარსო ტექსტია ',
       );
     });
+
+    // Make sure we clear the canvas in between frames.
+    test('empty frame after contentful frame', () async {
+      // First draw a frame with a red rectangle
+      final CkPictureRecorder recorder = CkPictureRecorder();
+      final CkCanvas canvas = recorder.beginRecording(ui.Rect.largest);
+      canvas.drawRect(ui.Rect.fromLTRB(20, 20, 100, 100),
+          CkPaint()..color = ui.Color(0xffff0000));
+      final CkPicture picture = recorder.endRecording();
+      final LayerSceneBuilder builder = LayerSceneBuilder();
+      builder.pushOffset(0, 0);
+      builder.addPicture(ui.Offset.zero, picture);
+      final LayerTree layerTree = builder.build().layerTree;
+      EnginePlatformDispatcher.instance.rasterizer!.draw(layerTree);
+
+      // Now draw an empty layer tree and confirm that the red rectangle is
+      // no longer drawn.
+      final LayerSceneBuilder emptySceneBuilder = LayerSceneBuilder();
+      emptySceneBuilder.pushOffset(0, 0);
+      final LayerTree emptyLayerTree = emptySceneBuilder.build().layerTree;
+      EnginePlatformDispatcher.instance.rasterizer!.draw(emptyLayerTree);
+
+      await matchGoldenFile('canvaskit_empty_scene.png',
+          region: ui.Rect.fromLTRB(0, 0, 100, 100), write: true);
+    });
     // TODO: https://github.com/flutter/flutter/issues/60040
     // TODO: https://github.com/flutter/flutter/issues/71520
   }, skip: isIosSafari || isFirefox);

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -804,7 +804,7 @@ void testMain() {
       EnginePlatformDispatcher.instance.rasterizer!.draw(emptyLayerTree);
 
       await matchGoldenFile('canvaskit_empty_scene.png',
-          region: ui.Rect.fromLTRB(0, 0, 100, 100), write: true);
+          region: ui.Rect.fromLTRB(0, 0, 100, 100));
     });
     // TODO: https://github.com/flutter/flutter/issues/60040
     // TODO: https://github.com/flutter/flutter/issues/71520


### PR DESCRIPTION
If we had previously drawn a scene, and then tried to draw an empty scene, the old scene wasn't overwritten. This PR fixes that.

Fixes https://github.com/flutter/flutter/issues/84624

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
