### PR TITLE
Handle null return from CommandRunner.run

### DIFF
--- a/lib/web_ui/dev/felt.dart
+++ b/lib/web_ui/dev/felt.dart
@@ -14,7 +14,7 @@ import 'exceptions.dart';
 import 'test_runner.dart';
 import 'utils.dart';
 
-CommandRunner runner = CommandRunner<bool>(
+CommandRunner<bool> runner = CommandRunner<bool>(
   'felt',
   'Command-line utility for building and testing Flutter web engine.',
 )
@@ -38,7 +38,11 @@ void main(List<String> rawArgs) async {
 
   int exitCode = -1;
   try {
-    final bool result = (await runner.run(args)) as bool;
+    final bool? result = await runner.run(args);
+    if (result == null) {
+      // result == null means Usage was printed.
+      exitCode = 0;
+    }
     if (result == false) {
       print('Sub-command failed: `${args.join(' ')}`');
       exitCode = 1;

--- a/lib/web_ui/dev/test/felt_test.dart
+++ b/lib/web_ui/dev/test/felt_test.dart
@@ -1,0 +1,14 @@
+import 'package:test/test.dart';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+void main() {
+  test('felt.dart --usage exits 0', () async {
+    var dartExecutable = Platform.executable;
+    var testPath = Platform.script.toFilePath();
+    var feltPath = p.join(p.dirname(p.dirname(testPath)), 'felt.dart');
+    var result = await Process.run(dartExecutable, [feltPath, '--help']);
+    expect(result.exitCode, equals(0));
+    expect(result.stdout, contains('usage'));
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/86040.

The analyzer didn't notice this because of the unintentional
cast from CommandRunner&lt;bool&gt; to CommandRunner.

This would cause felt --help to print an extra line about failing
to cast from null to bool.

I've added a test to test/felt_test.dart (the first for felt afaict).  It requires running with `dart run test/felt_test.dart` since there is not pubspec.yaml for felt, thus `dart test` does not work.  I have not attempted to teach any bots how to run this test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
