### PR TITLE
Revert "Use preDraw for the Android embedding"

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -542,8 +542,7 @@ public class FlutterActivity extends Activity
         /* inflater=*/ null,
         /* container=*/ null,
         /* savedInstanceState=*/ null,
-        /*flutterViewId=*/ FLUTTER_VIEW_ID,
-        /*shouldDelayFirstAndroidViewDraw=*/ getRenderMode() == RenderMode.surface);
+        /*flutterViewId=*/ FLUTTER_VIEW_ID);
   }
 
   private void configureStatusBarForFullscreenFlutterExperience() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -15,7 +15,6 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.ViewTreeObserver.OnPreDrawListener;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -68,17 +67,15 @@ import java.util.Arrays;
   private static final String TAG = "FlutterActivityAndFragmentDelegate";
   private static final String FRAMEWORK_RESTORATION_BUNDLE_KEY = "framework";
   private static final String PLUGINS_RESTORATION_BUNDLE_KEY = "plugins";
-  private static final int FLUTTER_SPLASH_VIEW_FALLBACK_ID = 486947586;
 
   // The FlutterActivity or FlutterFragment that is delegating most of its calls
   // to this FlutterActivityAndFragmentDelegate.
   @NonNull private Host host;
   @Nullable private FlutterEngine flutterEngine;
+  @Nullable private FlutterSplashView flutterSplashView;
   @Nullable private FlutterView flutterView;
   @Nullable private PlatformPlugin platformPlugin;
-  @VisibleForTesting @Nullable OnPreDrawListener activePreDrawListener;
   private boolean isFlutterEngineFromHost;
-  private boolean isFlutterUiDisplayed;
 
   @NonNull
   private final FlutterUiDisplayListener flutterUiDisplayListener =
@@ -86,13 +83,11 @@ import java.util.Arrays;
         @Override
         public void onFlutterUiDisplayed() {
           host.onFlutterUiDisplayed();
-          isFlutterUiDisplayed = true;
         }
 
         @Override
         public void onFlutterUiNoLongerDisplayed() {
           host.onFlutterUiNoLongerDisplayed();
-          isFlutterUiDisplayed = false;
         }
       };
 
@@ -259,16 +254,6 @@ import java.util.Arrays;
    *
    * <p>{@code inflater} and {@code container} may be null when invoked from an {@code Activity}.
    *
