### PR TITLE
[web] disable golden check for Noto-rendered text

### DIFF
--- a/lib/web_ui/test/canvaskit/canvas_golden_test.dart
+++ b/lib/web_ui/test/canvaskit/canvas_golden_test.dart
@@ -15,6 +15,12 @@ import 'package:web_engine_tester/golden_tester.dart';
 
 import 'common.dart';
 
+// TODO(yjbanov): tests that render using Noto are not hermetic, as those fonts
+//                come from fonts.google.com, where fonts can change any time.
+//                These tests are skipped.
+//                https://github.com/flutter/flutter/issues/86432
+const bool kIssue86432Exists = true;
+
 void main() {
   internalBootstrapBrowserTest(() => testMain);
 }
@@ -307,28 +313,28 @@ void testMain() {
           outerText: '次 化 刃 直 入 令',
           innerText: '',
           paragraphLocale: const ui.Locale('zh', 'CN'));
-    });
+    }, skip: kIssue86432Exists);
 
     test('text styles - paragraph locale zh_TW', () async {
       await testTextStyle('paragraph locale zh_TW',
           outerText: '次 化 刃 直 入 令',
           innerText: '',
           paragraphLocale: const ui.Locale('zh', 'TW'));
-    });
+    }, skip: kIssue86432Exists);
 
     test('text styles - paragraph locale ja', () async {
       await testTextStyle('paragraph locale ja',
           outerText: '次 化 刃 直 入 令',
           innerText: '',
           paragraphLocale: const ui.Locale('ja'));
-    });
+    }, skip: kIssue86432Exists);
 
     test('text styles - paragraph locale ko', () async {
       await testTextStyle('paragraph locale ko',
           outerText: '次 化 刃 直 入 令',
           innerText: '',
           paragraphLocale: const ui.Locale('ko'));
-    });
+    }, skip: kIssue86432Exists);
 
     test('text styles - color', () async {
       await testTextStyle('color', color: const ui.Color(0xFF009900));
@@ -428,28 +434,28 @@ void testMain() {
           innerText: '次 化 刃 直 入 令',
           outerText: '',
           locale: const ui.Locale('zh', 'CN'));
-    });
+    }, skip: kIssue86432Exists);
 
     test('text styles - locale zh_TW', () async {
       await testTextStyle('locale zh_TW',
           innerText: '次 化 刃 直 入 令',
           outerText: '',
           locale: const ui.Locale('zh', 'TW'));
-    });
+    }, skip: kIssue86432Exists);
 
     test('text styles - locale ja', () async {
       await testTextStyle('locale ja',
           innerText: '次 化 刃 直 入 令',
           outerText: '',
           locale: const ui.Locale('ja'));
-    });
+    }, skip: kIssue86432Exists);
 
     test('text styles - locale ko', () async {
       await testTextStyle('locale ko',
           innerText: '次 化 刃 直 入 令',
           outerText: '',
           locale: const ui.Locale('ko'));
-    });
+    }, skip: kIssue86432Exists);
 
     test('text styles - background', () async {
       await testTextStyle('background',
@@ -565,7 +571,7 @@ void testMain() {
         outerText: '欢',
         innerText: '',
       );
-    });
+    }, skip: kIssue86432Exists);
 
     test('text style - symbols', () async {
       // One of the CJK fonts loaded in one of the tests above also contains
@@ -578,7 +584,7 @@ void testMain() {
         outerText: '← ↑ → ↓ ',
         innerText: '',
       );
-    });
+    }, skip: kIssue86432Exists);
 
     test(
         'text style - foreground/background/color do not leak across paragraphs',
@@ -846,12 +852,14 @@ Future<void> testSampleText(String language, String text,
     paragraphHeight = paragraph.height;
     return recorder.endRecording();
   });
-  await matchPictureGolden(
-    'canvaskit_sample_text_$language.png',
-    picture,
-    region: ui.Rect.fromLTRB(0, 0, testWidth, paragraphHeight + 20),
-    write: write,
-  );
+  if (!kIssue86432Exists) {
+    await matchPictureGolden(
+      'canvaskit_sample_text_$language.png',
+      picture,
+      region: ui.Rect.fromLTRB(0, 0, testWidth, paragraphHeight + 20),
+      write: write,
+    );
+  }
 }
 
 typedef ParagraphFactory = CkParagraph Function();


### PR DESCRIPTION
Noto font comes from fonts.google.com making tests non-hermetic.

This caused two P0 issues already.

Fixes https://github.com/flutter/flutter/issues/86756.