### PR TITLE
disable the directives_ordering lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -100,7 +100,8 @@ linter:
     # - curly_braces_in_flow_control_structures # not required by flutter style
     - deprecated_consistency
     # - diagnostic_describe_all_properties # not yet tested
-    - directives_ordering
+    # TODO: Re-enable directives_ordering once roll https://github.com/flutter/engine/pull/27324 has completed.
+    # - directives_ordering
     # - do_not_use_environment # we do this commonly
     - empty_catches
     - empty_constructor_bodies

--- a/tools/licenses/analysis_options.yaml
+++ b/tools/licenses/analysis_options.yaml
@@ -75,7 +75,8 @@ linter:
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
     # - curly_braces_in_flow_control_structures # not yet tested
-    - directives_ordering
+    # TODO: Re-enable directives_ordering once roll https://github.com/flutter/engine/pull/27324 has completed.
+    # - directives_ordering
     - empty_catches
     - empty_constructor_bodies
     - empty_statements


### PR DESCRIPTION
This PR disabled the `directives_ordering` lint.

*List which issues are fixed by this PR. You must list at least one issue.*

This will allow the latest engine roll (https://github.com/flutter/engine/pull/27324) to make progress.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [-] I listed at least one issue that this PR fixes in the description above.
- [-] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