-   * <p>{@code shouldDelayFirstAndroidViewDraw} determines whether to set up an {@link
-   * android.view.ViewTreeObserver.OnPreDrawListener}, which will defer the current drawing pass
-   * till after the Flutter UI has been displayed. This results in more accurate timings reported
-   * with Android tools, such as "Displayed" timing printed with `am start`.
-   *
-   * <p>Note that it should only be set to true when {@code Host#getRenderMode()} is {@code
-   * RenderMode.surface}. This parameter is also ignored, disabling the delay should the legacy
-   * {@code Host#provideSplashScreen()} be non-null. See <a
-   * href="https://flutter.dev/go/android-splash-migration">Android Splash Migration</a>.
-   *
    * <p>This method:
    *
    * <ol>
@@ -284,8 +269,7 @@ import java.util.Arrays;
       LayoutInflater inflater,
       @Nullable ViewGroup container,
       @Nullable Bundle savedInstanceState,
-      int flutterViewId,
-      boolean shouldDelayFirstAndroidViewDraw) {
+      int flutterViewId) {
     Log.v(TAG, "Creating FlutterView.");
     ensureAlive();
 
@@ -314,28 +298,15 @@ import java.util.Arrays;
     // Add listener to be notified when Flutter renders its first frame.
     flutterView.addOnFirstFrameRenderedListener(flutterUiDisplayListener);
 
+    flutterSplashView = new FlutterSplashView(host.getContext());
+    flutterSplashView.setId(ViewUtils.generateViewId(486947586));
+    flutterSplashView.displayFlutterViewWithSplash(flutterView, host.provideSplashScreen());
+
     Log.v(TAG, "Attaching FlutterEngine to FlutterView.");
     flutterView.attachToFlutterEngine(flutterEngine);
     flutterView.setId(flutterViewId);
 
-    SplashScreen splashScreen = host.provideSplashScreen();
-
-    if (splashScreen != null) {
-      Log.w(
-          TAG,
-          "A splash screen was provided to Flutter, but this is deprecated. See"
-              + " flutter.dev/go/android-splash-migration for migration steps.");
-      FlutterSplashView flutterSplashView = new FlutterSplashView(host.getContext());
-      flutterSplashView.setId(ViewUtils.generateViewId(FLUTTER_SPLASH_VIEW_FALLBACK_ID));
-      flutterSplashView.displayFlutterViewWithSplash(flutterView, splashScreen);
-
-      return flutterSplashView;
-    }
-
-    if (shouldDelayFirstAndroidViewDraw) {
-      delayFirstAndroidViewDraw(flutterView);
-    }
-    return flutterView;
+    return flutterSplashView;
   }
 
   void onRestoreInstanceState(@Nullable Bundle bundle) {
@@ -445,38 +416,6 @@ import java.util.Arrays;
   }
 
   /**
-   * Delays the first drawing of the {@code flutterView} until the Flutter first has been displayed.
-   */
-  private void delayFirstAndroidViewDraw(FlutterView flutterView) {
-    if (host.getRenderMode() != RenderMode.surface) {
-      // Using a TextureView will cause a deadlock, where the underlying SurfaceTexture is never
-      // available since it will wait for drawing to be completed first. At the same time, the
-      // preDraw listener keeps returning false since the Flutter Engine waits for the
-      // SurfaceTexture to be available.
-      throw new IllegalArgumentException(
-          "Cannot delay the first Android view draw when the render mode is not set to"
-              + " `RenderMode.surface`.");
-    }
-
-    if (activePreDrawListener != null) {
-      flutterView.getViewTreeObserver().removeOnPreDrawListener(activePreDrawListener);
-    }
-
-    activePreDrawListener =
-        new OnPreDrawListener() {
-          @Override
-          public boolean onPreDraw() {
-            if (isFlutterUiDisplayed && activePreDrawListener != null) {
-              flutterView.getViewTreeObserver().removeOnPreDrawListener(this);
-              activePreDrawListener = null;
-            }
-            return isFlutterUiDisplayed;
-          }
-        };
-    flutterView.getViewTreeObserver().addOnPreDrawListener(activePreDrawListener);
-  }
-
-  /**
    * Invoke this from {@code Activity#onResume()} or {@code Fragment#onResume()}.
    *
    * <p>This method notifies the running Flutter app that it is "resumed" as per the Flutter app
@@ -557,10 +496,6 @@ import java.util.Arrays;
     Log.v(TAG, "onDestroyView()");
     ensureAlive();
 
-    if (activePreDrawListener != null) {
-      flutterView.getViewTreeObserver().removeOnPreDrawListener(activePreDrawListener);
-      activePreDrawListener = null;
-    }
     flutterView.detachFromFlutterEngine();
     flutterView.removeOnFirstFrameRenderedListener(flutterUiDisplayListener);
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -113,10 +113,6 @@ public class FlutterFragment extends Fragment
   protected static final String ARG_HANDLE_DEEPLINKING = "handle_deeplinking";
   /** Path to Flutter's Dart code. */
   protected static final String ARG_APP_BUNDLE_PATH = "app_bundle_path";
