### PR TITLE
Handle MaskFilter with 0 sigma

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -870,7 +870,10 @@ class SkShader {
 
 @JS()
 class SkMaskFilterNamespace {
-  external SkMaskFilter MakeBlur(
+  // Creates a blur MaskFilter.
+  //
+  // Returns `null` if [sigma] is 0 or infinite.
+  external SkMaskFilter? MakeBlur(
       SkBlurStyle blurStyle, double sigma, bool respectCTM);
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/mask_filter.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/mask_filter.dart
@@ -27,7 +27,7 @@ class CkMaskFilter extends ManagedSkiaObject<SkMaskFilter> {
       toSkBlurStyle(_blurStyle),
       _sigma,
       true,
-    );
+    )!;
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/canvaskit/painting.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/painting.dart
@@ -144,10 +144,16 @@ class CkPaint extends ManagedSkiaObject<SkPaint> implements ui.Paint {
     }
     _maskFilter = value;
     if (value != null) {
-      _ckMaskFilter = CkMaskFilter.blur(
-        value.webOnlyBlurStyle,
-        value.webOnlySigma,
-      );
+      // CanvasKit returns `null` if the sigma is `0` or infinite.
+      if (!(value.webOnlySigma.isFinite && value.webOnlySigma > 0)) {
+        // Don't create a [CkMaskFilter].
+        _ckMaskFilter = null;
+      } else {
+        _ckMaskFilter = CkMaskFilter.blur(
+          value.webOnlyBlurStyle,
+          value.webOnlySigma,
+        );
+      }
     } else {
       _ckMaskFilter = null;
     }

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -408,6 +408,11 @@ void _maskFilterTests() {
         ),
         isNotNull);
   });
+  test('MaskFilter.MakeBlur with 0 sigma returns null', () {
+    expect(
+        canvasKit.MaskFilter.MakeBlur(canvasKit.BlurStyle.Normal, 0.0, false),
+        isNull);
+  });
 }
 
 void _colorFilterTests() {
@@ -1099,7 +1104,8 @@ void _canvasTests() {
       const ui.Color color = ui.Color(0xAABBCCDD);
       final ui.Color inAmbient =
           color.withAlpha((color.alpha * ambientAlpha).round());
-      final ui.Color inSpot = color.withAlpha((color.alpha * spotAlpha).round());
+      final ui.Color inSpot =
+          color.withAlpha((color.alpha * spotAlpha).round());
 
       final SkTonalColors inTonalColors = SkTonalColors(
         ambient: makeFreshSkColor(inAmbient),
@@ -1154,8 +1160,8 @@ void _canvasTests() {
 
   test('drawPicture', () {
     final SkPictureRecorder otherRecorder = SkPictureRecorder();
-    final SkCanvas otherCanvas =
-        otherRecorder.beginRecording(Float32List.fromList(<double>[0, 0, 100, 100]));
+    final SkCanvas otherCanvas = otherRecorder
+        .beginRecording(Float32List.fromList(<double>[0, 0, 100, 100]));
     otherCanvas.drawLine(0, 0, 10, 10, SkPaint());
     canvas.drawPicture(otherRecorder.finishRecordingAsPicture());
   });
@@ -1180,8 +1186,8 @@ void _canvasTests() {
     // ProductionCollector)
     browserSupportsFinalizationRegistry = true;
     final SkPictureRecorder otherRecorder = SkPictureRecorder();
-    final SkCanvas otherCanvas =
-        otherRecorder.beginRecording(Float32List.fromList(<double>[0, 0, 1, 1]));
+    final SkCanvas otherCanvas = otherRecorder
+        .beginRecording(Float32List.fromList(<double>[0, 0, 1, 1]));
     otherCanvas.drawRect(
       Float32List.fromList(<double>[0, 0, 1, 1]),
       SkPaint(),

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -413,6 +413,11 @@ void _maskFilterTests() {
         canvasKit.MaskFilter.MakeBlur(canvasKit.BlurStyle.Normal, 0.0, false),
         isNull);
   });
+  test('MaskFilter.MakeBlur with NaN sigma returns null', () {
+    expect(
+        canvasKit.MaskFilter.MakeBlur(canvasKit.BlurStyle.Normal, double.nan, false),
+        isNull);
+  });
 }
 
 void _colorFilterTests() {

--- a/lib/web_ui/test/canvaskit/filter_test.dart
+++ b/lib/web_ui/test/canvaskit/filter_test.dart
@@ -91,4 +91,17 @@ void testMain() {
 
   // TODO: https://github.com/flutter/flutter/issues/60040
   }, skip: isIosSafari);
+
+  group('MaskFilter', () {
+    setUpCanvasKitTest();
+
+    test('with 0 sigma can be set on a Paint', () {
+      final ui.Paint paint = ui.Paint();
+      final ui.MaskFilter filter = ui.MaskFilter.blur(ui.BlurStyle.normal, 0);
+
+      expect(() => paint.maskFilter = filter, isNot(throwsException));
+    });
+
+  // TODO: https://github.com/flutter/flutter/issues/60040
+  }, skip: isIosSafari);
 }


### PR DESCRIPTION
CanvasKit returns `null` for `MaskFilter.MakeBlur` when `sigma` is infinite or 0. This change handles that case by just not setting the `Paint` `MaskFilter` if the sigma is 0.

Fixes https://github.com/flutter/flutter/issues/86422

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
