### PR TITLE
Reserve space for the line metrics styles created by ParagraphSkia::GetLineMetrics

### DIFF
--- a/third_party/txt/src/skia/paragraph_skia.cc
+++ b/third_party/txt/src/skia/paragraph_skia.cc
@@ -17,6 +17,7 @@
 #include "paragraph_skia.h"
 
 #include <algorithm>
+#include <numeric>
 
 namespace txt {
 
@@ -106,6 +107,12 @@ std::vector<LineMetrics>& ParagraphSkia::GetLineMetrics() {
     paragraph_->getLineMetrics(metrics);
 
     line_metrics_.emplace();
+    line_metrics_styles_.reserve(
+        std::accumulate(metrics.begin(), metrics.end(), 0,
+                        [](const int a, const skt::LineMetrics& b) {
+                          return a + b.fLineMetrics.size();
+                        }));
+
     for (const skt::LineMetrics& skm : metrics) {
       LineMetrics& txtm = line_metrics_->emplace_back(
           skm.fStartIndex, skm.fEndIndex, skm.fEndExcludingWhitespaces,


### PR DESCRIPTION
ParagraphSkia::GetLineMetrics converts an SkParagraph line metrics
object into the format used by the Flutter engine.  Flutter's
RunMetrics contain pointers to TextStyles that will be taken from the
ParagraphSkia's line_metrics_styles_ vector.
GetLineMetrics must reserve sufficient space in the vector so that these
pointers will not be invalidated due to reallocation of the vector.
