### PR TITLE
delete references to FilterQuality prior to its removal

### DIFF
--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -162,19 +162,6 @@ struct SetBlendModeOp final : DLOp {
   void dispatch(Dispatcher& dispatcher) const { dispatcher.setBlendMode(mode); }
 };
 
-// 4 byte header + 4 byte payload packs into minimum 8 bytes
-struct SetFilterQualityOp final : DLOp {
-  static const auto kType = DisplayListOpType::kSetFilterQuality;
-
-  SetFilterQualityOp(SkFilterQuality quality) : quality(quality) {}
-
-  const SkFilterQuality quality;
-
-  void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.setFilterQuality(quality);
-  }
-};
-
 // Clear: 4 byte header + unused 4 byte payload uses 8 bytes
 //        (4 bytes unused)
 // Set: 4 byte header + an sk_sp (ptr) uses 16 bytes due to the
@@ -1071,9 +1058,6 @@ void DisplayListBuilder::setColor(SkColor color) {
 }
 void DisplayListBuilder::setBlendMode(SkBlendMode mode) {
   Push<SetBlendModeOp>(0, mode);
-}
-void DisplayListBuilder::setFilterQuality(SkFilterQuality quality) {
-  Push<SetFilterQualityOp>(0, quality);
 }
 void DisplayListBuilder::setShader(sk_sp<SkShader> shader) {
   shader  //

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -77,8 +77,6 @@ namespace flutter {
   V(SetColor)                       \
   V(SetBlendMode)                   \
                                     \
-  V(SetFilterQuality)               \
-                                    \
   V(SetShader)                      \
   V(ClearShader)                    \
   V(SetColorFilter)                 \
@@ -232,7 +230,6 @@ class Dispatcher {
   virtual void setMiterLimit(SkScalar limit) = 0;
   virtual void setColor(SkColor color) = 0;
   virtual void setBlendMode(SkBlendMode mode) = 0;
-  virtual void setFilterQuality(SkFilterQuality quality) = 0;
   virtual void setShader(sk_sp<SkShader> shader) = 0;
   virtual void setImageFilter(sk_sp<SkImageFilter> filter) = 0;
   virtual void setColorFilter(sk_sp<SkColorFilter> filter) = 0;
@@ -344,7 +341,6 @@ class DisplayListBuilder final : public virtual Dispatcher, public SkRefCnt {
   void setMiterLimit(SkScalar limit) override;
   void setColor(SkColor color) override;
   void setBlendMode(SkBlendMode mode) override;
-  void setFilterQuality(SkFilterQuality quality) override;
   void setShader(sk_sp<SkShader> shader) override;
   void setImageFilter(sk_sp<SkImageFilter> filter) override;
   void setColorFilter(sk_sp<SkColorFilter> filter) override;

--- a/flow/display_list_canvas.cc
+++ b/flow/display_list_canvas.cc
@@ -453,10 +453,6 @@ void DisplayListCanvasRecorder::RecordPaintAttributes(const SkPaint* paint,
       builder_->setMiterLimit(current_miter_limit_ = paint->getStrokeMiter());
     }
   }
-  if ((dataNeeded & kFilterQualityNeeded_) != 0 &&
-      current_fq_ != paint->getFilterQuality()) {
-    builder_->setFilterQuality(current_fq_ = paint->getFilterQuality());
-  }
   if ((dataNeeded & kShaderNeeded_) != 0 &&
       current_shader_.get() != paint->getShader()) {
     builder_->setShader(current_shader_ = sk_ref_sp(paint->getShader()));

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -259,15 +259,14 @@ class DisplayListCanvasRecorder
   static constexpr int kColorNeeded_         = 1 << 1;
   static constexpr int kBlendNeeded_         = 1 << 2;
   static constexpr int kInvertColorsNeeded_  = 1 << 3;
-  static constexpr int kFilterQualityNeeded_ = 1 << 4;
-  static constexpr int kPaintStyleNeeded_    = 1 << 5;
-  static constexpr int kStrokeStyleNeeded_   = 1 << 6;
-  static constexpr int kShaderNeeded_        = 1 << 7;
-  static constexpr int kColorFilterNeeded_   = 1 << 8;
-  static constexpr int kImageFilterNeeded_   = 1 << 9;
-  static constexpr int kPathEffectNeeded_    = 1 << 10;
-  static constexpr int kMaskFilterNeeded_    = 1 << 11;
-  static constexpr int kDitherNeeded_        = 1 << 12;
+  static constexpr int kPaintStyleNeeded_    = 1 << 4;
+  static constexpr int kStrokeStyleNeeded_   = 1 << 5;
+  static constexpr int kShaderNeeded_        = 1 << 6;
+  static constexpr int kColorFilterNeeded_   = 1 << 7;
+  static constexpr int kImageFilterNeeded_   = 1 << 8;
+  static constexpr int kPathEffectNeeded_    = 1 << 9;
+  static constexpr int kMaskFilterNeeded_    = 1 << 10;
+  static constexpr int kDitherNeeded_        = 1 << 11;
   // clang-format on
 
   // Combinations of the above mask bits that are common to typical "draw"
@@ -283,10 +282,10 @@ class DisplayListCanvasRecorder
                                     kMaskFilterNeeded_ | kPathEffectNeeded_;
   static constexpr int kStrokeMask_ = kPaintMask_ | kStrokeStyleNeeded_ |
                                       kMaskFilterNeeded_ | kPathEffectNeeded_;
-  static constexpr int kImageMask_ =
-      kColorNeeded_ | kBlendNeeded_ | kInvertColorsNeeded_ |
-      kColorFilterNeeded_ | kDitherNeeded_ | kImageFilterNeeded_ |
-      kFilterQualityNeeded_ | kMaskFilterNeeded_;
+  static constexpr int kImageMask_ = kColorNeeded_ | kBlendNeeded_ |
+                                     kInvertColorsNeeded_ |
+                                     kColorFilterNeeded_ | kDitherNeeded_ |
+                                     kImageFilterNeeded_ | kMaskFilterNeeded_;
   static constexpr int kImageRectMask_ = kImageMask_ | kAaNeeded_;
   static constexpr int kSaveLayerMask_ =
       kColorNeeded_ | kBlendNeeded_ | kInvertColorsNeeded_ |
@@ -301,7 +300,6 @@ class DisplayListCanvasRecorder
   SkScalar current_miter_limit_ = 4.0;
   SkPaint::Cap current_cap_ = SkPaint::Cap::kButt_Cap;
   SkPaint::Join current_join_ = SkPaint::Join::kMiter_Join;
-  SkFilterQuality current_fq_ = SkFilterQuality::kNone_SkFilterQuality;
   sk_sp<SkShader> current_shader_;
   sk_sp<SkColorFilter> current_color_filter_;
   sk_sp<SkImageFilter> current_image_filter_;

--- a/flow/display_list_canvas_unittests.cc
+++ b/flow/display_list_canvas_unittests.cc
@@ -137,8 +137,6 @@ class CanvasCompareTester {
 
     RenderWithStrokes(cv_renderer, dl_renderer);
 
-    // Not testing FilterQuality here because there is no SkPaint version
-
     {
       // half opaque cyan
       SkColor blendableColor = SkColorSetARGB(0x7f, 0x00, 0xff, 0xff);

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -295,13 +295,6 @@ std::vector<DisplayListInvocationGroup> allGroups = {
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setBlendMode(SkBlendMode::kDstIn);}},
     }
   },
-  { "SetFilterQuality", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setFilterQuality(kNone_SkFilterQuality);}},
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setFilterQuality(kLow_SkFilterQuality);}},
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setFilterQuality(kMedium_SkFilterQuality);}},
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setFilterQuality(kHigh_SkFilterQuality);}},
-    }
-  },
   { "SetShader", {
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setShader(nullptr);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setShader(TestShader1);}},

