### PR TITLE
Windows: Implement GetPreferredLanguages for UWP and support l18n

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ SOTEC GmbH & Co. KG <sotec-contributors@sotec.eu>
 Hidenori Matsubayashi <Hidenori.Matsubayashi@sony.com>
 Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>
 Callum Moffat <callum@moffatman.com>
+Koutaro Mori <koutaro.mo@gmail.com>

--- a/shell/platform/windows/system_utils_winuwp.cc
+++ b/shell/platform/windows/system_utils_winuwp.cc
@@ -8,8 +8,8 @@
 
 #include <sstream>
 
-#include <third_party/cppwinrt/generated/winrt/Windows.Foundation.Collections.h>
-#include <third_party/cppwinrt/generated/winrt/Windows.System.UserProfile.h>
+#include "third_party/cppwinrt/generated/winrt/Windows.Foundation.Collections.h"
+#include "third_party/cppwinrt/generated/winrt/Windows.System.UserProfile.h"
 
 #include "flutter/shell/platform/windows/string_conversion.h"
 
@@ -28,7 +28,7 @@ std::vector<std::wstring> GetPreferredLanguages() {
   std::vector<std::wstring> languages;
   auto platform_langueages = winrt::Windows::System::UserProfile::
       GlobalizationPreferences::Languages();
-  for (auto platform_language : platform_langueages) {
+  for (const auto& platform_language : platform_langueages) {
     languages.push_back(std::wstring{platform_language});
   }
   return languages;

--- a/shell/platform/windows/system_utils_winuwp.cc
+++ b/shell/platform/windows/system_utils_winuwp.cc
@@ -8,6 +8,9 @@
 
 #include <sstream>
 
+#include <third_party/cppwinrt/generated/winrt/Windows.Foundation.Collections.h>
+#include <third_party/cppwinrt/generated/winrt/Windows.System.UserProfile.h>
+
 #include "flutter/shell/platform/windows/string_conversion.h"
 
 namespace flutter {
@@ -23,12 +26,11 @@ std::vector<LanguageInfo> GetPreferredLanguageInfo() {
 
 std::vector<std::wstring> GetPreferredLanguages() {
   std::vector<std::wstring> languages;
-  // TODO(clarkezone) need to implement a complete version of this function in
-  // order to get full list of platform languages
-  // https://github.com/flutter/flutter/issues/74156
-  languages.push_back(L"en-US");
-  languages.push_back(L"en");
-
+  auto platform_langueages = winrt::Windows::System::UserProfile::
+      GlobalizationPreferences::Languages();
+  for (auto platform_language : platform_langueages) {
+    languages.push_back(std::wstring{platform_language});
+  }
   return languages;
 }
 


### PR DESCRIPTION
Fixes flutter/flutter#74156

It implements ```GetPreferredLanguages``` for winuwp platform and replace the stub, and support l18n on UWP.
Test on both windows and winuwp for ```GetPreferredLanguages``` already exists in master branch.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
