### PR TITLE
FormatException.result?.stderr may be null

### DIFF
--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -29,8 +29,8 @@ class FormattingException implements Exception {
   String toString() {
     final StringBuffer output = StringBuffer(runtimeType.toString());
     output.write(': $message');
-    final String stderr = result?.stderr! as String;
-    if (stderr.isNotEmpty) {
+    final String? stderr = result?.stderr as String?;
+    if (stderr?.isNotEmpty == true) {
       output.write(':\n$stderr');
     }
     return output.toString();


### PR DESCRIPTION
If you attempt to gn format an invalid gn file (e.g. one with a syntax error), stderr comes out null.

When we go to print the exception, it throws another exception and crashes the formatt checker.

Fixes flutter/flutter#86719

We don't appear to have tests for this file and I'm not sure it's worth adding a test harness for it or not.