### PR TITLE
Enable Dart compressed pointers for 64-bit mobile targets

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -380,6 +380,11 @@ def to_gn_args(args):
     # on Android.
     gn_args['bssl_use_clang_integrated_as'] = True
 
+    # Enable pointer compression on 64-bit mobile targets.
+    if (args.target_os == 'android' or args.target_os == 'ios') and (
+        gn_args['target_cpu'] == 'x64' or gn_args['target_cpu'] == 'arm64'):
+      gn_args['dart_use_compressed_pointers'] = True
+
     return gn_args
 
 def parse_args(args):


### PR DESCRIPTION
Enable compressed pointers for 64-bit targets. We're going to land this temporarily to test compressed pointers in the flutter framework.