### PR TITLE
fuchsia: Handle clips on platform views

### DIFF
--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
@@ -35,6 +35,30 @@ namespace flutter_runner {
 using ViewCallback = std::function<void()>;
 using ViewIdCallback = std::function<void(scenic::ResourceId)>;
 
+// This struct represents a transformed clip rect.
+struct TransformedClip {
+  SkMatrix transform = SkMatrix::I();
+  SkRect rect = SkRect::MakeEmpty();
+
+  bool operator==(const TransformedClip& other) const {
+    return transform == other.transform && rect == other.rect;
+  }
+};
+
+// This struct represents all the mutators that can be applied to a
+// PlatformView, unpacked from the `MutatorStack`.
+struct ViewMutators {
+  std::vector<TransformedClip> clips;
+  SkMatrix total_transform = SkMatrix::I();
+  SkMatrix transform = SkMatrix::I();
+  SkScalar opacity = 1.f;
+
+  bool operator==(const ViewMutators& other) const {
+    return clips == other.clips && total_transform == other.total_transform &&
+           transform == other.transform && opacity == other.opacity;
+  }
+};
+
 // This class orchestrates interaction with the Scenic compositor on Fuchsia. It
 // ensures that flutter content and platform view content are both rendered
 // correctly in a unified scene.
@@ -104,8 +128,7 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
                          bool focusable);
 
  private:
-  // Reset state for a new frame.
-  void Reset();
+  void Reset();  // Reset state for a new frame.
 
   struct EmbedderLayer {
     EmbedderLayer(const SkISize& frame_size,
@@ -122,23 +145,24 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
     std::unique_ptr<flutter::CanvasSpy> canvas_spy;
     SkISize surface_size;
   };
+  using EmbedderLayerId = std::optional<uint32_t>;
+  constexpr static EmbedderLayerId kRootLayerId = EmbedderLayerId{};
 
   struct ScenicView {
+    std::vector<scenic::EntityNode> clip_nodes;
     scenic::OpacityNodeHACK opacity_node;
-    scenic::EntityNode entity_node;
+    scenic::EntityNode transform_node;
     scenic::ViewHolder view_holder;
 
-    SkPoint offset = SkPoint::Make(0.f, 0.f);
-    SkSize scale = SkSize::MakeEmpty();
+    ViewMutators mutators;
+    float elevation = 0.f;
+
     SkSize size = SkSize::MakeEmpty();
     SkRect occlusion_hint = SkRect::MakeEmpty();
-    float elevation = 0.f;
-    float opacity = 1.f;
-    bool hit_testable = true;
-    bool focusable = true;
-
     SkRect pending_occlusion_hint = SkRect::MakeEmpty();
+    bool hit_testable = true;
     bool pending_hit_testable = true;
+    bool focusable = true;
     bool pending_focusable = true;
   };
 
@@ -146,9 +170,6 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
     scenic::ShapeNode shape_node;
     scenic::Material material;
   };
-
-  using EmbedderLayerId = std::optional<uint32_t>;
-  constexpr static EmbedderLayerId kRootLayerId = EmbedderLayerId{};
 
   DefaultSessionConnection& session_;
   VulkanSurfaceProducer& surface_producer_;


### PR DESCRIPTION
Fuchsia's new ExternalViewEmbedder doesn't handle clip mutators on platform views.  Add support for these.

Test: Ran smart_display tests; unit-tests coming in a future PR
Fixes: https://buganizer.corp.google.com/issues/191159935
Fixes: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=79054