### PR TITLE
Follow up cleanup of some unit tests for right click handling.

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/iPadGestureTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/iPadGestureTests.m
@@ -28,9 +28,12 @@ static BOOL performBoolSelector(id target, SEL selector) {
   return returnValue;
 }
 
+// TODO(85810): Remove reflection in this test when Xcode version is upgraded to 13.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
 - (void)testPointerButtons {
   BOOL supportsPointerInteraction = NO;
-  // TODO(85810): Remove reflection in this test when Xcode version is upgraded to 13.
   SEL supportsPointerInteractionSelector = @selector(supportsPointerInteraction);
   if ([XCUIDevice.sharedDevice respondsToSelector:supportsPointerInteractionSelector]) {
     supportsPointerInteraction =
@@ -69,7 +72,6 @@ static BOOL performBoolSelector(id target, SEL selector) {
   SEL rightClick = @selector(rightClick);
   XCTAssertTrue([flutterView respondsToSelector:rightClick],
                 @"If supportsPointerInteraction is true, this should be true too.");
-  // TODO(85810): Remove reflection in this test when Xcode version is upgraded to 13.
   [flutterView performSelector:rightClick];
   // Since each touch is its own device, we can't distinguish the other add event(s)
   // Right click should have buttons = 2
@@ -78,5 +80,6 @@ static BOOL performBoolSelector(id target, SEL selector) {
   XCTAssertTrue([app.textFields[@"PointerChange.up:2"] waitForExistenceWithTimeout:1],
                 @"PointerChange.up event did not occur for a right-click");
 }
+#pragma clang diagnostic pop
 
 @end

--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/iPadGestureTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/iPadGestureTests.m
@@ -17,50 +17,66 @@ static const NSInteger kSecondsToWaitForFlutterView = 30;
   self.continueAfterFailure = NO;
 }
 
-#ifdef __IPHONE_15_0
-- (void)testPointerButtons {
-  if (@available(iOS 15, *)) {
-    XCTSkipUnless([XCUIDevice.sharedDevice supportsPointerInteraction],
-                  "Device does not support pointer interaction");
-    XCUIApplication* app = [[XCUIApplication alloc] init];
-    app.launchArguments = @[ @"--pointer-events" ];
-    [app launch];
-
-    NSPredicate* predicateToFindFlutterView =
-        [NSPredicate predicateWithBlock:^BOOL(id _Nullable evaluatedObject,
-                                              NSDictionary<NSString*, id>* _Nullable bindings) {
-          XCUIElement* element = evaluatedObject;
-          return [element.identifier hasPrefix:@"flutter_view"];
-        }];
-    XCUIElement* flutterView = [[app descendantsMatchingType:XCUIElementTypeAny]
-        elementMatchingPredicate:predicateToFindFlutterView];
-    if (![flutterView waitForExistenceWithTimeout:kSecondsToWaitForFlutterView]) {
-      NSLog(@"%@", app.debugDescription);
-      XCTFail(@"Failed due to not able to find any flutterView with %@ seconds",
-              @(kSecondsToWaitForFlutterView));
-    }
-
-    XCTAssertNotNil(flutterView);
-
-    [flutterView tap];
-    // Initial add event should have buttons = 0
-    XCTAssertTrue([app.textFields[@"PointerChange.add:0"] waitForExistenceWithTimeout:1],
-                  @"PointerChange.add event did not occur");
-    // Normal tap should have buttons = 0, the flutter framework will ensure it has buttons = 1
-    XCTAssertTrue([app.textFields[@"PointerChange.down:0"] waitForExistenceWithTimeout:1],
-                  @"PointerChange.down event did not occur for a normal tap");
-    XCTAssertTrue([app.textFields[@"PointerChange.up:0"] waitForExistenceWithTimeout:1],
-                  @"PointerChange.up event did not occur for a normal tap");
-    [flutterView rightClick];
-    // Since each touch is its own device, we can't distinguish the other add event(s)
-    // Right click should have buttons = 2
-    XCTAssertTrue([app.textFields[@"PointerChange.down:2"] waitForExistenceWithTimeout:1],
-                  @"PointerChange.down event did not occur for a right-click");
-    XCTAssertTrue([app.textFields[@"PointerChange.up:2"] waitForExistenceWithTimeout:1],
-                  @"PointerChange.up event did not occur for a right-click");
-    NSLog(@"DebugDescriptionX: %@", app.debugDescription);
-  }
+static BOOL performBoolSelector(id target, SEL selector) {
+  NSInvocation* invocation = [NSInvocation
+      invocationWithMethodSignature:[[target class] instanceMethodSignatureForSelector:selector]];
+  [invocation setSelector:selector];
+  [invocation setTarget:target];
+  [invocation invoke];
+  BOOL returnValue;
+  [invocation getReturnValue:&returnValue];
+  return returnValue;
 }
-#endif
+
+- (void)testPointerButtons {
+  BOOL supportsPointerInteraction = NO;
+  // TODO(85810): Remove reflection in this test when Xcode version is upgraded to 13.
+  SEL supportsPointerInteractionSelector = @selector(supportsPointerInteraction);
+  if ([XCUIDevice.sharedDevice respondsToSelector:supportsPointerInteractionSelector]) {
+    supportsPointerInteraction =
+        performBoolSelector(XCUIDevice.sharedDevice, supportsPointerInteractionSelector);
+  }
+  XCTSkipUnless(supportsPointerInteraction, "Device does not support pointer interaction.");
+  XCUIApplication* app = [[XCUIApplication alloc] init];
+  app.launchArguments = @[ @"--pointer-events" ];
+  [app launch];
+
+  NSPredicate* predicateToFindFlutterView =
+      [NSPredicate predicateWithBlock:^BOOL(id _Nullable evaluatedObject,
+                                            NSDictionary<NSString*, id>* _Nullable bindings) {
+        XCUIElement* element = evaluatedObject;
+        return [element.identifier hasPrefix:@"flutter_view"];
+      }];
+  XCUIElement* flutterView = [[app descendantsMatchingType:XCUIElementTypeAny]
+      elementMatchingPredicate:predicateToFindFlutterView];
+  if (![flutterView waitForExistenceWithTimeout:kSecondsToWaitForFlutterView]) {
+    NSLog(@"%@", app.debugDescription);
+    XCTFail(@"Failed due to not able to find any flutterView with %@ seconds",
+            @(kSecondsToWaitForFlutterView));
+  }
+
+  XCTAssertNotNil(flutterView);
+
+  [flutterView tap];
+  // Initial add event should have buttons = 0
+  XCTAssertTrue([app.textFields[@"PointerChange.add:0"] waitForExistenceWithTimeout:1],
+                @"PointerChange.add event did not occur");
+  // Normal tap should have buttons = 0, the flutter framework will ensure it has buttons = 1
+  XCTAssertTrue([app.textFields[@"PointerChange.down:0"] waitForExistenceWithTimeout:1],
+                @"PointerChange.down event did not occur for a normal tap");
+  XCTAssertTrue([app.textFields[@"PointerChange.up:0"] waitForExistenceWithTimeout:1],
+                @"PointerChange.up event did not occur for a normal tap");
+  SEL rightClick = @selector(rightClick);
+  XCTAssertTrue([flutterView respondsToSelector:rightClick],
+                @"If supportsPointerInteraction is true, this should be true too.");
+  // TODO(85810): Remove reflection in this test when Xcode version is upgraded to 13.
+  [flutterView performSelector:rightClick];
+  // Since each touch is its own device, we can't distinguish the other add event(s)
+  // Right click should have buttons = 2
+  XCTAssertTrue([app.textFields[@"PointerChange.down:2"] waitForExistenceWithTimeout:1],
+                @"PointerChange.down event did not occur for a right-click");
+  XCTAssertTrue([app.textFields[@"PointerChange.up:2"] waitForExistenceWithTimeout:1],
+                @"PointerChange.up event did not occur for a right-click");
+}
 
 @end


### PR DESCRIPTION
Some cleanup after an external contribution: https://github.com/flutter/engine/pull/27019

Removed conditional compilation which makes it easier to maintain until we transition to xcode 13 and it makes the steps for removal more apparent and easier to track.

cc @moffatman

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
