### PR TITLE
TimePoint::Now uses DartTimestampProvider

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -292,6 +292,8 @@ FILE: ../../../flutter/fml/thread_local_unittests.cc
 FILE: ../../../flutter/fml/thread_unittests.cc
 FILE: ../../../flutter/fml/time/chrono_timestamp_provider.cc
 FILE: ../../../flutter/fml/time/chrono_timestamp_provider.h
+FILE: ../../../flutter/fml/time/dart_timestamp_provider.cc
+FILE: ../../../flutter/fml/time/dart_timestamp_provider.h
 FILE: ../../../flutter/fml/time/time_delta.h
 FILE: ../../../flutter/fml/time/time_delta_unittest.cc
 FILE: ../../../flutter/fml/time/time_point.cc

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -77,6 +77,8 @@ source_set("fml") {
     "thread.h",
     "thread_local.cc",
     "thread_local.h",
+    "time/dart_timestamp_provider.cc",
+    "time/dart_timestamp_provider.h",
     "time/time_delta.h",
     "time/time_point.cc",
     "time/time_point.h",

--- a/fml/time/chrono_timestamp_provider.cc
+++ b/fml/time/chrono_timestamp_provider.cc
@@ -6,8 +6,6 @@
 
 #include <chrono>
 
-#include "fml/time/time_delta.h"
-
 namespace fml {
 
 ChronoTimestampProvider::ChronoTimestampProvider() = default;

--- a/fml/time/chrono_timestamp_provider.h
+++ b/fml/time/chrono_timestamp_provider.h
@@ -8,7 +8,7 @@
 #include "flutter/fml/time/timestamp_provider.h"
 
 #include "flutter/fml/macros.h"
-#include "fml/time/time_point.h"
+#include "flutter/fml/time/time_point.h"
 
 namespace fml {
 

--- a/fml/time/dart_timestamp_provider.cc
+++ b/fml/time/dart_timestamp_provider.cc
@@ -1,0 +1,23 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/time/dart_timestamp_provider.h"
+
+#include "dart_tools_api.h"
+
+namespace fml {
+
+DartTimestampProvider::DartTimestampProvider() = default;
+
+DartTimestampProvider::~DartTimestampProvider() = default;
+
+fml::TimePoint DartTimestampProvider::Now() {
+  return fml::TimePoint::FromTicks(Dart_TimelineGetTicks());
+}
+
+fml::TimePoint DartTimelineTicksSinceEpoch() {
+  return DartTimestampProvider::Instance().Now();
+}
+
+}  // namespace fml

--- a/fml/time/dart_timestamp_provider.h
+++ b/fml/time/dart_timestamp_provider.h
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_TIME_DART_TIMESTAMP_PROVIDER_H_
+#define FLUTTER_FML_TIME_DART_TIMESTAMP_PROVIDER_H_
+
+#include "flutter/fml/time/timestamp_provider.h"
+
+#include "flutter/fml/macros.h"
+#include "flutter/fml/time/time_point.h"
+
+namespace fml {
+
+fml::TimePoint DartTimelineTicksSinceEpoch();
+
+/// TimestampProvider implementation that is backed by Dart_TimelineGetTicks
+class DartTimestampProvider : TimestampProvider {
+ public:
+  static DartTimestampProvider& Instance() {
+    static DartTimestampProvider instance;
+    return instance;
+  }
+
+  ~DartTimestampProvider() override;
+
+  fml::TimePoint Now() override;
+
+ private:
+  DartTimestampProvider();
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DartTimestampProvider);
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_TIME_DART_TIMESTAMP_PROVIDER_H_

--- a/fml/time/dart_timestamp_provider.h
+++ b/fml/time/dart_timestamp_provider.h
@@ -27,6 +27,8 @@ class DartTimestampProvider : TimestampProvider {
   fml::TimePoint Now() override;
 
  private:
+  static constexpr int64_t kNanosPerSecond = 1000000000;
+
   DartTimestampProvider();
 
   FML_DISALLOW_COPY_AND_ASSIGN(DartTimestampProvider);

--- a/fml/time/dart_timestamp_provider.h
+++ b/fml/time/dart_timestamp_provider.h
@@ -29,6 +29,8 @@ class DartTimestampProvider : TimestampProvider {
  private:
   static constexpr int64_t kNanosPerSecond = 1000000000;
 
+  int64_t ConvertToNanos(int64_t ticks, int64_t frequency);
+
   DartTimestampProvider();
 
   FML_DISALLOW_COPY_AND_ASSIGN(DartTimestampProvider);

--- a/fml/time/time_point.cc
+++ b/fml/time/time_point.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
+#include "flutter/fml/time/dart_timestamp_provider.h"
 
 #if defined(OS_FUCHSIA)
 #include <zircon/syscalls.h>
@@ -36,8 +37,7 @@ static int64_t NanosSinceEpoch(
 }
 
 TimePoint TimePoint::Now() {
-  const int64_t nanos = NanosSinceEpoch(std::chrono::steady_clock::now());
-  return TimePoint(nanos);
+  return DartTimelineTicksSinceEpoch();
 }
 
 TimePoint TimePoint::CurrentWallTime() {

--- a/fml/time/time_point.h
+++ b/fml/time/time_point.h
@@ -39,6 +39,7 @@ class TimePoint {
     return TimePoint(ticks.ToNanoseconds());
   }
 
+  // Expects ticks in nanos.
   static constexpr TimePoint FromTicks(int64_t ticks) {
     return TimePoint(ticks);
   }

--- a/fml/time/time_point_unittest.cc
+++ b/fml/time/time_point_unittest.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/fml/time/chrono_timestamp_provider.h"
 
+#include "flutter/fml/time/dart_timestamp_provider.h"
+
 #include "gtest/gtest.h"
 
 namespace fml {
@@ -12,6 +14,16 @@ namespace {
 TEST(TimePoint, Control) {
   EXPECT_LT(TimePoint::Min(), ChronoTicksSinceEpoch());
   EXPECT_GT(TimePoint::Max(), ChronoTicksSinceEpoch());
+}
+
+TEST(TimePoint, DartClockIsMonotonic) {
+  const auto t1 = DartTimelineTicksSinceEpoch();
+  const auto t2 = DartTimelineTicksSinceEpoch();
+  const auto t3 = DartTimelineTicksSinceEpoch();
+  EXPECT_LT(TimePoint::Min(), t1);
+  EXPECT_LT(t1, t2);
+  EXPECT_LT(t2, t3);
+  EXPECT_LT(t3, TimePoint::Max());
 }
 
 }  // namespace

--- a/fml/time/time_point_unittest.cc
+++ b/fml/time/time_point_unittest.cc
@@ -6,6 +6,8 @@
 
 #include "flutter/fml/time/dart_timestamp_provider.h"
 
+#include <thread>
+
 #include "gtest/gtest.h"
 
 namespace fml {
@@ -17,8 +19,11 @@ TEST(TimePoint, Control) {
 }
 
 TEST(TimePoint, DartClockIsMonotonic) {
+  using namespace std::chrono_literals;
   const auto t1 = DartTimelineTicksSinceEpoch();
+  std::this_thread::sleep_for(1us);
   const auto t2 = DartTimelineTicksSinceEpoch();
+  std::this_thread::sleep_for(1us);
   const auto t3 = DartTimelineTicksSinceEpoch();
   EXPECT_LT(TimePoint::Min(), t1);
   EXPECT_LT(t1, t2);

--- a/fml/time/time_point_unittest.cc
+++ b/fml/time/time_point_unittest.cc
@@ -26,8 +26,8 @@ TEST(TimePoint, DartClockIsMonotonic) {
   std::this_thread::sleep_for(1us);
   const auto t3 = DartTimelineTicksSinceEpoch();
   EXPECT_LT(TimePoint::Min(), t1);
-  EXPECT_LT(t1, t2);
-  EXPECT_LT(t2, t3);
+  EXPECT_LE(t1, t2);
+  EXPECT_LE(t2, t3);
   EXPECT_LT(t3, TimePoint::Max());
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/76875

