### PR TITLE
Fixes some bugs when multiple Flutter VC shared one engine

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -255,6 +255,7 @@ shared_library("ios_test_flutter") {
     ":ios_gpu_configuration",
     ":ios_test_flutter_mrc",
     "//flutter/common:common",
+    "//flutter/lib/ui:ui",
     "//flutter/shell/platform/darwin/common:framework_shared",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/third_party/tonic",

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -641,7 +641,9 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
     _engineNeedsLaunch = NO;
   }
 
-  [_engine.get() attachView];
+  if ([_engine.get() viewController] == self) {
+    [_engine.get() attachView];
+  }
 
   if (@available(iOS 13.4, *)) {
     _pointerInteraction.reset([[UIPointerInteraction alloc] initWithDelegate:self]);
@@ -1005,7 +1007,9 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 #pragma mark - Handle view resizing
 
 - (void)updateViewportMetrics {
-  [_engine.get() updateViewportMetrics:_viewportMetrics];
+  if ([_engine.get() viewController] == self) {
+    [_engine.get() updateViewportMetrics:_viewportMetrics];
+  }
 }
 
 - (CGFloat)statusBarPadding {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -5,6 +5,7 @@
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
+#import "flutter/lib/ui/window/viewport_metrics.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterBinaryMessenger.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
@@ -67,6 +68,8 @@ class PointerDataPacket {};
          libraryURI:(NSString*)libraryURI
        initialRoute:(NSString*)initialRoute;
 - (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
+- (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics;
+- (void)attachView;
 @end
 
 @interface FlutterEngine (TestLowMemory)
@@ -115,6 +118,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
 - (void)handlePressEvent:(FlutterUIPressProxy*)press
               nextAction:(void (^)())next API_AVAILABLE(ios(13.4));
 - (void)scrollEvent:(UIPanGestureRecognizer*)recognizer;
+- (void)updateViewportMetrics;
 @end
 
 @interface FlutterViewControllerTest : XCTestCase
@@ -175,6 +179,63 @@ typedef enum UIAccessibilityContrast : NSInteger {
     OCMVerify([viewControllerMock surfaceUpdated:NO]);
   }
   XCTAssertNil(weakViewController);
+}
+
+- (void)testUpdateViewportMetricsDoesntInvokeEngineWhenNotTheViewController {
+  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
+  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
+  FlutterViewController* viewControllerA = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                 nibName:nil
+                                                                                  bundle:nil];
+  mockEngine.viewController = nil;
+  FlutterViewController* viewControllerB = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                 nibName:nil
+                                                                                  bundle:nil];
+  mockEngine.viewController = viewControllerB;
+  [viewControllerA updateViewportMetrics];
+  flutter::ViewportMetrics viewportMetrics;
+  OCMVerify(never(), [mockEngine updateViewportMetrics:viewportMetrics]);
+}
+
+- (void)testUpdateViewportMetricsDoesInvokeEngineWhenIsTheViewController {
+  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
+  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
+  mockEngine.viewController = viewController;
+  [viewController updateViewportMetrics];
+  flutter::ViewportMetrics viewportMetrics;
+  OCMVerify([mockEngine updateViewportMetrics:viewportMetrics]);
+}
+
+- (void)testViewDidLoadDoesntInvokeEngineWhenNotTheViewController {
+  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
+  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
+  FlutterViewController* viewControllerA = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                 nibName:nil
+                                                                                  bundle:nil];
+  mockEngine.viewController = nil;
+  FlutterViewController* viewControllerB = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                 nibName:nil
+                                                                                  bundle:nil];
+  mockEngine.viewController = viewControllerB;
+  UIView* view = viewControllerA.view;
+  XCTAssertNotNil(view);
+  OCMVerify(never(), [mockEngine attachView]);
+}
+
+- (void)testViewDidLoadDoesInvokeEngineWhenIsTheViewController {
+  FlutterEngine* mockEngine = OCMPartialMock([[FlutterEngine alloc] init]);
+  [mockEngine createShell:@"" libraryURI:@"" initialRoute:nil];
+  mockEngine.viewController = nil;
+  FlutterViewController* viewController = [[FlutterViewController alloc] initWithEngine:mockEngine
+                                                                                nibName:nil
+                                                                                 bundle:nil];
+  mockEngine.viewController = viewController;
+  UIView* view = viewController.view;
+  XCTAssertNotNil(view);
+  OCMVerify([mockEngine attachView]);
 }
 
 - (void)testBinaryMessenger {


### PR DESCRIPTION
This PR solves some shared engine issues.
1. At present, the `FlutterViewController.viewDidLoad` will directly call the `FlutterEngine.attachView`. However, in some cases, the FlutterViewController of FlutterEngine at this time may not be the current one.  
2. At present, even if FlutterViewController is not the viewController of FlutterEngine, it will still use updateViewportMetrics to change the metrics of Flutter App in some cases. A typical example is that the keyboard pops up or disappears.

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/86261
https://github.com/flutter/flutter/issues/86353
https://github.com/flutter/flutter/issues/65750

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
