### PR TITLE
Set AppStartUp UserTag from engine

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -361,6 +361,14 @@ bool DartIsolate::Initialize(Dart_Isolate dart_isolate) {
 
   tonic::DartIsolateScope scope(isolate());
 
+  // For the root isolate set the "AppStartUp" as soon as the root isolate
+  // has been initialized. This is to ensure that all the timeline events
+  // that have the set user-tag will be listed user AppStartUp.
+  if (IsRootIsolate()) {
+    tonic::DartApiScope api_scope;
+    Dart_SetCurrentUserTag(Dart_NewUserTag("AppStartUp"));
+  }
+
   SetMessageHandlingTaskRunner(GetTaskRunners().GetUITaskRunner());
 
   if (tonic::LogIfError(


### PR DESCRIPTION
This is the engine side of https://github.com/flutter/flutter/issues/84884. This 'AppStartUp' user tag will be unset in the framework once app start up is complete (https://github.com/flutter/flutter/pull/86516). Tools will pull the CPU profile tagged with 'AppStartUp' to provide better app start up profiling support.

Supersedes: https://github.com/flutter/engine/pull/27553