### PR TITLE
Revert "Reland enable DisplayList by default"

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -166,7 +166,7 @@ struct Settings {
   bool enable_skparagraph = false;
 
   // Selects the DisplayList for storage of rendering operations.
-  bool enable_display_list = true;
+  bool enable_display_list = false;
 
   // All shells in the process share the same VM. The last shell to shutdown
   // should typically shut down the VM as well. However, applications depend on


### PR DESCRIPTION
Reverts flutter/engine#27407

A number of failures were again detected upstream all in rendering shadows. Looking at the way we have been using the shadow utils it seems that this is a consequence of how we recorded shadows within one transform context and played them back under a different transform - which will affect the positioning of the lights.

There is a PR outstanding to switch our usage to directional lights and I should let that land first before trying to turn on DL since that change will set a stage where my attempts to record the shadows will be more consistent with how they are recorded under the current SkPicture code. As it stands with the current design, I don't think there is a way to record the information accurately.