### PR TITLE
add support for SkPathEffect to DisplayList

### DIFF
--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -1075,27 +1075,27 @@ void DisplayListBuilder::setBlendMode(SkBlendMode mode) {
 void DisplayListBuilder::setFilterQuality(SkFilterQuality quality) {
   Push<SetFilterQualityOp>(0, quality);
 }
-void DisplayListBuilder::setShader(const sk_sp<SkShader> shader) {
+void DisplayListBuilder::setShader(sk_sp<SkShader> shader) {
   shader  //
       ? Push<SetShaderOp>(0, std::move(shader))
       : Push<ClearShaderOp>(0);
 }
-void DisplayListBuilder::setImageFilter(const sk_sp<SkImageFilter> filter) {
+void DisplayListBuilder::setImageFilter(sk_sp<SkImageFilter> filter) {
   filter  //
       ? Push<SetImageFilterOp>(0, std::move(filter))
       : Push<ClearImageFilterOp>(0);
 }
-void DisplayListBuilder::setColorFilter(const sk_sp<SkColorFilter> filter) {
+void DisplayListBuilder::setColorFilter(sk_sp<SkColorFilter> filter) {
   filter  //
       ? Push<SetColorFilterOp>(0, std::move(filter))
       : Push<ClearColorFilterOp>(0);
 }
-void DisplayListBuilder::setPathEffect(const sk_sp<SkPathEffect> effect) {
+void DisplayListBuilder::setPathEffect(sk_sp<SkPathEffect> effect) {
   effect  //
       ? Push<SetPathEffectOp>(0, std::move(effect))
       : Push<ClearPathEffectOp>(0);
 }
-void DisplayListBuilder::setMaskFilter(const sk_sp<SkMaskFilter> filter) {
+void DisplayListBuilder::setMaskFilter(sk_sp<SkMaskFilter> filter) {
   Push<SetMaskFilterOp>(0, std::move(filter));
 }
 void DisplayListBuilder::setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) {

--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -205,6 +205,7 @@ DEFINE_SET_CLEAR_SKREF_OP(Shader, shader)
 DEFINE_SET_CLEAR_SKREF_OP(ImageFilter, filter)
 DEFINE_SET_CLEAR_SKREF_OP(ColorFilter, filter)
 DEFINE_SET_CLEAR_SKREF_OP(MaskFilter, filter)
+DEFINE_SET_CLEAR_SKREF_OP(PathEffect, effect)
 #undef DEFINE_SET_CLEAR_SKREF_OP
 
 // 4 byte header + 4 byte payload packs into minimum 8 bytes
@@ -1074,22 +1075,27 @@ void DisplayListBuilder::setBlendMode(SkBlendMode mode) {
 void DisplayListBuilder::setFilterQuality(SkFilterQuality quality) {
   Push<SetFilterQualityOp>(0, quality);
 }
-void DisplayListBuilder::setShader(sk_sp<SkShader> shader) {
+void DisplayListBuilder::setShader(const sk_sp<SkShader> shader) {
   shader  //
       ? Push<SetShaderOp>(0, std::move(shader))
       : Push<ClearShaderOp>(0);
 }
-void DisplayListBuilder::setImageFilter(sk_sp<SkImageFilter> filter) {
+void DisplayListBuilder::setImageFilter(const sk_sp<SkImageFilter> filter) {
   filter  //
       ? Push<SetImageFilterOp>(0, std::move(filter))
       : Push<ClearImageFilterOp>(0);
 }
-void DisplayListBuilder::setColorFilter(sk_sp<SkColorFilter> filter) {
+void DisplayListBuilder::setColorFilter(const sk_sp<SkColorFilter> filter) {
   filter  //
       ? Push<SetColorFilterOp>(0, std::move(filter))
       : Push<ClearColorFilterOp>(0);
 }
-void DisplayListBuilder::setMaskFilter(sk_sp<SkMaskFilter> filter) {
+void DisplayListBuilder::setPathEffect(const sk_sp<SkPathEffect> effect) {
+  effect  //
+      ? Push<SetPathEffectOp>(0, std::move(effect))
+      : Push<ClearPathEffectOp>(0);
+}
+void DisplayListBuilder::setMaskFilter(const sk_sp<SkMaskFilter> filter) {
   Push<SetMaskFilterOp>(0, std::move(filter));
 }
 void DisplayListBuilder::setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) {

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -10,6 +10,7 @@
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkImageFilter.h"
+#include "third_party/skia/include/core/SkPathEffect.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkShader.h"
 #include "third_party/skia/include/core/SkVertices.h"
@@ -84,6 +85,8 @@ namespace flutter {
   V(ClearColorFilter)               \
   V(SetImageFilter)                 \
   V(ClearImageFilter)               \
+  V(SetPathEffect)                  \
+  V(ClearPathEffect)                \
                                     \
   V(ClearMaskFilter)                \
   V(SetMaskFilter)                  \
@@ -233,6 +236,7 @@ class Dispatcher {
   virtual void setShader(const sk_sp<SkShader> shader) = 0;
   virtual void setImageFilter(const sk_sp<SkImageFilter> filter) = 0;
   virtual void setColorFilter(const sk_sp<SkColorFilter> filter) = 0;
+  virtual void setPathEffect(const sk_sp<SkPathEffect> effect) = 0;
   virtual void setMaskFilter(const sk_sp<SkMaskFilter> filter) = 0;
   virtual void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) = 0;
 
@@ -341,10 +345,11 @@ class DisplayListBuilder final : public virtual Dispatcher, public SkRefCnt {
   void setColor(SkColor color) override;
   void setBlendMode(SkBlendMode mode) override;
   void setFilterQuality(SkFilterQuality quality) override;
-  void setShader(sk_sp<SkShader> shader) override;
-  void setImageFilter(sk_sp<SkImageFilter> filter) override;
-  void setColorFilter(sk_sp<SkColorFilter> filter) override;
-  void setMaskFilter(sk_sp<SkMaskFilter> filter) override;
+  void setShader(const sk_sp<SkShader> shader) override;
+  void setImageFilter(const sk_sp<SkImageFilter> filter) override;
+  void setColorFilter(const sk_sp<SkColorFilter> filter) override;
+  void setPathEffect(const sk_sp<SkPathEffect> effect) override;
+  void setMaskFilter(const sk_sp<SkMaskFilter> filter) override;
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override;
 
   void save() override;

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -233,11 +233,11 @@ class Dispatcher {
   virtual void setColor(SkColor color) = 0;
   virtual void setBlendMode(SkBlendMode mode) = 0;
   virtual void setFilterQuality(SkFilterQuality quality) = 0;
-  virtual void setShader(const sk_sp<SkShader> shader) = 0;
-  virtual void setImageFilter(const sk_sp<SkImageFilter> filter) = 0;
-  virtual void setColorFilter(const sk_sp<SkColorFilter> filter) = 0;
-  virtual void setPathEffect(const sk_sp<SkPathEffect> effect) = 0;
-  virtual void setMaskFilter(const sk_sp<SkMaskFilter> filter) = 0;
+  virtual void setShader(sk_sp<SkShader> shader) = 0;
+  virtual void setImageFilter(sk_sp<SkImageFilter> filter) = 0;
+  virtual void setColorFilter(sk_sp<SkColorFilter> filter) = 0;
+  virtual void setPathEffect(sk_sp<SkPathEffect> effect) = 0;
+  virtual void setMaskFilter(sk_sp<SkMaskFilter> filter) = 0;
   virtual void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) = 0;
 
   virtual void save() = 0;
@@ -345,11 +345,11 @@ class DisplayListBuilder final : public virtual Dispatcher, public SkRefCnt {
   void setColor(SkColor color) override;
   void setBlendMode(SkBlendMode mode) override;
   void setFilterQuality(SkFilterQuality quality) override;
-  void setShader(const sk_sp<SkShader> shader) override;
-  void setImageFilter(const sk_sp<SkImageFilter> filter) override;
-  void setColorFilter(const sk_sp<SkColorFilter> filter) override;
-  void setPathEffect(const sk_sp<SkPathEffect> effect) override;
-  void setMaskFilter(const sk_sp<SkMaskFilter> filter) override;
+  void setShader(sk_sp<SkShader> shader) override;
+  void setImageFilter(sk_sp<SkImageFilter> filter) override;
+  void setColorFilter(sk_sp<SkColorFilter> filter) override;
+  void setPathEffect(sk_sp<SkPathEffect> effect) override;
+  void setMaskFilter(sk_sp<SkMaskFilter> filter) override;
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override;
 
   void save() override;

--- a/flow/display_list_canvas.cc
+++ b/flow/display_list_canvas.cc
@@ -471,6 +471,11 @@ void DisplayListCanvasRecorder::RecordPaintAttributes(const SkPaint* paint,
     builder_->setImageFilter(current_image_filter_ =
                                  sk_ref_sp(paint->getImageFilter()));
   }
+  if ((dataNeeded & kPathEffectNeeded_) != 0 &&
+      current_path_effect_.get() != paint->getPathEffect()) {
+    builder_->setPathEffect(current_path_effect_ =
+                                sk_ref_sp(paint->getPathEffect()));
+  }
   if ((dataNeeded & kMaskFilterNeeded_) != 0 &&
       current_mask_filter_.get() != paint->getMaskFilter()) {
     builder_->setMaskFilter(current_mask_filter_ =

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -265,8 +265,9 @@ class DisplayListCanvasRecorder
   static constexpr int kShaderNeeded_        = 1 << 7;
   static constexpr int kColorFilterNeeded_   = 1 << 8;
   static constexpr int kImageFilterNeeded_   = 1 << 9;
-  static constexpr int kMaskFilterNeeded_    = 1 << 10;
-  static constexpr int kDitherNeeded_        = 1 << 11;
+  static constexpr int kPathEffectNeeded_    = 1 << 10;
+  static constexpr int kMaskFilterNeeded_    = 1 << 11;
+  static constexpr int kDitherNeeded_        = 1 << 12;
   // clang-format on
 
   // Combinations of the above mask bits that are common to typical "draw"
@@ -278,10 +279,10 @@ class DisplayListCanvasRecorder
                                      kBlendNeeded_ | kInvertColorsNeeded_ |
                                      kColorFilterNeeded_ | kShaderNeeded_ |
                                      kDitherNeeded_ | kImageFilterNeeded_;
-  static constexpr int kDrawMask_ =
-      kPaintMask_ | kPaintStyleNeeded_ | kMaskFilterNeeded_;
-  static constexpr int kStrokeMask_ =
-      kPaintMask_ | kStrokeStyleNeeded_ | kMaskFilterNeeded_;
+  static constexpr int kDrawMask_ = kPaintMask_ | kPaintStyleNeeded_ |
+                                    kMaskFilterNeeded_ | kPathEffectNeeded_;
+  static constexpr int kStrokeMask_ = kPaintMask_ | kStrokeStyleNeeded_ |
+                                      kMaskFilterNeeded_ | kPathEffectNeeded_;
   static constexpr int kImageMask_ =
       kColorNeeded_ | kBlendNeeded_ | kInvertColorsNeeded_ |
       kColorFilterNeeded_ | kDitherNeeded_ | kImageFilterNeeded_ |
@@ -304,6 +305,7 @@ class DisplayListCanvasRecorder
   sk_sp<SkShader> current_shader_;
   sk_sp<SkColorFilter> current_color_filter_;
   sk_sp<SkImageFilter> current_image_filter_;
+  sk_sp<SkPathEffect> current_path_effect_;
   sk_sp<SkMaskFilter> current_mask_filter_;
 };
 

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -14,6 +14,7 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
 #include "third_party/skia/include/core/SkVertices.h"
+#include "third_party/skia/include/effects/SkDashPathEffect.h"
 #include "third_party/skia/include/effects/SkGradientShader.h"
 #include "third_party/skia/include/effects/SkImageFilters.h"
 
@@ -38,12 +39,24 @@ constexpr float stops[] = {
     0.5,
     1.0,
 };
+
+// clang-format off
 constexpr float rotate_color_matrix[20] = {
-    0, 1, 0, 0, 0,  //
-    0, 0, 1, 0, 0,  //
-    1, 0, 0, 0, 0,  //
-    0, 0, 0, 1, 0,  //
+    0, 1, 0, 0, 0,
+    0, 0, 1, 0, 0,
+    1, 0, 0, 0, 0,
+    0, 0, 0, 1, 0,
 };
+constexpr float invert_color_matrix[20] = {
+    -1.0,    0,    0, 1.0,   0,
+       0, -1.0,    0, 1.0,   0,
+       0,    0, -1.0, 1.0,   0,
+     1.0,  1.0,  1.0, 1.0,   0,
+};
+// clang-format on
+
+const SkScalar TestDashes1[] = {4.0, 2.0};
+const SkScalar TestDashes2[] = {1.0, 1.5};
 
 constexpr SkPoint TestPoints[] = {
     {10, 10},
@@ -80,10 +93,18 @@ static const sk_sp<SkShader> TestShader3 =
                                  SkTileMode::kDecal,
                                  0,
                                  nullptr);
-static const sk_sp<SkImageFilter> TestImageFilter =
+static const sk_sp<SkImageFilter> TestImageFilter1 =
     SkImageFilters::Blur(5.0, 5.0, SkTileMode::kDecal, nullptr, nullptr);
-static const sk_sp<SkColorFilter> TestColorFilter =
+static const sk_sp<SkImageFilter> TestImageFilter2 =
+    SkImageFilters::Blur(5.0, 5.0, SkTileMode::kClamp, nullptr, nullptr);
+static const sk_sp<SkColorFilter> TestColorFilter1 =
     SkColorFilters::Matrix(rotate_color_matrix);
+static const sk_sp<SkColorFilter> TestColorFilter2 =
+    SkColorFilters::Matrix(invert_color_matrix);
+static const sk_sp<SkPathEffect> TestPathEffect1 =
+    SkDashPathEffect::Make(TestDashes1, 2, 0.0f);
+static const sk_sp<SkPathEffect> TestPathEffect2 =
+    SkDashPathEffect::Make(TestDashes2, 2, 0.0f);
 static const sk_sp<SkMaskFilter> TestMaskFilter =
     SkMaskFilter::MakeBlur(kNormal_SkBlurStyle, 5.0);
 constexpr SkRect TestBounds = SkRect::MakeLTRB(10, 10, 50, 60);
@@ -290,12 +311,20 @@ std::vector<DisplayListInvocationGroup> allGroups = {
   },
   { "SetImageFilter", {
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(nullptr);}},
-      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(TestImageFilter);}},
+      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(TestImageFilter1);}},
+      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(TestImageFilter2);}},
     }
   },
   { "SetColorFilter", {
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(nullptr);}},
-      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(TestColorFilter);}},
+      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(TestColorFilter1);}},
+      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(TestColorFilter2);}},
+    }
+  },
+  { "SetPathEffect", {
+      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(nullptr);}},
+      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(TestPathEffect1);}},
+      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(TestPathEffect2);}},
     }
   },
   { "SetMaskFilter", {

--- a/flow/display_list_utils.cc
+++ b/flow/display_list_utils.cc
@@ -60,17 +60,20 @@ void SkPaintDispatchHelper::setBlendMode(SkBlendMode mode) {
 void SkPaintDispatchHelper::setFilterQuality(SkFilterQuality quality) {
   paint_.setFilterQuality(quality);
 }
-void SkPaintDispatchHelper::setShader(sk_sp<SkShader> shader) {
+void SkPaintDispatchHelper::setShader(const sk_sp<SkShader> shader) {
   paint_.setShader(shader);
 }
-void SkPaintDispatchHelper::setImageFilter(sk_sp<SkImageFilter> filter) {
+void SkPaintDispatchHelper::setImageFilter(const sk_sp<SkImageFilter> filter) {
   paint_.setImageFilter(filter);
 }
-void SkPaintDispatchHelper::setColorFilter(sk_sp<SkColorFilter> filter) {
+void SkPaintDispatchHelper::setColorFilter(const sk_sp<SkColorFilter> filter) {
   color_filter_ = filter;
   paint_.setColorFilter(makeColorFilter());
 }
-void SkPaintDispatchHelper::setMaskFilter(sk_sp<SkMaskFilter> filter) {
+void SkPaintDispatchHelper::setPathEffect(const sk_sp<SkPathEffect> effect) {
+  paint_.setPathEffect(effect);
+}
+void SkPaintDispatchHelper::setMaskFilter(const sk_sp<SkMaskFilter> filter) {
   paint_.setMaskFilter(filter);
 }
 void SkPaintDispatchHelper::setMaskBlurFilter(SkBlurStyle style,

--- a/flow/display_list_utils.cc
+++ b/flow/display_list_utils.cc
@@ -60,20 +60,20 @@ void SkPaintDispatchHelper::setBlendMode(SkBlendMode mode) {
 void SkPaintDispatchHelper::setFilterQuality(SkFilterQuality quality) {
   paint_.setFilterQuality(quality);
 }
-void SkPaintDispatchHelper::setShader(const sk_sp<SkShader> shader) {
+void SkPaintDispatchHelper::setShader(sk_sp<SkShader> shader) {
   paint_.setShader(shader);
 }
-void SkPaintDispatchHelper::setImageFilter(const sk_sp<SkImageFilter> filter) {
+void SkPaintDispatchHelper::setImageFilter(sk_sp<SkImageFilter> filter) {
   paint_.setImageFilter(filter);
 }
-void SkPaintDispatchHelper::setColorFilter(const sk_sp<SkColorFilter> filter) {
+void SkPaintDispatchHelper::setColorFilter(sk_sp<SkColorFilter> filter) {
   color_filter_ = filter;
   paint_.setColorFilter(makeColorFilter());
 }
-void SkPaintDispatchHelper::setPathEffect(const sk_sp<SkPathEffect> effect) {
+void SkPaintDispatchHelper::setPathEffect(sk_sp<SkPathEffect> effect) {
   paint_.setPathEffect(effect);
 }
-void SkPaintDispatchHelper::setMaskFilter(const sk_sp<SkMaskFilter> filter) {
+void SkPaintDispatchHelper::setMaskFilter(sk_sp<SkMaskFilter> filter) {
   paint_.setMaskFilter(filter);
 }
 void SkPaintDispatchHelper::setMaskBlurFilter(SkBlurStyle style,

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -50,11 +50,11 @@ class IngoreAttributeDispatchHelper : public virtual Dispatcher {
   void setColor(SkColor color) override {}
   void setBlendMode(SkBlendMode mode) override {}
   void setFilterQuality(SkFilterQuality quality) override {}
-  void setShader(const sk_sp<SkShader> shader) override {}
-  void setImageFilter(const sk_sp<SkImageFilter> filter) override {}
-  void setColorFilter(const sk_sp<SkColorFilter> filter) override {}
-  void setPathEffect(const sk_sp<SkPathEffect> effect) override {}
-  void setMaskFilter(const sk_sp<SkMaskFilter> filter) override {}
+  void setShader(sk_sp<SkShader> shader) override {}
+  void setImageFilter(sk_sp<SkImageFilter> filter) override {}
+  void setColorFilter(sk_sp<SkColorFilter> filter) override {}
+  void setPathEffect(sk_sp<SkPathEffect> effect) override {}
+  void setMaskFilter(sk_sp<SkMaskFilter> filter) override {}
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override {}
 };
 
@@ -107,11 +107,11 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
   void setColor(SkColor color) override;
   void setBlendMode(SkBlendMode mode) override;
   void setFilterQuality(SkFilterQuality quality) override;
-  void setShader(const sk_sp<SkShader> shader) override;
-  void setImageFilter(const sk_sp<SkImageFilter> filter) override;
-  void setColorFilter(const sk_sp<SkColorFilter> filter) override;
-  void setPathEffect(const sk_sp<SkPathEffect> effect) override;
-  void setMaskFilter(const sk_sp<SkMaskFilter> filter) override;
+  void setShader(sk_sp<SkShader> shader) override;
+  void setImageFilter(sk_sp<SkImageFilter> filter) override;
+  void setColorFilter(sk_sp<SkColorFilter> filter) override;
+  void setPathEffect(sk_sp<SkPathEffect> effect) override;
+  void setMaskFilter(sk_sp<SkMaskFilter> filter) override;
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override;
 
   const SkPaint& paint() { return paint_; }

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -50,10 +50,11 @@ class IngoreAttributeDispatchHelper : public virtual Dispatcher {
   void setColor(SkColor color) override {}
   void setBlendMode(SkBlendMode mode) override {}
   void setFilterQuality(SkFilterQuality quality) override {}
-  void setShader(sk_sp<SkShader> shader) override {}
-  void setImageFilter(sk_sp<SkImageFilter> filter) override {}
-  void setColorFilter(sk_sp<SkColorFilter> filter) override {}
-  void setMaskFilter(sk_sp<SkMaskFilter> filter) override {}
+  void setShader(const sk_sp<SkShader> shader) override {}
+  void setImageFilter(const sk_sp<SkImageFilter> filter) override {}
+  void setColorFilter(const sk_sp<SkColorFilter> filter) override {}
+  void setPathEffect(const sk_sp<SkPathEffect> effect) override {}
+  void setMaskFilter(const sk_sp<SkMaskFilter> filter) override {}
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override {}
 };
 
@@ -106,10 +107,11 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
   void setColor(SkColor color) override;
   void setBlendMode(SkBlendMode mode) override;
   void setFilterQuality(SkFilterQuality quality) override;
-  void setShader(sk_sp<SkShader> shader) override;
-  void setImageFilter(sk_sp<SkImageFilter> filter) override;
-  void setColorFilter(sk_sp<SkColorFilter> filter) override;
-  void setMaskFilter(sk_sp<SkMaskFilter> filter) override;
+  void setShader(const sk_sp<SkShader> shader) override;
+  void setImageFilter(const sk_sp<SkImageFilter> filter) override;
+  void setColorFilter(const sk_sp<SkColorFilter> filter) override;
+  void setPathEffect(const sk_sp<SkPathEffect> effect) override;
+  void setMaskFilter(const sk_sp<SkMaskFilter> filter) override;
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override;
 
   const SkPaint& paint() { return paint_; }


### PR DESCRIPTION
Fixes the problem of not preserving the SkPathEffects in the paint used by the Text engine as seen in the golden test failures in the engine roll (https://github.com/flutter/flutter/pull/85802)

Includes tests for the new attribute and some minor edits to other attributes.

Note that SkPictureRecorder does not compute the bounds of these path effects properly in the drawPoints() methods without the workaround included in the SkCanvas rendering in the tests. The DisplayList bounds calculations are OK in this respect and worked fine without modifications.