### PR TITLE
Re-add annotations to test files that use null safety features

### DIFF
--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.10
+
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui';

--- a/runtime/fixtures/runtime_test.dart
+++ b/runtime/fixtures/runtime_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.10
+
 import 'dart:async';
 import 'dart:isolate';
 import 'dart:ui';

--- a/runtime/fixtures/split_lib_test.dart
+++ b/runtime/fixtures/split_lib_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.10
+
 library splitlib;
 
 int splitAdd(int i, int j) {

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.10
+
 import 'dart:convert' show utf8, json;
 import 'dart:isolate';
 import 'dart:typed_data';

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.10
+
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui';


### PR DESCRIPTION
These annotations were removed in https://github.com/flutter/engine/pull/26828 and https://github.com/flutter/engine/pull/26870. I've been cherry-picking this small diff around as a local workaround.

Minimal portable example of a failing local build against head:
```
# working directory = out/host_debug_unopt

$ ./dart \
./frontend_server.dart.snapshot \
--sdk-root ./flutter_patched_sdk \
--target flutter \
--enable-experiment=non-nullable \
../../flutter/lib/ui/fixtures/ui_test.dart

result 08d02759-b49b-497b-87c1-2bd2cf64c5b0
../../flutter/lib/ui/fixtures/ui_test.dart:659:9: Error: Null safety features are disabled for this library.
Try removing the package language version or setting the language version to 2.10 or higher.
  Object? arg0,
        ^
...
```
```
./dart --version
Dart SDK version: 2.14.0-252.0.dev (dev) (Mon Jun 28 10:51:30 2021 -0700) on "macos_x64"
```

AFAICT, `--enable-experiment=non-nullable` doesn't work when the VM is set to a language version < 2.8. And in absence of a pubspec or annotation, I couldn't find a way to force a floor on the language version via arguments to the dart CLI or the frontend script.