### PR TITLE
Extract the prebuilt Dart SDK to a temp directory and then move it after the extraction completes

### DIFF
--- a/tools/download_dart_sdk.py
+++ b/tools/download_dart_sdk.py
@@ -150,7 +150,9 @@ def ExtractDartSDK(archive, os_name, arch, verbose):
   if os.path.isdir(dart_sdk):
     shutil.rmtree(dart_sdk)
 
-  extract_dest = os.path.join(FLUTTER_PREBUILTS_DIR, os_arch)
+  extract_dest = os.path.join(FLUTTER_PREBUILTS_DIR, 'temp')
+  if os.path.isdir(extract_dest):
+    shutil.rmtree(extract_dest)
   os.makedirs(extract_dest, exist_ok=True)
 
   if verbose:
@@ -158,6 +160,8 @@ def ExtractDartSDK(archive, os_name, arch, verbose):
 
   with ZipFileWithPermissions(archive, "r") as z:
     z.extractall(extract_dest)
+
+  shutil.move(os.path.join(extract_dest, 'dart-sdk'), dart_sdk)
 
 
 def PrintFileIfSmall(file):

--- a/tools/download_dart_sdk.py
+++ b/tools/download_dart_sdk.py
@@ -150,7 +150,7 @@ def ExtractDartSDK(archive, os_name, arch, verbose):
   if os.path.isdir(dart_sdk):
     shutil.rmtree(dart_sdk)
 
-  extract_dest = os.path.join(FLUTTER_PREBUILTS_DIR, 'temp')
+  extract_dest = os.path.join(FLUTTER_PREBUILTS_DIR, os_arch, 'temp')
   if os.path.isdir(extract_dest):
     shutil.rmtree(extract_dest)
   os.makedirs(extract_dest, exist_ok=True)


### PR DESCRIPTION
This ensures that the GN script will not see an invalid Dart SDK at the
expected path if the extract fails.