### PR TITLE
Revert "Make FlutterFragment usable without requiring it to be attached to an Android Activity."

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -276,15 +276,15 @@ import java.util.Arrays;
     if (host.getRenderMode() == RenderMode.surface) {
       FlutterSurfaceView flutterSurfaceView =
           new FlutterSurfaceView(
-              host.getContext(), host.getTransparencyMode() == TransparencyMode.transparent);
+              host.getActivity(), host.getTransparencyMode() == TransparencyMode.transparent);
 
       // Allow our host to customize FlutterSurfaceView, if desired.
       host.onFlutterSurfaceViewCreated(flutterSurfaceView);
 
       // Create the FlutterView that owns the FlutterSurfaceView.
-      flutterView = new FlutterView(host.getContext(), flutterSurfaceView);
+      flutterView = new FlutterView(host.getActivity(), flutterSurfaceView);
     } else {
-      FlutterTextureView flutterTextureView = new FlutterTextureView(host.getContext());
+      FlutterTextureView flutterTextureView = new FlutterTextureView(host.getActivity());
 
       flutterTextureView.setOpaque(host.getTransparencyMode() == TransparencyMode.opaque);
 
@@ -292,7 +292,7 @@ import java.util.Arrays;
       host.onFlutterTextureViewCreated(flutterTextureView);
 
       // Create the FlutterView that owns the FlutterTextureView.
-      flutterView = new FlutterView(host.getContext(), flutterTextureView);
+      flutterView = new FlutterView(host.getActivity(), flutterTextureView);
     }
 
     // Add listener to be notified when Flutter renders its first frame.

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -378,9 +378,6 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Declare that the host does NOT want Flutter to attach to the surrounding Activity.
     when(mockHost.shouldAttachEngineToActivity()).thenReturn(false);
 
-    // getActivity() returns null if the activity is not attached
-    when(mockHost.getActivity()).thenReturn(null);
-
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
@@ -388,21 +385,14 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Flutter is attached to the surrounding Activity in onAttach.
     delegate.onAttach(RuntimeEnvironment.application);
 
-    // Make sure all of the other lifecycle methods can run safely as well
-    // without a valid Activity
-    delegate.onCreateView(null, null, null);
-    delegate.onStart();
-    delegate.onResume();
-    delegate.onPause();
-    delegate.onStop();
-    delegate.onDestroyView();
+    // Verify that the ActivityControlSurface was NOT told to attach to an Activity.
+    verify(mockFlutterEngine.getActivityControlSurface(), never())
+        .attachToActivity(any(Activity.class), any(Lifecycle.class));
 
     // Flutter is detached from the surrounding Activity in onDetach.
     delegate.onDetach();
 
-    // Verify that the ActivityControlSurface was NOT told to attach or detach to an Activity.
-    verify(mockFlutterEngine.getActivityControlSurface(), never())
-        .attachToActivity(any(Activity.class), any(Lifecycle.class));
+    // Verify that the ActivityControlSurface was NOT told to detach from the Activity.
     verify(mockFlutterEngine.getActivityControlSurface(), never()).detachFromActivity();
   }
 


### PR DESCRIPTION
Reverts flutter/engine#27332

I don't know why this didn't fail in presubmit:

https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20Unopt/647/overview

```
../../flutter/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java:393: error: method onCreateView in class FlutterActivityAndFragmentDelegate cannot be applied to given types;
    delegate.onCreateView(null, null, null);
            ^
  required: LayoutInflater,ViewGroup,Bundle,int
  found: <null>,<null>,<null>
  reason: actual and formal argument lists differ in length
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 error
```

/cc @ajmalk 