### PR TITLE
[web] skip overlay test on Safari

### DIFF
--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -312,7 +312,8 @@ void testMain() {
       //   Expect: success. Just checking the system is not left in a corrupted state.
       await _createPlatformView(0, 'test-platform-view');
       renderTestScene(viewCount: 0);
-    });
+    // TODO(yjbanov): skipped due to https://github.com/flutter/flutter/issues/73867
+    }, skip: isSafari);
 
     test('embeds and disposes of a platform view', () async {
       ui.platformViewRegistry.registerViewFactory(


### PR DESCRIPTION
Skip the overlay test in Safari due to flaky WASM bug: https://github.com/flutter/flutter/issues/73867