### PR TITLE
Comment out terminate unit test until fix lands in Dart.

### DIFF
--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -126,6 +126,7 @@ TEST_F(EmbedderTest, CanInvokeCustomEntrypointMacro) {
 /*
  * Uncomment once a Dart roll with the fix to reinitialize dart-io state
  * correctly has landed and rolled into the engine.
+ * https://dart-review.googlesource.com/c/sdk/+/207642
  *
 TEST_F(EmbedderTest, CanTerminateCleanly) {
   auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -123,6 +123,10 @@ TEST_F(EmbedderTest, CanInvokeCustomEntrypointMacro) {
   ASSERT_TRUE(engine.is_valid());
 }
 
+/*
+ * Uncomment once a Dart roll with the fix to reinitialize dart-io state
+ * correctly has landed and rolled into the engine.
+ *
 TEST_F(EmbedderTest, CanTerminateCleanly) {
   auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
   EmbedderConfigBuilder builder(context);
@@ -131,6 +135,7 @@ TEST_F(EmbedderTest, CanTerminateCleanly) {
   auto engine = builder.LaunchEngine();
   ASSERT_TRUE(engine.is_valid());
 }
+*/
 
 std::atomic_size_t EmbedderTestTaskRunner::sEmbedderTaskRunnerIdentifiers = {};
 


### PR DESCRIPTION
Comment out the terminate unit test until a fix from the Dart side lands and is rolled into the engine.
This is the Dart side fix  https://dart-review.googlesource.com/c/sdk/+/207642