### PR TITLE
LibTx: Support multi-codepoint placeholders

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3496,6 +3496,12 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
   /// The `scale` parameter will scale the `width` and `height` by the specified amount,
   /// and keep track of the scale. The scales of placeholders added can be accessed
   /// through [placeholderScales]. This is primarily used for accessibility scaling.
+  ///
+  /// The `codepointLength` parameter is how many codepoints this placeholder will
+  /// take up. This impacts the indexes passed to and returned by [Paragraph]'s
+  /// getBoxesForRange, getPositionForOffset, getWordBoundary, and other methods
+  /// that deal directly with codepoint indexes. [Paragraph] will treat the placeholder
+  /// as if it were made up of `codepointLength` object replacement characters (0xFFFC).
   void addPlaceholder(double width, double height, PlaceholderAlignment alignment, {
     double scale = 1.0,
     double? baselineOffset,

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3500,6 +3500,7 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
     double scale = 1.0,
     double? baselineOffset,
     TextBaseline? baseline,
+    int codepointLength = 1,
   }) {
     // Require a baseline to be specified if using a baseline-based alignment.
     assert(!(alignment == PlaceholderAlignment.aboveBaseline ||
@@ -3508,11 +3509,11 @@ class ParagraphBuilder extends NativeFieldWrapperClass1 {
     // Default the baselineOffset to height if null. This will place the placeholder
     // fully above the baseline, similar to [PlaceholderAlignment.aboveBaseline].
     baselineOffset = baselineOffset ?? height;
-    _addPlaceholder(width * scale, height * scale, alignment.index, baselineOffset * scale, baseline?.index);
+    _addPlaceholder(width * scale, height * scale, alignment.index, baselineOffset * scale, baseline?.index, codepointLength);
     _placeholderCount++;
     _placeholderScales.add(scale);
   }
-  String? _addPlaceholder(double width, double height, int alignment, double baselineOffset, int? baseline) native 'ParagraphBuilder_addPlaceholder';
+  String? _addPlaceholder(double width, double height, int alignment, double baselineOffset, int? baseline, int codepointLength) native 'ParagraphBuilder_addPlaceholder';
 
   /// Applies the given paragraph style and returns a [Paragraph] containing the
   /// added text and associated styling.

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -512,10 +512,12 @@ Dart_Handle ParagraphBuilder::addPlaceholder(double width,
                                              double height,
                                              unsigned alignment,
                                              double baseline_offset,
-                                             unsigned baseline) {
+                                             unsigned baseline,
+                                             unsigned codepoint_length) {
   txt::PlaceholderRun placeholder_run(
       width, height, static_cast<txt::PlaceholderAlignment>(alignment),
-      static_cast<txt::TextBaseline>(baseline), baseline_offset);
+      static_cast<txt::TextBaseline>(baseline), baseline_offset,
+      codepoint_length);
 
   m_paragraphBuilder->AddPlaceholder(placeholder_run);
 

--- a/lib/ui/text/paragraph_builder.h
+++ b/lib/ui/text/paragraph_builder.h
@@ -67,7 +67,8 @@ class ParagraphBuilder : public RefCountedDartWrappable<ParagraphBuilder> {
                              double height,
                              unsigned alignment,
                              double baseline_offset,
-                             unsigned baseline);
+                             unsigned baseline,
+                             unsigned codepoint_length);
 
   void build(Dart_Handle paragraph_handle);
 

--- a/lib/web_ui/lib/src/engine/canvaskit/text.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/text.dart
@@ -857,6 +857,7 @@ class CkParagraphBuilder implements ui.ParagraphBuilder {
     double scale = 1.0,
     double? baselineOffset,
     ui.TextBaseline? baseline,
+    int codepointLength = 1,
   }) {
     // Require a baseline to be specified if using a baseline-based alignment.
     assert(!(alignment == ui.PlaceholderAlignment.aboveBaseline ||

--- a/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/canvas_paragraph.dart
@@ -666,6 +666,7 @@ class CanvasParagraphBuilder implements ui.ParagraphBuilder {
     double scale = 1.0,
     double? baselineOffset,
     ui.TextBaseline? baseline,
+    int codepointLength = 1,
   }) {
     // TODO(mdebbar): for measurement of placeholders, look at:
     // - https://github.com/flutter/engine/blob/c0f7e8acf9318d264ad6a235facd097de597ffcc/third_party/txt/src/txt/paragraph_txt.cc#L325-L350

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -1276,6 +1276,7 @@ class DomParagraphBuilder implements ui.ParagraphBuilder {
     double scale = 1.0,
     double? baselineOffset,
     ui.TextBaseline? baseline,
+    int codepointLength = 1,
   }) {
     // Require a baseline to be specified if using a baseline-based alignment.
     assert(!(alignment == ui.PlaceholderAlignment.aboveBaseline ||
@@ -1294,7 +1295,7 @@ class DomParagraphBuilder implements ui.ParagraphBuilder {
   }
 
   // TODO(yjbanov): do we need to do this?
-//  static String _encodeLocale(Locale locale) => locale?.toString() ?? '';
+  //  static String _encodeLocale(Locale locale) => locale?.toString() ?? '';
 
   /// Ends the effect of the most recent call to [pushStyle].
   ///

--- a/lib/web_ui/lib/src/ui/text.dart
+++ b/lib/web_ui/lib/src/ui/text.dart
@@ -726,6 +726,7 @@ abstract class ParagraphBuilder {
     double scale = 1.0,
     double? baselineOffset,
     TextBaseline? baseline,
+    int codepointLength = 1,
   });
 }
 

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -100,6 +100,8 @@ class Paragraph {
       start += delta;
       end += delta;
     }
+
+    bool contains(T index) const { return index >= start && index < end; }
   };
 
   virtual ~Paragraph() = default;

--- a/third_party/txt/src/txt/paragraph_builder_txt.cc
+++ b/third_party/txt/src/txt/paragraph_builder_txt.cc
@@ -64,8 +64,10 @@ void ParagraphBuilderTxt::AddText(const std::u16string& text) {
 void ParagraphBuilderTxt::AddPlaceholder(PlaceholderRun& span) {
   obj_replacement_char_indexes_.insert(text_.size());
   runs_.StartRun(PeekStyleIndex(), text_.size());
+  size_t start = text_.size();
   AddText(std::u16string(span.codepoint_length, objReplacementChar));
   runs_.StartRun(PeekStyleIndex(), text_.size());
+  inline_placeholder_ranges_.emplace_back(start, text_.size());
   inline_placeholders_.push_back(span);
 }
 
@@ -75,7 +77,8 @@ std::unique_ptr<Paragraph> ParagraphBuilderTxt::Build() {
   std::unique_ptr<ParagraphTxt> paragraph = std::make_unique<ParagraphTxt>();
   paragraph->SetText(std::move(text_), std::move(runs_));
   paragraph->SetInlinePlaceholders(std::move(inline_placeholders_),
-                                   std::move(obj_replacement_char_indexes_));
+                                   std::move(obj_replacement_char_indexes_),
+                                   std::move(inline_placeholder_ranges_));
   paragraph->SetParagraphStyle(paragraph_style_);
   paragraph->SetFontCollection(font_collection_);
   SetParagraphStyle(paragraph_style_);

--- a/third_party/txt/src/txt/paragraph_builder_txt.cc
+++ b/third_party/txt/src/txt/paragraph_builder_txt.cc
@@ -64,7 +64,7 @@ void ParagraphBuilderTxt::AddText(const std::u16string& text) {
 void ParagraphBuilderTxt::AddPlaceholder(PlaceholderRun& span) {
   obj_replacement_char_indexes_.insert(text_.size());
   runs_.StartRun(PeekStyleIndex(), text_.size());
-  AddText(std::u16string(1ull, objReplacementChar));
+  AddText(std::u16string(span.codepoint_length, objReplacementChar));
   runs_.StartRun(PeekStyleIndex(), text_.size());
   inline_placeholders_.push_back(span);
 }

--- a/third_party/txt/src/txt/paragraph_builder_txt.h
+++ b/third_party/txt/src/txt/paragraph_builder_txt.h
@@ -48,6 +48,8 @@ class ParagraphBuilderTxt : public ParagraphBuilder {
   // position in the text where the placeholder will occur. There should be an
   // equal number of 0xFFFC characters and elements in this vector.
   std::vector<PlaceholderRun> inline_placeholders_;
+  // Tracks the codepoint indexes of the Object replacement characters inserted
+  // for each placeholder.
   std::vector<Paragraph::Range<size_t>> inline_placeholder_ranges_;
   // The indexes of the obj replacement characters added through
   // ParagraphBuilder::addPlaceholder().

--- a/third_party/txt/src/txt/paragraph_builder_txt.h
+++ b/third_party/txt/src/txt/paragraph_builder_txt.h
@@ -19,6 +19,7 @@
 
 #include "paragraph_builder.h"
 
+#include "paragraph.h"
 #include "styled_runs.h"
 
 namespace txt {
@@ -47,6 +48,7 @@ class ParagraphBuilderTxt : public ParagraphBuilder {
   // position in the text where the placeholder will occur. There should be an
   // equal number of 0xFFFC characters and elements in this vector.
   std::vector<PlaceholderRun> inline_placeholders_;
+  std::vector<Paragraph::Range<size_t>> inline_placeholder_ranges_;
   // The indexes of the obj replacement characters added through
   // ParagraphBuilder::addPlaceholder().
   std::unordered_set<size_t> obj_replacement_char_indexes_;

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -1998,7 +1998,7 @@ Paragraph::Range<size_t> ParagraphTxt::GetWordBoundary(size_t offset) {
   // the whole placeholder range if the word contains the placeholder.
   for (Range<size_t> range : inline_placeholder_ranges_) {
     if (range.contains(offset)) {
-      return Range<size_t>(range.start, range.end);
+      return range;
     }
   }
 

--- a/third_party/txt/src/txt/paragraph_txt.h
+++ b/third_party/txt/src/txt/paragraph_txt.h
@@ -173,6 +173,8 @@ class ParagraphTxt : public Paragraph {
   // position in the text where the placeholder will occur. There should be an
   // equal number of 0xFFFC characters and elements in this vector.
   std::vector<PlaceholderRun> inline_placeholders_;
+  // Tracks the codepoint indexes of the Object replacement characters inserted
+  // for each placeholder.
   std::vector<Range<size_t>> inline_placeholder_ranges_;
   // The indexes of the boxes that correspond to an inline placeholder.
   std::vector<size_t> inline_placeholder_boxes_;

--- a/third_party/txt/src/txt/paragraph_txt.h
+++ b/third_party/txt/src/txt/paragraph_txt.h
@@ -173,6 +173,7 @@ class ParagraphTxt : public Paragraph {
   // position in the text where the placeholder will occur. There should be an
   // equal number of 0xFFFC characters and elements in this vector.
   std::vector<PlaceholderRun> inline_placeholders_;
+  std::vector<Range<size_t>> inline_placeholder_ranges_;
   // The indexes of the boxes that correspond to an inline placeholder.
   std::vector<size_t> inline_placeholder_boxes_;
   // The indexes of instances of 0xFFFC that correspond to placeholders. This is
@@ -340,7 +341,8 @@ class ParagraphTxt : public Paragraph {
 
   void SetInlinePlaceholders(
       std::vector<PlaceholderRun> inline_placeholders,
-      std::unordered_set<size_t> obj_replacement_char_indexes);
+      std::unordered_set<size_t> obj_replacement_char_indexes,
+      std::vector<Range<size_t>> inline_placeholder_ranges);
 
   // Break the text into lines.
   bool ComputeLineBreaks();

--- a/third_party/txt/src/txt/placeholder_run.cc
+++ b/third_party/txt/src/txt/placeholder_run.cc
@@ -24,11 +24,13 @@ PlaceholderRun::PlaceholderRun(double width,
                                double height,
                                PlaceholderAlignment alignment,
                                TextBaseline baseline,
-                               double baseline_offset)
+                               double baseline_offset,
+                               unsigned codepoint_length)
     : width(width),
       height(height),
       alignment(alignment),
       baseline(baseline),
-      baseline_offset(baseline_offset) {}
+      baseline_offset(baseline_offset),
+      codepoint_length(codepoint_length) {}
 
 }  // namespace txt

--- a/third_party/txt/src/txt/placeholder_run.h
+++ b/third_party/txt/src/txt/placeholder_run.h
@@ -75,13 +75,16 @@ class PlaceholderRun {
   // the alphabetic baseline.
   double baseline_offset = 0;
 
+  unsigned codepoint_length = 1;
+
   PlaceholderRun();
 
   PlaceholderRun(double width,
                  double height,
                  PlaceholderAlignment alignment,
                  TextBaseline baseline,
-                 double baseline_offset);
+                 double baseline_offset,
+                 unsigned codepoint_length);
 };
 
 }  // namespace txt

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -1640,6 +1640,10 @@ TEST_F(ParagraphTest,
 
   EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(5, 10).position, 0ull);
   EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(25, 10).position, 2ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(81, 10).position, 5ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(82, 10).position, 5ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(83, 10).position, 5ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(84, 10).position, 6ull);
   EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(85, 10).position, 6ull);
   EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(86, 10).position, 6ull);
   EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(87, 10).position, 6ull);

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -1455,6 +1455,112 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderGetRectsParagraph)) {
   ASSERT_TRUE(Snapshot());
 }
 
+TEST_F(ParagraphTest,
+       DISABLE_ON_WINDOWS(InlinePlaceholderMultiCodepointSimple)) {
+  const char* text = "012 34";
+  auto icu_text = icu::UnicodeString::fromUTF8(text);
+  std::u16string u16_text(icu_text.getBuffer(),
+                          icu_text.getBuffer() + icu_text.length());
+
+  txt::ParagraphStyle paragraph_style;
+  paragraph_style.max_lines = 14;
+  txt::ParagraphBuilderTxt builder(paragraph_style, GetTestFontCollection());
+
+  txt::TextStyle text_style;
+  text_style.font_families = std::vector<std::string>(1, "Roboto");
+  text_style.font_size = 26;
+  text_style.letter_spacing = 1;
+  text_style.word_spacing = 5;
+  text_style.color = SK_ColorBLACK;
+  text_style.height = 1;
+  text_style.decoration = TextDecoration::kUnderline;
+  text_style.decoration_color = SK_ColorBLACK;
+  builder.PushStyle(text_style);
+
+  txt::PlaceholderRun placeholder_run(50, 50, PlaceholderAlignment::kBaseline,
+                                      TextBaseline::kAlphabetic, 50, 5);
+  builder.AddText(u16_text);
+  builder.AddPlaceholder(placeholder_run);
+  builder.AddText(u16_text);
+
+  builder.Pop();
+
+  auto paragraph = BuildParagraph(builder);
+  paragraph->Layout(GetTestCanvasWidth());
+
+  paragraph->Paint(GetCanvas(), 0, 0);
+
+  SkPaint paint;
+  paint.setStyle(SkPaint::kStroke_Style);
+  paint.setAntiAlias(true);
+  paint.setStrokeWidth(1);
+  paint.setColor(SK_ColorRED);
+  std::vector<txt::Paragraph::TextBox> boxes =
+      paragraph->GetRectsForPlaceholders();
+  for (size_t i = 0; i < boxes.size(); ++i) {
+    GetCanvas()->drawRect(boxes[i].rect, paint);
+  }
+  EXPECT_EQ(boxes.size(), 1ull);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.945312);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), -0.34765625);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 140.94531);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 49.652344);
+
+  Paragraph::RectHeightStyle rect_height_style =
+      Paragraph::RectHeightStyle::kMax;
+  Paragraph::RectWidthStyle rect_width_style =
+      Paragraph::RectWidthStyle::kTight;
+  paint.setColor(SK_ColorBLUE);
+  boxes =
+      paragraph->GetRectsForRange(0, 15, rect_height_style, rect_width_style);
+  for (size_t i = 0; i < boxes.size(); ++i) {
+    GetCanvas()->drawRect(boxes[i].rect, paint);
+  }
+  EXPECT_EQ(boxes.size(), 3ull);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), -0.34765625);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.945312);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 56);
+
+  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 90.945312);
+  EXPECT_FLOAT_EQ(boxes[1].rect.top(), -0.34765625);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 140.94531);
+  EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 56);
+
+  EXPECT_FLOAT_EQ(boxes[2].rect.left(), 140.94531);
+  EXPECT_FLOAT_EQ(boxes[2].rect.top(), -0.34765625);
+  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 200.1875);
+  EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 56);
+
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(5, 10).position, 0ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(25, 10).position, 2ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(85, 10).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(91, 10).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(100, 11).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(110, 11).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(120, 11).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(145, 11).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(155, 11).position, 12ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(165, 11).position, 13ull);
+
+  EXPECT_EQ(paragraph->GetWordBoundary(5).start, 4ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(5).end, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(6).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(6).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(7).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(7).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(8).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(8).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(9).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(9).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(10).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(10).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(11).start, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(11).end, 14ull);
+
+  ASSERT_TRUE(Snapshot());
+}
+
 TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderLongestLine)) {
   txt::ParagraphStyle paragraph_style;
   paragraph_style.max_lines = 1;

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -1562,6 +1562,125 @@ TEST_F(ParagraphTest,
 }
 
 TEST_F(ParagraphTest,
+       DISABLE_ON_WINDOWS(InlinePlaceholderMultiCodepointSingleZeroSize)) {
+  const char* text = "012 34";
+  auto icu_text = icu::UnicodeString::fromUTF8(text);
+  std::u16string u16_text(icu_text.getBuffer(),
+                          icu_text.getBuffer() + icu_text.length());
+
+  txt::ParagraphStyle paragraph_style;
+  paragraph_style.max_lines = 14;
+  txt::ParagraphBuilderTxt builder(paragraph_style, GetTestFontCollection());
+
+  txt::TextStyle text_style;
+  text_style.font_families = std::vector<std::string>(1, "Roboto");
+  text_style.font_size = 26;
+  text_style.letter_spacing = 1;
+  text_style.word_spacing = 5;
+  text_style.color = SK_ColorBLACK;
+  text_style.height = 1;
+  text_style.decoration = TextDecoration::kUnderline;
+  text_style.decoration_color = SK_ColorBLACK;
+  builder.PushStyle(text_style);
+
+  txt::PlaceholderRun placeholder_run(0, 0, PlaceholderAlignment::kBottom,
+                                      TextBaseline::kAlphabetic, 0, 5);
+  builder.AddText(u16_text);
+  builder.AddPlaceholder(placeholder_run);
+  builder.AddText(u16_text);
+
+  builder.Pop();
+
+  auto paragraph = BuildParagraph(builder);
+  paragraph->Layout(GetTestCanvasWidth());
+
+  paragraph->Paint(GetCanvas(), 0, 0);
+
+  SkPaint paint;
+  paint.setStyle(SkPaint::kStroke_Style);
+  paint.setAntiAlias(true);
+  paint.setStrokeWidth(1);
+  paint.setColor(SK_ColorRED);
+  std::vector<txt::Paragraph::TextBox> boxes =
+      paragraph->GetRectsForPlaceholders();
+  for (size_t i = 0; i < boxes.size(); ++i) {
+    GetCanvas()->drawRect(boxes[i].rect, paint);
+  }
+  EXPECT_EQ(boxes.size(), 1ull);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.945312);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.945312);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 30);
+
+  Paragraph::RectHeightStyle rect_height_style =
+      Paragraph::RectHeightStyle::kTight;
+  Paragraph::RectWidthStyle rect_width_style =
+      Paragraph::RectWidthStyle::kTight;
+  paint.setColor(SK_ColorBLUE);
+  boxes =
+      paragraph->GetRectsForRange(0, 15, rect_height_style, rect_width_style);
+  for (size_t i = 0; i < boxes.size(); ++i) {
+    GetCanvas()->drawRect(boxes[i].rect, paint);
+  }
+  EXPECT_EQ(boxes.size(), 3ull);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), -0.46875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.945312);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 30);
+
+  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 90.945312);
+  EXPECT_FLOAT_EQ(boxes[1].rect.top(), 30);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 90.945312);
+  EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 30);
+
+  EXPECT_FLOAT_EQ(boxes[2].rect.left(), 90.945312);
+  EXPECT_FLOAT_EQ(boxes[2].rect.top(), -0.46875);
+  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 150.1875);
+  EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 30);
+
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(5, 10).position, 0ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(25, 10).position, 2ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(85, 10).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(86, 10).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(87, 10).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(88, 10).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(89, 10).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(90, 10).position, 6ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(91, 10).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(92, 10).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(93, 10).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(94, 10).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(95, 10).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(96, 10).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(97, 10).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(98, 10).position, 11ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(99, 10).position, 12ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(100, 11).position, 12ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(110, 11).position, 12ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(120, 11).position, 13ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(145, 11).position, 15ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(155, 11).position, 15ull);
+  EXPECT_EQ(paragraph->GetGlyphPositionAtCoordinate(165, 11).position, 16ull);
+
+  EXPECT_EQ(paragraph->GetWordBoundary(5).start, 4ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(5).end, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(6).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(6).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(7).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(7).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(8).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(8).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(9).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(9).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(10).start, 6ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(10).end, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(11).start, 11ull);
+  EXPECT_EQ(paragraph->GetWordBoundary(11).end, 14ull);
+
+  ASSERT_TRUE(Snapshot());
+}
+
+TEST_F(ParagraphTest,
        DISABLE_ON_WINDOWS(InlinePlaceholderMultiCodepointMultiConsecutive)) {
   const char* text = "012 34";
   auto icu_text = icu::UnicodeString::fromUTF8(text);

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -534,14 +534,14 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderParagraph)) {
   builder.AddText(u16_text);
 
   txt::PlaceholderRun placeholder_run(50, 50, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kAlphabetic, 0);
+                                      TextBaseline::kAlphabetic, 0, 1);
   builder.AddPlaceholder(placeholder_run);
 
   builder.AddText(u16_text);
 
   builder.AddPlaceholder(placeholder_run);
   txt::PlaceholderRun placeholder_run2(5, 50, PlaceholderAlignment::kBaseline,
-                                       TextBaseline::kAlphabetic, 50);
+                                       TextBaseline::kAlphabetic, 50, 1);
   builder.AddPlaceholder(placeholder_run2);
   builder.AddPlaceholder(placeholder_run);
   builder.AddPlaceholder(placeholder_run2);
