### PR TITLE
Unskip iOS launch URL tests

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -18,8 +18,7 @@ FLUTTER_ASSERT_ARC
 
 @implementation FlutterAppDelegateTest
 
-// TODO(dnfield): https://github.com/flutter/flutter/issues/74267
-- (void)skip_testLaunchUrl {
+- (void)testLaunchUrl {
   FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
   FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
   FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
@@ -42,7 +41,7 @@ FLUTTER_ASSERT_ARC
   OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
 }
 
-- (void)skip_testLaunchUrlWithQueryParameterAndFragment {
+- (void)testLaunchUrlWithQueryParameterAndFragment {
   FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
   FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
   FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
@@ -66,7 +65,7 @@ FLUTTER_ASSERT_ARC
                                   arguments:@"/custom/route?query=test#fragment"]);
 }
 
-- (void)skip_testLaunchUrlWithFragmentNoQueryParameter {
+- (void)testLaunchUrlWithFragmentNoQueryParameter {
   FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
   FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
   FlutterEngine* engine = OCMClassMock([FlutterEngine class]);


### PR DESCRIPTION
Let's see if the [new Xcode bundle](https://github.com/flutter/flutter/issues/84601) no longer crashes this test.  Hope springs eternal.

Also unskip tests that look like they were mistakenly never on? #26185
Fixes https://github.com/flutter/flutter/issues/74267