### PR TITLE
[refactor] Migrate to View.focus.*.

### DIFF
--- a/shell/platform/fuchsia/flutter/focus_delegate.cc
+++ b/shell/platform/fuchsia/flutter/focus_delegate.cc
@@ -16,12 +16,89 @@ void FocusDelegate::WatchLoop(std::function<void(bool)> callback) {
 
   watch_loop_ = [this, callback = std::move(callback)](auto focus_state) {
     callback(is_focused_ = focus_state.focused());
-    if (next_focus_request_) {
-      CompleteCurrentFocusState(std::exchange(next_focus_request_, nullptr));
-    }
+    Complete(std::exchange(next_focus_request_, nullptr),
+             is_focused_ ? "[true]" : "[false]");
     view_ref_focused_->Watch(watch_loop_);
   };
   view_ref_focused_->Watch(watch_loop_);
+}
+
+bool FocusDelegate::HandlePlatformMessage(
+    rapidjson::Value request,
+    fml::RefPtr<flutter::PlatformMessageResponse> response) {
+  auto method = request.FindMember("method");
+  if (method == request.MemberEnd() || !method->value.IsString()) {
+    return false;
+  }
+
+  if (method->value == "View.focus.getCurrent") {
+    Complete(std::move(response), is_focused_ ? "[true]" : "[false]");
+  } else if (method->value == "View.focus.getNext") {
+    if (next_focus_request_) {
+      FML_LOG(ERROR) << "An outstanding PlatformMessageResponse already exists "
+                        "for the next focus state!";
+      Complete(std::move(response), "[null]");
+    } else {
+      next_focus_request_ = std::move(response);
+    }
+  } else if (method->value == "View.focus.request") {
+    return RequestFocus(std::move(request), std::move(response));
+  } else {
+    return false;
+  }
+  // All of our methods complete the platform message response.
+  return true;
+}
+
+void FocusDelegate::Complete(
+    fml::RefPtr<flutter::PlatformMessageResponse> response,
+    std::string value) {
+  if (response) {
+    response->Complete(std::make_unique<fml::DataMapping>(
+        std::vector<uint8_t>(value.begin(), value.end())));
+  }
+}
+
+bool FocusDelegate::RequestFocus(
+    rapidjson::Value request,
+    fml::RefPtr<flutter::PlatformMessageResponse> response) {
+  auto args_it = request.FindMember("args");
+  if (args_it == request.MemberEnd() || !args_it->value.IsObject()) {
+    FML_LOG(ERROR) << "No arguments found.";
+    return false;
+  }
+  const auto& args = args_it->value;
+
+  auto view_ref = args.FindMember("viewRef");
+  if (!view_ref->value.IsUint64()) {
+    FML_LOG(ERROR) << "Argument 'viewRef' is not a uint64";
+    return false;
+  }
+
+  zx_handle_t handle = view_ref->value.GetUint64();
+  zx_handle_t out_handle;
+  zx_status_t status =
+      zx_handle_duplicate(handle, ZX_RIGHT_SAME_RIGHTS, &out_handle);
+  if (status != ZX_OK) {
+    FML_LOG(ERROR) << "Argument 'viewRef' is not valid";
+    return false;
+  }
+  auto ref = fuchsia::ui::views::ViewRef({
+      .reference = zx::eventpair(out_handle),
+  });
+  focuser_->RequestFocus(
+      std::move(ref),
+      [this, response = std::move(response)](
+          fuchsia::ui::views::Focuser_RequestFocus_Result result) {
+        int result_code =
+            result.is_err()
+                ? static_cast<
+                      std::underlying_type_t<fuchsia::ui::views::Error>>(
+                      result.err())
+                : 0;
+        Complete(std::move(response), "[" + std::to_string(result_code) + "]");
+      });
+  return true;
 }
 
 bool FocusDelegate::CompleteCurrentFocusState(
@@ -40,56 +117,6 @@ bool FocusDelegate::CompleteNextFocusState(
     return false;
   }
   next_focus_request_ = std::move(response);
-  return true;
-}
-
-bool FocusDelegate::RequestFocus(
-    rapidjson::Value request,
-    fml::RefPtr<flutter::PlatformMessageResponse> response) {
-  auto args_it = request.FindMember("args");
-  if (args_it == request.MemberEnd() || !args_it->value.IsObject()) {
-    FML_LOG(ERROR) << "No arguments found.";
-    return false;
-  }
-  const auto& args = args_it->value;
-
-  auto view_ref = args.FindMember("viewRef");
-  if (!view_ref->value.IsUint64()) {
-    FML_LOG(ERROR) << "Argument 'viewRef' is not a int64";
-    return false;
-  }
-
-  zx_handle_t handle = view_ref->value.GetUint64();
-  zx_handle_t out_handle;
-  zx_status_t status =
-      zx_handle_duplicate(handle, ZX_RIGHT_SAME_RIGHTS, &out_handle);
-  if (status != ZX_OK) {
-    FML_LOG(ERROR) << "Argument 'viewRef' is not valid";
-    return false;
-  }
-  auto ref = fuchsia::ui::views::ViewRef({
-      .reference = zx::eventpair(out_handle),
-  });
-  focuser_->RequestFocus(
-      std::move(ref),
-      [view_ref = view_ref->value.GetUint64(), response = std::move(response)](
-          fuchsia::ui::views::Focuser_RequestFocus_Result result) {
-        if (!response) {
-          return;
-        }
-        int result_code =
-            result.is_err()
-                ? static_cast<
-                      std::underlying_type_t<fuchsia::ui::views::Error>>(
-                      result.err())
-                : 0;
-
-        std::ostringstream out;
-        out << "[" << result_code << "]";
-        std::string output = out.str();
-        response->Complete(std::make_unique<fml::DataMapping>(
-            std::vector<uint8_t>(output.begin(), output.end())));
-      });
   return true;
 }
 