@@ -659,7 +659,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderBaselineParagraph)) {
   builder.AddText(u16_text);
 
   txt::PlaceholderRun placeholder_run(55, 50, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kAlphabetic, 38.34734);
+                                      TextBaseline::kAlphabetic, 38.34734, 1);
   builder.AddPlaceholder(placeholder_run);
 
   builder.AddText(u16_text);
@@ -733,9 +733,9 @@ TEST_F(ParagraphTest,
 
   builder.AddText(u16_text);
 
-  txt::PlaceholderRun placeholder_run(55, 50,
-                                      PlaceholderAlignment::kAboveBaseline,
-                                      TextBaseline::kAlphabetic, 903129.129308);
+  txt::PlaceholderRun placeholder_run(
+      55, 50, PlaceholderAlignment::kAboveBaseline, TextBaseline::kAlphabetic,
+      903129.129308, 1);
   builder.AddPlaceholder(placeholder_run);
 
   builder.AddText(u16_text);
@@ -809,9 +809,9 @@ TEST_F(ParagraphTest,
 
   builder.AddText(u16_text);
 
-  txt::PlaceholderRun placeholder_run(55, 50,
-                                      PlaceholderAlignment::kBelowBaseline,
-                                      TextBaseline::kAlphabetic, 903129.129308);
+  txt::PlaceholderRun placeholder_run(
+      55, 50, PlaceholderAlignment::kBelowBaseline, TextBaseline::kAlphabetic,
+      903129.129308, 1);
   builder.AddPlaceholder(placeholder_run);
 
   builder.AddText(u16_text);
@@ -885,7 +885,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderBottomParagraph)) {
   builder.AddText(u16_text);
 
   txt::PlaceholderRun placeholder_run(55, 50, PlaceholderAlignment::kBottom,
-                                      TextBaseline::kAlphabetic, 0);
+                                      TextBaseline::kAlphabetic, 0, 1);
   builder.AddPlaceholder(placeholder_run);
 
   builder.AddText(u16_text);
