### PR TITLE
[iOS TextInput] Disables system keyboard for TextInputType.none

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -55,6 +55,14 @@ static NSString* const kAutocorrectionType = @"autocorrect";
 
 #pragma mark - Static Functions
 
+// "TextInputType.none" is a made-up input type that's typically
+// used when there's an in-app virtual keyboard. If
+// "TextInputType.none" is specified, disable the system
+// keyboard.
+static BOOL shouldShowSystemKeyboard(NSDictionary* type) {
+  NSString* inputType = type[@"name"];
+  return ![inputType isEqualToString:@"TextInputType.none"];
+}
 static UIKeyboardType ToUIKeyboardType(NSDictionary* type) {
   NSString* inputType = type[@"name"];
   if ([inputType isEqualToString:@"TextInputType.address"])
@@ -516,7 +524,12 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   int _textInputClient;
   const char* _selectionAffinity;
   FlutterTextRange* _selectedTextRange;
+  UIInputViewController* _inputViewcController;
   CGRect _cachedFirstRect;
+  // Whether to show the system keyboard when this view
+  // becomes the first responder. Typically set to false
+  // when the app shows its own in-flutter keyboard.
+  bool _isSystemKeyboardEnabled;
   bool _isFloatingCursorActive;
   // The view has reached end of life, and is no longer
   // allowed to access its textInputDelegate.
@@ -579,6 +592,8 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   NSDictionary* autofill = configuration[kAutofillProperties];
 
   self.secureTextEntry = [configuration[kSecureTextEntry] boolValue];
+
+  _isSystemKeyboardEnabled = shouldShowSystemKeyboard(inputType);
   self.keyboardType = ToUIKeyboardType(inputType);
   self.returnKeyType = ToUIReturnKeyType(configuration[kInputAction]);
   self.autocapitalizationType = ToUITextAutoCapitalizationType(configuration);
@@ -625,6 +640,17 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   return _textContentType;
 }
 
+- (UIInputViewController*)inputViewController {
+  if (_isSystemKeyboardEnabled) {
+    return nil;
+  }
+
+  if (!_inputViewcController) {
+    _inputViewcController = [UIInputViewController new];
+  }
+  return _inputViewcController;
+}
+
 - (id<FlutterTextInputDelegate>)textInputDelegate {
   return _decommissioned ? nil : _textInputDelegate;
 }
@@ -649,6 +675,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   [_selectedTextRange release];
   [_tokenizer release];
   [_autofillId release];
+  [_inputViewcController release];
   [super dealloc];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -524,7 +524,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   int _textInputClient;
   const char* _selectionAffinity;
   FlutterTextRange* _selectedTextRange;
-  UIInputViewController* _inputViewcController;
+  UIInputViewController* _inputViewController;
   CGRect _cachedFirstRect;
   // Whether to show the system keyboard when this view
   // becomes the first responder. Typically set to false
@@ -645,10 +645,10 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
     return nil;
   }
 
-  if (!_inputViewcController) {
-    _inputViewcController = [UIInputViewController new];
+  if (!_inputViewController) {
+    _inputViewController = [UIInputViewController new];
   }
-  return _inputViewcController;
+  return _inputViewController;
 }
 
 - (id<FlutterTextInputDelegate>)textInputDelegate {
@@ -675,7 +675,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   [_selectedTextRange release];
   [_tokenizer release];
   [_autofillId release];
-  [_inputViewcController release];
+  [_inputViewController release];
   [super dealloc];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.m
@@ -194,6 +194,20 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqual(inputView.keyboardType, UIKeyboardTypeURL);
 }
 
+- (void)testSettingKeyboardTypeNoneDisablesSystemKeyboard {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [config setValue:@{@"name" : @"TextInputType.none"} forKey:@"inputType"];
+  [self setClientId:123 configuration:config];
+
+  // Verify the view's inputViewController is not nil;
+  XCTAssertNotNil(textInputPlugin.activeView.inputViewController);
+
+  [config setValue:@{@"name" : @"TextInputType.url"} forKey:@"inputType"];
+  [self setClientId:124 configuration:config];
+  XCTAssertNotNil(textInputPlugin.activeView);
+  XCTAssertNil(textInputPlugin.activeView.inputViewController);
+}
+
 - (void)testAutocorrectionPromptRectAppears {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] initWithFrame:CGRectZero];
   inputView.textInputDelegate = engine;


### PR DESCRIPTION
Continuation of https://github.com/flutter/engine/pull/26773
/cc @jpnurmi 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
