### PR TITLE
UWP: Fix uwptools that does not uninstall package

### DIFF
--- a/shell/platform/windows/uwptool_utils.cc
+++ b/shell/platform/windows/uwptool_utils.cc
@@ -96,7 +96,7 @@ bool ApplicationStore::Install(
 bool ApplicationStore::Uninstall(const std::wstring_view package_family) {
   bool success = true;
   for (const Application& app : GetApps(package_family)) {
-    if (Uninstall(app.GetPackageFullName())) {
+    if (UninstallPackage(app.GetPackageFullName())) {
       std::wcerr << L"Uninstalled application " << app.GetPackageFullName()
                  << std::endl;
     } else {


### PR DESCRIPTION
UWP tools does not uninstall UWP app that the tool installed previously.
This commit fixes it and enable to re-run `flutter run -d winuwp`.

This will solve them:
- flutter/flutter#86996
- flutter/flutter#82917

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
