### PR TITLE
Build the robolectric tests by default for debug armv7

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -585,6 +585,8 @@ zip_bundle("android") {
     deps += [ ":flutter_shell_native" ]
   }
 
+  # We only run the robolectric tests for android_debug_unopt (arm CPU), and
+  # the target is relatively expensive to build.
   if (flutter_runtime_mode == "debug" && current_cpu == "arm") {
     deps += [ ":robolectric_tests" ]
   }

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -584,6 +584,10 @@ zip_bundle("android") {
     ]
     deps += [ ":flutter_shell_native" ]
   }
+
+  if (flutter_runtime_mode == "debug" && current_cpu == "arm") {
+    deps += [ ":robolectric_tests" ]
+  }
 }
 
 action("gen_android_javadoc") {

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -543,7 +543,7 @@ action("robolectric_tests") {
   args += rebase_path(sources, root_build_dir)
 
   deps = [
-    ":android",
+    ":android_jar",
     ":flutter_shell_java",
   ]
 }


### PR DESCRIPTION
See discussion in https://github.com/flutter/engine/pull/27332

This target used to get built by default in run_tests.py, but we avoid doing that now for CI

Once this lands, we can remove the separate build step(s) for it from CI.