### PR TITLE
font-subset builds its own zip bundle and adds a README

### DIFF
--- a/build/zip_bundle.gni
+++ b/build/zip_bundle.gni
@@ -38,7 +38,7 @@ template("zip_bundle") {
   action(target_name) {
     script = "//flutter/build/zip.py"
     outputs = [ "$root_build_dir/zip_archives/${invoker.output}" ]
-    inputs = []
+    sources = []
     deps = invoker.deps
 
     args = [
@@ -51,7 +51,7 @@ template("zip_bundle") {
         rebase_path(input.source),
         rebase_path(input.destination),
       ]
-      inputs += [ input.source ]
+      sources += [ input.source ]
     }
   }
 }

--- a/tools/font-subset/BUILD.gn
+++ b/tools/font-subset/BUILD.gn
@@ -2,7 +2,12 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-executable("font-subset") {
+import("//flutter/build/zip_bundle.gni")
+import("//flutter/shell/version/version.gni")
+
+executable("_font-subset") {
+  output_name = "font-subset"
+
   sources = [
     "hb_wrappers.h",
     "main.cc",
@@ -10,7 +15,6 @@ executable("font-subset") {
 
   deps = [ "//third_party/harfbuzz" ]
 
-  libs = []
   if (is_mac) {
     frameworks = [
       "Foundation.framework",
@@ -18,4 +22,49 @@ executable("font-subset") {
       "CoreText.framework",
     ]
   }
+}
+
+generated_file("_font-subset-license") {
+  source_path = rebase_path(".", "//flutter")
+  license_path = rebase_path("//flutter/sky/packages/sky_engine/LICENSE", "//flutter")
+  git_url = "https://github.com/flutter/engine/tree/$engine_version"
+  outputs = [ "$target_gen_dir/README.md" ]
+  contents = [
+    "# font-subset",
+    "",
+    "This tool is used by the Flutter SDK to tree shake icon fonts.",
+    "",
+    "Source code for this tool: [flutter/engine/$source_path]($git_url/$source_path).",
+    "License for this tool: [flutter/engine/sky/packages/sky_engine/LICENSE]($git_url/$license_path).",
+  ]
+}
+
+zip_bundle("font-subset") {
+  output = "font-subset.zip"
+
+  font_subset_bin = "font-subset"
+  if (is_win) {
+    font_subset_bin = "$font_subset_bin$.exe"
+  }
+
+  files = [
+    {
+      source = "$root_build_dir/$font_subset_bin"
+      destination = font_subset_bin
+    },
+    {
+      source = "$root_gen_dir/const_finder.dart.snapshot"
+      destination = "const_finder.dart.snapshot"
+    },
+    {
+      source = "$target_gen_dir/README.md"
+      destination = "README.md"
+    },
+  ]
+
+  deps = [
+    ":_font-subset",
+    ":_font-subset-license",
+    "//flutter/tools/const_finder",
+  ]
 }

--- a/tools/font-subset/BUILD.gn
+++ b/tools/font-subset/BUILD.gn
@@ -26,7 +26,8 @@ executable("_font-subset") {
 
 generated_file("_font-subset-license") {
   source_path = rebase_path(".", "//flutter")
-  license_path = rebase_path("//flutter/sky/packages/sky_engine/LICENSE", "//flutter")
+  license_path =
+      rebase_path("//flutter/sky/packages/sky_engine/LICENSE", "//flutter")
   git_url = "https://github.com/flutter/engine/tree/$engine_version"
   outputs = [ "$target_gen_dir/README.md" ]
   contents = [

--- a/tools/font-subset/BUILD.gn
+++ b/tools/font-subset/BUILD.gn
@@ -45,7 +45,7 @@ zip_bundle("font-subset") {
 
   font_subset_bin = "font-subset"
   if (is_win) {
-    font_subset_bin = "$font_subset_bin$.exe"
+    font_subset_bin = "${font_subset_bin}.exe"
   }
 
   files = [


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/85080

Sample README generated:

```markdown
# font-subset

This tool is used by the Flutter SDK to tree shake icon fonts.

Source code for this tool: [flutter/engine/tools/font-subset](https://github.com/flutter/engine/tree/7aa61d664fc3234265a818646ecf22230535880f/tools/font-subset).
License for this tool: [flutter/engine/sky/packages/sky_engine/LICENSE](https://github.com/flutter/engine/tree/7aa61d664fc3234265a818646ecf22230535880f/sky/packages/sky_engine/LICENSE).
```

Next step will be to update the recipe(s) to use this zip file instead of creating their own.

/cc @godofredoc