### PR TITLE
[fuchsia] fix race in DefaultSessionConnection

### DIFF
--- a/shell/platform/fuchsia/flutter/default_session_connection.h
+++ b/shell/platform/fuchsia/flutter/default_session_connection.h
@@ -128,7 +128,6 @@ class DefaultSessionConnection final {
   const int kMaxFramesInFlight;
 
   int frames_in_flight_ = 0;
-  int frames_in_flight_allowed_ = 0;
   bool present_session_pending_ = false;
 
   // The time from vsync that the Flutter animator should begin its frames. This


### PR DESCRIPTION
DefaultSessionConnection can run on two threads - the UI and raster
threads. This change ensures that access to all variables, specifically frames_in_flight_, both
threads touch are guarded by the mutex.

Fixes fxbug.dev/80625