### PR TITLE
Bump leakcanary to latest version

### DIFF
--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.facebook.testing.screenshot'
 
-def leakcanary_version = '2.6'
+def leakcanary_version = '2.7'
 
 screenshots {
     failureDir = "${rootProject.buildDir}/reports/diff_failures"


### PR DESCRIPTION
This updates kotlin dependencies and cleans up some warning output like 

```
w: Runtime JAR files in the classpath have the version 1.3, which is older than the API version 1.4. Consider using the runtime of version 1.4, or pass '-api-version 1.3' explicitly to restrict the available APIs to the runtime of version 1.3. You can also pass '-language-version 1.3' instead, which will restrict not only the APIs to the specified version, but also the language features
w: /xxx/android_debug_unopt_arm64/scenario_app/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/8032138f12c0180bc4e51fe139d4c52b46db6109/kotlin-stdlib-1.3.72.jar: 
```
