### PR TITLE
Place Emoji fallback font at the front of the list

### DIFF
--- a/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
@@ -123,6 +123,102 @@ void testMain() {
       // TODO: https://github.com/flutter/flutter/issues/71520
     }, skip: isIosSafari || isFirefox);
 
+    test('will put the Noto Emoji font before other fallback fonts in the list',
+        () async {
+      Completer<void> fontChangeCompleter = Completer<void>();
+      // Intercept the system font change message.
+      ui.window.onPlatformMessage = (String name, ByteData? data,
+          ui.PlatformMessageResponseCallback? callback) {
+        if (name == 'flutter/system') {
+          const JSONMessageCodec codec = JSONMessageCodec();
+          final dynamic message = codec.decodeMessage(data);
+          if (message is Map) {
+            if (message['type'] == 'fontsChange') {
+              fontChangeCompleter.complete();
+            }
+          }
+        }
+        if (savedCallback != null) {
+          savedCallback!(name, data, callback);
+        }
+      };
+
+      TestDownloader.mockDownloads[
+              'https://fonts.googleapis.com/css2?family=Noto+Color+Emoji+Compat'] =
+          '''
+@font-face {
+  font-family: 'Noto Color Emoji';
+  src: url(packages/ui/assets/NotoColorEmoji.ttf) format('ttf');
+}
+''';
+
+      TestDownloader.mockDownloads[
+              'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic+UI'] =
+          '''
+/* arabic */
+@font-face {
+  font-family: 'Noto Naskh Arabic UI';
+  font-style: normal;
+  font-weight: 400;
+  src: url(packages/ui/assets/NotoNaskhArabic-Regular.ttf) format('ttf');
+  unicode-range: U+0600-06FF, U+200C-200E, U+2010-2011, U+204F, U+2E41, U+FB50-FDFF, U+FE80-FEFC;
+}
+''';
+
+      expect(FontFallbackData.instance.globalFontFallbacks, <String>['Roboto']);
+
+      // Creating this paragraph should cause us to start to download the
+      // Arabic fallback font.
+      CkParagraphBuilder pb = CkParagraphBuilder(
+        CkParagraphStyle(),
+      );
+      pb.addText('مرحبا');
+
+      EnginePlatformDispatcher.instance.rasterizer!
+          .debugRunPostFrameCallbacks();
+      await fontChangeCompleter.future;
+
+      expect(FontFallbackData.instance.globalFontFallbacks,
+          <String>['Roboto', 'Noto Naskh Arabic UI 0']);
+
+      pb = CkParagraphBuilder(
+        CkParagraphStyle(),
+      );
+      pb.pushStyle(ui.TextStyle(fontSize: 26));
+      pb.addText('Hello 😊 مرحبا');
+      pb.pop();
+      final CkParagraph paragraph = pb.build();
+      paragraph.layout(ui.ParagraphConstraints(width: 1000));
+
+      fontChangeCompleter = Completer<void>();
+      // Intercept the system font change message.
+      ui.window.onPlatformMessage = (String name, ByteData? data,
+          ui.PlatformMessageResponseCallback? callback) {
+        if (name == 'flutter/system') {
+          const JSONMessageCodec codec = JSONMessageCodec();
+          final dynamic message = codec.decodeMessage(data);
+          if (message is Map) {
+            if (message['type'] == 'fontsChange') {
+              fontChangeCompleter.complete();
+            }
+          }
+        }
+        if (savedCallback != null) {
+          savedCallback!(name, data, callback);
+        }
+      };
+
+      EnginePlatformDispatcher.instance.rasterizer!
+          .debugRunPostFrameCallbacks();
+      await fontChangeCompleter.future;
+
+      expect(FontFallbackData.instance.globalFontFallbacks, <String>[
+        'Roboto',
+        'Noto Color Emoji Compat 0',
+        'Noto Naskh Arabic UI 0',
+      ]);
+    });
+
     test('will download Noto Emojis and Noto Symbols if no matching Noto Font',
         () async {
       final Completer<void> fontChangeCompleter = Completer<void>();
@@ -146,7 +242,6 @@ void testMain() {
       TestDownloader.mockDownloads[
               'https://fonts.googleapis.com/css2?family=Noto+Color+Emoji+Compat'] =
           '''
-/* arabic */
 @font-face {
   font-family: 'Noto Color Emoji';
   src: url(packages/ui/assets/NotoColorEmoji.ttf) format('ttf');

--- a/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/fallback_fonts_golden_test.dart
@@ -56,24 +56,6 @@ void testMain() {
     });
 
     test('will download Noto Naskh Arabic if Arabic text is added', () async {
-      final Completer<void> fontChangeCompleter = Completer<void>();
-      // Intercept the system font change message.
-      ui.window.onPlatformMessage = (String name, ByteData? data,
-          ui.PlatformMessageResponseCallback? callback) {
-        if (name == 'flutter/system') {
-          const JSONMessageCodec codec = JSONMessageCodec();
-          final dynamic message = codec.decodeMessage(data);
-          if (message is Map) {
-            if (message['type'] == 'fontsChange') {
-              fontChangeCompleter.complete();
-            }
-          }
-        }
-        if (savedCallback != null) {
-          savedCallback!(name, data, callback);
-        }
-      };
-
       TestDownloader.mockDownloads[
               'https://fonts.googleapis.com/css2?family=Noto+Naskh+Arabic+UI'] =
           '''
@@ -98,7 +80,7 @@ void testMain() {
 
       EnginePlatformDispatcher.instance.rasterizer!
           .debugRunPostFrameCallbacks();
-      await fontChangeCompleter.future;
+      await notoDownloadQueue.debugWhenIdle();
 
       expect(FontFallbackData.instance.globalFontFallbacks,
           contains('Noto Naskh Arabic UI 0'));
@@ -125,24 +107,6 @@ void testMain() {
 
     test('will put the Noto Emoji font before other fallback fonts in the list',
         () async {
-      Completer<void> fontChangeCompleter = Completer<void>();
-      // Intercept the system font change message.
-      ui.window.onPlatformMessage = (String name, ByteData? data,
-          ui.PlatformMessageResponseCallback? callback) {
-        if (name == 'flutter/system') {
-          const JSONMessageCodec codec = JSONMessageCodec();
-          final dynamic message = codec.decodeMessage(data);
-          if (message is Map) {
-            if (message['type'] == 'fontsChange') {
-              fontChangeCompleter.complete();
-            }
-          }
-        }
-        if (savedCallback != null) {
-          savedCallback!(name, data, callback);
-        }
-      };
-
       TestDownloader.mockDownloads[
               'https://fonts.googleapis.com/css2?family=Noto+Color+Emoji+Compat'] =
           '''
@@ -176,7 +140,7 @@ void testMain() {
 
       EnginePlatformDispatcher.instance.rasterizer!
           .debugRunPostFrameCallbacks();
-      await fontChangeCompleter.future;
+      await notoDownloadQueue.debugWhenIdle();
 
       expect(FontFallbackData.instance.globalFontFallbacks,
           <String>['Roboto', 'Noto Naskh Arabic UI 0']);
@@ -190,27 +154,9 @@ void testMain() {
       final CkParagraph paragraph = pb.build();
       paragraph.layout(ui.ParagraphConstraints(width: 1000));
 
-      fontChangeCompleter = Completer<void>();
-      // Intercept the system font change message.
-      ui.window.onPlatformMessage = (String name, ByteData? data,
-          ui.PlatformMessageResponseCallback? callback) {
-        if (name == 'flutter/system') {
-          const JSONMessageCodec codec = JSONMessageCodec();
-          final dynamic message = codec.decodeMessage(data);
-          if (message is Map) {
-            if (message['type'] == 'fontsChange') {
-              fontChangeCompleter.complete();
-            }
-          }
-        }
-        if (savedCallback != null) {
-          savedCallback!(name, data, callback);
-        }
-      };
-
       EnginePlatformDispatcher.instance.rasterizer!
           .debugRunPostFrameCallbacks();
-      await fontChangeCompleter.future;
+      await notoDownloadQueue.debugWhenIdle();
 
       expect(FontFallbackData.instance.globalFontFallbacks, <String>[
         'Roboto',
@@ -221,24 +167,6 @@ void testMain() {
 
     test('will download Noto Emojis and Noto Symbols if no matching Noto Font',
         () async {
-      final Completer<void> fontChangeCompleter = Completer<void>();
-      // Intercept the system font change message.
-      ui.window.onPlatformMessage = (String name, ByteData? data,
-          ui.PlatformMessageResponseCallback? callback) {
-        if (name == 'flutter/system') {
-          const JSONMessageCodec codec = JSONMessageCodec();
-          final dynamic message = codec.decodeMessage(data);
-          if (message is Map) {
-            if (message['type'] == 'fontsChange') {
-              fontChangeCompleter.complete();
-            }
-          }
-        }
-        if (savedCallback != null) {
-          savedCallback!(name, data, callback);
-        }
-      };
-
       TestDownloader.mockDownloads[
               'https://fonts.googleapis.com/css2?family=Noto+Color+Emoji+Compat'] =
           '''
@@ -259,7 +187,7 @@ void testMain() {
 
       EnginePlatformDispatcher.instance.rasterizer!
           .debugRunPostFrameCallbacks();
-      await fontChangeCompleter.future;
+      await notoDownloadQueue.debugWhenIdle();
 
       expect(FontFallbackData.instance.globalFontFallbacks,
           contains('Noto Color Emoji Compat 0'));


### PR DESCRIPTION
The symbols font has glyphs for common emojis, but they are very ugly compared to the emoji font glyphs. This PR causes us to always place the emoji font at the front of the fallback font list so we prioritize the better looking glyphs.

Fixes https://github.com/flutter/flutter/issues/86204

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
