### PR TITLE
Fix edge swipes

### DIFF
--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -14,6 +14,7 @@
 #include <lib/sys/cpp/service_directory.h>
 #include <lib/ui/scenic/cpp/id.h>
 
+#include <array>
 #include <map>
 #include <set>
 #include <unordered_map>
@@ -181,20 +182,24 @@ class PlatformView final : public flutter::PlatformView,
       OnShaderWarmup on_shader_warmup,
       std::unique_ptr<flutter::PlatformMessage> message);
 
+  // Utility function for coordinate massaging.
+  std::array<float, 2> ClampToViewSpace(const float x, const float y) const;
+
   const std::string debug_label_;
   // TODO(MI4-2490): remove once ViewRefControl is passed to Scenic and kept
   // alive there
   const fuchsia::ui::views::ViewRef view_ref_;
   std::shared_ptr<FocusDelegate> focus_delegate_;
 
-  // Logical size and logical->physical ratio.  These are optional to provide
-  // an "unset" state during program startup, before Scenic has sent any
-  // metrics-related events to provide initial values for these.
+  // Logical size and origin, and logical->physical ratio.  These are optional
+  // to provide an "unset" state during program startup, before Scenic has sent
+  // any metrics-related events to provide initial values for these.
   //
   // The engine internally uses a default size of (0.f 0.f) with a default 1.f
   // ratio, so there is no need to emit events until Scenic has actually sent a
   // valid size and ratio.
-  std::optional<std::pair<float, float>> view_logical_size_;
+  std::optional<std::array<float, 2>> view_logical_size_;
+  std::optional<std::array<float, 2>> view_logical_origin_;
   std::optional<float> view_pixel_ratio_;
 
   fidl::Binding<fuchsia::ui::scenic::SessionListener> session_listener_binding_;


### PR DESCRIPTION
Floating point error can cause edge pointer coordinates to fall
slightly outside of the view's logical bounding box, causing a failure
of gesture recognition in Dart code. This patch coerces the DOWN pointer
to inside the logical view boundary.

## Pre-launch Checklist

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ x] I listed at least one issue that this PR fixes in the description above.
- [ x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] I signed the [CLA].
- [ x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
