### PR TITLE
Add `--build-before-test` to run_tests.py

### DIFF
--- a/shell/platform/android/test/README.md
+++ b/shell/platform/android/test/README.md
@@ -19,7 +19,7 @@ integration tests in other repos.
    `FlutterTestSuite.java`. This makes sure the test is actually executed at
    run time.
 4. Write your test.
-5. Build and run with `testing/run_tests.py [--type=java] [--java-filter=<test_class_name>]`.
+5. Build and run with `testing/run_tests.py --build-before-test [--type=java] [--java-filter=<test_class_name>]`.
 
 ## Q&A
 

--- a/testing/ios/IosUnitTests/README.md
+++ b/testing/ios/IosUnitTests/README.md
@@ -6,7 +6,7 @@ also run in LUCI builds.
 ## Running Tests
 
 ```sh
-testing/run_tests.py [--type=objc]
+testing/run_tests.py [--type=objc] --build-before-test
 ```
 
 After the `ios_test_flutter` target is built you can also run the tests inside

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -281,9 +281,9 @@ def RunDartTest(build_dir, test_packages, dart_file, verbose_dart_snapshot, mult
                       forbidden_output=forbidden_output, expect_failure=expect_failure)
 
 
-def EnsureDebugUnoptSkyPackagesAreBuilt(check_only):
+def EnsureDebugUnoptSkyPackagesAreBuilt(do_build):
   variant_out_dir = os.path.join(out_dir, 'host_debug_unopt')
-  if check_only:
+  if not do_build:
     message = []
     message.append('gn --runtime-mode debug --unopt --no-lto')
     message.append('ninja -C %s flutter/sky/packages' % variant_out_dir)
@@ -312,10 +312,10 @@ def EnsureDebugUnoptSkyPackagesAreBuilt(check_only):
   RunCmd(ninja_command, cwd=buildroot_dir)
 
 
-def EnsureJavaTestsAreBuilt(android_out_dir, check_only):
+def EnsureJavaTestsAreBuilt(android_out_dir, do_build):
   """Builds the engine variant and the test jar containing the JUnit tests"""
 
-  if check_only:
+  if not do_build:
     tmp_out_dir = os.path.join(out_dir, android_out_dir)
     message = []
     message.append('gn --android --unoptimized --runtime-mode=debug --no-lto')
@@ -347,10 +347,10 @@ def EnsureJavaTestsAreBuilt(android_out_dir, check_only):
   RunCmd(ninja_command, cwd=buildroot_dir)
 
 
-def EnsureIosTestsAreBuilt(ios_out_dir, check_only):
+def EnsureIosTestsAreBuilt(ios_out_dir, do_build):
   """Builds the engine variant and the test dylib containing the XCTests"""
 
-  if check_only:
+  if not do_build:
     tmp_out_dir = os.path.join(out_dir, ios_out_dir)
     message = []
     message.append('gn --ios --unoptimized --runtime-mode=debug --no-lto --simulator')
@@ -405,7 +405,7 @@ def RunJavaTests(filter, android_variant='android_debug_unopt', build_tests=Fals
   """Runs the Java JUnit unit tests for the Android embedding"""
   AssertExpectedJavaVersion()
   android_out_dir = os.path.join(out_dir, android_variant)
-  EnsureJavaTestsAreBuilt(android_out_dir, not build_tests)
+  EnsureJavaTestsAreBuilt(android_out_dir, build_tests)
 
   embedding_deps_dir = os.path.join(buildroot_dir, 'third_party', 'android_embedding_dependencies', 'lib')
   classpath = map(str, [
@@ -433,7 +433,7 @@ def RunObjcTests(ios_variant='ios_debug_sim_unopt', build_tests=False):
   """Runs Objective-C XCTest unit tests for the iOS embedding"""
   AssertExpectedXcodeVersion()
   ios_out_dir = os.path.join(out_dir, ios_variant)
-  EnsureIosTestsAreBuilt(ios_out_dir, not build_tests)
+  EnsureIosTestsAreBuilt(ios_out_dir, build_tests)
 
   ios_unit_test_dir = os.path.join(buildroot_dir, 'flutter', 'testing', 'ios', 'IosUnitTests')
 
@@ -457,7 +457,7 @@ def RunDartTests(build_dir, filter, verbose_dart_snapshot, build_tests=False):
   # This one is a bit messy. The pubspec.yaml at flutter/testing/dart/pubspec.yaml
   # has dependencies that are hardcoded to point to the sky packages at host_debug_unopt/
   # Before running Dart tests, make sure to run just that target (NOT the whole engine)
-  EnsureDebugUnoptSkyPackagesAreBuilt(not build_tests)
+  EnsureDebugUnoptSkyPackagesAreBuilt(build_tests)
 
   # Now that we have the Sky packages at the hardcoded location, run `pub get`.
   RunEngineExecutable(


### PR DESCRIPTION
For running the tests locally.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.
- [ ] The reviewer has submitted any presubmit flakes in this PR using the [engine presubmit flakes form] before re-triggering the failure.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[engine presubmit flakes form]: https://forms.gle/Wc1VyFRYJjQTH6w5A
