### PR TITLE
fix crash when SemanticsObject dealloc and access released the _children property

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -149,6 +149,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   }
   [_children removeAllObjects];
   [_children release];
+  _children = nil;
   _parent = nil;
   _container.get().semanticsObject = nil;
   [_platformViewSemanticsContainer release];
@@ -203,7 +204,11 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   if (_node.IsPlatformViewNode()) {
     return YES;
   }
-  return [self.children count] != 0;
+  if (_children){
+    return [self.children count] != 0;
+  }else{
+    return NO;
+  }
 }
 
 - (void)privateSetParent:(SemanticsObject*)parent {


### PR DESCRIPTION
I found a crash in SemanticsObject.mm when `[SemanticsObject dealloc]` and access property `self.children`
but the `children` has called release

Here is the crash logic:

1. `[_children release]` in   `[SemanticsObject dealloc]`

```
- (void)dealloc {
  for (SemanticsObject* child in _children) {
    [child privateSetParent:nil];
  }
  [_children removeAllObjects];
  [_children release];
  _parent = nil;
  _container.get().semanticsObject = nil;
  [_platformViewSemanticsContainer release];
  [super dealloc];
}
```
2. `[super dealloc]` will access  `[UIAccessibilityElementSuperCategory dealloc]` and then `[SemanticsObject accessibilityContainer]`  and access the released `_children` property

```
- (id)accessibilityContainer {
  if ([self hasChildren] || [self uid] == kRootNodeId) {
    if (_container == nil)
      _container.reset([[SemanticsObjectContainer alloc] initWithSemanticsObject:self
                                                                          bridge:[self bridge]]);
    return _container.get();
  }
  if ([self parent] == nil) {
    // This can happen when we have released the accessibility tree but iOS is
    // still holding onto our objects. iOS can take some time before it
    // realizes that the tree has changed.
    return nil;
  }
  return [[self parent] accessibilityContainer];
}

- (BOOL)hasChildren {
  if (_node.IsPlatformViewNode()) {
    return YES;
  }
  return [self.children count] != 0;
}

```

And the issue is here[https://github.com/flutter/flutter/issues/87247]( https://github.com/flutter/flutter/issues/87247)