### PR TITLE
Remove unnecessary experiment flag

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -46,7 +46,6 @@ compiled_action("generate_snapshot_bin") {
   ]
 
   args = [
-    "--enable-experiment=non-nullable",
     "--snapshot_kind=core",
     "--enable_mirrors=false",
     "--vm_snapshot_data=" + rebase_path(vm_snapshot_data),
@@ -256,7 +255,6 @@ compile_platform("strong_platform") {
   is_runtime_mode_release =
       flutter_runtime_mode == "release" || flutter_runtime_mode == "jit_release"
   args = [
-    "--enable-experiment=non-nullable",
     "--nnbd-agnostic",
     "--target=flutter",
     "-Ddart.vm.product=$is_runtime_mode_release",

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -654,7 +654,6 @@ class TestCommand extends Command<bool> with ArgUtils {
       '--no-minify',
       '--disable-inlining',
       '--enable-asserts',
-      '--enable-experiment=non-nullable',
       '--no-sound-null-safety',
 
       // We do not want to auto-select a renderer in tests. As of today, tests

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -20,7 +20,6 @@ compile_platform("kernel_platform_files") {
   ]
 
   args = [
-    "--enable-experiment=non-nullable",
     "--nnbd-agnostic",
     "--target=dart_runner",
     "dart:core",

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -20,7 +20,6 @@ compile_platform("kernel_platform_files") {
   ]
 
   args = [
-    "--enable-experiment=non-nullable",
     "--nnbd-agnostic",
     "--target=flutter_runner",
     "dart:core",

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -116,7 +116,7 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk_outline") {
   script = "//third_party/dart/utils/bazel/kernel_worker.dart"
 
   args = [
-    "--no-sound-null-saftey",
+    "--no-sound-null-safety",
     "--summary-only",
     "--target",
     "ddc",
@@ -270,6 +270,7 @@ prebuilt_dart_action("flutter_dartdevc_canvaskit_html_kernel_sdk") {
   ]
 
   args = [
+    "--no-sound-null-safety",
     "--compile-sdk",
     "dart:core",
 

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -116,6 +116,7 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk_outline") {
   script = "//third_party/dart/utils/bazel/kernel_worker.dart"
 
   args = [
+    "--no-sound-null-saftey",
     "--summary-only",
     "--target",
     "ddc",
@@ -161,6 +162,7 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk") {
   ]
 
   args = [
+    "--no-sound-null-safety",
     "--compile-sdk",
     "dart:core",
 
@@ -213,6 +215,7 @@ prebuilt_dart_action("flutter_dartdevc_canvaskit_kernel_sdk") {
   ]
 
   args = [
+    "--no-sound-null-safety",
     "--compile-sdk",
     "dart:core",
 

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -116,7 +116,6 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk_outline") {
   script = "//third_party/dart/utils/bazel/kernel_worker.dart"
 
   args = [
-    "--enable-experiment=non-nullable",
     "--summary-only",
     "--target",
     "ddc",
@@ -162,7 +161,6 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk") {
   ]
 
   args = [
-    "--enable-experiment=non-nullable",
     "--compile-sdk",
     "dart:core",
 
@@ -215,7 +213,6 @@ prebuilt_dart_action("flutter_dartdevc_canvaskit_kernel_sdk") {
   ]
 
   args = [
-    "--enable-experiment=non-nullable",
     "--compile-sdk",
     "dart:core",
 
@@ -270,7 +267,6 @@ prebuilt_dart_action("flutter_dartdevc_canvaskit_html_kernel_sdk") {
   ]
 
   args = [
-    "--enable-experiment=non-nullable",
     "--compile-sdk",
     "dart:core",
 
@@ -325,7 +321,6 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk_sound") {
   ]
 
   args = [
-    "--enable-experiment=non-nullable",
     "--sound-null-safety",
     "--compile-sdk",
     "dart:core",
@@ -380,7 +375,6 @@ prebuilt_dart_action("flutter_dartdevc_canvaskit_kernel_sdk_sound") {
   ]
 
   args = [
-    "--enable-experiment=non-nullable",
     "--sound-null-safety",
     "--compile-sdk",
     "dart:core",
@@ -436,7 +430,6 @@ prebuilt_dart_action("flutter_dartdevc_canvaskit_html_kernel_sdk_sound") {
   ]
 
   args = [
-    "--enable-experiment=non-nullable",
     "--sound-null-safety",
     "--compile-sdk",
     "dart:core",
@@ -487,7 +480,6 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk_outline_sound") {
   script = "//third_party/dart/utils/bazel/kernel_worker.dart"
 
   args = [
-    "--enable-experiment=non-nullable",
     "--sound-null-safety",
     "--summary-only",
     "--target",


### PR DESCRIPTION
This relands the rest of #27059

The difference here is that I'm _not_ adding any new `--sound-null-safety` flags.

Per @jakemac53 and @nshahan this is the right way to go - all of our dart files use either `@dart = 2.12` or `@dart = 2.[9 or less]`.

Adding the `--sound-null-safety` caused some dill files to get compiled with the wrong bits and made them unsuitable for use in unsound applications.

@yjbanov FYI
@bdero FYI
@chaselatta FYI