### PR TITLE
[ci.yaml] Fix open_jdk dep naming

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -22,7 +22,7 @@ platform_properties:
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
         [
-          {"dependency": "openjdk", "version": "1.8.0u202-b08"}
+          {"dependency": "open_jdk", "version": "1.8.0u202-b08"}
         ]
       os: Linux
   mac:
@@ -37,7 +37,7 @@ platform_properties:
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
         [
-          {"dependency": "openjdk", "version": "1.8.0u202-b08"}
+          {"dependency": "open_jdk", "version": "1.8.0u202-b08"}
         ]
       os: Mac-10.15
       xcode: 12a7209 # xcode 12
@@ -51,7 +51,7 @@ platform_properties:
       # CIPD flutter_internal/java/openjdk/$platform
       dependencies: >-
         [
-          {"dependency": "openjdk", "version": "1.8.0u202-b08"}
+          {"dependency": "open_jdk", "version": "1.8.0u202-b08"}
         ]
       os: Windows-10
 


### PR DESCRIPTION
This needs to match what's in flutter_deps, otherwise, we'll get the weird failure we saw. I'll update the module to give a more descriptive error.

https://github.com/flutter/flutter/issues/86892

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.