### PR TITLE
Build testing/dart snapshots with GN instead of in run_tests.py

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -129,6 +129,8 @@ group("flutter") {
       "//flutter/shell/platform/embedder:embedder_proctable_unittests",
       "//flutter/shell/platform/embedder:embedder_unittests",
       "//flutter/testing:testing_unittests",
+      "//flutter/testing/dart",
+      "//flutter/testing/smoke_test_failure",
       "//flutter/third_party/tonic/tests:tonic_unittests",
       "//flutter/third_party/txt:txt_unittests",
     ]

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -1,0 +1,54 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/testing/dart/compile_test.gni")
+
+tests = [
+  "canvas_test.dart",
+  "channel_buffers_test.dart",
+  "codec_test.dart",
+  "color_filter_test.dart",
+  "color_test.dart",
+  "compositing_test.dart",
+  "dart_test.dart",
+  "encoding_test.dart",
+  "geometry_test.dart",
+  "gradient_test.dart",
+  "http_allow_http_connections_test.dart",
+  "http_disallow_http_connections_test.dart",
+  "image_descriptor_test.dart",
+  "image_dispose_test.dart",
+  "image_filter_test.dart",
+  "image_resize_test.dart",
+  "isolate_name_server_test.dart",
+  "isolate_test.dart",
+  "lerp_test.dart",
+  "locale_test.dart",
+  "paragraph_builder_test.dart",
+  "paragraph_test.dart",
+  "path_test.dart",
+  "platform_view_test.dart",
+  "plugin_utilities_test.dart",
+  "semantics_test.dart",
+  "spirv_exception_test.dart",
+  "task_order_test.dart",
+  "text_test.dart",
+  "window_test.dart",
+]
+
+foreach(test, tests) {
+  compile_flutter_dart_test("compile_$test") {
+    dart_file = test
+    dart_kernel = "$root_gen_dir/$test.dill"
+    packages = ".packages"
+  }
+}
+
+group("dart") {
+  testonly = true
+  deps = [ "//flutter/testing/dart/observatory" ]
+  foreach(test, tests) {
+    deps += [ ":compile_$test" ]
+  }
+}

--- a/testing/dart/compile_test.gni
+++ b/testing/dart/compile_test.gni
@@ -1,0 +1,61 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//third_party/dart/build/dart/dart_action.gni")
+
+# Generates a Dart kernel snapshot using flutter_frontend_server.
+#
+# Arguments
+#     dart_main (required): The Main Dart file.
+#
+#     dart_kernel (required): The path to the output kernel snapshot in the out
+#                             directory.
+#
+#     packages (required): The path to the .packages file.
+template("compile_flutter_dart_test") {
+  assert(defined(invoker.dart_file), "The Dart test file must be specified.")
+  assert(defined(invoker.dart_kernel),
+         "The Dart Kernel file location must be specified.")
+  assert(defined(invoker.packages),
+         "The path to the .packages file must be specified.")
+
+  dart_action(target_name) {
+    testonly = true
+    deps = []
+    if (defined(invoker.deps)) {
+      deps += invoker.deps
+    }
+    deps += [
+      "//flutter/flutter_frontend_server:frontend_server",
+      "//flutter/lib/snapshot:strong_platform",
+    ]
+    script = "$root_gen_dir/frontend_server.dart.snapshot"
+    packages = rebase_path(invoker.packages)  # rebase_path(".packages")
+
+    inputs = [ invoker.dart_file ]
+    outputs = [ invoker.dart_kernel ]
+
+    snapshot_depfile =
+        "$root_gen_dir/flutter/testing/snapshot_$target_name.depfile.d"
+    depfile = snapshot_depfile
+
+    flutter_patched_sdk = rebase_path("$root_out_dir/flutter_patched_sdk")
+
+    vm_args = [ "--disable-dart-dev" ]
+
+    args = [
+      "--sound-null-safety",
+      "--sdk-root",
+      flutter_patched_sdk,
+      "--target=flutter",
+      "--packages",
+      packages,
+      "--depfile",
+      rebase_path(snapshot_depfile),
+      "--output-dill",
+      rebase_path(invoker.dart_kernel, root_out_dir),
+      rebase_path(invoker.dart_file),
+    ]
+  }
+}