@@ -959,7 +959,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderTopParagraph)) {
   builder.AddText(u16_text);
 
   txt::PlaceholderRun placeholder_run(55, 50, PlaceholderAlignment::kTop,
-                                      TextBaseline::kAlphabetic, 0);
+                                      TextBaseline::kAlphabetic, 0, 1);
   builder.AddPlaceholder(placeholder_run);
 
   builder.AddText(u16_text);
@@ -1033,7 +1033,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderMiddleParagraph)) {
   builder.AddText(u16_text);
 
   txt::PlaceholderRun placeholder_run(55, 50, PlaceholderAlignment::kMiddle,
-                                      TextBaseline::kAlphabetic, 0);
+                                      TextBaseline::kAlphabetic, 0, 1);
   builder.AddPlaceholder(placeholder_run);
 
   builder.AddText(u16_text);
@@ -1109,7 +1109,7 @@ TEST_F(ParagraphTest,
   builder.AddText(u16_text);
 
   txt::PlaceholderRun placeholder_run(55, 50, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kIdeographic, 38.34734);
+                                      TextBaseline::kIdeographic, 38.34734, 1);
   builder.AddPlaceholder(placeholder_run);
 
   builder.AddText(u16_text);
@@ -1183,9 +1183,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderBreakParagraph)) {
   builder.AddText(u16_text);
 
   txt::PlaceholderRun placeholder_run(50, 50, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kAlphabetic, 50);
+                                      TextBaseline::kAlphabetic, 50, 1);
   txt::PlaceholderRun placeholder_run2(25, 25, PlaceholderAlignment::kBaseline,
-                                       TextBaseline::kAlphabetic, 12.5);
+                                       TextBaseline::kAlphabetic, 12.5, 1);
   builder.AddPlaceholder(placeholder_run);
   builder.AddPlaceholder(placeholder_run);
   builder.AddPlaceholder(placeholder_run);
