### PR TITLE
remove references to deprecated SkPaint::getBlendMode()

### DIFF
--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -188,6 +188,7 @@ struct SetBlendModeOp final : DLOp {
       dispatcher.set##name(field);                                    \
     }                                                                 \
   };
+DEFINE_SET_CLEAR_SKREF_OP(Blender, blender)
 DEFINE_SET_CLEAR_SKREF_OP(Shader, shader)
 DEFINE_SET_CLEAR_SKREF_OP(ImageFilter, filter)
 DEFINE_SET_CLEAR_SKREF_OP(ColorFilter, filter)
@@ -1062,6 +1063,11 @@ void DisplayListBuilder::setColor(SkColor color) {
 }
 void DisplayListBuilder::setBlendMode(SkBlendMode mode) {
   Push<SetBlendModeOp>(0, mode);
+}
+void DisplayListBuilder::setBlender(sk_sp<SkBlender> blender) {
+  blender  //
+      ? Push<SetBlenderOp>(0, std::move(blender))
+      : Push<ClearBlenderOp>(0);
 }
 void DisplayListBuilder::setShader(sk_sp<SkShader> shader) {
   shader  //

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_FLOW_DISPLAY_LIST_H_
 #define FLUTTER_FLOW_DISPLAY_LIST_H_
 
+#include "third_party/skia/include/core/SkBlender.h"
 #include "third_party/skia/include/core/SkBlurTypes.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
@@ -77,6 +78,8 @@ namespace flutter {
   V(SetColor)                       \
   V(SetBlendMode)                   \
                                     \
+  V(SetBlender)                     \
+  V(ClearBlender)                   \
   V(SetShader)                      \
   V(ClearShader)                    \
   V(SetColorFilter)                 \
@@ -231,6 +234,7 @@ class Dispatcher {
   virtual void setMiterLimit(SkScalar limit) = 0;
   virtual void setColor(SkColor color) = 0;
   virtual void setBlendMode(SkBlendMode mode) = 0;
+  virtual void setBlender(sk_sp<SkBlender> blender) = 0;
   virtual void setShader(sk_sp<SkShader> shader) = 0;
   virtual void setImageFilter(sk_sp<SkImageFilter> filter) = 0;
   virtual void setColorFilter(sk_sp<SkColorFilter> filter) = 0;
@@ -343,6 +347,7 @@ class DisplayListBuilder final : public virtual Dispatcher, public SkRefCnt {
   void setMiterLimit(SkScalar limit) override;
   void setColor(SkColor color) override;
   void setBlendMode(SkBlendMode mode) override;
+  void setBlender(sk_sp<SkBlender> blender) override;
   void setShader(sk_sp<SkShader> shader) override;
   void setImageFilter(sk_sp<SkImageFilter> filter) override;
   void setColorFilter(sk_sp<SkColorFilter> filter) override;

--- a/flow/display_list_canvas.cc
+++ b/flow/display_list_canvas.cc
@@ -422,10 +422,16 @@ void DisplayListCanvasRecorder::RecordPaintAttributes(const SkPaint* paint,
   }
   if ((dataNeeded & kBlendNeeded_)) {
     skstd::optional<SkBlendMode> mode_optional = paint->asBlendMode();
-    FML_DCHECK(mode_optional);
-    SkBlendMode mode = mode_optional.value();
-    if (current_blend_ != mode) {
-      builder_->setBlendMode(current_blend_ = mode);
+    if (mode_optional) {
+      SkBlendMode mode = mode_optional.value();
+      if (current_blender_ || current_blend_ != mode) {
+        builder_->setBlendMode(current_blend_ = mode);
+        current_blender_ = nullptr;
+      }
+    } else {
+      if (current_blender_.get() != paint->getBlender()) {
+        builder_->setBlender(current_blender_ = sk_ref_sp(paint->getBlender()));
+      }
     }
   }
   // invert colors is a Flutter::Paint thing, not an SkPaint thing

--- a/flow/display_list_canvas.cc
+++ b/flow/display_list_canvas.cc
@@ -420,9 +420,13 @@ void DisplayListCanvasRecorder::RecordPaintAttributes(const SkPaint* paint,
       current_color_ != paint->getColor()) {
     builder_->setColor(current_color_ = paint->getColor());
   }
-  if ((dataNeeded & kBlendNeeded_) != 0 &&
-      current_blend_ != paint->getBlendMode()) {
-    builder_->setBlendMode(current_blend_ = paint->getBlendMode());
+  if ((dataNeeded & kBlendNeeded_)) {
+    skstd::optional<SkBlendMode> mode_optional = paint->asBlendMode();
+    FML_DCHECK(mode_optional);
+    SkBlendMode mode = mode_optional.value();
+    if (current_blend_ != mode) {
+      builder_->setBlendMode(current_blend_ = mode);
+    }
   }
   // invert colors is a Flutter::Paint thing, not an SkPaint thing
   // if ((dataNeeded & invertColorsNeeded_) != 0 &&

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -301,6 +301,7 @@ class DisplayListCanvasRecorder
   SkScalar current_miter_limit_ = 4.0;
   SkPaint::Cap current_cap_ = SkPaint::Cap::kButt_Cap;
   SkPaint::Join current_join_ = SkPaint::Join::kMiter_Join;
+  sk_sp<SkBlender> current_blender_;
   sk_sp<SkShader> current_shader_;
   sk_sp<SkColorFilter> current_color_filter_;
   sk_sp<SkImageFilter> current_image_filter_;

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -14,6 +14,7 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
 #include "third_party/skia/include/core/SkVertices.h"
+#include "third_party/skia/include/effects/SkBlenders.h"
 #include "third_party/skia/include/effects/SkDashPathEffect.h"
 #include "third_party/skia/include/effects/SkGradientShader.h"
 #include "third_party/skia/include/effects/SkImageFilters.h"
@@ -66,6 +67,12 @@ constexpr SkPoint TestPoints[] = {
 };
 #define TestPointCount sizeof(TestPoints) / (sizeof(TestPoints[0]))
 
+static const sk_sp<SkBlender> TestBlender1 =
+    SkBlenders::Arithmetic(0.2, 0.2, 0.2, 0.2, false);
+static const sk_sp<SkBlender> TestBlender2 =
+    SkBlenders::Arithmetic(0.2, 0.2, 0.2, 0.2, true);
+static const sk_sp<SkBlender> TestBlender3 =
+    SkBlenders::Arithmetic(0.3, 0.3, 0.3, 0.3, true);
 static const sk_sp<SkShader> TestShader1 =
     SkGradientShader::MakeLinear(end_points,
                                  colors,
@@ -293,6 +300,13 @@ std::vector<DisplayListInvocationGroup> allGroups = {
   { "SetBlendMode", {
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setBlendMode(SkBlendMode::kSrcIn);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setBlendMode(SkBlendMode::kDstIn);}},
+    }
+  },
+  { "SetBlender", {
+      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setBlender(nullptr);}},
+      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(TestBlender1);}},
+      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(TestBlender2);}},
+      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(TestBlender3);}},
     }
   },
   { "SetShader", {

--- a/flow/display_list_utils.cc
+++ b/flow/display_list_utils.cc
@@ -57,6 +57,9 @@ void SkPaintDispatchHelper::setColor(SkColor color) {
 void SkPaintDispatchHelper::setBlendMode(SkBlendMode mode) {
   paint_.setBlendMode(mode);
 }
+void SkPaintDispatchHelper::setBlender(sk_sp<SkBlender> blender) {
+  paint_.setBlender(blender);
+}
 void SkPaintDispatchHelper::setShader(sk_sp<SkShader> shader) {
   paint_.setShader(shader);
 }

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -49,6 +49,7 @@ class IgnoreAttributeDispatchHelper : public virtual Dispatcher {
   void setMiterLimit(SkScalar limit) override {}
   void setColor(SkColor color) override {}
   void setBlendMode(SkBlendMode mode) override {}
+  void setBlender(sk_sp<SkBlender> blender) override {}
   void setShader(sk_sp<SkShader> shader) override {}
   void setImageFilter(sk_sp<SkImageFilter> filter) override {}
   void setColorFilter(sk_sp<SkColorFilter> filter) override {}
@@ -105,6 +106,7 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
   void setMiterLimit(SkScalar limit) override;
   void setColor(SkColor color) override;
   void setBlendMode(SkBlendMode mode) override;
+  void setBlender(sk_sp<SkBlender> blender) override;
   void setShader(sk_sp<SkShader> shader) override;
   void setImageFilter(sk_sp<SkImageFilter> filter) override;
   void setColorFilter(sk_sp<SkColorFilter> filter) override;


### PR DESCRIPTION
Skia is moving the method under a "LEGACY" ifdef flag that will be deleted soon.

We could use "getBlendMode_or(default)", but I want to fail if anyone is using a non-enum blender as we'd need to do more to support it inside DisplayList.