### PR TITLE
Make const_finder a kernel snapshot rather than app_jit

### DIFF
--- a/tools/const_finder/BUILD.gn
+++ b/tools/const_finder/BUILD.gn
@@ -7,6 +7,7 @@ import("//third_party/dart/utils/application_snapshot.gni")
 application_snapshot("const_finder") {
   main_dart = "bin/main.dart"
   dot_packages = ".dart_tool/package_config.json"
+  dart_snapshot_kind = "kernel"
 
   training_args = [ "--help" ]
 


### PR DESCRIPTION
@zanderso @jonahwilliams 

This not only makes the snapshot smaller, it also will make this target run across VMs instead of requiring a product VM in release builds.