### PR TITLE
Dispose of embedded views in CanvasKit after resize

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -70,10 +70,6 @@ class HtmlViewEmbedder {
   ui.Size _frameSize = ui.window.physicalSize;
 
   void set frameSize(ui.Size size) {
-    if (_frameSize == size) {
-      return;
-    }
-    _activeCompositionOrder.clear();
     _frameSize = size;
   }
 

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -128,9 +128,6 @@ class PlatformViewManager {
   void clearPlatformView(int viewId) {
     // Remove from our cache, and then from the DOM...
     final html.Element? element = _contents.remove(viewId);
-    if (useCanvasKit) {
-      HtmlViewEmbedder.instance.disposeViews(<int>{viewId});
-    }
     _safelyRemoveSlottedElement(element);
   }
 

--- a/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
+++ b/lib/web_ui/lib/src/engine/platform_views/content_manager.dart
@@ -128,6 +128,9 @@ class PlatformViewManager {
   void clearPlatformView(int viewId) {
     // Remove from our cache, and then from the DOM...
     final html.Element? element = _contents.remove(viewId);
+    if (useCanvasKit) {
+      HtmlViewEmbedder.instance.disposeViews(<int>{viewId});
+    }
     _safelyRemoveSlottedElement(element);
   }
 

--- a/lib/web_ui/test/canvaskit/embedded_views_test.dart
+++ b/lib/web_ui/test/canvaskit/embedded_views_test.dart
@@ -312,7 +312,7 @@ void testMain() {
       //   Expect: success. Just checking the system is not left in a corrupted state.
       await _createPlatformView(0, 'test-platform-view');
       renderTestScene(viewCount: 0);
-    // TODO(yjbanov): skipped due to https://github.com/flutter/flutter/issues/73867
+      // TODO(yjbanov): skipped due to https://github.com/flutter/flutter/issues/73867
     }, skip: isSafari);
 
     test('embeds and disposes of a platform view', () async {
@@ -378,6 +378,20 @@ void testMain() {
         domRenderer.glassPaneElement!.querySelector('flt-platform-view'),
         isNotNull,
       );
+
+      // Render a frame with a different platform view.
+      await _createPlatformView(1, 'test-platform-view');
+      sb = LayerSceneBuilder();
+      sb.pushOffset(0, 0);
+      sb.addPlatformView(1, width: 10, height: 10);
+      dispatcher.rasterizer!.draw(sb.build().layerTree);
+
+      expect(
+          domRenderer.sceneElement!.querySelectorAll('flt-platform-view-slot'),
+          hasLength(1));
+      expect(
+          domRenderer.glassPaneElement!.querySelectorAll('flt-platform-view'),
+          hasLength(2));
 
       // Render a frame without a platform view, but also without disposing of
       // the platform view.


### PR DESCRIPTION
Don't clear the active composition order when the frame size
changes. This could cause us not to delete unused views since
we are tracking them via active composition order.

Fixes https://github.com/flutter/flutter/issues/85522

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
