### PR TITLE
Use the prebuilt SDK's VM to run its frontend_server

### DIFF
--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -40,6 +40,46 @@ template("fixtures_location") {
   }
 }
 
+# Invokes the frontend server using the built Dart SDK or the prebuilt Dart SDK
+# as appropriate.
+#
+# Parameters:
+#   The parameters testonly, deps, inputs, outputs, depfile, and args are
+#   forwarded from the invoker either to an 'action' target or a 'dart_action'
+#   target depending on whether a prebuilt Dart SDK is used or not,
+#   respectively.
+template("_frontend_server") {
+  if (flutter_prebuilt_dart_sdk) {
+    action(target_name) {
+      testonly = invoker.testonly
+      deps = invoker.deps + [ "//flutter:dart_sdk" ]
+      script = "//build/gn_run_binary.py"
+      inputs = invoker.inputs
+      outputs = invoker.outputs
+      depfile = invoker.depfile
+
+      ext = ""
+      if (is_win) {
+        ext = ".exe"
+      }
+      dart = rebase_path("$host_prebuilt_dart_sdk/bin/dart$ext", root_out_dir)
+      frontend_server = rebase_path(
+              "$root_out_dir/dart-sdk/bin/snapshots/frontend_server.dart.snapshot")
+
+      args = [
+               dart,
+               frontend_server,
+             ] + invoker.args
+    }
+  } else {
+    dart_action(target_name) {
+      forward_variables_from(invoker, "*")
+      deps += [ "//third_party/dart/utils/kernel-service:frontend_server" ]
+      script = "$root_out_dir/frontend_server.dart.snapshot"
+    }
+  }
+}
+
 # Generates the Dart kernel snapshot.
 #
 # Arguments
@@ -54,25 +94,10 @@ template("dart_snapshot_kernel") {
   assert(defined(invoker.dart_kernel),
          "The Dart Kernel file location must be specified")
 
-  dart_action(target_name) {
+  _frontend_server(target_name) {
     testonly = true
 
-    if (flutter_prebuilt_dart_sdk) {
-      deps = [ "//flutter:dart_sdk" ]
-      script =
-          "$root_out_dir/dart-sdk/bin/snapshots/frontend_server.dart.snapshot"
-    } else {
-      deps = [
-        # This generates the Frontend server snapshot used in this Dart action as
-        # well as the patched SDK.
-        "//third_party/dart/utils/kernel-service:frontend_server",
-      ]
-      script = "$root_out_dir/frontend_server.dart.snapshot"
-    }
-
-    if (is_aot_test) {
-      deps += [ "//flutter/lib/snapshot:strong_platform" ]
-    }
+    deps = [ "//flutter/lib/snapshot:strong_platform" ]
 
     inputs = [ invoker.dart_main ]
 


### PR DESCRIPTION
This allows a prebuilt Dart SDK to be used in a release mode build. Prior to this PR, when trying to use a prebuilt Dart SDK, the built (product mode) Dart VM would attempt to use an app-jit snapshot from the prebuilt (non-product) Dart SDK and fail. Since the frontend_server is being used to generate a kernel snapshot, it doesn't matter whether the Dart VM that runs it is product or non-product, so using the prebuilt Dart VM works fine.