### PR TITLE
Reland ios accessibility scrolling support

### DIFF
--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -44,11 +44,16 @@ enum class SemanticsAction : int32_t {
   kSetText = 1 << 21,
 };
 
-const int kScrollableSemanticsActions =
-    static_cast<int32_t>(SemanticsAction::kScrollLeft) |
-    static_cast<int32_t>(SemanticsAction::kScrollRight) |
+const int kVerticalScrollSemanticsActions =
     static_cast<int32_t>(SemanticsAction::kScrollUp) |
     static_cast<int32_t>(SemanticsAction::kScrollDown);
+
+const int kHorizontalScrollSemanticsActions =
+    static_cast<int32_t>(SemanticsAction::kScrollLeft) |
+    static_cast<int32_t>(SemanticsAction::kScrollRight);
+
+const int kScrollableSemanticsActions =
+    kVerticalScrollSemanticsActions | kHorizontalScrollSemanticsActions;
 
 /// C/C++ representation of `SemanticsFlags` defined in
 /// `lib/ui/semantics.dart`.

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
@@ -13,6 +13,8 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h"
 
 constexpr int32_t kRootNodeId = 0;
+// This can be arbitrary number as long as it is bigger than 0.
+constexpr float kScrollExtentMaxForInf = 1000;
 
 @class FlutterCustomAccessibilityAction;
 @class FlutterPlatformViewSemanticsContainer;
@@ -31,7 +33,7 @@ constexpr int32_t kRootNodeId = 0;
  * The parent of this node in the node tree. Will be nil for the root node and
  * during transient state changes.
  */
-@property(nonatomic, readonly) SemanticsObject* parent;
+@property(nonatomic, assign) SemanticsObject* parent;
 
 /**
  * The accessibility bridge that this semantics object is attached to. This
@@ -93,6 +95,14 @@ constexpr int32_t kRootNodeId = 0;
 - (NSString*)routeName;
 
 - (BOOL)onCustomAccessibilityAction:(FlutterCustomAccessibilityAction*)action;
+
+/**
+ * Called after accessibility bridge finishes a semantics update.
+ *
+ * Subclasses can override this method if they contain states that can only be
+ * updated once every node in the accessibility tree has finished updating.
+ */
+- (void)accessibilityBridgeDidFinishUpdate;
 
 #pragma mark - Designated initializers
 
@@ -156,6 +166,18 @@ constexpr int32_t kRootNodeId = 0;
 /// The semantics object for switch buttons. This class creates an UISwitch to interact with the
 /// iOS.
 @interface FlutterSwitchSemanticsObject : SemanticsObject
+
+@end
+
+/// The semantics object for scrollable. This class creates an UIScrollView to interact with the
+/// iOS.
+@interface FlutterScrollableSemanticsObject : UIScrollView
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
+- (instancetype)initWithCoder:(NSCoder*)coder NS_UNAVAILABLE;
+- (instancetype)initWithSemanticsObject:(SemanticsObject*)semanticsObject NS_DESIGNATED_INITIALIZER;
+- (void)accessibilityBridgeDidFinishUpdate;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -34,6 +34,58 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   return flutter::SemanticsAction::kScrollUp;
 }
 
