### PR TITLE
Specify the output paths of the scenario app lint task

### DIFF
--- a/testing/scenario_app/android/BUILD.gn
+++ b/testing/scenario_app/android/BUILD.gn
@@ -30,7 +30,7 @@ gradle_task("android_lint") {
   task = "lint"
   gradlew_dir = rebase_path(".")
   sources = _android_sources
-  outputs = [ "$root_out_dir/scenario_app/build/reports" ]
+  outputs = [ "$root_out_dir/scenario_app/reports/lint-results.xml" ]
   deps = [ "//flutter/testing/scenario_app:scenario_app_snapshot" ]
 }
 

--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -15,6 +15,9 @@ android {
         showAll true
         warningsAsErrors true
         checkTestSources true
+        htmlReport false
+        xmlReport true
+        xmlOutput file("${rootProject.buildDir}/reports/lint-results.xml")
         // UnpackedNativeCode can break stack unwinding - see b/193408481
         // NewerVersionAvailable and GradleDependency need to be taken care of
         // by a roller rather than as part of CI.


### PR DESCRIPTION
The Android lint task was writing its output to a different path than the
one listed in the BUILD.gn script.  This caused unnecessary build actions
when the build system failed to find the declared output.

This PR defines an output path for the lint task and ensures that it matches BUILD.gn