-  /** Whether to delay the Android drawing pass till after the Flutter UI has been displayed. */
-  protected static final String ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW =
-      "should_delay_first_android_view_draw";
-
   /** Flutter shell arguments. */
   protected static final String ARG_FLUTTER_INITIALIZATION_ARGS = "initialization_args";
   /**
@@ -233,7 +229,6 @@ public class FlutterFragment extends Fragment
     private TransparencyMode transparencyMode = TransparencyMode.transparent;
     private boolean shouldAttachEngineToActivity = true;
     private boolean shouldAutomaticallyHandleOnBackPressed = false;
-    private boolean shouldDelayFirstAndroidViewDraw = false;
 
     /**
      * Constructs a {@code NewEngineFragmentBuilder} that is configured to construct an instance of
@@ -388,18 +383,6 @@ public class FlutterFragment extends Fragment
     }
 
     /**
-     * Whether to delay the Android drawing pass till after the Flutter UI has been displayed.
-     *
-     * <p>See {#link FlutterActivityAndFragmentDelegate#onCreateView} for more details.
-     */
-    @NonNull
-    public NewEngineFragmentBuilder shouldDelayFirstAndroidViewDraw(
-        boolean shouldDelayFirstAndroidViewDraw) {
-      this.shouldDelayFirstAndroidViewDraw = shouldDelayFirstAndroidViewDraw;
-      return this;
-    }
-
-    /**
      * Creates a {@link Bundle} of arguments that are assigned to the new {@code FlutterFragment}.
      *
      * <p>Subclasses should override this method to add new properties to the {@link Bundle}.
@@ -427,7 +410,6 @@ public class FlutterFragment extends Fragment
       args.putBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, true);
       args.putBoolean(
           ARG_SHOULD_AUTOMATICALLY_HANDLE_ON_BACK_PRESSED, shouldAutomaticallyHandleOnBackPressed);
-      args.putBoolean(ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW, shouldDelayFirstAndroidViewDraw);
       return args;
     }
 
@@ -514,7 +496,6 @@ public class FlutterFragment extends Fragment
     private TransparencyMode transparencyMode = TransparencyMode.transparent;
     private boolean shouldAttachEngineToActivity = true;
     private boolean shouldAutomaticallyHandleOnBackPressed = false;
-    private boolean shouldDelayFirstAndroidViewDraw = false;
 
     private CachedEngineFragmentBuilder(@NonNull String engineId) {
       this(FlutterFragment.class, engineId);
@@ -641,18 +622,6 @@ public class FlutterFragment extends Fragment
     }
 
     /**
-     * Whether to delay the Android drawing pass till after the Flutter UI has been displayed.
-     *
-     * <p>See {#link FlutterActivityAndFragmentDelegate#onCreateView} for more details.
-     */
-    @NonNull
-    public CachedEngineFragmentBuilder shouldDelayFirstAndroidViewDraw(
-        @NonNull boolean shouldDelayFirstAndroidViewDraw) {
-      this.shouldDelayFirstAndroidViewDraw = shouldDelayFirstAndroidViewDraw;
-      return this;
-    }
-
-    /**
      * Creates a {@link Bundle} of arguments that are assigned to the new {@code FlutterFragment}.
      *
      * <p>Subclasses should override this method to add new properties to the {@link Bundle}.
@@ -673,7 +642,6 @@ public class FlutterFragment extends Fragment
       args.putBoolean(ARG_SHOULD_ATTACH_ENGINE_TO_ACTIVITY, shouldAttachEngineToActivity);
       args.putBoolean(
           ARG_SHOULD_AUTOMATICALLY_HANDLE_ON_BACK_PRESSED, shouldAutomaticallyHandleOnBackPressed);
-      args.putBoolean(ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW, shouldDelayFirstAndroidViewDraw);
       return args;
     }
 
@@ -759,11 +727,7 @@ public class FlutterFragment extends Fragment
   public View onCreateView(
       LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
     return delegate.onCreateView(
-        inflater,
-        container,
-        savedInstanceState,
-        /*flutterViewId=*/ FLUTTER_VIEW_ID,
-        shouldDelayFirstAndroidViewDraw());
+        inflater, container, savedInstanceState, /*flutterViewId=*/ FLUTTER_VIEW_ID);
   }
 
   @Override
@@ -1301,12 +1265,6 @@ public class FlutterFragment extends Fragment
     }
     // Hook for subclass. No-op if returns false.
     return false;
-  }
-
-  @VisibleForTesting
-  @NonNull
-  boolean shouldDelayFirstAndroidViewDraw() {
-    return getArguments().getBoolean(ARG_SHOULD_DELAY_FIRST_ANDROID_VIEW_DRAW);
   }
 
   private boolean stillAttachedForEvent(String event) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -424,7 +424,6 @@ public class FlutterFragmentActivity extends FragmentActivity
         backgroundMode == BackgroundMode.opaque
             ? TransparencyMode.opaque
             : TransparencyMode.transparent;
