### PR TITLE
[flutter_releases] Flutter Beta 2.4.x Infra cherrypicks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -29,7 +29,7 @@ platform_properties:
           {"name":"builder_mac_engine","path":"builder"}
         ]
       os: Mac-10.15
-      xcode: "11e708" # xcode 11
+      xcode: "12a7209" # xcode 12
   windows:
     properties:
       caches: >-


### PR DESCRIPTION
Bring 2.4 branch .ci.yaml up to date with builder config, see: https://flutter.googlesource.com/infra/+/5e6f1acf8489c45c5a391eca79c4e5eb428034b1%5E%21/#F0