### PR TITLE
remove the use of package:isolate

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -433,9 +433,6 @@ deps = {
   'src/third_party/pkg/googleapis':
   Var('github_git') + '/google/googleapis.dart.git' + '@' + '07f01b7aa6985e4cafd0fd4b98724841bc9e85a1', # various
 
-  'src/third_party/pkg/isolate':
-  Var('github_git') + '/dart-lang/isolate.git' + '@' + 'ca133acb5af3a60a026fa2aab12b81e60048b3be', # 2.0.3
-
   'src/third_party/pkg/platform':
   Var('github_git') + '/google/platform.dart.git' + '@' + 'f63fd0bc3021354a0687dc935962c9acc003f47e', # 3.0.1
 

--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -12,8 +12,6 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-// ignore: import_of_legacy_library_into_null_safe
-import 'package:isolate/isolate.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:process/process.dart';
@@ -706,7 +704,7 @@ class WhitespaceFormatChecker extends FormatChecker {
     return true;
   }
 
-  static Future<_GrepResult> _hasTrailingWhitespace(File file) async {
+  static _GrepResult _hasTrailingWhitespace(File file) {
     final List<String> hits = <String>[];
     final List<int> lineNumbers = <int>[];
     int lineNumber = 0;
@@ -723,12 +721,8 @@ class WhitespaceFormatChecker extends FormatChecker {
     return _GrepResult(file, hits, lineNumbers);
   }
 
-  Stream<_GrepResult> _whereHasTrailingWhitespace(Iterable<File> files) async* {
-    final LoadBalancer pool =
-        await LoadBalancer.create(Platform.numberOfProcessors, IsolateRunner.spawn);
-    for (final File file in files) {
-      yield await pool.run<_GrepResult, File>(_hasTrailingWhitespace, file);
-    }
+  Iterable<_GrepResult> _whereHasTrailingWhitespace(Iterable<File> files) {
+    return files.map(_hasTrailingWhitespace);
   }
 
   Future<List<File>> _getWhitespaceFailures() async {
@@ -764,7 +758,7 @@ class WhitespaceFormatChecker extends FormatChecker {
     int inProgress = Platform.numberOfProcessors;
     int pending = total;
     int failed = 0;
-    await for (final _GrepResult result in _whereHasTrailingWhitespace(
+    for (final _GrepResult result in _whereHasTrailingWhitespace(
       files.map<File>(
         (String file) => File(
           path.join(repoDir.absolute.path, file),

--- a/ci/pubspec.yaml
+++ b/ci/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   args: any
   meta: any
   path: any
-  isolate: any
   process_runner: any
 
 dependency_overrides:
@@ -32,8 +31,6 @@ dependency_overrides:
     path: ../../third_party/dart/third_party/pkg/collection
   file:
     path: ../../third_party/pkg/file/packages/file
-  isolate:
-    path: ../../third_party/pkg/isolate
   meta:
     path: ../../third_party/dart/pkg/meta
   path:


### PR DESCRIPTION
- remove the use of `package:isolate`

I noticed the `ignore: import_of_legacy_library_into_null_safe` while doing some work to simplify the analysis of flutter/engine. package:isolate has been discontinued and won't be upgraded to null safety (https://pub.dev/packages/isolate).  In practice, I don't think that moving from a pool of async workers to sync file IO will have any real performance implications.
