### PR TITLE
[web][felt] Fix stdout inheritance for sub-processes

### DIFF
--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -83,6 +83,11 @@ Future<ProcessManager> startProcess(
     // Running the process in a system shell for Windows. Otherwise
     // the process is not able to get Dart from path.
     runInShell: io.Platform.isWindows,
+    // When [evalOutput] is false, we don't need to intercept the stdout of the
+    // sub-process. In this case, it's better to run the sub-process in the
+    // `inheritStdio` mode which lets it print directly to the terminal.
+    // This allows sub-processes such as `ninja` to use all kinds of terminal
+    // features like printing colors, printing progress on the same line, etc.
     mode: evalOutput ? io.ProcessStartMode.normal : io.ProcessStartMode.inheritStdio,
     environment: environment,
   );

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -83,7 +83,7 @@ Future<ProcessManager> startProcess(
     // Running the process in a system shell for Windows. Otherwise
     // the process is not able to get Dart from path.
     runInShell: io.Platform.isWindows,
-    mode: io.ProcessStartMode.normal,
+    mode: evalOutput ? io.ProcessStartMode.normal : io.ProcessStartMode.inheritStdio,
     environment: environment,
   );
   processesToCleanUp.add(process);
@@ -112,9 +112,6 @@ class ProcessManager {
     if (_evalOutput) {
       _forwardStream(process.stdout, _stdout);
       _forwardStream(process.stderr, _stderr);
-    } else {
-      _forwardStream(process.stdout, io.stdout);
-      _forwardStream(process.stderr, io.stderr);
     }
   }
 

--- a/lib/web_ui/dev/watcher.dart
+++ b/lib/web_ui/dev/watcher.dart
@@ -245,6 +245,7 @@ class PipelineWatcher {
   void _pipelineDone(int pipelineRunCount) {
     if (pipelineRunCount == _pipelineRunCount) {
       print('*** Done! ***');
+      print('Press \'q\' to exit felt');
     }
   }
 }


### PR DESCRIPTION
1. Use the `inheritStdout` mode for subprocesses when possible. This allows the subprocess to make better use of the terminal stdout (printing colors, printing progress on the same line, etc).
2. Remind the user after each rebuild that they can quit using `q`.