### PR TITLE
[web] Reassign content to temporary slot so Safari can delete it.

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -132,7 +132,7 @@ class PlatformViewManager {
   }
 
   // We need to remove slotted elements like this because of a Safari bug that
-  // gets triggered when a slotted element is removed in a JS tick different
+  // gets triggered when a slotted element is removed in a JS event different
   // than its slot (after the slot is removed).
   //
   // TODO(web): Cleanup https://github.com/flutter/flutter/issues/85816
@@ -144,14 +144,14 @@ class PlatformViewManager {
       element.remove();
       return;
     }
-    final String slotName = "tombstone-${element.getAttribute('slot')}";
-    // Create and inject a new slot in the Shadow Root
+    final String tombstoneName = "tombstone-${element.getAttribute('slot')}";
+    // Create and inject a new slot in the shadow root
     final html.Element slot = html.document.createElement('slot')
       ..style.display = 'none'
-      ..setAttribute('name', slotName);
+      ..setAttribute('name', tombstoneName);
     domRenderer._glassPaneShadow!.append(slot);
     // Link the element to the new slot
-    element.setAttribute('slot', slotName);
+    element.setAttribute('slot', tombstoneName);
     // Delete both the element, and the new slot
     element.remove();
     slot.remove();

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -127,7 +127,34 @@ class PlatformViewManager {
   /// never been rendered before.
   void clearPlatformView(int viewId) {
     // Remove from our cache, and then from the DOM...
-    _contents.remove(viewId)?.remove();
+    final html.Element? element = _contents.remove(viewId);
+    _safelyRemoveSlottedElement(element);
+  }
+
+  // We need to remove slotted elements like this because of a Safari bug that
+  // gets triggered when a slotted element is removed in a JS tick different
+  // than its slot (after the slot is removed).
+  //
+  // TODO(web): Cleanup https://github.com/flutter/flutter/issues/85816
+  void _safelyRemoveSlottedElement(html.Element? element) {
+    if (element == null) {
+      return;
+    }
+    if (browserEngine != BrowserEngine.webkit) {
+      element.remove();
+      return;
+    }
+    final String slotName = "tombstone-${element.getAttribute('slot')}";
+    // Create and inject a new slot in the Shadow Root
+    final html.Element slot = html.document.createElement('slot')
+      ..style.display = 'none'
+      ..setAttribute('name', slotName);
+    domRenderer._glassPaneShadow!.append(slot);
+    // Link the element to the new slot
+    element.setAttribute('slot', slotName);
+    // Delete both the element, and the new slot
+    element.remove();
+    slot.remove();
   }
 
   /// Attempt to ensure that the contents of the user-supplied DOM element will


### PR DESCRIPTION
This small tweak is required to workaround a Safari issue that will make a Flutter web app's flt-glass-pane lose its layout after removing slotted content *after* its slot has been removed.

This code just creates a slot at the moment that some slotted content needs to be removed, reassigns said content to that new "tombstone" slot, and then deletes BOTH from the DOM in the same tick.

This seems to not trigger the Safari bug. 

### Issues

* Safari bug: [Webkit:227652](https://bugs.webkit.org/show_bug.cgi?id=227652)
* Fixes https://github.com/flutter/flutter/issues/84832
* To be cleaned up by: https://github.com/flutter/flutter/issues/85816

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
