### PR TITLE
Roll to buildtools 30.0.2

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -98,7 +98,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '5c61df1b8e5ae701c1bd76f089b888b51326a72a',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e31959c36be2c556f5018f06929c039c22f306d1',
 
    # Fuchsia compatibility
    #
@@ -477,7 +477,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/sdk/build-tools/${{platform}}',
-        'version': 'version:30.0.1'
+        'version': 'version:30.0.2'
        }
      ],
      'condition': 'download_android_deps',

--- a/DEPS
+++ b/DEPS
@@ -98,7 +98,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e31959c36be2c556f5018f06929c039c22f306d1',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'cc7ee4df801df9be3028b0ef5ef58c8868877dd7',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Depends on https://github.com/flutter/buildroot/pull/484 - will update the hash after that lands.

Allows relanding https://github.com/flutter/engine/pull/27607