### PR TITLE
Use preDraw for the Android embedding

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -543,7 +543,7 @@ public class FlutterActivity extends Activity
         /* container=*/ null,
         /* savedInstanceState=*/ null,
         /*flutterViewId=*/ FLUTTER_VIEW_ID,
-        /*shouldInterceptFirstDraw=*/ getRenderMode() == RenderMode.surface);
+        /*shouldDelayFirstAndroidViewDraw=*/ getRenderMode() == RenderMode.surface);
   }
 
   private void configureStatusBarForFullscreenFlutterExperience() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -542,7 +542,8 @@ public class FlutterActivity extends Activity
         /* inflater=*/ null,
         /* container=*/ null,
         /* savedInstanceState=*/ null,
-        /*flutterViewId=*/ FLUTTER_VIEW_ID);
+        /*flutterViewId=*/ FLUTTER_VIEW_ID,
+        /*shouldInterceptFirstDraw=*/ getRenderMode() == RenderMode.surface);
   }
 
   private void configureStatusBarForFullscreenFlutterExperience() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -76,7 +76,7 @@ import java.util.Arrays;
   @Nullable private FlutterEngine flutterEngine;
   @Nullable private FlutterView flutterView;
   @Nullable private PlatformPlugin platformPlugin;
-  @Nullable private OnPreDrawListener activePreDrawListener;
+  @VisibleForTesting @Nullable OnPreDrawListener activePreDrawListener;
   private boolean isFlutterEngineFromHost;
   private boolean isFlutterUiDisplayed;
 
@@ -452,7 +452,7 @@ import java.util.Arrays;
       // available since it will wait for drawing to be completed first. At the same time, the
       // preDraw listener keeps returning false since the Flutter Engine waits for the
       // SurfaceTexture to be available.
-      throw new RuntimeException(
+      throw new IllegalArgumentException(
           "Cannot delay the first Android view draw when the render mode is not set to"
               + " `RenderMode.surface`.");
     }
