### PR TITLE
Set ANDROID_HOME in run_gradle.py

### DIFF
--- a/testing/scenario_app/android/run_gradle.py
+++ b/testing/scenario_app/android/run_gradle.py
@@ -11,6 +11,10 @@ import os
 import sys
 import subprocess
 
+SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
+ANDROID_HOME = os.path.join(SCRIPT_PATH, '..', '..', '..', '..', 'third_party',
+    'android_tools', 'sdk')
+
 def main():
   BAT = '.bat' if sys.platform.startswith(('cygwin', 'win')) else ''
   android_dir = os.path.abspath(os.path.dirname(__file__))
@@ -18,6 +22,7 @@ def main():
   result = subprocess.check_output(
     args=[gradle_bin] + sys.argv[1:],
     cwd=android_dir,
+    env=dict(os.environ, ANDROID_HOME=ANDROID_HOME),
   )
   return 0
 

--- a/testing/scenario_app/android/run_gradle.py
+++ b/testing/scenario_app/android/run_gradle.py
@@ -16,6 +16,9 @@ ANDROID_HOME = os.path.join(SCRIPT_PATH, '..', '..', '..', '..', 'third_party',
     'android_tools', 'sdk')
 
 def main():
+  if not os.path.isdir(ANDROID_HOME):
+    raise Exception('%s (ANDROID_HOME) is not a directory' % ANDROID_HOME)
+
   BAT = '.bat' if sys.platform.startswith(('cygwin', 'win')) else ''
   android_dir = os.path.abspath(os.path.dirname(__file__))
   gradle_bin = os.path.join('.', 'gradlew%s' % BAT)


### PR DESCRIPTION
@whesse @zanderso @chinmaygarde 

An internal benchmark builder fails because it does not set ANDROID_HOME. At any rate, we don't want to use a random ANDROID_HOME for this anyway.