### PR TITLE
(Reland) enable DisplayList mechanism over SkPicture by default

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -166,7 +166,7 @@ struct Settings {
   bool enable_skparagraph = false;
 
   // Selects the DisplayList for storage of rendering operations.
-  bool enable_display_list = false;
+  bool enable_display_list = true;
 
   // All shells in the process share the same VM. The last shell to shutdown
   // should typically shut down the VM as well. However, applications depend on


### PR DESCRIPTION
Reland the DisplayList flag default changing to true after failures seen in:

https://flutter-gold.skia.org/search?issue=85804&crs=github&corpus=flutter (Fixed by https://github.com/flutter/engine/pull/27155)