### PR TITLE
[ios] Fix memory leak in CFRef's move assignment operator.

### DIFF
--- a/fml/platform/darwin/cf_utils.h
+++ b/fml/platform/darwin/cf_utils.h
@@ -41,9 +41,6 @@ class CFRef {
   }
 
   void Reset(T instance = nullptr) {
-    if (instance_ == instance) {
-      return;
-    }
     if (instance_ != nullptr) {
       CFRelease(instance_);
     }


### PR DESCRIPTION
```
void test() {
  CFDictionaryRef empty = CFDictionaryCreate(kCFAllocatorDefault, NULL, NULL, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
  auto ref_a = fml::CFRef<CFDictionaryRef>(empty);
  fml::CFRef<CFDictionaryRef> ref_b = ref_a;
  ref_a = std::move(ref_b);
}
```
CFRef::Reset will return before CFRelease called cause they point to the same instance.
When test() function return, the dictionary still has retain count 1, which cause a memory leak.