### PR TITLE
fix a number of conditions for computing bounds from saveLayers

### DIFF
--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -830,8 +830,9 @@ void DisplayList::ComputeBounds() {
 
 void DisplayList::Dispatch(Dispatcher& dispatcher,
                            uint8_t* ptr,
-                           uint8_t* end) const {
-  while (ptr < end) {
+                           uint8_t* end,
+                           DisplayList::AbortFunction* abort) const {
+  while (ptr < end && !(abort && (*abort)())) {
     auto op = (const DLOp*)ptr;
     ptr += op->size;
     FML_DCHECK(ptr <= end);
@@ -867,7 +868,7 @@ static void DisposeOps(uint8_t* ptr, uint8_t* end) {
 
       FOR_EACH_DISPLAY_LIST_OP(DL_OP_DISPOSE)
 
-#undef DL_OP_DISPATCH
+#undef DL_OP_DISPOSE
 
       default:
         FML_DCHECK(false);
@@ -905,7 +906,7 @@ static bool CompareOps(uint8_t* ptrA,
 
       FOR_EACH_DISPLAY_LIST_OP(DL_OP_EQUALS)
 
-#undef DL_OP_DISPATCH
+#undef DL_OP_EQUALS
 
       default:
         FML_DCHECK(false);
@@ -1246,7 +1247,7 @@ void DisplayListBuilder::drawPoints(SkCanvas::PointMode mode,
                                     uint32_t count,
                                     const SkPoint pts[]) {
   void* data_ptr;
-  FML_DCHECK(count < MaxDrawPointsCount);
+  FML_DCHECK(count < kMaxDrawPointsCount);
   int bytes = count * sizeof(SkPoint);
   switch (mode) {
     case SkCanvas::PointMode::kPoints_PointMode:

--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -830,9 +830,8 @@ void DisplayList::ComputeBounds() {
 
 void DisplayList::Dispatch(Dispatcher& dispatcher,
                            uint8_t* ptr,
-                           uint8_t* end,
-                           DisplayList::AbortFunction* abort) const {
-  while (ptr < end && !(abort && (*abort)())) {
+                           uint8_t* end) const {
+  while (ptr < end) {
     auto op = (const DLOp*)ptr;
     ptr += op->size;
     FML_DCHECK(ptr <= end);

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -177,12 +177,7 @@ class DisplayList : public SkRefCnt {
 
   ~DisplayList();
 
-  typedef const std::function<bool()> AbortFunction;
-
-  void Dispatch(Dispatcher& ctx,
-                AbortFunction* abort_function = nullptr) const {
-    Dispatch(ctx, ptr_, ptr_ + used_, abort_function);
-  }
+  void Dispatch(Dispatcher& ctx) const { Dispatch(ctx, ptr_, ptr_ + used_); }
 
   void RenderTo(SkCanvas* canvas) const;
 
@@ -215,10 +210,7 @@ class DisplayList : public SkRefCnt {
   SkRect bounds_cull_;
 
   void ComputeBounds();
-  void Dispatch(Dispatcher& ctx,
-                uint8_t* ptr,
-                uint8_t* end,
-                AbortFunction* abort) const;
+  void Dispatch(Dispatcher& ctx, uint8_t* ptr, uint8_t* end) const;
 
   friend class DisplayListBuilder;
 };

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -6,6 +6,8 @@
 #define FLUTTER_FLOW_DISPLAY_LIST_UTILS_H_
 
 #include "flutter/flow/display_list.h"
+#include "flutter/fml/logging.h"
+#include "flutter/fml/macros.h"
 
 #include "third_party/skia/include/core/SkMaskFilter.h"
 
@@ -313,7 +315,10 @@ class DisplayListBoundsCalculator final
                   bool occludes,
                   SkScalar dpr) override;
 
-  SkRect getBounds() { return accumulator_->getBounds(); }
+  SkRect getBounds() {
+    FML_DCHECK(accumulator_ == &root_accumulator_);
+    return root_accumulator_.getBounds();
+  }
 
  private:
   // current accumulator based on saveLayer history
@@ -334,6 +339,9 @@ class DisplayListBoundsCalculator final
 
    protected:
     BoundsAccumulator* saved_accumulator_;
+
+   private:
+    FML_DISALLOW_COPY_AND_ASSIGN(SaveInfo);
   };
 
   class SaveLayerInfo : public SaveInfo {
@@ -347,6 +355,9 @@ class DisplayListBoundsCalculator final
    protected:
     BoundsAccumulator layer_accumulator_;
     const SkMatrix matrix_;
+
+   private:
+    FML_DISALLOW_COPY_AND_ASSIGN(SaveLayerInfo);
   };
 
   class SaveLayerWithPaintInfo : public SaveLayerInfo {
@@ -354,6 +365,7 @@ class DisplayListBoundsCalculator final
     SaveLayerWithPaintInfo(DisplayListBoundsCalculator* calculator,
                            BoundsAccumulator* accumulator,
                            const SkMatrix& save_matrix,
+                           const SkRect* bounds,
                            const SkPaint& save_paint);
     virtual ~SaveLayerWithPaintInfo() = default;
 
@@ -362,10 +374,16 @@ class DisplayListBoundsCalculator final
    protected:
     DisplayListBoundsCalculator* calculator_;
 
+    SkRect bounds_;
     SkPaint paint_;
+
+   private:
+    static constexpr SkRect kMissingBounds = SkRect::MakeWH(-1, -1);
+
+    FML_DISALLOW_COPY_AND_ASSIGN(SaveLayerWithPaintInfo);
   };
 
-  std::vector<SaveInfo> saved_infos_;
+  std::vector<std::unique_ptr<SaveInfo>> saved_infos_;
 
   void accumulateRect(const SkRect& rect, bool force_stroke = false);
 };

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_FLOW_DISPLAY_LIST_UTILS_H_
 #define FLUTTER_FLOW_DISPLAY_LIST_UTILS_H_
 
+#include <optional>
+
 #include "flutter/flow/display_list.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
@@ -374,7 +376,7 @@ class DisplayListBoundsCalculator final
    protected:
     DisplayListBoundsCalculator* calculator_;
 
-    SkRect bounds_;
+    std::optional<SkRect> bounds_;
     SkPaint paint_;
 
    private:


### PR DESCRIPTION
This PR fixes a number of issues:
- We weren't doing anything about saveLayer(paint) where the paint could modify transparent alpha
- We should have been doing a roundOut() on the saveLayer results before transforming its bounds
- We needed to remember the bounds of the saveLayer in case we ran into something whose bounds couldn't be computed

There are a couple of minor edits that got swept up into this as I was doing minor code cleanup before I started working on it. They should be harmless, but:
- some of the #undef's were undef'ing the wrong name
- Renamed a constant with a leading k
- ~Added an abort mechanism for Dispatch which will be needed when we start writing scanners that look for conditions and may want to abort the readback as soon as they come to a conclusion.~ (Removed it - I may want to go with an iterator concept eventually)