+SkM44 GetGlobalTransform(SemanticsObject* reference) {
+  SkM44 globalTransform = [reference node].transform;
+  for (SemanticsObject* parent = [reference parent]; parent; parent = parent.parent) {
+    globalTransform = parent.node.transform * globalTransform;
+  }
+  return globalTransform;
+}
+
+SkPoint ApplyTransform(SkPoint& point, const SkM44& transform) {
+  SkV4 vector = transform.map(point.x(), point.y(), 0, 1);
+  return SkPoint::Make(vector.x / vector.w, vector.y / vector.w);
+}
+
+CGPoint ConvertPointToGlobal(SemanticsObject* reference, CGPoint local_point) {
+  SkM44 globalTransform = GetGlobalTransform(reference);
+  SkPoint point = SkPoint::Make(local_point.x, local_point.y);
+  point = ApplyTransform(point, globalTransform);
+  // `rect` is in the physical pixel coordinate system. iOS expects the accessibility frame in
+  // the logical pixel coordinate system. Therefore, we divide by the `scale` (pixel ratio) to
+  // convert.
+  CGFloat scale = [[[reference bridge]->view() window] screen].scale;
+  auto result = CGPointMake(point.x() / scale, point.y() / scale);
+  return [[reference bridge]->view() convertPoint:result toView:nil];
+}
+
+CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
+  SkM44 globalTransform = GetGlobalTransform(reference);
+
+  SkPoint quad[4] = {
+      SkPoint::Make(local_rect.origin.x, local_rect.origin.y),                          // top left
+      SkPoint::Make(local_rect.origin.x + local_rect.size.width, local_rect.origin.y),  // top right
+      SkPoint::Make(local_rect.origin.x + local_rect.size.width,
+                    local_rect.origin.y + local_rect.size.height),  // bottom right
+      SkPoint::Make(local_rect.origin.x,
+                    local_rect.origin.y + local_rect.size.height)  // bottom left
+  };
+  for (auto& point : quad) {
+    point = ApplyTransform(point, globalTransform);
+  }
+  SkRect rect;
+  NSCAssert(rect.setBoundsCheck(quad, 4), @"Transformed points can't form a rect");
+  rect.setBounds(quad, 4);
+
+  // `rect` is in the physical pixel coordinate system. iOS expects the accessibility frame in
+  // the logical pixel coordinate system. Therefore, we divide by the `scale` (pixel ratio) to
+  // convert.
+  CGFloat scale = [[[reference bridge]->view() window] screen].scale;
+  auto result =
+      CGRectMake(rect.x() / scale, rect.y() / scale, rect.width() / scale, rect.height() / scale);
+  return UIAccessibilityConvertFrameToScreenCoordinates(result, [reference bridge]->view());
+}
+
 }  // namespace
 
 @implementation FlutterSwitchSemanticsObject {
@@ -87,6 +139,175 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 @end  // FlutterSwitchSemanticsObject
+
+@interface FlutterScrollableSemanticsObject ()
+@property(nonatomic, strong) SemanticsObject* semanticsObject;
+@end
+
+@implementation FlutterScrollableSemanticsObject {
+  fml::scoped_nsobject<SemanticsObjectContainer> _container;
+}
+
+- (instancetype)initWithSemanticsObject:(SemanticsObject*)semanticsObject {
+  self = [super initWithFrame:CGRectZero];
+  if (self) {
+    _semanticsObject = [semanticsObject retain];
+    [semanticsObject.bridge->view() addSubview:self];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  _container.get().semanticsObject = nil;
+  [_semanticsObject release];
+  [self removeFromSuperview];
+  [super dealloc];
+}
+
+- (UIView*)hitTest:(CGPoint)point withEvent:(UIEvent*)event {
+  return nil;
+}
+
+- (NSMethodSignature*)methodSignatureForSelector:(SEL)sel {
+  NSMethodSignature* result = [super methodSignatureForSelector:sel];
+  if (!result) {
+    result = [_semanticsObject methodSignatureForSelector:sel];
+  }
+  return result;
+}
+
+- (void)forwardInvocation:(NSInvocation*)anInvocation {
+  [anInvocation setTarget:_semanticsObject];
+  [anInvocation invoke];
+}
+
+- (void)accessibilityBridgeDidFinishUpdate {
+  // In order to make iOS think this UIScrollView is scrollable, the following
+  // requirements must be true.
+  // 1. contentSize must be bigger than the frame size.
+  // 2. The scrollable isAccessibilityElement must return YES
+  //
+  // Once the requirements are met, the iOS uses contentOffset to determine
+  // what scroll actions are available. e.g. If the view scrolls vertically and
+  // contentOffset is 0.0, only the scroll down action is available.
+  [self setFrame:[_semanticsObject accessibilityFrame]];
+  [self setContentSize:[self contentSizeInternal]];
+  [self setContentOffset:[self contentOffsetInternal] animated:NO];
+  if (self.contentSize.width > self.frame.size.width ||
+      self.contentSize.height > self.frame.size.height) {
+    self.isAccessibilityElement = YES;
+  } else {
+    self.isAccessibilityElement = NO;
+  }
+}
+
+- (void)setChildren:(NSArray<SemanticsObject*>*)children {
+  [_semanticsObject setChildren:children];
+  // The children's parent is pointing to _semanticsObject, need to manually
+  // set it this object.
+  for (SemanticsObject* child in _semanticsObject.children) {
+    child.parent = (SemanticsObject*)self;
+  }
+}
+
+- (id)accessibilityContainer {
+  if (_container == nil) {
+    _container.reset([[SemanticsObjectContainer alloc]
+        initWithSemanticsObject:(SemanticsObject*)self
+                         bridge:[_semanticsObject bridge]]);
+  }
+  return _container.get();
+}
+
+// private methods
+
+- (float)scrollExtentMax {
+  if (![_semanticsObject isAccessibilityBridgeAlive]) {
+    return 0.0f;
+  }
+  float scrollExtentMax = _semanticsObject.node.scrollExtentMax;
+  if (isnan(scrollExtentMax)) {
+    scrollExtentMax = 0.0f;
+  } else if (!isfinite(scrollExtentMax)) {
+    scrollExtentMax = kScrollExtentMaxForInf + [self scrollPosition];
+  }
+  return scrollExtentMax;
+}
+
+- (float)scrollPosition {
+  if (![_semanticsObject isAccessibilityBridgeAlive]) {
+    return 0.0f;
+  }
+  float scrollPosition = _semanticsObject.node.scrollPosition;
+  if (isnan(scrollPosition)) {
+    scrollPosition = 0.0f;
+  }
+  NSCAssert(isfinite(scrollPosition), @"The scrollPosition must not be infinity");
+  return scrollPosition;
+}
+
+- (CGSize)contentSizeInternal {
+  CGRect result;
+  const SkRect& rect = _semanticsObject.node.rect;
+
+  if (_semanticsObject.node.actions & flutter::kVerticalScrollSemanticsActions) {
+    result = CGRectMake(rect.x(), rect.y(), rect.width(), rect.height() + [self scrollExtentMax]);
+  } else if (_semanticsObject.node.actions & flutter::kHorizontalScrollSemanticsActions) {
+    result = CGRectMake(rect.x(), rect.y(), rect.width() + [self scrollExtentMax], rect.height());
+  } else {
+    result = CGRectMake(rect.x(), rect.y(), rect.width(), rect.height());
+  }
+  return ConvertRectToGlobal(_semanticsObject, result).size;
+}
+
+- (CGPoint)contentOffsetInternal {
+  CGPoint result;
+  CGPoint origin = self.frame.origin;
+  const SkRect& rect = _semanticsObject.node.rect;
+  if (_semanticsObject.node.actions & flutter::kVerticalScrollSemanticsActions) {
+    result = ConvertPointToGlobal(_semanticsObject,
+                                  CGPointMake(rect.x(), rect.y() + [self scrollPosition]));
+  } else if (_semanticsObject.node.actions & flutter::kHorizontalScrollSemanticsActions) {
+    result = ConvertPointToGlobal(_semanticsObject,
+                                  CGPointMake(rect.x() + [self scrollPosition], rect.y()));
+  } else {
+    result = origin;
+  }
+  return CGPointMake(result.x - origin.x, result.y - origin.y);
+}
+
+// The following methods are explicitly forwarded to the wrapped SemanticsObject because the
+// forwarding logic above doesn't apply to them since they are also implemented in the
+// UIScrollView class, the base class.
+
+- (BOOL)accessibilityActivate {
+  return [_semanticsObject accessibilityActivate];
+}
+
+- (void)accessibilityIncrement {
+  [_semanticsObject accessibilityIncrement];
+}
+
+- (void)accessibilityDecrement {
+  [_semanticsObject accessibilityDecrement];
+}
+
+- (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
+  return [_semanticsObject accessibilityScroll:direction];
+}
+
+- (BOOL)accessibilityPerformEscape {
+  return [_semanticsObject accessibilityPerformEscape];
+}
+
+- (void)accessibilityElementDidBecomeFocused {
+  [_semanticsObject accessibilityElementDidBecomeFocused];
+}
+
+- (void)accessibilityElementDidLoseFocus {
+  [_semanticsObject accessibilityElementDidLoseFocus];
+}
+@end  // FlutterScrollableSemanticsObject
 
 @implementation FlutterCustomAccessibilityAction {
 }
@@ -172,6 +393,9 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 
 - (void)setSemanticsNode:(const flutter::SemanticsNode*)node {
   _node = *node;
+}
+
+- (void)accessibilityBridgeDidFinishUpdate { /* Do nothing by default */
 }
 
 /**
@@ -398,27 +622,9 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (CGRect)globalRect {
-  SkM44 globalTransform = [self node].transform;
-  for (SemanticsObject* parent = [self parent]; parent; parent = parent.parent) {
-    globalTransform = parent.node.transform * globalTransform;
-  }
-
-  SkPoint quad[4];
-  [self node].rect.toQuad(quad);
-  for (auto& point : quad) {
-    SkV4 vector = globalTransform.map(point.x(), point.y(), 0, 1);
-    point.set(vector.x / vector.w, vector.y / vector.w);
-  }
-  SkRect rect;
-  rect.setBounds(quad, 4);
-
-  // `rect` is in the physical pixel coordinate system. iOS expects the accessibility frame in
-  // the logical pixel coordinate system. Therefore, we divide by the `scale` (pixel ratio) to
-  // convert.
-  CGFloat scale = [[[self bridge]->view() window] screen].scale;
-  auto result =
-      CGRectMake(rect.x() / scale, rect.y() / scale, rect.width() / scale, rect.height() / scale);
-  return UIAccessibilityConvertFrameToScreenCoordinates(result, [self bridge]->view());
+  const SkRect& rect = [self node].rect;
+  CGRect localRect = CGRectMake(rect.x(), rect.y(), rect.width(), rect.height());
+  return ConvertRectToGlobal(self, localRect);
 }
 
 #pragma mark - UIAccessibilityElement protocol

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -200,10 +200,15 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     view_controller_.view.accessibilityElements = nil;
   }
 
-  NSMutableArray<NSNumber*>* doomed_uids = [NSMutableArray arrayWithArray:[objects_.get() allKeys]];
-  if (root)
+  NSMutableArray<NSNumber*>* doomed_uids = [NSMutableArray arrayWithArray:[objects_ allKeys]];
+  if (root) {
     VisitObjectsRecursivelyAndRemove(root, doomed_uids);
+  }
   [objects_ removeObjectsForKeys:doomed_uids];
+
+  for (SemanticsObject* object in [objects_ allValues]) {
+    [object accessibilityBridgeDidFinishUpdate];
+  }
 
   if (!ios_delegate_->IsFlutterViewControllerPresentingModalViewController(view_controller_)) {
     layoutChanged = layoutChanged || [doomed_uids count] > 0;
@@ -258,6 +263,11 @@ static SemanticsObject* CreateObject(const flutter::SemanticsNode& node,
   } else if (node.HasFlag(flutter::SemanticsFlags::kHasToggledState) ||
              node.HasFlag(flutter::SemanticsFlags::kHasCheckedState)) {
     return [[[FlutterSwitchSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
+  } else if (node.HasFlag(flutter::SemanticsFlags::kHasImplicitScrolling)) {
+    SemanticsObject* delegateObject =
+        [[[FlutterSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
+    return (SemanticsObject*)[[[FlutterScrollableSemanticsObject alloc]
+        initWithSemanticsObject:delegateObject] autorelease];
   } else {
     return [[[FlutterSemanticsObject alloc] initWithBridge:weak_ptr uid:node.id] autorelease];
   }


### PR DESCRIPTION
The previous pr is causing internal test failure. The issue is due to the scroll extend and scroll position can be NaN.
The fix is in the second commit

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
