### PR TITLE
Builder configuration for windows_host_engine.

### DIFF
--- a/ci/builders/windows_host_engine.json
+++ b/ci/builders/windows_host_engine.json
@@ -1,0 +1,77 @@
+[
+    {
+        "archives": [],
+        "drone_dimensions": [
+            "device_type=none",
+            "os=Windows-10"
+        ],
+        "gn": [
+            "--runtime-mode",
+            "debug",
+            "--full-dart-sdk",
+            "--no-lto"
+        ],
+        "name": "host_debug",
+        "ninja": {
+            "config": "host_debug",
+            "targets": []
+        },
+        "tests": [
+            {
+                "language": "python",
+                "name": "Host Tests for host_debug",
+                "parameters": [
+                    "--variant",
+                    "host_debug",
+                    "--type",
+                    "engine"
+                ],
+                "script": "flutter/testing/run_tests.py",
+                "type": "local"
+            }
+        ]
+    },
+    {
+        "archives": [],
+        "drone_dimensions": [
+            "device_type=none",
+            "os=Windows-10"
+        ],
+        "gn": [
+            "--runtime-mode",
+            "profile",
+            "--no-lto"
+        ],
+        "name": "host_profile",
+        "ninja": {
+            "config": "host_profile",
+            "targets": [
+                "windows",
+                "gen_snapshot"
+            ]
+        },
+        "tests": []
+    },
+    {
+        "archives": [],
+        "drone_dimensions": [
+            "device_type=none",
+            "os=Windows-10"
+        ],
+        "generators": [],
+        "gn": [
+            "--runtime-mode",
+            "release",
+            "--no-lto"
+        ],
+        "name": "host_release",
+        "ninja": {
+            "config": "host_release",
+            "targets": [
+                "windows",
+                "gen_snapshot"
+            ]
+        },
+        "tests": []
+    }
+]


### PR DESCRIPTION
This builder config add some more sections to the configuration: tests
and drone_dimensions.

Tests can be local if they are cheap to execute and/or remote if the
execution is expensive and we have more than 1.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
- [X] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
