### PR TITLE
Fix dart analysis

### DIFF
--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -62,7 +62,7 @@ function analyze() (
 echo "Analyzing dart:ui library..."
 analyze \
   --options "$FLUTTER_DIR/analysis_options.yaml" \
-  "$SRC_DIR/out/host_debug_unopt/gen/sky/bindings/dart_ui/ui.dart"
+  "$SRC_DIR/out/host_debug_unopt/gen/dart-pkg/sky_engine/lib/ui/ui.dart"
 
 echo "Analyzing spirv library..."
 analyze \

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -8,13 +8,9 @@ import("//flutter/common/config.gni")
 import("//flutter/lib/ui/dart_ui.gni")
 import("//third_party/dart/utils/compile_platform.gni")
 
-bindings_output_dir = "$root_gen_dir/sky/bindings"
-
-copy("generate_dart_ui") {
+# TODO(dnfield): Remove this when recipes are updated to not use it.
+group("generate_dart_ui") {
   visibility = [ ":*" ]
-  sources = dart_ui_files
-
-  outputs = [ "$bindings_output_dir/dart_ui/{{source_file_part}}" ]
 }
 
 compiled_action("generate_snapshot_bin") {

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -9,6 +9,7 @@ import("//flutter/lib/ui/dart_ui.gni")
 import("//third_party/dart/utils/compile_platform.gni")
 
 # TODO(dnfield): Remove this when recipes are updated to not use it.
+# https://flutter-review.googlesource.com/c/recipes/+/15420
 group("generate_dart_ui") {
   visibility = [ ":*" ]
 }

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -662,10 +662,10 @@ abstract class StringAttribute extends NativeFieldWrapperClass1 {
     required this.range,
   });
 
-  // The range of the text to which this attribute applies.
+  /// The range of the text to which this attribute applies.
   final TextRange range;
 
-  // Returns a copy of this atttribute with the given range.
+  /// Returns a copy of this atttribute with the given range.
   StringAttribute copy({required TextRange range});
 }
 

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -665,7 +665,13 @@ abstract class StringAttribute extends NativeFieldWrapperClass1 {
   /// The range of the text to which this attribute applies.
   final TextRange range;
 
-  /// Returns a copy of this atttribute with the given range.
+  /// Creates a new attribute with all properties copied except for range, which
+  /// is updated to the specified value.
+  ///
+  /// For example, the [LocaleStringAttribute] specifies a [Locale] for its
+  /// range of characters. Copying it will result in a new
+  /// [LocaleStringAttribute] that has the same locale but an updated
+  /// [TextRange].
   StringAttribute copy({required TextRange range});
 }
 


### PR DESCRIPTION
the generate_dart_ui target is redundant with the sky_engine target.

We should just point the analyzer to that one to avoid the extra file copies.

For reasons I do not understand, analyzing the generate_dart_ui target fails to catch some doc-comments missing in semantics.dart, but catches them correctly in the updated location.

I'm making `generate_dart_ui` an empty target until we can remove references from it in CI.