### PR TITLE
Do not expect WM_CHAR if control or windows key is pressed

### DIFF
--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -372,10 +372,10 @@ WindowWin32::HandleMessage(UINT const message,
       // be sent with the character produced at WM_CHAR. Store the produced
       // keycode (it's not accessible from WM_CHAR) to be used in WM_CHAR.
       //
-      // Messages with Control or Win modifiers down are never considered as character
-      // messages. This allows key combinations such as "CTRL + Digit" to properly
-      // produce key down events even though `MapVirtualKey` returns a valid character.
-      // See https://github.com/flutter/flutter/issues/85587.
+      // Messages with Control or Win modifiers down are never considered as
+      // character messages. This allows key combinations such as "CTRL + Digit"
+      // to properly produce key down events even though `MapVirtualKey` returns
+      // a valid character. See https://github.com/flutter/flutter/issues/85587.
       unsigned int character = MapVirtualKey(wparam, MAPVK_VK_TO_CHAR);
       if (character > 0 && is_keydown_message && GetKeyState(VK_CONTROL) == 0 &&
           GetKeyState(VK_LWIN) == 0 && GetKeyState(VK_RWIN) == 0) {

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -371,8 +371,11 @@ WindowWin32::HandleMessage(UINT const message,
       // Check if this key produces a character. If so, the key press should
       // be sent with the character produced at WM_CHAR. Store the produced
       // keycode (it's not accessible from WM_CHAR) to be used in WM_CHAR.
+      // As an exception with control or windows key pressed WM_CHAR may not
+      // come even though the event produced a character (i.e. CTRL + number).
       const unsigned int character = MapVirtualKey(wparam, MAPVK_VK_TO_CHAR);
-      if (character > 0 && is_keydown_message) {
+      if (character > 0 && is_keydown_message && GetKeyState(VK_CONTROL) == 0 &&
+          GetKeyState(VK_LWIN) == 0 && GetKeyState(VK_RWIN) == 0) {
         keycode_for_char_message_ = wparam;
         break;
       }

--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -371,14 +371,18 @@ WindowWin32::HandleMessage(UINT const message,
       // Check if this key produces a character. If so, the key press should
       // be sent with the character produced at WM_CHAR. Store the produced
       // keycode (it's not accessible from WM_CHAR) to be used in WM_CHAR.
-      // As an exception with control or windows key pressed WM_CHAR may not
-      // come even though the event produced a character (i.e. CTRL + number).
-      const unsigned int character = MapVirtualKey(wparam, MAPVK_VK_TO_CHAR);
+      //
+      // Messages with Control or Win modifiers down are never considered as character
+      // messages. This allows key combinations such as "CTRL + Digit" to properly
+      // produce key down events even though `MapVirtualKey` returns a valid character.
+      // See https://github.com/flutter/flutter/issues/85587.
+      unsigned int character = MapVirtualKey(wparam, MAPVK_VK_TO_CHAR);
       if (character > 0 && is_keydown_message && GetKeyState(VK_CONTROL) == 0 &&
           GetKeyState(VK_LWIN) == 0 && GetKeyState(VK_RWIN) == 0) {
         keycode_for_char_message_ = wparam;
         break;
       }
+      character = 0;
       unsigned int keyCode(wparam);
       const unsigned int scancode = (lparam >> 16) & 0xff;
       const bool extended = ((lparam >> 24) & 0x01) == 0x01;

--- a/shell/platform/windows/window_win32_unittests.cc
+++ b/shell/platform/windows/window_win32_unittests.cc
@@ -84,5 +84,27 @@ TEST(MockWin32Window, KeyDownPrintable) {
   window.InjectWindowMessage(WM_CHAR, 65, lparam);
 }
 
+TEST(MockWin32Window, KeyDownWithCtrl) {
+  MockWin32Window window;
+
+  // Simulate CONTROL pressed
+  BYTE keyboard_state[256];
+  memset(keyboard_state, 0, 256);
+  keyboard_state[VK_CONTROL] = -1;
+  SetKeyboardState(keyboard_state);
+
+  LPARAM lparam = CreateKeyEventLparam(30);
+
+  // Expect OnKey, but not OnText, because Control + Key is not followed by
+  // WM_CHAR
+  EXPECT_CALL(window, OnKey(65, 30, WM_KEYDOWN, 0, false, true)).Times(1);
+  EXPECT_CALL(window, OnText(_)).Times(0);
+
+  window.InjectWindowMessage(WM_KEYDOWN, 65, lparam);
+
+  memset(keyboard_state, 0, 256);
+  SetKeyboardState(keyboard_state);
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/85587

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