-    final boolean shouldDelayFirstAndroidViewDraw = renderMode == RenderMode.surface;
 
     if (getCachedEngineId() != null) {
       Log.v(
@@ -448,7 +447,6 @@ public class FlutterFragmentActivity extends FragmentActivity
           .handleDeeplinking(shouldHandleDeeplinking())
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
           .destroyEngineWithFragment(shouldDestroyEngineWithHost())
-          .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
           .build();
     } else {
       Log.v(
@@ -478,7 +476,6 @@ public class FlutterFragmentActivity extends FragmentActivity
           .renderMode(renderMode)
           .transparencyMode(transparencyMode)
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
-          .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
           .build();
     }
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -2,9 +2,7 @@ package io.flutter.embedding.android;
 
 import static android.content.ComponentCallbacks2.*;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.notNull;
@@ -17,8 +15,6 @@ import static org.mockito.Mockito.when;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.graphics.Color;
-import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.Lifecycle;
@@ -90,7 +86,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // We're testing lifecycle behaviors, which require/expect that certain methods have already
     // been executed by the time they run. Therefore, we run those expected methods first.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
 
     // --- Execute the behavior under test ---
     // By the time an Activity/Fragment is started, we don't expect any lifecycle messages
@@ -168,7 +164,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // The FlutterEngine is obtained in onAttach().
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
     delegate.onResume();
 
@@ -224,7 +220,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
 
     // Verify that the host was asked to configure a FlutterSurfaceView.
     verify(mockHost, times(1)).onFlutterSurfaceViewCreated(notNull(FlutterSurfaceView.class));
@@ -253,7 +249,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Execute the behavior under test ---
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, false);
+    delegate.onCreateView(null, null, null, 0);
 
     // Verify that the host was asked to configure a FlutterTextureView.
     verify(customMockHost, times(1)).onFlutterTextureViewCreated(notNull(FlutterTextureView.class));
@@ -286,7 +282,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // The initial route is sent in onStart().
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
 
     // Verify that the navigation channel was given our initial route.
@@ -310,7 +306,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Dart is executed in onStart().
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
 
     // Verify that the host's Dart entrypoint was used.
@@ -339,7 +335,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Dart is executed in onStart().
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
 
     // Verify that the host's Dart entrypoint was used.
@@ -394,7 +390,7 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // Make sure all of the other lifecycle methods can run safely as well
     // without a valid Activity
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -755,7 +751,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -779,7 +775,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -810,7 +806,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -842,7 +838,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -852,77 +848,6 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // --- Verify that the cached engine was NOT destroyed ---
     verify(cachedEngine, never()).destroy();
-  }
-
-  @Test
-  public void itDelaysFirstDrawWhenRequested() {
-    // ---- Test setup ----
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
-
-    // We're testing lifecycle behaviors, which require/expect that certain methods have already
-    // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
-
-    // --- Execute the behavior under test ---
-    boolean shouldDelayFirstAndroidViewDraw = true;
-    delegate.onCreateView(null, null, null, 0, shouldDelayFirstAndroidViewDraw);
-
-    assertNotNull(delegate.activePreDrawListener);
-  }
-
-  @Test
-  public void itDoesNotDelayFirstDrawWhenNotRequested() {
-    // ---- Test setup ----
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
-
-    // We're testing lifecycle behaviors, which require/expect that certain methods have already
-    // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
-
-    // --- Execute the behavior under test ---
-    boolean shouldDelayFirstAndroidViewDraw = false;
-    delegate.onCreateView(null, null, null, 0, shouldDelayFirstAndroidViewDraw);
-
-    assertNull(delegate.activePreDrawListener);
-  }
-
-  @Test
-  public void itThrowsWhenDelayingTheFirstDrawAndUsingATextureView() {
-    // ---- Test setup ----
-    when(mockHost.getRenderMode()).thenReturn(RenderMode.texture);
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
-
-    // We're testing lifecycle behaviors, which require/expect that certain methods have already
-    // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
-
-    // --- Execute the behavior under test ---
-    boolean shouldDelayFirstAndroidViewDraw = true;
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> {
-          delegate.onCreateView(null, null, null, 0, shouldDelayFirstAndroidViewDraw);
-        });
-  }
-
-  @Test
-  public void itDoesNotDelayTheFirstDrawWhenRequestedAndWithAProvidedSplashScreen() {
-    when(mockHost.provideSplashScreen())
-        .thenReturn(new DrawableSplashScreen(new ColorDrawable(Color.GRAY)));
-
-    // ---- Test setup ----
-    // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
-
-    // We're testing lifecycle behaviors, which require/expect that certain methods have already
-    // been executed by the time they run. Therefore, we run those expected methods first.
-    delegate.onAttach(RuntimeEnvironment.application);
-
-    // --- Execute the behavior under test ---
-    boolean shouldDelayFirstAndroidViewDraw = true;
-    delegate.onCreateView(null, null, null, 0, shouldDelayFirstAndroidViewDraw);
-
-    assertNull(delegate.activePreDrawListener);
   }
 
   /**

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -292,31 +292,6 @@ public class FlutterActivityTest {
   }
 
   @Test
-  public void itDelaysDrawing() {
-    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
-    ActivityController<FlutterActivity> activityController =
-        Robolectric.buildActivity(FlutterActivity.class, intent);
-    FlutterActivity flutterActivity = activityController.get();
-
-    flutterActivity.onCreate(null);
-
-    assertNotNull(flutterActivity.delegate.activePreDrawListener);
-  }
-
-  @Test
-  public void itDoesNotDelayDrawingwhenUsingTextureRendering() {
-    Intent intent =
-        FlutterActivityWithTextureRendering.createDefaultIntent(RuntimeEnvironment.application);
-    ActivityController<FlutterActivityWithTextureRendering> activityController =
-        Robolectric.buildActivity(FlutterActivityWithTextureRendering.class, intent);
-    FlutterActivityWithTextureRendering flutterActivity = activityController.get();
-
-    flutterActivity.onCreate(null);
-
-    assertNull(flutterActivity.delegate.activePreDrawListener);
-  }
-
-  @Test
   public void itRestoresPluginStateBeforePluginOnCreate() {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
@@ -465,13 +440,6 @@ public class FlutterActivityTest {
 
     public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {
       return new CachedEngineIntentBuilder(FlutterActivityWithIntentBuilders.class, cachedEngineId);
-    }
-  }
-
-  private static class FlutterActivityWithTextureRendering extends FlutterActivity {
-    @Override
-    public RenderMode getRenderMode() {
-      return RenderMode.texture;
     }
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -82,7 +82,7 @@ public class FlutterAndroidComponentTest {
     assertNotNull(binding.getPlatformViewRegistry());
 
     delegate.onRestoreInstanceState(null);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -156,7 +156,7 @@ public class FlutterAndroidComponentTest {
     // Verify that after Activity creation, the plugin was allowed to restore state.
     verify(mockSaveStateListener, times(1)).onRestoreInstanceState(any(Bundle.class));
 
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -195,7 +195,7 @@ public class FlutterAndroidComponentTest {
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
     delegate.onRestoreInstanceState(null);
-    delegate.onCreateView(null, null, null, 0, true);
+    delegate.onCreateView(null, null, null, 0);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -3,7 +3,6 @@ package io.flutter.embedding.android;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -42,7 +41,6 @@ public class FlutterFragmentTest {
     assertTrue(fragment.shouldDestroyEngineWithHost());
     assertEquals(RenderMode.surface, fragment.getRenderMode());
     assertEquals(TransparencyMode.transparent, fragment.getTransparencyMode());
-    assertFalse(fragment.shouldDelayFirstAndroidViewDraw());
   }
 
   @Test
@@ -70,21 +68,12 @@ public class FlutterFragmentTest {
   }
 
   @Test
-  public void itCreatesNewEngineFragmentThatDelaysFirstDrawWhenRequested() {
-    FlutterFragment fragment =
-        FlutterFragment.withNewEngine().shouldDelayFirstAndroidViewDraw(true).build();
-
-    assertNotNull(fragment.shouldDelayFirstAndroidViewDraw());
-  }
-
-  @Test
-  public void itCreatesCachedEngineFragmentWithExpectedDefaults() {
+  public void itCreatesCachedEngineFragmentThatDoesNotDestroyTheEngine() {
     FlutterFragment fragment = FlutterFragment.withCachedEngine("my_cached_engine").build();
 
     assertTrue(fragment.shouldAttachEngineToActivity());
     assertEquals("my_cached_engine", fragment.getCachedEngineId());
     assertFalse(fragment.shouldDestroyEngineWithHost());
-    assertFalse(fragment.shouldDelayFirstAndroidViewDraw());
   }
 
   @Test
@@ -97,16 +86,6 @@ public class FlutterFragmentTest {
     assertTrue(fragment.shouldAttachEngineToActivity());
     assertEquals("my_cached_engine", fragment.getCachedEngineId());
     assertTrue(fragment.shouldDestroyEngineWithHost());
-  }
-
-  @Test
-  public void itCreatesCachedEngineFragmentThatDelaysFirstDrawWhenRequested() {
-    FlutterFragment fragment =
-        FlutterFragment.withCachedEngine("my_cached_engine")
-            .shouldDelayFirstAndroidViewDraw(true)
-            .build();
-
-    assertNotNull(fragment.shouldDelayFirstAndroidViewDraw());
   }
 
   @Test


### PR DESCRIPTION
Reverts flutter/engine#27645

Breaks the framework tree