### PR TITLE
Allow fuchsia_archive to accept a cml file and cmx file

### DIFF
--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -148,14 +148,7 @@ template("aot_runner_package") {
 
     binary = "dart_aot${product_suffix}_runner"
 
-    meta_dir = "//flutter/shell/platform/fuchsia/dart_runner/meta"
-
-    meta = [
-      {
-        path = rebase_path("meta/dart_aot${product_suffix}_runner.cmx")
-        dest = "dart_aot${product_suffix}_runner.cmx"
-      },
-    ]
+    cmx_file = rebase_path("meta/dart_aot${product_suffix}_runner.cmx")
 
     libraries = common_libs
 
@@ -215,7 +208,7 @@ template("jit_runner_package") {
 
     binary = "dart_jit${product_suffix}_runner"
 
-    meta_dir = "//flutter/shell/platform/fuchsia/dart_runner/meta"
+    cmx_file = rebase_path("meta/dart_jit${product_suffix}_runner.cmx")
 
     libraries = common_libs
 
@@ -257,13 +250,6 @@ template("jit_runner_package") {
         },
       ]
     }
-
-    meta = [
-      {
-        path = rebase_path("meta/dart_jit${product_suffix}_runner.cmx")
-        dest = "dart_jit${product_suffix}_runner.cmx"
-      },
-    ]
   }
 }
 

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -286,7 +286,7 @@ template("jit_runner") {
 
     binary = "flutter_jit${product_suffix}_runner"
 
-    meta_dir = "//flutter/shell/platform/fuchsia/flutter/meta"
+    cmx_file = rebase_path("meta/flutter_jit${product_suffix}_runner.cmx")
 
     resources = [
       {
@@ -345,13 +345,6 @@ template("jit_runner") {
     resources += _vulkan_icds
 
     libraries = _libs
-
-    meta = [
-      {
-        path = rebase_path("meta/flutter_jit${product_suffix}_runner.cmx")
-        dest = "flutter_jit${product_suffix}_runner.cmx"
-      },
-    ]
   }
 }
 
@@ -372,7 +365,7 @@ template("aot_runner") {
       ]
     }
 
-    meta_dir = "//flutter/shell/platform/fuchsia/flutter/meta"
+    cmx_file = rebase_path("meta/flutter_aot${product_suffix}_runner.cmx")
 
     binary = "flutter_aot${product_suffix}_runner"
 
@@ -410,13 +403,6 @@ template("aot_runner") {
     resources += _vulkan_icds
 
     libraries = _libs
-
-    meta = [
-      {
-        path = rebase_path("meta/flutter_aot${product_suffix}_runner.cmx")
-        dest = "flutter_aot${product_suffix}_runner.cmx"
-      },
-    ]
   }
 }
 
@@ -562,16 +548,9 @@ fuchsia_archive("flutter_runner_tests") {
     },
   ]
 
-  meta_dir = "//flutter/shell/platform/fuchsia/flutter/meta"
+  cmx_file = rebase_path("meta/$target_name.cmx")
 
   libraries = common_libs
-
-  meta = [
-    {
-      path = rebase_path("meta/$target_name.cmx")
-      dest = "$target_name.cmx"
-    },
-  ]
 }
 
 fuchsia_archive("flutter_runner_tzdata_tests") {
@@ -588,16 +567,9 @@ fuchsia_archive("flutter_runner_tzdata_tests") {
     },
   ]
 
-  meta_dir = "//flutter/shell/platform/fuchsia/flutter/meta"
+  cmx_file = rebase_path("meta/$target_name.cmx")
 
   libraries = common_libs
-
-  meta = [
-    {
-      path = rebase_path("meta/$target_name.cmx")
-      dest = "$target_name.cmx"
-    },
-  ]
 }
 
 fuchsia_archive("flutter_runner_scenic_tests") {
@@ -614,16 +586,9 @@ fuchsia_archive("flutter_runner_scenic_tests") {
     },
   ]
 
-  meta_dir = "//flutter/shell/platform/fuchsia/flutter/meta"
+  cmx_file = rebase_path("meta/$target_name.cmx")
 
   libraries = common_libs
