### PR TITLE
Make clang_tidy test more hermetic

### DIFF
--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -107,8 +107,11 @@ class ClangTidy {
       }
     }
 
+    final List<dynamic> buildCommandsData = jsonDecode(
+      options.buildCommandsPath.readAsStringSync(),
+    ) as List<dynamic>;
     final List<Command> changedFileBuildCommands = getLintCommandsForChangedFiles(
-      options.buildCommandsPath,
+      buildCommandsData,
       changedFiles,
     );
 
@@ -163,14 +166,11 @@ class ClangTidy {
   /// compute the lint commands to run.
   @visibleForTesting
   List<Command> getLintCommandsForChangedFiles(
-    io.File buildCommandsPath,
+    List<dynamic> buildCommandsData,
     List<io.File> changedFiles,
   ) {
-    final List<dynamic> buildCommandMaps = jsonDecode(
-      buildCommandsPath.readAsStringSync(),
-    ) as List<dynamic>;
     final List<Command> buildCommands = <Command>[
-      for (final dynamic c in buildCommandMaps)
+      for (final dynamic c in buildCommandsData)
         Command.fromMap(c as Map<String, dynamic>),
     ];
 

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -159,8 +159,16 @@ Future<int> main(List<String> args) async {
       outSink: outBuffer,
       errSink: errBuffer,
     );
+    const String filePath = '/path/to/a/source_file.cc';
+    final List<dynamic> buildCommandsData = <Map<String, dynamic>>[
+      <String, dynamic>{
+        'directory': '/unused',
+        'command': '../../buildtools/mac-x64/clang/bin/clang $filePath',
+        'file': filePath,
+      },
+    ];
     final List<Command> commands = clangTidy.getLintCommandsForChangedFiles(
-      clangTidy.options.buildCommandsPath,
+      buildCommandsData,
       <io.File>[],
     );
 
@@ -177,13 +185,17 @@ Future<int> main(List<String> args) async {
       outSink: outBuffer,
       errSink: errBuffer,
     );
-    final List<io.File> fileList = await clangTidy.computeChangedFiles();
-    final io.File file = fileList.firstWhere((io.File f) {
-      return f.path.endsWith('.cc');
-    });
+    const String filePath = '/path/to/a/source_file.cc';
+    final List<dynamic> buildCommandsData = <Map<String, dynamic>>[
+      <String, dynamic>{
+        'directory': '/unused',
+        'command': '../../buildtools/mac-x64/clang/bin/clang $filePath',
+        'file': filePath,
+      },
+    ];
     final List<Command> commands = clangTidy.getLintCommandsForChangedFiles(
-      clangTidy.options.buildCommandsPath,
-      <io.File>[file],
+      buildCommandsData,
+      <io.File>[io.File(filePath)],
     );
 
     expect(commands, isNotEmpty);


### PR DESCRIPTION
Previously this test read actual data from the local file system. This PR changes the test to use mock data.