### PR TITLE
Remove built-in shadows from the @Config annotation

### DIFF
--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -55,12 +55,11 @@ import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
 import org.robolectric.shadow.api.Shadow;
-import org.robolectric.shadows.ShadowClipboardManager;
 import org.robolectric.shadows.ShadowInputMethodManager;
 
 @Config(
     manifest = Config.NONE,
-    shadows = {ShadowClipboardManager.class, InputConnectionAdaptorTest.TestImm.class})
+    shadows = {InputConnectionAdaptorTest.TestImm.class})
 @RunWith(RobolectricTestRunner.class)
 public class InputConnectionAdaptorTest {
   @Mock KeyboardManager mockKeyboardManager;

--- a/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/SingleViewPresentationTest.java
@@ -15,13 +15,8 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowDisplay;
-import org.robolectric.shadows.ShadowDisplayManager;
-import org.robolectric.shadows.ShadowInputMethodManager;
 
-@Config(
-    manifest = Config.NONE,
-    shadows = {ShadowInputMethodManager.class, ShadowDisplayManager.class, ShadowDisplay.class})
+@Config(manifest = Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 @TargetApi(28)
 public class SingleViewPresentationTest {


### PR DESCRIPTION
In Robolectric tests it is not necessary to specify built-in shadows in
the @Config annotation parameter. These are implicitly used by
Robolectric.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
- [x] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