@@ -1338,9 +1338,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderGetRectsParagraph)) {
   builder.AddText(u16_text);
 
   txt::PlaceholderRun placeholder_run(50, 50, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kAlphabetic, 50);
+                                      TextBaseline::kAlphabetic, 50, 1);
   txt::PlaceholderRun placeholder_run2(5, 20, PlaceholderAlignment::kBaseline,
-                                       TextBaseline::kAlphabetic, 10);
+                                       TextBaseline::kAlphabetic, 10, 1);
   builder.AddPlaceholder(placeholder_run);
   builder.AddPlaceholder(placeholder_run);
   builder.AddPlaceholder(placeholder_run);
@@ -1472,7 +1472,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderLongestLine)) {
   builder.PushStyle(text_style);
 
   txt::PlaceholderRun placeholder_run(50, 50, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kAlphabetic, 0);
+                                      TextBaseline::kAlphabetic, 0, 1);
   builder.AddPlaceholder(placeholder_run);
   builder.Pop();
 
@@ -1491,7 +1491,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderIntrinsicWidth)) {
                           icu_text.getBuffer() + icu_text.length());
 
   txt::PlaceholderRun placeholder_run(50, 50, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kAlphabetic, 0);
+                                      TextBaseline::kAlphabetic, 0, 1);
 
   txt::ParagraphStyle paragraph_style;
   txt::ParagraphBuilderTxt builder(paragraph_style, GetTestFontCollection());