@@ -465,7 +465,6 @@ import java.util.Arrays;
         new OnPreDrawListener() {
           @Override
           public boolean onPreDraw() {
-            Log.w(TAG, "blah predraw " + isFlutterUiDisplayed);
             if (isFlutterUiDisplayed && activePreDrawListener != null) {
               flutterView.getViewTreeObserver().removeOnPreDrawListener(this);
               activePreDrawListener = null;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -262,10 +262,11 @@ import java.util.Arrays;
    * <p>{@code shouldDelayFirstAndroidViewDraw} determines whether to set up an {@link
    * android.view.ViewTreeObserver.OnPreDrawListener}, which will defer the current drawing pass
    * till after the Flutter UI has been displayed. This results in more accurate timings reported
-   * with Android tools, such as "Displayed" timing printed with `am start`. Note that it should
-   * only be set to true when {@code Host#getRenderMode()} is {@code RenderMode.surface}. This
-   * parameter is also ignored, disabling the delay should the legacy {@code
-   * Host#provideSplashScreen()} be non-null. See <a
+   * with Android tools, such as "Displayed" timing printed with `am start`.
+   *
+   * <p>Note that it should only be set to true when {@code Host#getRenderMode()} is {@code
+   * RenderMode.surface}. This parameter is also ignored, disabling the delay should the legacy
+   * {@code Host#provideSplashScreen()} be non-null. See <a
    * href="https://flutter.dev/go/android-splash-migration">Android Splash Migration</a>.
    *
    * <p>This method:

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
@@ -18,6 +18,9 @@ public class FlutterActivityLaunchConfigs {
       "io.flutter.embedding.android.NormalTheme";
   /* package */ static final String HANDLE_DEEPLINKING_META_DATA_KEY =
       "flutter_deeplinking_enabled";
+  /* package */ static final String USE_LEGACY_SPLASH_SCREEN_META_DATA_KEY =
+      "io.flutter.embedding.android.use-legacy-splash-screen";
+
   // Intent extra arguments.
   /* package */ static final String EXTRA_INITIAL_ROUTE = "route";
   /* package */ static final String EXTRA_BACKGROUND_MODE = "background_mode";

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityLaunchConfigs.java
@@ -18,9 +18,6 @@ public class FlutterActivityLaunchConfigs {
       "io.flutter.embedding.android.NormalTheme";
   /* package */ static final String HANDLE_DEEPLINKING_META_DATA_KEY =
       "flutter_deeplinking_enabled";
-  /* package */ static final String USE_LEGACY_SPLASH_SCREEN_META_DATA_KEY =
-      "io.flutter.embedding.android.use-legacy-splash-screen";
-
   // Intent extra arguments.
   /* package */ static final String EXTRA_INITIAL_ROUTE = "route";
   /* package */ static final String EXTRA_BACKGROUND_MODE = "background_mode";

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -113,6 +113,8 @@ public class FlutterFragment extends Fragment
   protected static final String ARG_HANDLE_DEEPLINKING = "handle_deeplinking";
   /** Path to Flutter's Dart code. */
   protected static final String ARG_APP_BUNDLE_PATH = "app_bundle_path";
+
+  protected static final String ARG_SHOULD_INTERCEPT_FIRST_DRAW = "should_intercept_first_draw";
   /** Flutter shell arguments. */
   protected static final String ARG_FLUTTER_INITIALIZATION_ARGS = "initialization_args";
   /**
@@ -229,6 +231,7 @@ public class FlutterFragment extends Fragment
     private TransparencyMode transparencyMode = TransparencyMode.transparent;
     private boolean shouldAttachEngineToActivity = true;
     private boolean shouldAutomaticallyHandleOnBackPressed = false;
+    private boolean shouldInterceptFirstDraw = false;
 
     /**
      * Constructs a {@code NewEngineFragmentBuilder} that is configured to construct an instance of
@@ -383,6 +386,18 @@ public class FlutterFragment extends Fragment
     }
 
     /**
+     * Whether to defer the Android drawing pass till after the Flutter UI has been displayed.
+     *
+     * <p>See {#link FlutterActivityAndFragmentDelegate#onCreateView} for more details.
+     */
+    @NonNull
+    public NewEngineFragmentBuilder shouldInterceptFirstDraw(
+        @NonNull boolean shouldInterceptFirstDraw) {
+      this.shouldInterceptFirstDraw = shouldInterceptFirstDraw;
+      return this;
+    }
+
+    /**
      * Creates a {@link Bundle} of arguments that are assigned to the new {@code FlutterFragment}.
      *
      * <p>Subclasses should override this method to add new properties to the {@link Bundle}.
@@ -410,6 +425,7 @@ public class FlutterFragment extends Fragment
       args.putBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, true);
       args.putBoolean(
           ARG_SHOULD_AUTOMATICALLY_HANDLE_ON_BACK_PRESSED, shouldAutomaticallyHandleOnBackPressed);
+      args.putBoolean(ARG_SHOULD_INTERCEPT_FIRST_DRAW, shouldInterceptFirstDraw);
       return args;
     }
 
@@ -496,6 +512,7 @@ public class FlutterFragment extends Fragment
     private TransparencyMode transparencyMode = TransparencyMode.transparent;
     private boolean shouldAttachEngineToActivity = true;
     private boolean shouldAutomaticallyHandleOnBackPressed = false;
+    private boolean shouldInterceptFirstDraw = false;
 
     private CachedEngineFragmentBuilder(@NonNull String engineId) {
       this(FlutterFragment.class, engineId);
@@ -622,6 +639,18 @@ public class FlutterFragment extends Fragment
     }
 
     /**
+     * Whether to defer the Android drawing pass till after the Flutter UI has been displayed.
+     *
+     * <p>See {#link FlutterActivityAndFragmentDelegate#onCreateView} for more details.
+     */
+    @NonNull
+    public CachedEngineFragmentBuilder shouldInterceptFirstDraw(
+        @NonNull boolean shouldInterceptFirstDraw) {
+      this.shouldInterceptFirstDraw = shouldInterceptFirstDraw;
+      return this;
+    }
+
+    /**
      * Creates a {@link Bundle} of arguments that are assigned to the new {@code FlutterFragment}.
      *
      * <p>Subclasses should override this method to add new properties to the {@link Bundle}.
@@ -642,6 +671,7 @@ public class FlutterFragment extends Fragment
       args.putBoolean(ARG_SHOULD_ATTACH_ENGINE_TO_ACTIVITY, shouldAttachEngineToActivity);
       args.putBoolean(
           ARG_SHOULD_AUTOMATICALLY_HANDLE_ON_BACK_PRESSED, shouldAutomaticallyHandleOnBackPressed);
+      args.putBoolean(ARG_SHOULD_INTERCEPT_FIRST_DRAW, shouldInterceptFirstDraw);
       return args;
     }
 
@@ -727,7 +757,11 @@ public class FlutterFragment extends Fragment
   public View onCreateView(
       LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
     return delegate.onCreateView(
-        inflater, container, savedInstanceState, /*flutterViewId=*/ FLUTTER_VIEW_ID);
+        inflater,
+        container,
+        savedInstanceState,
+        /*flutterViewId=*/ FLUTTER_VIEW_ID,
+        shouldInterceptFirstDraw());
   }
 
   @Override
@@ -1003,6 +1037,10 @@ public class FlutterFragment extends Fragment
   @NonNull
   public String getAppBundlePath() {
     return getArguments().getString(ARG_APP_BUNDLE_PATH);
+  }
+
+  private boolean shouldInterceptFirstDraw() {
+    return getArguments().getBoolean(ARG_SHOULD_INTERCEPT_FIRST_DRAW);
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -1041,10 +1041,6 @@ public class FlutterFragment extends Fragment
     return getArguments().getString(ARG_APP_BUNDLE_PATH);
   }
 
-  private boolean shouldDelayFirstAndroidViewDraw() {
-    return getArguments().getBoolean(ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW);
-  }
-
   /**
    * Returns the initial route that should be rendered within Flutter, once the Flutter app starts.
    *
@@ -1305,6 +1301,12 @@ public class FlutterFragment extends Fragment
     }
     // Hook for subclass. No-op if returns false.
     return false;
+  }
+
+  @VisibleForTesting
+  @NonNull
+  boolean shouldDelayFirstAndroidViewDraw() {
+    return getArguments().getBoolean(ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW);
   }
 
   private boolean stillAttachedForEvent(String event) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -113,8 +113,10 @@ public class FlutterFragment extends Fragment
   protected static final String ARG_HANDLE_DEEPLINKING = "handle_deeplinking";
   /** Path to Flutter's Dart code. */
   protected static final String ARG_APP_BUNDLE_PATH = "app_bundle_path";
+  /** Whether to delay the Android drawing pass till after the Flutter UI has been displayed. */
+  protected static final String ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW =
+      "should_delay_first_android_view_draw";
 
-  protected static final String ARG_SHOULD_INTERCEPT_FIRST_DRAW = "should_intercept_first_draw";
   /** Flutter shell arguments. */
   protected static final String ARG_FLUTTER_INITIALIZATION_ARGS = "initialization_args";
   /**
@@ -231,7 +233,7 @@ public class FlutterFragment extends Fragment
     private TransparencyMode transparencyMode = TransparencyMode.transparent;
     private boolean shouldAttachEngineToActivity = true;
     private boolean shouldAutomaticallyHandleOnBackPressed = false;
-    private boolean shouldInterceptFirstDraw = false;
+    private boolean shouldDelayFirstAndroidViewDraw = false;
 
     /**
      * Constructs a {@code NewEngineFragmentBuilder} that is configured to construct an instance of
@@ -386,14 +388,14 @@ public class FlutterFragment extends Fragment
     }
 
     /**
-     * Whether to defer the Android drawing pass till after the Flutter UI has been displayed.
+     * Whether to delay the Android drawing pass till after the Flutter UI has been displayed.
      *
      * <p>See {#link FlutterActivityAndFragmentDelegate#onCreateView} for more details.
      */
     @NonNull
-    public NewEngineFragmentBuilder shouldInterceptFirstDraw(
-        @NonNull boolean shouldInterceptFirstDraw) {
-      this.shouldInterceptFirstDraw = shouldInterceptFirstDraw;
+    public NewEngineFragmentBuilder shouldDelayFirstAndroidViewDraw(
+        @NonNull boolean shouldDelayFirstAndroidViewDraw) {
+      this.shouldDelayFirstAndroidViewDraw = shouldDelayFirstAndroidViewDraw;
       return this;
     }
 
@@ -425,7 +427,7 @@ public class FlutterFragment extends Fragment
       args.putBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, true);
       args.putBoolean(
           ARG_SHOULD_AUTOMATICALLY_HANDLE_ON_BACK_PRESSED, shouldAutomaticallyHandleOnBackPressed);
-      args.putBoolean(ARG_SHOULD_INTERCEPT_FIRST_DRAW, shouldInterceptFirstDraw);
+      args.putBoolean(ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW, shouldDelayFirstAndroidViewDraw);
       return args;
     }
 
@@ -512,7 +514,7 @@ public class FlutterFragment extends Fragment
     private TransparencyMode transparencyMode = TransparencyMode.transparent;
     private boolean shouldAttachEngineToActivity = true;
     private boolean shouldAutomaticallyHandleOnBackPressed = false;
-    private boolean shouldInterceptFirstDraw = false;
+    private boolean shouldDelayFirstAndroidViewDraw = false;
 
     private CachedEngineFragmentBuilder(@NonNull String engineId) {
       this(FlutterFragment.class, engineId);
@@ -639,14 +641,14 @@ public class FlutterFragment extends Fragment
     }
 
     /**
-     * Whether to defer the Android drawing pass till after the Flutter UI has been displayed.
+     * Whether to delay the Android drawing pass till after the Flutter UI has been displayed.
      *
      * <p>See {#link FlutterActivityAndFragmentDelegate#onCreateView} for more details.
      */
     @NonNull
-    public CachedEngineFragmentBuilder shouldInterceptFirstDraw(
-        @NonNull boolean shouldInterceptFirstDraw) {
-      this.shouldInterceptFirstDraw = shouldInterceptFirstDraw;
+    public CachedEngineFragmentBuilder shouldDelayFirstAndroidViewDraw(
+        @NonNull boolean shouldDelayFirstAndroidViewDraw) {
+      this.shouldDelayFirstAndroidViewDraw = shouldDelayFirstAndroidViewDraw;
       return this;
     }
 
@@ -671,7 +673,7 @@ public class FlutterFragment extends Fragment
       args.putBoolean(ARG_SHOULD_ATTACH_ENGINE_TO_ACTIVITY, shouldAttachEngineToActivity);
       args.putBoolean(
           ARG_SHOULD_AUTOMATICALLY_HANDLE_ON_BACK_PRESSED, shouldAutomaticallyHandleOnBackPressed);
-      args.putBoolean(ARG_SHOULD_INTERCEPT_FIRST_DRAW, shouldInterceptFirstDraw);
+      args.putBoolean(ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW, shouldDelayFirstAndroidViewDraw);
       return args;
     }
 
@@ -761,7 +763,7 @@ public class FlutterFragment extends Fragment
         container,
         savedInstanceState,
         /*flutterViewId=*/ FLUTTER_VIEW_ID,
-        shouldInterceptFirstDraw());
+        shouldDelayFirstAndroidViewDraw());
   }
 
   @Override
@@ -1039,8 +1041,8 @@ public class FlutterFragment extends Fragment
     return getArguments().getString(ARG_APP_BUNDLE_PATH);
   }
 
