### PR TITLE
Added assertion up to cv99 for FontFeature.characterVariant

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -472,7 +472,7 @@ class FontFeature {
   ///  * <https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99>
   factory FontFeature.characterVariant(int value) {
     assert(value >= 1);
-    assert(value <= 20);
+    assert(value <= 99);
     return FontFeature('cv${value.toString().padLeft(2, "0")}');
   }
 

--- a/testing/dart/text_test.dart
+++ b/testing/dart/text_test.dart
@@ -198,6 +198,7 @@ void testFontFeatureClass() {
     expect(const FontFeature.caseSensitiveForms(), const FontFeature('case', 1));
     expect(      FontFeature.characterVariant(1), const FontFeature('cv01', 1));
     expect(      FontFeature.characterVariant(18), const FontFeature('cv18', 1));
+    expect(      FontFeature.characterVariant(99), const FontFeature('cv99', 1));
     expect(const FontFeature.denominator(), const FontFeature('dnom', 1));
     expect(const FontFeature.fractions(), const FontFeature('frac', 1));
     expect(const FontFeature.historicalForms(), const FontFeature('hist', 1));


### PR DESCRIPTION
This PR changes the assertion in `factory FontFeature.characterVaraint` from up to `20` to up to `99` in order to support additional Character Variants

- Previously whenever you would setup to use a character variant after 20 flutter would give an error during runtime.

You can check the OpenType docs to confirm the character variants go from cv01 to cv99

https://docs.microsoft.com/en-us/typography/opentype/spec/features_ae#cv01-cv99

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.