### PR TITLE
Accounts for inverse pixel ratio transform in screen rects.

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.cc
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.cc
@@ -692,7 +692,19 @@ void AccessibilityBridge::RequestAnnounce(const std::string message) {
 
 void AccessibilityBridge::UpdateScreenRects() {
   std::unordered_set<int32_t> visited_nodes;
-  UpdateScreenRects(kRootNodeId, SkM44{}, &visited_nodes);
+
+  // The embedder applies a special pixel ratio transform to the root of the
+  // view, and the accessibility bridge applies the inverse of this transform
+  // to the root node. However, this transform is not persisted in the flutter
+  // representation of the root node, so we need to account for it explicitly
+  // here.
+  float inverse_view_pixel_ratio = 1.f / last_seen_view_pixel_ratio_;
+  SkM44 inverse_view_pixel_ratio_transform;
+  inverse_view_pixel_ratio_transform.setScale(inverse_view_pixel_ratio,
+                                              inverse_view_pixel_ratio, 1.f);
+
+  UpdateScreenRects(kRootNodeId, inverse_view_pixel_ratio_transform,
+                    &visited_nodes);
 }
 
 void AccessibilityBridge::UpdateScreenRects(


### PR DESCRIPTION
The accessibility bridge applies an inverse pixel ratio transform to the root fuchsia semantic node, but doesn't persist this transform on the flutter side. This change ensures that the cached screen rects account for this transform.

fxb.dev/80751


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
