### PR TITLE
Disables pre-push checks on Windows, runs checks in sequence elsewhere

### DIFF
--- a/tools/githooks/lib/src/pre_push_command.dart
+++ b/tools/githooks/lib/src/pre_push_command.dart
@@ -23,10 +23,10 @@ class PrePushCommand extends Command<bool> {
     final Stopwatch sw = Stopwatch()..start();
     final bool verbose = globalResults!['verbose']! as bool;
     final String flutterRoot = globalResults!['flutter']! as String;
-    final List<bool> checkResults = await Future.wait<bool>(<Future<bool>>[
-      _runClangTidy(flutterRoot, verbose),
-      _runFormatter(flutterRoot, verbose),
-    ]);
+    final List<bool> checkResults = <bool>[
+      await _runClangTidy(flutterRoot, verbose),
+      await _runFormatter(flutterRoot, verbose),
+    ];
     sw.stop();
     io.stdout.writeln('pre-push checks finished in ${sw.elapsed}');
     return !checkResults.contains(false);

--- a/tools/githooks/setup.py
+++ b/tools/githooks/setup.py
@@ -16,15 +16,23 @@ SRC_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.pa
 FLUTTER_DIR = os.path.join(SRC_ROOT, 'flutter')
 
 
+def IsWindows():
+  os_id = sys.platform
+  return os_id.startswith('win32') or os_id.startswith('cygwin')
+
+
 def Main(argv):
+  githooks = os.path.join(FLUTTER_DIR, 'tools', 'githooks')
+  if IsWindows():
+    githooks = os.path.join(githooks, 'windows')
   result = subprocess.run([
     'git',
     'config',
     'core.hooksPath',
-    os.path.join(FLUTTER_DIR, 'tools', 'githooks'),
+    githooks,
   ], cwd=FLUTTER_DIR)
   return result.returncode
 
 
 if __name__ == '__main__':
-    sys.exit(Main(sys.argv))
+  sys.exit(Main(sys.argv))

--- a/tools/githooks/windows/pre-push
+++ b/tools/githooks/windows/pre-push
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+RED='[31m'
+NC='[0m'
+BOLD='[1m'
+echo "${BOLD}${RED}Warning:${NC} ${BOLD}Pre-push checks not supported on Windows${NC}"
+echo "${BOLD}See: https://github.com/flutter/flutter/issues/86506${NC}"


### PR DESCRIPTION
Runs pre-push hooks in sequence rather than in parallel, and disables checks on Windows.

See: https://github.com/flutter/flutter/issues/86506

`FETCH_HEAD` is a just a file under the `.git` directory. Running the format and clang-tidy checks in parallel would cause those two checks to independently run `git` commands that would touch that file. Running them in sequence will take longer, but should avoid the `FETCH_HEAD` error.

This PR also sets up the githook on Windows to point at a shell script that just emits a warning that the checks aren't running. This script could invoke the checks, but making that useful would need some extra binaries to be pulled in, so I'll save that for another day.