### PR TITLE
Remove usages of --no-causal-async-stacks

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -255,13 +255,11 @@ compile_platform("strong_platform") {
 
   is_runtime_mode_release =
       flutter_runtime_mode == "release" || flutter_runtime_mode == "jit_release"
-  allow_causal_async_stacks = !is_runtime_mode_release
   args = [
     "--enable-experiment=non-nullable",
     "--nnbd-agnostic",
     "--target=flutter",
     "-Ddart.vm.product=$is_runtime_mode_release",
-    "-Ddart.developer.causal_async_stacks=$allow_causal_async_stacks",
     "-Ddart.isVM=true",
     "dart:core",
   ]

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -60,7 +60,6 @@ static const char* kDartLanguageArgs[] = {
     // clang-format off
     "--enable_mirrors=false",
     "--background_compilation",
-    "--no-causal_async_stacks",
     "--lazy_async_stacks",
     // clang-format on
 };

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -457,7 +457,6 @@ TEST_F(ShellTest, AllowedDartVMFlag) {
       "--enable-isolate-groups",
       "--no-enable-isolate-groups",
       "--lazy_async_stacks",
-      "--no-causal_async_stacks",
   };
 #if !FLUTTER_RELEASE
   flags.push_back("--max_profile_depth 1");

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -43,7 +43,6 @@ struct SwitchDesc {
 static const std::string gAllowedDartFlags[] = {
     "--enable-isolate-groups",
     "--no-enable-isolate-groups",
-    "--no-causal_async_stacks",
     "--lazy_async_stacks",
 };
 // clang-format on
@@ -58,7 +57,6 @@ static const std::string gAllowedDartFlags[] = {
     "--enable-service-port-fallback",
     "--lazy_async_stacks",
     "--max_profile_depth",
-    "--no-causal_async_stacks",
     "--profile_period",
     "--random_seed",
     "--sample-buffer-duration",

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -36,7 +36,6 @@ namespace {
 
 const char* kDartVMArgs[] = {
     // clang-format off
-    "--no_causal_async_stacks",
     "--lazy_async_stacks",
 
     "--systrace_timeline",

--- a/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
@@ -46,7 +46,6 @@ template("create_aot_snapshot") {
     }
 
     args = [
-      "--no_causal_async_stacks",
       "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=vm-aot-assembly",

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -63,7 +63,6 @@ template("create_kernel_core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
-      "--no_causal_async_stacks",
       "--lazy_async_stacks",
       "--enable_mirrors=false",
       "--deterministic",

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -57,7 +57,6 @@ template("aot_snapshot") {
     }
 
     args = [
-      "--no_causal_async_stacks",
       "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -505,7 +505,7 @@ Application::Application(
     std::cout << message << std::endl;
   };
 
-  settings_.dart_flags = {"--no_causal_async_stacks", "--lazy_async_stacks"};
+  settings_.dart_flags = {"--lazy_async_stacks"};
 
   // Don't collect CPU samples from Dart VM C++ code.
   settings_.dart_flags.push_back("--no_profile_vm");

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -67,7 +67,6 @@ template("core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
-      "--no_causal_async_stacks",
       "--lazy_async_stacks",
       "--enable_mirrors=false",
       "--deterministic",

--- a/testing/scenario_app/compile_android_jit.sh
+++ b/testing/scenario_app/compile_android_jit.sh
@@ -85,7 +85,6 @@ echo "Compiling JIT Snapshot..."
 
 "$GEN_SNAPSHOT" --deterministic \
   --enable-asserts \
-  --no-causal_async_stacks \
   --lazy_async_stacks \
   --isolate_snapshot_instructions="$OUTDIR/isolate_snapshot_instr" \
   --snapshot_kind=app-jit \

--- a/testing/scenario_app/compile_ios_jit.sh
+++ b/testing/scenario_app/compile_ios_jit.sh
@@ -74,7 +74,6 @@ echo "Compiling JIT Snapshot..."
 
 "$DEVICE_TOOLS/gen_snapshot" --deterministic \
   --enable-asserts \
-  --no-causal_async_stacks \
   --lazy_async_stacks \
   --isolate_snapshot_instructions="$OUTDIR/isolate_snapshot_instr" \
   --snapshot_kind=app-jit \

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -136,7 +136,6 @@ template("dart_snapshot_aot") {
     outputs = [ elf_object ]
 
     args = [
-      "--no-causal_async_stacks",
       "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",


### PR DESCRIPTION
Passing the --causal-async-stacks flag to the VM will cause it to error
on VM startup. The VM will remove the flag entirely, but before doing so
we'll have to remove usages of the negated version of the flag, namely
--no-causal-async-stacks.