@@ -1552,7 +1552,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholder0xFFFCParagraph)) {
   truth_text.insert(truth_text.end(), u16_text2.begin(), u16_text2.end());
 
   txt::PlaceholderRun placeholder_run(50, 50, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kAlphabetic, 25);
+                                      TextBaseline::kAlphabetic, 25, 1);
   builder.AddPlaceholder(placeholder_run);
   truth_text.push_back(0xFFFC);
 
@@ -2913,7 +2913,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(JustifyPlaceholder)) {
                            icu_text1.getBuffer() + icu_text1.length());
 
   txt::PlaceholderRun placeholder_run(60, 60, PlaceholderAlignment::kBaseline,
-                                      TextBaseline::kAlphabetic, 0);
+                                      TextBaseline::kAlphabetic, 0, 1);
 
   const char* text2 = " B CCCCC";
   auto icu_text2 = icu::UnicodeString::fromUTF8(text2);


### PR DESCRIPTION
Adds text layout level support for handling placeholders that represent multiple codepoints.

Needed for https://github.com/flutter/flutter/pull/84986 and clipboard behavior to function properly.

Previously, we represented each placeholder with a single object replacement character 0xFFFC. This patch allows each placeholder to specify how many replacement characters to use to represent it. This allows operations such as GetRectsForRange or GetPositionForOffset to produce and handle indexes that work cleanly with higher level concepts such as TextEditingValue which must use multi-char strings to represent placeholders.

This needs to be replicated in SkParagraph.