### PR TITLE
Don't specify the secondary build tree when importing glfw.

### DIFF
--- a/shell/platform/glfw/BUILD.gn
+++ b/shell/platform/glfw/BUILD.gn
@@ -54,12 +54,12 @@ source_set("flutter_glfw") {
 
   deps = [
     ":flutter_glfw_headers",
-    "//build/secondary/third_party/glfw",
     "//flutter/shell/platform/common:common_cpp",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common/client_wrapper:client_wrapper",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/platform/glfw/client_wrapper:client_wrapper_glfw",
+    "//third_party/glfw",
     "//third_party/rapidjson",
   ]
 


### PR DESCRIPTION
This lookup is implicit in GN. Explicitly specifying the glfw in
//build/secondary makes GN think multiple sources generate the same
intermediate object file.

This used to work because no other target also includes glfw. But I
am changing that in an upcoming test harness.