### PR TITLE
[draft] Use preDraw for the Android embedding

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
@@ -18,6 +18,9 @@ public class FlutterActivityLaunchConfigs {
       "io.flutter.embedding.android.NormalTheme";
   /* package */ static final String HANDLE_DEEPLINKING_META_DATA_KEY =
       "flutter_deeplinking_enabled";
+  /* package */ static final String USE_LEGACY_SPLASH_SCREEN_META_DATA_KEY =
+      "io.flutter.embedding.android.use-legacy-splash-screen";
+
   // Intent extra arguments.
   /* package */ static final String EXTRA_INITIAL_ROUTE = "route";
   /* package */ static final String EXTRA_BACKGROUND_MODE = "background_mode";

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -378,9 +378,6 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Declare that the host does NOT want Flutter to attach to the surrounding Activity.
     when(mockHost.shouldAttachEngineToActivity()).thenReturn(false);
 
-    // getActivity() returns null if the activity is not attached
-    when(mockHost.getActivity()).thenReturn(null);
-
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 


### PR DESCRIPTION
On Android, use the preDraw listener to report that the application is drawn only when Flutter has shown the first frame, when using the V2 `FlutterActivity` and `FlutterFragmentActivity`. 

Related issue: https://github.com/flutter/flutter/issues/85292

### Changes

- The preDraw listener is used by default. This will break usage of provided custom Flutter splash screens, through `io.flutter.embedding.android.SplashScreenDrawable` / `provideSplashScreen`
- If a custom splash screen is detected, logs are printed to direct users to a migration guide `flutter.dev/go/android-splash-migration` (not written yet)
- Add a manifest value `io.flutter.embedding.android.use-legacy-splash-screen` that can be set to true to revert to the previous legacy behavior

### Implementation Notes

- Implement the check in `FlutterActivityAndFragmentDelegate` instead of `FlutterView`, to avoid the need to add yet another constructor to conditionally trigger this behavior. `FlutterActivityAndFragmentDelegate` also knows about the splash screen, and this implementation keeps the splash screen logic consolidated
- Remove the mock to return null for `getActivity` in  `itDoesNotAttachFlutterToTheActivityIfNotDesired(io.flutter.embedding.android.FlutterActivityAndFragmentDelegateTest)`. It should be unrealistic for null to be returned by `getActivity`, since fragments are always attached to an activity first before any lifecycle methods are called.

WIP:

- Tested locally on a physical API 30 and API 31 device and it works as expected, but still need to write tests
- There are some issues with internal tests timing out, presumably from starting Flutter activities that do not draw any frames. Still need to figure this out

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