-  private boolean shouldInterceptFirstDraw() {
-    return getArguments().getBoolean(ARG_SHOULD_INTERCEPT_FIRST_DRAW);
+  private boolean shouldDelayFirstAndroidViewDraw() {
+    return getArguments().getBoolean(ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW);
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -394,7 +394,7 @@ public class FlutterFragment extends Fragment
      */
     @NonNull
     public NewEngineFragmentBuilder shouldDelayFirstAndroidViewDraw(
-        @NonNull boolean shouldDelayFirstAndroidViewDraw) {
+        boolean shouldDelayFirstAndroidViewDraw) {
       this.shouldDelayFirstAndroidViewDraw = shouldDelayFirstAndroidViewDraw;
       return this;
     }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -425,7 +425,7 @@ public class FlutterFragmentActivity extends FragmentActivity
         backgroundMode == BackgroundMode.opaque
             ? TransparencyMode.opaque
             : TransparencyMode.transparent;
-    final boolean shouldInterceptFirstDraw = renderMode == RenderMode.surface;
+    final boolean shouldDelayFirstAndroidViewDraw = renderMode == RenderMode.surface;
 
     if (getCachedEngineId() != null) {
       Log.v(
@@ -449,7 +449,7 @@ public class FlutterFragmentActivity extends FragmentActivity
           .handleDeeplinking(shouldHandleDeeplinking())
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
           .destroyEngineWithFragment(shouldDestroyEngineWithHost())
-          .shouldInterceptFirstDraw(shouldInterceptFirstDraw)
+          .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
           .build();
     } else {
       Log.v(
@@ -479,7 +479,7 @@ public class FlutterFragmentActivity extends FragmentActivity
           .renderMode(renderMode)
           .transparencyMode(transparencyMode)
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
-          .shouldInterceptFirstDraw(shouldInterceptFirstDraw)
+          .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
           .build();
     }
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -425,6 +425,7 @@ public class FlutterFragmentActivity extends FragmentActivity
         backgroundMode == BackgroundMode.opaque
             ? TransparencyMode.opaque
             : TransparencyMode.transparent;
+    final boolean shouldInterceptFirstDraw = renderMode == RenderMode.surface;
 
     if (getCachedEngineId() != null) {
       Log.v(
@@ -448,6 +449,7 @@ public class FlutterFragmentActivity extends FragmentActivity
           .handleDeeplinking(shouldHandleDeeplinking())
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
           .destroyEngineWithFragment(shouldDestroyEngineWithHost())
+          .shouldInterceptFirstDraw(shouldInterceptFirstDraw)
           .build();
     } else {
       Log.v(
@@ -477,6 +479,7 @@ public class FlutterFragmentActivity extends FragmentActivity
           .renderMode(renderMode)
           .transparencyMode(transparencyMode)
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
+          .shouldInterceptFirstDraw(shouldInterceptFirstDraw)
           .build();
     }
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -888,7 +888,6 @@ public class FlutterActivityAndFragmentDelegateTest {
 
   @Test
   public void itThrowsWhenDelayingTheFirstDrawAndUsingATextureView() {
-
     // ---- Test setup ----
     when(mockHost.getRenderMode()).thenReturn(RenderMode.texture);
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -86,7 +86,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // We're testing lifecycle behaviors, which require/expect that certain methods have already
     // been executed by the time they run. Therefore, we run those expected methods first.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
 
     // --- Execute the behavior under test ---
     // By the time an Activity/Fragment is started, we don't expect any lifecycle messages
@@ -164,7 +164,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // The FlutterEngine is obtained in onAttach().
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
 
@@ -220,7 +220,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
 
     // Verify that the host was asked to configure a FlutterSurfaceView.
     verify(mockHost, times(1)).onFlutterSurfaceViewCreated(notNull(FlutterSurfaceView.class));
@@ -249,7 +249,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, false);
 
     // Verify that the host was asked to configure a FlutterTextureView.
     verify(customMockHost, times(1)).onFlutterTextureViewCreated(notNull(FlutterTextureView.class));
@@ -282,7 +282,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // The initial route is sent in onStart().
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
 
     // Verify that the navigation channel was given our initial route.
@@ -306,7 +306,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Dart is executed in onStart().
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
 
     // Verify that the host's Dart entrypoint was used.
@@ -335,7 +335,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Dart is executed in onStart().
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
 
     // Verify that the host's Dart entrypoint was used.
@@ -390,7 +390,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // Make sure all of the other lifecycle methods can run safely as well
     // without a valid Activity
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -751,7 +751,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -775,7 +775,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -806,7 +806,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -838,7 +838,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -378,6 +378,9 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Declare that the host does NOT want Flutter to attach to the surrounding Activity.
     when(mockHost.shouldAttachEngineToActivity()).thenReturn(false);
 
+    // getActivity() returns null if the activity is not attached
+    when(mockHost.getActivity()).thenReturn(null);
+
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -378,9 +378,6 @@ public class FlutterActivityAndFragmentDelegateTest {
     // Declare that the host does NOT want Flutter to attach to the surrounding Activity.
     when(mockHost.shouldAttachEngineToActivity()).thenReturn(false);
 
-    // getActivity() returns null if the activity is not attached
-    when(mockHost.getActivity()).thenReturn(null);
-
     // Create the real object that we're testing.
     FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -292,6 +292,31 @@ public class FlutterActivityTest {
   }
 
   @Test
+  public void itDelaysDrawing() {
+    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    flutterActivity.onCreate(null);
+
+    assertNotNull(flutterActivity.delegate.activePreDrawListener);
+  }
+
+  @Test
+  public void itDoesNotDelayDrawingwhenUsingTextureRendering() {
+    Intent intent =
+        FlutterActivityWithTextureRendering.createDefaultIntent(RuntimeEnvironment.application);
+    ActivityController<FlutterActivityWithTextureRendering> activityController =
+        Robolectric.buildActivity(FlutterActivityWithTextureRendering.class, intent);
+    FlutterActivityWithTextureRendering flutterActivity = activityController.get();
+
+    flutterActivity.onCreate(null);
+
+    assertNull(flutterActivity.delegate.activePreDrawListener);
+  }
+
+  @Test
   public void itRestoresPluginStateBeforePluginOnCreate() {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
@@ -420,6 +445,13 @@ public class FlutterActivityTest {
 
     public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {
       return new CachedEngineIntentBuilder(FlutterActivityWithIntentBuilders.class, cachedEngineId);
+    }
+  }
+
+  private static class FlutterActivityWithTextureRendering extends FlutterActivity {
+    @Override
+    public RenderMode getRenderMode() {
+      return RenderMode.texture;
     }
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -82,7 +82,7 @@ public class FlutterAndroidComponentTest {
     assertNotNull(binding.getPlatformViewRegistry());
 
     delegate.onRestoreInstanceState(null);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -156,7 +156,7 @@ public class FlutterAndroidComponentTest {
     // Verify that after Activity creation, the plugin was allowed to restore state.
     verify(mockSaveStateListener, times(1)).onRestoreInstanceState(any(Bundle.class));
 
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -195,7 +195,7 @@ public class FlutterAndroidComponentTest {
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
     delegate.onRestoreInstanceState(null);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -3,6 +3,7 @@ package io.flutter.embedding.android;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -41,6 +42,7 @@ public class FlutterFragmentTest {
     assertTrue(fragment.shouldDestroyEngineWithHost());
     assertEquals(RenderMode.surface, fragment.getRenderMode());
     assertEquals(TransparencyMode.transparent, fragment.getTransparencyMode());
+    assertFalse(fragment.shouldDelayFirstAndroidViewDraw());
   }
 
   @Test
@@ -68,12 +70,21 @@ public class FlutterFragmentTest {
   }
 
   @Test
-  public void itCreatesCachedEngineFragmentThatDoesNotDestroyTheEngine() {
+  public void itCreatesNewEngineFragmentThatDelaysFirstDrawWhenRequested() {
+    FlutterFragment fragment =
+        FlutterFragment.withNewEngine().shouldDelayFirstAndroidViewDraw(true).build();
+
+    assertNotNull(fragment.shouldDelayFirstAndroidViewDraw());
+  }
+
+  @Test
+  public void itCreatesCachedEngineFragmentWithExpectedDefaults() {
     FlutterFragment fragment = FlutterFragment.withCachedEngine("my_cached_engine").build();
 
     assertTrue(fragment.shouldAttachEngineToActivity());
     assertEquals("my_cached_engine", fragment.getCachedEngineId());
     assertFalse(fragment.shouldDestroyEngineWithHost());
+    assertFalse(fragment.shouldDelayFirstAndroidViewDraw());
   }
 
   @Test
@@ -86,6 +97,16 @@ public class FlutterFragmentTest {
     assertTrue(fragment.shouldAttachEngineToActivity());
     assertEquals("my_cached_engine", fragment.getCachedEngineId());
     assertTrue(fragment.shouldDestroyEngineWithHost());
+  }
+
+  @Test
+  public void itCreatesCachedEngineFragmentThatDelaysFirstDrawWhenRequested() {
+    FlutterFragment fragment =
+        FlutterFragment.withCachedEngine("my_cached_engine")
+            .shouldDelayFirstAndroidViewDraw(true)
+            .build();
+
+    assertNotNull(fragment.shouldDelayFirstAndroidViewDraw());
   }
 
   @Test


### PR DESCRIPTION
On Android, use the preDraw listener to report that the application is drawn only when Flutter has shown the first frame, when using the V2 `FlutterActivity` and `FlutterFragmentActivity`. 

Related issue: https://github.com/flutter/flutter/issues/85292

### Changes

- The preDraw listener is used by default for users of the `FlutterActivity` and `FlutterFragmentActivity`, **unless**:
  - A custom splash screen is detected (through `io.flutter.embedding.android.SplashScreenDrawable` / `provideSplashScreen`). When this is detected, add log warnings to direct users to a migration guide `flutter.dev/go/android-splash-migration` (not written yet)
  - `RenderMode.surface` is not used. This is because otherwise, `FlutterTextureView` will be used, but a deadlock will be caused because the underlying `SurfaceTexture` will never be available when preDraw returns false
- Users who use `FlutterFragment` directly can enable this behavior through the `shouldDelayFirstAndroidViewDraw ` builder method

### Implementation Notes

- Implement the check in `FlutterActivityAndFragmentDelegate` instead of `FlutterView`, to avoid the need to add yet another constructor to conditionally trigger this behavior. `FlutterActivityAndFragmentDelegate` also knows about the splash screen, and this implementation keeps the splash screen logic consolidated
- Added a new parameter to `FlutterActivityAndFragmentDelegate.onCreateView`. I did not add a overload to preserve the old behavior since `FlutterActivityAndFragmentDelegate` is package private

### Tested

- Tested locally on a physical API 30 and API 31 device and it works as expected
- Internal presubmit - minor changes needed to start activities asynchronously since some Integration Tests do not draw any frames

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
