### PR TITLE
Roll CanvasKit to 0.28.1

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 619b764a68c7cffb000f474f9051d3d2bf0777bb
+revision: 8df047cbfb1edb34569f3170a26e718fef22ffa7

--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: 76ee6c69bf493b4b860e6685d0145ec8ac734f2c
+revision: 619b764a68c7cffb000f474f9051d3d2bf0777bb

--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -84,7 +84,7 @@ const bool canvasKitForceCpuOnly = bool.fromEnvironment(
 /// NPM, update this URL to `https://unpkg.com/canvaskit-wasm@0.34.0/bin/`.
 const String canvasKitBaseUrl = String.fromEnvironment(
   'FLUTTER_WEB_CANVASKIT_URL',
-  defaultValue: 'https://unpkg.com/canvaskit-wasm@0.28.0/bin/',
+  defaultValue: 'https://unpkg.com/canvaskit-wasm@0.28.1/bin/',
 );
 final String canvasKitBuildUrl =
     canvasKitBaseUrl + (kProfileMode ? 'profiling/' : '');

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -761,6 +761,17 @@ void testMain() {
       );
     });
 
+    test('sample Bengali text', () async {
+      await testSampleText(
+        'bengali',
+        'ঈদের জামাত মসজিদে, মানতে হবে স্বাস্থ্যবিধি: ধর্ম মন্ত্রণালয়',
+      );
+    });
+
+    test('hindi svayan test', () async {
+      await testSampleText('hindi_svayan', 'स्वयं');
+    });
+
     // We've seen text break when we load many fonts simultaneously. This test
     // combines text in multiple languages into one long paragraph to make sure
     // we can handle it.

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -782,6 +782,11 @@ void testMain() {
       );
     });
 
+    test('emoji text with skin tone', () async {
+      await testSampleText('emoji_with_skin_tone', '👋🏿 👋🏾 👋🏽 👋🏼 👋🏻',
+          write: true);
+    });
+
     // Make sure we clear the canvas in between frames.
     test('empty frame after contentful frame', () async {
       // First draw a frame with a red rectangle

--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -783,8 +783,7 @@ void testMain() {
     });
 
     test('emoji text with skin tone', () async {
-      await testSampleText('emoji_with_skin_tone', '👋🏿 👋🏾 👋🏽 👋🏼 👋🏻',
-          write: true);
+      await testSampleText('emoji_with_skin_tone', '👋🏿 👋🏾 👋🏽 👋🏼 👋🏻');
     });
 
     // Make sure we clear the canvas in between frames.

--- a/lib/web_ui/test/canvaskit/common.dart
+++ b/lib/web_ui/test/canvaskit/common.dart
@@ -7,11 +7,12 @@ import 'package:test/test.dart';
 import 'package:ui/src/engine.dart';
 import 'package:ui/ui.dart' as ui;
 
+/// Whether the current browser is Safari.
+bool get isSafari => browserEngine == BrowserEngine.webkit;
+
 /// Whether the current browser is Safari on iOS.
 // TODO: https://github.com/flutter/flutter/issues/60040
-bool get isIosSafari =>
-    browserEngine == BrowserEngine.webkit &&
-    operatingSystem == OperatingSystem.iOs;
+bool get isIosSafari => isSafari && operatingSystem == OperatingSystem.iOs;
 
 /// Whether the current browser is Firefox.
 bool get isFirefox => browserEngine == BrowserEngine.firefox;

--- a/lib/web_ui/test/canvaskit/surface_test.dart
+++ b/lib/web_ui/test/canvaskit/surface_test.dart
@@ -89,6 +89,7 @@ void testMain() {
         final html.CanvasElement canvas =
             surface.htmlElement.children.single as html.CanvasElement;
         final dynamic ctx = canvas.getContext('webgl2');
+        expect(ctx, isNotNull);
         final dynamic loseContextExtension =
             ctx.getExtension('WEBGL_lose_context');
         loseContextExtension.loseContext();
@@ -112,7 +113,7 @@ void testMain() {
         expect(afterContextLost, isNot(same(before)));
       },
       // Firefox doesn't have the WEBGL_lose_context extension.
-      skip: isFirefox || isIosSafari,
+      skip: isFirefox || isSafari,
     );
 
     // Regression test for https://github.com/flutter/flutter/issues/75286


### PR DESCRIPTION
Rolls CanvasKit to 0.28.1, which includes a fix in text rendering which supports unicode sequences for woff2 fonts.

Fixes https://github.com/flutter/flutter/issues/79808
Fixes https://github.com/flutter/flutter/issues/81166

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
