### PR TITLE
TimePoint::Now uses DartTimestampProvider

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -77,6 +77,8 @@ source_set("fml") {
     "thread.h",
     "thread_local.cc",
     "thread_local.h",
+    "time/dart_timestamp_provider.cc",
+    "time/dart_timestamp_provider.h",
     "time/time_delta.h",
     "time/time_point.cc",
     "time/time_point.h",

--- a/fml/time/chrono_timestamp_provider.cc
+++ b/fml/time/chrono_timestamp_provider.cc
@@ -6,8 +6,6 @@
 
 #include <chrono>
 
-#include "fml/time/time_delta.h"
-
 namespace fml {
 
 ChronoTimestampProvider::ChronoTimestampProvider() = default;

--- a/fml/time/chrono_timestamp_provider.h
+++ b/fml/time/chrono_timestamp_provider.h
@@ -8,7 +8,7 @@
 #include "flutter/fml/time/timestamp_provider.h"
 
 #include "flutter/fml/macros.h"
-#include "fml/time/time_point.h"
+#include "flutter/fml/time/time_point.h"
 
 namespace fml {
 

--- a/fml/time/dart_timestamp_provider.cc
+++ b/fml/time/dart_timestamp_provider.cc
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/time/dart_timestamp_provider.h"
+
+#include "dart_tools_api.h"
+
+namespace fml {
+
+DartTimestampProvider::DartTimestampProvider() = default;
+
+DartTimestampProvider::~DartTimestampProvider() = default;
+
+fml::TimePoint DartTimestampProvider::Now() {
+  return fml::TimePoint::FromTicks(Dart_TimelineGetTicks());
+}
+
+fml::TimePoint DartTimelineTicksSinceEpoch() {
+  return DartTimestampProvider::Instance().Now();
+}
+
+}  // namespace fml

--- a/fml/time/dart_timestamp_provider.h
+++ b/fml/time/dart_timestamp_provider.h
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_TIME_DART_TIMESTAMP_PROVIDER_H_
+#define FLUTTER_FML_TIME_DART_TIMESTAMP_PROVIDER_H_
+
+#include "flutter/fml/time/timestamp_provider.h"
+
+#include "flutter/fml/macros.h"
+#include "flutter/fml/time/time_point.h"
+
+namespace fml {
+
+fml::TimePoint DartTimelineTicksSinceEpoch();
+
+/// TimestampProvider implementation that is backed by Dart_TimelineGetTicks
+class DartTimestampProvider : TimestampProvider {
+ public:
+  static DartTimestampProvider& Instance() {
+    static DartTimestampProvider instance;
+    return instance;
+  }
+
+  ~DartTimestampProvider() override;
+
+  fml::TimePoint Now() override;
+
+ private:
+  DartTimestampProvider();
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DartTimestampProvider);
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_TIME_DART_TIMESTAMP_PROVIDER_H_

--- a/fml/time/time_point.cc
+++ b/fml/time/time_point.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
+#include "flutter/fml/time/dart_timestamp_provider.h"
 
 #if defined(OS_FUCHSIA)
 #include <zircon/syscalls.h>
@@ -36,8 +37,7 @@ static int64_t NanosSinceEpoch(
 }
 
 TimePoint TimePoint::Now() {
-  const int64_t nanos = NanosSinceEpoch(std::chrono::steady_clock::now());
-  return TimePoint(nanos);
+  return DartTimelineTicksSinceEpoch();
 }
 
 TimePoint TimePoint::CurrentWallTime() {


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/76875
