### PR TITLE
[web] make analysis options delta of root options

### DIFF
--- a/lib/web_ui/analysis_options.yaml
+++ b/lib/web_ui/analysis_options.yaml
@@ -1,91 +1,101 @@
-# This is copy of the root analysis_options.yaml. As we clean up the Web code,
-# we'll be uncommenting rules and gradually fix the code. When all rules are
-# uncommented, we'll delete this file and simply inherit the root options.
+# Web-specific analysis options.
+#
+# As of today the web code contains quite a few deviations from the repo-wide
+# analysis options due to having been migrated from google3. The ultimate goal
+# is to clean up our code and delete this file.
+
+include: ../../analysis_options.yaml
 
 analyzer:
-  exclude:
-    - build/**
-  enable-experiment:
-    - non-nullable
   strong-mode:
-    # TODO(uncomment) implicit-casts: false
-    implicit-dynamic: false
-  errors:
-    missing_required_param: warning
-    missing_return: warning
-    native_function_body_in_non_sdk_code: ignore
-    todo: ignore
+    implicit-casts: true
+    implicit-dynamic: true
 
 linter:
   rules:
-    - always_declare_return_types
-    - always_put_control_body_on_new_line
-    # TODO(uncomment) - always_specify_types
-    # TODO(uncomment) - annotate_overrides
-    # TODO(uncomment) - avoid_classes_with_only_static_members
-    # TODO(uncomment) - avoid_empty_else
-    # TODO(uncomment) - avoid_function_literals_in_foreach_calls
-    # TODO(uncomment) - avoid_init_to_null
-    # TODO(uncomment) - avoid_null_checks_in_equality_operators
-    # TODO(uncomment) - avoid_relative_lib_imports
-    # TODO(uncomment) - avoid_renaming_method_parameters
-    # TODO(uncomment) - avoid_return_types_on_setters
-    # TODO(uncomment) - avoid_slow_async_io
-    # TODO(uncomment) - await_only_futures
-    # TODO(uncomment) - camel_case_types
-    # TODO(uncomment) - cancel_subscriptions
-    # TODO(uncomment) - control_flow_in_finally
-    # TODO(uncomment) - directives_ordering
-    # TODO(uncomment) - empty_catches
-    # TODO(uncomment) - empty_constructor_bodies
-    # TODO(uncomment) - empty_statements
-    # TODO(uncomment) - hash_and_equals
-    # TODO(uncomment) - implementation_imports
-    # TODO(uncomment) - iterable_contains_unrelated_type
-    # TODO(uncomment) - library_names
-    # TODO(uncomment) - library_prefixes
-    # TODO(uncomment) - list_remove_unrelated_type
-    # TODO(uncomment) - no_adjacent_strings_in_list
-    # TODO(uncomment) - no_duplicate_case_values
-    # TODO(uncomment) - non_constant_identifier_names
-    # TODO(uncomment) - overridden_fields
-    # TODO(uncomment) - package_api_docs
-    # TODO(uncomment) - package_names
-    # TODO(uncomment) - package_prefixed_library_names
-    # TODO(uncomment) - prefer_adjacent_string_concatenation
-    # TODO(uncomment) - prefer_asserts_in_initializer_lists
-    # TODO(uncomment) - prefer_collection_literals
-    # TODO(uncomment) - prefer_conditional_assignment
-    # TODO(uncomment) - prefer_const_constructors
-    # TODO(uncomment) - prefer_const_constructors_in_immutables
-    # TODO(uncomment) - prefer_const_declarations
-    # TODO(uncomment) - prefer_const_literals_to_create_immutables
-    # TODO(uncomment) - prefer_contains
-    # TODO(uncomment) - prefer_equal_for_default_values
-    # TODO(uncomment) - prefer_final_locals
-    # TODO(uncomment) - prefer_foreach
-    # TODO(uncomment) - prefer_generic_function_type_aliases
-    # TODO(uncomment) - prefer_initializing_formals
-    # TODO(uncomment) - prefer_is_empty
-    # TODO(uncomment) - prefer_is_not_empty
-    # TODO(uncomment) - prefer_single_quotes
-    # TODO(uncomment) - prefer_typing_uninitialized_variables
-    # TODO(uncomment) - public_member_api_docs
-    # TODO(uncomment) - recursive_getters
-    # TODO(uncomment) - slash_for_doc_comments
-    # TODO(uncomment) - sort_unnamed_constructors_first
-    # TODO(uncomment) - test_types_in_equals
-    # TODO(uncomment) - throw_in_finally
-    # TODO(uncomment) - type_init_formals
-    # TODO(uncomment) - unnecessary_brace_in_string_interps
-    # TODO(uncomment) - unnecessary_const
-    # TODO(uncomment) - unnecessary_getters_setters
-    # TODO(uncomment) - unnecessary_new
-    # TODO(uncomment) - unnecessary_null_aware_assignments
-    # TODO(uncomment) - unnecessary_null_in_if_null_operators
-    # TODO(uncomment) - unnecessary_overrides
-    # TODO(uncomment) - unnecessary_parenthesis
-    # TODO(uncomment) - unnecessary_this
-    # TODO(uncomment) - unrelated_type_equality_checks
-    # TODO(uncomment) - use_rethrow_when_possible
-    # TODO(uncomment) - valid_regexps
+    always_declare_return_types: true
+    always_put_control_body_on_new_line: true
+    always_specify_types: false
+    annotate_overrides: false
+    avoid_classes_with_only_static_members: false
+    avoid_empty_else: false
+    avoid_function_literals_in_foreach_calls: false
+    avoid_init_to_null: false
+    avoid_null_checks_in_equality_operators: false
+    avoid_relative_lib_imports: false
+    avoid_renaming_method_parameters: false
+    avoid_return_types_on_setters: false
+    avoid_slow_async_io: false
+    await_only_futures: false
+    camel_case_types: false
+    cancel_subscriptions: false
+    control_flow_in_finally: false
+    directives_ordering: false
+    empty_catches: false
+    empty_constructor_bodies: false
+    empty_statements: false
+    hash_and_equals: false
+    implementation_imports: false
+    iterable_contains_unrelated_type: false
+    library_names: false
+    library_prefixes: false
+    list_remove_unrelated_type: false
+    no_adjacent_strings_in_list: false
+    no_duplicate_case_values: false
+    non_constant_identifier_names: false
+    overridden_fields: false
+    package_api_docs: false
+    package_names: false
+    package_prefixed_library_names: false
+    prefer_adjacent_string_concatenation: false
+    prefer_asserts_in_initializer_lists: false
+    prefer_collection_literals: false
+    prefer_conditional_assignment: false
+    prefer_const_constructors: false
+    prefer_const_constructors_in_immutables: false
+    prefer_const_declarations: false
+    prefer_const_literals_to_create_immutables: false
+    prefer_contains: false
+    prefer_equal_for_default_values: false
+    prefer_final_locals: false
+    prefer_foreach: false
+    prefer_generic_function_type_aliases: false
+    prefer_initializing_formals: false
+    prefer_is_empty: false
+    prefer_is_not_empty: false
+    prefer_single_quotes: false
+    prefer_typing_uninitialized_variables: false
+    public_member_api_docs: false
+    recursive_getters: false
+    slash_for_doc_comments: false
+    sort_unnamed_constructors_first: false
+    test_types_in_equals: false
+    throw_in_finally: false
+    type_init_formals: false
+    unnecessary_brace_in_string_interps: false
+    unnecessary_const: false
+    unnecessary_getters_setters: false
+    unnecessary_new: false
+    unnecessary_null_aware_assignments: false
+    unnecessary_null_in_if_null_operators: false
+    unnecessary_overrides: false
+    unnecessary_parenthesis: false
+    unnecessary_this: false
+    unrelated_type_equality_checks: false
+    use_rethrow_when_possible: false
+    valid_regexps: false
+    use_function_type_syntax_for_parameters: false
+    prefer_final_in_for_each: false
+    avoid_single_cascade_in_expression_statements: false
+    unnecessary_string_interpolations: false
+    unnecessary_string_escapes: false
+    cast_nullable_to_non_nullable: false
+    flutter_style_todos: false
+    avoid_unused_constructor_parameters: false
+    avoid_void_async: false
+    prefer_if_elements_to_conditional_expressions: false
+    unnecessary_await_in_return: false
+    avoid_bool_literals_in_conditional_expressions: false
+    unnecessary_statements: false
+    # We have some legitimate use-cases for this (preserve tear-off identity)
+    prefer_function_declarations_over_variables: false

--- a/lib/web_ui/dev/analysis_options.yaml
+++ b/lib/web_ui/dev/analysis_options.yaml
@@ -1,7 +1,0 @@
-# This is a temporary file used to clean up dev/ before other directories
-include: ../analysis_options.yaml
-
-analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false

--- a/lib/web_ui/lib/src/engine/assets.dart
+++ b/lib/web_ui/lib/src/engine/assets.dart
@@ -86,7 +86,8 @@ class AssetManagerException implements Exception {
 class WebOnlyMockAssetManager implements AssetManager {
   String defaultAssetsDir = '';
   String defaultAssetManifest = '{}';
-  String defaultFontManifest = '''[
+  String defaultFontManifest = '''
+  [
    {
       "family":"$_robotoFontFamily",
       "fonts":[{"asset":"$_robotoTestFontUrl"}]

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -925,18 +925,18 @@ class SkImageFilterNamespace {
     double sigmaX,
     double sigmaY,
     SkTileMode tileMode,
-    Null input, // we don't use this yet
+    void input, // we don't use this yet
   );
 
   external SkImageFilter MakeMatrixTransform(
     Float32List matrix, // 3x3 matrix
     SkFilterQuality filterQuality,
-    Null input, // we don't use this yet
+    void input, // we don't use this yet
   );
 
   external SkImageFilter MakeColorFilter(
     SkColorFilter colorFilter,
-    Null input, // we don't use this yet
+    void input, // we don't use this yet
   );
 
   external SkImageFilter MakeCompose(

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -441,7 +441,7 @@ class DomRenderer {
       late StreamSubscription<html.Event> loadSubscription;
       loadSubscription = _canvasKitScript!.onLoad.listen((_) {
         loadSubscription.cancel();
-        canvasKitLoadCompleter.complete(true);
+        canvasKitLoadCompleter.complete();
       });
 
       // TODO(hterkelsen): Rather than this monkey-patch hack, we should

--- a/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
@@ -1267,7 +1267,7 @@ List<html.Element> _clipContent(List<_SaveClipEntry> clipStack,
     content,
     transformWithOffset(currentTransform, offset).storage,
   );
-  return <html.Element>[root]..addAll(clipDefs);
+  return <html.Element>[root, ...clipDefs];
 }
 
 /// Converts a [maskFilter] to the value to be used on a `<canvas>`.

--- a/lib/web_ui/lib/src/engine/html/shaders/webgl_context.dart
+++ b/lib/web_ui/lib/src/engine/html/shaders/webgl_context.dart
@@ -364,26 +364,24 @@ class GlContext {
 
   /// Sets float uniform value.
   void setUniform1f(Object uniform, double value) {
-    return js_util
-        .callMethod(glContext, 'uniform1f', <dynamic>[uniform, value]);
+    js_util.callMethod(glContext, 'uniform1f', <dynamic>[uniform, value]);
   }
 
   /// Sets vec2 uniform values.
   void setUniform2f(Object uniform, double value1, double value2) {
-    return js_util
-        .callMethod(glContext, 'uniform2f', <dynamic>[uniform, value1, value2]);
+    js_util.callMethod(glContext, 'uniform2f', <dynamic>[uniform, value1, value2]);
   }
 
   /// Sets vec4 uniform values.
   void setUniform4f(Object uniform, double value1, double value2, double value3,
       double value4) {
-    return js_util.callMethod(
+    js_util.callMethod(
         glContext, 'uniform4f', <dynamic>[uniform, value1, value2, value3, value4]);
   }
 
   /// Sets mat4 uniform values.
   void setUniformMatrix4fv(Object uniform, bool transpose, Float32List value) {
-    return js_util.callMethod(
+    js_util.callMethod(
         glContext, 'uniformMatrix4fv', <dynamic>[uniform, transpose, value]);
   }
 

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -1130,7 +1130,7 @@ class EngineTextStyle implements ui.TextStyle {
   String toString() {
     if (assertionsEnabled) {
       return 'TextStyle('
-          'color: ${color != null ? color : "unspecified"}, '
+          'color: ${color ?? "unspecified"}, '
           'decoration: ${decoration ?? "unspecified"}, '
           'decorationColor: ${decorationColor ?? "unspecified"}, '
           'decorationStyle: ${decorationStyle ?? "unspecified"}, '

--- a/lib/web_ui/lib/src/engine/text/word_breaker.dart
+++ b/lib/web_ui/lib/src/engine/text/word_breaker.dart
@@ -57,8 +57,8 @@ abstract class WordBreaker {
       return false;
     }
 
-    final WordCharProperty? immediateRight = wordLookup.find(text, index);
-    WordCharProperty? immediateLeft = wordLookup.find(text, index - 1);
+    final WordCharProperty immediateRight = wordLookup.find(text, index);
+    WordCharProperty immediateLeft = wordLookup.find(text, index - 1);
 
     // Do not break within CRLF.
     // WB3: CR × LF

--- a/lib/web_ui/lib/src/engine/text_editing/input_type.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/input_type.dart
@@ -93,7 +93,7 @@ class NoTextInputType extends EngineInputType {
   const NoTextInputType();
 
   @override
-  final String inputmodeAttribute = 'none';
+  String get inputmodeAttribute => 'none';
 }
 
 /// Single-line text input type.
@@ -101,7 +101,7 @@ class TextInputType extends EngineInputType {
   const TextInputType();
 
   @override
-  final String inputmodeAttribute = 'text';
+  String get inputmodeAttribute => 'text';
 }
 
 /// Numeric input type.
@@ -111,7 +111,7 @@ class NumberInputType extends EngineInputType {
   const NumberInputType();
 
   @override
-  final String inputmodeAttribute = 'numeric';
+  String get inputmodeAttribute => 'numeric';
 }
 
 /// Decimal input type.
@@ -122,7 +122,7 @@ class DecimalInputType extends EngineInputType {
   const DecimalInputType();
 
   @override
-  final String inputmodeAttribute = 'decimal';
+  String get inputmodeAttribute => 'decimal';
 }
 
 /// Phone number input type.
@@ -130,7 +130,7 @@ class PhoneInputType extends EngineInputType {
   const PhoneInputType();
 
   @override
-  final String inputmodeAttribute = 'tel';
+  String get inputmodeAttribute => 'tel';
 }
 
 /// Email address input type.
@@ -138,7 +138,7 @@ class EmailInputType extends EngineInputType {
   const EmailInputType();
 
   @override
-  final String inputmodeAttribute = 'email';
+  String get inputmodeAttribute => 'email';
 }
 
 /// URL input type.
@@ -146,7 +146,7 @@ class UrlInputType extends EngineInputType {
   const UrlInputType();
 
   @override
-  final String inputmodeAttribute = 'url';
+  String get inputmodeAttribute => 'url';
 }
 
 /// Multi-line text input type.
@@ -154,7 +154,7 @@ class MultilineInputType extends EngineInputType {
   const MultilineInputType();
 
   @override
-  final String? inputmodeAttribute = null;
+  String? get inputmodeAttribute => null;
 
   @override
   bool get submitActionOnEnter => false;

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -410,7 +410,8 @@ void _testCullRectComputation() {
 
     final PersistedPicture picture = enumeratePictures().single;
     expect(picture.optimalLocalCullRect, const ui.Rect.fromLTRB(0, 0, 500, 100));
-  }, skip: '''TODO(https://github.com/flutter/flutter/issues/40395)
+  }, skip: '''
+  TODO(https://github.com/flutter/flutter/issues/40395)
   Needs ability to set iframe to 500,100 size. Current screen seems to be 500,500''');
 
   // Draw a picture that overflows the screen. Verify that cull rect is the
@@ -492,7 +493,8 @@ void _testCullRectComputation() {
     expect(
         picture.debugExactGlobalCullRect, const ui.Rect.fromLTRB(0, 70, 20, 100));
     expect(picture.optimalLocalCullRect, const ui.Rect.fromLTRB(0, -20, 20, 10));
-  }, skip: '''TODO(https://github.com/flutter/flutter/issues/40395)
+  }, skip: '''
+  TODO(https://github.com/flutter/flutter/issues/40395)
   Needs ability to set iframe to 500,100 size. Current screen seems to be 500,500''');
 
   // Draw a picture inside a layer clip but fill all available space inside it.

--- a/lib/web_ui/test/locale_test.dart
+++ b/lib/web_ui/test/locale_test.dart
@@ -12,7 +12,7 @@ void main() {
 
 void testMain() {
   test('Locale', () {
-    const Null $null = null;
+    const String? $null = null;
     expect(const Locale('en').toString(), 'en');
     expect(const Locale('en'), const Locale('en', $null));
     expect(const Locale('en').hashCode, const Locale('en', $null).hashCode);

--- a/lib/web_ui/test/path_test.dart
+++ b/lib/web_ui/test/path_test.dart
@@ -475,8 +475,9 @@ void testMain() {
 
     test('Should be able to construct from empty path', () {
       final SurfacePath path = SurfacePath();
-      final SurfacePath? path2 = SurfacePath.from(path);
-      expect(path2, isNotNull);
+      expect(path.isEmpty, isTrue);
+      final SurfacePath path2 = SurfacePath.from(path);
+      expect(path2.isEmpty, isTrue);
     });
   });
 

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -104,7 +104,7 @@ void testMain() async {
       await ui.loadFontFromList(Uint8List.view(response.response),
           fontFamily: 'Blehm');
       final Completer<void> completer = Completer();
-      html.window.requestAnimationFrame( (_) { completer.complete(true); } );
+      html.window.requestAnimationFrame( (_) { completer.complete(); } );
       await(completer.future);
       window.onPlatformMessage = oldHandler;
       expect(actualName, 'flutter/system');

--- a/lib/web_ui/test/text/line_breaker_test.dart
+++ b/lib/web_ui/test/text/line_breaker_test.dart
@@ -304,9 +304,9 @@ class Line {
     final String bk = String.fromCharCode(0x000B);
     final String nl = String.fromCharCode(0x0085);
     return text
-        .replaceAll('"', '\\"')
-        .replaceAll('\n', '\\n')
-        .replaceAll('\r', '\\r')
+        .replaceAll('"', r'\"')
+        .replaceAll('\n', r'\n')
+        .replaceAll('\r', r'\r')
         .replaceAll(bk, '{BK}')
         .replaceAll(nl, '{NL}');
   }


### PR DESCRIPTION
The root analysis options has been updated over time. However, because the web version effectively ignores it (despite trying to list all lints that don't work yet) we haven't picked up any of the new lints, because the analyzer wasn't making the author aware of the violations in the web code. This PR changes the approach:

- Import the root options and explicitly disable lints that our code violates. This way any new lints introduced in the root file will automatically take effect in the web code.
- Fix several lint violations.
