### PR TITLE
Uncomment terminate unit test (Dart side fix has rolled into the engine)

### DIFF
--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -123,11 +123,6 @@ TEST_F(EmbedderTest, CanInvokeCustomEntrypointMacro) {
   ASSERT_TRUE(engine.is_valid());
 }
 
-/*
- * Uncomment once a Dart roll with the fix to reinitialize dart-io state
- * correctly has landed and rolled into the engine.
- * https://dart-review.googlesource.com/c/sdk/+/207642
- *
 TEST_F(EmbedderTest, CanTerminateCleanly) {
   auto& context = GetEmbedderContext(EmbedderTestContextType::kSoftwareContext);
   EmbedderConfigBuilder builder(context);
@@ -136,7 +131,6 @@ TEST_F(EmbedderTest, CanTerminateCleanly) {
   auto engine = builder.LaunchEngine();
   ASSERT_TRUE(engine.is_valid());
 }
-*/
 
 std::atomic_size_t EmbedderTestTaskRunner::sEmbedderTaskRunnerIdentifiers = {};
 


### PR DESCRIPTION
The Dart side fix for the flaky engine crash in the terminate test has rolled into the engine
(https://dart-review.googlesource.com/c/sdk/+/207642).