### PR TITLE
Fix use-after-free.

### DIFF
--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -964,9 +964,8 @@ bool PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
           // The client is waiting for view creation. Send an empty response
           // back to signal the view was created.
           if (message->response()) {
-            message->response()->Complete(
-                std::make_unique<fml::NonOwnedMapping>((const uint8_t*)"[0]",
-                                                       3u));
+            message->response()->Complete(std::make_unique<fml::DataMapping>(
+                std::vector<uint8_t>({'[', '0', ']'})));
           }
         });
     auto on_view_bound =


### PR DESCRIPTION
Switch from `fml::NonOwnedMapping` to `fml::DataMapping`.

All other uses of `fml::NonOwnedMapping` are not in `PlatformView` and do not access data after references are out of scope.

This fixes fxbug.dev/77924.

CC: @naudzghebre 