### PR TITLE
Warn, but don't fail if prebuilt SDK could not be fetched

### DIFF
--- a/tools/download_dart_sdk.py
+++ b/tools/download_dart_sdk.py
@@ -160,6 +160,15 @@ def ExtractDartSDK(archive, os_name, arch, verbose):
     z.extractall(extract_dest)
 
 
+def PrintFileIfSmall(file):
+  if not os.path.isfile(file):
+    return
+  size = os.path.getsize(file)
+  if size < (1 << 14): # < 16KB
+    with open(file) as f:
+      contents = f.read()
+      eprint(contents)
+
 
 def DownloadAndExtract(channel, version, os_name, arch, verbose):
   archive = DownloadDartSDK(channel, version, os_name, arch, verbose)
@@ -171,6 +180,7 @@ def DownloadAndExtract(channel, version, os_name, arch, verbose):
     ExtractDartSDK(archive, os_name, arch, verbose)
   except Exception as e:
     eprint('Failed to extract Dart SDK archive:\n%s' % e)
+    PrintFileIfSmall(archive)
     return 1
   try:
     stamp_file = '{}.stamp'.format(archive)
@@ -187,7 +197,7 @@ def Main():
   parser.add_argument(
     '--fail-loudly',
     action='store_true',
-    default='LUCI_CONTEXT' in os.environ,
+    default=False,
     help="Return an error code if a prebuilt couldn't be fetched and extracted")
   parser.add_argument(
     '--verbose',

--- a/tools/gn
+++ b/tools/gn
@@ -334,7 +334,6 @@ def to_gn_args(args):
         print('--prebuilt-dart-sdk was specified, but an appropriate prebuilt '
               'could not be found! Try running '
               'flutter/tools/download_dart_sdk.py manually.')
-        sys.exit(1)
     elif args.target_os is None or args.target_os == 'linux':
       # dart_platform_sdk is only defined for host builds, linux arm host builds
       # specify target_os=linux.


### PR DESCRIPTION
Dart SDK roll attempts are failing because there is apparently a race where the roll is triggered before the bits are available for Flutter CI to download. This PR makes failure to download the prebuilt Dart SDK non-fatal. Instead a warning will be issued. This PR also prints the bits downloaded by the script if there weren't too many.

Using the prebuilt Dart SDK does save some cycles, so I'll also be following-up with some issues to track improvements to the way we fetch it.