### PR TITLE
restore the directives_ordering lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -100,8 +100,7 @@ linter:
     # - curly_braces_in_flow_control_structures # not required by flutter style
     - deprecated_consistency
     # - diagnostic_describe_all_properties # not yet tested
-    # TODO: Re-enable directives_ordering once roll https://github.com/flutter/engine/pull/27324 has completed.
-    # - directives_ordering
+    - directives_ordering
     # - do_not_use_environment # we do this commonly
     - empty_catches
     - empty_constructor_bodies

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 5754c1ee0193299dad20012e408d4ce2
+Signature: 17e2c7f169a5804317b8f79ab1f8a838
 

--- a/tools/licenses/lib/filesystem.dart
+++ b/tools/licenses/lib/filesystem.dart
@@ -6,8 +6,8 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io' as io;
 
-import 'package:path/path.dart' as path;
 import 'package:archive/archive.dart' as a;
+import 'package:path/path.dart' as path;
 
 import 'cache.dart';
 import 'limits.dart';


### PR DESCRIPTION
- restore the directives_ordering lint

This is a follow-up to https://github.com/flutter/engine/pull/27331.