### PR TITLE
MacOS (metal): Block raster thread instead of platform thread

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterResizableBackingStoreProvider.mm
@@ -78,16 +78,15 @@
 }
 
 - (void)resizeSynchronizerFlush:(nonnull FlutterResizeSynchronizer*)synchronizer {
-  // no-op when using Metal rendering backend.
+  id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
+  [commandBuffer commit];
+  [commandBuffer waitUntilScheduled];
 }
 
 - (void)resizeSynchronizerCommit:(nonnull FlutterResizeSynchronizer*)synchronizer {
   [CATransaction begin];
   [CATransaction setDisableActions:YES];
 
-  id<MTLCommandBuffer> commandBuffer = [_commandQueue commandBuffer];
-  [commandBuffer commit];
-  [commandBuffer waitUntilScheduled];
   [_surfaceManager swapBuffers];
 
   [CATransaction commit];


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/85967

Under normal circumstances (not resizing) `resizeSynchronizerFlush` is called from raster thread, so it is better place to wait until command buffer gets scheduled than `resizeSynchronizerCommit`, which is always called on platform thread.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