-
-  meta = [
-    {
-      path = rebase_path("meta/$target_name.cmx")
-      dest = "$target_name.cmx"
-    },
-  ]
 }
 
 fuchsia_test_archive("fml_tests") {

--- a/tools/fuchsia/compile_cml.py
+++ b/tools/fuchsia/compile_cml.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+""" Compiles a cml manifest file.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+def main():
+  parser = argparse.ArgumentParser()
+
+  parser.add_argument('--cmc-bin', dest='cmc_bin', action='store', required=True)
+  parser.add_argument(
+      '--output', dest='output', action='store', required=True)
+  parser.add_argument(
+      '--manifest-file', dest='manifest_file', action='store', required=True)
+  parser.add_argument(
+      '--includepath', dest='includepath', action='store', required=True
+  )
+
+  args = parser.parse_args()
+
+  assert os.path.exists(args.cmc_bin)
+  assert os.path.exists(args.manifest_file)
+
+  print(args.includepath)
+  subprocess.check_output([
+      args.cmc_bin,
+      'compile',
+      '--output',
+      args.output,
+      args.manifest_file,
+      '--includepath',
+      args.includepath,
+  ])
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -5,10 +5,41 @@
 import("//flutter/tools/fuchsia/fuchsia_debug_symbols.gni")
 import("//flutter/tools/fuchsia/fuchsia_libs.gni")
 
+# Compiles a cml file
+template("_compile_cml") {
+  assert(defined(invoker.manifest), "_compile_cml must define manifest")
+
+  action(target_name) {
+    forward_variables_from(invoker,
+                           [
+                             "visibility",
+                             "testonly",
+                           ])
+    script = "//flutter/tools/fuchsia/compile_cml.py"
+
+    sources = [ invoker.manifest ]
+
+    inputs = [ "//fuchsia/sdk/$host_os/tools/cmc" ]
+
+    args = [
+      "--cmc-bin",
+      rebase_path("//fuchsia/sdk/$host_os/tools/cmc"),
+      "--manifest-file",
+      invoker.manifest,
+      "--output",
+      rebase_path(invoker.output, root_build_dir),
+      "--includepath",
+      get_path_info(invoker.manifest, "dir"),
+    ]
+    outputs = [ invoker.output ]
+  }
+}
+
 # Creates a Fuchsia archive (.far) file using PM from the Fuchsia SDK.
 template("fuchsia_archive") {
   assert(defined(invoker.binary), "package must define binary")
-  assert(defined(invoker.meta_dir), "package must define meta_dir")
+  assert(defined(invoker.cmx_file) || defined(invoker.cml_file),
+         "must specify either a cmx file, cml file or both")
 
   pkg_testonly = defined(invoker.testonly) && invoker.testonly
   pkg_target_name = target_name
@@ -18,16 +49,12 @@ template("fuchsia_archive") {
                            [
                              "binary",
                              "deps",
-                             "meta",
                              "resources",
                              "libraries",
                              "meta_dir",
                            ])
     if (!defined(package_name)) {
       package_name = pkg_target_name
-    }
-    if (!defined(meta)) {
-      meta = []
     }
     if (!defined(deps)) {
       deps = []
@@ -55,17 +82,20 @@ template("fuchsia_archive") {
     copy_outputs += [ "$far_base_dir/lib/${lib.name}" ]
   }
 
-  cmx_target = "$pkg_target_name.copy_cmx"
+  pkg_dir_deps = pkg.deps
 
   if (defined(invoker.cmx_file)) {
+    # cmx files are used for v1 components, only copy it if it is defined
     cmx_file = invoker.cmx_file
-  } else {
-    cmx_file = "${pkg.meta_dir}/${pkg_target_name}.cmx"
-  }
 
-  copy("$cmx_target") {
-    sources = [ "$cmx_file" ]
-    outputs = [ "$far_base_dir/meta/${pkg_target_name}.cmx" ]
+    cmx_target = "$pkg_target_name.copy_cmx"
+
+    copy("$cmx_target") {
+      sources = [ "$cmx_file" ]
+      outputs = [ "$far_base_dir/meta/${pkg_target_name}.cmx" ]
+    }
+
+    pkg_dir_deps += [ ":$cmx_target" ]
   }
 
   write_file("${far_base_dir}/meta/package",
@@ -82,7 +112,13 @@ template("fuchsia_archive") {
     binary = invoker.binary
   }
 
-  pkg_dir_deps = pkg.deps + [ ":$cmx_target" ]
+  if (defined(invoker.cml_file)) {
+    _compile_cml(target_name + "_compile_cml") {
+      manifest = invoker.cml_file
+      output = "$far_base_dir/meta/${pkg_target_name}.cm"
+    }
+    pkg_dir_deps += [ ":${target_name}_compile_cml" ]
+  }
 
   action("${target_name}_dir") {
     script = "//flutter/tools/fuchsia/copy_path.py"
@@ -145,7 +181,6 @@ template("fuchsia_test_archive") {
       libraries += invoker.libraries
     }
 
-    meta_dir = "//flutter/testing/fuchsia/meta"
-    cmx_file = "$meta_dir/fuchsia_test.cmx"
+    cmx_file = rebase_path("//flutter/testing/fuchsia/meta/fuchsia_test.cmx")
   }
 }


### PR DESCRIPTION
This adds support for adding a cml file to a fuchsia package. The
cml file will be compiled to a cm file and included in the archive.
