### PR TITLE
Switch test_suites to yaml.

### DIFF
--- a/testing/fuchsia/test_suites.yaml
+++ b/testing/fuchsia/test_suites.yaml
@@ -1,0 +1,4 @@
+# This configuration file specifies test suites along with their gtest filters
+# to be passed as test arguments for flutter on FEMU tests.
+
+test_suites:


### PR DESCRIPTION
This will allow us to include package, url, and argument information in the engine repo, requiring less infra soft transitions.

The schema of this file should be something like:
```yaml
test_suites:
 - package: tests-0.far
 - url: fuchsia-pkg://fuchsia.com/tests/meta#tests.cm
 - test_args: -- --gtest_filter=-Test.Disabled
```

test_args is optional.

See https://fxbug.dev/79691.