### PR TITLE
Avoid using CompletableFuture

### DIFF
--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0-alpha01'
     implementation "com.squareup.leakcanary:leakcanary-android:$leakcanary_version"
+    implementation 'com.google.guava:guava:28.1-android'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
@@ -10,11 +10,11 @@ import android.content.Context;
 import androidx.test.InstrumentationRegistry;
 import androidx.test.internal.runner.junit4.statement.UiThreadStatement;
 import androidx.test.runner.AndroidJUnit4;
+import com.google.common.util.concurrent.SettableFuture;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -34,7 +34,7 @@ public class EngineLaunchE2ETest {
     // as @UiThreadTest because having the message handler and the CompletableFuture both being
     // on the same thread will create deadlocks.
     UiThreadStatement.runOnUiThread(() -> engine.set(new FlutterEngine(applicationContext)));
-    CompletableFuture<Boolean> statusReceived = new CompletableFuture<>();
+    SettableFuture<Boolean> statusReceived = new SettableFuture<>();
 
     // Resolve locale to `en_US`.
     // This is required, so `window.locale` in populated in dart.
@@ -49,8 +49,7 @@ public class EngineLaunchE2ETest {
         .get()
         .getDartExecutor()
         .setMessageHandler(
-            "waiting_for_status",
-            (byteBuffer, binaryReply) -> statusReceived.complete(Boolean.TRUE));
+            "waiting_for_status", (byteBuffer, binaryReply) -> statusReceived.set(Boolean.TRUE));
 
     // Launching the entrypoint will run the Dart code that sends the "waiting_for_status" platform
     // message.


### PR DESCRIPTION
CompletableFuture was added in API 24

We're trying to run tests on API 23, and the app claims to work to API 18. 

I've filed https://github.com/flutter/flutter/issues/86430 to track linting this

Semi-related: https://github.com/flutter/flutter/pull/69622

fixes https://github.com/flutter/flutter/issues/86427