--- a/shell/platform/fuchsia/flutter/focus_delegate.h
+++ b/shell/platform/fuchsia/flutter/focus_delegate.h
@@ -21,17 +21,34 @@ class FocusDelegate {
                 fidl::InterfaceHandle<fuchsia::ui::views::Focuser> focuser)
       : view_ref_focused_(view_ref_focused.Bind()), focuser_(focuser.Bind()) {}
 
-  virtual ~FocusDelegate() = default;
-
   /// Continuously watches the host viewRef for focus events, invoking a
   /// callback each time.
   ///
   /// This can only be called once.
-  virtual void WatchLoop(std::function<void(bool)> callback);
+  void WatchLoop(std::function<void(bool)> callback);
+
+  /// Handles the following focus-related platform message requests:
+  /// View.focus.getCurrent
+  ///  - Completes with the FocusDelegate's most recent focus state, either
+  ///    [true] or [false].
+  /// View.focus.getNext
+  ///  - Completes with the FocusDelegate's next focus state, either [true] or
+  ///    [false].
+  ///  - Only one outstanding request may exist at a time. Any others will be
+  ///    completed with [null].
+  /// View.focus.request
+  ///  - Attempts to give focus for a given viewRef. Completes with [0] on
+  ///    success, or [fuchsia::ui::views::Error] on failure.
+  ///
+  /// Returns false if a malformed/invalid request needs to be completed empty.
+  bool HandlePlatformMessage(
+      rapidjson::Value request,
+      fml::RefPtr<flutter::PlatformMessageResponse> response);
 
   /// Completes the platform message request with the FocusDelegate's most
   /// recent focus state.
