### PR TITLE
[macos] Don't swap buffers when back-buffer is empty

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterSurfaceManager.mm
@@ -57,6 +57,13 @@ static const double kIdleDelay = 1.0;
 }
 
 - (void)swapBuffers {
+  if (_ioSurfaces[kFlutterSurfaceManagerBackBuffer] == nil) {
+    // We can have a `nil` back-buffer when we call present on an embedded view
+    // this isn't supported: https://github.com/flutter/flutter/issues/86932
+    // but to prevent crashes, no-op is preferred.
+    return;
+  }
+
   _contentLayer.frame = _containingLayer.bounds;
   _contentLayer.transform = _contentTransform;
   IOSurfaceRef contentIOSurface = [_ioSurfaces[kFlutterSurfaceManagerBackBuffer] ioSurface];


### PR DESCRIPTION
This only happens when an external view is embedded. Platform views on macOS aren't supported yet. This prevents the app from crashing as we continue to display the front buffer.

See: https://github.com/flutter/flutter/issues/86932
