### PR TITLE
Fix zip bundle structure

### DIFF
--- a/build/zip_bundle.gni
+++ b/build/zip_bundle.gni
@@ -49,7 +49,7 @@ template("zip_bundle") {
       args += [
         "-i",
         rebase_path(input.source),
-        rebase_path(input.destination),
+        input.destination,
       ]
       sources += [ input.source ]
     }


### PR DESCRIPTION
We shouldn't be `rebase_path`ing the destination.

Before:

```
Archive:  out/host_debug_unopt/zip_archives/font-subset.zip
Zip file size: 4163109 bytes, number of entries: 3
-rwxr-xr-x  2.0 unx 18887040 b- defN 21-Jul-01 14:16 Users/dnfield/src/flutter/engine/src/flutter/tools/font-subset/font-subset
-rw-r--r--  2.0 unx  1387680 b- defN 21-Jul-02 08:56 Users/dnfield/src/flutter/engine/src/flutter/tools/font-subset/const_finder.dart.snapshot
-rw-r--r--  2.0 unx      427 b- defN 21-Jul-02 08:54 Users/dnfield/src/flutter/engine/src/flutter/tools/font-subset/README.md
```

After:

```
Archive:  out/host_debug_unopt/zip_archives/font-subset.zip
Zip file size: 4162733 bytes, number of entries: 3
-rwxr-xr-x  2.0 unx 18887040 b- defN 21-Jul-01 14:16 font-subset
-rw-r--r--  2.0 unx  1387680 b- defN 21-Jul-02 08:56 const_finder.dart.snapshot
-rw-r--r--  2.0 unx      427 b- defN 21-Jul-02 15:12 README.md
```

