### PR TITLE
Make scrollable unfocusable when voiceover is running

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1228,7 +1228,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   platformView->SetSemanticsEnabled(true);
   platformView->SetAccessibilityFeatures(flags);
 #else
-  bool enabled = UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning();
+  _isVoiceOverRunning = UIAccessibilityIsVoiceOverRunning();
+  bool enabled = _isVoiceOverRunning || UIAccessibilityIsSwitchControlRunning();
   if (enabled)
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kAccessibleNavigation);
   platformView->SetSemanticsEnabled(enabled || UIAccessibilityIsSpeakScreenEnabled());

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -26,6 +26,7 @@ extern NSNotificationName const FlutterViewControllerShowHomeIndicator;
 @interface FlutterViewController ()
 
 @property(nonatomic, readonly) BOOL isPresentingViewController;
+@property(nonatomic, readonly) BOOL isVoiceOverRunning;
 - (fml::WeakPtr<FlutterViewController>)getWeakPtr;
 - (std::shared_ptr<flutter::FlutterPlatformViewsController>&)platformViewsController;
 - (FlutterRestorationPlugin*)restorationPlugin;

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -193,12 +193,6 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   [self setFrame:[_semanticsObject accessibilityFrame]];
   [self setContentSize:[self contentSizeInternal]];
   [self setContentOffset:[self contentOffsetInternal] animated:NO];
-  if (self.contentSize.width > self.frame.size.width ||
-      self.contentSize.height > self.frame.size.height) {
-    self.isAccessibilityElement = YES;
-  } else {
-    self.isAccessibilityElement = NO;
-  }
 }
 
 - (void)setChildren:(NSArray<SemanticsObject*>*)children {
@@ -217,6 +211,18 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
                          bridge:[_semanticsObject bridge]]);
   }
   return _container.get();
+}
+
+- (BOOL)isAccessibilityElement {
+  if (![_semanticsObject isAccessibilityBridgeAlive]) {
+    return NO;
+  }
+  if (self.contentSize.width > self.frame.size.width ||
+      self.contentSize.height > self.frame.size.height) {
+    return !_semanticsObject.bridge->isVoiceOverRunning();
+  } else {
+    return NO;
+  }
 }
 
 // private methods

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -18,9 +18,9 @@
 #include "flutter/lib/ui/semantics/custom_accessibility_action.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterChannels.h"
-#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.h"
 #import "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h"
 #include "third_party/skia/include/core/SkRect.h"
@@ -67,6 +67,8 @@ class AccessibilityBridge final : public AccessibilityBridgeIos {
   UIView<UITextInput>* textInputView() override;
 
   UIView* view() const override { return view_controller_.view; }
+
+  bool isVoiceOverRunning() const override { return view_controller_.isVoiceOverRunning; }
 
   fml::WeakPtr<AccessibilityBridge> GetWeakPtr();
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
@@ -21,6 +21,7 @@ class AccessibilityBridgeIos {
  public:
   virtual ~AccessibilityBridgeIos() = default;
   virtual UIView* view() const = 0;
+  virtual bool isVoiceOverRunning() const = 0;
   virtual UIView<UITextInput>* textInputView() = 0;
   virtual void DispatchSemanticsAction(int32_t id, flutter::SemanticsAction action) = 0;
   virtual void DispatchSemanticsAction(int32_t id,

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge_test.mm
@@ -224,6 +224,32 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   OCMVerifyAll(mockFlutterView);
 }
 
+- (void)testIsVoiceOverRunning {
+  flutter::MockDelegate mock_delegate;
+  auto thread_task_runner = CreateNewThread("AccessibilityBridgeTest");
+  flutter::TaskRunners runners(/*label=*/self.name.UTF8String,
+                               /*platform=*/thread_task_runner,
+                               /*raster=*/thread_task_runner,
+                               /*ui=*/thread_task_runner,
+                               /*io=*/thread_task_runner);
+  auto platform_view = std::make_unique<flutter::PlatformViewIOS>(
+      /*delegate=*/mock_delegate,
+      /*rendering_api=*/flutter::IOSRenderingAPI::kSoftware,
+      /*platform_views_controller=*/nil,
+      /*task_runners=*/runners);
+  id mockFlutterView = OCMClassMock([FlutterView class]);
+  id mockFlutterViewController = OCMClassMock([FlutterViewController class]);
+  OCMStub([mockFlutterViewController view]).andReturn(mockFlutterView);
+  OCMStub([mockFlutterViewController isVoiceOverRunning]).andReturn(YES);
+
+  __block auto bridge =
+      std::make_unique<flutter::AccessibilityBridge>(/*view_controller=*/mockFlutterViewController,
+                                                     /*platform_view=*/platform_view.get(),
+                                                     /*platform_views_controller=*/nil);
+
+  XCTAssertTrue(bridge->isVoiceOverRunning());
+}
+
 - (void)testSemanticsDeallocated {
   @autoreleasepool {
     flutter::MockDelegate mock_delegate;


### PR DESCRIPTION
The feature is not needed in voiceover.

Fixes https://github.com/flutter/flutter/issues/85725

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