--- a/flow/display_list_utils.cc
+++ b/flow/display_list_utils.cc
@@ -57,9 +57,6 @@ void SkPaintDispatchHelper::setColor(SkColor color) {
 void SkPaintDispatchHelper::setBlendMode(SkBlendMode mode) {
   paint_.setBlendMode(mode);
 }
-void SkPaintDispatchHelper::setFilterQuality(SkFilterQuality quality) {
-  paint_.setFilterQuality(quality);
-}
 void SkPaintDispatchHelper::setShader(sk_sp<SkShader> shader) {
   paint_.setShader(shader);
 }

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -49,7 +49,6 @@ class IgnoreAttributeDispatchHelper : public virtual Dispatcher {
   void setMiterLimit(SkScalar limit) override {}
   void setColor(SkColor color) override {}
   void setBlendMode(SkBlendMode mode) override {}
-  void setFilterQuality(SkFilterQuality quality) override {}
   void setShader(sk_sp<SkShader> shader) override {}
   void setImageFilter(sk_sp<SkImageFilter> filter) override {}
   void setColorFilter(sk_sp<SkColorFilter> filter) override {}
@@ -106,7 +105,6 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
   void setMiterLimit(SkScalar limit) override;
   void setColor(SkColor color) override;
   void setBlendMode(SkBlendMode mode) override;
-  void setFilterQuality(SkFilterQuality quality) override;
   void setShader(sk_sp<SkShader> shader) override;
   void setImageFilter(sk_sp<SkImageFilter> filter) override;
   void setColorFilter(sk_sp<SkColorFilter> filter) override;

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -6,7 +6,6 @@
 #define FLUTTER_FLOW_LAYERS_TEXTURE_LAYER_H_
 
 #include "flutter/flow/layers/layer.h"
-#include "third_party/skia/include/core/SkFilterQuality.h"
 #include "third_party/skia/include/core/SkPoint.h"
 #include "third_party/skia/include/core/SkSize.h"
 

--- a/flow/layers/texture_layer_unittests.cc
+++ b/flow/layers/texture_layer_unittests.cc
@@ -68,7 +68,7 @@ TEST_F(TextureLayerTest, PaintBeforePrerollDies) {
 }
 #endif
 
-TEST_F(TextureLayerTest, PaintingWithLowFilterQuality) {
+TEST_F(TextureLayerTest, PaintingWithLinearSampling) {
   const SkPoint layer_offset = SkPoint::Make(0.0f, 0.0f);
   const SkSize layer_size = SkSize::Make(8.0f, 8.0f);
   const int64_t texture_id = 0;

--- a/flow/testing/mock_texture_unittests.cc
+++ b/flow/testing/mock_texture_unittests.cc
@@ -40,7 +40,7 @@ TEST(MockTextureTest, PaintCalls) {
   EXPECT_EQ(texture->paint_calls(), expected_paint_calls);
 }
 
-TEST(MockTextureTest, PaintCallsWithLowFilterQuality) {
+TEST(MockTextureTest, PaintCallsWithLinearSampling) {
   SkCanvas canvas;
   const SkRect paint_bounds1 = SkRect::MakeWH(1.0f, 1.0f);
   const SkRect paint_bounds2 = SkRect::MakeWH(2.0f, 2.0f);


### PR DESCRIPTION
Most of these are in the DisplayList code - I probably shouldn't have added them in the first place knowing the pending removal of FilterQuality.

A few other changes are just removing including the header that is no longer relevant or renaming tests that no longer use the property.

No tests needed as this is removing dead code.