--- a/testing/dart/observatory/BUILD.gn
+++ b/testing/dart/observatory/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/testing/dart/compile_test.gni")
+
+tests = [ "skp_test.dart" ]
+
+foreach(test, tests) {
+  compile_flutter_dart_test("compile_$test") {
+    dart_file = test
+    dart_kernel = "$root_gen_dir/$test.dill"
+    packages = "../.packages"
+  }
+}
+
+group("observatory") {
+  testonly = true
+  deps = []
+  foreach(test, tests) {
+    deps += [ ":compile_$test" ]
+  }
+}

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -218,54 +218,13 @@ def RunEngineBenchmarks(build_dir, filter):
     RunEngineExecutable(build_dir, 'txt_benchmarks', filter, icu_flags)
 
 
-def SnapshotTest(build_dir, test_packages, dart_file, kernel_file_output, verbose_dart_snapshot):
-  print("Generating snapshot for test %s" % dart_file)
-
-  dart = os.path.join(build_dir, 'dart')
-  frontend_server = os.path.join(build_dir, 'gen', 'frontend_server.dart.snapshot')
-  flutter_patched_sdk = os.path.join(build_dir, 'flutter_patched_sdk')
-
-  assert os.path.exists(dart)
-  assert os.path.exists(frontend_server)
-  assert os.path.exists(flutter_patched_sdk)
-  assert os.path.exists(test_packages)
-
-  snapshot_command = [
-    dart,
-    '--disable-dart-dev',
-    frontend_server,
-    '--sound-null-safety',
-    '--sdk-root',
-    flutter_patched_sdk,
-    '--incremental',
-    '--target=flutter',
-    '--packages',
-    test_packages,
-    '--output-dill',
-    kernel_file_output,
-    dart_file
-  ]
-
-  if verbose_dart_snapshot:
-    RunCmd(snapshot_command, cwd=buildroot_dir)
-  else:
-    try:
-      subprocess.check_output(snapshot_command, cwd=buildroot_dir)
-    except subprocess.CalledProcessError as error:
-      # CalledProcessError's string doesn't print the output. Print it before
-      # the crash for easier inspection.
-      print('Error occurred from the subprocess, with the output:')
-      print(error.output)
-      raise
-  assert os.path.exists(kernel_file_output)
-
-
 def RunDartTest(build_dir, test_packages, dart_file, verbose_dart_snapshot, multithreaded,
                 enable_observatory=False, expect_failure=False):
-  kernel_file_name = os.path.basename(dart_file) + '.kernel.dill'
-  kernel_file_output = os.path.join(out_dir, kernel_file_name)
-
-  SnapshotTest(build_dir, test_packages, dart_file, kernel_file_output, verbose_dart_snapshot)
+  kernel_file_name = os.path.basename(dart_file) + '.dill'
+  kernel_file_output = os.path.join(build_dir, 'gen', kernel_file_name)
+  error_message = "%s doesn't exist. Please run the build that populates %s" % (
+      kernel_file_output, build_dir)
+  assert os.path.isfile(kernel_file_output), error_message
 
   command_args = []
   if not enable_observatory:

--- a/testing/smoke_test_failure/BUILD.gn
+++ b/testing/smoke_test_failure/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//flutter/testing/dart/compile_test.gni")
+
+tests = [ "fail_test.dart" ]
+
+foreach(test, tests) {
+  compile_flutter_dart_test("compile_$test") {
+    dart_file = test
+    dart_kernel = "$root_gen_dir/$test.dill"
+    packages = ".packages"
+  }
+}
+
+group("smoke_test_failure") {
+  testonly = true
+  deps = []
+  foreach(test, tests) {
+    deps += [ ":compile_$test" ]
+  }
+}


### PR DESCRIPTION
As mentioned in https://github.com/flutter/engine/pull/27284, shifting the build of these snapshots from the python script to the GN build.