### PR TITLE
Windows: Resize synchronization shouldn't wait for vsync if window is hidden

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -323,7 +323,11 @@ bool AngleSurfaceManager::MakeResourceCurrent() {
 }
 
 EGLBoolean AngleSurfaceManager::SwapBuffers() {
-  return (eglSwapBuffers(egl_display_, render_surface_));
+  if (surface_width_ > 0 && surface_height_ > 0) {
+    return (eglSwapBuffers(egl_display_, render_surface_));
+  } else {
+    return EGL_TRUE;
+  }
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -323,11 +323,7 @@ bool AngleSurfaceManager::MakeResourceCurrent() {
 }
 
 EGLBoolean AngleSurfaceManager::SwapBuffers() {
-  if (surface_width_ > 0 && surface_height_ > 0) {
-    return (eglSwapBuffers(egl_display_, render_surface_));
-  } else {
-    return EGL_TRUE;
-  }
+  return (eglSwapBuffers(egl_display_, render_surface_));
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_window_win32.cc
+++ b/shell/platform/windows/flutter_window_win32.cc
@@ -89,6 +89,10 @@ float FlutterWindowWin32::GetDpiScale() {
   return static_cast<float>(GetCurrentDPI()) / static_cast<float>(base_dpi);
 }
 
+bool FlutterWindowWin32::IsVisible() {
+  return IsWindowVisible(GetWindowHandle());
+}
+
 PhysicalWindowBounds FlutterWindowWin32::GetPhysicalWindowBounds() {
   return {GetCurrentWidth(), GetCurrentHeight()};
 }

--- a/shell/platform/windows/flutter_window_win32.h
+++ b/shell/platform/windows/flutter_window_win32.h
@@ -93,6 +93,9 @@ class FlutterWindowWin32 : public WindowWin32, public WindowBindingHandler {
   float GetDpiScale() override;
 
   // |FlutterWindowBindingHandler|
+  bool IsVisible() override;
+
+  // |FlutterWindowBindingHandler|
   PhysicalWindowBounds GetPhysicalWindowBounds() override;
 
   // |FlutterWindowBindingHandler|

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -156,6 +156,7 @@ class MockFlutterWindowWin32 : public FlutterWindowWin32 {
   MOCK_METHOD2(OnScroll, void(double, double));
   MOCK_METHOD4(DefaultWindowProc, LRESULT(HWND, UINT, WPARAM, LPARAM));
   MOCK_METHOD0(GetDpiScale, float());
+  MOCK_METHOD0(IsVisible, bool());
   MOCK_METHOD1(UpdateCursorRect, void(const Rect&));
 };
 

--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -117,6 +117,10 @@ float FlutterWindowWinUWP::GetDpiScale() {
   return display_helper_->GetDpiScale();
 }
 
+bool FlutterWindowWinUWP::IsVisible() {
+  return window_.Visible();
+}
+
 void FlutterWindowWinUWP::OnDpiChanged(
     winrt::Windows::Graphics::Display::DisplayInformation const& args,
     winrt::Windows::Foundation::IInspectable const&) {

--- a/shell/platform/windows/flutter_window_winuwp.h
+++ b/shell/platform/windows/flutter_window_winuwp.h
@@ -43,6 +43,9 @@ class FlutterWindowWinUWP : public WindowBindingHandler {
   // |WindowBindingHandler|
   float GetDpiScale() override;
 
+  // |FlutterWindowBindingHandler|
+  bool IsVisible() override;
+
   // |WindowBindingHandler|
   PhysicalWindowBounds GetPhysicalWindowBounds() override;
 

--- a/shell/platform/windows/testing/mock_window_binding_handler.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler.h
@@ -27,6 +27,7 @@ class MockWindowBindingHandler : public WindowBindingHandler {
   MOCK_METHOD0(GetRenderTarget, WindowsRenderTarget());
   MOCK_METHOD0(GetPlatformWindow, PlatformWindow());
   MOCK_METHOD0(GetDpiScale, float());
+  MOCK_METHOD0(IsVisible, bool());
   MOCK_METHOD0(OnWindowResized, void());
   MOCK_METHOD0(GetPhysicalWindowBounds, PhysicalWindowBounds());
   MOCK_METHOD1(UpdateFlutterCursor, void(const std::string& cursor_name));

--- a/shell/platform/windows/window_binding_handler.h
+++ b/shell/platform/windows/window_binding_handler.h
@@ -68,6 +68,9 @@ class WindowBindingHandler {
   // Returns the scale factor for the backing window.
   virtual float GetDpiScale() = 0;
 
+  // Returns whether the PlatformWindow is currently visible.
+  virtual bool IsVisible() = 0;
+
   // Returns the bounds of the backing window in physical pixels.
   virtual PhysicalWindowBounds GetPhysicalWindowBounds() = 0;
 


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/84985

Depending on circumstances this change can shave off about 30-40 ms from the time it takes to show new window.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
