### PR TITLE
Redraw layer tree after surface changed

### DIFF
--- a/shell/platform/android/android_shell_holder.h
+++ b/shell/platform/android/android_shell_holder.h
@@ -96,6 +96,14 @@ class AndroidShellHolder {
 
   void NotifyLowMemoryWarning();
 
+  //----------------------------------------------------------------------------
+  /// @brief      Draws the last layer tree.
+  ///
+  /// @details    This is used when the screen is rotated, or the background
+  //              surface changed.
+  ///
+  void DrawLastLayerTree();
+
  private:
   const flutter::Settings settings_;
   const std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -228,6 +228,8 @@ static void SurfaceWindowChanged(JNIEnv* env,
       ANativeWindow_fromSurface(env, jsurface));
   ANDROID_SHELL_HOLDER->GetPlatformView()->NotifySurfaceWindowChanged(
       std::move(window));
+  // Redraw the last layer tree.
+  ANDROID_SHELL_HOLDER->DrawLastLayerTree();
 }
 
 static void SurfaceChanged(JNIEnv* env,


### PR DESCRIPTION
Redraws the layer tree after the surface has changed.

This is the case when the device is rotated or the Android surface has changed.