### PR TITLE
Log all Skia trace events if the --trace-skia flag is passed

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -728,6 +728,7 @@ FILE: ../../../flutter/shell/common/skp_shader_warmup_unittests.cc
 FILE: ../../../flutter/shell/common/snapshot_surface_producer.h
 FILE: ../../../flutter/shell/common/switches.cc
 FILE: ../../../flutter/shell/common/switches.h
+FILE: ../../../flutter/shell/common/switches_unittests.cc
 FILE: ../../../flutter/shell/common/thread_host.cc
 FILE: ../../../flutter/shell/common/thread_host.h
 FILE: ../../../flutter/shell/common/vsync_waiter.cc

--- a/common/settings.h
+++ b/common/settings.h
@@ -111,7 +111,7 @@ struct Settings {
   bool start_paused = false;
   bool trace_skia = false;
   std::vector<std::string> trace_allowlist;
-  std::vector<std::string> trace_skia_allowlist;
+  std::optional<std::vector<std::string>> trace_skia_allowlist;
   bool trace_startup = false;
   bool trace_systrace = false;
   bool dump_skp_on_shader_compilation = false;

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -259,6 +259,7 @@ if (enable_unittests) {
       "rasterizer_unittests.cc",
       "shell_unittests.cc",
       "skp_shader_warmup_unittests.cc",
+      "switches_unittests.cc",
     ]
 
     deps = [

--- a/shell/common/skia_event_tracer_impl.h
+++ b/shell/common/skia_event_tracer_impl.h
@@ -5,13 +5,15 @@
 #ifndef FLUTTER_SHELL_COMMON_SKIA_EVENT_TRACER_IMPL_H_
 #define FLUTTER_SHELL_COMMON_SKIA_EVENT_TRACER_IMPL_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
 namespace flutter {
 
-void InitSkiaEventTracer(bool enabled,
-                         const std::vector<std::string>& allowlist);
+void InitSkiaEventTracer(
+    bool enabled,
+    const std::optional<std::vector<std::string>>& allowlist);
 
 }  // namespace flutter
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -299,13 +299,18 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
 #if !FLUTTER_RELEASE
   settings.trace_skia = true;
 
-  std::string trace_skia_allowlist;
-  command_line.GetOptionValue(FlagForSwitch(Switch::TraceSkiaAllowlist),
-                              &trace_skia_allowlist);
-  if (trace_skia_allowlist.size()) {
-    settings.trace_skia_allowlist = ParseCommaDelimited(trace_skia_allowlist);
+  if (command_line.HasOption(FlagForSwitch(Switch::TraceSkia))) {
+    // If --trace-skia is specified, then log all Skia events.
+    settings.trace_skia_allowlist.reset();
   } else {
-    settings.trace_skia_allowlist = {"skia.shaders"};
+    std::string trace_skia_allowlist;
+    command_line.GetOptionValue(FlagForSwitch(Switch::TraceSkiaAllowlist),
+                                &trace_skia_allowlist);
+    if (trace_skia_allowlist.size()) {
+      settings.trace_skia_allowlist = ParseCommaDelimited(trace_skia_allowlist);
+    } else {
+      settings.trace_skia_allowlist = {"skia.shaders"};
+    }
   }
 #endif  // !FLUTTER_RELEASE
 

--- a/shell/common/switches_unittests.cc
+++ b/shell/common/switches_unittests.cc
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/common/settings.h"
+#include "flutter/fml/command_line.h"
+#include "flutter/shell/common/switches.h"
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+
+TEST(SwitchesTest, SkiaTraceAllowlistFlag) {
+  fml::CommandLine command_line =
+      fml::CommandLineFromInitializerList({"command"});
+  Settings settings = SettingsFromCommandLine(command_line);
+#if !FLUTTER_RELEASE
+  EXPECT_TRUE(settings.trace_skia);
+  EXPECT_TRUE(settings.trace_skia_allowlist.has_value());
+  EXPECT_EQ(settings.trace_skia_allowlist->size(), 1ul);
+#else
+  EXPECT_FALSE(settings.trace_skia);
+#endif
+
+  command_line =
+      fml::CommandLineFromInitializerList({"command", "--trace-skia"});
+  settings = SettingsFromCommandLine(command_line);
+#if !FLUTTER_RELEASE
+  EXPECT_TRUE(settings.trace_skia);
+  EXPECT_FALSE(settings.trace_skia_allowlist.has_value());
+#else
+  EXPECT_FALSE(settings.trace_skia);
+#endif
+
+  command_line = fml::CommandLineFromInitializerList(
+      {"command", "--trace-skia-allowlist=aaa,bbb,ccc"});
+  settings = SettingsFromCommandLine(command_line);
+#if !FLUTTER_RELEASE
+  EXPECT_TRUE(settings.trace_skia);
+  EXPECT_TRUE(settings.trace_skia_allowlist.has_value());
+  EXPECT_EQ(settings.trace_skia_allowlist->size(), 3ul);
+  EXPECT_EQ(settings.trace_skia_allowlist->back(), "ccc");
+#else
+  EXPECT_FALSE(settings.trace_skia);
+#endif
+}
+
+}  // namespace testing
+}  // namespace flutter


### PR DESCRIPTION
Currently Skia tracing is always enabled for debug/profile builds, but
the default allowlist only logs shader events.

With this PR, if the --trace-skia flag is passed to the engine, then
the engine will log all Skia events.  This is similar to the original
behavior of --trace-skia.
