### PR TITLE
[web] fix macOS info collection; print only on bot; propagate errors

### DIFF
--- a/lib/web_ui/dev/macos_info.dart
+++ b/lib/web_ui/dev/macos_info.dart
@@ -11,23 +11,9 @@ class MacOSInfo {
   ///
   /// Built in tools such as `system_profiler` and `defaults` are utilized.
   Future<void> printInformation() async {
-    try {
-      await _printSafariApplications();
-    } catch (error) {
-      print('Error thrown while getting Safari Applications: $error');
-    }
-
-    try {
-      await _printSafariDefaults();
-    } catch (error) {
-      print('Error thrown while getting Safari defaults: $error');
-    }
-
-    try {
-      await _printUserLimits();
-    } catch (error) {
-      print('Error thrown while getting user limits defaults: $error');
-    }
+    await _printSafariApplications();
+    await _printSafariDefaults();
+    await _printUserLimits();
   }
 
   /// Print information on applications in the system that contains string
@@ -59,17 +45,18 @@ class MacOSInfo {
     final ProcessManager defaults = await startProcess(
       '/usr/bin/defaults',
       ['find', 'Safari'],
+      evalOutput: true,
     );
     print('Safari related defaults:\n ${await defaults.evalStdout()}');
   }
 
   /// Print user limits (file and process).
   Future<void> _printUserLimits() async {
-    ProcessManager ulimit = await startProcess('ulimit', ['-n']);
+    ProcessManager ulimit = await startProcess('ulimit', ['-n'], evalOutput: true);
     final String fileLimit = await ulimit.evalStdout();
     print('MacOS file limit: $fileLimit');
 
-    ulimit = await startProcess('ulimit', ['-u']);
+    ulimit = await startProcess('ulimit', ['-u'], evalOutput: true);
     final String processLimit = await ulimit.evalStdout();
     print('MacOS process limit: $processLimit');
   }

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -187,8 +187,8 @@ class TestCommand extends Command<bool> with ArgUtils {
       ..argParsers.forEach((t) => t.parseOptions(argResults!));
     GeneralTestsArgumentParser.instance.parseOptions(argResults!);
 
-    if (isSafariOnMacOS) {
-      /// Collect information on the bot.
+    /// Collect information on the bot.
+    if (isSafariOnMacOS && isLuci) {
       final MacOSInfo macOsInfo = new MacOSInfo();
       await macOsInfo.printInformation();
     }


### PR DESCRIPTION
* Fix macOS info collection logic
* Do not swallow exceptions when collecting macOS info.
* Only print macOS info on LUCI bots; locally this generates way too much noise.