-  virtual bool CompleteCurrentFocusState(
+  // TODO(fxbug.dev/79740): Delete after soft transition.
+  bool CompleteCurrentFocusState(
       fml::RefPtr<flutter::PlatformMessageResponse> response);
 
   /// Completes the platform message request with the FocusDelegate's next focus
@@ -39,14 +56,15 @@ class FocusDelegate {
   ///
   /// Only one outstanding request may exist at a time. Any others will be
   /// completed empty.
-  virtual bool CompleteNextFocusState(
+  // TODO(fxbug.dev/79740): Delete after soft transition.
+  bool CompleteNextFocusState(
       fml::RefPtr<flutter::PlatformMessageResponse> response);
 
   /// Completes a platform message request by attempting to give focus for a
   /// given viewRef.
-  virtual bool RequestFocus(
-      rapidjson::Value request,
-      fml::RefPtr<flutter::PlatformMessageResponse> response);
+  // TODO(fxbug.dev/79740): Make private after soft transition.
+  bool RequestFocus(rapidjson::Value request,
+                    fml::RefPtr<flutter::PlatformMessageResponse> response);
 
  private:
   fuchsia::ui::views::ViewRefFocusedPtr view_ref_focused_;
@@ -57,7 +75,7 @@ class FocusDelegate {
   fml::RefPtr<flutter::PlatformMessageResponse> next_focus_request_;
 
   void Complete(fml::RefPtr<flutter::PlatformMessageResponse> response,
-                bool value);
+                std::string value);
 
   FML_DISALLOW_COPY_AND_ASSIGN(FocusDelegate);
 };

--- a/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
+++ b/shell/platform/fuchsia/flutter/focus_delegate_unittests.cc
@@ -73,6 +73,129 @@ TEST_F(FocusDelegateTest, WatchCallbackSeries) {
     // what was fired from the vrf.
     EXPECT_EQ(vrf_states[callback_index], focus_state);
 
+    // View.focus.getCurrent should complete with the current (up to date) focus
+    // state.
+    auto response = FakePlatformMessageResponse::Create();
+    EXPECT_TRUE(focus_delegate->HandlePlatformMessage(
+        ParsePlatformMessage("{\"method\":\"View.focus.getCurrent\"}"),
+        response));
+    response->ExpectCompleted(focus_state ? "[true]" : "[false]");
+
+    // Ensure this callback always happens in lockstep with
+    // vrf->ScheduleCallback.
+    EXPECT_EQ(vrf_index, callback_index++);
+  });
+
+  // Subsequent WatchLoop calls should not be respected.
+  focus_delegate->WatchLoop([](bool _) {
+    ADD_FAILURE() << "Subsequent WatchLoops should not be respected!";
+  });
+
+  do {
+    // Ensure the next focus state is handled correctly.
+    auto response1 = FakePlatformMessageResponse::Create();
+    EXPECT_TRUE(focus_delegate->HandlePlatformMessage(
+        ParsePlatformMessage("{\"method\":\"View.focus.getNext\"}"),
+        response1));
+
+    // Since there's already an outstanding PlatformMessageResponse, this one
+    // should be completed null.
+    auto response2 = FakePlatformMessageResponse::Create();
+    EXPECT_TRUE(focus_delegate->HandlePlatformMessage(
+        ParsePlatformMessage("{\"method\":\"View.focus.getNext\"}"),
+        response2));
+    response2->ExpectCompleted("[null]");
+
+    // Post watch events and trigger the next vrf event.
+    RunLoopUntilIdle();
+    vrf->ScheduleCallback(vrf_states[vrf_index]);
+    RunLoopUntilIdle();
+
+    // Next focus state should be completed by now.
+    response1->ExpectCompleted(vrf_states[vrf_index] ? "[true]" : "[false]");
+
+    // Check View.focus.getCurrent again, and increment vrf_index since we move
+    // on to the next focus state.
+    auto response3 = FakePlatformMessageResponse::Create();
+    EXPECT_TRUE(focus_delegate->HandlePlatformMessage(
+        ParsePlatformMessage("{\"method\":\"View.focus.getCurrent\"}"),
+        response3));
+    response3->ExpectCompleted(vrf_states[vrf_index++] ? "[true]" : "[false]");
+
+    // vrf->times_watched should always be 1 more than the amount of vrf events
+    // emitted.
+    EXPECT_EQ(vrf_index + 1, vrf->times_watched);
+  } while (vrf_index < vrf_states.size());
+}
+
+// Tests that HandlePlatformMessage() completes a "View.focus.request" response
+// with a non-error status code.
+TEST_F(FocusDelegateTest, RequestFocusTest) {
+  // This "Mock" ViewRef serves as the target for the RequestFocus operation.
+  auto mock_view_ref_pair = scenic::ViewRefPair::New();
+  // Create the platform message request.
+  std::ostringstream message;
+  message << "{"
+          << "    \"method\":\"View.focus.request\","
+          << "    \"args\": {"
+          << "       \"viewRef\":"
+          << mock_view_ref_pair.view_ref.reference.get() << "    }"
+          << "}";
+
+  // Dispatch the plaform message request with an expected completion response.
+  auto response = FakePlatformMessageResponse::Create();
+  EXPECT_TRUE(focus_delegate->HandlePlatformMessage(
+      ParsePlatformMessage(message.str()), response));
+  RunLoopUntilIdle();
+
+  response->ExpectCompleted("[0]");
+  EXPECT_TRUE(focuser->request_focus_called());
+}
+
+// Tests that HandlePlatformMessage() completes a "View.focus.request" response
+// with a Error::DENIED status code.
+TEST_F(FocusDelegateTest, RequestFocusFailTest) {
+  // This "Mock" ViewRef serves as the target for the RequestFocus operation.
+  auto mock_view_ref_pair = scenic::ViewRefPair::New();
+  // We're testing the focus failure case.
+  focuser->fail_request_focus();
+  // Create the platform message request.
+  std::ostringstream message;
+  message << "{"
+          << "    \"method\":\"View.focus.request\","
+          << "    \"args\": {"
+          << "       \"viewRef\":"
+          << mock_view_ref_pair.view_ref.reference.get() << "    }"
+          << "}";
+
+  // Dispatch the plaform message request with an expected completion response.
+  auto response = FakePlatformMessageResponse::Create();
+  EXPECT_TRUE(focus_delegate->HandlePlatformMessage(
+      ParsePlatformMessage(message.str()), response));
+  RunLoopUntilIdle();
+
+  response->ExpectCompleted(
+      "[" +
+      std::to_string(
+          static_cast<std::underlying_type_t<fuchsia::ui::views::Error>>(
+              fuchsia::ui::views::Error::DENIED)) +
+      "]");
+  EXPECT_TRUE(focuser->request_focus_called());
+}
+
+// Tests that WatchLoop() should callback and complete PlatformMessageResponses
+// correctly, given a series of vrf invocations.
+// TODO(fxbug.dev/79740): Delete after soft transition.
+TEST_F(FocusDelegateTest, DeprecatedWatchCallbackSeries) {
+  std::vector<bool> vrf_states{false, true,  true, false,
+                               true,  false, true, true};
+  std::size_t vrf_index = 0;
+  std::size_t callback_index = 0;
+  focus_delegate->WatchLoop([&](bool focus_state) {
+    // Make sure the focus state that FocusDelegate gives us is consistent with
+    // what was fired from the vrf.
+    EXPECT_EQ(vrf_states[callback_index], focus_state);
+
     // CompleteCurrentFocusState should complete with the current (up to date)
     // focus state.
     auto response = FakePlatformMessageResponse::Create();
@@ -121,7 +244,8 @@ TEST_F(FocusDelegateTest, WatchCallbackSeries) {
 
 // Tests that RequestFocus() completes the platform message's response with a
 // non-error status code.
-TEST_F(FocusDelegateTest, RequestFocusTest) {
+// TODO(fxbug.dev/79740): Delete after soft transition.
+TEST_F(FocusDelegateTest, DeprecatedRequestFocusTest) {
   // This "Mock" ViewRef serves as the target for the RequestFocus operation.
   auto mock_view_ref_pair = scenic::ViewRefPair::New();
   // Create the platform message request.
@@ -144,7 +268,8 @@ TEST_F(FocusDelegateTest, RequestFocusTest) {
 
 // Tests that RequestFocus() completes the platform message's response with a
 // Error::DENIED status code.
-TEST_F(FocusDelegateTest, RequestFocusFailTest) {
+// TODO(fxbug.dev/79740): Delete after soft transition.
+TEST_F(FocusDelegateTest, DeprecatedRequestFocusFailTest) {
   // This "Mock" ViewRef serves as the target for the RequestFocus operation.
   auto mock_view_ref_pair = scenic::ViewRefPair::New();
   // We're testing the focus failure case.

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -1018,9 +1018,169 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
 }
 
 // This test makes sure that the PlatformView forwards messages on the
+// "flutter/platform_views" channel for View.focus.getCurrent and
+// View.focus.getNext.
+TEST_F(PlatformViewTests, GetFocusStatesTest) {
+  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
+  MockPlatformViewDelegate delegate;
+  flutter::TaskRunners task_runners =
+      flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
+
+  FakeViewRefFocused vrf;
+  fidl::BindingSet<fuchsia::ui::views::ViewRefFocused> vrf_bindings;
+  auto vrf_handle = vrf_bindings.AddBinding(&vrf);
+
+  flutter_runner::PlatformView platform_view =
+      PlatformViewBuilder(delegate, std::move(task_runners),
+                          services_provider.service_directory())
+          .SetViewRefFocused(std::move(vrf_handle))
+          .Build();
+
+  // Cast platform_view to its base view so we can have access to the public
+  // "HandlePlatformMessage" function.
+  auto base_view = static_cast<flutter::PlatformView*>(&platform_view);
+  EXPECT_TRUE(base_view);
+
+  std::vector<bool> vrf_states{false, true,  true, false,
+                               true,  false, true, true};
+
+  for (std::size_t i = 0; i < vrf_states.size(); ++i) {
+    // View.focus.getNext should complete with the next focus state.
+    auto response1 = FakePlatformMessageResponse::Create();
+    base_view->HandlePlatformMessage(response1->WithMessage(
+        "flutter/platform_views", "{\"method\":\"View.focus.getNext\"}"));
+    // Duplicate View.focus.getNext requests should complete empty.
+    auto response2 = FakePlatformMessageResponse::Create();
+    base_view->HandlePlatformMessage(response2->WithMessage(
+        "flutter/platform_views", "{\"method\":\"View.focus.getNext\"}"));
+
+    // Post watch events and make sure the hanging get is invoked each time.
+    RunLoopUntilIdle();
+    EXPECT_EQ(vrf.times_watched, i + 1);
+
+    // Dispatch the next vrf event.
+    vrf.ScheduleCallback(vrf_states[i]);
+    RunLoopUntilIdle();
+
+    // Make sure View.focus.getCurrent completes with the current focus state.
+    auto response3 = FakePlatformMessageResponse::Create();
+    base_view->HandlePlatformMessage(response3->WithMessage(
+        "flutter/platform_views", "{\"method\":\"View.focus.getCurrent\"}"));
+    // Duplicate View.focus.getCurrent are allowed.
+    auto response4 = FakePlatformMessageResponse::Create();
+    base_view->HandlePlatformMessage(response4->WithMessage(
+        "flutter/platform_views", "{\"method\":\"View.focus.getCurrent\"}"));
+
+    // Run event loop and check our results.
+    RunLoopUntilIdle();
+    response1->ExpectCompleted(vrf_states[i] ? "[true]" : "[false]");
+    response2->ExpectCompleted("[null]");
+    response3->ExpectCompleted(vrf_states[i] ? "[true]" : "[false]");
+    response4->ExpectCompleted(vrf_states[i] ? "[true]" : "[false]");
+  }
+}
+
+// This test makes sure that the PlatformView forwards messages on the
+// "flutter/platform_views" channel for View.focus.request.
+TEST_F(PlatformViewTests, RequestFocusTest) {
+  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
+  MockPlatformViewDelegate delegate;
+  flutter::TaskRunners task_runners =
+      flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
+
+  FakeFocuser focuser;
+  fidl::BindingSet<fuchsia::ui::views::Focuser> focuser_bindings;
+  auto focuser_handle = focuser_bindings.AddBinding(&focuser);
+
+  flutter_runner::PlatformView platform_view =
+      PlatformViewBuilder(delegate, std::move(task_runners),
+                          services_provider.service_directory())
+          .SetFocuser(std::move(focuser_handle))
+          .Build();
+
+  // Cast platform_view to its base view so we can have access to the public
+  // "HandlePlatformMessage" function.
+  auto base_view = static_cast<flutter::PlatformView*>(&platform_view);
+  EXPECT_TRUE(base_view);
+
+  // This "Mock" ViewRef serves as the target for the RequestFocus operation.
+  auto mock_view_ref_pair = scenic::ViewRefPair::New();
+
+  // JSON for the message to be passed into the PlatformView.
+  std::ostringstream message;
+  message << "{"
+          << "    \"method\":\"View.focus.request\","
+          << "    \"args\": {"
+          << "       \"viewRef\":"
+          << mock_view_ref_pair.view_ref.reference.get() << "    }"
+          << "}";
+
+  // Dispatch the plaform message request.
+  auto response = FakePlatformMessageResponse::Create();
+  base_view->HandlePlatformMessage(
+      response->WithMessage("flutter/platform_views", message.str()));
+  RunLoopUntilIdle();
+
+  response->ExpectCompleted("[0]");
+  EXPECT_TRUE(focuser.request_focus_called());
+}
+
+// This test makes sure that the PlatformView correctly replies with an error
+// response when a View.focus.request call fails.
+TEST_F(PlatformViewTests, RequestFocusFailTest) {
+  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
+  MockPlatformViewDelegate delegate;
+  flutter::TaskRunners task_runners =
+      flutter::TaskRunners("test_runners", nullptr, nullptr, nullptr, nullptr);
+
+  FakeFocuser focuser;
+  focuser.fail_request_focus();
+  fidl::BindingSet<fuchsia::ui::views::Focuser> focuser_bindings;
+  auto focuser_handle = focuser_bindings.AddBinding(&focuser);
+
+  flutter_runner::PlatformView platform_view =
+      PlatformViewBuilder(delegate, std::move(task_runners),
+                          services_provider.service_directory())
+          .SetFocuser(std::move(focuser_handle))
+          .Build();
+
+  // Cast platform_view to its base view so we can have access to the public
+  // "HandlePlatformMessage" function.
+  auto base_view = static_cast<flutter::PlatformView*>(&platform_view);
+  EXPECT_TRUE(base_view);
+
+  // This "Mock" ViewRef serves as the target for the RequestFocus operation.
+  auto mock_view_ref_pair = scenic::ViewRefPair::New();
+
+  // JSON for the message to be passed into the PlatformView.
+  std::ostringstream message;
+  message << "{"
+          << "    \"method\":\"View.focus.request\","
+          << "    \"args\": {"
+          << "       \"viewRef\":"
+          << mock_view_ref_pair.view_ref.reference.get() << "    }"
+          << "}";
+
+  // Dispatch the plaform message request.
+  auto response = FakePlatformMessageResponse::Create();
+  base_view->HandlePlatformMessage(
+      response->WithMessage("flutter/platform_views", message.str()));
+  RunLoopUntilIdle();
+
+  response->ExpectCompleted(
+      "[" +
+      std::to_string(
+          static_cast<std::underlying_type_t<fuchsia::ui::views::Error>>(
+              fuchsia::ui::views::Error::DENIED)) +
+      "]");
+  EXPECT_TRUE(focuser.request_focus_called());
+}
+
+// This test makes sure that the PlatformView forwards messages on the
 // "flutter/platform_views" channel for GetCurrentFocusState and
 // GetNextFocusState.
-TEST_F(PlatformViewTests, GetFocusStatesTest) {
+// TODO(fxbug.dev/79740): Delete after soft transition.
+TEST_F(PlatformViewTests, DeprecatedGetFocusStatesTest) {
   sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
   MockPlatformViewDelegate delegate;
   flutter::TaskRunners task_runners =
@@ -1087,7 +1247,8 @@ TEST_F(PlatformViewTests, GetFocusStatesTest) {
 
 // This test makes sure that the PlatformView forwards messages on the
 // "flutter/platform_views" channel for RequestFocus.
-TEST_F(PlatformViewTests, RequestFocusTest) {
+// TODO(fxbug.dev/79740): Delete after soft transition.
+TEST_F(PlatformViewTests, DeprecatedRequestFocusTest) {
   sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
   MockPlatformViewDelegate delegate;
   flutter::TaskRunners task_runners =
@@ -1132,7 +1293,8 @@ TEST_F(PlatformViewTests, RequestFocusTest) {
 
 // This test makes sure that the PlatformView correctly replies with an error
 // response when a RequestFocus call fails.
-TEST_F(PlatformViewTests, RequestFocusFailTest) {
+// TODO(fxbug.dev/79740): Delete after soft transition.
+TEST_F(PlatformViewTests, DeprecatedRequestFocusFailTest) {
   sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
   MockPlatformViewDelegate delegate;
   flutter::TaskRunners task_runners =


### PR DESCRIPTION
This allows us to better encapsulate our platform_view delegates' responsibilities.

This fixes https://fxbug.dev/79740.

CC: @naudzghebre 