### PR TITLE
Fix NPE and remove global focus listener when tearing down the view

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -77,7 +77,7 @@ public class FlutterMutatorView extends FrameLayout {
   @Nullable private ViewTreeObserver.OnGlobalFocusChangeListener focusListener;
 
   /**
-   * Adds a focus change listener that notifies when the current view or any of its descendant views
+   * Sets a focus change listener that notifies when the current view or any of its descendant views
    * have received focus.
    *
    * <p>If there's an active focus listener, it will first remove the current listener, and then add
@@ -85,8 +85,8 @@ public class FlutterMutatorView extends FrameLayout {
    *
    * @param userFocusListener A user provided focus listener.
    */
-  public void addOnFocusChangeListener(@NonNull OnFocusChangeListener userFocusListener) {
-    removeOnFocusChangeListenerIfNeeded();
+  public void setOnDescendantFocusChangeListener(@NonNull OnFocusChangeListener userFocusListener) {
+    unsetOnDescendantFocusChangeListener();
 
     final View mutatorView = this;
     final ViewTreeObserver observer = getViewTreeObserver();
@@ -102,8 +102,8 @@ public class FlutterMutatorView extends FrameLayout {
     }
   }
 
-  /** Removes any active focus listener. */
-  public void removeOnFocusChangeListenerIfNeeded() {
+  /** Unsets any active focus listener. */
+  public void unsetOnDescendantFocusChangeListener() {
     final ViewTreeObserver observer = getViewTreeObserver();
     if (observer.isAlive() && focusListener != null) {
       final ViewTreeObserver.OnGlobalFocusChangeListener currFocusListener = focusListener;

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -86,7 +86,7 @@ public class FlutterMutatorView extends FrameLayout {
    * @param userFocusListener A user provided focus listener.
    */
   public void addOnFocusChangeListener(@NonNull OnFocusChangeListener userFocusListener) {
-    this.removeOnFocusChangeListenerIfNeeded();
+    removeOnFocusChangeListenerIfNeeded();
 
     final View mutatorView = this;
     final ViewTreeObserver observer = getViewTreeObserver();

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -74,7 +74,7 @@ public class FlutterMutatorView extends FrameLayout {
     return false;
   }
 
-  @Nullable private ViewTreeObserver.OnGlobalFocusChangeListener focusListener;
+  @Nullable @VisibleForTesting ViewTreeObserver.OnGlobalFocusChangeListener activeFocusListener;
 
   /**
    * Sets a focus change listener that notifies when the current view or any of its descendant views
@@ -90,24 +90,24 @@ public class FlutterMutatorView extends FrameLayout {
 
     final View mutatorView = this;
     final ViewTreeObserver observer = getViewTreeObserver();
-    if (observer.isAlive() && focusListener == null) {
-      focusListener =
+    if (observer.isAlive() && activeFocusListener == null) {
+      activeFocusListener =
           new ViewTreeObserver.OnGlobalFocusChangeListener() {
             @Override
             public void onGlobalFocusChanged(View oldFocus, View newFocus) {
               userFocusListener.onFocusChange(mutatorView, childHasFocus(mutatorView));
             }
           };
-      observer.addOnGlobalFocusChangeListener(focusListener);
+      observer.addOnGlobalFocusChangeListener(activeFocusListener);
     }
   }
 
   /** Unsets any active focus listener. */
   public void unsetOnDescendantFocusChangeListener() {
     final ViewTreeObserver observer = getViewTreeObserver();
-    if (observer.isAlive() && focusListener != null) {
-      final ViewTreeObserver.OnGlobalFocusChangeListener currFocusListener = focusListener;
-      focusListener = null;
+    if (observer.isAlive() && activeFocusListener != null) {
+      final ViewTreeObserver.OnGlobalFocusChangeListener currFocusListener = activeFocusListener;
+      activeFocusListener = null;
       observer.removeOnGlobalFocusChangeListener(currFocusListener);
     }
   }

--- a/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorView.java
@@ -74,23 +74,41 @@ public class FlutterMutatorView extends FrameLayout {
     return false;
   }
 
+  @Nullable private ViewTreeObserver.OnGlobalFocusChangeListener focusListener;
+
   /**
    * Adds a focus change listener that notifies when the current view or any of its descendant views
    * have received focus.
    *
-   * @param focusListener The focus listener.
+   * <p>If there's an active focus listener, it will first remove the current listener, and then add
+   * the new one.
+   *
+   * @param userFocusListener A user provided focus listener.
    */
-  public void addOnFocusChangeListener(@NonNull OnFocusChangeListener focusListener) {
+  public void addOnFocusChangeListener(@NonNull OnFocusChangeListener userFocusListener) {
+    this.removeOnFocusChangeListenerIfNeeded();
+
     final View mutatorView = this;
-    final ViewTreeObserver observer = this.getViewTreeObserver();
-    if (observer.isAlive()) {
-      observer.addOnGlobalFocusChangeListener(
+    final ViewTreeObserver observer = getViewTreeObserver();
+    if (observer.isAlive() && focusListener == null) {
+      focusListener =
           new ViewTreeObserver.OnGlobalFocusChangeListener() {
             @Override
             public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-              focusListener.onFocusChange(mutatorView, childHasFocus(mutatorView));
+              userFocusListener.onFocusChange(mutatorView, childHasFocus(mutatorView));
             }
-          });
+          };
+      observer.addOnGlobalFocusChangeListener(focusListener);
+    }
+  }
+
+  /** Removes any active focus listener. */
+  public void removeOnFocusChangeListenerIfNeeded() {
+    final ViewTreeObserver observer = getViewTreeObserver();
+    if (observer.isAlive() && focusListener != null) {
+      final ViewTreeObserver.OnGlobalFocusChangeListener currFocusListener = focusListener;
+      focusListener = null;
+      observer.removeOnGlobalFocusChangeListener(currFocusListener);
     }
   }
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -165,7 +165,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
             platformView.dispose();
           }
           if (parentView != null) {
-            parentView.removeOnFocusChangeListenerIfNeeded();
+            parentView.unsetOnDescendantFocusChangeListener();
             ((ViewGroup) parentView.getParent()).removeView(parentView);
             platformViewParent.remove(viewId);
           }
@@ -748,7 +748,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
         new FlutterMutatorView(
             context, context.getResources().getDisplayMetrics().density, androidTouchProcessor);
 
-    parentView.addOnFocusChangeListener(
+    parentView.setOnDescendantFocusChangeListener(
         (view, hasFocus) -> {
           if (hasFocus) {
             platformViewsChannel.invokeViewFocused(viewId);

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -61,7 +61,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
   // The texture registry maintaining the textures into which the embedded views will be rendered.
   private TextureRegistry textureRegistry;
 
-  private TextInputPlugin textInputPlugin;
+  @Nullable private TextInputPlugin textInputPlugin;
 
   // The system channel used to communicate with the framework about platform views.
   private PlatformViewsChannel platformViewsChannel;
@@ -164,8 +164,8 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
             platformViews.remove(viewId);
             platformView.dispose();
           }
-
           if (parentView != null) {
+            parentView.removeOnFocusChangeListenerIfNeeded();
             ((ViewGroup) parentView.getParent()).removeView(parentView);
             platformViewParent.remove(viewId);
           }
@@ -752,7 +752,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
         (view, hasFocus) -> {
           if (hasFocus) {
             platformViewsChannel.invokeViewFocused(viewId);
-          } else {
+          } else if (textInputPlugin != null) {
             textInputPlugin.clearPlatformViewClient(viewId);
           }
         });

--- a/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -212,10 +212,15 @@ public class FlutterMutatorViewTest {
     assertNull(view.activeFocusListener);
 
     view.setOnDescendantFocusChangeListener(mock(OnFocusChangeListener.class));
-    view.setOnDescendantFocusChangeListener(mock(OnFocusChangeListener.class));
-
     assertNotNull(view.activeFocusListener);
-    verify(viewTreeObserver, times(1)).removeOnGlobalFocusChangeListener(view.activeFocusListener);
+
+    final ViewTreeObserver.OnGlobalFocusChangeListener activeFocusListener =
+        view.activeFocusListener;
+
+    view.setOnDescendantFocusChangeListener(mock(OnFocusChangeListener.class));
+    assertNotNull(view.activeFocusListener);
+
+    verify(viewTreeObserver, times(1)).removeOnGlobalFocusChangeListener(activeFocusListener);
   }
 
   @Test
@@ -235,14 +240,14 @@ public class FlutterMutatorViewTest {
 
     view.setOnDescendantFocusChangeListener(mock(OnFocusChangeListener.class));
     assertNotNull(view.activeFocusListener);
+
     final ViewTreeObserver.OnGlobalFocusChangeListener activeFocusListener =
         view.activeFocusListener;
 
     view.unsetOnDescendantFocusChangeListener();
-    verify(viewTreeObserver, times(1)).removeOnGlobalFocusChangeListener(activeFocusListener);
     assertNull(view.activeFocusListener);
 
     view.unsetOnDescendantFocusChangeListener();
-    verify(viewTreeObserver, never()).removeOnGlobalFocusChangeListener(any());
+    verify(viewTreeObserver, times(1)).removeOnGlobalFocusChangeListener(activeFocusListener);
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -195,4 +195,54 @@ public class FlutterMutatorViewTest {
         };
     view.setOnDescendantFocusChangeListener(mock(OnFocusChangeListener.class));
   }
+
+  @Test
+  public void setOnDescendantFocusChangeListener_keepsSingleListener() {
+    final ViewTreeObserver viewTreeObserver = mock(ViewTreeObserver.class);
+    when(viewTreeObserver.isAlive()).thenReturn(true);
+
+    final FlutterMutatorView view =
+        new FlutterMutatorView(RuntimeEnvironment.systemContext) {
+          @Override
+          public ViewTreeObserver getViewTreeObserver() {
+            return viewTreeObserver;
+          }
+        };
+
+    assertNull(view.activeFocusListener);
+
+    view.setOnDescendantFocusChangeListener(mock(OnFocusChangeListener.class));
+    view.setOnDescendantFocusChangeListener(mock(OnFocusChangeListener.class));
+
+    assertNotNull(view.activeFocusListener);
+    verify(viewTreeObserver, times(1)).removeOnGlobalFocusChangeListener(view.activeFocusListener);
+  }
+
+  @Test
+  public void unsetOnDescendantFocusChangeListener_removesActiveListener() {
+    final ViewTreeObserver viewTreeObserver = mock(ViewTreeObserver.class);
+    when(viewTreeObserver.isAlive()).thenReturn(true);
+
+    final FlutterMutatorView view =
+        new FlutterMutatorView(RuntimeEnvironment.systemContext) {
+          @Override
+          public ViewTreeObserver getViewTreeObserver() {
+            return viewTreeObserver;
+          }
+        };
+
+    assertNull(view.activeFocusListener);
+
+    view.setOnDescendantFocusChangeListener(mock(OnFocusChangeListener.class));
+    assertNotNull(view.activeFocusListener);
+    final ViewTreeObserver.OnGlobalFocusChangeListener activeFocusListener =
+        view.activeFocusListener;
+
+    view.unsetOnDescendantFocusChangeListener();
+    verify(viewTreeObserver, times(1)).removeOnGlobalFocusChangeListener(activeFocusListener);
+    assertNull(view.activeFocusListener);
+
+    view.unsetOnDescendantFocusChangeListener();
+    verify(viewTreeObserver, never()).removeOnGlobalFocusChangeListener(any());
+  }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/mutatorsstack/FlutterMutatorViewTest.java
@@ -143,7 +143,7 @@ public class FlutterMutatorViewTest {
         };
 
     final OnFocusChangeListener focusListener = mock(OnFocusChangeListener.class);
-    view.addOnFocusChangeListener(focusListener);
+    view.setOnDescendantFocusChangeListener(focusListener);
 
     final ArgumentCaptor<ViewTreeObserver.OnGlobalFocusChangeListener> focusListenerCaptor =
         ArgumentCaptor.forClass(ViewTreeObserver.OnGlobalFocusChangeListener.class);
@@ -172,7 +172,7 @@ public class FlutterMutatorViewTest {
         };
 
     final OnFocusChangeListener focusListener = mock(OnFocusChangeListener.class);
-    view.addOnFocusChangeListener(focusListener);
+    view.setOnDescendantFocusChangeListener(focusListener);
 
     final ArgumentCaptor<ViewTreeObserver.OnGlobalFocusChangeListener> focusListenerCaptor =
         ArgumentCaptor.forClass(ViewTreeObserver.OnGlobalFocusChangeListener.class);
@@ -193,6 +193,6 @@ public class FlutterMutatorViewTest {
             return viewTreeObserver;
           }
         };
-    view.addOnFocusChangeListener(mock(OnFocusChangeListener.class));
+    view.setOnDescendantFocusChangeListener(mock(OnFocusChangeListener.class));
   }
 }


### PR DESCRIPTION
* `textInputPlugin` is nullable, so add a check for it.
* Remove the global focus listener when removing the view to avoid leaking the parent view. 

Fixes http://b/194167160