### PR TITLE
Fixes scrollable behavior in voiceover

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -225,6 +225,10 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (BOOL)isAccessibilityElement {
+  if (![_semanticsObject isAccessibilityBridgeAlive]) {
+    return NO;
+  }
+
   if ([_semanticsObject isAccessibilityElement]) {
     return YES;
   }

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -207,20 +207,31 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (id)accessibilityContainer {
-  if (_container == nil) {
-    _container.reset([[SemanticsObjectContainer alloc]
-        initWithSemanticsObject:(SemanticsObject*)self
-                         bridge:[_semanticsObject bridge]]);
+  if ([_semanticsObject hasChildren] || [_semanticsObject uid] == kRootNodeId) {
+    if (_container == nil) {
+      _container.reset([[SemanticsObjectContainer alloc]
+          initWithSemanticsObject:(SemanticsObject*)self
+                           bridge:[_semanticsObject bridge]]);
+    }
+    return _container.get();
   }
-  return _container.get();
+  if ([_semanticsObject parent] == nil) {
+    // This can happen when we have released the accessibility tree but iOS is
+    // still holding onto our objects. iOS can take some time before it
+    // realizes that the tree has changed.
+    return nil;
+  }
+  return [[_semanticsObject parent] accessibilityContainer];
 }
 
 - (BOOL)isAccessibilityElement {
-  if (![_semanticsObject isAccessibilityBridgeAlive]) {
-    return NO;
+  if ([_semanticsObject isAccessibilityElement]) {
+    return YES;
   }
   if (self.contentSize.width > self.frame.size.width ||
       self.contentSize.height > self.frame.size.height) {
+    // In SwitchControl or VoiceControl, the isAccessibilityElement must return YES
+    // in order to use scroll actions.
     return !_semanticsObject.bridge->isVoiceOverRunning();
   } else {
     return NO;
@@ -287,6 +298,30 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 // The following methods are explicitly forwarded to the wrapped SemanticsObject because the
 // forwarding logic above doesn't apply to them since they are also implemented in the
 // UIScrollView class, the base class.
+
+- (NSString*)accessibilityLabel {
+  return [_semanticsObject accessibilityLabel];
+}
+
+- (NSAttributedString*)accessibilityAttributedLabel {
+  return [_semanticsObject accessibilityAttributedLabel];
+}
+
+- (NSString*)accessibilityValue {
+  return [_semanticsObject accessibilityValue];
+}
+
+- (NSAttributedString*)accessibilityAttributedValue {
+  return [_semanticsObject accessibilityAttributedValue];
+}
+
+- (NSString*)accessibilityHint {
+  return [_semanticsObject accessibilityHint];
+}
+
+- (NSAttributedString*)accessibilityAttributedHint {
+  return [_semanticsObject accessibilityAttributedHint];
+}
 
 - (BOOL)accessibilityActivate {
   return [_semanticsObject accessibilityActivate];


### PR DESCRIPTION
Two issues,

If there is accessibility label for a scrollable in voiceover, the scrollable should be focusable

If there is no child in a scrollable, it should return parent's accessibilitycontainer.

fixes https://github.com/flutter/flutter/issues/86499

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
