### PR TITLE
Windows: Allow win32 apps to initialize with different assets path or AOT filename

### DIFF
--- a/shell/platform/windows/client_wrapper/dart_project_unittests.cc
+++ b/shell/platform/windows/client_wrapper/dart_project_unittests.cc
@@ -35,4 +35,11 @@ TEST_F(DartProjectTest, StandardProjectFormat) {
   EXPECT_EQ(GetProjectAotLibraryPath(project), L"test\\app.so");
 }
 
+TEST_F(DartProjectTest, ProjectWithCustomPaths) {
+  DartProject project(L"data\\assets", L"icu\\icudtl.dat", L"lib\\file.so");
+  EXPECT_EQ(GetProjectIcuDataPath(project), L"icu\\icudtl.dat");
+  EXPECT_EQ(GetProjectAssetsPath(project), L"data\\assets");
+  EXPECT_EQ(GetProjectAotLibraryPath(project), L"lib\\file.so");
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
@@ -13,14 +13,14 @@ namespace flutter {
 // A set of Flutter and Dart assets used to initialize a Flutter engine.
 class DartProject {
  public:
-#ifdef WINUWP
   // Creates a DartProject from a series of absolute paths.
-  // The directory should contain the following top-level items:
-  // - icudtl.dat (provided as a resource by the Flutter tool)
-  // - flutter_assets (as built by the Flutter tool)
-  // - app.so, for an AOT build (as built by the Flutter tool)
+  // The three paths are:
+  // - assetspath: Path to the assets directory as built by the Flutter tool.
+  // - icupath: Path to the icudtl.dat file.
+  // - aotpath: Path to the AOT snapshot file.
   //
-  // The path must be absolute.
+  // The paths must be absolute in a UWP app. In a win32 app, they can be
+  // relative to the directory containing the running executable.
   explicit DartProject(const std::wstring& assetspath,
                        const std::wstring& icupath,
                        const std::wstring& aotpath) {
@@ -28,7 +28,8 @@ class DartProject {
     icu_data_path_ = icupath;
     aot_library_path_ = aotpath;
   }
-#else
+
+#ifndef WINUWP
   // Creates a DartProject from a directory path. The directory should contain
   // the following top-level items:
   // - icudtl.dat (provided as a resource by the Flutter tool)

--- a/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/dart_project.h
@@ -15,18 +15,18 @@ class DartProject {
  public:
   // Creates a DartProject from a series of absolute paths.
   // The three paths are:
-  // - assetspath: Path to the assets directory as built by the Flutter tool.
-  // - icupath: Path to the icudtl.dat file.
-  // - aotpath: Path to the AOT snapshot file.
+  // - assets_path: Path to the assets directory as built by the Flutter tool.
+  // - icu_data_path: Path to the icudtl.dat file.
+  // - aot_library_path: Path to the AOT snapshot file.
   //
   // The paths must be absolute in a UWP app. In a win32 app, they can be
   // relative to the directory containing the running executable.
-  explicit DartProject(const std::wstring& assetspath,
-                       const std::wstring& icupath,
-                       const std::wstring& aotpath) {
-    assets_path_ = assetspath;
-    icu_data_path_ = icupath;
-    aot_library_path_ = aotpath;
+  explicit DartProject(const std::wstring& assets_path,
+                       const std::wstring& icu_data_path,
+                       const std::wstring& aot_library_path) {
+    assets_path_ = assets_path;
+    icu_data_path_ = icu_data_path;
+    aot_library_path_ = aot_library_path;
   }
 
 #ifndef WINUWP


### PR DESCRIPTION
Our build system internally generates files with different names. This PR allows us to generate a `DartProject` with custom paths for assets, icu file and AOT file.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
