### PR TITLE
enable DisplayList by default

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -166,7 +166,7 @@ struct Settings {
   bool enable_skparagraph = false;
 
   // Selects the DisplayList for storage of rendering operations.
-  bool enable_display_list = false;
+  bool enable_display_list = true;
 
   // All shells in the process share the same VM. The last shell to shutdown
   // should typically shut down the VM as well. However, applications depend on


### PR DESCRIPTION
This PR will enable Flutter to use the new DisplayList format for its Picture objects.

I have briefly marked it as a WIP awaiting the original [add a DisplayList mechanism](https://github.com/flutter/engine/pull/26928) PR to percolate up the chain of integrations and pass all of its own testing. When we see it successfully land in the top repos this PR will be pushed to follow it and switch our work over to the new mechanism.

Since it is just changing the default value of a flag, no further tests will be needed and it will hopefully pass all rendering and other tests in the engine and framework repos with no further work.