### PR TITLE
fix javadoc

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -599,6 +599,8 @@ action("gen_android_javadoc") {
     "--third-party",
     rebase_path("//third_party"),
   ]
+
+  deps = [ ":gen_android_build_config_java" ]
 }
 
 zip_bundle("android_javadoc") {

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -597,6 +597,7 @@ action("gen_android_javadoc") {
     rebase_path(target_gen_dir),
     "--third-party",
     rebase_path("//third_party"),
+    "--quiet",
   ]
 
   deps = [ ":gen_android_build_config_java" ]

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -569,6 +569,7 @@ zip_bundle("android") {
   deps = [
     ":android_jar",
     ":android_symbols",
+    ":android_javadoc",
   ]
 
   if (current_cpu == "x86" || current_cpu == "x64") {
@@ -582,8 +583,6 @@ zip_bundle("android") {
   }
 }
 
-# TODO(dnfield): make these targets pass.
-# https://github.com/flutter/flutter/issues/42400
 action("gen_android_javadoc") {
   script = "//flutter/tools/gen_javadoc.py"
   sources = android_java_sources + embedding_dependencies_jars

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -568,8 +568,8 @@ zip_bundle("android") {
 
   deps = [
     ":android_jar",
-    ":android_symbols",
     ":android_javadoc",
+    ":android_symbols",
   ]
 
   if (current_cpu == "x86" || current_cpu == "x64") {

--- a/shell/platform/android/io/flutter/FlutterInjector.java
+++ b/shell/platform/android/io/flutter/FlutterInjector.java
@@ -78,7 +78,10 @@ public final class FlutterInjector {
   private DeferredComponentManager deferredComponentManager;
   private FlutterJNI.Factory flutterJniFactory;
 
-  /** Returns the {@link io.flutter.embedding.engine.loader.FlutterLoader} instance to use for the Flutter Android engine embedding. */
+  /**
+   * Returns the {@link io.flutter.embedding.engine.loader.FlutterLoader} instance to use for the
+   * Flutter Android engine embedding.
+   */
   @NonNull
   public FlutterLoader flutterLoader() {
     return flutterLoader;

--- a/shell/platform/android/io/flutter/FlutterInjector.java
+++ b/shell/platform/android/io/flutter/FlutterInjector.java
@@ -78,7 +78,7 @@ public final class FlutterInjector {
   private DeferredComponentManager deferredComponentManager;
   private FlutterJNI.Factory flutterJniFactory;
 
-  /** Returns the {@link FlutterLoader} instance to use for the Flutter Android engine embedding. */
+  /** Returns the {@link io.flutter.embedding.engine.loader.FlutterLoader} instance to use for the Flutter Android engine embedding. */
   @NonNull
   public FlutterLoader flutterLoader() {
     return flutterLoader;
@@ -109,7 +109,7 @@ public final class FlutterInjector {
     private DeferredComponentManager deferredComponentManager;
     private FlutterJNI.Factory flutterJniFactory;
     /**
-     * Sets a {@link FlutterLoader} override.
+     * Sets a {@link io.flutter.embedding.engine.loader.FlutterLoader} override.
      *
      * <p>A reasonable default will be used if unspecified.
      */

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -35,8 +35,8 @@ import io.flutter.view.FlutterView;
 import java.util.ArrayList;
 
 /**
- * Deprecated class that performs the actual work of tying Android {@link android.app.Activity} instances to
- * Flutter.
+ * Deprecated class that performs the actual work of tying Android {@link android.app.Activity}
+ * instances to Flutter.
  *
  * <p>This exists as a dedicated class (as opposed to being integrated directly into {@link
  * FlutterActivity}) to facilitate applications that don't wish to subclass {@code FlutterActivity}.

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -35,7 +35,7 @@ import io.flutter.view.FlutterView;
 import java.util.ArrayList;
 
 /**
- * Deprecated class that performs the actual work of tying Android {@link Activity} instances to
+ * Deprecated class that performs the actual work of tying Android {@link android.app.Activity} instances to
  * Flutter.
  *
  * <p>This exists as a dedicated class (as opposed to being integrated directly into {@link
@@ -84,6 +84,8 @@ public final class FlutterActivityDelegate
     /**
      * Hook for subclasses to indicate that the {@code FlutterNativeView} returned by {@link
      * #createFlutterNativeView()} should not be destroyed when this activity is destroyed.
+     *
+     * @return Whether the FlutterNativeView is retained.
      */
     boolean retainFlutterNativeView();
   }

--- a/shell/platform/android/io/flutter/embedding/android/DrawableSplashScreen.java
+++ b/shell/platform/android/io/flutter/embedding/android/DrawableSplashScreen.java
@@ -39,8 +39,8 @@ public final class DrawableSplashScreen implements SplashScreen {
    * <p>
    *
    * @param drawable The {@code Drawable} to be displayed as a splash screen.
-   * @param scaleType The {@link android.widget.ImageView.ScaleType} to be applied to the {@code Drawable} when the
-   *     {@code Drawable} is displayed full-screen.
+   * @param scaleType The {@link android.widget.ImageView.ScaleType} to be applied to the {@code
+   *     Drawable} when the {@code Drawable} is displayed full-screen.
    */
   public DrawableSplashScreen(
       @NonNull Drawable drawable,

--- a/shell/platform/android/io/flutter/embedding/android/DrawableSplashScreen.java
+++ b/shell/platform/android/io/flutter/embedding/android/DrawableSplashScreen.java
@@ -39,7 +39,7 @@ public final class DrawableSplashScreen implements SplashScreen {
    * <p>
    *
    * @param drawable The {@code Drawable} to be displayed as a splash screen.
-   * @param scaleType The {@link ImageView.ScaleType} to be applied to the {@code Drawable} when the
+   * @param scaleType The {@link android.widget.ImageView.ScaleType} to be applied to the {@code Drawable} when the
    *     {@code Drawable} is displayed full-screen.
    */
   public DrawableSplashScreen(

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -976,7 +976,7 @@ public class FlutterActivity extends Activity
    * shouldAttachEngineToActivity} is true, then this {@code FlutterActivity} will connect its {@link
    * io.flutter.embedding.engine.FlutterEngine} to itself, along with any plugins that are
    * registered with that {@link io.flutter.embedding.engine.FlutterEngine}. This allows plugins to
-   * access the {@code Activity}, as well as receive {@code Activity}-specific calls, e.g., {@link
+   * access the {@code Activity}, as well as receive {@code Activity}-specific calls, e.g. {@link
    * Activity#onNewIntent(Intent)}. If {@code shouldAttachEngineToActivity} is false, then this
    * {@code FlutterActivity} will not automatically manage the connection between its {@link
    * FlutterEngine} and itself. In this case, plugins will not be offered a reference to an {@code

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -973,7 +973,7 @@ public class FlutterActivity extends Activity
    *
    * <p>Control surfaces are used to provide Android resources and lifecycle events to plugins that
    * are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code
-   * shouldAttachEngineToActivity} is true then this {@code FlutterActivity} will connect its {@link
+   * shouldAttachEngineToActivity} is true, then this {@code FlutterActivity} will connect its {@link
    * io.flutter.embedding.engine.FlutterEngine} to itself, along with any plugins that are
    * registered with that {@link io.flutter.embedding.engine.FlutterEngine}. This allows plugins to
    * access the {@code Activity}, as well as receive {@code Activity}-specific calls, e.g., {@link

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -973,8 +973,8 @@ public class FlutterActivity extends Activity
    *
    * <p>Control surfaces are used to provide Android resources and lifecycle events to plugins that
    * are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code
-   * shouldAttachEngineToActivity} is true, then this {@code FlutterActivity} will connect its {@link
-   * io.flutter.embedding.engine.FlutterEngine} to itself, along with any plugins that are
+   * shouldAttachEngineToActivity} is true, then this {@code FlutterActivity} will connect its
+   * {@link io.flutter.embedding.engine.FlutterEngine} to itself, along with any plugins that are
    * registered with that {@link io.flutter.embedding.engine.FlutterEngine}. This allows plugins to
    * access the {@code Activity}, as well as receive {@code Activity}-specific calls, e.g. {@link
    * Activity#onNewIntent(Intent)}. If {@code shouldAttachEngineToActivity} is false, then this

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -63,7 +63,7 @@ import io.flutter.plugin.platform.PlatformPlugin;
  *   <li>Chooses the Dart execution app bundle path and entrypoint.
  *   <li>Chooses Flutter's initial route.
  *   <li>Renders {@code Activity} transparently, if desired.
- *   <li>Offers hooks for subclasses to provide and configure a {@link FlutterEngine}.
+ *   <li>Offers hooks for subclasses to provide and configure a {@link io.flutter.embedding.engine.FlutterEngine}.
  *   <li>Save and restore instance state, see {@code #shouldRestoreAndSaveState()};
  * </ul>
  *
@@ -96,36 +96,36 @@ import io.flutter.plugin.platform.PlatformPlugin;
  *
  * <p><strong>Using a cached FlutterEngine</strong>
  *
- * <p>{@code FlutterActivity} can be used with a cached {@link FlutterEngine} instead of creating a
+ * <p>{@code FlutterActivity} can be used with a cached {@link io.flutter.embedding.engine.FlutterEngine} instead of creating a
  * new one. Use {@link #withCachedEngine(String)} to build a {@code FlutterActivity} {@code Intent}
- * that is configured to use an existing, cached {@link FlutterEngine}. {@link
+ * that is configured to use an existing, cached {@link io.flutter.embedding.engine.FlutterEngine}. {@link
  * io.flutter.embedding.engine.FlutterEngineCache} is the cache that is used to obtain a given
- * cached {@link FlutterEngine}. You must create and put a {@link FlutterEngine} into the {@link
+ * cached {@link io.flutter.embedding.engine.FlutterEngine}. You must create and put a {@link io.flutter.embedding.engine.FlutterEngine} into the {@link
  * io.flutter.embedding.engine.FlutterEngineCache} yourself before using the {@link
  * #withCachedEngine(String)} builder. An {@code IllegalStateException} will be thrown if a cached
  * engine is requested but does not exist in the cache.
  *
- * <p>When using a cached {@link FlutterEngine}, that {@link FlutterEngine} should already be
+ * <p>When using a cached {@link io.flutter.embedding.engine.FlutterEngine}, that {@link io.flutter.embedding.engine.FlutterEngine} should already be
  * executing Dart code, which means that the Dart entrypoint and initial route have already been
  * defined. Therefore, {@link CachedEngineIntentBuilder} does not offer configuration of these
  * properties.
  *
- * <p>It is generally recommended to use a cached {@link FlutterEngine} to avoid a momentary delay
- * when initializing a new {@link FlutterEngine}. The two exceptions to using a cached {@link
+ * <p>It is generally recommended to use a cached {@link io.flutter.embedding.engine.FlutterEngine} to avoid a momentary delay
+ * when initializing a new {@link io.flutter.embedding.engine.FlutterEngine}. The two exceptions to using a cached {@link
  * FlutterEngine} are:
  *
  * <p>
  *
  * <ul>
  *   <li>When {@code FlutterActivity} is the first {@code Activity} displayed by the app, because
- *       pre-warming a {@link FlutterEngine} would have no impact in this situation.
+ *       pre-warming a {@link io.flutter.embedding.engine.FlutterEngine} would have no impact in this situation.
  *   <li>When you are unsure when/if you will need to display a Flutter experience.
  * </ul>
  *
  * <p>See https://flutter.dev/docs/development/add-to-app/performance for additional performance
  * explorations on engine loading.
  *
- * <p>The following illustrates how to pre-warm and cache a {@link FlutterEngine}:
+ * <p>The following illustrates how to pre-warm and cache a {@link io.flutter.embedding.engine.FlutterEngine}:
  *
  * <pre>{@code
  * // Create and pre-warm a FlutterEngine.
@@ -207,7 +207,7 @@ public class FlutterActivity extends Activity
    * Flutter's initial route.
    *
    * <p>Consider using the {@link #withCachedEngine(String)} {@link Intent} builder to control when
-   * the {@link FlutterEngine} should be created in your application.
+   * the {@link io.flutter.embedding.engine.FlutterEngine} should be created in your application.
    */
   @NonNull
   public static Intent createDefaultIntent(@NonNull Context launchContext) {
@@ -216,7 +216,7 @@ public class FlutterActivity extends Activity
 
   /**
    * Creates an {@link NewEngineIntentBuilder}, which can be used to configure an {@link Intent} to
-   * launch a {@code FlutterActivity} that internally creates a new {@link FlutterEngine} using the
+   * launch a {@code FlutterActivity} that internally creates a new {@link io.flutter.embedding.engine.FlutterEngine} using the
    * desired Dart entrypoint, initial route, etc.
    */
   @NonNull
@@ -294,7 +294,7 @@ public class FlutterActivity extends Activity
 
   /**
    * Creates a {@link CachedEngineIntentBuilder}, which can be used to configure an {@link Intent}
-   * to launch a {@code FlutterActivity} that internally uses an existing {@link FlutterEngine} that
+   * to launch a {@code FlutterActivity} that internally uses an existing {@link io.flutter.embedding.engine.FlutterEngine} that
    * is cached in {@link io.flutter.embedding.engine.FlutterEngineCache}.
    */
   public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {
@@ -303,7 +303,7 @@ public class FlutterActivity extends Activity
 
   /**
    * Builder to create an {@code Intent} that launches a {@code FlutterActivity} with an existing
-   * {@link FlutterEngine} that is cached in {@link io.flutter.embedding.engine.FlutterEngineCache}.
+   * {@link io.flutter.embedding.engine.FlutterEngine} that is cached in {@link io.flutter.embedding.engine.FlutterEngineCache}.
    */
   public static class CachedEngineIntentBuilder {
     private final Class<? extends FlutterActivity> activityClass;
@@ -316,7 +316,7 @@ public class FlutterActivity extends Activity
      * {@code FlutterActivity}.
      *
      * <p>Subclasses of {@code FlutterActivity} should provide their own static version of {@link
-     * #withCachedEngine()}, which returns an instance of {@code CachedEngineIntentBuilder}
+     * FlutterActivity#withCachedEngine(String)}, which returns an instance of {@code CachedEngineIntentBuilder}
      * constructed with a {@code Class} reference to the {@code FlutterActivity} subclass, e.g.:
      *
      * <p>{@code return new CachedEngineIntentBuilder(MyFlutterActivity.class, engineId); }
@@ -328,7 +328,7 @@ public class FlutterActivity extends Activity
     }
 
     /**
-     * Returns true if the cached {@link FlutterEngine} should be destroyed and removed from the
+     * Returns true if the cached {@link io.flutter.embedding.engine.FlutterEngine} should be destroyed and removed from the
      * cache when this {@code FlutterActivity} is destroyed.
      *
      * <p>The default value is {@code false}.
@@ -581,7 +581,7 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Irreversibly release this activity's control of the {@link FlutterEngine} and its
+   * Irreversibly release this activity's control of the {@link io.flutter.embedding.engine.FlutterEngine} and its
    * subcomponents.
    *
    * <p>Calling will disconnect this activity's view from the Flutter renderer, disconnect this
@@ -709,9 +709,9 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Returns the ID of a statically cached {@link FlutterEngine} to use within this {@code
+   * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use within this {@code
    * FlutterActivity}, or {@code null} if this {@code FlutterActivity} does not want to use a cached
-   * {@link FlutterEngine}.
+   * {@link io.flutter.embedding.engine.FlutterEngine}.
    */
   @Override
   @Nullable
@@ -720,12 +720,12 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Returns false if the {@link FlutterEngine} backing this {@code FlutterActivity} should outlive
+   * Returns false if the {@link io.flutter.embedding.engine.FlutterEngine} backing this {@code FlutterActivity} should outlive
    * this {@code FlutterActivity}, or true to be destroyed when the {@code FlutterActivity} is
    * destroyed.
    *
    * <p>The default value is {@code true} in cases where {@code FlutterActivity} created its own
-   * {@link FlutterEngine}, and {@code false} in cases where a cached {@link FlutterEngine} was
+   * {@link io.flutter.embedding.engine.FlutterEngine}, and {@code false} in cases where a cached {@link io.flutter.embedding.engine.FlutterEngine} was
    * provided.
    */
   @Override
@@ -810,7 +810,7 @@ public class FlutterActivity extends Activity
    * the launching {@code Intent}, that data String is interpreted as an app bundle path.
    *
    * <p>When otherwise unspecified, the value is null, which defaults to the app bundle path defined
-   * in {@link FlutterLoader#findAppBundlePath()}.
+   * in {@link io.flutter.embedding.engine.loader.FlutterLoader#findAppBundlePath()}.
    *
    * <p>Subclasses may override this method to return a custom app bundle path.
    */
@@ -877,9 +877,9 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Hook for subclasses to easily provide a custom {@link FlutterEngine}.
+   * Hook for subclasses to easily provide a custom {@link io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>This hook is where a cached {@link FlutterEngine} should be provided, if a cached {@link
+   * <p>This hook is where a cached {@link io.flutter.embedding.engine.FlutterEngine} should be provided, if a cached {@link
    * FlutterEngine} is desired.
    */
   @Nullable
@@ -890,7 +890,7 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Hook for subclasses to obtain a reference to the {@link FlutterEngine} that is owned by this
+   * Hook for subclasses to obtain a reference to the {@link io.flutter.embedding.engine.FlutterEngine} that is owned by this
    * {@code FlutterActivity}.
    */
   @Nullable
@@ -950,37 +950,37 @@ public class FlutterActivity extends Activity
 
   /**
    * Hook for subclasses to control whether or not the {@link FlutterFragment} within this {@code
-   * Activity} automatically attaches its {@link FlutterEngine} to this {@code Activity}.
+   * Activity} automatically attaches its {@link io.flutter.embedding.engine.FlutterEngine} to this {@code Activity}.
    *
    * <p>This property is controlled with a protected method instead of an {@code Intent} argument
    * because the only situation where changing this value would help, is a situation in which {@code
-   * FlutterActivity} is being subclassed to utilize a custom and/or cached {@link FlutterEngine}.
+   * FlutterActivity} is being subclassed to utilize a custom and/or cached {@link io.flutter.embedding.engine.FlutterEngine}.
    *
    * <p>Defaults to {@code true}.
    *
    * <p>Control surfaces are used to provide Android resources and lifecycle events to plugins that
-   * are attached to the {@link FlutterEngine}. If {@code shouldAttachEngineToActivity} is true then
-   * this {@code FlutterActivity} will connect its {@link FlutterEngine} to itself, along with any
-   * plugins that are registered with that {@link FlutterEngine}. This allows plugins to access the
+   * are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code shouldAttachEngineToActivity} is true then
+   * this {@code FlutterActivity} will connect its {@link io.flutter.embedding.engine.FlutterEngine} to itself, along with any
+   * plugins that are registered with that {@link io.flutter.embedding.engine.FlutterEngine}. This allows plugins to access the
    * {@code Activity}, as well as receive {@code Activity}-specific calls, e.g., {@link
    * Activity#onNewIntent(Intent)}. If {@code shouldAttachEngineToActivity} is false, then this
    * {@code FlutterActivity} will not automatically manage the connection between its {@link
    * FlutterEngine} and itself. In this case, plugins will not be offered a reference to an {@code
    * Activity} or its OS hooks.
    *
-   * <p>Returning false from this method does not preclude a {@link FlutterEngine} from being
+   * <p>Returning false from this method does not preclude a {@link io.flutter.embedding.engine.FlutterEngine} from being
    * attaching to a {@code FlutterActivity} - it just prevents the attachment from happening
    * automatically. A developer can choose to subclass {@code FlutterActivity} and then invoke
    * {@link ActivityControlSurface#attachToActivity(ExclusiveAppComponent, Lifecycle)} and {@link
    * ActivityControlSurface#detachFromActivity()} at the desired times.
    *
    * <p>One reason that a developer might choose to manually manage the relationship between the
-   * {@code Activity} and {@link FlutterEngine} is if the developer wants to move the {@link
-   * FlutterEngine} somewhere else. For example, a developer might want the {@link FlutterEngine} to
+   * {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to move the {@link
+   * FlutterEngine} somewhere else. For example, a developer might want the {@link io.flutter.embedding.engine.FlutterEngine} to
    * outlive this {@code FlutterActivity} so that it can be used later in a different {@code
-   * Activity}. To accomplish this, the {@link FlutterEngine} may need to be disconnected from this
+   * Activity}. To accomplish this, the {@link io.flutter.embedding.engine.FlutterEngine} may need to be disconnected from this
    * {@code FluttterActivity} at an unusual time, preventing this {@code FlutterActivity} from
-   * correctly managing the relationship between the {@link FlutterEngine} and itself.
+   * correctly managing the relationship between the {@link io.flutter.embedding.engine.FlutterEngine} and itself.
    */
   @Override
   public boolean shouldAttachEngineToActivity() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -63,7 +63,8 @@ import io.flutter.plugin.platform.PlatformPlugin;
  *   <li>Chooses the Dart execution app bundle path and entrypoint.
  *   <li>Chooses Flutter's initial route.
  *   <li>Renders {@code Activity} transparently, if desired.
- *   <li>Offers hooks for subclasses to provide and configure a {@link io.flutter.embedding.engine.FlutterEngine}.
+ *   <li>Offers hooks for subclasses to provide and configure a {@link
+ *       io.flutter.embedding.engine.FlutterEngine}.
  *   <li>Save and restore instance state, see {@code #shouldRestoreAndSaveState()};
  * </ul>
  *
@@ -96,36 +97,41 @@ import io.flutter.plugin.platform.PlatformPlugin;
  *
  * <p><strong>Using a cached FlutterEngine</strong>
  *
- * <p>{@code FlutterActivity} can be used with a cached {@link io.flutter.embedding.engine.FlutterEngine} instead of creating a
- * new one. Use {@link #withCachedEngine(String)} to build a {@code FlutterActivity} {@code Intent}
- * that is configured to use an existing, cached {@link io.flutter.embedding.engine.FlutterEngine}. {@link
+ * <p>{@code FlutterActivity} can be used with a cached {@link
+ * io.flutter.embedding.engine.FlutterEngine} instead of creating a new one. Use {@link
+ * #withCachedEngine(String)} to build a {@code FlutterActivity} {@code Intent} that is configured
+ * to use an existing, cached {@link io.flutter.embedding.engine.FlutterEngine}. {@link
  * io.flutter.embedding.engine.FlutterEngineCache} is the cache that is used to obtain a given
- * cached {@link io.flutter.embedding.engine.FlutterEngine}. You must create and put a {@link io.flutter.embedding.engine.FlutterEngine} into the {@link
+ * cached {@link io.flutter.embedding.engine.FlutterEngine}. You must create and put a {@link
+ * io.flutter.embedding.engine.FlutterEngine} into the {@link
  * io.flutter.embedding.engine.FlutterEngineCache} yourself before using the {@link
  * #withCachedEngine(String)} builder. An {@code IllegalStateException} will be thrown if a cached
  * engine is requested but does not exist in the cache.
  *
- * <p>When using a cached {@link io.flutter.embedding.engine.FlutterEngine}, that {@link io.flutter.embedding.engine.FlutterEngine} should already be
- * executing Dart code, which means that the Dart entrypoint and initial route have already been
- * defined. Therefore, {@link CachedEngineIntentBuilder} does not offer configuration of these
- * properties.
+ * <p>When using a cached {@link io.flutter.embedding.engine.FlutterEngine}, that {@link
+ * io.flutter.embedding.engine.FlutterEngine} should already be executing Dart code, which means
+ * that the Dart entrypoint and initial route have already been defined. Therefore, {@link
+ * CachedEngineIntentBuilder} does not offer configuration of these properties.
  *
- * <p>It is generally recommended to use a cached {@link io.flutter.embedding.engine.FlutterEngine} to avoid a momentary delay
- * when initializing a new {@link io.flutter.embedding.engine.FlutterEngine}. The two exceptions to using a cached {@link
+ * <p>It is generally recommended to use a cached {@link io.flutter.embedding.engine.FlutterEngine}
+ * to avoid a momentary delay when initializing a new {@link
+ * io.flutter.embedding.engine.FlutterEngine}. The two exceptions to using a cached {@link
  * FlutterEngine} are:
  *
  * <p>
  *
  * <ul>
  *   <li>When {@code FlutterActivity} is the first {@code Activity} displayed by the app, because
- *       pre-warming a {@link io.flutter.embedding.engine.FlutterEngine} would have no impact in this situation.
+ *       pre-warming a {@link io.flutter.embedding.engine.FlutterEngine} would have no impact in
+ *       this situation.
  *   <li>When you are unsure when/if you will need to display a Flutter experience.
  * </ul>
  *
  * <p>See https://flutter.dev/docs/development/add-to-app/performance for additional performance
  * explorations on engine loading.
  *
- * <p>The following illustrates how to pre-warm and cache a {@link io.flutter.embedding.engine.FlutterEngine}:
+ * <p>The following illustrates how to pre-warm and cache a {@link
+ * io.flutter.embedding.engine.FlutterEngine}:
  *
  * <pre>{@code
  * // Create and pre-warm a FlutterEngine.
@@ -216,8 +222,9 @@ public class FlutterActivity extends Activity
 
   /**
    * Creates an {@link NewEngineIntentBuilder}, which can be used to configure an {@link Intent} to
-   * launch a {@code FlutterActivity} that internally creates a new {@link io.flutter.embedding.engine.FlutterEngine} using the
-   * desired Dart entrypoint, initial route, etc.
+   * launch a {@code FlutterActivity} that internally creates a new {@link
+   * io.flutter.embedding.engine.FlutterEngine} using the desired Dart entrypoint, initial route,
+   * etc.
    */
   @NonNull
   public static NewEngineIntentBuilder withNewEngine() {
@@ -294,8 +301,9 @@ public class FlutterActivity extends Activity
 
   /**
    * Creates a {@link CachedEngineIntentBuilder}, which can be used to configure an {@link Intent}
-   * to launch a {@code FlutterActivity} that internally uses an existing {@link io.flutter.embedding.engine.FlutterEngine} that
-   * is cached in {@link io.flutter.embedding.engine.FlutterEngineCache}.
+   * to launch a {@code FlutterActivity} that internally uses an existing {@link
+   * io.flutter.embedding.engine.FlutterEngine} that is cached in {@link
+   * io.flutter.embedding.engine.FlutterEngineCache}.
    */
   public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {
     return new CachedEngineIntentBuilder(FlutterActivity.class, cachedEngineId);
@@ -303,7 +311,8 @@ public class FlutterActivity extends Activity
 
   /**
    * Builder to create an {@code Intent} that launches a {@code FlutterActivity} with an existing
-   * {@link io.flutter.embedding.engine.FlutterEngine} that is cached in {@link io.flutter.embedding.engine.FlutterEngineCache}.
+   * {@link io.flutter.embedding.engine.FlutterEngine} that is cached in {@link
+   * io.flutter.embedding.engine.FlutterEngineCache}.
    */
   public static class CachedEngineIntentBuilder {
     private final Class<? extends FlutterActivity> activityClass;
@@ -316,8 +325,9 @@ public class FlutterActivity extends Activity
      * {@code FlutterActivity}.
      *
      * <p>Subclasses of {@code FlutterActivity} should provide their own static version of {@link
-     * FlutterActivity#withCachedEngine(String)}, which returns an instance of {@code CachedEngineIntentBuilder}
-     * constructed with a {@code Class} reference to the {@code FlutterActivity} subclass, e.g.:
+     * FlutterActivity#withCachedEngine(String)}, which returns an instance of {@code
+     * CachedEngineIntentBuilder} constructed with a {@code Class} reference to the {@code
+     * FlutterActivity} subclass, e.g.:
      *
      * <p>{@code return new CachedEngineIntentBuilder(MyFlutterActivity.class, engineId); }
      */
@@ -328,8 +338,8 @@ public class FlutterActivity extends Activity
     }
 
     /**
-     * Returns true if the cached {@link io.flutter.embedding.engine.FlutterEngine} should be destroyed and removed from the
-     * cache when this {@code FlutterActivity} is destroyed.
+     * Returns true if the cached {@link io.flutter.embedding.engine.FlutterEngine} should be
+     * destroyed and removed from the cache when this {@code FlutterActivity} is destroyed.
      *
      * <p>The default value is {@code false}.
      */
@@ -581,8 +591,8 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Irreversibly release this activity's control of the {@link io.flutter.embedding.engine.FlutterEngine} and its
-   * subcomponents.
+   * Irreversibly release this activity's control of the {@link
+   * io.flutter.embedding.engine.FlutterEngine} and its subcomponents.
    *
    * <p>Calling will disconnect this activity's view from the Flutter renderer, disconnect this
    * activity from plugins' {@link ActivityControlSurface}, and stop system channel messages from
@@ -709,9 +719,9 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use within this {@code
-   * FlutterActivity}, or {@code null} if this {@code FlutterActivity} does not want to use a cached
-   * {@link io.flutter.embedding.engine.FlutterEngine}.
+   * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use
+   * within this {@code FlutterActivity}, or {@code null} if this {@code FlutterActivity} does not
+   * want to use a cached {@link io.flutter.embedding.engine.FlutterEngine}.
    */
   @Override
   @Nullable
@@ -720,13 +730,13 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Returns false if the {@link io.flutter.embedding.engine.FlutterEngine} backing this {@code FlutterActivity} should outlive
-   * this {@code FlutterActivity}, or true to be destroyed when the {@code FlutterActivity} is
-   * destroyed.
+   * Returns false if the {@link io.flutter.embedding.engine.FlutterEngine} backing this {@code
+   * FlutterActivity} should outlive this {@code FlutterActivity}, or true to be destroyed when the
+   * {@code FlutterActivity} is destroyed.
    *
    * <p>The default value is {@code true} in cases where {@code FlutterActivity} created its own
-   * {@link io.flutter.embedding.engine.FlutterEngine}, and {@code false} in cases where a cached {@link io.flutter.embedding.engine.FlutterEngine} was
-   * provided.
+   * {@link io.flutter.embedding.engine.FlutterEngine}, and {@code false} in cases where a cached
+   * {@link io.flutter.embedding.engine.FlutterEngine} was provided.
    */
   @Override
   public boolean shouldDestroyEngineWithHost() {
@@ -877,10 +887,11 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Hook for subclasses to easily provide a custom {@link io.flutter.embedding.engine.FlutterEngine}.
+   * Hook for subclasses to easily provide a custom {@link
+   * io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>This hook is where a cached {@link io.flutter.embedding.engine.FlutterEngine} should be provided, if a cached {@link
-   * FlutterEngine} is desired.
+   * <p>This hook is where a cached {@link io.flutter.embedding.engine.FlutterEngine} should be
+   * provided, if a cached {@link FlutterEngine} is desired.
    */
   @Nullable
   @Override
@@ -890,8 +901,8 @@ public class FlutterActivity extends Activity
   }
 
   /**
-   * Hook for subclasses to obtain a reference to the {@link io.flutter.embedding.engine.FlutterEngine} that is owned by this
-   * {@code FlutterActivity}.
+   * Hook for subclasses to obtain a reference to the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that is owned by this {@code FlutterActivity}.
    */
   @Nullable
   protected FlutterEngine getFlutterEngine() {
@@ -950,37 +961,43 @@ public class FlutterActivity extends Activity
 
   /**
    * Hook for subclasses to control whether or not the {@link FlutterFragment} within this {@code
-   * Activity} automatically attaches its {@link io.flutter.embedding.engine.FlutterEngine} to this {@code Activity}.
+   * Activity} automatically attaches its {@link io.flutter.embedding.engine.FlutterEngine} to this
+   * {@code Activity}.
    *
    * <p>This property is controlled with a protected method instead of an {@code Intent} argument
    * because the only situation where changing this value would help, is a situation in which {@code
-   * FlutterActivity} is being subclassed to utilize a custom and/or cached {@link io.flutter.embedding.engine.FlutterEngine}.
+   * FlutterActivity} is being subclassed to utilize a custom and/or cached {@link
+   * io.flutter.embedding.engine.FlutterEngine}.
    *
    * <p>Defaults to {@code true}.
    *
    * <p>Control surfaces are used to provide Android resources and lifecycle events to plugins that
-   * are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code shouldAttachEngineToActivity} is true then
-   * this {@code FlutterActivity} will connect its {@link io.flutter.embedding.engine.FlutterEngine} to itself, along with any
-   * plugins that are registered with that {@link io.flutter.embedding.engine.FlutterEngine}. This allows plugins to access the
-   * {@code Activity}, as well as receive {@code Activity}-specific calls, e.g., {@link
+   * are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code
+   * shouldAttachEngineToActivity} is true then this {@code FlutterActivity} will connect its {@link
+   * io.flutter.embedding.engine.FlutterEngine} to itself, along with any plugins that are
+   * registered with that {@link io.flutter.embedding.engine.FlutterEngine}. This allows plugins to
+   * access the {@code Activity}, as well as receive {@code Activity}-specific calls, e.g., {@link
    * Activity#onNewIntent(Intent)}. If {@code shouldAttachEngineToActivity} is false, then this
    * {@code FlutterActivity} will not automatically manage the connection between its {@link
    * FlutterEngine} and itself. In this case, plugins will not be offered a reference to an {@code
    * Activity} or its OS hooks.
    *
-   * <p>Returning false from this method does not preclude a {@link io.flutter.embedding.engine.FlutterEngine} from being
-   * attaching to a {@code FlutterActivity} - it just prevents the attachment from happening
-   * automatically. A developer can choose to subclass {@code FlutterActivity} and then invoke
-   * {@link ActivityControlSurface#attachToActivity(ExclusiveAppComponent, Lifecycle)} and {@link
+   * <p>Returning false from this method does not preclude a {@link
+   * io.flutter.embedding.engine.FlutterEngine} from being attaching to a {@code FlutterActivity} -
+   * it just prevents the attachment from happening automatically. A developer can choose to
+   * subclass {@code FlutterActivity} and then invoke {@link
+   * ActivityControlSurface#attachToActivity(ExclusiveAppComponent, Lifecycle)} and {@link
    * ActivityControlSurface#detachFromActivity()} at the desired times.
    *
    * <p>One reason that a developer might choose to manually manage the relationship between the
-   * {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to move the {@link
-   * FlutterEngine} somewhere else. For example, a developer might want the {@link io.flutter.embedding.engine.FlutterEngine} to
-   * outlive this {@code FlutterActivity} so that it can be used later in a different {@code
-   * Activity}. To accomplish this, the {@link io.flutter.embedding.engine.FlutterEngine} may need to be disconnected from this
-   * {@code FluttterActivity} at an unusual time, preventing this {@code FlutterActivity} from
-   * correctly managing the relationship between the {@link io.flutter.embedding.engine.FlutterEngine} and itself.
+   * {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer
+   * wants to move the {@link FlutterEngine} somewhere else. For example, a developer might want the
+   * {@link io.flutter.embedding.engine.FlutterEngine} to outlive this {@code FlutterActivity} so
+   * that it can be used later in a different {@code Activity}. To accomplish this, the {@link
+   * io.flutter.embedding.engine.FlutterEngine} may need to be disconnected from this {@code
+   * FluttterActivity} at an unusual time, preventing this {@code FlutterActivity} from correctly
+   * managing the relationship between the {@link io.flutter.embedding.engine.FlutterEngine} and
+   * itself.
    */
   @Override
   public boolean shouldAttachEngineToActivity() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -102,8 +102,8 @@ import java.util.Arrays;
    * <p>No further method invocations may occur on this {@code FlutterActivityAndFragmentDelegate}
    * after invoking this method. If a method is invoked, an exception will occur.
    *
-   * <p>This method only clears out references. It does not destroy its {@link FlutterEngine}. The
-   * behavior that destroys a {@link FlutterEngine} can be found in {@link #onDetach()}.
+   * <p>This method only clears out references. It does not destroy its {@link io.flutter.embedding.engine.FlutterEngine}. The
+   * behavior that destroys a {@link io.flutter.embedding.engine.FlutterEngine} can be found in {@link #onDetach()}.
    */
   void release() {
     this.host = null;
@@ -113,7 +113,7 @@ import java.util.Arrays;
   }
 
   /**
-   * Returns the {@link FlutterEngine} that is owned by this delegate and its host {@code Activity}
+   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} that is owned by this delegate and its host {@code Activity}
    * or {@code Fragment}.
    */
   @Nullable
@@ -139,10 +139,10 @@ import java.util.Arrays;
    *
    * <ol>
    *   <li>Initializes the Flutter system.
-   *   <li>Obtains or creates a {@link FlutterEngine}.
+   *   <li>Obtains or creates a {@link io.flutter.embedding.engine.FlutterEngine}.
    *   <li>Creates and configures a {@link PlatformPlugin}.
-   *   <li>Attaches the {@link FlutterEngine} to the surrounding {@code Activity}, if desired.
-   *   <li>Configures the {@link FlutterEngine} via {@link
+   *   <li>Attaches the {@link io.flutter.embedding.engine.FlutterEngine} to the surrounding {@code Activity}, if desired.
+   *   <li>Configures the {@link io.flutter.embedding.engine.FlutterEngine} via {@link
    *       Host#configureFlutterEngine(FlutterEngine)}.
    * </ol>
    */
@@ -196,13 +196,13 @@ import java.util.Arrays;
    *
    * <p>
    *
-   * <p>First, the {@code host} is asked if it would like to use a cached {@link FlutterEngine}, and
-   * if so, the cached {@link FlutterEngine} is retrieved.
+   * <p>First, the {@code host} is asked if it would like to use a cached {@link io.flutter.embedding.engine.FlutterEngine}, and
+   * if so, the cached {@link io.flutter.embedding.engine.FlutterEngine} is retrieved.
    *
-   * <p>Second, the {@code host} is given an opportunity to provide a {@link FlutterEngine} via
+   * <p>Second, the {@code host} is given an opportunity to provide a {@link io.flutter.embedding.engine.FlutterEngine} via
    * {@link Host#provideFlutterEngine(Context)}.
    *
-   * <p>If the {@code host} does not provide a {@link FlutterEngine}, then a new {@link
+   * <p>If the {@code host} does not provide a {@link io.flutter.embedding.engine.FlutterEngine}, then a new {@link
    * FlutterEngine} is instantiated.
    */
   @VisibleForTesting
@@ -256,7 +256,7 @@ import java.util.Arrays;
    * <ol>
    *   <li>creates a new {@link FlutterView} in a {@code View} hierarchy
    *   <li>adds a {@link FlutterUiDisplayListener} to it
-   *   <li>attaches a {@link FlutterEngine} to the new {@link FlutterView}
+   *   <li>attaches a {@link io.flutter.embedding.engine.FlutterEngine} to the new {@link FlutterView}
    *   <li>returns the new {@code View} hierarchy
    * </ol>
    */
@@ -473,7 +473,7 @@ import java.util.Arrays;
    * <ol>
    *   <li>This method notifies the running Flutter app that it is "paused" as per the Flutter app
    *       lifecycle.
-   *   <li>Detaches this delegate's {@link FlutterEngine} from this delegate's {@link FlutterView}.
+   *   <li>Detaches this delegate's {@link io.flutter.embedding.engine.FlutterEngine} from this delegate's {@link FlutterView}.
    * </ol>
    */
   void onStop() {
@@ -538,10 +538,10 @@ import java.util.Arrays;
    * <p>
    *
    * <ol>
-   *   <li>Detaches this delegate's {@link FlutterEngine} from its surrounding {@code Activity}, if
+   *   <li>Detaches this delegate's {@link io.flutter.embedding.engine.FlutterEngine} from its surrounding {@code Activity}, if
    *       it was previously attached.
    *   <li>Destroys this delegate's {@link PlatformPlugin}.
-   *   <li>Destroys this delegate's {@link FlutterEngine} if {@link
+   *   <li>Destroys this delegate's {@link io.flutter.embedding.engine.FlutterEngine} if {@link
    *       Host#shouldDestroyEngineWithHost()} ()} returns true.
    * </ol>
    */
@@ -586,7 +586,7 @@ import java.util.Arrays;
   }
 
   /**
-   * Invoke this from {@link Activity#onBackPressed()}.
+   * Invoke this from {@link android.app.Activity#onBackPressed()}.
    *
    * <p>A {@code Fragment} host must have its containing {@code Activity} forward this call so that
    * the {@code Fragment} can then invoke this method.
@@ -604,7 +604,7 @@ import java.util.Arrays;
   }
 
   /**
-   * Invoke this from {@link Activity#onRequestPermissionsResult(int, String[], int[])} or {@code
+   * Invoke this from {@link android.app.Activity#onRequestPermissionsResult(int, String[], int[])} or {@code
    * Fragment#onRequestPermissionsResult(int, String[], int[])}.
    *
    * <p>This method forwards to interested Flutter plugins.
@@ -701,7 +701,7 @@ import java.util.Arrays;
   }
 
   /**
-   * Invoke this from {@link Activity#onTrimMemory(int)}.
+   * Invoke this from {@link android.app.Activity#onTrimMemory(int)}.
    *
    * <p>A {@code Fragment} host must have its containing {@code Activity} forward this call so that
    * the {@code Fragment} can then invoke this method.
@@ -726,7 +726,7 @@ import java.util.Arrays;
   }
 
   /**
-   * Invoke this from {@link Activity#onLowMemory()}.
+   * Invoke this from {@link android.app.Activity#onLowMemory()}.
    *
    * <p>A {@code Fragment} host must have its containing {@code Activity} forward this call so that
    * the {@code Fragment} can then invoke this method.
@@ -761,7 +761,7 @@ import java.util.Arrays;
           FlutterEngineProvider,
           FlutterEngineConfigurator,
           PlatformPlugin.PlatformPluginDelegate {
-    /** Returns the {@link Context} that backs the host {@link Activity} or {@code Fragment}. */
+    /** Returns the {@link Context} that backs the host {@link android.app.Activity} or {@code Fragment}. */
     @NonNull
     Context getContext();
 
@@ -770,13 +770,13 @@ import java.util.Arrays;
     boolean shouldHandleDeeplinking();
 
     /**
-     * Returns the host {@link Activity} or the {@code Activity} that is currently attached to the
+     * Returns the host {@link android.app.Activity} or the {@code Activity} that is currently attached to the
      * host {@code Fragment}.
      */
     @Nullable
     Activity getActivity();
 
-    /** Returns the {@link Lifecycle} that backs the host {@link Activity} or {@code Fragment}. */
+    /** Returns the {@link Lifecycle} that backs the host {@link android.app.Activity} or {@code Fragment}. */
     @NonNull
     Lifecycle getLifecycle();
 
@@ -785,7 +785,7 @@ import java.util.Arrays;
     FlutterShellArgs getFlutterShellArgs();
 
     /**
-     * Returns the ID of a statically cached {@link FlutterEngine} to use within this delegate's
+     * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use within this delegate's
      * host, or {@code null} if this delegate's host does not want to use a cached {@link
      * FlutterEngine}.
      */
@@ -793,17 +793,17 @@ import java.util.Arrays;
     String getCachedEngineId();
 
     /**
-     * Returns true if the {@link FlutterEngine} used in this delegate should be destroyed when the
+     * Returns true if the {@link io.flutter.embedding.engine.FlutterEngine} used in this delegate should be destroyed when the
      * host/delegate are destroyed.
      *
      * <p>The default value is {@code true} in cases where {@code FlutterFragment} created its own
-     * {@link FlutterEngine}, and {@code false} in cases where a cached {@link FlutterEngine} was
+     * {@link io.flutter.embedding.engine.FlutterEngine}, and {@code false} in cases where a cached {@link io.flutter.embedding.engine.FlutterEngine} was
      * provided.
      */
     boolean shouldDestroyEngineWithHost();
 
     /**
-     * Callback called when the {@link FlutterEngine} has been attached to by another activity
+     * Callback called when the {@link io.flutter.embedding.engine.FlutterEngine} has been attached to by another activity
      * before this activity was destroyed.
      *
      * <p>The expected behavior is for this activity to synchronously stop using the {@link
@@ -811,7 +811,7 @@ import java.util.Arrays;
      */
     void detachFromFlutterEngine();
 
-    /** Returns the Dart entrypoint that should run when a new {@link FlutterEngine} is created. */
+    /** Returns the Dart entrypoint that should run when a new {@link io.flutter.embedding.engine.FlutterEngine} is created. */
     @NonNull
     String getDartEntrypointFunctionName();
 
@@ -841,9 +841,9 @@ import java.util.Arrays;
     SplashScreen provideSplashScreen();
 
     /**
-     * Returns the {@link FlutterEngine} that should be rendered to a {@link FlutterView}.
+     * Returns the {@link io.flutter.embedding.engine.FlutterEngine} that should be rendered to a {@link FlutterView}.
      *
-     * <p>If {@code null} is returned, a new {@link FlutterEngine} will be created automatically.
+     * <p>If {@code null} is returned, a new {@link io.flutter.embedding.engine.FlutterEngine} will be created automatically.
      */
     @Nullable
     FlutterEngine provideFlutterEngine(@NonNull Context context);
@@ -856,7 +856,7 @@ import java.util.Arrays;
     PlatformPlugin providePlatformPlugin(
         @Nullable Activity activity, @NonNull FlutterEngine flutterEngine);
 
-    /** Hook for the host to configure the {@link FlutterEngine} as desired. */
+    /** Hook for the host to configure the {@link io.flutter.embedding.engine.FlutterEngine} as desired. */
     void configureFlutterEngine(@NonNull FlutterEngine flutterEngine);
 
     /**
@@ -866,8 +866,8 @@ import java.util.Arrays;
     void cleanUpFlutterEngine(@NonNull FlutterEngine flutterEngine);
 
     /**
-     * Returns true if the {@link FlutterEngine}'s plugin system should be connected to the host
-     * {@link Activity}, allowing plugins to interact with it.
+     * Returns true if the {@link io.flutter.embedding.engine.FlutterEngine}'s plugin system should be connected to the host
+     * {@link android.app.Activity}, allowing plugins to interact with it.
      */
     boolean shouldAttachEngineToActivity();
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -102,8 +102,9 @@ import java.util.Arrays;
    * <p>No further method invocations may occur on this {@code FlutterActivityAndFragmentDelegate}
    * after invoking this method. If a method is invoked, an exception will occur.
    *
-   * <p>This method only clears out references. It does not destroy its {@link io.flutter.embedding.engine.FlutterEngine}. The
-   * behavior that destroys a {@link io.flutter.embedding.engine.FlutterEngine} can be found in {@link #onDetach()}.
+   * <p>This method only clears out references. It does not destroy its {@link
+   * io.flutter.embedding.engine.FlutterEngine}. The behavior that destroys a {@link
+   * io.flutter.embedding.engine.FlutterEngine} can be found in {@link #onDetach()}.
    */
   void release() {
     this.host = null;
@@ -113,8 +114,8 @@ import java.util.Arrays;
   }
 
   /**
-   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} that is owned by this delegate and its host {@code Activity}
-   * or {@code Fragment}.
+   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} that is owned by this delegate
+   * and its host {@code Activity} or {@code Fragment}.
    */
   @Nullable
   /* package */ FlutterEngine getFlutterEngine() {
@@ -141,7 +142,8 @@ import java.util.Arrays;
    *   <li>Initializes the Flutter system.
    *   <li>Obtains or creates a {@link io.flutter.embedding.engine.FlutterEngine}.
    *   <li>Creates and configures a {@link PlatformPlugin}.
-   *   <li>Attaches the {@link io.flutter.embedding.engine.FlutterEngine} to the surrounding {@code Activity}, if desired.
+   *   <li>Attaches the {@link io.flutter.embedding.engine.FlutterEngine} to the surrounding {@code
+   *       Activity}, if desired.
    *   <li>Configures the {@link io.flutter.embedding.engine.FlutterEngine} via {@link
    *       Host#configureFlutterEngine(FlutterEngine)}.
    * </ol>
@@ -196,14 +198,15 @@ import java.util.Arrays;
    *
    * <p>
    *
-   * <p>First, the {@code host} is asked if it would like to use a cached {@link io.flutter.embedding.engine.FlutterEngine}, and
-   * if so, the cached {@link io.flutter.embedding.engine.FlutterEngine} is retrieved.
+   * <p>First, the {@code host} is asked if it would like to use a cached {@link
+   * io.flutter.embedding.engine.FlutterEngine}, and if so, the cached {@link
+   * io.flutter.embedding.engine.FlutterEngine} is retrieved.
    *
-   * <p>Second, the {@code host} is given an opportunity to provide a {@link io.flutter.embedding.engine.FlutterEngine} via
-   * {@link Host#provideFlutterEngine(Context)}.
+   * <p>Second, the {@code host} is given an opportunity to provide a {@link
+   * io.flutter.embedding.engine.FlutterEngine} via {@link Host#provideFlutterEngine(Context)}.
    *
-   * <p>If the {@code host} does not provide a {@link io.flutter.embedding.engine.FlutterEngine}, then a new {@link
-   * FlutterEngine} is instantiated.
+   * <p>If the {@code host} does not provide a {@link io.flutter.embedding.engine.FlutterEngine},
+   * then a new {@link FlutterEngine} is instantiated.
    */
   @VisibleForTesting
   /* package */ void setupFlutterEngine() {
@@ -256,7 +259,8 @@ import java.util.Arrays;
    * <ol>
    *   <li>creates a new {@link FlutterView} in a {@code View} hierarchy
    *   <li>adds a {@link FlutterUiDisplayListener} to it
-   *   <li>attaches a {@link io.flutter.embedding.engine.FlutterEngine} to the new {@link FlutterView}
+   *   <li>attaches a {@link io.flutter.embedding.engine.FlutterEngine} to the new {@link
+   *       FlutterView}
    *   <li>returns the new {@code View} hierarchy
    * </ol>
    */
@@ -473,7 +477,8 @@ import java.util.Arrays;
    * <ol>
    *   <li>This method notifies the running Flutter app that it is "paused" as per the Flutter app
    *       lifecycle.
-   *   <li>Detaches this delegate's {@link io.flutter.embedding.engine.FlutterEngine} from this delegate's {@link FlutterView}.
+   *   <li>Detaches this delegate's {@link io.flutter.embedding.engine.FlutterEngine} from this
+   *       delegate's {@link FlutterView}.
    * </ol>
    */
   void onStop() {
@@ -538,8 +543,8 @@ import java.util.Arrays;
    * <p>
    *
    * <ol>
-   *   <li>Detaches this delegate's {@link io.flutter.embedding.engine.FlutterEngine} from its surrounding {@code Activity}, if
-   *       it was previously attached.
+   *   <li>Detaches this delegate's {@link io.flutter.embedding.engine.FlutterEngine} from its
+   *       surrounding {@code Activity}, if it was previously attached.
    *   <li>Destroys this delegate's {@link PlatformPlugin}.
    *   <li>Destroys this delegate's {@link io.flutter.embedding.engine.FlutterEngine} if {@link
    *       Host#shouldDestroyEngineWithHost()} ()} returns true.
@@ -604,8 +609,8 @@ import java.util.Arrays;
   }
 
   /**
-   * Invoke this from {@link android.app.Activity#onRequestPermissionsResult(int, String[], int[])} or {@code
-   * Fragment#onRequestPermissionsResult(int, String[], int[])}.
+   * Invoke this from {@link android.app.Activity#onRequestPermissionsResult(int, String[], int[])}
+   * or {@code Fragment#onRequestPermissionsResult(int, String[], int[])}.
    *
    * <p>This method forwards to interested Flutter plugins.
    */
@@ -761,7 +766,10 @@ import java.util.Arrays;
           FlutterEngineProvider,
           FlutterEngineConfigurator,
           PlatformPlugin.PlatformPluginDelegate {
-    /** Returns the {@link Context} that backs the host {@link android.app.Activity} or {@code Fragment}. */
+    /**
+     * Returns the {@link Context} that backs the host {@link android.app.Activity} or {@code
+     * Fragment}.
+     */
     @NonNull
     Context getContext();
 
@@ -770,13 +778,16 @@ import java.util.Arrays;
     boolean shouldHandleDeeplinking();
 
     /**
-     * Returns the host {@link android.app.Activity} or the {@code Activity} that is currently attached to the
-     * host {@code Fragment}.
+     * Returns the host {@link android.app.Activity} or the {@code Activity} that is currently
+     * attached to the host {@code Fragment}.
      */
     @Nullable
     Activity getActivity();
 
-    /** Returns the {@link Lifecycle} that backs the host {@link android.app.Activity} or {@code Fragment}. */
+    /**
+     * Returns the {@link Lifecycle} that backs the host {@link android.app.Activity} or {@code
+     * Fragment}.
+     */
     @NonNull
     Lifecycle getLifecycle();
 
@@ -785,33 +796,36 @@ import java.util.Arrays;
     FlutterShellArgs getFlutterShellArgs();
 
     /**
-     * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use within this delegate's
-     * host, or {@code null} if this delegate's host does not want to use a cached {@link
-     * FlutterEngine}.
+     * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to
+     * use within this delegate's host, or {@code null} if this delegate's host does not want to use
+     * a cached {@link FlutterEngine}.
      */
     @Nullable
     String getCachedEngineId();
 
     /**
-     * Returns true if the {@link io.flutter.embedding.engine.FlutterEngine} used in this delegate should be destroyed when the
-     * host/delegate are destroyed.
+     * Returns true if the {@link io.flutter.embedding.engine.FlutterEngine} used in this delegate
+     * should be destroyed when the host/delegate are destroyed.
      *
      * <p>The default value is {@code true} in cases where {@code FlutterFragment} created its own
-     * {@link io.flutter.embedding.engine.FlutterEngine}, and {@code false} in cases where a cached {@link io.flutter.embedding.engine.FlutterEngine} was
-     * provided.
+     * {@link io.flutter.embedding.engine.FlutterEngine}, and {@code false} in cases where a cached
+     * {@link io.flutter.embedding.engine.FlutterEngine} was provided.
      */
     boolean shouldDestroyEngineWithHost();
 
     /**
-     * Callback called when the {@link io.flutter.embedding.engine.FlutterEngine} has been attached to by another activity
-     * before this activity was destroyed.
+     * Callback called when the {@link io.flutter.embedding.engine.FlutterEngine} has been attached
+     * to by another activity before this activity was destroyed.
      *
      * <p>The expected behavior is for this activity to synchronously stop using the {@link
      * FlutterEngine} to avoid lifecycle crosstalk with the new activity.
      */
     void detachFromFlutterEngine();
 
-    /** Returns the Dart entrypoint that should run when a new {@link io.flutter.embedding.engine.FlutterEngine} is created. */
+    /**
+     * Returns the Dart entrypoint that should run when a new {@link
+     * io.flutter.embedding.engine.FlutterEngine} is created.
+     */
     @NonNull
     String getDartEntrypointFunctionName();
 
@@ -841,9 +855,11 @@ import java.util.Arrays;
     SplashScreen provideSplashScreen();
 
     /**
-     * Returns the {@link io.flutter.embedding.engine.FlutterEngine} that should be rendered to a {@link FlutterView}.
+     * Returns the {@link io.flutter.embedding.engine.FlutterEngine} that should be rendered to a
+     * {@link FlutterView}.
      *
-     * <p>If {@code null} is returned, a new {@link io.flutter.embedding.engine.FlutterEngine} will be created automatically.
+     * <p>If {@code null} is returned, a new {@link io.flutter.embedding.engine.FlutterEngine} will
+     * be created automatically.
      */
     @Nullable
     FlutterEngine provideFlutterEngine(@NonNull Context context);
@@ -856,7 +872,10 @@ import java.util.Arrays;
     PlatformPlugin providePlatformPlugin(
         @Nullable Activity activity, @NonNull FlutterEngine flutterEngine);
 
-    /** Hook for the host to configure the {@link io.flutter.embedding.engine.FlutterEngine} as desired. */
+    /**
+     * Hook for the host to configure the {@link io.flutter.embedding.engine.FlutterEngine} as
+     * desired.
+     */
     void configureFlutterEngine(@NonNull FlutterEngine flutterEngine);
 
     /**
@@ -866,8 +885,8 @@ import java.util.Arrays;
     void cleanUpFlutterEngine(@NonNull FlutterEngine flutterEngine);
 
     /**
-     * Returns true if the {@link io.flutter.embedding.engine.FlutterEngine}'s plugin system should be connected to the host
-     * {@link android.app.Activity}, allowing plugins to interact with it.
+     * Returns true if the {@link io.flutter.embedding.engine.FlutterEngine}'s plugin system should
+     * be connected to the host {@link android.app.Activity}, allowing plugins to interact with it.
      */
     boolean shouldAttachEngineToActivity();
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterEngineConfigurator.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterEngineConfigurator.java
@@ -9,16 +9,16 @@ import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.engine.FlutterEngine;
 
 /**
- * Configures a {@link FlutterEngine} after it is created, e.g., adds plugins.
+ * Configures a {@link io.flutter.embedding.engine.FlutterEngine} after it is created, e.g., adds plugins.
  *
  * <p>This interface may be applied to a {@link androidx.fragment.app.FragmentActivity} that owns a
  * {@code FlutterFragment}.
  */
 public interface FlutterEngineConfigurator {
   /**
-   * Configures the given {@link FlutterEngine}.
+   * Configures the given {@link io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>This method is called after the given {@link FlutterEngine} has been attached to the owning
+   * <p>This method is called after the given {@link io.flutter.embedding.engine.FlutterEngine} has been attached to the owning
    * {@code FragmentActivity}. See {@link
    * io.flutter.embedding.engine.plugins.activity.ActivityControlSurface#attachToActivity(
    * ExclusiveAppComponent, Lifecycle)}.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterEngineConfigurator.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterEngineConfigurator.java
@@ -9,7 +9,8 @@ import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.engine.FlutterEngine;
 
 /**
- * Configures a {@link io.flutter.embedding.engine.FlutterEngine} after it is created, e.g., adds plugins.
+ * Configures a {@link io.flutter.embedding.engine.FlutterEngine} after it is created, e.g., adds
+ * plugins.
  *
  * <p>This interface may be applied to a {@link androidx.fragment.app.FragmentActivity} that owns a
  * {@code FlutterFragment}.
@@ -18,8 +19,8 @@ public interface FlutterEngineConfigurator {
   /**
    * Configures the given {@link io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>This method is called after the given {@link io.flutter.embedding.engine.FlutterEngine} has been attached to the owning
-   * {@code FragmentActivity}. See {@link
+   * <p>This method is called after the given {@link io.flutter.embedding.engine.FlutterEngine} has
+   * been attached to the owning {@code FragmentActivity}. See {@link
    * io.flutter.embedding.engine.plugins.activity.ActivityControlSurface#attachToActivity(
    * ExclusiveAppComponent, Lifecycle)}.
    *

--- a/shell/platform/android/io/flutter/embedding/android/FlutterEngineProvider.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterEngineProvider.java
@@ -10,21 +10,23 @@ import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.FlutterEngine;
 
 /**
- * Provides a {@link io.flutter.embedding.engine.FlutterEngine} instance to be used by a {@code FlutterActivity} or {@code
- * FlutterFragment}.
+ * Provides a {@link io.flutter.embedding.engine.FlutterEngine} instance to be used by a {@code
+ * FlutterActivity} or {@code FlutterFragment}.
  *
- * <p>{@link io.flutter.embedding.engine.FlutterEngine} instances require significant time to warm up. Therefore, a developer
- * might choose to hold onto an existing {@link io.flutter.embedding.engine.FlutterEngine} and connect it to various {@link
- * FlutterActivity}s and/or {@code FlutterFragment}s. This interface facilitates providing a cached,
- * pre-warmed {@link io.flutter.embedding.engine.FlutterEngine}.
+ * <p>{@link io.flutter.embedding.engine.FlutterEngine} instances require significant time to warm
+ * up. Therefore, a developer might choose to hold onto an existing {@link
+ * io.flutter.embedding.engine.FlutterEngine} and connect it to various {@link FlutterActivity}s
+ * and/or {@code FlutterFragment}s. This interface facilitates providing a cached, pre-warmed {@link
+ * io.flutter.embedding.engine.FlutterEngine}.
  */
 public interface FlutterEngineProvider {
   /**
-   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} that should be used by a child {@code FlutterFragment}.
+   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} that should be used by a child
+   * {@code FlutterFragment}.
    *
-   * <p>This method may return a new {@link io.flutter.embedding.engine.FlutterEngine}, an existing, cached {@link
-   * FlutterEngine}, or null to express that the {@code FlutterEngineProvider} would like the {@code
-   * FlutterFragment} to provide its own {@code FlutterEngine} instance.
+   * <p>This method may return a new {@link io.flutter.embedding.engine.FlutterEngine}, an existing,
+   * cached {@link FlutterEngine}, or null to express that the {@code FlutterEngineProvider} would
+   * like the {@code FlutterFragment} to provide its own {@code FlutterEngine} instance.
    */
   @Nullable
   FlutterEngine provideFlutterEngine(@NonNull Context context);

--- a/shell/platform/android/io/flutter/embedding/android/FlutterEngineProvider.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterEngineProvider.java
@@ -10,19 +10,19 @@ import androidx.annotation.Nullable;
 import io.flutter.embedding.engine.FlutterEngine;
 
 /**
- * Provides a {@link FlutterEngine} instance to be used by a {@code FlutterActivity} or {@code
+ * Provides a {@link io.flutter.embedding.engine.FlutterEngine} instance to be used by a {@code FlutterActivity} or {@code
  * FlutterFragment}.
  *
- * <p>{@link FlutterEngine} instances require significant time to warm up. Therefore, a developer
- * might choose to hold onto an existing {@link FlutterEngine} and connect it to various {@link
+ * <p>{@link io.flutter.embedding.engine.FlutterEngine} instances require significant time to warm up. Therefore, a developer
+ * might choose to hold onto an existing {@link io.flutter.embedding.engine.FlutterEngine} and connect it to various {@link
  * FlutterActivity}s and/or {@code FlutterFragment}s. This interface facilitates providing a cached,
- * pre-warmed {@link FlutterEngine}.
+ * pre-warmed {@link io.flutter.embedding.engine.FlutterEngine}.
  */
 public interface FlutterEngineProvider {
   /**
-   * Returns the {@link FlutterEngine} that should be used by a child {@code FlutterFragment}.
+   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} that should be used by a child {@code FlutterFragment}.
    *
-   * <p>This method may return a new {@link FlutterEngine}, an existing, cached {@link
+   * <p>This method may return a new {@link io.flutter.embedding.engine.FlutterEngine}, an existing, cached {@link
    * FlutterEngine}, or null to express that the {@code FlutterEngineProvider} would like the {@code
    * FlutterFragment} to provide its own {@code FlutterEngine} instance.
    */

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -51,24 +51,30 @@ import io.flutter.plugin.platform.PlatformPlugin;
  * <p>If convenient, consider using a {@link FlutterActivity} instead of a {@code FlutterFragment}
  * to avoid the work of forwarding calls.
  *
- * <p>{@code FlutterFragment} supports the use of an existing, cached {@link io.flutter.embedding.engine.FlutterEngine}. To use
- * a cached {@link io.flutter.embedding.engine.FlutterEngine}, ensure that the {@link io.flutter.embedding.engine.FlutterEngine} is stored in {@link
- * io.flutter.embedding.engine.FlutterEngineCache} and then use {@link #withCachedEngine(String)} to build a {@code
- * FlutterFragment} with the cached {@link io.flutter.embedding.engine.FlutterEngine}'s ID.
+ * <p>{@code FlutterFragment} supports the use of an existing, cached {@link
+ * io.flutter.embedding.engine.FlutterEngine}. To use a cached {@link
+ * io.flutter.embedding.engine.FlutterEngine}, ensure that the {@link
+ * io.flutter.embedding.engine.FlutterEngine} is stored in {@link
+ * io.flutter.embedding.engine.FlutterEngineCache} and then use {@link #withCachedEngine(String)} to
+ * build a {@code FlutterFragment} with the cached {@link
+ * io.flutter.embedding.engine.FlutterEngine}'s ID.
  *
- * <p>It is generally recommended to use a cached {@link io.flutter.embedding.engine.FlutterEngine} to avoid a momentary delay
- * when initializing a new {@link io.flutter.embedding.engine.FlutterEngine}. The two exceptions to using a cached {@link
+ * <p>It is generally recommended to use a cached {@link io.flutter.embedding.engine.FlutterEngine}
+ * to avoid a momentary delay when initializing a new {@link
+ * io.flutter.embedding.engine.FlutterEngine}. The two exceptions to using a cached {@link
  * FlutterEngine} are:
  *
  * <p>
  *
  * <ul>
  *   <li>When {@code FlutterFragment} is in the first {@code Activity} displayed by the app, because
- *       pre-warming a {@link io.flutter.embedding.engine.FlutterEngine} would have no impact in this situation.
+ *       pre-warming a {@link io.flutter.embedding.engine.FlutterEngine} would have no impact in
+ *       this situation.
  *   <li>When you are unsure when/if you will need to display a Flutter experience.
  * </ul>
  *
- * <p>The following illustrates how to pre-warm and cache a {@link io.flutter.embedding.engine.FlutterEngine}:
+ * <p>The following illustrates how to pre-warm and cache a {@link
+ * io.flutter.embedding.engine.FlutterEngine}:
  *
  * <pre>{@code
  * // Create and pre-warm a FlutterEngine.
@@ -109,14 +115,16 @@ public class FlutterFragment extends Fragment
   protected static final String ARG_SHOULD_ATTACH_ENGINE_TO_ACTIVITY =
       "should_attach_engine_to_activity";
   /**
-   * The ID of a {@link io.flutter.embedding.engine.FlutterEngine} cached in {@link io.flutter.embedding.engine.FlutterEngineCache} that will be used within
-   * the created {@code FlutterFragment}.
+   * The ID of a {@link io.flutter.embedding.engine.FlutterEngine} cached in {@link
+   * io.flutter.embedding.engine.FlutterEngineCache} that will be used within the created {@code
+   * FlutterFragment}.
    */
   protected static final String ARG_CACHED_ENGINE_ID = "cached_engine_id";
   /**
-   * True if the {@link io.flutter.embedding.engine.FlutterEngine} in the created {@code FlutterFragment} should be destroyed
-   * when the {@code FlutterFragment} is destroyed, false if the {@link io.flutter.embedding.engine.FlutterEngine} should
-   * outlive the {@code FlutterFragment}.
+   * True if the {@link io.flutter.embedding.engine.FlutterEngine} in the created {@code
+   * FlutterFragment} should be destroyed when the {@code FlutterFragment} is destroyed, false if
+   * the {@link io.flutter.embedding.engine.FlutterEngine} should outlive the {@code
+   * FlutterFragment}.
    */
   protected static final String ARG_DESTROY_ENGINE_WITH_FRAGMENT = "destroy_engine_with_fragment";
   /**
@@ -134,8 +142,9 @@ public class FlutterFragment extends Fragment
   /**
    * Creates a {@code FlutterFragment} with a default configuration.
    *
-   * <p>{@code FlutterFragment}'s default configuration creates a new {@link io.flutter.embedding.engine.FlutterEngine} within
-   * the {@code FlutterFragment} and uses the following settings:
+   * <p>{@code FlutterFragment}'s default configuration creates a new {@link
+   * io.flutter.embedding.engine.FlutterEngine} within the {@code FlutterFragment} and uses the
+   * following settings:
    *
    * <ul>
    *   <li>Dart entrypoint: "main"
@@ -144,10 +153,11 @@ public class FlutterFragment extends Fragment
    *   <li>Transparency mode: transparent
    * </ul>
    *
-   * <p>To use a new {@link io.flutter.embedding.engine.FlutterEngine} with different settings, use {@link #withNewEngine()}.
+   * <p>To use a new {@link io.flutter.embedding.engine.FlutterEngine} with different settings, use
+   * {@link #withNewEngine()}.
    *
-   * <p>To use a cached {@link io.flutter.embedding.engine.FlutterEngine} instead of creating a new one, use {@link
-   * #withCachedEngine(String)}.
+   * <p>To use a cached {@link io.flutter.embedding.engine.FlutterEngine} instead of creating a new
+   * one, use {@link #withCachedEngine(String)}.
    */
   @NonNull
   public static FlutterFragment createDefault() {
@@ -251,7 +261,8 @@ public class FlutterFragment extends Fragment
 
     /**
      * The path to the app bundle which contains the Dart app to execute. Null when unspecified,
-     * which defaults to {@link io.flutter.embedding.engine.loader.FlutterLoader#findAppBundlePath()}
+     * which defaults to {@link
+     * io.flutter.embedding.engine.loader.FlutterLoader#findAppBundlePath()}
      */
     @NonNull
     public NewEngineFragmentBuilder appBundlePath(@NonNull String appBundlePath) {
@@ -295,34 +306,37 @@ public class FlutterFragment extends Fragment
      * as a control surface for its {@link io.flutter.embedding.engine.FlutterEngine}.
      *
      * <p>Control surfaces are used to provide Android resources and lifecycle events to plugins
-     * that are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code shouldAttachEngineToActivity} is
-     * true then this {@code FlutterFragment} will connect its {@link io.flutter.embedding.engine.FlutterEngine} to the
-     * surrounding {@code Activity}, along with any plugins that are registered with that {@link
-     * FlutterEngine}. This allows plugins to access the {@code Activity}, as well as receive {@code
-     * Activity}-specific calls, e.g., {@link android.app.Activity#onNewIntent(Intent)}. If {@code
-     * shouldAttachEngineToActivity} is false, then this {@code FlutterFragment} will not
-     * automatically manage the connection between its {@link io.flutter.embedding.engine.FlutterEngine} and the surrounding
-     * {@code Activity}. The {@code Activity} will need to be manually connected to this {@code
-     * FlutterFragment}'s {@link io.flutter.embedding.engine.FlutterEngine} by the app developer. See {@link
+     * that are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code
+     * shouldAttachEngineToActivity} is true then this {@code FlutterFragment} will connect its
+     * {@link io.flutter.embedding.engine.FlutterEngine} to the surrounding {@code Activity}, along
+     * with any plugins that are registered with that {@link FlutterEngine}. This allows plugins to
+     * access the {@code Activity}, as well as receive {@code Activity}-specific calls, e.g., {@link
+     * android.app.Activity#onNewIntent(Intent)}. If {@code shouldAttachEngineToActivity} is false,
+     * then this {@code FlutterFragment} will not automatically manage the connection between its
+     * {@link io.flutter.embedding.engine.FlutterEngine} and the surrounding {@code Activity}. The
+     * {@code Activity} will need to be manually connected to this {@code FlutterFragment}'s {@link
+     * io.flutter.embedding.engine.FlutterEngine} by the app developer. See {@link
      * FlutterEngine#getActivityControlSurface()}.
      *
      * <p>One reason that a developer might choose to manually manage the relationship between the
-     * {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to move the {@link
-     * FlutterEngine} somewhere else. For example, a developer might want the {@link io.flutter.embedding.engine.FlutterEngine}
-     * to outlive the surrounding {@code Activity} so that it can be used later in a different
-     * {@code Activity}. To accomplish this, the {@link io.flutter.embedding.engine.FlutterEngine} will need to be disconnected
-     * from the surrounding {@code Activity} at an unusual time, preventing this {@code
-     * FlutterFragment} from correctly managing the relationship between the {@link io.flutter.embedding.engine.FlutterEngine}
-     * and the surrounding {@code Activity}.
+     * {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer
+     * wants to move the {@link FlutterEngine} somewhere else. For example, a developer might want
+     * the {@link io.flutter.embedding.engine.FlutterEngine} to outlive the surrounding {@code
+     * Activity} so that it can be used later in a different {@code Activity}. To accomplish this,
+     * the {@link io.flutter.embedding.engine.FlutterEngine} will need to be disconnected from the
+     * surrounding {@code Activity} at an unusual time, preventing this {@code FlutterFragment} from
+     * correctly managing the relationship between the {@link
+     * io.flutter.embedding.engine.FlutterEngine} and the surrounding {@code Activity}.
      *
      * <p>Another reason that a developer might choose to manually manage the relationship between
-     * the {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to prevent, or
-     * explicitly control when the {@link io.flutter.embedding.engine.FlutterEngine}'s plugins have access to the surrounding
-     * {@code Activity}. For example, imagine that this {@code FlutterFragment} only takes up part
-     * of the screen and the app developer wants to ensure that none of the Flutter plugins are able
-     * to manipulate the surrounding {@code Activity}. In this case, the developer would not want
-     * the {@link io.flutter.embedding.engine.FlutterEngine} to have access to the {@code Activity}, which can be accomplished
-     * by setting {@code shouldAttachEngineToActivity} to {@code false}.
+     * the {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the
+     * developer wants to prevent, or explicitly control when the {@link
+     * io.flutter.embedding.engine.FlutterEngine}'s plugins have access to the surrounding {@code
+     * Activity}. For example, imagine that this {@code FlutterFragment} only takes up part of the
+     * screen and the app developer wants to ensure that none of the Flutter plugins are able to
+     * manipulate the surrounding {@code Activity}. In this case, the developer would not want the
+     * {@link io.flutter.embedding.engine.FlutterEngine} to have access to the {@code Activity},
+     * which can be accomplished by setting {@code shouldAttachEngineToActivity} to {@code false}.
      */
     @NonNull
     public NewEngineFragmentBuilder shouldAttachEngineToActivity(
@@ -413,14 +427,16 @@ public class FlutterFragment extends Fragment
 
   /**
    * Returns a {@link CachedEngineFragmentBuilder} to create a {@code FlutterFragment} with a cached
-   * {@link io.flutter.embedding.engine.FlutterEngine} in {@link io.flutter.embedding.engine.FlutterEngineCache}.
+   * {@link io.flutter.embedding.engine.FlutterEngine} in {@link
+   * io.flutter.embedding.engine.FlutterEngineCache}.
    *
    * <p>An {@code IllegalStateException} will be thrown during the lifecycle of the {@code
-   * FlutterFragment} if a cached {@link io.flutter.embedding.engine.FlutterEngine} is requested but does not exist in the
-   * cache.
+   * FlutterFragment} if a cached {@link io.flutter.embedding.engine.FlutterEngine} is requested but
+   * does not exist in the cache.
    *
-   * <p>To create a {@code FlutterFragment} that uses a new {@link io.flutter.embedding.engine.FlutterEngine}, use {@link
-   * #createDefault()} or {@link #withNewEngine()}.
+   * <p>To create a {@code FlutterFragment} that uses a new {@link
+   * io.flutter.embedding.engine.FlutterEngine}, use {@link #createDefault()} or {@link
+   * #withNewEngine()}.
    */
   @NonNull
   public static CachedEngineFragmentBuilder withCachedEngine(@NonNull String engineId) {
@@ -428,8 +444,9 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Builder that creates a new {@code FlutterFragment} that uses a cached {@link io.flutter.embedding.engine.FlutterEngine}
-   * with {@code arguments} that correspond to the values set on this {@code Builder}.
+   * Builder that creates a new {@code FlutterFragment} that uses a cached {@link
+   * io.flutter.embedding.engine.FlutterEngine} with {@code arguments} that correspond to the values
+   * set on this {@code Builder}.
    *
    * <p>Subclasses of {@code FlutterFragment} that do not introduce any new arguments can use this
    * {@code Builder} to construct instances of the subclass without subclassing this {@code
@@ -476,9 +493,9 @@ public class FlutterFragment extends Fragment
     }
 
     /**
-     * Pass {@code true} to destroy the cached {@link io.flutter.embedding.engine.FlutterEngine} when this {@code
-     * FlutterFragment} is destroyed, or {@code false} for the cached {@link io.flutter.embedding.engine.FlutterEngine} to
-     * outlive this {@code FlutterFragment}.
+     * Pass {@code true} to destroy the cached {@link io.flutter.embedding.engine.FlutterEngine}
+     * when this {@code FlutterFragment} is destroyed, or {@code false} for the cached {@link
+     * io.flutter.embedding.engine.FlutterEngine} to outlive this {@code FlutterFragment}.
      */
     @NonNull
     public CachedEngineFragmentBuilder destroyEngineWithFragment(
@@ -527,34 +544,37 @@ public class FlutterFragment extends Fragment
      * as a control surface for its {@link io.flutter.embedding.engine.FlutterEngine}.
      *
      * <p>Control surfaces are used to provide Android resources and lifecycle events to plugins
-     * that are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code shouldAttachEngineToActivity} is
-     * true then this {@code FlutterFragment} will connect its {@link io.flutter.embedding.engine.FlutterEngine} to the
-     * surrounding {@code Activity}, along with any plugins that are registered with that {@link
-     * FlutterEngine}. This allows plugins to access the {@code Activity}, as well as receive {@code
-     * Activity}-specific calls, e.g., {@link android.app.Activity#onNewIntent(Intent)}. If {@code
-     * shouldAttachEngineToActivity} is false, then this {@code FlutterFragment} will not
-     * automatically manage the connection between its {@link io.flutter.embedding.engine.FlutterEngine} and the surrounding
-     * {@code Activity}. The {@code Activity} will need to be manually connected to this {@code
-     * FlutterFragment}'s {@link io.flutter.embedding.engine.FlutterEngine} by the app developer. See {@link
+     * that are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code
+     * shouldAttachEngineToActivity} is true then this {@code FlutterFragment} will connect its
+     * {@link io.flutter.embedding.engine.FlutterEngine} to the surrounding {@code Activity}, along
+     * with any plugins that are registered with that {@link FlutterEngine}. This allows plugins to
+     * access the {@code Activity}, as well as receive {@code Activity}-specific calls, e.g., {@link
+     * android.app.Activity#onNewIntent(Intent)}. If {@code shouldAttachEngineToActivity} is false,
+     * then this {@code FlutterFragment} will not automatically manage the connection between its
+     * {@link io.flutter.embedding.engine.FlutterEngine} and the surrounding {@code Activity}. The
+     * {@code Activity} will need to be manually connected to this {@code FlutterFragment}'s {@link
+     * io.flutter.embedding.engine.FlutterEngine} by the app developer. See {@link
      * FlutterEngine#getActivityControlSurface()}.
      *
      * <p>One reason that a developer might choose to manually manage the relationship between the
-     * {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to move the {@link
-     * FlutterEngine} somewhere else. For example, a developer might want the {@link io.flutter.embedding.engine.FlutterEngine}
-     * to outlive the surrounding {@code Activity} so that it can be used later in a different
-     * {@code Activity}. To accomplish this, the {@link io.flutter.embedding.engine.FlutterEngine} will need to be disconnected
-     * from the surrounding {@code Activity} at an unusual time, preventing this {@code
-     * FlutterFragment} from correctly managing the relationship between the {@link io.flutter.embedding.engine.FlutterEngine}
-     * and the surrounding {@code Activity}.
+     * {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer
+     * wants to move the {@link FlutterEngine} somewhere else. For example, a developer might want
+     * the {@link io.flutter.embedding.engine.FlutterEngine} to outlive the surrounding {@code
+     * Activity} so that it can be used later in a different {@code Activity}. To accomplish this,
+     * the {@link io.flutter.embedding.engine.FlutterEngine} will need to be disconnected from the
+     * surrounding {@code Activity} at an unusual time, preventing this {@code FlutterFragment} from
+     * correctly managing the relationship between the {@link
+     * io.flutter.embedding.engine.FlutterEngine} and the surrounding {@code Activity}.
      *
      * <p>Another reason that a developer might choose to manually manage the relationship between
-     * the {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to prevent, or
-     * explicitly control when the {@link io.flutter.embedding.engine.FlutterEngine}'s plugins have access to the surrounding
-     * {@code Activity}. For example, imagine that this {@code FlutterFragment} only takes up part
-     * of the screen and the app developer wants to ensure that none of the Flutter plugins are able
-     * to manipulate the surrounding {@code Activity}. In this case, the developer would not want
-     * the {@link io.flutter.embedding.engine.FlutterEngine} to have access to the {@code Activity}, which can be accomplished
-     * by setting {@code shouldAttachEngineToActivity} to {@code false}.
+     * the {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the
+     * developer wants to prevent, or explicitly control when the {@link
+     * io.flutter.embedding.engine.FlutterEngine}'s plugins have access to the surrounding {@code
+     * Activity}. For example, imagine that this {@code FlutterFragment} only takes up part of the
+     * screen and the app developer wants to ensure that none of the Flutter plugins are able to
+     * manipulate the surrounding {@code Activity}. In this case, the developer would not want the
+     * {@link io.flutter.embedding.engine.FlutterEngine} to have access to the {@code Activity},
+     * which can be accomplished by setting {@code shouldAttachEngineToActivity} to {@code false}.
      */
     @NonNull
     public CachedEngineFragmentBuilder shouldAttachEngineToActivity(
@@ -900,9 +920,9 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use within this {@code
-   * FlutterFragment}, or {@code null} if this {@code FlutterFragment} does not want to use a cached
-   * {@link io.flutter.embedding.engine.FlutterEngine}.
+   * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use
+   * within this {@code FlutterFragment}, or {@code null} if this {@code FlutterFragment} does not
+   * want to use a cached {@link io.flutter.embedding.engine.FlutterEngine}.
    */
   @Nullable
   @Override
@@ -919,11 +939,11 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Returns false if the {@link io.flutter.embedding.engine.FlutterEngine} within this {@code FlutterFragment} should outlive
-   * the {@code FlutterFragment}, itself.
+   * Returns false if the {@link io.flutter.embedding.engine.FlutterEngine} within this {@code
+   * FlutterFragment} should outlive the {@code FlutterFragment}, itself.
    *
-   * <p>Defaults to true if no custom {@link io.flutter.embedding.engine.FlutterEngine is provided}, false if a custom {@link
-   * FlutterEngine} is provided.
+   * <p>Defaults to true if no custom {@link io.flutter.embedding.engine.FlutterEngine is provided},
+   * false if a custom {@link FlutterEngine} is provided.
    */
   @Override
   public boolean shouldDestroyEngineWithHost() {
@@ -1027,18 +1047,22 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Hook for subclasses to return a {@link io.flutter.embedding.engine.FlutterEngine} with whatever configuration is desired.
+   * Hook for subclasses to return a {@link io.flutter.embedding.engine.FlutterEngine} with whatever
+   * configuration is desired.
    *
    * <p>By default this method defers to this {@code FlutterFragment}'s surrounding {@code
-   * Activity}, if that {@code Activity} implements {@link io.flutter.embedding.android.FlutterEngineProvider}. If this method is
-   * overridden, the surrounding {@code Activity} will no longer be given an opportunity to provide
-   * a {@link io.flutter.embedding.engine.FlutterEngine}, unless the subclass explicitly implements that behavior.
+   * Activity}, if that {@code Activity} implements {@link
+   * io.flutter.embedding.android.FlutterEngineProvider}. If this method is overridden, the
+   * surrounding {@code Activity} will no longer be given an opportunity to provide a {@link
+   * io.flutter.embedding.engine.FlutterEngine}, unless the subclass explicitly implements that
+   * behavior.
    *
-   * <p>Consider returning a cached {@link io.flutter.embedding.engine.FlutterEngine} instance from this method to avoid the
-   * typical warm-up time that a new {@link io.flutter.embedding.engine.FlutterEngine} instance requires.
+   * <p>Consider returning a cached {@link io.flutter.embedding.engine.FlutterEngine} instance from
+   * this method to avoid the typical warm-up time that a new {@link
+   * io.flutter.embedding.engine.FlutterEngine} instance requires.
    *
-   * <p>If null is returned then a new default {@link io.flutter.embedding.engine.FlutterEngine} will be created to back this
-   * {@code FlutterFragment}.
+   * <p>If null is returned then a new default {@link io.flutter.embedding.engine.FlutterEngine}
+   * will be created to back this {@code FlutterFragment}.
    *
    * <p>Used by this {@code FlutterFragment}'s {@link FlutterActivityAndFragmentDelegate.Host}
    */
@@ -1060,8 +1084,8 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Hook for subclasses to obtain a reference to the {@link io.flutter.embedding.engine.FlutterEngine} that is owned by this
-   * {@code FlutterActivity}.
+   * Hook for subclasses to obtain a reference to the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that is owned by this {@code FlutterActivity}.
    */
   @Nullable
   public FlutterEngine getFlutterEngine() {
@@ -1083,7 +1107,8 @@ public class FlutterFragment extends Fragment
    * Configures a {@link io.flutter.embedding.engine.FlutterEngine} after its creation.
    *
    * <p>This method is called after {@link #provideFlutterEngine(Context)}, and after the given
-   * {@link io.flutter.embedding.engine.FlutterEngine} has been attached to the owning {@code FragmentActivity}. See {@link
+   * {@link io.flutter.embedding.engine.FlutterEngine} has been attached to the owning {@code
+   * FragmentActivity}. See {@link
    * io.flutter.embedding.engine.plugins.activity.ActivityControlSurface#attachToActivity(
    * ExclusiveAppComponent, Lifecycle)}.
    *
@@ -1093,8 +1118,8 @@ public class FlutterFragment extends Fragment
    * the time that this method is invoked.
    *
    * <p>The default behavior of this method is to defer to the owning {@code FragmentActivity} as a
-   * {@link io.flutter.embedding.android.FlutterEngineConfigurator}. Subclasses can override this method if the subclass needs to
-   * override the {@code FragmentActivity}'s behavior, or add to it.
+   * {@link io.flutter.embedding.android.FlutterEngineConfigurator}. Subclasses can override this
+   * method if the subclass needs to override the {@code FragmentActivity}'s behavior, or add to it.
    *
    * <p>Used by this {@code FlutterFragment}'s {@link FlutterActivityAndFragmentDelegate.Host}
    */

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -51,24 +51,24 @@ import io.flutter.plugin.platform.PlatformPlugin;
  * <p>If convenient, consider using a {@link FlutterActivity} instead of a {@code FlutterFragment}
  * to avoid the work of forwarding calls.
  *
- * <p>{@code FlutterFragment} supports the use of an existing, cached {@link FlutterEngine}. To use
- * a cached {@link FlutterEngine}, ensure that the {@link FlutterEngine} is stored in {@link
- * FlutterEngineCache} and then use {@link #withCachedEngine(String)} to build a {@code
- * FlutterFragment} with the cached {@link FlutterEngine}'s ID.
+ * <p>{@code FlutterFragment} supports the use of an existing, cached {@link io.flutter.embedding.engine.FlutterEngine}. To use
+ * a cached {@link io.flutter.embedding.engine.FlutterEngine}, ensure that the {@link io.flutter.embedding.engine.FlutterEngine} is stored in {@link
+ * io.flutter.embedding.engine.FlutterEngineCache} and then use {@link #withCachedEngine(String)} to build a {@code
+ * FlutterFragment} with the cached {@link io.flutter.embedding.engine.FlutterEngine}'s ID.
  *
- * <p>It is generally recommended to use a cached {@link FlutterEngine} to avoid a momentary delay
- * when initializing a new {@link FlutterEngine}. The two exceptions to using a cached {@link
+ * <p>It is generally recommended to use a cached {@link io.flutter.embedding.engine.FlutterEngine} to avoid a momentary delay
+ * when initializing a new {@link io.flutter.embedding.engine.FlutterEngine}. The two exceptions to using a cached {@link
  * FlutterEngine} are:
  *
  * <p>
  *
  * <ul>
  *   <li>When {@code FlutterFragment} is in the first {@code Activity} displayed by the app, because
- *       pre-warming a {@link FlutterEngine} would have no impact in this situation.
+ *       pre-warming a {@link io.flutter.embedding.engine.FlutterEngine} would have no impact in this situation.
  *   <li>When you are unsure when/if you will need to display a Flutter experience.
  * </ul>
  *
- * <p>The following illustrates how to pre-warm and cache a {@link FlutterEngine}:
+ * <p>The following illustrates how to pre-warm and cache a {@link io.flutter.embedding.engine.FlutterEngine}:
  *
  * <pre>{@code
  * // Create and pre-warm a FlutterEngine.
@@ -109,13 +109,13 @@ public class FlutterFragment extends Fragment
   protected static final String ARG_SHOULD_ATTACH_ENGINE_TO_ACTIVITY =
       "should_attach_engine_to_activity";
   /**
-   * The ID of a {@link FlutterEngine} cached in {@link FlutterEngineCache} that will be used within
+   * The ID of a {@link io.flutter.embedding.engine.FlutterEngine} cached in {@link io.flutter.embedding.engine.FlutterEngineCache} that will be used within
    * the created {@code FlutterFragment}.
    */
   protected static final String ARG_CACHED_ENGINE_ID = "cached_engine_id";
   /**
-   * True if the {@link FlutterEngine} in the created {@code FlutterFragment} should be destroyed
-   * when the {@code FlutterFragment} is destroyed, false if the {@link FlutterEngine} should
+   * True if the {@link io.flutter.embedding.engine.FlutterEngine} in the created {@code FlutterFragment} should be destroyed
+   * when the {@code FlutterFragment} is destroyed, false if the {@link io.flutter.embedding.engine.FlutterEngine} should
    * outlive the {@code FlutterFragment}.
    */
   protected static final String ARG_DESTROY_ENGINE_WITH_FRAGMENT = "destroy_engine_with_fragment";
@@ -134,7 +134,7 @@ public class FlutterFragment extends Fragment
   /**
    * Creates a {@code FlutterFragment} with a default configuration.
    *
-   * <p>{@code FlutterFragment}'s default configuration creates a new {@link FlutterEngine} within
+   * <p>{@code FlutterFragment}'s default configuration creates a new {@link io.flutter.embedding.engine.FlutterEngine} within
    * the {@code FlutterFragment} and uses the following settings:
    *
    * <ul>
@@ -144,9 +144,9 @@ public class FlutterFragment extends Fragment
    *   <li>Transparency mode: transparent
    * </ul>
    *
-   * <p>To use a new {@link FlutterEngine} with different settings, use {@link #withNewEngine()}.
+   * <p>To use a new {@link io.flutter.embedding.engine.FlutterEngine} with different settings, use {@link #withNewEngine()}.
    *
-   * <p>To use a cached {@link FlutterEngine} instead of creating a new one, use {@link
+   * <p>To use a cached {@link io.flutter.embedding.engine.FlutterEngine} instead of creating a new one, use {@link
    * #withCachedEngine(String)}.
    */
   @NonNull
@@ -156,7 +156,7 @@ public class FlutterFragment extends Fragment
 
   /**
    * Returns a {@link NewEngineFragmentBuilder} to create a {@code FlutterFragment} with a new
-   * {@link FlutterEngine} and a desired engine configuration.
+   * {@link io.flutter.embedding.engine.FlutterEngine} and a desired engine configuration.
    */
   @NonNull
   public static NewEngineFragmentBuilder withNewEngine() {
@@ -251,7 +251,7 @@ public class FlutterFragment extends Fragment
 
     /**
      * The path to the app bundle which contains the Dart app to execute. Null when unspecified,
-     * which defaults to {@link FlutterLoader#findAppBundlePath()}
+     * which defaults to {@link io.flutter.embedding.engine.loader.FlutterLoader#findAppBundlePath()}
      */
     @NonNull
     public NewEngineFragmentBuilder appBundlePath(@NonNull String appBundlePath) {
@@ -292,36 +292,36 @@ public class FlutterFragment extends Fragment
 
     /**
      * Whether or not this {@code FlutterFragment} should automatically attach its {@code Activity}
-     * as a control surface for its {@link FlutterEngine}.
+     * as a control surface for its {@link io.flutter.embedding.engine.FlutterEngine}.
      *
      * <p>Control surfaces are used to provide Android resources and lifecycle events to plugins
-     * that are attached to the {@link FlutterEngine}. If {@code shouldAttachEngineToActivity} is
-     * true then this {@code FlutterFragment} will connect its {@link FlutterEngine} to the
+     * that are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code shouldAttachEngineToActivity} is
+     * true then this {@code FlutterFragment} will connect its {@link io.flutter.embedding.engine.FlutterEngine} to the
      * surrounding {@code Activity}, along with any plugins that are registered with that {@link
      * FlutterEngine}. This allows plugins to access the {@code Activity}, as well as receive {@code
      * Activity}-specific calls, e.g., {@link android.app.Activity#onNewIntent(Intent)}. If {@code
      * shouldAttachEngineToActivity} is false, then this {@code FlutterFragment} will not
-     * automatically manage the connection between its {@link FlutterEngine} and the surrounding
+     * automatically manage the connection between its {@link io.flutter.embedding.engine.FlutterEngine} and the surrounding
      * {@code Activity}. The {@code Activity} will need to be manually connected to this {@code
-     * FlutterFragment}'s {@link FlutterEngine} by the app developer. See {@link
+     * FlutterFragment}'s {@link io.flutter.embedding.engine.FlutterEngine} by the app developer. See {@link
      * FlutterEngine#getActivityControlSurface()}.
      *
      * <p>One reason that a developer might choose to manually manage the relationship between the
-     * {@code Activity} and {@link FlutterEngine} is if the developer wants to move the {@link
-     * FlutterEngine} somewhere else. For example, a developer might want the {@link FlutterEngine}
+     * {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to move the {@link
+     * FlutterEngine} somewhere else. For example, a developer might want the {@link io.flutter.embedding.engine.FlutterEngine}
      * to outlive the surrounding {@code Activity} so that it can be used later in a different
-     * {@code Activity}. To accomplish this, the {@link FlutterEngine} will need to be disconnected
+     * {@code Activity}. To accomplish this, the {@link io.flutter.embedding.engine.FlutterEngine} will need to be disconnected
      * from the surrounding {@code Activity} at an unusual time, preventing this {@code
-     * FlutterFragment} from correctly managing the relationship between the {@link FlutterEngine}
+     * FlutterFragment} from correctly managing the relationship between the {@link io.flutter.embedding.engine.FlutterEngine}
      * and the surrounding {@code Activity}.
      *
      * <p>Another reason that a developer might choose to manually manage the relationship between
-     * the {@code Activity} and {@link FlutterEngine} is if the developer wants to prevent, or
-     * explicitly control when the {@link FlutterEngine}'s plugins have access to the surrounding
+     * the {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to prevent, or
+     * explicitly control when the {@link io.flutter.embedding.engine.FlutterEngine}'s plugins have access to the surrounding
      * {@code Activity}. For example, imagine that this {@code FlutterFragment} only takes up part
      * of the screen and the app developer wants to ensure that none of the Flutter plugins are able
      * to manipulate the surrounding {@code Activity}. In this case, the developer would not want
-     * the {@link FlutterEngine} to have access to the {@code Activity}, which can be accomplished
+     * the {@link io.flutter.embedding.engine.FlutterEngine} to have access to the {@code Activity}, which can be accomplished
      * by setting {@code shouldAttachEngineToActivity} to {@code false}.
      */
     @NonNull
@@ -413,13 +413,13 @@ public class FlutterFragment extends Fragment
 
   /**
    * Returns a {@link CachedEngineFragmentBuilder} to create a {@code FlutterFragment} with a cached
-   * {@link FlutterEngine} in {@link FlutterEngineCache}.
+   * {@link io.flutter.embedding.engine.FlutterEngine} in {@link io.flutter.embedding.engine.FlutterEngineCache}.
    *
    * <p>An {@code IllegalStateException} will be thrown during the lifecycle of the {@code
-   * FlutterFragment} if a cached {@link FlutterEngine} is requested but does not exist in the
+   * FlutterFragment} if a cached {@link io.flutter.embedding.engine.FlutterEngine} is requested but does not exist in the
    * cache.
    *
-   * <p>To create a {@code FlutterFragment} that uses a new {@link FlutterEngine}, use {@link
+   * <p>To create a {@code FlutterFragment} that uses a new {@link io.flutter.embedding.engine.FlutterEngine}, use {@link
    * #createDefault()} or {@link #withNewEngine()}.
    */
   @NonNull
@@ -428,7 +428,7 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Builder that creates a new {@code FlutterFragment} that uses a cached {@link FlutterEngine}
+   * Builder that creates a new {@code FlutterFragment} that uses a cached {@link io.flutter.embedding.engine.FlutterEngine}
    * with {@code arguments} that correspond to the values set on this {@code Builder}.
    *
    * <p>Subclasses of {@code FlutterFragment} that do not introduce any new arguments can use this
@@ -476,8 +476,8 @@ public class FlutterFragment extends Fragment
     }
 
     /**
-     * Pass {@code true} to destroy the cached {@link FlutterEngine} when this {@code
-     * FlutterFragment} is destroyed, or {@code false} for the cached {@link FlutterEngine} to
+     * Pass {@code true} to destroy the cached {@link io.flutter.embedding.engine.FlutterEngine} when this {@code
+     * FlutterFragment} is destroyed, or {@code false} for the cached {@link io.flutter.embedding.engine.FlutterEngine} to
      * outlive this {@code FlutterFragment}.
      */
     @NonNull
@@ -524,36 +524,36 @@ public class FlutterFragment extends Fragment
 
     /**
      * Whether or not this {@code FlutterFragment} should automatically attach its {@code Activity}
-     * as a control surface for its {@link FlutterEngine}.
+     * as a control surface for its {@link io.flutter.embedding.engine.FlutterEngine}.
      *
      * <p>Control surfaces are used to provide Android resources and lifecycle events to plugins
-     * that are attached to the {@link FlutterEngine}. If {@code shouldAttachEngineToActivity} is
-     * true then this {@code FlutterFragment} will connect its {@link FlutterEngine} to the
+     * that are attached to the {@link io.flutter.embedding.engine.FlutterEngine}. If {@code shouldAttachEngineToActivity} is
+     * true then this {@code FlutterFragment} will connect its {@link io.flutter.embedding.engine.FlutterEngine} to the
      * surrounding {@code Activity}, along with any plugins that are registered with that {@link
      * FlutterEngine}. This allows plugins to access the {@code Activity}, as well as receive {@code
      * Activity}-specific calls, e.g., {@link android.app.Activity#onNewIntent(Intent)}. If {@code
      * shouldAttachEngineToActivity} is false, then this {@code FlutterFragment} will not
-     * automatically manage the connection between its {@link FlutterEngine} and the surrounding
+     * automatically manage the connection between its {@link io.flutter.embedding.engine.FlutterEngine} and the surrounding
      * {@code Activity}. The {@code Activity} will need to be manually connected to this {@code
-     * FlutterFragment}'s {@link FlutterEngine} by the app developer. See {@link
+     * FlutterFragment}'s {@link io.flutter.embedding.engine.FlutterEngine} by the app developer. See {@link
      * FlutterEngine#getActivityControlSurface()}.
      *
      * <p>One reason that a developer might choose to manually manage the relationship between the
-     * {@code Activity} and {@link FlutterEngine} is if the developer wants to move the {@link
-     * FlutterEngine} somewhere else. For example, a developer might want the {@link FlutterEngine}
+     * {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to move the {@link
+     * FlutterEngine} somewhere else. For example, a developer might want the {@link io.flutter.embedding.engine.FlutterEngine}
      * to outlive the surrounding {@code Activity} so that it can be used later in a different
-     * {@code Activity}. To accomplish this, the {@link FlutterEngine} will need to be disconnected
+     * {@code Activity}. To accomplish this, the {@link io.flutter.embedding.engine.FlutterEngine} will need to be disconnected
      * from the surrounding {@code Activity} at an unusual time, preventing this {@code
-     * FlutterFragment} from correctly managing the relationship between the {@link FlutterEngine}
+     * FlutterFragment} from correctly managing the relationship between the {@link io.flutter.embedding.engine.FlutterEngine}
      * and the surrounding {@code Activity}.
      *
      * <p>Another reason that a developer might choose to manually manage the relationship between
-     * the {@code Activity} and {@link FlutterEngine} is if the developer wants to prevent, or
-     * explicitly control when the {@link FlutterEngine}'s plugins have access to the surrounding
+     * the {@code Activity} and {@link io.flutter.embedding.engine.FlutterEngine} is if the developer wants to prevent, or
+     * explicitly control when the {@link io.flutter.embedding.engine.FlutterEngine}'s plugins have access to the surrounding
      * {@code Activity}. For example, imagine that this {@code FlutterFragment} only takes up part
      * of the screen and the app developer wants to ensure that none of the Flutter plugins are able
      * to manipulate the surrounding {@code Activity}. In this case, the developer would not want
-     * the {@link FlutterEngine} to have access to the {@code Activity}, which can be accomplished
+     * the {@link io.flutter.embedding.engine.FlutterEngine} to have access to the {@code Activity}, which can be accomplished
      * by setting {@code shouldAttachEngineToActivity} to {@code false}.
      */
     @NonNull
@@ -900,9 +900,9 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Returns the ID of a statically cached {@link FlutterEngine} to use within this {@code
+   * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use within this {@code
    * FlutterFragment}, or {@code null} if this {@code FlutterFragment} does not want to use a cached
-   * {@link FlutterEngine}.
+   * {@link io.flutter.embedding.engine.FlutterEngine}.
    */
   @Nullable
   @Override
@@ -919,10 +919,10 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Returns false if the {@link FlutterEngine} within this {@code FlutterFragment} should outlive
+   * Returns false if the {@link io.flutter.embedding.engine.FlutterEngine} within this {@code FlutterFragment} should outlive
    * the {@code FlutterFragment}, itself.
    *
-   * <p>Defaults to true if no custom {@link FlutterEngine is provided}, false if a custom {@link
+   * <p>Defaults to true if no custom {@link io.flutter.embedding.engine.FlutterEngine is provided}, false if a custom {@link
    * FlutterEngine} is provided.
    */
   @Override
@@ -958,7 +958,7 @@ public class FlutterFragment extends Fragment
    * snapshots.
    *
    * <p>When unspecified, the value is null, which defaults to the app bundle path defined in {@link
-   * FlutterLoader#findAppBundlePath()}.
+   * io.flutter.embedding.engine.loader.FlutterLoader#findAppBundlePath()}.
    *
    * <p>Used by this {@code FlutterFragment}'s {@link FlutterActivityAndFragmentDelegate.Host}
    */
@@ -1027,17 +1027,17 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Hook for subclasses to return a {@link FlutterEngine} with whatever configuration is desired.
+   * Hook for subclasses to return a {@link io.flutter.embedding.engine.FlutterEngine} with whatever configuration is desired.
    *
    * <p>By default this method defers to this {@code FlutterFragment}'s surrounding {@code
-   * Activity}, if that {@code Activity} implements {@link FlutterEngineProvider}. If this method is
+   * Activity}, if that {@code Activity} implements {@link io.flutter.embedding.android.FlutterEngineProvider}. If this method is
    * overridden, the surrounding {@code Activity} will no longer be given an opportunity to provide
-   * a {@link FlutterEngine}, unless the subclass explicitly implements that behavior.
+   * a {@link io.flutter.embedding.engine.FlutterEngine}, unless the subclass explicitly implements that behavior.
    *
-   * <p>Consider returning a cached {@link FlutterEngine} instance from this method to avoid the
-   * typical warm-up time that a new {@link FlutterEngine} instance requires.
+   * <p>Consider returning a cached {@link io.flutter.embedding.engine.FlutterEngine} instance from this method to avoid the
+   * typical warm-up time that a new {@link io.flutter.embedding.engine.FlutterEngine} instance requires.
    *
-   * <p>If null is returned then a new default {@link FlutterEngine} will be created to back this
+   * <p>If null is returned then a new default {@link io.flutter.embedding.engine.FlutterEngine} will be created to back this
    * {@code FlutterFragment}.
    *
    * <p>Used by this {@code FlutterFragment}'s {@link FlutterActivityAndFragmentDelegate.Host}
@@ -1060,7 +1060,7 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Hook for subclasses to obtain a reference to the {@link FlutterEngine} that is owned by this
+   * Hook for subclasses to obtain a reference to the {@link io.flutter.embedding.engine.FlutterEngine} that is owned by this
    * {@code FlutterActivity}.
    */
   @Nullable
@@ -1080,10 +1080,10 @@ public class FlutterFragment extends Fragment
   }
 
   /**
-   * Configures a {@link FlutterEngine} after its creation.
+   * Configures a {@link io.flutter.embedding.engine.FlutterEngine} after its creation.
    *
    * <p>This method is called after {@link #provideFlutterEngine(Context)}, and after the given
-   * {@link FlutterEngine} has been attached to the owning {@code FragmentActivity}. See {@link
+   * {@link io.flutter.embedding.engine.FlutterEngine} has been attached to the owning {@code FragmentActivity}. See {@link
    * io.flutter.embedding.engine.plugins.activity.ActivityControlSurface#attachToActivity(
    * ExclusiveAppComponent, Lifecycle)}.
    *
@@ -1093,7 +1093,7 @@ public class FlutterFragment extends Fragment
    * the time that this method is invoked.
    *
    * <p>The default behavior of this method is to defer to the owning {@code FragmentActivity} as a
-   * {@link FlutterEngineConfigurator}. Subclasses can override this method if the subclass needs to
+   * {@link io.flutter.embedding.android.FlutterEngineConfigurator}. Subclasses can override this method if the subclass needs to
    * override the {@code FragmentActivity}'s behavior, or add to it.
    *
    * <p>Used by this {@code FlutterFragment}'s {@link FlutterActivityAndFragmentDelegate.Host}

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -76,7 +76,8 @@ public class FlutterFragmentActivity extends FragmentActivity
   /**
    * Creates an {@link FlutterFragmentActivity.NewEngineIntentBuilder}, which can be used to
    * configure an {@link Intent} to launch a {@code FlutterFragmentActivity} that internally creates
-   * a new {@link io.flutter.embedding.engine.FlutterEngine} using the desired Dart entrypoint, initial route, etc.
+   * a new {@link io.flutter.embedding.engine.FlutterEngine} using the desired Dart entrypoint,
+   * initial route, etc.
    */
   @NonNull
   public static NewEngineIntentBuilder withNewEngine() {
@@ -178,9 +179,9 @@ public class FlutterFragmentActivity extends FragmentActivity
      * {@code FlutterFragmentActivity}.
      *
      * <p>Subclasses of {@code FlutterFragmentActivity} should provide their own static version of
-     * {@link #withCachedEngine(String)}, which returns an instance of {@code CachedEngineIntentBuilder}
-     * constructed with a {@code Class} reference to the {@code FlutterFragmentActivity} subclass,
-     * e.g.:
+     * {@link #withCachedEngine(String)}, which returns an instance of {@code
+     * CachedEngineIntentBuilder} constructed with a {@code Class} reference to the {@code
+     * FlutterFragmentActivity} subclass, e.g.:
      *
      * <p>{@code return new CachedEngineIntentBuilder(MyFlutterActivity.class, engineId); }
      */
@@ -191,8 +192,8 @@ public class FlutterFragmentActivity extends FragmentActivity
     }
 
     /**
-     * Returns true if the cached {@link io.flutter.embedding.engine.FlutterEngine} should be destroyed and removed from the
-     * cache when this {@code FlutterFragmentActivity} is destroyed.
+     * Returns true if the cached {@link io.flutter.embedding.engine.FlutterEngine} should be
+     * destroyed and removed from the cache when this {@code FlutterFragmentActivity} is destroyed.
      *
      * <p>The default value is {@code false}.
      */
@@ -536,13 +537,13 @@ public class FlutterFragmentActivity extends FragmentActivity
   }
 
   /**
-   * Returns false if the {@link io.flutter.embedding.engine.FlutterEngine} backing this {@code FlutterFragmentActivity} should
-   * outlive this {@code FlutterFragmentActivity}, or true to be destroyed when the {@code
-   * FlutterFragmentActivity} is destroyed.
+   * Returns false if the {@link io.flutter.embedding.engine.FlutterEngine} backing this {@code
+   * FlutterFragmentActivity} should outlive this {@code FlutterFragmentActivity}, or true to be
+   * destroyed when the {@code FlutterFragmentActivity} is destroyed.
    *
    * <p>The default value is {@code true} in cases where {@code FlutterFragmentActivity} created its
-   * own {@link io.flutter.embedding.engine.FlutterEngine}, and {@code false} in cases where a cached {@link io.flutter.embedding.engine.FlutterEngine} was
-   * provided.
+   * own {@link io.flutter.embedding.engine.FlutterEngine}, and {@code false} in cases where a
+   * cached {@link io.flutter.embedding.engine.FlutterEngine} was provided.
    */
   public boolean shouldDestroyEngineWithHost() {
     return getIntent().getBooleanExtra(EXTRA_DESTROY_ENGINE_WITH_ACTIVITY, false);
@@ -550,7 +551,8 @@ public class FlutterFragmentActivity extends FragmentActivity
 
   /**
    * Hook for subclasses to control whether or not the {@link FlutterFragment} within this {@code
-   * Activity} automatically attaches its {@link io.flutter.embedding.engine.FlutterEngine} to this {@code Activity}.
+   * Activity} automatically attaches its {@link io.flutter.embedding.engine.FlutterEngine} to this
+   * {@code Activity}.
    *
    * <p>For an explanation of why this control exists, see {@link
    * FlutterFragment.NewEngineFragmentBuilder#shouldAttachEngineToActivity()}.
@@ -727,9 +729,10 @@ public class FlutterFragmentActivity extends FragmentActivity
   }
 
   /**
-   * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use within this {@code
-   * FlutterFragmentActivity}, or {@code null} if this {@code FlutterFragmentActivity} does not want
-   * to use a cached {@link io.flutter.embedding.engine.FlutterEngine}.
+   * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use
+   * within this {@code FlutterFragmentActivity}, or {@code null} if this {@code
+   * FlutterFragmentActivity} does not want to use a cached {@link
+   * io.flutter.embedding.engine.FlutterEngine}.
    */
   @Nullable
   protected String getCachedEngineId() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -76,7 +76,7 @@ public class FlutterFragmentActivity extends FragmentActivity
   /**
    * Creates an {@link FlutterFragmentActivity.NewEngineIntentBuilder}, which can be used to
    * configure an {@link Intent} to launch a {@code FlutterFragmentActivity} that internally creates
-   * a new {@link FlutterEngine} using the desired Dart entrypoint, initial route, etc.
+   * a new {@link io.flutter.embedding.engine.FlutterEngine} using the desired Dart entrypoint, initial route, etc.
    */
   @NonNull
   public static NewEngineIntentBuilder withNewEngine() {
@@ -85,7 +85,7 @@ public class FlutterFragmentActivity extends FragmentActivity
 
   /**
    * Builder to create an {@code Intent} that launches a {@code FlutterFragmentActivity} with a new
-   * {@link FlutterEngine} and the desired configuration.
+   * {@link io.flutter.embedding.engine.FlutterEngine} and the desired configuration.
    */
   public static class NewEngineIntentBuilder {
     private final Class<? extends FlutterFragmentActivity> activityClass;
@@ -164,7 +164,7 @@ public class FlutterFragmentActivity extends FragmentActivity
 
   /**
    * Builder to create an {@code Intent} that launches a {@code FlutterFragmentActivity} with an
-   * existing {@link FlutterEngine} that is cached in {@link
+   * existing {@link io.flutter.embedding.engine.FlutterEngine} that is cached in {@link
    * io.flutter.embedding.engine.FlutterEngineCache}.
    */
   public static class CachedEngineIntentBuilder {
@@ -178,7 +178,7 @@ public class FlutterFragmentActivity extends FragmentActivity
      * {@code FlutterFragmentActivity}.
      *
      * <p>Subclasses of {@code FlutterFragmentActivity} should provide their own static version of
-     * {@link #withCachedEngine()}, which returns an instance of {@code CachedEngineIntentBuilder}
+     * {@link #withCachedEngine(String)}, which returns an instance of {@code CachedEngineIntentBuilder}
      * constructed with a {@code Class} reference to the {@code FlutterFragmentActivity} subclass,
      * e.g.:
      *
@@ -191,7 +191,7 @@ public class FlutterFragmentActivity extends FragmentActivity
     }
 
     /**
-     * Returns true if the cached {@link FlutterEngine} should be destroyed and removed from the
+     * Returns true if the cached {@link io.flutter.embedding.engine.FlutterEngine} should be destroyed and removed from the
      * cache when this {@code FlutterFragmentActivity} is destroyed.
      *
      * <p>The default value is {@code false}.
@@ -536,12 +536,12 @@ public class FlutterFragmentActivity extends FragmentActivity
   }
 
   /**
-   * Returns false if the {@link FlutterEngine} backing this {@code FlutterFragmentActivity} should
+   * Returns false if the {@link io.flutter.embedding.engine.FlutterEngine} backing this {@code FlutterFragmentActivity} should
    * outlive this {@code FlutterFragmentActivity}, or true to be destroyed when the {@code
    * FlutterFragmentActivity} is destroyed.
    *
    * <p>The default value is {@code true} in cases where {@code FlutterFragmentActivity} created its
-   * own {@link FlutterEngine}, and {@code false} in cases where a cached {@link FlutterEngine} was
+   * own {@link io.flutter.embedding.engine.FlutterEngine}, and {@code false} in cases where a cached {@link io.flutter.embedding.engine.FlutterEngine} was
    * provided.
    */
   public boolean shouldDestroyEngineWithHost() {
@@ -550,7 +550,7 @@ public class FlutterFragmentActivity extends FragmentActivity
 
   /**
    * Hook for subclasses to control whether or not the {@link FlutterFragment} within this {@code
-   * Activity} automatically attaches its {@link FlutterEngine} to this {@code Activity}.
+   * Activity} automatically attaches its {@link io.flutter.embedding.engine.FlutterEngine} to this {@code Activity}.
    *
    * <p>For an explanation of why this control exists, see {@link
    * FlutterFragment.NewEngineFragmentBuilder#shouldAttachEngineToActivity()}.
@@ -638,7 +638,7 @@ public class FlutterFragmentActivity extends FragmentActivity
    * path.
    *
    * <p>When otherwise unspecified, the value is null, which defaults to the app bundle path defined
-   * in {@link FlutterLoader#findAppBundlePath()}.
+   * in {@link io.flutter.embedding.engine.loader.FlutterLoader#findAppBundlePath()}.
    *
    * <p>Subclasses may override this method to return a custom app bundle path.
    */
@@ -727,9 +727,9 @@ public class FlutterFragmentActivity extends FragmentActivity
   }
 
   /**
-   * Returns the ID of a statically cached {@link FlutterEngine} to use within this {@code
+   * Returns the ID of a statically cached {@link io.flutter.embedding.engine.FlutterEngine} to use within this {@code
    * FlutterFragmentActivity}, or {@code null} if this {@code FlutterFragmentActivity} does not want
-   * to use a cached {@link FlutterEngine}.
+   * to use a cached {@link io.flutter.embedding.engine.FlutterEngine}.
    */
   @Nullable
   protected String getCachedEngineId() {
@@ -754,7 +754,7 @@ public class FlutterFragmentActivity extends FragmentActivity
    * FlutterFragmentActivity}.
    *
    * <p>That is, {@link RenderMode#surface} if {@link FlutterFragmentActivity#getBackgroundMode()}
-   * is {@link BackgroundMode.opaque} or {@link RenderMode#texture} otherwise.
+   * is {@link BackgroundMode#opaque} or {@link RenderMode#texture} otherwise.
    */
   @NonNull
   protected RenderMode getRenderMode() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -834,9 +834,9 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
    * Prior to Android Q, it's impossible to add real views as descendants of virtual nodes. This
    * breaks accessibility when an Android view is embedded in a Flutter app.
    *
-   * <p>This method overrides a This member is not intended for public use, and is only visible for
-   * testing. method in {@code ViewGroup} to workaround this limitation. This solution is derivated
-   * from Jetpack Compose, and can be found in the Android source code as well.
+   * <p>This method overrides a hidden method in {@code ViewGroup} to workaround this limitation.
+   * This solution is derivated from Jetpack Compose, and can be found in the Android source code as
+   * well.
    *
    * <p>This workaround finds the descendant {@code View} that matches the provided accessibility
    * id.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -53,7 +53,7 @@ import java.util.Set;
 /**
  * Displays a Flutter UI on an Android device.
  *
- * <p>A {@code FlutterView}'s UI is painted by a corresponding {@link FlutterEngine}.
+ * <p>A {@code FlutterView}'s UI is painted by a corresponding {@link io.flutter.embedding.engine.FlutterEngine}.
  *
  * <p>A {@code FlutterView} can operate in 2 different {@link
  * io.flutter.embedding.android.RenderMode}s:
@@ -336,12 +336,12 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * Returns true if an attached {@link FlutterEngine} has rendered at least 1 frame to this {@code
+   * Returns true if an attached {@link io.flutter.embedding.engine.FlutterEngine} has rendered at least 1 frame to this {@code
    * FlutterView}.
    *
-   * <p>Returns false if no {@link FlutterEngine} is attached.
+   * <p>Returns false if no {@link io.flutter.embedding.engine.FlutterEngine} is attached.
    *
-   * <p>This flag is specific to a given {@link FlutterEngine}. The following hypothetical timeline
+   * <p>This flag is specific to a given {@link io.flutter.embedding.engine.FlutterEngine}. The following hypothetical timeline
    * demonstrates how this flag changes over time.
    *
    * <ol>
@@ -498,7 +498,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
    * these insets. Therefore, this method calculates the viewport metrics that Flutter should use
    * and then sends those metrics to Flutter.
    *
-   * <p>This callback is not present in API < 20, which means lower API devices will see the wider
+   * <p>This callback is not present in API &lt; 20, which means lower API devices will see the wider
    * than expected padding when the status and navigation bars are hidden.
    */
   @Override
@@ -833,7 +833,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
    * Prior to Android Q, it's impossible to add real views as descendants of virtual nodes. This
    * breaks accessibility when an Android view is embedded in a Flutter app.
    *
-   * <p>This method overrides a @hide method in {@code ViewGroup} to workaround this limitation.
+   * <p>This method overrides a This member is not intended for public use, and is only visible for testing. method in {@code ViewGroup} to workaround this limitation.
    * This solution is derivated from Jetpack Compose, and can be found in the Android source code as
    * well.
    *
@@ -851,7 +851,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     // Android Q or later doesn't call this method.
     //
     // However, since this is implementation detail, a future version of Android might call
-    // this method again, fallback to calling the @hide method as expected by ViewGroup.
+    // this method again, fallback to calling the This member is not intended for public use, and is only visible for testing. method as expected by ViewGroup.
     Method findViewByAccessibilityIdTraversalMethod;
     try {
       findViewByAccessibilityIdTraversalMethod =
@@ -929,11 +929,11 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   // -------- End: Mouse ---------
 
   /**
-   * Connects this {@code FlutterView} to the given {@link FlutterEngine}.
+   * Connects this {@code FlutterView} to the given {@link io.flutter.embedding.engine.FlutterEngine}.
    *
    * <p>This {@code FlutterView} will begin rendering the UI painted by the given {@link
    * FlutterEngine}. This {@code FlutterView} will also begin forwarding interaction events from
-   * this {@code FlutterView} to the given {@link FlutterEngine}, e.g., user touch events,
+   * this {@code FlutterView} to the given {@link io.flutter.embedding.engine.FlutterEngine}, e.g., user touch events,
    * accessibility events, keyboard events, and others.
    *
    * <p>See {@link #detachFromFlutterEngine()} for information on how to detach from a {@link
@@ -1030,10 +1030,10 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * Disconnects this {@code FlutterView} from a previously attached {@link FlutterEngine}.
+   * Disconnects this {@code FlutterView} from a previously attached {@link io.flutter.embedding.engine.FlutterEngine}.
    *
    * <p>This {@code FlutterView} will clear its UI and stop forwarding all events to the
-   * previously-attached {@link FlutterEngine}. This includes touch events, accessibility events,
+   * previously-attached {@link io.flutter.embedding.engine.FlutterEngine}. This includes touch events, accessibility events,
    * keyboard events, and others.
    *
    * <p>See {@link #attachToFlutterEngine(FlutterEngine)} for information on how to attach a {@link
@@ -1179,7 +1179,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     return false;
   }
 
-  /** Returns true if this {@code FlutterView} is currently attached to a {@link FlutterEngine}. */
+  /** Returns true if this {@code FlutterView} is currently attached to a {@link io.flutter.embedding.engine.FlutterEngine}. */
   @VisibleForTesting
   public boolean isAttachedToFlutterEngine() {
     return flutterEngine != null
@@ -1187,8 +1187,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * Returns the {@link FlutterEngine} to which this {@code FlutterView} is currently attached, or
-   * null if this {@code FlutterView} is not currently attached to a {@link FlutterEngine}.
+   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} to which this {@code FlutterView} is currently attached, or
+   * null if this {@code FlutterView} is not currently attached to a {@link io.flutter.embedding.engine.FlutterEngine}.
    */
   @VisibleForTesting
   @Nullable
@@ -1198,7 +1198,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
 
   /**
    * Adds a {@link FlutterEngineAttachmentListener}, which is notified whenever this {@code
-   * FlutterView} attached to/detaches from a {@link FlutterEngine}.
+   * FlutterView} attached to/detaches from a {@link io.flutter.embedding.engine.FlutterEngine}.
    */
   @VisibleForTesting
   public void addFlutterEngineAttachmentListener(
@@ -1344,7 +1344,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * Listener that is notified when a {@link FlutterEngine} is attached to/detached from a given
+   * Listener that is notified when a {@link io.flutter.embedding.engine.FlutterEngine} is attached to/detached from a given
    * {@code FlutterView}.
    */
   @VisibleForTesting
@@ -1353,7 +1353,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     void onFlutterEngineAttachedToFlutterView(@NonNull FlutterEngine engine);
 
     /**
-     * A previously attached {@link FlutterEngine} has been detached from the associated {@code
+     * A previously attached {@link io.flutter.embedding.engine.FlutterEngine} has been detached from the associated {@code
      * FlutterView}.
      */
     void onFlutterEngineDetachedFromFlutterView();

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -53,7 +53,8 @@ import java.util.Set;
 /**
  * Displays a Flutter UI on an Android device.
  *
- * <p>A {@code FlutterView}'s UI is painted by a corresponding {@link io.flutter.embedding.engine.FlutterEngine}.
+ * <p>A {@code FlutterView}'s UI is painted by a corresponding {@link
+ * io.flutter.embedding.engine.FlutterEngine}.
  *
  * <p>A {@code FlutterView} can operate in 2 different {@link
  * io.flutter.embedding.android.RenderMode}s:
@@ -336,13 +337,13 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * Returns true if an attached {@link io.flutter.embedding.engine.FlutterEngine} has rendered at least 1 frame to this {@code
-   * FlutterView}.
+   * Returns true if an attached {@link io.flutter.embedding.engine.FlutterEngine} has rendered at
+   * least 1 frame to this {@code FlutterView}.
    *
    * <p>Returns false if no {@link io.flutter.embedding.engine.FlutterEngine} is attached.
    *
-   * <p>This flag is specific to a given {@link io.flutter.embedding.engine.FlutterEngine}. The following hypothetical timeline
-   * demonstrates how this flag changes over time.
+   * <p>This flag is specific to a given {@link io.flutter.embedding.engine.FlutterEngine}. The
+   * following hypothetical timeline demonstrates how this flag changes over time.
    *
    * <ol>
    *   <li>{@code flutterEngineA} is attached to this {@code FlutterView}: returns false
@@ -498,8 +499,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
    * these insets. Therefore, this method calculates the viewport metrics that Flutter should use
    * and then sends those metrics to Flutter.
    *
-   * <p>This callback is not present in API &lt; 20, which means lower API devices will see the wider
-   * than expected padding when the status and navigation bars are hidden.
+   * <p>This callback is not present in API &lt; 20, which means lower API devices will see the
+   * wider than expected padding when the status and navigation bars are hidden.
    */
   @Override
   @TargetApi(20)
@@ -833,9 +834,9 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
    * Prior to Android Q, it's impossible to add real views as descendants of virtual nodes. This
    * breaks accessibility when an Android view is embedded in a Flutter app.
    *
-   * <p>This method overrides a This member is not intended for public use, and is only visible for testing. method in {@code ViewGroup} to workaround this limitation.
-   * This solution is derivated from Jetpack Compose, and can be found in the Android source code as
-   * well.
+   * <p>This method overrides a This member is not intended for public use, and is only visible for
+   * testing. method in {@code ViewGroup} to workaround this limitation. This solution is derivated
+   * from Jetpack Compose, and can be found in the Android source code as well.
    *
    * <p>This workaround finds the descendant {@code View} that matches the provided accessibility
    * id.
@@ -851,7 +852,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     // Android Q or later doesn't call this method.
     //
     // However, since this is implementation detail, a future version of Android might call
-    // this method again, fallback to calling the This member is not intended for public use, and is only visible for testing. method as expected by ViewGroup.
+    // this method again, fallback to calling the This member is not intended for public use, and is
+    // only visible for testing. method as expected by ViewGroup.
     Method findViewByAccessibilityIdTraversalMethod;
     try {
       findViewByAccessibilityIdTraversalMethod =
@@ -929,12 +931,13 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   // -------- End: Mouse ---------
 
   /**
-   * Connects this {@code FlutterView} to the given {@link io.flutter.embedding.engine.FlutterEngine}.
+   * Connects this {@code FlutterView} to the given {@link
+   * io.flutter.embedding.engine.FlutterEngine}.
    *
    * <p>This {@code FlutterView} will begin rendering the UI painted by the given {@link
    * FlutterEngine}. This {@code FlutterView} will also begin forwarding interaction events from
-   * this {@code FlutterView} to the given {@link io.flutter.embedding.engine.FlutterEngine}, e.g., user touch events,
-   * accessibility events, keyboard events, and others.
+   * this {@code FlutterView} to the given {@link io.flutter.embedding.engine.FlutterEngine}, e.g.,
+   * user touch events, accessibility events, keyboard events, and others.
    *
    * <p>See {@link #detachFromFlutterEngine()} for information on how to detach from a {@link
    * FlutterEngine}.
@@ -1030,11 +1033,12 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * Disconnects this {@code FlutterView} from a previously attached {@link io.flutter.embedding.engine.FlutterEngine}.
+   * Disconnects this {@code FlutterView} from a previously attached {@link
+   * io.flutter.embedding.engine.FlutterEngine}.
    *
    * <p>This {@code FlutterView} will clear its UI and stop forwarding all events to the
-   * previously-attached {@link io.flutter.embedding.engine.FlutterEngine}. This includes touch events, accessibility events,
-   * keyboard events, and others.
+   * previously-attached {@link io.flutter.embedding.engine.FlutterEngine}. This includes touch
+   * events, accessibility events, keyboard events, and others.
    *
    * <p>See {@link #attachToFlutterEngine(FlutterEngine)} for information on how to attach a {@link
    * FlutterEngine}.
@@ -1179,7 +1183,10 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     return false;
   }
 
-  /** Returns true if this {@code FlutterView} is currently attached to a {@link io.flutter.embedding.engine.FlutterEngine}. */
+  /**
+   * Returns true if this {@code FlutterView} is currently attached to a {@link
+   * io.flutter.embedding.engine.FlutterEngine}.
+   */
   @VisibleForTesting
   public boolean isAttachedToFlutterEngine() {
     return flutterEngine != null
@@ -1187,8 +1194,9 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} to which this {@code FlutterView} is currently attached, or
-   * null if this {@code FlutterView} is not currently attached to a {@link io.flutter.embedding.engine.FlutterEngine}.
+   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} to which this {@code FlutterView}
+   * is currently attached, or null if this {@code FlutterView} is not currently attached to a
+   * {@link io.flutter.embedding.engine.FlutterEngine}.
    */
   @VisibleForTesting
   @Nullable
@@ -1344,8 +1352,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
   }
 
   /**
-   * Listener that is notified when a {@link io.flutter.embedding.engine.FlutterEngine} is attached to/detached from a given
-   * {@code FlutterView}.
+   * Listener that is notified when a {@link io.flutter.embedding.engine.FlutterEngine} is attached
+   * to/detached from a given {@code FlutterView}.
    */
   @VisibleForTesting
   public interface FlutterEngineAttachmentListener {
@@ -1353,8 +1361,8 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     void onFlutterEngineAttachedToFlutterView(@NonNull FlutterEngine engine);
 
     /**
-     * A previously attached {@link io.flutter.embedding.engine.FlutterEngine} has been detached from the associated {@code
-     * FlutterView}.
+     * A previously attached {@link io.flutter.embedding.engine.FlutterEngine} has been detached
+     * from the associated {@code FlutterView}.
      */
     void onFlutterEngineDetachedFromFlutterView();
   }

--- a/shell/platform/android/io/flutter/embedding/android/KeyChannelResponder.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyChannelResponder.java
@@ -10,8 +10,8 @@ import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.systemchannels.KeyEventChannel;
 
 /**
- * A {@link KeyboardManager.Responder} of {@link KeyboardManager} that handles events by sending the raw information
- * through the method channel.
+ * A {@link KeyboardManager.Responder} of {@link KeyboardManager} that handles events by sending the
+ * raw information through the method channel.
  *
  * <p>This class corresponds to the RawKeyboard API in the framework.
  */

--- a/shell/platform/android/io/flutter/embedding/android/KeyChannelResponder.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyChannelResponder.java
@@ -10,7 +10,7 @@ import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.systemchannels.KeyEventChannel;
 
 /**
- * A {@link Responder} of {@link KeyboardManager} that handles events by sending the raw information
+ * A {@link KeyboardManager.Responder} of {@link KeyboardManager} that handles events by sending the raw information
  * through the method channel.
  *
  * <p>This class corresponds to the RawKeyboard API in the framework.

--- a/shell/platform/android/io/flutter/embedding/android/KeyboardManager.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyboardManager.java
@@ -16,7 +16,7 @@ import java.util.HashSet;
  * A class to process {@link KeyEvent}s dispatched to a {@link FlutterView}, either from a hardware
  * keyboard or an IME event.
  *
- * <p>A class that sends Android {@link KeyEvent} to the a list of {@link Responder}s, and
+ * <p>A class that sends Android {@link KeyEvent} to the a list of {@link KeyboardManager.Responder}s, and
  * re-dispatches those not handled by the primary responders.
  *
  * <p>Flutter uses asynchronous event handling to avoid blocking the UI thread, but Android requires
@@ -30,19 +30,19 @@ import java.util.HashSet;
  * types of responders (in the listed order):
  *
  * <ul>
- *   <li>{@link Responder}s: An immutable list of key responders in a {@link KeyboardManager} that
- *       each implements the {@link Responder} interface. A {@link Responder} is a key responder
+ *   <li>{@link KeyboardManager.Responder}s: An immutable list of key responders in a {@link KeyboardManager} that
+ *       each implements the {@link KeyboardManager.Responder} interface. A {@link KeyboardManager.Responder} is a key responder
  *       that's capable of handling {@link KeyEvent}s asynchronously.
  *       <p>When a new {@link KeyEvent} is received, {@link KeyboardManager} calls the {@link
- *       Responder#handleEvent(KeyEvent, OnKeyEventHandledCallback)} method on its {@link
- *       Responder}s. Each {@link Responder} must call the supplied {@link
+ *       KeyboardManager.Responder#handleEvent(KeyEvent, OnKeyEventHandledCallback)} method on its {@link
+ *       KeyboardManager.Responder}s. Each {@link KeyboardManager.Responder} must call the supplied {@link
  *       OnKeyEventHandledCallback} exactly once, when it has decided whether to handle the key
- *       event callback. More than one {@link Responder} is allowed to reply true and handle the
+ *       event callback. More than one {@link KeyboardManager.Responder} is allowed to reply true and handle the
  *       same {@link KeyEvent}.
  *       <p>Typically a {@link KeyboardManager} uses a {@link KeyChannelResponder} as its only
- *       {@link Responder}.
- *   <li>{@link TextInputPlugin}: if every {@link Responder} has replied false to a {@link
- *       KeyEvent}, or if the {@link KeyboardManager} has zero {@link Responder}s, the {@link
+ *       {@link KeyboardManager.Responder}.
+ *   <li>{@link TextInputPlugin}: if every {@link KeyboardManager.Responder} has replied false to a {@link
+ *       KeyEvent}, or if the {@link KeyboardManager} has zero {@link KeyboardManager.Responder}s, the {@link
  *       KeyEvent} will be sent to the currently focused editable text field in {@link
  *       TextInputPlugin}, if any.
  *   <li><b>"Redispatch"</b>: if there's no currently focused text field in {@link TextInputPlugin},
@@ -56,10 +56,10 @@ public class KeyboardManager {
   private static final String TAG = "KeyboardManager";
 
   /**
-   * Constructor for {@link KeyboardManager} that takes a list of {@link Responder}s.
+   * Constructor for {@link KeyboardManager} that takes a list of {@link KeyboardManager.Responder}s.
    *
    * <p>The view is used as the destination to send the synthesized key to. This means that the the
-   * next thing in the focus chain will get the event when the {@link Responder}s return false from
+   * next thing in the focus chain will get the event when the {@link KeyboardManager.Responder}s return false from
    * onKeyDown/onKeyUp.
    *
    * <p>It is possible that that in the middle of the async round trip, the focus chain could
@@ -73,7 +73,7 @@ public class KeyboardManager {
    * @param textInputPlugin a plugin, which, if set, is given key events before the framework is,
    *     and if it has a valid input connection and is accepting text, then it will handle the event
    *     and the framework will not receive it.
-   * @param responders the {@link Responder}s new {@link KeyEvent}s will be first dispatched to.
+   * @param responders the {@link KeyboardManager.Responder}s new {@link KeyEvent}s will be first dispatched to.
    */
   public KeyboardManager(
       View view, @NonNull TextInputPlugin textInputPlugin, Responder[] responders) {
@@ -108,7 +108,7 @@ public class KeyboardManager {
      *
      * @param keyEvent the new {@link KeyEvent} this {@link Responder} may be interested in.
      * @param onKeyEventHandledCallback the method to call when this {@link Responder} has decided
-     *     whether to handle the {@link keyEvent}.
+     *     whether to handle the {@link KeyEvent}.
      */
     void handleEvent(
         @NonNull KeyEvent keyEvent, @NonNull OnKeyEventHandledCallback onKeyEventHandledCallback);

--- a/shell/platform/android/io/flutter/embedding/android/KeyboardManager.java
+++ b/shell/platform/android/io/flutter/embedding/android/KeyboardManager.java
@@ -16,8 +16,8 @@ import java.util.HashSet;
  * A class to process {@link KeyEvent}s dispatched to a {@link FlutterView}, either from a hardware
  * keyboard or an IME event.
  *
- * <p>A class that sends Android {@link KeyEvent} to the a list of {@link KeyboardManager.Responder}s, and
- * re-dispatches those not handled by the primary responders.
+ * <p>A class that sends Android {@link KeyEvent} to the a list of {@link
+ * KeyboardManager.Responder}s, and re-dispatches those not handled by the primary responders.
  *
  * <p>Flutter uses asynchronous event handling to avoid blocking the UI thread, but Android requires
  * that events are handled synchronously. So, when the Android system sends new @{link KeyEvent} to
@@ -30,21 +30,22 @@ import java.util.HashSet;
  * types of responders (in the listed order):
  *
  * <ul>
- *   <li>{@link KeyboardManager.Responder}s: An immutable list of key responders in a {@link KeyboardManager} that
- *       each implements the {@link KeyboardManager.Responder} interface. A {@link KeyboardManager.Responder} is a key responder
- *       that's capable of handling {@link KeyEvent}s asynchronously.
+ *   <li>{@link KeyboardManager.Responder}s: An immutable list of key responders in a {@link
+ *       KeyboardManager} that each implements the {@link KeyboardManager.Responder} interface. A
+ *       {@link KeyboardManager.Responder} is a key responder that's capable of handling {@link
+ *       KeyEvent}s asynchronously.
  *       <p>When a new {@link KeyEvent} is received, {@link KeyboardManager} calls the {@link
- *       KeyboardManager.Responder#handleEvent(KeyEvent, OnKeyEventHandledCallback)} method on its {@link
- *       KeyboardManager.Responder}s. Each {@link KeyboardManager.Responder} must call the supplied {@link
- *       OnKeyEventHandledCallback} exactly once, when it has decided whether to handle the key
- *       event callback. More than one {@link KeyboardManager.Responder} is allowed to reply true and handle the
- *       same {@link KeyEvent}.
+ *       KeyboardManager.Responder#handleEvent(KeyEvent, OnKeyEventHandledCallback)} method on its
+ *       {@link KeyboardManager.Responder}s. Each {@link KeyboardManager.Responder} must call the
+ *       supplied {@link OnKeyEventHandledCallback} exactly once, when it has decided whether to
+ *       handle the key event callback. More than one {@link KeyboardManager.Responder} is allowed
+ *       to reply true and handle the same {@link KeyEvent}.
  *       <p>Typically a {@link KeyboardManager} uses a {@link KeyChannelResponder} as its only
  *       {@link KeyboardManager.Responder}.
- *   <li>{@link TextInputPlugin}: if every {@link KeyboardManager.Responder} has replied false to a {@link
- *       KeyEvent}, or if the {@link KeyboardManager} has zero {@link KeyboardManager.Responder}s, the {@link
- *       KeyEvent} will be sent to the currently focused editable text field in {@link
- *       TextInputPlugin}, if any.
+ *   <li>{@link TextInputPlugin}: if every {@link KeyboardManager.Responder} has replied false to a
+ *       {@link KeyEvent}, or if the {@link KeyboardManager} has zero {@link
+ *       KeyboardManager.Responder}s, the {@link KeyEvent} will be sent to the currently focused
+ *       editable text field in {@link TextInputPlugin}, if any.
  *   <li><b>"Redispatch"</b>: if there's no currently focused text field in {@link TextInputPlugin},
  *       or the text field does not handle the {@link KeyEvent} either, the {@link KeyEvent} will be
  *       sent back to the top of the activity's view hierachy, allowing it to be "redispatched",
@@ -56,11 +57,12 @@ public class KeyboardManager {
   private static final String TAG = "KeyboardManager";
 
   /**
-   * Constructor for {@link KeyboardManager} that takes a list of {@link KeyboardManager.Responder}s.
+   * Constructor for {@link KeyboardManager} that takes a list of {@link
+   * KeyboardManager.Responder}s.
    *
    * <p>The view is used as the destination to send the synthesized key to. This means that the the
-   * next thing in the focus chain will get the event when the {@link KeyboardManager.Responder}s return false from
-   * onKeyDown/onKeyUp.
+   * next thing in the focus chain will get the event when the {@link KeyboardManager.Responder}s
+   * return false from onKeyDown/onKeyUp.
    *
    * <p>It is possible that that in the middle of the async round trip, the focus chain could
    * change, and instead of the native widget that was "next" when the event was fired getting the
@@ -73,7 +75,8 @@ public class KeyboardManager {
    * @param textInputPlugin a plugin, which, if set, is given key events before the framework is,
    *     and if it has a valid input connection and is accepting text, then it will handle the event
    *     and the framework will not receive it.
-   * @param responders the {@link KeyboardManager.Responder}s new {@link KeyEvent}s will be first dispatched to.
+   * @param responders the {@link KeyboardManager.Responder}s new {@link KeyEvent}s will be first
+   *     dispatched to.
    */
   public KeyboardManager(
       View view, @NonNull TextInputPlugin textInputPlugin, Responder[] responders) {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -144,9 +144,10 @@ public class FlutterEngine {
    *
    * <p>In order to pass Dart VM initialization arguments (see {@link
    * io.flutter.embedding.engine.FlutterShellArgs}) when creating the VM, manually set the
-   * initialization arguments by calling {@link io.flutter.embedding.engine.loader.FlutterLoader#startInitialization(Context)} and
-   * {@link io.flutter.embedding.engine.loader.FlutterLoader#ensureInitializationComplete(Context, String[])} before constructing the
-   * engine.
+   * initialization arguments by calling {@link
+   * io.flutter.embedding.engine.loader.FlutterLoader#startInitialization(Context)} and {@link
+   * io.flutter.embedding.engine.loader.FlutterLoader#ensureInitializationComplete(Context,
+   * String[])} before constructing the engine.
    */
   public FlutterEngine(@NonNull Context context) {
     this(context, null);
@@ -213,8 +214,8 @@ public class FlutterEngine {
   }
 
   /**
-   * Same as {@link #FlutterEngine(Context, FlutterLoader, FlutterJNI, String[], boolean)} but with no Dart
-   * VM flags and automatically registers plugins.
+   * Same as {@link #FlutterEngine(Context, FlutterLoader, FlutterJNI, String[], boolean)} but with
+   * no Dart VM flags and automatically registers plugins.
    *
    * <p>{@code flutterJNI} should be a new instance that has never been attached to an engine
    * before.
@@ -370,12 +371,13 @@ public class FlutterEngine {
   }
 
   /**
-   * Create a second {@link io.flutter.embedding.engine.FlutterEngine} based on this current one by sharing as much resources
-   * together as possible to minimize startup latency and memory cost.
+   * Create a second {@link io.flutter.embedding.engine.FlutterEngine} based on this current one by
+   * sharing as much resources together as possible to minimize startup latency and memory cost.
    *
-   * @param context is a Context used to create the {@link io.flutter.embedding.engine.FlutterEngine}. Could be the same Context
-   *     as the current engine or a different one. Generally, only an application Context is needed
-   *     for the {@link io.flutter.embedding.engine.FlutterEngine} and its dependencies.
+   * @param context is a Context used to create the {@link
+   *     io.flutter.embedding.engine.FlutterEngine}. Could be the same Context as the current engine
+   *     or a different one. Generally, only an application Context is needed for the {@link
+   *     io.flutter.embedding.engine.FlutterEngine} and its dependencies.
    * @param dartEntrypoint specifies the {@link DartEntrypoint} the new engine should run. It
    *     doesn't need to be the same entrypoint as the current engine but must be built in the same
    *     AOT or snapshot.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -133,7 +133,7 @@ public class FlutterEngine {
    *
    * <p>A new {@code FlutterEngine} will not display any UI until a {@link RenderSurface} is
    * registered. See {@link #getRenderer()} and {@link
-   * FlutterRenderer#startRenderingToSurface(RenderSurface)}.
+   * FlutterRenderer#startRenderingToSurface(Surface)}.
    *
    * <p>A new {@code FlutterEngine} automatically attaches all plugins. See {@link #getPlugins()}.
    *
@@ -144,8 +144,8 @@ public class FlutterEngine {
    *
    * <p>In order to pass Dart VM initialization arguments (see {@link
    * io.flutter.embedding.engine.FlutterShellArgs}) when creating the VM, manually set the
-   * initialization arguments by calling {@link FlutterLoader#startInitialization(Context)} and
-   * {@link FlutterLoader#ensureInitializationComplete(Context, String[])} before constructing the
+   * initialization arguments by calling {@link io.flutter.embedding.engine.loader.FlutterLoader#startInitialization(Context)} and
+   * {@link io.flutter.embedding.engine.loader.FlutterLoader#ensureInitializationComplete(Context, String[])} before constructing the
    * engine.
    */
   public FlutterEngine(@NonNull Context context) {
@@ -213,8 +213,8 @@ public class FlutterEngine {
   }
 
   /**
-   * Same as {@link #FlutterEngine(Context, FlutterLoader, FlutterJNI, String[])} but with no Dart
-   * VM flags.
+   * Same as {@link #FlutterEngine(Context, FlutterLoader, FlutterJNI, String[], boolean)} but with no Dart
+   * VM flags and automatically registers plugins.
    *
    * <p>{@code flutterJNI} should be a new instance that has never been attached to an engine
    * before.
@@ -370,16 +370,16 @@ public class FlutterEngine {
   }
 
   /**
-   * Create a second {@link FlutterEngine} based on this current one by sharing as much resources
+   * Create a second {@link io.flutter.embedding.engine.FlutterEngine} based on this current one by sharing as much resources
    * together as possible to minimize startup latency and memory cost.
    *
-   * @param context is a Context used to create the {@link FlutterEngine}. Could be the same Context
+   * @param context is a Context used to create the {@link io.flutter.embedding.engine.FlutterEngine}. Could be the same Context
    *     as the current engine or a different one. Generally, only an application Context is needed
-   *     for the {@link FlutterEngine} and its dependencies.
+   *     for the {@link io.flutter.embedding.engine.FlutterEngine} and its dependencies.
    * @param dartEntrypoint specifies the {@link DartEntrypoint} the new engine should run. It
    *     doesn't need to be the same entrypoint as the current engine but must be built in the same
    *     AOT or snapshot.
-   * @return a new {@link FlutterEngine}.
+   * @return a new {@link io.flutter.embedding.engine.FlutterEngine}.
    */
   @NonNull
   /*package*/ FlutterEngine spawn(

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
@@ -11,14 +11,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Static singleton cache that holds {@link FlutterEngine} instances identified by {@code String}s.
+ * Static singleton cache that holds {@link io.flutter.embedding.engine.FlutterEngine} instances identified by {@code String}s.
  *
- * <p>The ID of a given {@link FlutterEngine} can be whatever {@code String} is desired.
+ * <p>The ID of a given {@link io.flutter.embedding.engine.FlutterEngine} can be whatever {@code String} is desired.
  *
- * <p>{@code FlutterEngineCache} is useful for storing pre-warmed {@link FlutterEngine} instances.
+ * <p>{@code FlutterEngineCache} is useful for storing pre-warmed {@link io.flutter.embedding.engine.FlutterEngine} instances.
  * {@link io.flutter.embedding.android.FlutterActivity} and {@link
  * io.flutter.embedding.android.FlutterFragment} use the {@code FlutterEngineCache} singleton
- * internally when instructed to use a cached {@link FlutterEngine} based on a given ID. See {@link
+ * internally when instructed to use a cached {@link io.flutter.embedding.engine.FlutterEngine} based on a given ID. See {@link
  * io.flutter.embedding.android.FlutterActivity.CachedEngineIntentBuilder} and {@link
  * io.flutter.embedding.android.FlutterFragment#withCachedEngine(String)} for related APIs.
  */
@@ -44,7 +44,7 @@ public class FlutterEngineCache {
   /* package */ FlutterEngineCache() {}
 
   /**
-   * Returns {@code true} if a {@link FlutterEngine} in this cache is associated with the given
+   * Returns {@code true} if a {@link io.flutter.embedding.engine.FlutterEngine} in this cache is associated with the given
    * {@code engineId}.
    */
   public boolean contains(@NonNull String engineId) {
@@ -52,8 +52,8 @@ public class FlutterEngineCache {
   }
 
   /**
-   * Returns the {@link FlutterEngine} in this cache that is associated with the given {@code
-   * engineId}, or {@code null} is no such {@link FlutterEngine} exists.
+   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} in this cache that is associated with the given {@code
+   * engineId}, or {@code null} is no such {@link io.flutter.embedding.engine.FlutterEngine} exists.
    */
   @Nullable
   public FlutterEngine get(@NonNull String engineId) {
@@ -61,11 +61,11 @@ public class FlutterEngineCache {
   }
 
   /**
-   * Places the given {@link FlutterEngine} in this cache and associates it with the given {@code
+   * Places the given {@link io.flutter.embedding.engine.FlutterEngine} in this cache and associates it with the given {@code
    * engineId}.
    *
-   * <p>If a {@link FlutterEngine} already exists in this cache for the given {@code engineId}, that
-   * {@link FlutterEngine} is removed from this cache.
+   * <p>If a {@link io.flutter.embedding.engine.FlutterEngine} already exists in this cache for the given {@code engineId}, that
+   * {@link io.flutter.embedding.engine.FlutterEngine} is removed from this cache.
    */
   public void put(@NonNull String engineId, @Nullable FlutterEngine engine) {
     if (engine != null) {
@@ -76,14 +76,14 @@ public class FlutterEngineCache {
   }
 
   /**
-   * Removes any {@link FlutterEngine} that is currently in the cache that is identified by the
+   * Removes any {@link io.flutter.embedding.engine.FlutterEngine} that is currently in the cache that is identified by the
    * given {@code engineId}.
    */
   public void remove(@NonNull String engineId) {
     put(engineId, null);
   }
 
-  /** Removes all {@link FlutterEngine}'s that are currently in the cache. */
+  /** Removes all {@link io.flutter.embedding.engine.FlutterEngine}'s that are currently in the cache. */
   public void clear() {
     cachedEngines.clear();
   }

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
@@ -11,14 +11,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Static singleton cache that holds {@link io.flutter.embedding.engine.FlutterEngine} instances identified by {@code String}s.
+ * Static singleton cache that holds {@link io.flutter.embedding.engine.FlutterEngine} instances
+ * identified by {@code String}s.
  *
- * <p>The ID of a given {@link io.flutter.embedding.engine.FlutterEngine} can be whatever {@code String} is desired.
+ * <p>The ID of a given {@link io.flutter.embedding.engine.FlutterEngine} can be whatever {@code
+ * String} is desired.
  *
- * <p>{@code FlutterEngineCache} is useful for storing pre-warmed {@link io.flutter.embedding.engine.FlutterEngine} instances.
- * {@link io.flutter.embedding.android.FlutterActivity} and {@link
+ * <p>{@code FlutterEngineCache} is useful for storing pre-warmed {@link
+ * io.flutter.embedding.engine.FlutterEngine} instances. {@link
+ * io.flutter.embedding.android.FlutterActivity} and {@link
  * io.flutter.embedding.android.FlutterFragment} use the {@code FlutterEngineCache} singleton
- * internally when instructed to use a cached {@link io.flutter.embedding.engine.FlutterEngine} based on a given ID. See {@link
+ * internally when instructed to use a cached {@link io.flutter.embedding.engine.FlutterEngine}
+ * based on a given ID. See {@link
  * io.flutter.embedding.android.FlutterActivity.CachedEngineIntentBuilder} and {@link
  * io.flutter.embedding.android.FlutterFragment#withCachedEngine(String)} for related APIs.
  */
@@ -44,16 +48,17 @@ public class FlutterEngineCache {
   /* package */ FlutterEngineCache() {}
 
   /**
-   * Returns {@code true} if a {@link io.flutter.embedding.engine.FlutterEngine} in this cache is associated with the given
-   * {@code engineId}.
+   * Returns {@code true} if a {@link io.flutter.embedding.engine.FlutterEngine} in this cache is
+   * associated with the given {@code engineId}.
    */
   public boolean contains(@NonNull String engineId) {
     return cachedEngines.containsKey(engineId);
   }
 
   /**
-   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} in this cache that is associated with the given {@code
-   * engineId}, or {@code null} is no such {@link io.flutter.embedding.engine.FlutterEngine} exists.
+   * Returns the {@link io.flutter.embedding.engine.FlutterEngine} in this cache that is associated
+   * with the given {@code engineId}, or {@code null} is no such {@link
+   * io.flutter.embedding.engine.FlutterEngine} exists.
    */
   @Nullable
   public FlutterEngine get(@NonNull String engineId) {
@@ -61,11 +66,12 @@ public class FlutterEngineCache {
   }
 
   /**
-   * Places the given {@link io.flutter.embedding.engine.FlutterEngine} in this cache and associates it with the given {@code
-   * engineId}.
+   * Places the given {@link io.flutter.embedding.engine.FlutterEngine} in this cache and associates
+   * it with the given {@code engineId}.
    *
-   * <p>If a {@link io.flutter.embedding.engine.FlutterEngine} already exists in this cache for the given {@code engineId}, that
-   * {@link io.flutter.embedding.engine.FlutterEngine} is removed from this cache.
+   * <p>If a {@link io.flutter.embedding.engine.FlutterEngine} already exists in this cache for the
+   * given {@code engineId}, that {@link io.flutter.embedding.engine.FlutterEngine} is removed from
+   * this cache.
    */
   public void put(@NonNull String engineId, @Nullable FlutterEngine engine) {
     if (engine != null) {
@@ -76,14 +82,17 @@ public class FlutterEngineCache {
   }
 
   /**
-   * Removes any {@link io.flutter.embedding.engine.FlutterEngine} that is currently in the cache that is identified by the
-   * given {@code engineId}.
+   * Removes any {@link io.flutter.embedding.engine.FlutterEngine} that is currently in the cache
+   * that is identified by the given {@code engineId}.
    */
   public void remove(@NonNull String engineId) {
     put(engineId, null);
   }
 
-  /** Removes all {@link io.flutter.embedding.engine.FlutterEngine}'s that are currently in the cache. */
+  /**
+   * Removes all {@link io.flutter.embedding.engine.FlutterEngine}'s that are currently in the
+   * cache.
+   */
   public void clear() {
     cachedEngines.clear();
   }

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
@@ -38,8 +38,8 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * This class is owned by the {@link io.flutter.embedding.engine.FlutterEngine} and its role is to managed its connections with
- * Android App Components and Flutter plugins.
+ * This class is owned by the {@link io.flutter.embedding.engine.FlutterEngine} and its role is to
+ * managed its connections with Android App Components and Flutter plugins.
  *
  * <p>It enforces the {0|1}:1 relationship between activity and engine, and propagates the app
  * component connection to the plugins.
@@ -700,8 +700,9 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link android.app.Activity} has its {@code onRequestPermissionsResult(...)} method invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+     * ActivityPluginBinding} when its associated {@link android.app.Activity} has its {@code
+     * onRequestPermissionsResult(...)} method invoked.
      */
     boolean onRequestPermissionsResult(
         int requestCode, @NonNull String[] permissions, @NonNull int[] grantResult) {
@@ -728,8 +729,9 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link android.app.Activity} has its {@code onActivityResult(...)} method invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+     * ActivityPluginBinding} when its associated {@link android.app.Activity} has its {@code
+     * onActivityResult(...)} method invoked.
      */
     boolean onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
       boolean didConsumeResult = false;
@@ -754,8 +756,9 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link android.app.Activity} has its {@code onNewIntent(...)} method invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+     * ActivityPluginBinding} when its associated {@link android.app.Activity} has its {@code
+     * onNewIntent(...)} method invoked.
      */
     void onNewIntent(@Nullable Intent intent) {
       for (io.flutter.plugin.common.PluginRegistry.NewIntentListener listener :
@@ -787,8 +790,9 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link android.app.Activity} has its {@code onUserLeaveHint()} method invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+     * ActivityPluginBinding} when its associated {@link android.app.Activity} has its {@code
+     * onUserLeaveHint()} method invoked.
      */
     void onUserLeaveHint() {
       for (io.flutter.plugin.common.PluginRegistry.UserLeaveHintListener listener :
@@ -798,9 +802,9 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link android.app.Activity} or {@code Fragment} has its {@code onSaveInstanceState(Bundle)}
-     * method invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+     * ActivityPluginBinding} when its associated {@link android.app.Activity} or {@code Fragment}
+     * has its {@code onSaveInstanceState(Bundle)} method invoked.
      */
     void onSaveInstanceState(@NonNull Bundle bundle) {
       for (OnSaveInstanceStateListener listener : onSaveInstanceStateListeners) {
@@ -809,9 +813,9 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link android.app.Activity} or {@code Fragment} has its {@code onCreate(Bundle)} method
-     * invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+     * ActivityPluginBinding} when its associated {@link android.app.Activity} or {@code Fragment}
+     * has its {@code onCreate(Bundle)} method invoked.
      */
     void onRestoreInstanceState(@Nullable Bundle bundle) {
       for (OnSaveInstanceStateListener listener : onSaveInstanceStateListeners) {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineConnectionRegistry.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * This class is owned by the {@link FlutterEngine} and its role is to managed its connections with
+ * This class is owned by the {@link io.flutter.embedding.engine.FlutterEngine} and its role is to managed its connections with
  * Android App Components and Flutter plugins.
  *
  * <p>It enforces the {0|1}:1 relationship between activity and engine, and propagates the app
@@ -700,8 +700,8 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link Activity} has its {@code onRequestPermissionsResult(...)} method invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
+     * associated {@link android.app.Activity} has its {@code onRequestPermissionsResult(...)} method invoked.
      */
     boolean onRequestPermissionsResult(
         int requestCode, @NonNull String[] permissions, @NonNull int[] grantResult) {
@@ -728,8 +728,8 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link Activity} has its {@code onActivityResult(...)} method invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
+     * associated {@link android.app.Activity} has its {@code onActivityResult(...)} method invoked.
      */
     boolean onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
       boolean didConsumeResult = false;
@@ -754,8 +754,8 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link Activity} has its {@code onNewIntent(...)} method invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
+     * associated {@link android.app.Activity} has its {@code onNewIntent(...)} method invoked.
      */
     void onNewIntent(@Nullable Intent intent) {
       for (io.flutter.plugin.common.PluginRegistry.NewIntentListener listener :
@@ -787,8 +787,8 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link Activity} has its {@code onUserLeaveHint()} method invoked.
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
+     * associated {@link android.app.Activity} has its {@code onUserLeaveHint()} method invoked.
      */
     void onUserLeaveHint() {
       for (io.flutter.plugin.common.PluginRegistry.UserLeaveHintListener listener :
@@ -798,8 +798,8 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link Activity} or {@code Fragment} has its {@code onSaveInstanceState(Bundle)}
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
+     * associated {@link android.app.Activity} or {@code Fragment} has its {@code onSaveInstanceState(Bundle)}
      * method invoked.
      */
     void onSaveInstanceState(@NonNull Bundle bundle) {
@@ -809,8 +809,8 @@ import java.util.Set;
     }
 
     /**
-     * Invoked by the {@link FlutterEngine} that owns this {@code ActivityPluginBinding} when its
-     * associated {@link Activity} or {@code Fragment} has its {@code onCreate(Bundle)} method
+     * Invoked by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding} when its
+     * associated {@link android.app.Activity} or {@code Fragment} has its {@code onCreate(Bundle)} method
      * invoked.
      */
     void onRestoreInstanceState(@Nullable Bundle bundle) {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -77,13 +77,10 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * flutterJNI.detachFromNativeAndReleaseResources();
  * }</pre>
  *
- * <p>To provide a visual, interactive surface for Flutter rendering and touch events, register a
- * {@link RenderSurface} with {@link #setRenderSurface(RenderSurface)}
- *
  * <p>To receive callbacks for certain events that occur on the native side, register listeners:
  *
  * <ol>
- *   <li>{@link #addEngineLifecycleListener(EngineLifecycleListener)}
+ *   <li>{@link #addEngineLifecycleListener(FlutterEngine.EngineLifecycleListener)}
  *   <li>{@link #addIsDisplayingFlutterUiListener(FlutterUiDisplayListener)}
  * </ol>
  *
@@ -722,7 +719,7 @@ public class FlutterJNI {
 
   /**
    * Call this method to inform Flutter that a texture previously registered with {@link
-   * #registerTexture(long, SurfaceTexture)} has a new frame available.
+   * #registerTexture(long, SurfaceTextureWrapper)} has a new frame available.
    *
    * <p>Invoking this method instructs Flutter to update its presentation of the given texture so
    * that the new frame is displayed.
@@ -737,7 +734,7 @@ public class FlutterJNI {
   private native void nativeMarkTextureFrameAvailable(long nativeShellHolderId, long textureId);
 
   /**
-   * Unregisters a texture that was registered with {@link #registerTexture(long, SurfaceTexture)}.
+   * Unregisters a texture that was registered with {@link #registerTexture(long, SurfaceTextureWrapper)}.
    */
   @UiThread
   public void unregisterTexture(long textureId) {
@@ -803,7 +800,7 @@ public class FlutterJNI {
    * will be dropped (ignored). Therefore, when using {@code FlutterJNI} to integrate a Flutter
    * context in an app, a {@link PlatformMessageHandler} must be registered for 2-way Java/Dart
    * communication to operate correctly. Moreover, the handler must be implemented such that
-   * fundamental platform messages are handled as expected. See {@link FlutterNativeView} for an
+   * fundamental platform messages are handled as expected. See {@link io.flutter.view.FlutterNativeView} for an
    * example implementation.
    */
   @UiThread

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -23,7 +23,6 @@ import io.flutter.embedding.engine.dart.PlatformMessageHandler;
 import io.flutter.embedding.engine.deferredcomponents.DeferredComponentManager;
 import io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack;
 import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
-import io.flutter.embedding.engine.renderer.RenderSurface;
 import io.flutter.embedding.engine.renderer.SurfaceTextureWrapper;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.localization.LocalizationPlugin;
@@ -734,7 +733,8 @@ public class FlutterJNI {
   private native void nativeMarkTextureFrameAvailable(long nativeShellHolderId, long textureId);
 
   /**
-   * Unregisters a texture that was registered with {@link #registerTexture(long, SurfaceTextureWrapper)}.
+   * Unregisters a texture that was registered with {@link #registerTexture(long,
+   * SurfaceTextureWrapper)}.
    */
   @UiThread
   public void unregisterTexture(long textureId) {
@@ -800,8 +800,8 @@ public class FlutterJNI {
    * will be dropped (ignored). Therefore, when using {@code FlutterJNI} to integrate a Flutter
    * context in an app, a {@link PlatformMessageHandler} must be registered for 2-way Java/Dart
    * communication to operate correctly. Moreover, the handler must be implemented such that
-   * fundamental platform messages are handled as expected. See {@link io.flutter.view.FlutterNativeView} for an
-   * example implementation.
+   * fundamental platform messages are handled as expected. See {@link
+   * io.flutter.view.FlutterNativeView} for an example implementation.
    */
   @UiThread
   public void setPlatformMessageHandler(@Nullable PlatformMessageHandler platformMessageHandler) {

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -246,7 +246,7 @@ public class DartExecutor implements BinaryMessenger {
    * is an appropriate time to free resources, such as going to the background.
    *
    * <p>This does not notify a Flutter application about memory pressure. For that, use the {@link
-   * SystemChannel#sendMemoryPressureWarning}.
+   * io.flutter.embedding.engine.systemchannels.SystemChannel#sendMemoryPressureWarning}.
    */
   public void notifyLowMemoryWarning() {
     if (flutterJNI.isAttached()) {

--- a/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
@@ -56,7 +56,7 @@ public final class ApplicationInfoLoader {
 
   private static String getNetworkPolicy(ApplicationInfo appInfo, Context context) {
     // We cannot use reflection to look at networkSecurityConfigRes because
-    // Android throws an error when we try to access fields marked as @hide.
+    // Android throws an error when we try to access fields marked as This member is not intended for public use, and is only visible for testing..
     // Instead we rely on metadata.
     Bundle metadata = appInfo.metaData;
     if (metadata == null) {

--- a/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/ApplicationInfoLoader.java
@@ -56,7 +56,8 @@ public final class ApplicationInfoLoader {
 
   private static String getNetworkPolicy(ApplicationInfo appInfo, Context context) {
     // We cannot use reflection to look at networkSecurityConfigRes because
-    // Android throws an error when we try to access fields marked as This member is not intended for public use, and is only visible for testing..
+    // Android throws an error when we try to access fields marked as This member is not intended
+    // for public use, and is only visible for testing..
     // Instead we rely on metadata.
     Bundle metadata = appInfo.metaData;
     if (metadata == null) {

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -18,7 +18,7 @@ import androidx.annotation.VisibleForTesting;
 import io.flutter.embedding.android.AndroidTouchProcessor;
 
 /**
- * A view that applies the {@link io.flutter.embedding.engine.mutatorsstack.MutatorsStack} to its
+ * A view that applies the {@link io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack} to its
  * children.
  */
 public class FlutterMutatorView extends FrameLayout {

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -18,8 +18,8 @@ import androidx.annotation.VisibleForTesting;
 import io.flutter.embedding.android.AndroidTouchProcessor;
 
 /**
- * A view that applies the {@link io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack} to its
- * children.
+ * A view that applies the {@link io.flutter.embedding.engine.mutatorsstack.FlutterMutatorsStack} to
+ * its children.
  */
 public class FlutterMutatorView extends FrameLayout {
   private FlutterMutatorsStack mutatorsStack;

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStack.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStack.java
@@ -18,14 +18,13 @@ import java.util.List;
  * The mutator stack containing a list of mutators
  *
  * <p>The mutators can be applied to a {@link io.flutter.plugin.platform.PlatformView} to perform a
- * series mutations. See {@link FlutterMutatorsStack.FlutterMutator} for informations
- * on Mutators.
+ * series mutations. See {@link FlutterMutatorsStack.FlutterMutator} for informations on Mutators.
  */
 @Keep
 public class FlutterMutatorsStack {
   /**
-   * The type of a Mutator See {@link FlutterMutatorsStack.FlutterMutator} for
-   * informations on Mutators.
+   * The type of a Mutator See {@link FlutterMutatorsStack.FlutterMutator} for informations on
+   * Mutators.
    */
   public enum FlutterMutatorType {
     CLIP_RECT,
@@ -199,8 +198,8 @@ public class FlutterMutatorsStack {
    * Get a list of all the clipping operations. All the clipping operations -- whether it is clip
    * rect, clip rrect, or clip path -- are converted into Paths. The paths are also transformed with
    * the matrix that up to their stack positions. For example: If the stack looks like (from top to
-   * bottom): TransA -&gt; ClipA -&gt; TransB -&gt; ClipB, the final paths will look like [TransA*ClipA,
-   * TransA*TransB*ClipB].
+   * bottom): TransA -&gt; ClipA -&gt; TransB -&gt; ClipB, the final paths will look like
+   * [TransA*ClipA, TransA*TransB*ClipB].
    *
    * <p>Clipping this list to the parent canvas of a view results the final clipping path.
    */

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStack.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorsStack.java
@@ -18,13 +18,13 @@ import java.util.List;
  * The mutator stack containing a list of mutators
  *
  * <p>The mutators can be applied to a {@link io.flutter.plugin.platform.PlatformView} to perform a
- * series mutations. See {@link io.flutter.embedding.engine.mutatorsstack.Mutator} for informations
+ * series mutations. See {@link FlutterMutatorsStack.FlutterMutator} for informations
  * on Mutators.
  */
 @Keep
 public class FlutterMutatorsStack {
   /**
-   * The type of a Mutator See {@link io.flutter.embedding.engine.mutatorsstack.Mutator} for
+   * The type of a Mutator See {@link FlutterMutatorsStack.FlutterMutator} for
    * informations on Mutators.
    */
   public enum FlutterMutatorType {
@@ -40,7 +40,7 @@ public class FlutterMutatorsStack {
    *
    * <p>A mutator contains information of a single mutation operation that can be applied to a
    * {@link io.flutter.plugin.platform.PlatformView}. See {@link
-   * io.flutter.embedding.engine.mutatorsstack.Mutator} for informations on Mutators.
+   * FlutterMutatorsStack.FlutterMutator} for informations on Mutators.
    */
   public class FlutterMutator {
 
@@ -77,7 +77,7 @@ public class FlutterMutatorsStack {
     /**
      * Initialize a clip path mutator.
      *
-     * @param rect the path to be clipped.
+     * @param path the path to be clipped.
      */
     public FlutterMutator(Path path) {
       this.type = FlutterMutatorType.CLIP_PATH;
@@ -144,7 +144,7 @@ public class FlutterMutatorsStack {
   }
 
   /**
-   * Push a transform {@link io.flutter.embedding.engine.mutatorsstack.Mutator} to the stack.
+   * Push a transform {@link FlutterMutatorsStack.FlutterMutator} to the stack.
    *
    * @param values the transform matrix to be pushed to the stack. The array matches how a {@link
    *     android.graphics.Matrix} is constructed.
@@ -157,7 +157,7 @@ public class FlutterMutatorsStack {
     finalMatrix.preConcat(mutator.getMatrix());
   }
 
-  /** Push a clipRect {@link io.flutter.embedding.engine.mutatorsstack.Mutator} to the stack. */
+  /** Push a clipRect {@link FlutterMutatorsStack.FlutterMutator} to the stack. */
   public void pushClipRect(int left, int top, int right, int bottom) {
     Rect rect = new Rect(left, top, right, bottom);
     FlutterMutator mutator = new FlutterMutator(rect);
@@ -169,7 +169,7 @@ public class FlutterMutatorsStack {
   }
 
   /**
-   * Push a clipRRect {@link io.flutter.embedding.engine.mutatorsstack.Mutator} to the stack.
+   * Push a clipRRect {@link FlutterMutatorsStack.FlutterMutator} to the stack.
    *
    * @param left left offset of the rrect.
    * @param top top offset of the rrect.
@@ -199,7 +199,7 @@ public class FlutterMutatorsStack {
    * Get a list of all the clipping operations. All the clipping operations -- whether it is clip
    * rect, clip rrect, or clip path -- are converted into Paths. The paths are also transformed with
    * the matrix that up to their stack positions. For example: If the stack looks like (from top to
-   * bottom): TransA -> ClipA -> TransB -> ClipB, the final paths will look like [TransA*ClipA,
+   * bottom): TransA -&gt; ClipA -&gt; TransB -&gt; ClipB, the final paths will look like [TransA*ClipA,
    * TransA*TransB*ClipB].
    *
    * <p>Clipping this list to the parent canvas of a view results the final clipping path.

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
@@ -21,18 +21,21 @@ import io.flutter.view.TextureRegistry;
  * communicate between platform code and Dart code.
  *
  * <p>A Flutter plugin has a lifecycle. First, a developer must add a {@code FlutterPlugin} to an
- * instance of {@link io.flutter.embedding.engine.FlutterEngine}. To do this, obtain a {@link PluginRegistry} with {@link
- * FlutterEngine#getPlugins()}, then call {@link PluginRegistry#add(FlutterPlugin)}, passing the
- * instance of the Flutter plugin. During the call to {@link PluginRegistry#add(FlutterPlugin)}, the
- * {@link io.flutter.embedding.engine.FlutterEngine} will invoke {@link #onAttachedToEngine(FlutterPluginBinding)} on the given
- * {@code FlutterPlugin}. If the {@code FlutterPlugin} is removed from the {@link io.flutter.embedding.engine.FlutterEngine} via
- * {@link PluginRegistry#remove(Class)}, or if the {@link io.flutter.embedding.engine.FlutterEngine} is destroyed, the {@link
- * FlutterEngine} will invoke {@link FlutterPlugin#onDetachedFromEngine(FlutterPluginBinding)} on
- * the given {@code FlutterPlugin}.
+ * instance of {@link io.flutter.embedding.engine.FlutterEngine}. To do this, obtain a {@link
+ * PluginRegistry} with {@link FlutterEngine#getPlugins()}, then call {@link
+ * PluginRegistry#add(FlutterPlugin)}, passing the instance of the Flutter plugin. During the call
+ * to {@link PluginRegistry#add(FlutterPlugin)}, the {@link
+ * io.flutter.embedding.engine.FlutterEngine} will invoke {@link
+ * #onAttachedToEngine(FlutterPluginBinding)} on the given {@code FlutterPlugin}. If the {@code
+ * FlutterPlugin} is removed from the {@link io.flutter.embedding.engine.FlutterEngine} via {@link
+ * PluginRegistry#remove(Class)}, or if the {@link io.flutter.embedding.engine.FlutterEngine} is
+ * destroyed, the {@link FlutterEngine} will invoke {@link
+ * FlutterPlugin#onDetachedFromEngine(FlutterPluginBinding)} on the given {@code FlutterPlugin}.
  *
- * <p>Once a {@code FlutterPlugin} is attached to a {@link io.flutter.embedding.engine.FlutterEngine}, the plugin's code is
- * permitted to access and invoke methods on resources within the {@link FlutterPluginBinding} that
- * the {@link io.flutter.embedding.engine.FlutterEngine} gave to the {@code FlutterPlugin} in {@link
+ * <p>Once a {@code FlutterPlugin} is attached to a {@link
+ * io.flutter.embedding.engine.FlutterEngine}, the plugin's code is permitted to access and invoke
+ * methods on resources within the {@link FlutterPluginBinding} that the {@link
+ * io.flutter.embedding.engine.FlutterEngine} gave to the {@code FlutterPlugin} in {@link
  * #onAttachedToEngine(FlutterPluginBinding)}. This includes, for example, the application {@link
  * Context} for the running app.
  *
@@ -63,7 +66,8 @@ import io.flutter.view.TextureRegistry;
 public interface FlutterPlugin {
 
   /**
-   * This {@code FlutterPlugin} has been associated with a {@link io.flutter.embedding.engine.FlutterEngine} instance.
+   * This {@code FlutterPlugin} has been associated with a {@link
+   * io.flutter.embedding.engine.FlutterEngine} instance.
    *
    * <p>Relevant resources that this {@code FlutterPlugin} may need are provided via the {@code
    * binding}. The {@code binding} may be cached and referenced until {@link
@@ -72,7 +76,8 @@ public interface FlutterPlugin {
   void onAttachedToEngine(@NonNull FlutterPluginBinding binding);
 
   /**
-   * This {@code FlutterPlugin} has been removed from a {@link io.flutter.embedding.engine.FlutterEngine} instance.
+   * This {@code FlutterPlugin} has been removed from a {@link
+   * io.flutter.embedding.engine.FlutterEngine} instance.
    *
    * <p>The {@code binding} passed to this method is the same instance that was passed in {@link
    * #onAttachedToEngine(FlutterPluginBinding)}. It is provided again in this method as a
@@ -84,13 +89,15 @@ public interface FlutterPlugin {
   void onDetachedFromEngine(@NonNull FlutterPluginBinding binding);
 
   /**
-   * Resources made available to all plugins registered with a given {@link io.flutter.embedding.engine.FlutterEngine}.
+   * Resources made available to all plugins registered with a given {@link
+   * io.flutter.embedding.engine.FlutterEngine}.
    *
    * <p>The provided {@link BinaryMessenger} can be used to communicate with Dart code running in
    * the Flutter context associated with this plugin binding.
    *
    * <p>Plugins that need to respond to {@code Lifecycle} events should implement the additional
-   * {@link io.flutter.embedding.engine.plugins.activity.ActivityAware} and/or {@link io.flutter.embedding.engine.plugins.service.ServiceAware} interfaces, where a {@link Lifecycle}
+   * {@link io.flutter.embedding.engine.plugins.activity.ActivityAware} and/or {@link
+   * io.flutter.embedding.engine.plugins.service.ServiceAware} interfaces, where a {@link Lifecycle}
    * reference can be obtained.
    */
   class FlutterPluginBinding {

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
@@ -21,18 +21,18 @@ import io.flutter.view.TextureRegistry;
  * communicate between platform code and Dart code.
  *
  * <p>A Flutter plugin has a lifecycle. First, a developer must add a {@code FlutterPlugin} to an
- * instance of {@link FlutterEngine}. To do this, obtain a {@link PluginRegistry} with {@link
+ * instance of {@link io.flutter.embedding.engine.FlutterEngine}. To do this, obtain a {@link PluginRegistry} with {@link
  * FlutterEngine#getPlugins()}, then call {@link PluginRegistry#add(FlutterPlugin)}, passing the
  * instance of the Flutter plugin. During the call to {@link PluginRegistry#add(FlutterPlugin)}, the
- * {@link FlutterEngine} will invoke {@link #onAttachedToEngine(FlutterPluginBinding)} on the given
- * {@code FlutterPlugin}. If the {@code FlutterPlugin} is removed from the {@link FlutterEngine} via
- * {@link PluginRegistry#remove(Class)}, or if the {@link FlutterEngine} is destroyed, the {@link
+ * {@link io.flutter.embedding.engine.FlutterEngine} will invoke {@link #onAttachedToEngine(FlutterPluginBinding)} on the given
+ * {@code FlutterPlugin}. If the {@code FlutterPlugin} is removed from the {@link io.flutter.embedding.engine.FlutterEngine} via
+ * {@link PluginRegistry#remove(Class)}, or if the {@link io.flutter.embedding.engine.FlutterEngine} is destroyed, the {@link
  * FlutterEngine} will invoke {@link FlutterPlugin#onDetachedFromEngine(FlutterPluginBinding)} on
  * the given {@code FlutterPlugin}.
  *
- * <p>Once a {@code FlutterPlugin} is attached to a {@link FlutterEngine}, the plugin's code is
+ * <p>Once a {@code FlutterPlugin} is attached to a {@link io.flutter.embedding.engine.FlutterEngine}, the plugin's code is
  * permitted to access and invoke methods on resources within the {@link FlutterPluginBinding} that
- * the {@link FlutterEngine} gave to the {@code FlutterPlugin} in {@link
+ * the {@link io.flutter.embedding.engine.FlutterEngine} gave to the {@code FlutterPlugin} in {@link
  * #onAttachedToEngine(FlutterPluginBinding)}. This includes, for example, the application {@link
  * Context} for the running app.
  *
@@ -63,7 +63,7 @@ import io.flutter.view.TextureRegistry;
 public interface FlutterPlugin {
 
   /**
-   * This {@code FlutterPlugin} has been associated with a {@link FlutterEngine} instance.
+   * This {@code FlutterPlugin} has been associated with a {@link io.flutter.embedding.engine.FlutterEngine} instance.
    *
    * <p>Relevant resources that this {@code FlutterPlugin} may need are provided via the {@code
    * binding}. The {@code binding} may be cached and referenced until {@link
@@ -72,7 +72,7 @@ public interface FlutterPlugin {
   void onAttachedToEngine(@NonNull FlutterPluginBinding binding);
 
   /**
-   * This {@code FlutterPlugin} has been removed from a {@link FlutterEngine} instance.
+   * This {@code FlutterPlugin} has been removed from a {@link io.flutter.embedding.engine.FlutterEngine} instance.
    *
    * <p>The {@code binding} passed to this method is the same instance that was passed in {@link
    * #onAttachedToEngine(FlutterPluginBinding)}. It is provided again in this method as a
@@ -84,13 +84,13 @@ public interface FlutterPlugin {
   void onDetachedFromEngine(@NonNull FlutterPluginBinding binding);
 
   /**
-   * Resources made available to all plugins registered with a given {@link FlutterEngine}.
+   * Resources made available to all plugins registered with a given {@link io.flutter.embedding.engine.FlutterEngine}.
    *
    * <p>The provided {@link BinaryMessenger} can be used to communicate with Dart code running in
    * the Flutter context associated with this plugin binding.
    *
    * <p>Plugins that need to respond to {@code Lifecycle} events should implement the additional
-   * {@link ActivityAware} and/or {@link ServiceAware} interfaces, where a {@link Lifecycle}
+   * {@link io.flutter.embedding.engine.plugins.activity.ActivityAware} and/or {@link io.flutter.embedding.engine.plugins.service.ServiceAware} interfaces, where a {@link Lifecycle}
    * reference can be obtained.
    */
   class FlutterPluginBinding {

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityAware.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityAware.java
@@ -7,25 +7,25 @@ package io.flutter.embedding.engine.plugins.activity;
 import androidx.annotation.NonNull;
 
 /**
- * {@link FlutterPlugin} that is interested in {@link Activity} lifecycle events related to a {@link
- * FlutterEngine} running within the given {@link Activity}.
+ * {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that is interested in {@link android.app.Activity} lifecycle events related to a {@link
+ * io.flutter.embedding.engine.FlutterEngine} running within the given {@link android.app.Activity}.
  */
 public interface ActivityAware {
   /**
-   * This {@code ActivityAware} {@link FlutterPlugin} is now associated with an {@link Activity}.
+   * This {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is now associated with an {@link android.app.Activity}.
    *
    * <p>This method can be invoked in 1 of 2 situations:
    *
    * <ul>
-   *   <li>This {@code ActivityAware} {@link FlutterPlugin} was just added to a {@link
-   *       FlutterEngine} that was already connected to a running {@link Activity}.
-   *   <li>This {@code ActivityAware} {@link FlutterPlugin} was already added to a {@link
-   *       FlutterEngine} and that {@link FlutterEngine} was just connected to an {@link Activity}.
+   *   <li>This {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} was just added to a {@link
+   *       io.flutter.embedding.engine.FlutterEngine} that was already connected to a running {@link android.app.Activity}.
+   *   <li>This {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} was already added to a {@link
+   *       io.flutter.embedding.engine.FlutterEngine} and that {@link io.flutter.embedding.engine.FlutterEngine} was just connected to an {@link android.app.Activity}.
    * </ul>
    *
-   * The given {@link ActivityPluginBinding} contains {@link Activity}-related references that an
-   * {@code ActivityAware} {@link FlutterPlugin} may require, such as a reference to the actual
-   * {@link Activity} in question. The {@link ActivityPluginBinding} may be referenced until either
+   * The given {@link ActivityPluginBinding} contains {@link android.app.Activity}-related references that an
+   * {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} may require, such as a reference to the actual
+   * {@link android.app.Activity} in question. The {@link ActivityPluginBinding} may be referenced until either
    * {@link #onDetachedFromActivityForConfigChanges()} or {@link #onDetachedFromActivity()} is
    * invoked. At the conclusion of either of those methods, the binding is no longer valid. Clear
    * any references to the binding or its resources, and do not invoke any further methods on the
@@ -34,19 +34,19 @@ public interface ActivityAware {
   void onAttachedToActivity(@NonNull ActivityPluginBinding binding);
 
   /**
-   * The {@link Activity} that was attached and made available in {@link
+   * The {@link android.app.Activity} that was attached and made available in {@link
    * #onAttachedToActivity(ActivityPluginBinding)} has been detached from this {@code
-   * ActivityAware}'s {@link FlutterEngine} for the purpose of processing a configuration change.
+   * ActivityAware}'s {@link io.flutter.embedding.engine.FlutterEngine} for the purpose of processing a configuration change.
    *
-   * <p>By the end of this method, the {@link Activity} that was made available in {@link
+   * <p>By the end of this method, the {@link android.app.Activity} that was made available in {@link
    * #onAttachedToActivity(ActivityPluginBinding)} is no longer valid. Any references to the
-   * associated {@link Activity} or {@link ActivityPluginBinding} should be cleared.
+   * associated {@link android.app.Activity} or {@link ActivityPluginBinding} should be cleared.
    *
    * <p>This method should be quickly followed by {@link
    * #onReattachedToActivityForConfigChanges(ActivityPluginBinding)}, which signifies that a new
-   * {@link Activity} has been created with the new configuration options. That method provides a
+   * {@link android.app.Activity} has been created with the new configuration options. That method provides a
    * new {@link ActivityPluginBinding}, which references the newly created and associated {@link
-   * Activity}.
+   * android.app.Activity}.
    *
    * <p>Any {@code Lifecycle} listeners that were registered in {@link
    * #onAttachedToActivity(ActivityPluginBinding)} should be deregistered here to avoid a possible
@@ -55,10 +55,10 @@ public interface ActivityAware {
   void onDetachedFromActivityForConfigChanges();
 
   /**
-   * This plugin and its {@link FlutterEngine} have been re-attached to an {@link Activity} after
-   * the {@link Activity} was recreated to handle configuration changes.
+   * This plugin and its {@link io.flutter.embedding.engine.FlutterEngine} have been re-attached to an {@link android.app.Activity} after
+   * the {@link android.app.Activity} was recreated to handle configuration changes.
    *
-   * <p>{@code binding} includes a reference to the new instance of the {@link Activity}. {@code
+   * <p>{@code binding} includes a reference to the new instance of the {@link android.app.Activity}. {@code
    * binding} and its references may be cached and used from now until either {@link
    * #onDetachedFromActivityForConfigChanges()} or {@link #onDetachedFromActivity()} is invoked. At
    * the conclusion of either of those methods, the binding is no longer valid. Clear any references
@@ -68,20 +68,20 @@ public interface ActivityAware {
   void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding);
 
   /**
-   * This plugin has been detached from an {@link Activity}.
+   * This plugin has been detached from an {@link android.app.Activity}.
    *
    * <p>Detachment can occur for a number of reasons.
    *
    * <ul>
-   *   <li>The app is no longer visible and the {@link Activity} instance has been destroyed.
-   *   <li>The {@link FlutterEngine} that this plugin is connected to has been detached from its
-   *       {@link FlutterView}.
-   *   <li>This {@code ActivityAware} plugin has been removed from its {@link FlutterEngine}.
+   *   <li>The app is no longer visible and the {@link android.app.Activity} instance has been destroyed.
+   *   <li>The {@link io.flutter.embedding.engine.FlutterEngine} that this plugin is connected to has been detached from its
+   *       {@link io.flutter.embedding.android.FlutterView}.
+   *   <li>This {@code ActivityAware} plugin has been removed from its {@link io.flutter.embedding.engine.FlutterEngine}.
    * </ul>
    *
-   * By the end of this method, the {@link Activity} that was made available in {@link
+   * By the end of this method, the {@link android.app.Activity} that was made available in {@link
    * #onAttachedToActivity(ActivityPluginBinding)} is no longer valid. Any references to the
-   * associated {@link Activity} or {@link ActivityPluginBinding} should be cleared.
+   * associated {@link android.app.Activity} or {@link ActivityPluginBinding} should be cleared.
    *
    * <p>Any {@code Lifecycle} listeners that were registered in {@link
    * #onAttachedToActivity(ActivityPluginBinding)} or {@link

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityAware.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityAware.java
@@ -7,46 +7,53 @@ package io.flutter.embedding.engine.plugins.activity;
 import androidx.annotation.NonNull;
 
 /**
- * {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that is interested in {@link android.app.Activity} lifecycle events related to a {@link
+ * {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that is interested in {@link
+ * android.app.Activity} lifecycle events related to a {@link
  * io.flutter.embedding.engine.FlutterEngine} running within the given {@link android.app.Activity}.
  */
 public interface ActivityAware {
   /**
-   * This {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is now associated with an {@link android.app.Activity}.
+   * This {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is now
+   * associated with an {@link android.app.Activity}.
    *
    * <p>This method can be invoked in 1 of 2 situations:
    *
    * <ul>
-   *   <li>This {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} was just added to a {@link
-   *       io.flutter.embedding.engine.FlutterEngine} that was already connected to a running {@link android.app.Activity}.
-   *   <li>This {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} was already added to a {@link
-   *       io.flutter.embedding.engine.FlutterEngine} and that {@link io.flutter.embedding.engine.FlutterEngine} was just connected to an {@link android.app.Activity}.
+   *   <li>This {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} was
+   *       just added to a {@link io.flutter.embedding.engine.FlutterEngine} that was already
+   *       connected to a running {@link android.app.Activity}.
+   *   <li>This {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} was
+   *       already added to a {@link io.flutter.embedding.engine.FlutterEngine} and that {@link
+   *       io.flutter.embedding.engine.FlutterEngine} was just connected to an {@link
+   *       android.app.Activity}.
    * </ul>
    *
-   * The given {@link ActivityPluginBinding} contains {@link android.app.Activity}-related references that an
-   * {@code ActivityAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} may require, such as a reference to the actual
-   * {@link android.app.Activity} in question. The {@link ActivityPluginBinding} may be referenced until either
-   * {@link #onDetachedFromActivityForConfigChanges()} or {@link #onDetachedFromActivity()} is
-   * invoked. At the conclusion of either of those methods, the binding is no longer valid. Clear
-   * any references to the binding or its resources, and do not invoke any further methods on the
-   * binding or its resources.
+   * The given {@link ActivityPluginBinding} contains {@link android.app.Activity}-related
+   * references that an {@code ActivityAware} {@link
+   * io.flutter.embedding.engine.plugins.FlutterPlugin} may require, such as a reference to the
+   * actual {@link android.app.Activity} in question. The {@link ActivityPluginBinding} may be
+   * referenced until either {@link #onDetachedFromActivityForConfigChanges()} or {@link
+   * #onDetachedFromActivity()} is invoked. At the conclusion of either of those methods, the
+   * binding is no longer valid. Clear any references to the binding or its resources, and do not
+   * invoke any further methods on the binding or its resources.
    */
   void onAttachedToActivity(@NonNull ActivityPluginBinding binding);
 
   /**
    * The {@link android.app.Activity} that was attached and made available in {@link
    * #onAttachedToActivity(ActivityPluginBinding)} has been detached from this {@code
-   * ActivityAware}'s {@link io.flutter.embedding.engine.FlutterEngine} for the purpose of processing a configuration change.
+   * ActivityAware}'s {@link io.flutter.embedding.engine.FlutterEngine} for the purpose of
+   * processing a configuration change.
    *
-   * <p>By the end of this method, the {@link android.app.Activity} that was made available in {@link
-   * #onAttachedToActivity(ActivityPluginBinding)} is no longer valid. Any references to the
+   * <p>By the end of this method, the {@link android.app.Activity} that was made available in
+   * {@link #onAttachedToActivity(ActivityPluginBinding)} is no longer valid. Any references to the
    * associated {@link android.app.Activity} or {@link ActivityPluginBinding} should be cleared.
    *
    * <p>This method should be quickly followed by {@link
    * #onReattachedToActivityForConfigChanges(ActivityPluginBinding)}, which signifies that a new
-   * {@link android.app.Activity} has been created with the new configuration options. That method provides a
-   * new {@link ActivityPluginBinding}, which references the newly created and associated {@link
-   * android.app.Activity}.
+   * {@link android.app.Activity} has been created with the new configuration options. That method
+   * provides a new {@link ActivityPluginBinding}, which references the newly created and associated
+   * {@link android.app.Activity}.
    *
    * <p>Any {@code Lifecycle} listeners that were registered in {@link
    * #onAttachedToActivity(ActivityPluginBinding)} should be deregistered here to avoid a possible
@@ -55,15 +62,16 @@ public interface ActivityAware {
   void onDetachedFromActivityForConfigChanges();
 
   /**
-   * This plugin and its {@link io.flutter.embedding.engine.FlutterEngine} have been re-attached to an {@link android.app.Activity} after
-   * the {@link android.app.Activity} was recreated to handle configuration changes.
+   * This plugin and its {@link io.flutter.embedding.engine.FlutterEngine} have been re-attached to
+   * an {@link android.app.Activity} after the {@link android.app.Activity} was recreated to handle
+   * configuration changes.
    *
-   * <p>{@code binding} includes a reference to the new instance of the {@link android.app.Activity}. {@code
-   * binding} and its references may be cached and used from now until either {@link
-   * #onDetachedFromActivityForConfigChanges()} or {@link #onDetachedFromActivity()} is invoked. At
-   * the conclusion of either of those methods, the binding is no longer valid. Clear any references
-   * to the binding or its resources, and do not invoke any further methods on the binding or its
-   * resources.
+   * <p>{@code binding} includes a reference to the new instance of the {@link
+   * android.app.Activity}. {@code binding} and its references may be cached and used from now until
+   * either {@link #onDetachedFromActivityForConfigChanges()} or {@link #onDetachedFromActivity()}
+   * is invoked. At the conclusion of either of those methods, the binding is no longer valid. Clear
+   * any references to the binding or its resources, and do not invoke any further methods on the
+   * binding or its resources.
    */
   void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding);
 
@@ -73,10 +81,12 @@ public interface ActivityAware {
    * <p>Detachment can occur for a number of reasons.
    *
    * <ul>
-   *   <li>The app is no longer visible and the {@link android.app.Activity} instance has been destroyed.
-   *   <li>The {@link io.flutter.embedding.engine.FlutterEngine} that this plugin is connected to has been detached from its
-   *       {@link io.flutter.embedding.android.FlutterView}.
-   *   <li>This {@code ActivityAware} plugin has been removed from its {@link io.flutter.embedding.engine.FlutterEngine}.
+   *   <li>The app is no longer visible and the {@link android.app.Activity} instance has been
+   *       destroyed.
+   *   <li>The {@link io.flutter.embedding.engine.FlutterEngine} that this plugin is connected to
+   *       has been detached from its {@link io.flutter.embedding.android.FlutterView}.
+   *   <li>This {@code ActivityAware} plugin has been removed from its {@link
+   *       io.flutter.embedding.engine.FlutterEngine}.
    * </ul>
    *
    * By the end of this method, the {@link android.app.Activity} that was made available in {@link

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityControlSurface.java
@@ -13,47 +13,44 @@ import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.android.ExclusiveAppComponent;
 
 /**
- * Control surface through which an {@link Activity} attaches to a {@link FlutterEngine}.
+ * Control surface through which an {@link android.app.Activity} attaches to a {@link io.flutter.embedding.engine.FlutterEngine}.
  *
- * <p>An {@link Activity} that contains a {@link FlutterView} and associated {@link FlutterEngine}
- * should coordinate itself with the {@link FlutterEngine}'s {@code ActivityControlSurface}.
+ * <p>An {@link android.app.Activity} that contains a {@link io.flutter.embedding.android.FlutterView} and associated {@link io.flutter.embedding.engine.FlutterEngine}
+ * should coordinate itself with the {@link io.flutter.embedding.engine.FlutterEngine}'s {@code ActivityControlSurface}.
  *
  * <ol>
- *   <li>Once an {@link Activity} is created, and its associated {@link FlutterEngine} is executing
- *       Dart code, the {@link Activity} should invoke {@link #attachToActivity(
- *       ExclusiveAppComponent, Lifecycle)}. At this point the {@link FlutterEngine} is considered
- *       "attached" to the {@link Activity} and all {@link ActivityAware} plugins are given access
- *       to the {@link Activity}.
- *   <li>Just before an attached {@link Activity} is destroyed for configuration change purposes,
- *       that {@link Activity} should invoke {@link #detachFromActivityForConfigChanges()}, giving
+ *   <li>Once an {@link android.app.Activity} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is executing
+ *       Dart code, the {@link android.app.Activity} should invoke {@link #attachToActivity(
+ *       ExclusiveAppComponent, Lifecycle)}. At this point the {@link io.flutter.embedding.engine.FlutterEngine} is considered
+ *       "attached" to the {@link android.app.Activity} and all {@link ActivityAware} plugins are given access
+ *       to the {@link android.app.Activity}.
+ *   <li>Just before an attached {@link android.app.Activity} is destroyed for configuration change purposes,
+ *       that {@link android.app.Activity} should invoke {@link #detachFromActivityForConfigChanges()}, giving
  *       each {@link ActivityAware} plugin an opportunity to clean up its references before the
- *       {@link Activity is destroyed}.
- *   <li>When an {@link Activity} is recreated after configuration changes, that {@link Activity}
- *       should invoke {@link #reattachToActivityAfterConfigChange(Activity)} so that all {@link
- *       ActivityAware} plugins can re-establish references to the {@link Activity}.
- *   <li>When an {@link Activity} is destroyed for non-configuration-change purposes, or when the
- *       {@link Activity} is no longer interested in displaying a {@link FlutterEngine}'s content,
- *       the {@link Activity} should invoke {@link #detachFromActivity()}.
- *   <li>When a {@link Activity} is being attached while an existing {@link ExclusiveAppComponent}
+ *       {@link android.app.Activity is destroyed}.
+ *   <li>When an {@link android.app.Activity} is destroyed for non-configuration-change purposes, or when the
+ *       {@link android.app.Activity} is no longer interested in displaying a {@link io.flutter.embedding.engine.FlutterEngine}'s content,
+ *       the {@link android.app.Activity} should invoke {@link #detachFromActivity()}.
+ *   <li>When a {@link android.app.Activity} is being attached while an existing {@link ExclusiveAppComponent}
  *       is already attached, the existing {@link ExclusiveAppComponent} is given a chance to detach
  *       first via {@link ExclusiveAppComponent#detachFromFlutterEngine()} before the new activity
  *       attaches.
  * </ol>
  *
- * The attached {@link Activity} should also forward all {@link Activity} calls that this {@code
+ * The attached {@link android.app.Activity} should also forward all {@link android.app.Activity} calls that this {@code
  * ActivityControlSurface} supports, e.g., {@link #onRequestPermissionsResult(int, String[],
  * int[])}. These forwarded calls are made available to all {@link ActivityAware} plugins that are
- * added to the attached {@link FlutterEngine}.
+ * added to the attached {@link io.flutter.embedding.engine.FlutterEngine}.
  */
 public interface ActivityControlSurface {
   /**
-   * Call this method from the {@link Activity} that is displaying the visual content of the {@link
-   * FlutterEngine} that is associated with this {@code ActivityControlSurface}.
+   * Call this method from the {@link android.app.Activity} that is displaying the visual content of the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that is associated with this {@code ActivityControlSurface}.
    *
-   * <p>Once an {@link Activity} is created, and its associated {@link FlutterEngine} is executing
-   * Dart code, the {@link Activity} should invoke this method. At that point the {@link
-   * FlutterEngine} is considered "attached" to the {@link Activity} and all {@link ActivityAware}
-   * plugins are given access to the {@link Activity}.
+   * <p>Once an {@link android.app.Activity} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is executing
+   * Dart code, the {@link android.app.Activity} should invoke this method. At that point the {@link
+   * io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link android.app.Activity} and all {@link ActivityAware}
+   * plugins are given access to the {@link android.app.Activity}.
    *
    * @deprecated Prefer using the {@link #attachToActivity(ExclusiveAppComponent, Lifecycle)} API to
    *     avoid situations where multiple activities are driving the FlutterEngine simultaneously.
@@ -64,13 +61,13 @@ public interface ActivityControlSurface {
 
   /**
    * Call this method from the {@link ExclusiveAppComponent} that is displaying the visual content
-   * of the {@link FlutterEngine} that is associated with this {@code ActivityControlSurface}.
+   * of the {@link io.flutter.embedding.engine.FlutterEngine} that is associated with this {@code ActivityControlSurface}.
    *
-   * <p>Once an {@link ExclusiveAppComponent} is created, and its associated {@link FlutterEngine}
+   * <p>Once an {@link ExclusiveAppComponent} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine}
    * is executing Dart code, the {@link ExclusiveAppComponent} should invoke this method. At that
-   * point the {@link FlutterEngine} is considered "attached" to the {@link ExclusiveAppComponent}
+   * point the {@link io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link ExclusiveAppComponent}
    * and all {@link ActivityAware} plugins are given access to the {@link ExclusiveAppComponent}'s
-   * {@link Activity}.
+   * {@link android.app.Activity}.
    *
    * <p>This method differs from {@link #attachToActivity(Activity, Lifecycle)} in that it calls
    * back the existing {@link ExclusiveAppComponent} to give it a chance to cleanly detach before a
@@ -80,28 +77,28 @@ public interface ActivityControlSurface {
       @NonNull ExclusiveAppComponent<Activity> exclusiveActivity, @NonNull Lifecycle lifecycle);
 
   /**
-   * Call this method from the {@link Activity} that is attached to this {@code
-   * ActivityControlSurfaces}'s {@link FlutterEngine} when the {@link Activity} is about to be
+   * Call this method from the {@link android.app.Activity} that is attached to this {@code
+   * ActivityControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link android.app.Activity} is about to be
    * destroyed due to configuration changes.
    *
    * <p>This method gives each {@link ActivityAware} plugin an opportunity to clean up its
-   * references before the {@link Activity is destroyed}.
+   * references before the {@link android.app.Activity is destroyed}.
    */
   void detachFromActivityForConfigChanges();
 
   /**
-   * Call this method from the {@link Activity} that is attached to this {@code
-   * ActivityControlSurfaces}'s {@link FlutterEngine} when the {@link Activity} is about to be
+   * Call this method from the {@link android.app.Activity} that is attached to this {@code
+   * ActivityControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link android.app.Activity} is about to be
    * destroyed for non-configuration-change reasons.
    *
    * <p>This method gives each {@link ActivityAware} plugin an opportunity to clean up its
-   * references before the {@link Activity is destroyed}.
+   * references before the {@link android.app.Activity is destroyed}.
    */
   void detachFromActivity();
 
   /**
-   * Call this method from the {@link Activity} that is attached to this {@code
-   * ActivityControlSurface}'s {@link FlutterEngine} and the associated method in the {@link
+   * Call this method from the {@link android.app.Activity} that is attached to this {@code
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated method in the {@link
    * Activity} is invoked.
    *
    * <p>Returns true if one or more plugins utilized this permission result.
@@ -110,39 +107,39 @@ public interface ActivityControlSurface {
       int requestCode, @NonNull String[] permissions, @NonNull int[] grantResult);
 
   /**
-   * Call this method from the {@link Activity} that is attached to this {@code
-   * ActivityControlSurface}'s {@link FlutterEngine} and the associated method in the {@link
+   * Call this method from the {@link android.app.Activity} that is attached to this {@code
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated method in the {@link
    * Activity} is invoked.
    *
-   * <p>Returns true if one or more plugins utilized this {@link Activity} result.
+   * <p>Returns true if one or more plugins utilized this {@link android.app.Activity} result.
    */
   boolean onActivityResult(int requestCode, int resultCode, @Nullable Intent data);
 
   /**
-   * Call this method from the {@link Activity} that is attached to this {@code
-   * ActivityControlSurface}'s {@link FlutterEngine} and the associated method in the {@link
+   * Call this method from the {@link android.app.Activity} that is attached to this {@code
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated method in the {@link
    * Activity} is invoked.
    */
   void onNewIntent(@NonNull Intent intent);
 
   /**
-   * Call this method from the {@link Activity} that is attached to this {@code
-   * ActivityControlSurface}'s {@link FlutterEngine} and the associated method in the {@link
+   * Call this method from the {@link android.app.Activity} that is attached to this {@code
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated method in the {@link
    * Activity} is invoked.
    */
   void onUserLeaveHint();
 
   /**
-   * Call this method from the {@link Activity} or {@code Fragment} that is attached to this {@code
-   * ActivityControlSurface}'s {@link FlutterEngine} when the associated method is invoked in the
-   * {@link Activity} or {@code Fragment}.
+   * Call this method from the {@link android.app.Activity} or {@code Fragment} that is attached to this {@code
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when the associated method is invoked in the
+   * {@link android.app.Activity} or {@code Fragment}.
    */
   void onSaveInstanceState(@NonNull Bundle bundle);
 
   /**
-   * Call this method from the {@link Activity} or {@code Fragment} that is attached to this {@code
-   * ActivityControlSurface}'s {@link FlutterEngine} when {@link Activity#onCreate(Bundle)} or
-   * {@code Fragment#onCreate(Bundle)} is invoked in the {@link Activity} or {@code Fragment}.
+   * Call this method from the {@link android.app.Activity} or {@code Fragment} that is attached to this {@code
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when {@link android.app.Activity#onCreate(Bundle)} or
+   * {@code Fragment#onCreate(Bundle)} is invoked in the {@link android.app.Activity} or {@code Fragment}.
    */
   void onRestoreInstanceState(@Nullable Bundle bundle);
 }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityControlSurface.java
@@ -13,44 +13,54 @@ import androidx.lifecycle.Lifecycle;
 import io.flutter.embedding.android.ExclusiveAppComponent;
 
 /**
- * Control surface through which an {@link android.app.Activity} attaches to a {@link io.flutter.embedding.engine.FlutterEngine}.
+ * Control surface through which an {@link android.app.Activity} attaches to a {@link
+ * io.flutter.embedding.engine.FlutterEngine}.
  *
- * <p>An {@link android.app.Activity} that contains a {@link io.flutter.embedding.android.FlutterView} and associated {@link io.flutter.embedding.engine.FlutterEngine}
- * should coordinate itself with the {@link io.flutter.embedding.engine.FlutterEngine}'s {@code ActivityControlSurface}.
+ * <p>An {@link android.app.Activity} that contains a {@link
+ * io.flutter.embedding.android.FlutterView} and associated {@link
+ * io.flutter.embedding.engine.FlutterEngine} should coordinate itself with the {@link
+ * io.flutter.embedding.engine.FlutterEngine}'s {@code ActivityControlSurface}.
  *
  * <ol>
- *   <li>Once an {@link android.app.Activity} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is executing
- *       Dart code, the {@link android.app.Activity} should invoke {@link #attachToActivity(
- *       ExclusiveAppComponent, Lifecycle)}. At this point the {@link io.flutter.embedding.engine.FlutterEngine} is considered
- *       "attached" to the {@link android.app.Activity} and all {@link ActivityAware} plugins are given access
- *       to the {@link android.app.Activity}.
- *   <li>Just before an attached {@link android.app.Activity} is destroyed for configuration change purposes,
- *       that {@link android.app.Activity} should invoke {@link #detachFromActivityForConfigChanges()}, giving
- *       each {@link ActivityAware} plugin an opportunity to clean up its references before the
- *       {@link android.app.Activity is destroyed}.
- *   <li>When an {@link android.app.Activity} is destroyed for non-configuration-change purposes, or when the
- *       {@link android.app.Activity} is no longer interested in displaying a {@link io.flutter.embedding.engine.FlutterEngine}'s content,
- *       the {@link android.app.Activity} should invoke {@link #detachFromActivity()}.
- *   <li>When a {@link android.app.Activity} is being attached while an existing {@link ExclusiveAppComponent}
- *       is already attached, the existing {@link ExclusiveAppComponent} is given a chance to detach
- *       first via {@link ExclusiveAppComponent#detachFromFlutterEngine()} before the new activity
- *       attaches.
+ *   <li>Once an {@link android.app.Activity} is created, and its associated {@link
+ *       io.flutter.embedding.engine.FlutterEngine} is executing Dart code, the {@link
+ *       android.app.Activity} should invoke {@link #attachToActivity( ExclusiveAppComponent,
+ *       Lifecycle)}. At this point the {@link io.flutter.embedding.engine.FlutterEngine} is
+ *       considered "attached" to the {@link android.app.Activity} and all {@link ActivityAware}
+ *       plugins are given access to the {@link android.app.Activity}.
+ *   <li>Just before an attached {@link android.app.Activity} is destroyed for configuration change
+ *       purposes, that {@link android.app.Activity} should invoke {@link
+ *       #detachFromActivityForConfigChanges()}, giving each {@link ActivityAware} plugin an
+ *       opportunity to clean up its references before the {@link android.app.Activity is
+ *       destroyed}.
+ *   <li>When an {@link android.app.Activity} is destroyed for non-configuration-change purposes, or
+ *       when the {@link android.app.Activity} is no longer interested in displaying a {@link
+ *       io.flutter.embedding.engine.FlutterEngine}'s content, the {@link android.app.Activity}
+ *       should invoke {@link #detachFromActivity()}.
+ *   <li>When a {@link android.app.Activity} is being attached while an existing {@link
+ *       ExclusiveAppComponent} is already attached, the existing {@link ExclusiveAppComponent} is
+ *       given a chance to detach first via {@link ExclusiveAppComponent#detachFromFlutterEngine()}
+ *       before the new activity attaches.
  * </ol>
  *
- * The attached {@link android.app.Activity} should also forward all {@link android.app.Activity} calls that this {@code
- * ActivityControlSurface} supports, e.g., {@link #onRequestPermissionsResult(int, String[],
- * int[])}. These forwarded calls are made available to all {@link ActivityAware} plugins that are
- * added to the attached {@link io.flutter.embedding.engine.FlutterEngine}.
+ * The attached {@link android.app.Activity} should also forward all {@link android.app.Activity}
+ * calls that this {@code ActivityControlSurface} supports, e.g., {@link
+ * #onRequestPermissionsResult(int, String[], int[])}. These forwarded calls are made available to
+ * all {@link ActivityAware} plugins that are added to the attached {@link
+ * io.flutter.embedding.engine.FlutterEngine}.
  */
 public interface ActivityControlSurface {
   /**
-   * Call this method from the {@link android.app.Activity} that is displaying the visual content of the {@link
-   * io.flutter.embedding.engine.FlutterEngine} that is associated with this {@code ActivityControlSurface}.
+   * Call this method from the {@link android.app.Activity} that is displaying the visual content of
+   * the {@link io.flutter.embedding.engine.FlutterEngine} that is associated with this {@code
+   * ActivityControlSurface}.
    *
-   * <p>Once an {@link android.app.Activity} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is executing
-   * Dart code, the {@link android.app.Activity} should invoke this method. At that point the {@link
-   * io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link android.app.Activity} and all {@link ActivityAware}
-   * plugins are given access to the {@link android.app.Activity}.
+   * <p>Once an {@link android.app.Activity} is created, and its associated {@link
+   * io.flutter.embedding.engine.FlutterEngine} is executing Dart code, the {@link
+   * android.app.Activity} should invoke this method. At that point the {@link
+   * io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link
+   * android.app.Activity} and all {@link ActivityAware} plugins are given access to the {@link
+   * android.app.Activity}.
    *
    * @deprecated Prefer using the {@link #attachToActivity(ExclusiveAppComponent, Lifecycle)} API to
    *     avoid situations where multiple activities are driving the FlutterEngine simultaneously.
@@ -61,13 +71,15 @@ public interface ActivityControlSurface {
 
   /**
    * Call this method from the {@link ExclusiveAppComponent} that is displaying the visual content
-   * of the {@link io.flutter.embedding.engine.FlutterEngine} that is associated with this {@code ActivityControlSurface}.
+   * of the {@link io.flutter.embedding.engine.FlutterEngine} that is associated with this {@code
+   * ActivityControlSurface}.
    *
-   * <p>Once an {@link ExclusiveAppComponent} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine}
-   * is executing Dart code, the {@link ExclusiveAppComponent} should invoke this method. At that
-   * point the {@link io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link ExclusiveAppComponent}
-   * and all {@link ActivityAware} plugins are given access to the {@link ExclusiveAppComponent}'s
-   * {@link android.app.Activity}.
+   * <p>Once an {@link ExclusiveAppComponent} is created, and its associated {@link
+   * io.flutter.embedding.engine.FlutterEngine} is executing Dart code, the {@link
+   * ExclusiveAppComponent} should invoke this method. At that point the {@link
+   * io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link
+   * ExclusiveAppComponent} and all {@link ActivityAware} plugins are given access to the {@link
+   * ExclusiveAppComponent}'s {@link android.app.Activity}.
    *
    * <p>This method differs from {@link #attachToActivity(Activity, Lifecycle)} in that it calls
    * back the existing {@link ExclusiveAppComponent} to give it a chance to cleanly detach before a
@@ -78,8 +90,8 @@ public interface ActivityControlSurface {
 
   /**
    * Call this method from the {@link android.app.Activity} that is attached to this {@code
-   * ActivityControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link android.app.Activity} is about to be
-   * destroyed due to configuration changes.
+   * ActivityControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link
+   * android.app.Activity} is about to be destroyed due to configuration changes.
    *
    * <p>This method gives each {@link ActivityAware} plugin an opportunity to clean up its
    * references before the {@link android.app.Activity is destroyed}.
@@ -88,8 +100,8 @@ public interface ActivityControlSurface {
 
   /**
    * Call this method from the {@link android.app.Activity} that is attached to this {@code
-   * ActivityControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link android.app.Activity} is about to be
-   * destroyed for non-configuration-change reasons.
+   * ActivityControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link
+   * android.app.Activity} is about to be destroyed for non-configuration-change reasons.
    *
    * <p>This method gives each {@link ActivityAware} plugin an opportunity to clean up its
    * references before the {@link android.app.Activity is destroyed}.
@@ -98,8 +110,8 @@ public interface ActivityControlSurface {
 
   /**
    * Call this method from the {@link android.app.Activity} that is attached to this {@code
-   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated method in the {@link
-   * Activity} is invoked.
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated
+   * method in the {@link Activity} is invoked.
    *
    * <p>Returns true if one or more plugins utilized this permission result.
    */
@@ -108,8 +120,8 @@ public interface ActivityControlSurface {
 
   /**
    * Call this method from the {@link android.app.Activity} that is attached to this {@code
-   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated method in the {@link
-   * Activity} is invoked.
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated
+   * method in the {@link Activity} is invoked.
    *
    * <p>Returns true if one or more plugins utilized this {@link android.app.Activity} result.
    */
@@ -117,29 +129,30 @@ public interface ActivityControlSurface {
 
   /**
    * Call this method from the {@link android.app.Activity} that is attached to this {@code
-   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated method in the {@link
-   * Activity} is invoked.
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated
+   * method in the {@link Activity} is invoked.
    */
   void onNewIntent(@NonNull Intent intent);
 
   /**
    * Call this method from the {@link android.app.Activity} that is attached to this {@code
-   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated method in the {@link
-   * Activity} is invoked.
+   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} and the associated
+   * method in the {@link Activity} is invoked.
    */
   void onUserLeaveHint();
 
   /**
-   * Call this method from the {@link android.app.Activity} or {@code Fragment} that is attached to this {@code
-   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when the associated method is invoked in the
-   * {@link android.app.Activity} or {@code Fragment}.
+   * Call this method from the {@link android.app.Activity} or {@code Fragment} that is attached to
+   * this {@code ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when
+   * the associated method is invoked in the {@link android.app.Activity} or {@code Fragment}.
    */
   void onSaveInstanceState(@NonNull Bundle bundle);
 
   /**
-   * Call this method from the {@link android.app.Activity} or {@code Fragment} that is attached to this {@code
-   * ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when {@link android.app.Activity#onCreate(Bundle)} or
-   * {@code Fragment#onCreate(Bundle)} is invoked in the {@link android.app.Activity} or {@code Fragment}.
+   * Call this method from the {@link android.app.Activity} or {@code Fragment} that is attached to
+   * this {@code ActivityControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when
+   * {@link android.app.Activity#onCreate(Bundle)} or {@code Fragment#onCreate(Bundle)} is invoked
+   * in the {@link android.app.Activity} or {@code Fragment}.
    */
   void onRestoreInstanceState(@Nullable Bundle bundle);
 }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityPluginBinding.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityPluginBinding.java
@@ -11,8 +11,8 @@ import androidx.annotation.Nullable;
 import io.flutter.plugin.common.PluginRegistry;
 
 /**
- * Binding that gives {@link ActivityAware} plugins access to an associated {@link Activity} and the
- * {@link Activity}'s lifecycle methods.
+ * Binding that gives {@link ActivityAware} plugins access to an associated {@link android.app.Activity} and the
+ * {@link android.app.Activity}'s lifecycle methods.
  *
  * <p>To obtain an instance of an {@code ActivityPluginBinding} in a Flutter plugin, implement the
  * {@link ActivityAware} interface. A binding is provided in {@link
@@ -22,7 +22,7 @@ import io.flutter.plugin.common.PluginRegistry;
 public interface ActivityPluginBinding {
 
   /**
-   * Returns the {@link Activity} that is currently attached to the {@link FlutterEngine} that owns
+   * Returns the {@link android.app.Activity} that is currently attached to the {@link io.flutter.embedding.engine.FlutterEngine} that owns
    * this {@code ActivityPluginBinding}.
    */
   @NonNull
@@ -42,7 +42,7 @@ public interface ActivityPluginBinding {
   Object getLifecycle();
 
   /**
-   * Adds a listener that is invoked whenever the associated {@link Activity}'s {@code
+   * Adds a listener that is invoked whenever the associated {@link android.app.Activity}'s {@code
    * onRequestPermissionsResult(...)} method is invoked.
    */
   void addRequestPermissionsResultListener(
@@ -56,7 +56,7 @@ public interface ActivityPluginBinding {
       @NonNull PluginRegistry.RequestPermissionsResultListener listener);
 
   /**
-   * Adds a listener that is invoked whenever the associated {@link Activity}'s {@code
+   * Adds a listener that is invoked whenever the associated {@link android.app.Activity}'s {@code
    * onActivityResult(...)} method is invoked.
    */
   void addActivityResultListener(@NonNull PluginRegistry.ActivityResultListener listener);
@@ -68,7 +68,7 @@ public interface ActivityPluginBinding {
   void removeActivityResultListener(@NonNull PluginRegistry.ActivityResultListener listener);
 
   /**
-   * Adds a listener that is invoked whenever the associated {@link Activity}'s {@code
+   * Adds a listener that is invoked whenever the associated {@link android.app.Activity}'s {@code
    * onNewIntent(...)} method is invoked.
    */
   void addOnNewIntentListener(@NonNull PluginRegistry.NewIntentListener listener);
@@ -80,7 +80,7 @@ public interface ActivityPluginBinding {
   void removeOnNewIntentListener(@NonNull PluginRegistry.NewIntentListener listener);
 
   /**
-   * Adds a listener that is invoked whenever the associated {@link Activity}'s {@code
+   * Adds a listener that is invoked whenever the associated {@link android.app.Activity}'s {@code
    * onUserLeaveHint()} method is invoked.
    */
   void addOnUserLeaveHintListener(@NonNull PluginRegistry.UserLeaveHintListener listener);
@@ -111,7 +111,7 @@ public interface ActivityPluginBinding {
     void onSaveInstanceState(@NonNull Bundle bundle);
 
     /**
-     * Invoked when the associated {@code Activity} executes {@link Activity#onCreate(Bundle)} or
+     * Invoked when the associated {@code Activity} executes {@link android.app.Activity#onCreate(Bundle)} or
      * associated {@code Fragment} executes {@code Fragment#onCreate(Bundle)}.
      */
     void onRestoreInstanceState(@Nullable Bundle bundle);

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityPluginBinding.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityPluginBinding.java
@@ -11,8 +11,8 @@ import androidx.annotation.Nullable;
 import io.flutter.plugin.common.PluginRegistry;
 
 /**
- * Binding that gives {@link ActivityAware} plugins access to an associated {@link android.app.Activity} and the
- * {@link android.app.Activity}'s lifecycle methods.
+ * Binding that gives {@link ActivityAware} plugins access to an associated {@link
+ * android.app.Activity} and the {@link android.app.Activity}'s lifecycle methods.
  *
  * <p>To obtain an instance of an {@code ActivityPluginBinding} in a Flutter plugin, implement the
  * {@link ActivityAware} interface. A binding is provided in {@link
@@ -22,8 +22,8 @@ import io.flutter.plugin.common.PluginRegistry;
 public interface ActivityPluginBinding {
 
   /**
-   * Returns the {@link android.app.Activity} that is currently attached to the {@link io.flutter.embedding.engine.FlutterEngine} that owns
-   * this {@code ActivityPluginBinding}.
+   * Returns the {@link android.app.Activity} that is currently attached to the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that owns this {@code ActivityPluginBinding}.
    */
   @NonNull
   Activity getActivity();
@@ -111,8 +111,9 @@ public interface ActivityPluginBinding {
     void onSaveInstanceState(@NonNull Bundle bundle);
 
     /**
-     * Invoked when the associated {@code Activity} executes {@link android.app.Activity#onCreate(Bundle)} or
-     * associated {@code Fragment} executes {@code Fragment#onCreate(Bundle)}.
+     * Invoked when the associated {@code Activity} executes {@link
+     * android.app.Activity#onCreate(Bundle)} or associated {@code Fragment} executes {@code
+     * Fragment#onCreate(Bundle)}.
      */
     void onRestoreInstanceState(@Nullable Bundle bundle);
   }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverAware.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverAware.java
@@ -7,18 +7,21 @@ package io.flutter.embedding.engine.plugins.broadcastreceiver;
 import androidx.annotation.NonNull;
 
 /**
- * A {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that wants to know when it is running within a {@link android.content.BroadcastReceiver}.
+ * A {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that wants to know when it is running
+ * within a {@link android.content.BroadcastReceiver}.
  */
 public interface BroadcastReceiverAware {
   /**
-   * Callback triggered when a {@code BroadcastReceiverAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is associated
-   * with a {@link android.content.BroadcastReceiver}.
+   * Callback triggered when a {@code BroadcastReceiverAware} {@link
+   * io.flutter.embedding.engine.plugins.FlutterPlugin} is associated with a {@link
+   * android.content.BroadcastReceiver}.
    */
   void onAttachedToBroadcastReceiver(@NonNull BroadcastReceiverPluginBinding binding);
 
   /**
-   * Callback triggered when a {@code BroadcastReceiverAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is detached from
-   * a {@link android.content.BroadcastReceiver}.
+   * Callback triggered when a {@code BroadcastReceiverAware} {@link
+   * io.flutter.embedding.engine.plugins.FlutterPlugin} is detached from a {@link
+   * android.content.BroadcastReceiver}.
    */
   void onDetachedFromBroadcastReceiver();
 }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverAware.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverAware.java
@@ -7,18 +7,18 @@ package io.flutter.embedding.engine.plugins.broadcastreceiver;
 import androidx.annotation.NonNull;
 
 /**
- * A {@link FlutterPlugin} that wants to know when it is running within a {@link BroadcastReceiver}.
+ * A {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that wants to know when it is running within a {@link android.content.BroadcastReceiver}.
  */
 public interface BroadcastReceiverAware {
   /**
-   * Callback triggered when a {@code BroadcastReceiverAware} {@link FlutterPlugin} is associated
-   * with a {@link BroadcastReceiver}.
+   * Callback triggered when a {@code BroadcastReceiverAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is associated
+   * with a {@link android.content.BroadcastReceiver}.
    */
   void onAttachedToBroadcastReceiver(@NonNull BroadcastReceiverPluginBinding binding);
 
   /**
-   * Callback triggered when a {@code BroadcastReceiverAware} {@link FlutterPlugin} is detached from
-   * a {@link BroadcastReceiver}.
+   * Callback triggered when a {@code BroadcastReceiverAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is detached from
+   * a {@link android.content.BroadcastReceiver}.
    */
   void onDetachedFromBroadcastReceiver();
 }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverControlSurface.java
@@ -9,19 +9,19 @@ import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 
 /**
- * Control surface through which a {@link BroadcastReceiver} attaches to a {@link FlutterEngine}.
+ * Control surface through which a {@link BroadcastReceiver} attaches to a {@link io.flutter.embedding.engine.FlutterEngine}.
  *
- * <p>A {@link BroadcastReceiver} that contains a {@link FlutterEngine} should coordinate itself
- * with the {@link FlutterEngine}'s {@code BroadcastReceiverControlSurface}.
+ * <p>A {@link BroadcastReceiver} that contains a {@link io.flutter.embedding.engine.FlutterEngine} should coordinate itself
+ * with the {@link io.flutter.embedding.engine.FlutterEngine}'s {@code BroadcastReceiverControlSurface}.
  */
 public interface BroadcastReceiverControlSurface {
   /**
-   * Call this method from the {@link BroadcastReceiver} that is running the {@link FlutterEngine}
+   * Call this method from the {@link BroadcastReceiver} that is running the {@link io.flutter.embedding.engine.FlutterEngine}
    * that is associated with this {@code BroadcastReceiverControlSurface}.
    *
-   * <p>Once a {@link BroadcastReceiver} is created, and its associated {@link FlutterEngine} is
+   * <p>Once a {@link BroadcastReceiver} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is
    * executing Dart code, the {@link BroadcastReceiver} should invoke this method. At that point the
-   * {@link FlutterEngine} is considered "attached" to the {@link BroadcastReceiver} and all {@link
+   * {@link io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link BroadcastReceiver} and all {@link
    * BroadcastReceiverAware} plugins are given access to the {@link BroadcastReceiver}.
    */
   void attachToBroadcastReceiver(
@@ -29,7 +29,7 @@ public interface BroadcastReceiverControlSurface {
 
   /**
    * Call this method from the {@link BroadcastReceiver} that is attached to this {@code
-   * BroadcastReceiverControlSurfaces}'s {@link FlutterEngine} when the {@link BroadcastReceiver} is
+   * BroadcastReceiverControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link BroadcastReceiver} is
    * about to be destroyed.
    *
    * <p>This method gives each {@link BroadcastReceiverAware} plugin an opportunity to clean up its

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverControlSurface.java
@@ -9,28 +9,33 @@ import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 
 /**
- * Control surface through which a {@link BroadcastReceiver} attaches to a {@link io.flutter.embedding.engine.FlutterEngine}.
+ * Control surface through which a {@link BroadcastReceiver} attaches to a {@link
+ * io.flutter.embedding.engine.FlutterEngine}.
  *
- * <p>A {@link BroadcastReceiver} that contains a {@link io.flutter.embedding.engine.FlutterEngine} should coordinate itself
- * with the {@link io.flutter.embedding.engine.FlutterEngine}'s {@code BroadcastReceiverControlSurface}.
+ * <p>A {@link BroadcastReceiver} that contains a {@link io.flutter.embedding.engine.FlutterEngine}
+ * should coordinate itself with the {@link io.flutter.embedding.engine.FlutterEngine}'s {@code
+ * BroadcastReceiverControlSurface}.
  */
 public interface BroadcastReceiverControlSurface {
   /**
-   * Call this method from the {@link BroadcastReceiver} that is running the {@link io.flutter.embedding.engine.FlutterEngine}
-   * that is associated with this {@code BroadcastReceiverControlSurface}.
+   * Call this method from the {@link BroadcastReceiver} that is running the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that is associated with this {@code
+   * BroadcastReceiverControlSurface}.
    *
-   * <p>Once a {@link BroadcastReceiver} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is
-   * executing Dart code, the {@link BroadcastReceiver} should invoke this method. At that point the
-   * {@link io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link BroadcastReceiver} and all {@link
-   * BroadcastReceiverAware} plugins are given access to the {@link BroadcastReceiver}.
+   * <p>Once a {@link BroadcastReceiver} is created, and its associated {@link
+   * io.flutter.embedding.engine.FlutterEngine} is executing Dart code, the {@link
+   * BroadcastReceiver} should invoke this method. At that point the {@link
+   * io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link
+   * BroadcastReceiver} and all {@link BroadcastReceiverAware} plugins are given access to the
+   * {@link BroadcastReceiver}.
    */
   void attachToBroadcastReceiver(
       @NonNull BroadcastReceiver broadcastReceiver, @NonNull Lifecycle lifecycle);
 
   /**
    * Call this method from the {@link BroadcastReceiver} that is attached to this {@code
-   * BroadcastReceiverControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link BroadcastReceiver} is
-   * about to be destroyed.
+   * BroadcastReceiverControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the
+   * {@link BroadcastReceiver} is about to be destroyed.
    *
    * <p>This method gives each {@link BroadcastReceiverAware} plugin an opportunity to clean up its
    * references before the {@link BroadcastReceiver is destroyed}.

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverPluginBinding.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverPluginBinding.java
@@ -14,8 +14,9 @@ import androidx.annotation.NonNull;
 public interface BroadcastReceiverPluginBinding {
 
   /**
-   * Returns the {@link BroadcastReceiver} that is currently attached to the {@link io.flutter.embedding.engine.FlutterEngine}
-   * that owns this {@code BroadcastReceiverAwarePluginBinding}.
+   * Returns the {@link BroadcastReceiver} that is currently attached to the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+   * BroadcastReceiverAwarePluginBinding}.
    */
   @NonNull
   BroadcastReceiver getBroadcastReceiver();

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverPluginBinding.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/broadcastreceiver/BroadcastReceiverPluginBinding.java
@@ -14,7 +14,7 @@ import androidx.annotation.NonNull;
 public interface BroadcastReceiverPluginBinding {
 
   /**
-   * Returns the {@link BroadcastReceiver} that is currently attached to the {@link FlutterEngine}
+   * Returns the {@link BroadcastReceiver} that is currently attached to the {@link io.flutter.embedding.engine.FlutterEngine}
    * that owns this {@code BroadcastReceiverAwarePluginBinding}.
    */
   @NonNull

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderAware.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderAware.java
@@ -7,18 +7,21 @@ package io.flutter.embedding.engine.plugins.contentprovider;
 import androidx.annotation.NonNull;
 
 /**
- * A {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that wants to know when it is running within a {@link android.content.ContentProvider}.
+ * A {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that wants to know when it is running
+ * within a {@link android.content.ContentProvider}.
  */
 public interface ContentProviderAware {
   /**
-   * Callback triggered when a {@code ContentProviderAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is associated with
-   * a {@link android.content.ContentProvider}.
+   * Callback triggered when a {@code ContentProviderAware} {@link
+   * io.flutter.embedding.engine.plugins.FlutterPlugin} is associated with a {@link
+   * android.content.ContentProvider}.
    */
   void onAttachedToContentProvider(@NonNull ContentProviderPluginBinding binding);
 
   /**
-   * Callback triggered when a {@code ContentProviderAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is detached from a
-   * {@link android.content.ContentProvider}.
+   * Callback triggered when a {@code ContentProviderAware} {@link
+   * io.flutter.embedding.engine.plugins.FlutterPlugin} is detached from a {@link
+   * android.content.ContentProvider}.
    */
   void onDetachedFromContentProvider();
 }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderAware.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderAware.java
@@ -7,18 +7,18 @@ package io.flutter.embedding.engine.plugins.contentprovider;
 import androidx.annotation.NonNull;
 
 /**
- * A {@link FlutterPlugin} that wants to know when it is running within a {@link ContentProvider}.
+ * A {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that wants to know when it is running within a {@link android.content.ContentProvider}.
  */
 public interface ContentProviderAware {
   /**
-   * Callback triggered when a {@code ContentProviderAware} {@link FlutterPlugin} is associated with
-   * a {@link ContentProvider}.
+   * Callback triggered when a {@code ContentProviderAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is associated with
+   * a {@link android.content.ContentProvider}.
    */
   void onAttachedToContentProvider(@NonNull ContentProviderPluginBinding binding);
 
   /**
-   * Callback triggered when a {@code ContentProviderAware} {@link FlutterPlugin} is detached from a
-   * {@link ContentProvider}.
+   * Callback triggered when a {@code ContentProviderAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is detached from a
+   * {@link android.content.ContentProvider}.
    */
   void onDetachedFromContentProvider();
 }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderControlSurface.java
@@ -9,19 +9,19 @@ import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 
 /**
- * Control surface through which a {@link ContentProvider} attaches to a {@link FlutterEngine}.
+ * Control surface through which a {@link ContentProvider} attaches to a {@link io.flutter.embedding.engine.FlutterEngine}.
  *
- * <p>A {@link ContentProvider} that contains a {@link FlutterEngine} should coordinate itself with
- * the {@link FlutterEngine}'s {@code ContentProviderControlSurface}.
+ * <p>A {@link ContentProvider} that contains a {@link io.flutter.embedding.engine.FlutterEngine} should coordinate itself with
+ * the {@link io.flutter.embedding.engine.FlutterEngine}'s {@code ContentProviderControlSurface}.
  */
 public interface ContentProviderControlSurface {
   /**
-   * Call this method from the {@link ContentProvider} that is running the {@link FlutterEngine}
+   * Call this method from the {@link ContentProvider} that is running the {@link io.flutter.embedding.engine.FlutterEngine}
    * that is associated with this {@code ContentProviderControlSurface}.
    *
-   * <p>Once a {@link ContentProvider} is created, and its associated {@link FlutterEngine} is
+   * <p>Once a {@link ContentProvider} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is
    * executing Dart code, the {@link ContentProvider} should invoke this method. At that point the
-   * {@link FlutterEngine} is considered "attached" to the {@link ContentProvider} and all {@link
+   * {@link io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link ContentProvider} and all {@link
    * ContentProviderAware} plugins are given access to the {@link ContentProvider}.
    */
   void attachToContentProvider(
@@ -29,7 +29,7 @@ public interface ContentProviderControlSurface {
 
   /**
    * Call this method from the {@link ContentProvider} that is attached to this {@code
-   * ContentProviderControlSurfaces}'s {@link FlutterEngine} when the {@link ContentProvider} is
+   * ContentProviderControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link ContentProvider} is
    * about to be destroyed.
    *
    * <p>This method gives each {@link ContentProviderAware} plugin an opportunity to clean up its

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderControlSurface.java
@@ -9,28 +9,32 @@ import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
 
 /**
- * Control surface through which a {@link ContentProvider} attaches to a {@link io.flutter.embedding.engine.FlutterEngine}.
+ * Control surface through which a {@link ContentProvider} attaches to a {@link
+ * io.flutter.embedding.engine.FlutterEngine}.
  *
- * <p>A {@link ContentProvider} that contains a {@link io.flutter.embedding.engine.FlutterEngine} should coordinate itself with
- * the {@link io.flutter.embedding.engine.FlutterEngine}'s {@code ContentProviderControlSurface}.
+ * <p>A {@link ContentProvider} that contains a {@link io.flutter.embedding.engine.FlutterEngine}
+ * should coordinate itself with the {@link io.flutter.embedding.engine.FlutterEngine}'s {@code
+ * ContentProviderControlSurface}.
  */
 public interface ContentProviderControlSurface {
   /**
-   * Call this method from the {@link ContentProvider} that is running the {@link io.flutter.embedding.engine.FlutterEngine}
-   * that is associated with this {@code ContentProviderControlSurface}.
+   * Call this method from the {@link ContentProvider} that is running the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that is associated with this {@code
+   * ContentProviderControlSurface}.
    *
-   * <p>Once a {@link ContentProvider} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is
-   * executing Dart code, the {@link ContentProvider} should invoke this method. At that point the
-   * {@link io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link ContentProvider} and all {@link
-   * ContentProviderAware} plugins are given access to the {@link ContentProvider}.
+   * <p>Once a {@link ContentProvider} is created, and its associated {@link
+   * io.flutter.embedding.engine.FlutterEngine} is executing Dart code, the {@link ContentProvider}
+   * should invoke this method. At that point the {@link io.flutter.embedding.engine.FlutterEngine}
+   * is considered "attached" to the {@link ContentProvider} and all {@link ContentProviderAware}
+   * plugins are given access to the {@link ContentProvider}.
    */
   void attachToContentProvider(
       @NonNull ContentProvider contentProvider, @NonNull Lifecycle lifecycle);
 
   /**
    * Call this method from the {@link ContentProvider} that is attached to this {@code
-   * ContentProviderControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link ContentProvider} is
-   * about to be destroyed.
+   * ContentProviderControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the
+   * {@link ContentProvider} is about to be destroyed.
    *
    * <p>This method gives each {@link ContentProviderAware} plugin an opportunity to clean up its
    * references before the {@link ContentProvider is destroyed}.

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderPluginBinding.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderPluginBinding.java
@@ -14,8 +14,9 @@ import androidx.annotation.NonNull;
 public interface ContentProviderPluginBinding {
 
   /**
-   * Returns the {@link ContentProvider} that is currently attached to the {@link io.flutter.embedding.engine.FlutterEngine}
-   * that owns this {@code ContentProviderAwarePluginBinding}.
+   * Returns the {@link ContentProvider} that is currently attached to the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+   * ContentProviderAwarePluginBinding}.
    */
   @NonNull
   ContentProvider getContentProvider();

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderPluginBinding.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/contentprovider/ContentProviderPluginBinding.java
@@ -14,7 +14,7 @@ import androidx.annotation.NonNull;
 public interface ContentProviderPluginBinding {
 
   /**
-   * Returns the {@link ContentProvider} that is currently attached to the {@link FlutterEngine}
+   * Returns the {@link ContentProvider} that is currently attached to the {@link io.flutter.embedding.engine.FlutterEngine}
    * that owns this {@code ContentProviderAwarePluginBinding}.
    */
   @NonNull

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServiceAware.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServiceAware.java
@@ -6,17 +6,17 @@ package io.flutter.embedding.engine.plugins.service;
 
 import androidx.annotation.NonNull;
 
-/** A {@link FlutterPlugin} that wants to know when it is running within a {@link Service}. */
+/** A {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that wants to know when it is running within a {@link android.app.Service}. */
 public interface ServiceAware {
   /**
-   * Callback triggered when a {@code ServiceAware} {@link FlutterPlugin} is associated with a
-   * {@link Service}.
+   * Callback triggered when a {@code ServiceAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is associated with a
+   * {@link android.app.Service}.
    */
   void onAttachedToService(@NonNull ServicePluginBinding binding);
 
   /**
-   * Callback triggered when a {@code ServiceAware} {@link FlutterPlugin} is detached from a {@link
-   * Service}.
+   * Callback triggered when a {@code ServiceAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is detached from a {@link
+   * android.app.Service}.
    *
    * <p>Any {@code Lifecycle} listeners that were registered in {@link
    * #onAttachedToService(ServicePluginBinding)} should be deregistered here to avoid a possible
@@ -26,13 +26,13 @@ public interface ServiceAware {
 
   interface OnModeChangeListener {
     /**
-     * Callback triggered when the associated {@link Service} goes from background execution to
+     * Callback triggered when the associated {@link android.app.Service} goes from background execution to
      * foreground execution.
      */
     void onMoveToForeground();
 
     /**
-     * Callback triggered when the associated {@link Service} goes from foreground execution to
+     * Callback triggered when the associated {@link android.app.Service} goes from foreground execution to
      * background execution.
      */
     void onMoveToBackground();

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServiceAware.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServiceAware.java
@@ -6,16 +6,21 @@ package io.flutter.embedding.engine.plugins.service;
 
 import androidx.annotation.NonNull;
 
-/** A {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that wants to know when it is running within a {@link android.app.Service}. */
+/**
+ * A {@link io.flutter.embedding.engine.plugins.FlutterPlugin} that wants to know when it is running
+ * within a {@link android.app.Service}.
+ */
 public interface ServiceAware {
   /**
-   * Callback triggered when a {@code ServiceAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is associated with a
-   * {@link android.app.Service}.
+   * Callback triggered when a {@code ServiceAware} {@link
+   * io.flutter.embedding.engine.plugins.FlutterPlugin} is associated with a {@link
+   * android.app.Service}.
    */
   void onAttachedToService(@NonNull ServicePluginBinding binding);
 
   /**
-   * Callback triggered when a {@code ServiceAware} {@link io.flutter.embedding.engine.plugins.FlutterPlugin} is detached from a {@link
+   * Callback triggered when a {@code ServiceAware} {@link
+   * io.flutter.embedding.engine.plugins.FlutterPlugin} is detached from a {@link
    * android.app.Service}.
    *
    * <p>Any {@code Lifecycle} listeners that were registered in {@link
@@ -26,14 +31,14 @@ public interface ServiceAware {
 
   interface OnModeChangeListener {
     /**
-     * Callback triggered when the associated {@link android.app.Service} goes from background execution to
-     * foreground execution.
+     * Callback triggered when the associated {@link android.app.Service} goes from background
+     * execution to foreground execution.
      */
     void onMoveToForeground();
 
     /**
-     * Callback triggered when the associated {@link android.app.Service} goes from foreground execution to
-     * background execution.
+     * Callback triggered when the associated {@link android.app.Service} goes from foreground
+     * execution to background execution.
      */
     void onMoveToBackground();
   }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServiceControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServiceControlSurface.java
@@ -10,19 +10,19 @@ import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 
 /**
- * Control surface through which a {@link Service} attaches to a {@link FlutterEngine}.
+ * Control surface through which a {@link Service} attaches to a {@link io.flutter.embedding.engine.FlutterEngine}.
  *
- * <p>A {@link Service} that contains a {@link FlutterEngine} should coordinate itself with the
- * {@link FlutterEngine}'s {@code ServiceControlSurface}.
+ * <p>A {@link Service} that contains a {@link io.flutter.embedding.engine.FlutterEngine} should coordinate itself with the
+ * {@link io.flutter.embedding.engine.FlutterEngine}'s {@code ServiceControlSurface}.
  */
 public interface ServiceControlSurface {
   /**
-   * Call this method from the {@link Service} that is running the {@link FlutterEngine} that is
+   * Call this method from the {@link Service} that is running the {@link io.flutter.embedding.engine.FlutterEngine} that is
    * associated with this {@code ServiceControlSurface}.
    *
-   * <p>Once a {@link Service} is created, and its associated {@link FlutterEngine} is executing
+   * <p>Once a {@link Service} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is executing
    * Dart code, the {@link Service} should invoke this method. At that point the {@link
-   * FlutterEngine} is considered "attached" to the {@link Service} and all {@link ServiceAware}
+   * io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link Service} and all {@link ServiceAware}
    * plugins are given access to the {@link Service}.
    *
    * <p>{@code isForeground} should be true if the given {@link Service} is running in the
@@ -33,7 +33,7 @@ public interface ServiceControlSurface {
 
   /**
    * Call this method from the {@link Service} that is attached to this {@code
-   * ServiceControlSurfaces}'s {@link FlutterEngine} when the {@link Service} is about to be
+   * ServiceControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link Service} is about to be
    * destroyed.
    *
    * <p>This method gives each {@link ServiceAware} plugin an opportunity to clean up its references
@@ -43,14 +43,14 @@ public interface ServiceControlSurface {
 
   /**
    * Call this method from the {@link Service} that is attached to this {@code
-   * ServiceControlSurface}'s {@link FlutterEngine} when the {@link Service} goes from background to
+   * ServiceControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link Service} goes from background to
    * foreground.
    */
   void onMoveToForeground();
 
   /**
    * Call this method from the {@link Service} that is attached to this {@code
-   * ServiceControlSurface}'s {@link FlutterEngine} when the {@link Service} goes from foreground to
+   * ServiceControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link Service} goes from foreground to
    * background.
    */
   void onMoveToBackground();

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServiceControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServiceControlSurface.java
@@ -10,20 +10,24 @@ import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 
 /**
- * Control surface through which a {@link Service} attaches to a {@link io.flutter.embedding.engine.FlutterEngine}.
+ * Control surface through which a {@link Service} attaches to a {@link
+ * io.flutter.embedding.engine.FlutterEngine}.
  *
- * <p>A {@link Service} that contains a {@link io.flutter.embedding.engine.FlutterEngine} should coordinate itself with the
- * {@link io.flutter.embedding.engine.FlutterEngine}'s {@code ServiceControlSurface}.
+ * <p>A {@link Service} that contains a {@link io.flutter.embedding.engine.FlutterEngine} should
+ * coordinate itself with the {@link io.flutter.embedding.engine.FlutterEngine}'s {@code
+ * ServiceControlSurface}.
  */
 public interface ServiceControlSurface {
   /**
-   * Call this method from the {@link Service} that is running the {@link io.flutter.embedding.engine.FlutterEngine} that is
-   * associated with this {@code ServiceControlSurface}.
+   * Call this method from the {@link Service} that is running the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that is associated with this {@code
+   * ServiceControlSurface}.
    *
-   * <p>Once a {@link Service} is created, and its associated {@link io.flutter.embedding.engine.FlutterEngine} is executing
-   * Dart code, the {@link Service} should invoke this method. At that point the {@link
-   * io.flutter.embedding.engine.FlutterEngine} is considered "attached" to the {@link Service} and all {@link ServiceAware}
-   * plugins are given access to the {@link Service}.
+   * <p>Once a {@link Service} is created, and its associated {@link
+   * io.flutter.embedding.engine.FlutterEngine} is executing Dart code, the {@link Service} should
+   * invoke this method. At that point the {@link io.flutter.embedding.engine.FlutterEngine} is
+   * considered "attached" to the {@link Service} and all {@link ServiceAware} plugins are given
+   * access to the {@link Service}.
    *
    * <p>{@code isForeground} should be true if the given {@link Service} is running in the
    * foreground, false otherwise.
@@ -33,8 +37,8 @@ public interface ServiceControlSurface {
 
   /**
    * Call this method from the {@link Service} that is attached to this {@code
-   * ServiceControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link Service} is about to be
-   * destroyed.
+   * ServiceControlSurfaces}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link
+   * Service} is about to be destroyed.
    *
    * <p>This method gives each {@link ServiceAware} plugin an opportunity to clean up its references
    * before the {@link Service is destroyed}.
@@ -43,15 +47,15 @@ public interface ServiceControlSurface {
 
   /**
    * Call this method from the {@link Service} that is attached to this {@code
-   * ServiceControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link Service} goes from background to
-   * foreground.
+   * ServiceControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link
+   * Service} goes from background to foreground.
    */
   void onMoveToForeground();
 
   /**
    * Call this method from the {@link Service} that is attached to this {@code
-   * ServiceControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link Service} goes from foreground to
-   * background.
+   * ServiceControlSurface}'s {@link io.flutter.embedding.engine.FlutterEngine} when the {@link
+   * Service} goes from foreground to background.
    */
   void onMoveToBackground();
 }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServicePluginBinding.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServicePluginBinding.java
@@ -12,7 +12,7 @@ import androidx.annotation.Nullable;
 public interface ServicePluginBinding {
 
   /**
-   * Returns the {@link Service} that is currently attached to the {@link FlutterEngine} that owns
+   * Returns the {@link Service} that is currently attached to the {@link io.flutter.embedding.engine.FlutterEngine} that owns
    * this {@code ServicePluginBinding}.
    */
   @NonNull
@@ -39,7 +39,7 @@ public interface ServicePluginBinding {
 
   /**
    * Removes the given {@code listener}, which was previously added with {@link
-   * #addOnModeChangeListener(OnModeChangeListener)}.
+   * #addOnModeChangeListener(ServiceAware.OnModeChangeListener)}.
    */
   void removeOnModeChangeListener(@NonNull ServiceAware.OnModeChangeListener listener);
 }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServicePluginBinding.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/service/ServicePluginBinding.java
@@ -12,8 +12,8 @@ import androidx.annotation.Nullable;
 public interface ServicePluginBinding {
 
   /**
-   * Returns the {@link Service} that is currently attached to the {@link io.flutter.embedding.engine.FlutterEngine} that owns
-   * this {@code ServicePluginBinding}.
+   * Returns the {@link Service} that is currently attached to the {@link
+   * io.flutter.embedding.engine.FlutterEngine} that owns this {@code ServicePluginBinding}.
    */
   @NonNull
   Service getService();

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/util/GeneratedPluginRegister.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/util/GeneratedPluginRegister.java
@@ -29,14 +29,16 @@ public class GeneratedPluginRegister {
    * <p>In a normal full-Flutter application, the {@link
    * io.flutter.embedding.android.FlutterActivity} will automatically call the {@code
    * GeneratedPluginRegistrant} to register all plugins. In a typical full-Flutter application, the
-   * {@link io.flutter.embedding.android.FlutterActivity} creates a {@link io.flutter.embedding.engine.FlutterEngine}. When a
-   * {@link io.flutter.embedding.engine.FlutterEngine} is explicitly created, it automatically registers plugins during its
-   * construction.
+   * {@link io.flutter.embedding.android.FlutterActivity} creates a {@link
+   * io.flutter.embedding.engine.FlutterEngine}. When a {@link
+   * io.flutter.embedding.engine.FlutterEngine} is explicitly created, it automatically registers
+   * plugins during its construction.
    *
-   * <p>Since the {@link io.flutter.embedding.engine.FlutterEngine} belongs to the Flutter engine and the
-   * GeneratedPluginRegistrant class belongs to the app project, the {@link io.flutter.embedding.engine.FlutterEngine} cannot
-   * place a compile-time dependency on GeneratedPluginRegistrant to invoke it. Instead, this class
-   * uses reflection to attempt to locate the generated file and then uses it at runtime.
+   * <p>Since the {@link io.flutter.embedding.engine.FlutterEngine} belongs to the Flutter engine
+   * and the GeneratedPluginRegistrant class belongs to the app project, the {@link
+   * io.flutter.embedding.engine.FlutterEngine} cannot place a compile-time dependency on
+   * GeneratedPluginRegistrant to invoke it. Instead, this class uses reflection to attempt to
+   * locate the generated file and then uses it at runtime.
    *
    * <p>This method fizzles if the GeneratedPluginRegistrant cannot be found or invoked. This
    * situation should never occur, but if any eventuality comes up that prevents an app from using
@@ -45,12 +47,14 @@ public class GeneratedPluginRegister {
    * <p>To disable this automatic plugin registration behavior:
    *
    * <ul>
-   *   <li>If you manually construct {@link io.flutter.embedding.engine.FlutterEngine}s, construct the {@link io.flutter.embedding.engine.FlutterEngine}
-   *       with the {@code automaticallyRegisterPlugins} construction parameter set to false.
+   *   <li>If you manually construct {@link io.flutter.embedding.engine.FlutterEngine}s, construct
+   *       the {@link io.flutter.embedding.engine.FlutterEngine} with the {@code
+   *       automaticallyRegisterPlugins} construction parameter set to false.
    *   <li>If you let the {@link io.flutter.embedding.android.FlutterActivity} or {@link
-   *       io.flutter.embedding.android.FlutterFragmentActivity} construct a {@link io.flutter.embedding.engine.FlutterEngine}
-   *       implicitly, override the {@code configureFlutterEngine} implementation and don't call
-   *       through to the superclass implementation.
+   *       io.flutter.embedding.android.FlutterFragmentActivity} construct a {@link
+   *       io.flutter.embedding.engine.FlutterEngine} implicitly, override the {@code
+   *       configureFlutterEngine} implementation and don't call through to the superclass
+   *       implementation.
    * </ul>
    *
    * <p>Disabling the automatic plugin registration or deferring it by calling this method

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/util/GeneratedPluginRegister.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/util/GeneratedPluginRegister.java
@@ -29,12 +29,12 @@ public class GeneratedPluginRegister {
    * <p>In a normal full-Flutter application, the {@link
    * io.flutter.embedding.android.FlutterActivity} will automatically call the {@code
    * GeneratedPluginRegistrant} to register all plugins. In a typical full-Flutter application, the
-   * {@link io.flutter.embedding.android.FlutterActivity} creates a {@link FlutterEngine}. When a
-   * {@link FlutterEngine} is explicitly created, it automatically registers plugins during its
+   * {@link io.flutter.embedding.android.FlutterActivity} creates a {@link io.flutter.embedding.engine.FlutterEngine}. When a
+   * {@link io.flutter.embedding.engine.FlutterEngine} is explicitly created, it automatically registers plugins during its
    * construction.
    *
-   * <p>Since the {@link FlutterEngine} belongs to the Flutter engine and the
-   * GeneratedPluginRegistrant class belongs to the app project, the {@link FlutterEngine} cannot
+   * <p>Since the {@link io.flutter.embedding.engine.FlutterEngine} belongs to the Flutter engine and the
+   * GeneratedPluginRegistrant class belongs to the app project, the {@link io.flutter.embedding.engine.FlutterEngine} cannot
    * place a compile-time dependency on GeneratedPluginRegistrant to invoke it. Instead, this class
    * uses reflection to attempt to locate the generated file and then uses it at runtime.
    *
@@ -45,10 +45,10 @@ public class GeneratedPluginRegister {
    * <p>To disable this automatic plugin registration behavior:
    *
    * <ul>
-   *   <li>If you manually construct {@link FlutterEngine}s, construct the {@link FlutterEngine}
+   *   <li>If you manually construct {@link io.flutter.embedding.engine.FlutterEngine}s, construct the {@link io.flutter.embedding.engine.FlutterEngine}
    *       with the {@code automaticallyRegisterPlugins} construction parameter set to false.
    *   <li>If you let the {@link io.flutter.embedding.android.FlutterActivity} or {@link
-   *       io.flutter.embedding.android.FlutterFragmentActivity} construct a {@link FlutterEngine}
+   *       io.flutter.embedding.android.FlutterFragmentActivity} construct a {@link io.flutter.embedding.engine.FlutterEngine}
    *       implicitly, override the {@code configureFlutterEngine} implementation and don't call
    *       through to the superclass implementation.
    * </ul>

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -301,8 +301,8 @@ public class PlatformViewsChannel {
     /**
      * The layout direction of the new platform view.
      *
-     * <p>See {@link android.view.View.LAYOUT_DIRECTION_LTR} and {@link
-     * android.view.View.LAYOUT_DIRECTION_RTL}
+     * <p>See {@link android.view.View#LAYOUT_DIRECTION_LTR} and {@link
+     * android.view.View#LAYOUT_DIRECTION_RTL}
      */
     public final int direction;
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -166,7 +166,8 @@ public class TextInputChannel {
    * Instructs Flutter to reattach the last active text input client, if any.
    *
    * <p>This is necessary when the view hierarchy has been detached and reattached to a {@link
-   * io.flutter.embedding.engine.FlutterEngine}, as the engine may have kept alive a text editing client on the Dart side.
+   * io.flutter.embedding.engine.FlutterEngine}, as the engine may have kept alive a text editing
+   * client on the Dart side.
    */
   public void requestExistingInputState() {
     channel.invokeMethod("TextInputClient.requestExistingInputState", null);
@@ -347,7 +348,8 @@ public class TextInputChannel {
     void requestAutofill();
 
     /**
-     * Requests that the {@link android.view.autofill.AutofillManager} cancel or commit the current autofill context.
+     * Requests that the {@link android.view.autofill.AutofillManager} cancel or commit the current
+     * autofill context.
      *
      * <p>The method calls {@link android.view.autofill.AutofillManager#commit()} when {@code
      * shouldSave} is true, and calls {@link android.view.autofill.AutofillManager#cancel()}

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -166,7 +166,7 @@ public class TextInputChannel {
    * Instructs Flutter to reattach the last active text input client, if any.
    *
    * <p>This is necessary when the view hierarchy has been detached and reattached to a {@link
-   * FlutterEngine}, as the engine may have kept alive a text editing client on the Dart side.
+   * io.flutter.embedding.engine.FlutterEngine}, as the engine may have kept alive a text editing client on the Dart side.
    */
   public void requestExistingInputState() {
     channel.invokeMethod("TextInputClient.requestExistingInputState", null);
@@ -347,7 +347,7 @@ public class TextInputChannel {
     void requestAutofill();
 
     /**
-     * Requests that the {@link AutofillManager} cancel or commit the current autofill context.
+     * Requests that the {@link android.view.autofill.AutofillManager} cancel or commit the current autofill context.
      *
      * <p>The method calls {@link android.view.autofill.AutofillManager#commit()} when {@code
      * shouldSave} is true, and calls {@link android.view.autofill.AutofillManager#cancel()}

--- a/shell/platform/android/io/flutter/plugin/common/BinaryCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/BinaryCodec.java
@@ -22,7 +22,7 @@ public final class BinaryCodec implements MessageCodec<ByteBuffer> {
   /**
    * A BinaryCodec that returns direct ByteBuffers from `decodeMessage` for better performance.
    *
-   * @see BinaryCodec.BinaryCodec(boolean)
+   * @see BinaryCodec#BinaryCodec(boolean)
    */
   public static final BinaryCodec INSTANCE_DIRECT = new BinaryCodec(true);
 

--- a/shell/platform/android/io/flutter/plugin/common/EventChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/EventChannel.java
@@ -91,10 +91,10 @@ public final class EventChannel {
    * Handler of stream setup and teardown requests.
    *
    * <p>Implementations must be prepared to accept sequences of alternating calls to {@link
-   * #onListen(Object, EventChannel.EventSink)} and {@link #onCancel(Object)}. Implementations should ideally
-   * consume no resources when the last such call is not {@code onListen}. In typical situations,
-   * this means that the implementation should register itself with platform-specific event sources
-   * {@code onListen} and deregister again {@code onCancel}.
+   * #onListen(Object, EventChannel.EventSink)} and {@link #onCancel(Object)}. Implementations
+   * should ideally consume no resources when the last such call is not {@code onListen}. In typical
+   * situations, this means that the implementation should register itself with platform-specific
+   * event sources {@code onListen} and deregister again {@code onCancel}.
    */
   public interface StreamHandler {
     /**

--- a/shell/platform/android/io/flutter/plugin/common/EventChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/EventChannel.java
@@ -91,7 +91,7 @@ public final class EventChannel {
    * Handler of stream setup and teardown requests.
    *
    * <p>Implementations must be prepared to accept sequences of alternating calls to {@link
-   * #onListen(Object, EventSink)} and {@link #onCancel(Object)}. Implementations should ideally
+   * #onListen(Object, EventChannel.EventSink)} and {@link #onCancel(Object)}. Implementations should ideally
    * consume no resources when the last such call is not {@code onListen}. In typical situations,
    * this means that the implementation should register itself with platform-specific event sources
    * {@code onListen} and deregister again {@code onCancel}.

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -23,8 +23,8 @@ import io.flutter.view.TextureRegistry;
  * <p>In v1 Android applications, an auto-generated and auto-updated plugin registrant class
  * (GeneratedPluginRegistrant) makes use of a {@link PluginRegistry} to register contributions from
  * each plugin mentioned in the application's pubspec file. The generated registrant class is, again
- * by default, called from the application's main {@link android.app.Activity}, which defaults to an instance of
- * {@link io.flutter.app.FlutterActivity}, itself a {@link PluginRegistry}.
+ * by default, called from the application's main {@link android.app.Activity}, which defaults to an
+ * instance of {@link io.flutter.app.FlutterActivity}, itself a {@link PluginRegistry}.
  */
 public interface PluginRegistry {
   /**
@@ -263,7 +263,8 @@ public interface PluginRegistry {
      * Activity#onNewIntent(Intent)}.
      *
      * <p>This registrar is for Flutter's v1 embedding. To listen for new {@code Intent}s in the v2
-     * embedding, use {@link ActivityPluginBinding#addOnNewIntentListener(PluginRegistry.NewIntentListener)}.
+     * embedding, use {@link
+     * ActivityPluginBinding#addOnNewIntentListener(PluginRegistry.NewIntentListener)}.
      *
      * <p>For instructions on migrating a plugin from Flutter's v1 Android embedding to v2, visit
      * http://flutter.dev/go/android-plugin-migration
@@ -323,27 +324,35 @@ public interface PluginRegistry {
     boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults);
   }
 
-  /** Delegate interface for handling activity results on behalf of the main {@link android.app.Activity}. */
+  /**
+   * Delegate interface for handling activity results on behalf of the main {@link
+   * android.app.Activity}.
+   */
   interface ActivityResultListener {
     /** @return true if the result has been handled. */
     boolean onActivityResult(int requestCode, int resultCode, Intent data);
   }
 
-  /** Delegate interface for handling new intents on behalf of the main {@link android.app.Activity}. */
+  /**
+   * Delegate interface for handling new intents on behalf of the main {@link android.app.Activity}.
+   */
   interface NewIntentListener {
     /** @return true if the new intent has been handled. */
     boolean onNewIntent(Intent intent);
   }
 
-  /** Delegate interface for handling user leave hints on behalf of the main {@link android.app.Activity}. */
+  /**
+   * Delegate interface for handling user leave hints on behalf of the main {@link
+   * android.app.Activity}.
+   */
   interface UserLeaveHintListener {
     void onUserLeaveHint();
   }
 
   /**
-   * Delegate interface for handling an {@link android.app.Activity}'s onDestroy method being called. A plugin
-   * that implements this interface can adopt the FlutterNativeView by retaining a reference and
-   * returning true.
+   * Delegate interface for handling an {@link android.app.Activity}'s onDestroy method being
+   * called. A plugin that implements this interface can adopt the FlutterNativeView by retaining a
+   * reference and returning true.
    *
    * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
    */

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -351,8 +351,8 @@ public interface PluginRegistry {
 
   /**
    * Delegate interface for handling an {@link android.app.Activity}'s onDestroy method being
-   * called. A plugin that implements this interface can adopt the {@link FlutterNativeView} by retaining a
-   * reference and returning true.
+   * called. A plugin that implements this interface can adopt the {@link FlutterNativeView} by
+   * retaining a reference and returning true.
    *
    * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
    */

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -351,7 +351,7 @@ public interface PluginRegistry {
 
   /**
    * Delegate interface for handling an {@link android.app.Activity}'s onDestroy method being
-   * called. A plugin that implements this interface can adopt the FlutterNativeView by retaining a
+   * called. A plugin that implements this interface can adopt the {@link FlutterNativeView} by retaining a
    * reference and returning true.
    *
    * @deprecated See https://flutter.dev/go/android-project-migration for migration details.

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -23,7 +23,7 @@ import io.flutter.view.TextureRegistry;
  * <p>In v1 Android applications, an auto-generated and auto-updated plugin registrant class
  * (GeneratedPluginRegistrant) makes use of a {@link PluginRegistry} to register contributions from
  * each plugin mentioned in the application's pubspec file. The generated registrant class is, again
- * by default, called from the application's main {@link Activity}, which defaults to an instance of
+ * by default, called from the application's main {@link android.app.Activity}, which defaults to an instance of
  * {@link io.flutter.app.FlutterActivity}, itself a {@link PluginRegistry}.
  */
 public interface PluginRegistry {
@@ -32,6 +32,7 @@ public interface PluginRegistry {
    *
    * @param pluginKey a unique String identifying the plugin; typically the fully qualified name of
    *     the plugin's main class.
+   * @return A {@link Registrar} for receiving the registrations pertianing to the specified plugin.
    * @deprecated See https://flutter.dev/go/android-project-migration for migration details.
    */
   @Deprecated
@@ -55,6 +56,7 @@ public interface PluginRegistry {
    * situations where external control or interaction is needed. Clients are expected to know the
    * value's type.
    *
+   * @param <T> The type of the value.
    * @param pluginKey a unique String identifying the plugin; typically the fully qualified name of
    *     the plugin's main class.
    * @return the published value, possibly null.
@@ -73,7 +75,7 @@ public interface PluginRegistry {
   @Deprecated
   interface Registrar {
     /**
-     * Returns the {@link Activity} that forms the plugin's operating context.
+     * Returns the {@link android.app.Activity} that forms the plugin's operating context.
      *
      * <p>Plugin authors should not assume the type returned by this method is any specific subclass
      * of {@code Activity} (such as {@link io.flutter.app.FlutterActivity} or {@link
@@ -230,7 +232,7 @@ public interface PluginRegistry {
      *
      * <p>This registrar is for Flutter's v1 embedding. To listen for permission results in the v2
      * embedding, use {@link
-     * ActivityPluginBinding#addRequestPermissionsResultListener(RequestPermissionsResultListener)}.
+     * ActivityPluginBinding#addRequestPermissionsResultListener(PluginRegistry.RequestPermissionsResultListener)}.
      *
      * <p>For instructions on migrating a plugin from Flutter's v1 Android embedding to v2, visit
      * http://flutter.dev/go/android-plugin-migration
@@ -246,7 +248,7 @@ public interface PluginRegistry {
      *
      * <p>This registrar is for Flutter's v1 embedding. To listen for {@code Activity} results in
      * the v2 embedding, use {@link
-     * ActivityPluginBinding#addActivityResultListener(ActivityResultListener)}.
+     * ActivityPluginBinding#addActivityResultListener(PluginRegistry.ActivityResultListener)}.
      *
      * <p>For instructions on migrating a plugin from Flutter's v1 Android embedding to v2, visit
      * http://flutter.dev/go/android-plugin-migration
@@ -261,7 +263,7 @@ public interface PluginRegistry {
      * Activity#onNewIntent(Intent)}.
      *
      * <p>This registrar is for Flutter's v1 embedding. To listen for new {@code Intent}s in the v2
-     * embedding, use {@link ActivityPluginBinding#addOnNewIntentListener(NewIntentListener)}.
+     * embedding, use {@link ActivityPluginBinding#addOnNewIntentListener(PluginRegistry.NewIntentListener)}.
      *
      * <p>For instructions on migrating a plugin from Flutter's v1 Android embedding to v2, visit
      * http://flutter.dev/go/android-plugin-migration
@@ -277,7 +279,7 @@ public interface PluginRegistry {
      *
      * <p>This registrar is for Flutter's v1 embedding. To listen for leave hints in the v2
      * embedding, use {@link
-     * ActivityPluginBinding#addOnUserLeaveHintListener(UserLeaveHintListener)}.
+     * ActivityPluginBinding#addOnUserLeaveHintListener(PluginRegistry.UserLeaveHintListener)}.
      *
      * <p>For instructions on migrating a plugin from Flutter's v1 Android embedding to v2, visit
      * http://flutter.dev/go/android-plugin-migration
@@ -321,25 +323,25 @@ public interface PluginRegistry {
     boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults);
   }
 
-  /** Delegate interface for handling activity results on behalf of the main {@link Activity}. */
+  /** Delegate interface for handling activity results on behalf of the main {@link android.app.Activity}. */
   interface ActivityResultListener {
     /** @return true if the result has been handled. */
     boolean onActivityResult(int requestCode, int resultCode, Intent data);
   }
 
-  /** Delegate interface for handling new intents on behalf of the main {@link Activity}. */
+  /** Delegate interface for handling new intents on behalf of the main {@link android.app.Activity}. */
   interface NewIntentListener {
     /** @return true if the new intent has been handled. */
     boolean onNewIntent(Intent intent);
   }
 
-  /** Delegate interface for handling user leave hints on behalf of the main {@link Activity}. */
+  /** Delegate interface for handling user leave hints on behalf of the main {@link android.app.Activity}. */
   interface UserLeaveHintListener {
     void onUserLeaveHint();
   }
 
   /**
-   * Delegate interface for handling an {@link Activity}'s onDestroy method being called. A plugin
+   * Delegate interface for handling an {@link android.app.Activity}'s onDestroy method being called. A plugin
    * that implements this interface can adopt the FlutterNativeView by retaining a reference and
    * returning true.
    *

--- a/shell/platform/android/io/flutter/plugin/mouse/MouseCursorPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/mouse/MouseCursorPlugin.java
@@ -118,7 +118,7 @@ public class MouseCursorPlugin {
      *
      * <p>If typeis not recognized, returns the default pointer icon.
      *
-     * <p>This is typically implemented by calling {@link android.view.PointerIcon.getSystemIcon}
+     * <p>This is typically implemented by calling {@link android.view.PointerIcon#getSystemIcon}
      * with the context associated with this view.
      */
     public PointerIcon getSystemPointerIcon(int type);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -244,7 +244,8 @@ public class PlatformPlugin {
    * PlatformChannel.SystemChromeStyle}.
    *
    * <p>Updating the system UI Overlays is accomplished by altering the decor view of the {@link
-   * Window} associated with the {@link android.app.Activity} that was provided to this {@code PlatformPlugin}.
+   * Window} associated with the {@link android.app.Activity} that was provided to this {@code
+   * PlatformPlugin}.
    */
   public void updateSystemUiOverlays() {
     activity.getWindow().getDecorView().setSystemUiVisibility(mEnabledOverlays);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -244,7 +244,7 @@ public class PlatformPlugin {
    * PlatformChannel.SystemChromeStyle}.
    *
    * <p>Updating the system UI Overlays is accomplished by altering the decor view of the {@link
-   * Window} associated with the {@link Activity} that was provided to this {@code PlatformPlugin}.
+   * Window} associated with the {@link android.app.Activity} that was provided to this {@code PlatformPlugin}.
    */
   public void updateSystemUiOverlays() {
     activity.getWindow().getDecorView().setSystemUiVisibility(mEnabledOverlays);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformView.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformView.java
@@ -14,10 +14,10 @@ public interface PlatformView {
   View getView();
 
   /**
-   * Called by the {@link FlutterEngine} that owns this {@code PlatformView} when the Android {@link
-   * View} responsible for rendering a Flutter UI is associated with the {@link FlutterEngine}.
+   * Called by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code PlatformView} when the Android {@link
+   * View} responsible for rendering a Flutter UI is associated with the {@link io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>This means that our associated {@link FlutterEngine} can now render a UI and interact with
+   * <p>This means that our associated {@link io.flutter.embedding.engine.FlutterEngine} can now render a UI and interact with
    * the user.
    *
    * <p>Some platform views may have unusual dependencies on the {@link View} that renders Flutter
@@ -31,11 +31,11 @@ public interface PlatformView {
   default void onFlutterViewAttached(@NonNull View flutterView) {}
 
   /**
-   * Called by the {@link FlutterEngine} that owns this {@code PlatformView} when the Android {@link
+   * Called by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code PlatformView} when the Android {@link
    * View} responsible for rendering a Flutter UI is detached and disassociated from the {@link
-   * FlutterEngine}.
+   * io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>This means that our associated {@link FlutterEngine} no longer has a rendering surface, or a
+   * <p>This means that our associated {@link io.flutter.embedding.engine.FlutterEngine} no longer has a rendering surface, or a
    * user interaction surface of any kind.
    *
    * <p>This platform view must release any references related to the Android {@link View} that was
@@ -60,7 +60,7 @@ public interface PlatformView {
 
   /**
    * Callback fired when the platform's input connection is locked, or should be used. See also
-   * {@link TextInputPlugin#lockPlatformViewInputConnection}.
+   * {@link io.flutter.plugin.editing.TextInputPlugin#lockPlatformViewInputConnection}.
    *
    * <p>This hook only exists for rare cases where the plugin relies on the state of the input
    * connection. This probably doesn't need to be implemented.
@@ -71,7 +71,7 @@ public interface PlatformView {
 
   /**
    * Callback fired when the platform input connection has been unlocked. See also {@link
-   * TextInputPlugin#lockPlatformViewInputConnection}.
+   * io.flutter.plugin.editing.TextInputPlugin#lockPlatformViewInputConnection}.
    *
    * <p>This hook only exists for rare cases where the plugin relies on the state of the input
    * connection. This probably doesn't need to be implemented.

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformView.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformView.java
@@ -14,11 +14,12 @@ public interface PlatformView {
   View getView();
 
   /**
-   * Called by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code PlatformView} when the Android {@link
-   * View} responsible for rendering a Flutter UI is associated with the {@link io.flutter.embedding.engine.FlutterEngine}.
+   * Called by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+   * PlatformView} when the Android {@link View} responsible for rendering a Flutter UI is
+   * associated with the {@link io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>This means that our associated {@link io.flutter.embedding.engine.FlutterEngine} can now render a UI and interact with
-   * the user.
+   * <p>This means that our associated {@link io.flutter.embedding.engine.FlutterEngine} can now
+   * render a UI and interact with the user.
    *
    * <p>Some platform views may have unusual dependencies on the {@link View} that renders Flutter
    * UIs, such as unique keyboard interactions. That {@link View} is provided here for those
@@ -31,12 +32,12 @@ public interface PlatformView {
   default void onFlutterViewAttached(@NonNull View flutterView) {}
 
   /**
-   * Called by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code PlatformView} when the Android {@link
-   * View} responsible for rendering a Flutter UI is detached and disassociated from the {@link
-   * io.flutter.embedding.engine.FlutterEngine}.
+   * Called by the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@code
+   * PlatformView} when the Android {@link View} responsible for rendering a Flutter UI is detached
+   * and disassociated from the {@link io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>This means that our associated {@link io.flutter.embedding.engine.FlutterEngine} no longer has a rendering surface, or a
-   * user interaction surface of any kind.
+   * <p>This means that our associated {@link io.flutter.embedding.engine.FlutterEngine} no longer
+   * has a rendering surface, or a user interaction surface of any kind.
    *
    * <p>This platform view must release any references related to the Android {@link View} that was
    * provided in {@link #onFlutterViewAttached(View)}.

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
@@ -15,9 +15,7 @@ public interface PlatformViewsAccessibilityDelegate {
    */
   View getPlatformViewById(Integer id);
 
-  /**
-   * Returns true if the platform view uses virtual displays.
-   */
+  /** Returns true if the platform view uses virtual displays. */
   boolean usesVirtualDisplay(Integer id);
 
   /**

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
@@ -17,8 +17,6 @@ public interface PlatformViewsAccessibilityDelegate {
 
   /**
    * Returns true if the platform view uses virtual displays.
-   *
-   * @hide
    */
   boolean usesVirtualDisplay(Integer id);
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -713,8 +713,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   /**
    * Initializes a platform view and adds it to the view hierarchy.
    *
-   * @param viewId The view ID.
-   * This member is not intended for public use, and is only visible for testing.
+   * @param viewId The view ID. This member is not intended for public use, and is only visible for
+   *     testing.
    */
   @VisibleForTesting
   void initializePlatformViewIfNeeded(int viewId) {
@@ -766,8 +766,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    * @param height The height of the platform view.
    * @param viewWidth The original width of the platform view before applying the mutator stack.
    * @param viewHeight The original height of the platform view before applying the mutator stack.
-   * @param mutatorsStack The mutator stack.
-   * This member is not intended for public use, and is only visible for testing.
+   * @param mutatorsStack The mutator stack. This member is not intended for public use, and is only
+   *     visible for testing.
    */
   public void onDisplayPlatformView(
       int viewId,
@@ -803,8 +803,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    * @param x The left position relative to {@code FlutterView}.
    * @param y The top position relative to {@code FlutterView}.
    * @param width The width of the surface.
-   * @param height The height of the surface.
-   * This member is not intended for public use, and is only visible for testing.
+   * @param height The height of the surface. This member is not intended for public use, and is
+   *     only visible for testing.
    */
   public void onDisplayOverlaySurface(int id, int x, int y, int width, int height) {
     if (overlayLayerViews.get(id) == null) {
@@ -834,7 +834,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   /**
    * Called by {@code FlutterJNI} when the Flutter frame was submitted.
    *
-   * This member is not intended for public use, and is only visible for testing.
+   * <p>This member is not intended for public use, and is only visible for testing.
    */
   public void onEndFrame() {
     final FlutterView view = (FlutterView) flutterView;
@@ -908,8 +908,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    * Creates and tracks the overlay surface.
    *
    * @param imageView The surface that displays the overlay.
-   * @return Wrapper object that provides the layer id and the surface.
-   * This member is not intended for public use, and is only visible for testing.
+   * @return Wrapper object that provides the layer id and the surface. This member is not intended
+   *     for public use, and is only visible for testing.
    */
   @VisibleForTesting
   @TargetApi(19)
@@ -924,7 +924,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    *
    * <p>This method is invoked by {@code FlutterJNI} only.
    *
-   * This member is not intended for public use, and is only visible for testing.
+   * <p>This member is not intended for public use, and is only visible for testing.
    */
   @TargetApi(19)
   public FlutterOverlaySurface createOverlaySurface() {
@@ -947,7 +947,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    *
    * <p>This method is used only internally by {@code FlutterJNI}.
    *
-   * This member is not intended for public use, and is only visible for testing.
+   * <p>This member is not intended for public use, and is only visible for testing.
    */
   public void destroyOverlaySurfaces() {
     for (int i = 0; i < overlayLayerViews.size(); i++) {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -714,7 +714,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    * Initializes a platform view and adds it to the view hierarchy.
    *
    * @param viewId The view ID.
-   * @hide
+   * This member is not intended for public use, and is only visible for testing.
    */
   @VisibleForTesting
   void initializePlatformViewIfNeeded(int viewId) {
@@ -767,7 +767,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    * @param viewWidth The original width of the platform view before applying the mutator stack.
    * @param viewHeight The original height of the platform view before applying the mutator stack.
    * @param mutatorsStack The mutator stack.
-   * @hide
+   * This member is not intended for public use, and is only visible for testing.
    */
   public void onDisplayPlatformView(
       int viewId,
@@ -804,7 +804,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    * @param y The top position relative to {@code FlutterView}.
    * @param width The width of the surface.
    * @param height The height of the surface.
-   * @hide
+   * This member is not intended for public use, and is only visible for testing.
    */
   public void onDisplayOverlaySurface(int id, int x, int y, int width, int height) {
     if (overlayLayerViews.get(id) == null) {
@@ -834,7 +834,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   /**
    * Called by {@code FlutterJNI} when the Flutter frame was submitted.
    *
-   * @hide
+   * This member is not intended for public use, and is only visible for testing.
    */
   public void onEndFrame() {
     final FlutterView view = (FlutterView) flutterView;
@@ -909,7 +909,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    *
    * @param imageView The surface that displays the overlay.
    * @return Wrapper object that provides the layer id and the surface.
-   * @hide
+   * This member is not intended for public use, and is only visible for testing.
    */
   @VisibleForTesting
   @TargetApi(19)
@@ -924,7 +924,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    *
    * <p>This method is invoked by {@code FlutterJNI} only.
    *
-   * @hide
+   * This member is not intended for public use, and is only visible for testing.
    */
   @TargetApi(19)
   public FlutterOverlaySurface createOverlaySurface() {
@@ -947,7 +947,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
    *
    * <p>This method is used only internally by {@code FlutterJNI}.
    *
-   * @hide
+   * This member is not intended for public use, and is only visible for testing.
    */
   public void destroyOverlaySurfaces() {
     for (int i = 0; i < overlayLayerViews.size(); i++) {

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -56,7 +56,7 @@ import java.util.regex.Pattern;
  *       View#onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo)}. The {@link
  *       #rootAccessibilityView} is expected to notify the {@code AccessibilityBridge} of relevant
  *       interactions: {@link #onAccessibilityHoverEvent(MotionEvent)}, {@link #reset()}, {@link
- *       #updateSemantics(ByteBuffer, String[])}, and {@link
+ *       #updateSemantics(ByteBuffer, String[], ByteBuffer[])}, and {@link
  *       #updateCustomAccessibilityActions(ByteBuffer, String[])}
  *   <li>An {@link AccessibilityChannel} that is connected to the running Flutter app.
  *   <li>Android's {@link AccessibilityManager} to query and listen for accessibility settings.

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -91,6 +91,8 @@ public class FlutterView extends SurfaceView
   public interface Provider {
     /**
      * Returns a reference to the Flutter view maintained by this object. This may be {@code null}.
+     *
+     * @return a reference to the Flutter view maintained by this object.
      */
     FlutterView getFlutterView();
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -749,10 +749,11 @@ public class FlutterActivityAndFragmentDelegateTest {
   /**
    * Creates a mock {@link io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>The heuristic for deciding what to mock in the given {@link io.flutter.embedding.engine.FlutterEngine} is that we should
-   * mock the minimum number of necessary methods and associated objects. Maintaining developers
-   * should add more mock behavior as required for tests, but should avoid mocking things that are
-   * not required for the correct execution of tests.
+   * <p>The heuristic for deciding what to mock in the given {@link
+   * io.flutter.embedding.engine.FlutterEngine} is that we should mock the minimum number of
+   * necessary methods and associated objects. Maintaining developers should add more mock behavior
+   * as required for tests, but should avoid mocking things that are not required for the correct
+   * execution of tests.
    */
   @NonNull
   private FlutterEngine mockFlutterEngine() {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -747,9 +747,9 @@ public class FlutterActivityAndFragmentDelegateTest {
   }
 
   /**
-   * Creates a mock {@link FlutterEngine}.
+   * Creates a mock {@link io.flutter.embedding.engine.FlutterEngine}.
    *
-   * <p>The heuristic for deciding what to mock in the given {@link FlutterEngine} is that we should
+   * <p>The heuristic for deciding what to mock in the given {@link io.flutter.embedding.engine.FlutterEngine} is that we should
    * mock the minimum number of necessary methods and associated objects. Maintaining developers
    * should add more mock behavior as required for tests, but should avoid mocking things that are
    * not required for the correct execution of tests.

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestActivity.java
@@ -109,7 +109,8 @@ public class TestActivity extends TestableFlutterActivity {
   }
 
   /**
-   * This method verifies that {@link io.flutter.embedding.engine.loader.FlutterLoader#ensureInitializationCompleteAsync(Context,
+   * This method verifies that {@link
+   * io.flutter.embedding.engine.loader.FlutterLoader#ensureInitializationCompleteAsync(Context,
    * String[], Handler, Runnable)} invokes its callback when called after initialization.
    */
   private void testFlutterLoaderCallbackWhenInitializedTwice() {

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TestActivity.java
@@ -109,7 +109,7 @@ public class TestActivity extends TestableFlutterActivity {
   }
 
   /**
-   * This method verifies that {@link FlutterLoader#ensureInitializationCompleteAsync(Context,
+   * This method verifies that {@link io.flutter.embedding.engine.loader.FlutterLoader#ensureInitializationCompleteAsync(Context,
    * String[], Handler, Runnable)} invokes its callback when called after initialization.
    */
   private void testFlutterLoaderCallbackWhenInitializedTwice() {

--- a/tools/gen_javadoc.py
+++ b/tools/gen_javadoc.py
@@ -70,12 +70,14 @@ def main():
     print(' '.join(command))
 
   try:
-    subprocess.check_output(command, stderr=subprocess.STDOUT)
+    output = subprocess.check_output(command, stderr=subprocess.STDOUT)
     if not args.quiet:
       print(output)
   except subprocess.CalledProcessError as e:
     print(e.output)
     return e.returncode
+
+  return 0
 
 
 if __name__ == '__main__':

--- a/tools/gen_javadoc.py
+++ b/tools/gen_javadoc.py
@@ -30,6 +30,7 @@ def main():
   classpath = [
     args.android_source_root,
     os.path.join(args.third_party, 'android_embedding_dependencies', 'lib', '*'),
+    os.path.join(args.third_party, 'android_tools/sdk//platforms/android-30/android.jar'),
   ]
   if args.build_config_path:
     classpath.append(args.build_config_path)

--- a/tools/gen_javadoc.py
+++ b/tools/gen_javadoc.py
@@ -17,6 +17,7 @@ def main():
   parser.add_argument('--android-source-root', type=str, default=ANDROID_SRC_ROOT)
   parser.add_argument('--build-config-path', type=str)
   parser.add_argument('--third-party', type=str, default='third_party')
+  parser.add_argument('--quiet', default=False, action='store_true')
   args = parser.parse_args()
 
   if not os.path.exists(args.android_source_root):
@@ -64,9 +65,17 @@ def main():
     '-d', args.out_dir,
     '-link', 'https://developer.android.com/reference/',
   ] + packages
-  print(' '.join(command))
 
-  return subprocess.call(command)
+  if not args.quiet:
+    print(' '.join(command))
+
+  try:
+    subprocess.check_output(command, stderr=subprocess.STDOUT)
+    if not args.quiet:
+      print(output)
+  except subprocess.CalledProcessError as e:
+    print(e.output)
+    return e.returncode
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cleans up all errors with gen_javadoc, but still leaves a lot of warnings.

Part of https://github.com/flutter/flutter/issues/42400

This should enable recipes to avoid directly invoking the gen_javadoc.py and instead just grab the docs from the build output directory.

Also causes the docs to build on every build of the Android target, so authors will know if they're introducing new errors.