### PR TITLE
Fix import order to unblock Dart roll

### DIFF
--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -16,8 +16,8 @@ import 'package:args/args.dart';
 import 'package:isolate/isolate.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
-import 'package:process_runner/process_runner.dart';
 import 'package:process/process.dart';
+import 'package:process_runner/process_runner.dart';
 
 class FormattingException implements Exception {
   FormattingException(this.message, [this.result]);


### PR DESCRIPTION
Flagged by roll in https://github.com/flutter/engine/pull/27317, which updates the Dart SDK in //third_party/dart/tools/sdks/dart-sdk