### PR TITLE
Ensure gclient sync is successful on an M1 Mac host.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -66,7 +66,7 @@ vars = {
   'ios_tools_revision': '69b7c1b160e7107a6a98d948363772dc9caea46f',
 
   # Checkout Android dependencies only on platforms where we build for Android targets.
-  'download_android_deps': 'host_os == "mac" or host_os == "linux"',
+  'download_android_deps': 'host_cpu == "x64" and (host_os == "mac" or host_os == "linux")',
 
   # Checkout Windows dependencies only if we are building on Windows.
   'download_windows_deps' : 'host_os == "win"',
@@ -546,7 +546,7 @@ deps = {
     'packages': [
       {
         'package': 'gn/gn/${{platform}}',
-        'version': 'git_revision:1e3fd10c5df6b704fc764ee388149e4f32862823'
+        'version': 'git_revision:24e2f7df92641de0351a96096fb2c490b2436bb8'
       },
     ],
     'dep_type': 'cipd',

--- a/DEPS
+++ b/DEPS
@@ -98,7 +98,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'ff4a363e89f032071e8845c39807ce17c85a9b0b',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '5c61df1b8e5ae701c1bd76f089b888b51326a72a',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -98,7 +98,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '647c7f8935017e00bcabe82f0bc3a8aa327521f5',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'ff4a363e89f032071e8845c39807ce17c85a9b0b',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -98,7 +98,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '41cc1d37ca8b59a1bb1a678d11d75871aa2a5c1b',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '647c7f8935017e00bcabe82f0bc3a8aa327521f5',
 
    # Fuchsia compatibility
    #

--- a/shell/platform/darwin/graphics/BUILD.gn
+++ b/shell/platform/darwin/graphics/BUILD.gn
@@ -24,7 +24,7 @@ source_set("graphics") {
     "//flutter/shell/platform/darwin/common:framework_shared",
   ]
 
-  libs = [ "CoreVideo.framework" ]
+  frameworks = [ "CoreVideo.framework" ]
 
   public_deps = [ "//third_party/skia" ]
 

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -168,7 +168,7 @@ source_set("flutter_framework_source") {
     "//flutter:config",
   ]
 
-  libs = [
+  frameworks = [
     "AudioToolbox.framework",
     "CoreMedia.framework",
     "CoreVideo.framework",
@@ -179,7 +179,7 @@ source_set("flutter_framework_source") {
   if (flutter_runtime_mode == "profile" || flutter_runtime_mode == "debug") {
     # This is required by the profiler_metrics_ios.mm to get GPU statistics.
     # Usage in release builds will cause rejection from the App Store.
-    libs += [ "IOKit.framework" ]
+    frameworks += [ "IOKit.framework" ]
   }
 }
 
@@ -227,7 +227,7 @@ shared_library("ios_test_flutter") {
     "-F$platform_frameworks_path",
     "-Wl,-install_name,@rpath/Frameworks/libios_test_flutter.dylib",
   ]
-  libs = [ "XCTest.framework" ]
+  frameworks = [ "XCTest.framework" ]
   configs -= [
     "//build/config/gcc:symbol_visibility_hidden",
     "//build/config:symbol_visibility_hidden",

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -143,7 +143,7 @@ source_set("flutter_framework_source") {
 
   cflags_objcc = flutter_cflags_objcc_arc
 
-  libs = [
+  frameworks = [
     "Cocoa.framework",
     "CoreVideo.framework",
     "IOSurface.framework",

--- a/shell/platform/glfw/BUILD.gn
+++ b/shell/platform/glfw/BUILD.gn
@@ -68,7 +68,7 @@ source_set("flutter_glfw") {
 
     configs += [ "//flutter/shell/platform/linux/config:x11" ]
   } else if (is_mac) {
-    libs = [
+    frameworks = [
       "CoreVideo.framework",
       "IOKit.framework",
     ]

--- a/third_party/accessibility/BUILD.gn
+++ b/third_party/accessibility/BUILD.gn
@@ -27,7 +27,7 @@ source_set("accessibility") {
   public_configs = [ ":accessibility_config" ]
 
   if (is_mac) {
-    libs = [
+    frameworks = [
       "AppKit.framework",
       "CoreFoundation.framework",
       "CoreGraphics.framework",


### PR DESCRIPTION
We don't have access to Android tools of the native architecture.
While it is possible to shim x64 Android tools to work on M1, I
have opted to disable the Android targets instead. Currently focusing
on Mac and iOS targets and don't want to spend too much time on an
Android shim when we can probably just publish the right tools
to the CIPD bucket and bypass emulation.

The GN version has also been updated as it contains the native
architecture binaries. The udpate did cause old warnings in GN rules
to become errors. I have patched those here and in the buildroot.

This does require a buildroot update in https://github.com/flutter/buildroot/pull/480.
