### PR TITLE
[canvaskit] make picture disposal work on older browsers

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -11,7 +11,7 @@ import 'image.dart';
 import 'skia_object_cache.dart';
 
 /// Implements [ui.Picture] on top of [SkPicture].
-/// 
+///
 /// Unlike most other [ManagedSkiaObject] implementations, instances of this
 /// class may have their Skia counterparts deleted before finalization registry
 /// or [SkiaObjectCache] decide to delete it.
@@ -31,13 +31,13 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
   int get approximateBytesUsed => 0;
 
   /// Whether the picture has been disposed of.
-  /// 
+  ///
   /// This is indended to be used in tests and assertions only.
   bool get debugIsDisposed => _isDisposed;
 
   /// This is set to true when [dispose] is called and is never reset back to
   /// false.
-  /// 
+  ///
   /// This extra flag is necessary on top of [rawSkiaObject] because
   /// [rawSkiaObject] being null does not indicate permanent deletion. See
   /// similar flag [SkiaObjectBox.isDeletedPermanently].

--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -45,9 +45,7 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
 
   @override
   void dispose() {
-    if (_isDisposed) {
-      return;
-    }
+    assert(!_isDisposed, 'Object has been disposed.');
     if (Instrumentation.enabled) {
       Instrumentation.instance.incrementCounter('Picture disposed');
     }

--- a/lib/web_ui/lib/src/engine/canvaskit/picture.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/picture.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
 import 'canvas.dart';
@@ -9,6 +10,11 @@ import 'canvaskit_api.dart';
 import 'image.dart';
 import 'skia_object_cache.dart';
 
+/// Implements [ui.Picture] on top of [SkPicture].
+/// 
+/// Unlike most other [ManagedSkiaObject] implementations, instances of this
+/// class may have their Skia counterparts deleted before finalization registry
+/// or [SkiaObjectCache] decide to delete it.
 class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
   final ui.Rect? cullRect;
   final CkPictureSnapshot? _snapshot;
@@ -24,14 +30,38 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
   @override
   int get approximateBytesUsed => 0;
 
+  /// Whether the picture has been disposed of.
+  /// 
+  /// This is indended to be used in tests and assertions only.
+  bool get debugIsDisposed => _isDisposed;
+
+  /// This is set to true when [dispose] is called and is never reset back to
+  /// false.
+  /// 
+  /// This extra flag is necessary on top of [rawSkiaObject] because
+  /// [rawSkiaObject] being null does not indicate permanent deletion. See
+  /// similar flag [SkiaObjectBox.isDeletedPermanently].
+  bool _isDisposed = false;
+
   @override
   void dispose() {
+    if (_isDisposed) {
+      return;
+    }
+    if (Instrumentation.enabled) {
+      Instrumentation.instance.incrementCounter('Picture disposed');
+    }
+    _isDisposed = true;
     _snapshot?.dispose();
-    skiaObject.delete();
+
+    // Emulate what SkiaObjectCache does.
+    rawSkiaObject?.delete();
+    rawSkiaObject = null;
   }
 
   @override
   Future<ui.Image> toImage(int width, int height) async {
+    assert(!_isDisposed);
     final SkSurface skSurface = canvasKit.MakeSurface(width, height);
     final SkCanvas skCanvas = skSurface.getCanvas();
     skCanvas.drawPicture(skiaObject);
@@ -51,11 +81,19 @@ class CkPicture extends ManagedSkiaObject<SkPicture> implements ui.Picture {
 
   @override
   SkPicture resurrect() {
+    // If a picture has been explicitly disposed of, it can no longer be
+    // resurrected. An attempt to resurrect after the framework told the
+    // engine to dispose of the picture likely indicates a bug in the engine.
+    assert(!_isDisposed);
     return _snapshot!.toPicture();
   }
 
   @override
   void delete() {
-    rawSkiaObject?.delete();
+    // This method may be called after [dispose], in which case there's nothing
+    // left to do. The Skia object is deleted permanently.
+    if (!_isDisposed) {
+      rawSkiaObject?.delete();
+    }
   }
 }

--- a/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/skia_object_cache.dart
@@ -267,6 +267,13 @@ abstract class ManagedSkiaObject<T extends Object> extends SkiaObject<T> {
   @override
   void didDelete() {
     assert(!browserSupportsFinalizationRegistry);
+
+    // Null indicates that the object has been manually disposed of. This
+    // happens for objects with manual lifecycles, such as Picture.
+    if (rawSkiaObject == null) {
+      return;
+    }
+
     if (Instrumentation.enabled) {
       Instrumentation.instance.incrementCounter(
         '${(rawSkiaObject as SkDeletable).constructor.name} deleted',

--- a/lib/web_ui/test/canvaskit/picture_test.dart
+++ b/lib/web_ui/test/canvaskit/picture_test.dart
@@ -41,6 +41,7 @@ void testMain() {
         // A Picture that's been disposed of can no longer be resurrected
         expect(() => picture.resurrect(), throwsAssertionError);
         expect(() => picture.toImage(10, 10), throwsAssertionError);
+        expect(() => picture.dispose(), throwsAssertionError);
       });
 
       test('can be deleted by SkiaObjectCache', () {

--- a/lib/web_ui/test/canvaskit/picture_test.dart
+++ b/lib/web_ui/test/canvaskit/picture_test.dart
@@ -1,0 +1,68 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+import 'package:ui/src/engine.dart';
+import 'package:ui/ui.dart' as ui;
+
+import '../matchers.dart';
+import 'common.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  group('CkPicture', () {
+    setUpCanvasKitTest();
+
+    group('in browsers that do not support FinalizationRegistry', () {
+      test('can be disposed of manually', () {
+        browserSupportsFinalizationRegistry = false;
+
+        final ui.PictureRecorder recorder = ui.PictureRecorder();
+        final ui.Canvas canvas = ui.Canvas(recorder);
+        canvas.drawPaint(ui.Paint());
+        final CkPicture picture = recorder.endRecording() as CkPicture;
+        expect(picture.rawSkiaObject, isNotNull);
+        expect(picture.debugIsDisposed, isFalse);
+        picture.dispose();
+        expect(picture.rawSkiaObject, isNull);
+        expect(picture.debugIsDisposed, isTrue);
+
+        // Emulate SkiaObjectCache deleting the picture
+        picture.delete();
+        picture.didDelete();
+        expect(picture.rawSkiaObject, isNull);
+
+        // A Picture that's been disposed of can no longer be resurrected
+        expect(() => picture.resurrect(), throwsAssertionError);
+        expect(() => picture.toImage(10, 10), throwsAssertionError);
+      });
+
+      test('can be deleted by SkiaObjectCache', () {
+        browserSupportsFinalizationRegistry = false;
+
+        final ui.PictureRecorder recorder = ui.PictureRecorder();
+        final ui.Canvas canvas = ui.Canvas(recorder);
+        canvas.drawPaint(ui.Paint());
+        final CkPicture picture = recorder.endRecording() as CkPicture;
+        expect(picture.rawSkiaObject, isNotNull);
+
+        // Emulate SkiaObjectCache deleting the picture
+        picture.delete();
+        picture.didDelete();
+        expect(picture.rawSkiaObject, isNull);
+
+        // Deletion is softer than disposal. An object may still be resurrected
+        // if it was deleted prematurely.
+        expect(picture.debugIsDisposed, isFalse);
+        expect(picture.resurrect(), isNotNull);
+      });
+    });
+    // TODO: https://github.com/flutter/flutter/issues/60040
+  }, skip: isIosSafari);
+}


### PR DESCRIPTION
Our object cache and resurrection for browsers that don't support `FinalizationRegistry` (which includes current Safari 14) was incompatible with `Picture.dispose`. This fixes it.