### PR TITLE
Make dart wrappable classes use only one native field

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -13,7 +13,7 @@ part of dart.ui;
 /// Scene objects can be displayed on the screen using the [FlutterView.render]
 /// method.
 @pragma('vm:entry-point')
-class Scene extends NativeFieldWrapperClass2 {
+class Scene extends NativeFieldWrapperClass1 {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
   ///
@@ -205,7 +205,7 @@ class PhysicalShapeEngineLayer extends _EngineLayerWrapper {
 /// To draw graphical operations onto a [Scene], first create a
 /// [Picture] using a [PictureRecorder] and a [Canvas], and then add
 /// it to the scene using [addPicture].
-class SceneBuilder extends NativeFieldWrapperClass2 {
+class SceneBuilder extends NativeFieldWrapperClass1 {
   /// Creates an empty [SceneBuilder] object.
   @pragma('vm:entry-point')
   SceneBuilder() {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1831,7 +1831,7 @@ class Image {
 }
 
 @pragma('vm:entry-point')
-class _Image extends NativeFieldWrapperClass2 {
+class _Image extends NativeFieldWrapperClass1 {
   // This class is created by the engine, and should not be instantiated
   // or extended directly.
   //
@@ -1953,7 +1953,7 @@ class FrameInfo {
 /// To obtain an instance of the [Codec] interface, see
 /// [instantiateImageCodec].
 @pragma('vm:entry-point')
-class Codec extends NativeFieldWrapperClass2 {
+class Codec extends NativeFieldWrapperClass1 {
   //
   // This class is created by the engine, and should not be instantiated
   // or extended directly.
@@ -2238,7 +2238,7 @@ enum PathOperation {
 
 /// A handle for the framework to hold and retain an engine layer across frames.
 @pragma('vm:entry-point')
-class EngineLayer extends NativeFieldWrapperClass2 {
+class EngineLayer extends NativeFieldWrapperClass1 {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
   @pragma('vm:entry-point')
@@ -2277,7 +2277,7 @@ class EngineLayer extends NativeFieldWrapperClass2 {
 /// Paths can be drawn on canvases using [Canvas.drawPath], and can
 /// used to create clip regions using [Canvas.clipPath].
 @pragma('vm:entry-point')
-class Path extends NativeFieldWrapperClass2 {
+class Path extends NativeFieldWrapperClass1 {
   /// Create a new empty [Path] object.
   @pragma('vm:entry-point')
   Path() { _constructor(); }
@@ -2828,7 +2828,7 @@ class PathMetric {
   String toString() => '$runtimeType{length: $length, isClosed: $isClosed, contourIndex:$contourIndex}';
 }
 
-class _PathMeasure extends NativeFieldWrapperClass2 {
+class _PathMeasure extends NativeFieldWrapperClass1 {
   _PathMeasure(Path path, bool forceClosed) {
     _constructor(path, forceClosed);
   }
@@ -3158,7 +3158,7 @@ class ColorFilter implements ImageFilter {
 /// ColorFilter, because we want ColorFilter to be const constructible and
 /// efficiently comparable, so that widgets can check for ColorFilter equality to
 /// avoid repainting.
-class _ColorFilter extends NativeFieldWrapperClass2 {
+class _ColorFilter extends NativeFieldWrapperClass1 {
   _ColorFilter.mode(this.creator)
     : assert(creator != null),
       assert(creator._type == ColorFilter._kTypeMode) {
@@ -3354,7 +3354,7 @@ class _ComposeImageFilter implements ImageFilter {
 /// This is a private class, rather than being the implementation of the public
 /// ImageFilter, because we want ImageFilter to be efficiently comparable, so that
 /// widgets can check for ImageFilter equality to avoid repainting.
-class _ImageFilter extends NativeFieldWrapperClass2 {
+class _ImageFilter extends NativeFieldWrapperClass1 {
   void _constructor() native 'ImageFilter_constructor';
 
   /// Creates an image filter that applies a Gaussian blur.
@@ -3407,7 +3407,7 @@ class _ImageFilter extends NativeFieldWrapperClass2 {
 
 /// Base class for objects such as [Gradient] and [ImageShader] which
 /// correspond to shaders as used by [Paint.shader].
-class Shader extends NativeFieldWrapperClass2 {
+class Shader extends NativeFieldWrapperClass1 {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
   @pragma('vm:entry-point')
@@ -3762,7 +3762,7 @@ enum VertexMode {
 }
 
 /// A set of vertex data used by [Canvas.drawVertices].
-class Vertices extends NativeFieldWrapperClass2 {
+class Vertices extends NativeFieldWrapperClass1 {
   /// Creates a set of vertex data for use with [Canvas.drawVertices].
   ///
   /// The [mode] and [positions] parameters must not be null.
@@ -3907,7 +3907,7 @@ enum ClipOp {
 ///
 /// The current transform and clip can be saved and restored using the stack
 /// managed by the [save], [saveLayer], and [restore] methods.
-class Canvas extends NativeFieldWrapperClass2 {
+class Canvas extends NativeFieldWrapperClass1 {
   /// Creates a canvas for recording graphical operations into the
   /// given picture recorder.
   ///
@@ -4907,7 +4907,7 @@ class Canvas extends NativeFieldWrapperClass2 {
 /// the [SceneBuilder.addPicture] method. A [Picture] can also be
 /// drawn into a [Canvas], using the [Canvas.drawPicture] method.
 @pragma('vm:entry-point')
-class Picture extends NativeFieldWrapperClass2 {
+class Picture extends NativeFieldWrapperClass1 {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
   ///
@@ -4954,7 +4954,7 @@ class Picture extends NativeFieldWrapperClass2 {
 ///
 /// To begin recording, construct a [Canvas] to record the commands.
 /// To end recording, use the [PictureRecorder.endRecording] method.
-class PictureRecorder extends NativeFieldWrapperClass2 {
+class PictureRecorder extends NativeFieldWrapperClass1 {
   /// Creates a new idle PictureRecorder. To associate it with a
   /// [Canvas] and begin recording, pass this [PictureRecorder] to the
   /// [Canvas] constructor.
@@ -5198,7 +5198,7 @@ class Shadow {
 ///
 /// The creator of this object is responsible for calling [dispose] when it is
 /// no longer needed.
-class ImmutableBuffer extends NativeFieldWrapperClass2 {
+class ImmutableBuffer extends NativeFieldWrapperClass1 {
   ImmutableBuffer._(this.length);
 
   /// Creates a copy of the data from a [Uint8List] suitable for internal use
@@ -5253,7 +5253,7 @@ class ImmutableBuffer extends NativeFieldWrapperClass2 {
 ///
 /// Use this class to determine the height, width, and byte size of image data
 /// before decoding it.
-class ImageDescriptor extends NativeFieldWrapperClass2 {
+class ImageDescriptor extends NativeFieldWrapperClass1 {
   ImageDescriptor._();
 
   /// Creates an image descriptor from encoded data in a supported format.

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -657,7 +657,7 @@ class SemanticsFlag {
 ///    spell out the string character by character when announcing the string.
 ///  * [LocaleStringAttribute], which causes the assistive technologies to
 ///    treat the string in the specific language.
-abstract class StringAttribute extends NativeFieldWrapperClass2 {
+abstract class StringAttribute extends NativeFieldWrapperClass1 {
   StringAttribute._({
     required this.range,
   });
@@ -749,7 +749,7 @@ class LocaleStringAttribute extends StringAttribute {
 /// [PlatformDispatcher.updateSemantics] to update the semantics conveyed to the
 /// user.
 @pragma('vm:entry-point')
-class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
+class SemanticsUpdateBuilder extends NativeFieldWrapperClass1 {
   /// Creates an empty [SemanticsUpdateBuilder] object.
   @pragma('vm:entry-point')
   SemanticsUpdateBuilder() { _constructor(); }
@@ -991,7 +991,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
 /// Semantics updates can be applied to the system's retained semantics tree
 /// using the [PlatformDispatcher.updateSemantics] method.
 @pragma('vm:entry-point')
-class SemanticsUpdate extends NativeFieldWrapperClass2 {
+class SemanticsUpdate extends NativeFieldWrapperClass1 {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
   ///

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3116,7 +3116,7 @@ class LineMetrics {
 /// Paragraphs can be displayed on a [Canvas] using the [Canvas.drawParagraph]
 /// method.
 @pragma('vm:entry-point')
-class Paragraph extends NativeFieldWrapperClass2 {
+class Paragraph extends NativeFieldWrapperClass1 {
   /// This class is created by the engine, and should not be instantiated
   /// or extended directly.
   ///
@@ -3306,7 +3306,7 @@ class Paragraph extends NativeFieldWrapperClass2 {
 ///
 /// After constructing a [Paragraph], call [Paragraph.layout] on it and then
 /// paint it with [Canvas.drawParagraph].
-class ParagraphBuilder extends NativeFieldWrapperClass2 {
+class ParagraphBuilder extends NativeFieldWrapperClass1 {
 
   /// Creates a new [ParagraphBuilder] object, which is used to create a
   /// [Paragraph].

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle.dart
@@ -8,7 +8,7 @@ part of zircon;
 // ignore_for_file: public_member_api_docs
 
 @pragma('vm:entry-point')
-class Handle extends NativeFieldWrapperClass2 {
+class Handle extends NativeFieldWrapperClass1 {
   // No public constructor - this can only be created from native code.
   @pragma('vm:entry-point')
   Handle._();

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_disposition.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_disposition.dart
@@ -8,7 +8,7 @@ part of zircon;
 // ignore_for_file: public_member_api_docs
 
 @pragma('vm:entry-point')
-class HandleDisposition extends NativeFieldWrapperClass2 {
+class HandleDisposition extends NativeFieldWrapperClass1 {
   @pragma('vm:entry-point')
   HandleDisposition(int operation, Handle handle, int type, int rights) {
     _constructor(operation, handle, type, rights);

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_waiter.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/handle_waiter.dart
@@ -10,7 +10,7 @@ part of zircon;
 typedef AsyncWaitCallback = void Function(int status, int pending);
 
 @pragma('vm:entry-point')
-class HandleWaiter extends NativeFieldWrapperClass2 {
+class HandleWaiter extends NativeFieldWrapperClass1 {
   // Private constructor.
   @pragma('vm:entry-point')
   HandleWaiter._();

--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
@@ -191,7 +191,7 @@ class MapResult extends _Result {
 }
 
 @pragma('vm:entry-point')
-class System extends NativeFieldWrapperClass2 {
+class System extends NativeFieldWrapperClass1 {
   // No public constructor - this only has static methods.
   System._();
 

--- a/third_party/tonic/dart_args.h
+++ b/third_party/tonic/dart_args.h
@@ -234,7 +234,6 @@ void DartCallConstructor(Sig func, Dart_NativeArguments args) {
   TONIC_CHECK(!LogIfError(Dart_GetNativeFieldsOfArgument(
       args, 0, DartWrappable::kNumberOfNativeFields, native_fields)));
   TONIC_CHECK(!native_fields[DartWrappable::kPeerIndex]);
-  TONIC_CHECK(!native_fields[DartWrappable::kWrapperInfoIndex]);
 
   wrappable->AssociateWithDartWrapper(wrapper);
 }

--- a/third_party/tonic/dart_wrappable.cc
+++ b/third_party/tonic/dart_wrappable.cc
@@ -53,8 +53,6 @@ void DartWrappable::AssociateWithDartWrapper(Dart_Handle wrapper) {
 
   TONIC_CHECK(!LogIfError(wrapper));
 
-  const DartWrapperInfo& info = GetDartWrapperInfo();
-
   TONIC_CHECK(!LogIfError(Dart_SetNativeInstanceField(
       wrapper, kPeerIndex, reinterpret_cast<intptr_t>(this))));
 

--- a/third_party/tonic/dart_wrappable.cc
+++ b/third_party/tonic/dart_wrappable.cc
@@ -36,9 +36,6 @@ Dart_Handle DartWrappable::CreateDartWrapper(DartState* dart_state) {
   Dart_Handle res = Dart_SetNativeInstanceField(
       wrapper, kPeerIndex, reinterpret_cast<intptr_t>(this));
   TONIC_DCHECK(!LogIfError(res));
-  res = Dart_SetNativeInstanceField(wrapper, kWrapperInfoIndex,
-                                    reinterpret_cast<intptr_t>(&info));
-  TONIC_DCHECK(!LogIfError(res));
 
   this->RetainDartWrappableReference();  // Balanced in FinalizeDartWrapper.
   dart_wrapper_.Set(dart_state, wrapper, this, GetAllocationSize(),
@@ -60,8 +57,6 @@ void DartWrappable::AssociateWithDartWrapper(Dart_Handle wrapper) {
 
   TONIC_CHECK(!LogIfError(Dart_SetNativeInstanceField(
       wrapper, kPeerIndex, reinterpret_cast<intptr_t>(this))));
-  TONIC_CHECK(!LogIfError(Dart_SetNativeInstanceField(
-      wrapper, kWrapperInfoIndex, reinterpret_cast<intptr_t>(&info))));
 
   this->RetainDartWrappableReference();  // Balanced in FinalizeDartWrapper.
 
@@ -74,8 +69,6 @@ void DartWrappable::ClearDartWrapper() {
   TONIC_DCHECK(!dart_wrapper_.is_empty());
   Dart_Handle wrapper = dart_wrapper_.Get();
   TONIC_CHECK(!LogIfError(Dart_SetNativeInstanceField(wrapper, kPeerIndex, 0)));
-  TONIC_CHECK(
-      !LogIfError(Dart_SetNativeInstanceField(wrapper, kWrapperInfoIndex, 0)));
   dart_wrapper_.Clear();
   this->ReleaseDartWrappableReference();
 }

--- a/third_party/tonic/dart_wrappable.h
+++ b/third_party/tonic/dart_wrappable.h
@@ -23,7 +23,6 @@ class DartWrappable {
  public:
   enum DartNativeFields {
     kPeerIndex,  // Must be first to work with Dart_GetNativeReceiver.
-    kWrapperInfoIndex,
     kNumberOfNativeFields,
   };
 


### PR DESCRIPTION
It appears like the second native field is never really used for
anything: It is set, cleared and verified it was cleared, but that is
it.

=> The only native field that is necessary is the `this` pointer of the
   equivalent C++ object.
=> The [DartWrapperInfo] object which was stored as second native field
   is always accessible via the virtual `GetDartWrapperInfo()` method on
   `this`.