### PR TITLE
Always complete platform message requests.

### DIFF
--- a/shell/platform/fuchsia/flutter/focus_delegate.h
+++ b/shell/platform/fuchsia/flutter/focus_delegate.h
@@ -31,7 +31,7 @@ class FocusDelegate {
 
   /// Completes the platform message request with the FocusDelegate's most
   /// recent focus state.
-  virtual void CompleteCurrentFocusState(
+  virtual bool CompleteCurrentFocusState(
       fml::RefPtr<flutter::PlatformMessageResponse> response);
 
   /// Completes the platform message request with the FocusDelegate's next focus
@@ -39,12 +39,12 @@ class FocusDelegate {
   ///
   /// Only one outstanding request may exist at a time. Any others will be
   /// completed empty.
-  virtual void CompleteNextFocusState(
+  virtual bool CompleteNextFocusState(
       fml::RefPtr<flutter::PlatformMessageResponse> response);
 
   /// Completes a platform message request by attempting to give focus for a
   /// given viewRef.
-  virtual void RequestFocus(
+  virtual bool RequestFocus(
       rapidjson::Value request,
       fml::RefPtr<flutter::PlatformMessageResponse> response);
 

--- a/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
+++ b/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
@@ -76,7 +76,7 @@ TEST_F(FocusDelegateTest, WatchCallbackSeries) {
     // CompleteCurrentFocusState should complete with the current (up to date)
     // focus state.
     auto response = FakePlatformMessageResponse::Create();
-    focus_delegate->CompleteCurrentFocusState(response);
+    EXPECT_TRUE(focus_delegate->CompleteCurrentFocusState(response));
     response->ExpectCompleted(focus_state ? "[true]" : "[false]");
 
     // Ensure this callback always happens in lockstep with
@@ -92,13 +92,12 @@ TEST_F(FocusDelegateTest, WatchCallbackSeries) {
   do {
     // Ensure the next focus state is handled correctly.
     auto response1 = FakePlatformMessageResponse::Create();
-    focus_delegate->CompleteNextFocusState(response1);
+    EXPECT_TRUE(focus_delegate->CompleteNextFocusState(response1));
 
     // Since there's already an outstanding PlatformMessageResponse, this one
     // should be completed empty.
     auto response = FakePlatformMessageResponse::Create();
-    focus_delegate->CompleteNextFocusState(response);
-    response->ExpectCompleted("");
+    EXPECT_FALSE(focus_delegate->CompleteNextFocusState(response));
 
     // Post watch events and trigger the next vrf event.
     RunLoopUntilIdle();
@@ -111,7 +110,7 @@ TEST_F(FocusDelegateTest, WatchCallbackSeries) {
     // Check CompleteCurrentFocusState again, and increment vrf_index, since we
     // move on to the next focus state.
     response = FakePlatformMessageResponse::Create();
-    focus_delegate->CompleteCurrentFocusState(response);
+    EXPECT_TRUE(focus_delegate->CompleteCurrentFocusState(response));
     response->ExpectCompleted(vrf_states[vrf_index++] ? "[true]" : "[false]");
 
     // vrf->times_watched should always be 1 more than the amount of vrf events

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -733,7 +733,15 @@ void PlatformView::HandlePlatformMessage(
     flutter::PlatformView::HandlePlatformMessage(std::move(message));
     return;
   }
-  found->second(std::move(message));
+  auto response = message->response();
+  bool response_handled = found->second(std::move(message));
+
+  // Ensure all responses are completed.
+  if (response && !response_handled) {
+    // response_handled should be true if the response was completed.
+    FML_DCHECK(!response->is_complete());
+    response->CompleteEmpty();
+  }
 }
 
 // |flutter::PlatformView|
@@ -758,7 +766,7 @@ void PlatformView::UpdateSemantics(
 }
 
 // Channel handler for kAccessibilityChannel
-void PlatformView::HandleAccessibilityChannelPlatformMessage(
+bool PlatformView::HandleAccessibilityChannelPlatformMessage(
     std::unique_ptr<flutter::PlatformMessage> message) {
   FML_DCHECK(message->channel() == kAccessibilityChannel);
 
@@ -780,33 +788,23 @@ void PlatformView::HandleAccessibilityChannelPlatformMessage(
     on_request_announce_callback_(text);
   }
 
-  message->response()->CompleteEmpty();
+  // Complete with an empty response.
+  return false;
 }
 
 // Channel handler for kFlutterPlatformChannel
-void PlatformView::HandleFlutterPlatformChannelPlatformMessage(
+bool PlatformView::HandleFlutterPlatformChannelPlatformMessage(
     std::unique_ptr<flutter::PlatformMessage> message) {
   FML_DCHECK(message->channel() == kFlutterPlatformChannel);
-  const auto& data = message->data();
-  rapidjson::Document document;
-  document.Parse(reinterpret_cast<const char*>(data.GetMapping()),
-                 data.GetSize());
-  if (document.HasParseError() || !document.IsObject()) {
-    return;
-  }
-
-  auto root = document.GetObject();
-  auto method = root.FindMember("method");
-  if (method == root.MemberEnd() || !method->value.IsString()) {
-    return;
-  }
 
   // Fuchsia does not handle any platform messages at this time.
-  message->response()->CompleteEmpty();
+
+  // Complete with an empty response.
+  return false;
 }
 
 // Channel handler for kTextInputChannel
-void PlatformView::HandleFlutterTextInputChannelPlatformMessage(
+bool PlatformView::HandleFlutterTextInputChannelPlatformMessage(
     std::unique_ptr<flutter::PlatformMessage> message) {
   FML_DCHECK(message->channel() == kTextInputChannel);
   const auto& data = message->data();
@@ -814,12 +812,12 @@ void PlatformView::HandleFlutterTextInputChannelPlatformMessage(
   document.Parse(reinterpret_cast<const char*>(data.GetMapping()),
                  data.GetSize());
   if (document.HasParseError() || !document.IsObject()) {
-    return;
+    return false;
   }
   auto root = document.GetObject();
   auto method = root.FindMember("method");
   if (method == root.MemberEnd() || !method->value.IsString()) {
-    return;
+    return false;
   }
 
   if (method->value == "TextInput.show") {
@@ -836,10 +834,10 @@ void PlatformView::HandleFlutterTextInputChannelPlatformMessage(
     auto args = root.FindMember("args");
     if (args == root.MemberEnd() || !args->value.IsArray() ||
         args->value.Size() != 2)
-      return;
+      return false;
     const auto& configuration = args->value[1];
     if (!configuration.IsObject()) {
-      return;
+      return false;
     }
     // TODO(abarth): Read the keyboard type from the configuration.
     current_text_input_client_ = args->value[0].GetInt();
@@ -853,7 +851,7 @@ void PlatformView::HandleFlutterTextInputChannelPlatformMessage(
     if (ime_) {
       auto args_it = root.FindMember("args");
       if (args_it == root.MemberEnd() || !args_it->value.IsObject()) {
-        return;
+        return false;
       }
       const auto& args = args_it->value;
       fuchsia::ui::input::TextInputState state;
@@ -895,9 +893,11 @@ void PlatformView::HandleFlutterTextInputChannelPlatformMessage(
     FML_DLOG(ERROR) << "Unknown " << message->channel() << " method "
                     << method->value.GetString();
   }
+  // Complete with an empty response.
+  return false;
 }
 
-void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
+bool PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
     std::unique_ptr<flutter::PlatformMessage> message) {
   FML_DCHECK(message->channel() == kFlutterPlatformViewsChannel);
   const auto& data = message->data();
@@ -906,26 +906,26 @@ void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
                  data.GetSize());
   if (document.HasParseError() || !document.IsObject()) {
     FML_LOG(ERROR) << "Could not parse document";
-    return;
+    return false;
   }
   auto root = document.GetObject();
   auto method = root.FindMember("method");
   if (method == root.MemberEnd() || !method->value.IsString()) {
-    return;
+    return false;
   }
 
   if (method->value == "View.enableWireframe") {
     auto args_it = root.FindMember("args");
     if (args_it == root.MemberEnd() || !args_it->value.IsObject()) {
       FML_LOG(ERROR) << "No arguments found.";
-      return;
+      return false;
     }
     const auto& args = args_it->value;
 
     auto enable = args.FindMember("enable");
     if (!enable->value.IsBool()) {
       FML_LOG(ERROR) << "Argument 'enable' is not a bool";
-      return;
+      return false;
     }
 
     wireframe_enabled_callback_(enable->value.GetBool());
@@ -933,26 +933,26 @@ void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
     auto args_it = root.FindMember("args");
     if (args_it == root.MemberEnd() || !args_it->value.IsObject()) {
       FML_LOG(ERROR) << "No arguments found.";
-      return;
+      return false;
     }
     const auto& args = args_it->value;
 
     auto view_id = args.FindMember("viewId");
     if (!view_id->value.IsUint64()) {
       FML_LOG(ERROR) << "Argument 'viewId' is not a int64";
-      return;
+      return false;
     }
 
     auto hit_testable = args.FindMember("hitTestable");
     if (!hit_testable->value.IsBool()) {
       FML_LOG(ERROR) << "Argument 'hitTestable' is not a bool";
-      return;
+      return false;
     }
 
     auto focusable = args.FindMember("focusable");
     if (!focusable->value.IsBool()) {
       FML_LOG(ERROR) << "Argument 'focusable' is not a bool";
-      return;
+      return false;
     }
 
     const int64_t view_id_raw = view_id->value.GetUint64();
@@ -962,7 +962,7 @@ void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
          message = std::move(message)]() {
           // The client is waiting for view creation. Send an empty response
           // back to signal the view was created.
-          if (message->response().get()) {
+          if (message->response()) {
             message->response()->Complete(
                 std::make_unique<fml::NonOwnedMapping>((const uint8_t*)"[0]",
                                                        3u));
@@ -987,30 +987,31 @@ void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
     on_create_view_callback_(
         view_id_raw, std::move(on_view_created), std::move(on_view_bound),
         hit_testable->value.GetBool(), focusable->value.GetBool());
+    return true;
   } else if (method->value == "View.update") {
     auto args_it = root.FindMember("args");
     if (args_it == root.MemberEnd() || !args_it->value.IsObject()) {
       FML_LOG(ERROR) << "No arguments found.";
-      return;
+      return false;
     }
     const auto& args = args_it->value;
 
     auto view_id = args.FindMember("viewId");
     if (!view_id->value.IsUint64()) {
       FML_LOG(ERROR) << "Argument 'viewId' is not a int64";
-      return;
+      return false;
     }
 
     auto hit_testable = args.FindMember("hitTestable");
     if (!hit_testable->value.IsBool()) {
       FML_LOG(ERROR) << "Argument 'hitTestable' is not a bool";
-      return;
+      return false;
     }
 
     auto focusable = args.FindMember("focusable");
     if (!focusable->value.IsBool()) {
       FML_LOG(ERROR) << "Argument 'focusable' is not a bool";
-      return;
+      return false;
     }
 
     SkRect view_occlusion_hint_raw = SkRect::MakeEmpty();
@@ -1058,14 +1059,14 @@ void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
     auto args_it = root.FindMember("args");
     if (args_it == root.MemberEnd() || !args_it->value.IsObject()) {
       FML_LOG(ERROR) << "No arguments found.";
-      return;
+      return false;
     }
     const auto& args = args_it->value;
 
     auto view_id = args.FindMember("viewId");
     if (!view_id->value.IsUint64()) {
       FML_LOG(ERROR) << "Argument 'viewId' is not a int64";
-      return;
+      return false;
     }
 
     const int64_t view_id_raw = view_id->value.GetUint64();
@@ -1087,18 +1088,20 @@ void PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
         };
     on_destroy_view_callback_(view_id_raw, std::move(on_view_unbound));
   } else if (method->value == "HostView.getCurrentFocusState") {
-    focus_delegate_->CompleteCurrentFocusState(message->response());
+    return focus_delegate_->CompleteCurrentFocusState(message->response());
   } else if (method->value == "HostView.getNextFocusState") {
-    focus_delegate_->CompleteNextFocusState(message->response());
+    return focus_delegate_->CompleteNextFocusState(message->response());
   } else if (method->value == "View.requestFocus") {
-    focus_delegate_->RequestFocus(root, message->response());
+    return focus_delegate_->RequestFocus(root, message->response());
   } else {
     FML_DLOG(ERROR) << "Unknown " << message->channel() << " method "
                     << method->value.GetString();
   }
+  // Complete with an empty response by default.
+  return false;
 }
 
-void PlatformView::HandleFuchsiaShaderWarmupChannelPlatformMessage(
+bool PlatformView::HandleFuchsiaShaderWarmupChannelPlatformMessage(
     OnShaderWarmup on_shader_warmup,
     std::unique_ptr<flutter::PlatformMessage> message) {
   FML_DCHECK(message->channel() == kFuchsiaShaderWarmupChannel);
@@ -1110,7 +1113,7 @@ void PlatformView::HandleFuchsiaShaderWarmupChannelPlatformMessage(
         std::make_unique<fml::DataMapping>(std::vector<uint8_t>(
             (const uint8_t*)result.c_str(),
             (const uint8_t*)result.c_str() + result.length())));
-    return;
+    return true;
   }
 
   const auto& data = message->data();
@@ -1119,37 +1122,37 @@ void PlatformView::HandleFuchsiaShaderWarmupChannelPlatformMessage(
                  data.GetSize());
   if (document.HasParseError() || !document.IsObject()) {
     FML_LOG(ERROR) << "Could not parse document";
-    return;
+    return false;
   }
   auto root = document.GetObject();
   auto method = root.FindMember("method");
   if (method == root.MemberEnd() || !method->value.IsString() ||
       method->value != "WarmupSkps") {
     FML_LOG(ERROR) << "Invalid method name";
-    return;
+    return false;
   }
 
   auto args_it = root.FindMember("args");
   if (args_it == root.MemberEnd() || !args_it->value.IsObject()) {
     FML_LOG(ERROR) << "No arguments found.";
-    return;
+    return false;
   }
 
   auto shaders_it = root["args"].FindMember("shaders");
   if (shaders_it == root["args"].MemberEnd() || !shaders_it->value.IsArray()) {
     FML_LOG(ERROR) << "No shaders found.";
-    return;
+    return false;
   }
 
   auto width_it = root["args"].FindMember("width");
   auto height_it = root["args"].FindMember("height");
   if (width_it == root["args"].MemberEnd() || !width_it->value.IsNumber()) {
     FML_LOG(ERROR) << "Invalid width";
-    return;
+    return false;
   }
   if (height_it == root["args"].MemberEnd() || !height_it->value.IsNumber()) {
     FML_LOG(ERROR) << "Invalid height";
-    return;
+    return false;
   }
   auto width = width_it->value.GetUint64();
   auto height = height_it->value.GetUint64();
@@ -1174,6 +1177,8 @@ void PlatformView::HandleFuchsiaShaderWarmupChannelPlatformMessage(
   };
 
   on_shader_warmup(skp_paths, completion_callback, width, height);
+  // The response has already been completed by us.
+  return true;
 }
 
 }  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -161,23 +161,23 @@ class PlatformView final : public flutter::PlatformView,
   // Channel handler for kAccessibilityChannel. This is currently not
   // being used, but it is necessary to handle accessibility messages
   // that are sent by Flutter when semantics is enabled.
-  void HandleAccessibilityChannelPlatformMessage(
+  bool HandleAccessibilityChannelPlatformMessage(
       std::unique_ptr<flutter::PlatformMessage> message);
 
   // Channel handler for kFlutterPlatformChannel
-  void HandleFlutterPlatformChannelPlatformMessage(
+  bool HandleFlutterPlatformChannelPlatformMessage(
       std::unique_ptr<flutter::PlatformMessage> message);
 
   // Channel handler for kTextInputChannel
-  void HandleFlutterTextInputChannelPlatformMessage(
+  bool HandleFlutterTextInputChannelPlatformMessage(
       std::unique_ptr<flutter::PlatformMessage> message);
 
   // Channel handler for kPlatformViewsChannel.
-  void HandleFlutterPlatformViewsChannelPlatformMessage(
+  bool HandleFlutterPlatformViewsChannelPlatformMessage(
       std::unique_ptr<flutter::PlatformMessage> message);
 
   // Channel handler for kFuchsiaShaderWarmupChannel.
-  static void HandleFuchsiaShaderWarmupChannelPlatformMessage(
+  static bool HandleFuchsiaShaderWarmupChannelPlatformMessage(
       OnShaderWarmup on_shader_warmup,
       std::unique_ptr<flutter::PlatformMessage> message);
 
@@ -230,7 +230,7 @@ class PlatformView final : public flutter::PlatformView,
 
   std::set<int> down_pointers_;
   std::map<std::string /* channel */,
-           std::function<void(
+           std::function<bool /* response_handled */ (
                std::unique_ptr<
                    flutter::PlatformMessage> /* message */)> /* handler */>
       platform_message_handlers_;

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -331,6 +331,71 @@ class PlatformViewTests : public ::testing::Test {
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewTests);
 };
 
+// This test makes sure that the PlatformView always completes a platform
+// message request, even for error conditions or if the request is malformed.
+TEST_F(PlatformViewTests, InvalidPlatformMessageRequest) {
+  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
+  MockPlatformViewDelegate delegate;
+  flutter::TaskRunners task_runners =
+      flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
+
+  FakeViewRefFocused vrf;
+  fidl::BindingSet<fuchsia::ui::views::ViewRefFocused> vrf_bindings;
+  auto vrf_handle = vrf_bindings.AddBinding(&vrf);
+
+  flutter_runner::PlatformView platform_view =
+      PlatformViewBuilder(delegate, std::move(task_runners),
+                          services_provider.service_directory())
+          .SetViewRefFocused(std::move(vrf_handle))
+          .Build();
+
+  // Cast platform_view to its base view so we can have access to the public
+  // "HandlePlatformMessage" function.
+  auto base_view = static_cast<flutter::PlatformView*>(&platform_view);
+  EXPECT_TRUE(base_view);
+
+  // Invalid platform channel.
+  auto response1 = FakePlatformMessageResponse::Create();
+  base_view->HandlePlatformMessage(response1->WithMessage(
+      "flutter/invalid", "{\"method\":\"Invalid.invalidMethod\"}"));
+
+  // Invalid json.
+  auto response2 = FakePlatformMessageResponse::Create();
+  base_view->HandlePlatformMessage(
+      response2->WithMessage("flutter/platform_views", "{Invalid JSON"));
+
+  // Invalid method.
+  auto response3 = FakePlatformMessageResponse::Create();
+  base_view->HandlePlatformMessage(response3->WithMessage(
+      "flutter/platform_views", "{\"method\":\"View.focus.invalidMethod\"}"));
+
+  // Missing arguments.
+  auto response4 = FakePlatformMessageResponse::Create();
+  base_view->HandlePlatformMessage(response4->WithMessage(
+      "flutter/platform_views", "{\"method\":\"View.update\"}"));
+  auto response5 = FakePlatformMessageResponse::Create();
+  base_view->HandlePlatformMessage(
+      response5->WithMessage("flutter/platform_views",
+                             "{\"method\":\"View.update\",\"args\":{"
+                             "\"irrelevantField\":\"irrelevantValue\"}}"));
+
+  // Wrong argument types.
+  auto response6 = FakePlatformMessageResponse::Create();
+  base_view->HandlePlatformMessage(response6->WithMessage(
+      "flutter/platform_views",
+      "{\"method\":\"View.update\",\"args\":{\"viewId\":false,\"hitTestable\":"
+      "123,\"focusable\":\"yes\"}}"));
+
+  // Run the event loop and check our responses.
+  RunLoopUntilIdle();
+  response1->ExpectCompleted("");
+  response2->ExpectCompleted("");
+  response3->ExpectCompleted("");
+  response4->ExpectCompleted("");
+  response5->ExpectCompleted("");
+  response6->ExpectCompleted("");
+}
+
 // This test makes sure that the PlatformView correctly returns a Surface
 // instance that can surface the provided gr_context and view_embedder.
 TEST_F(PlatformViewTests, CreateSurfaceTest) {
@@ -413,7 +478,7 @@ TEST_F(PlatformViewTests, SetViewportMetrics) {
   RunLoopUntilIdle();
   EXPECT_EQ(delegate.metrics(), flutter::ViewportMetrics());
 
-  // Test updating with an invalid size.  The final metrics should be unchanged.
+  // Test updating with an invalid size. The final metrics should be unchanged.
   events.clear();
   events.emplace_back(
       fuchsia::ui::scenic::Event::WithGfx(


### PR DESCRIPTION
Functions/methods registered in `platform_message_handlers_` should return true or false, indicating whether the response was handled by them.
This makes it more explicit whether a platform message handler will asynchronously complete a response, versus if there was malformed/invalid request.

If the response was not handled, `CompleteEmpty` in `PlatformView::HandlePlatformMessage` to avoid hanging `Future`s in dart.

This fixes https://fxbug.dev/79056.

CC: @naudzghebre 