### PR TITLE
Improve documentation of Path.extendWithPath

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2495,8 +2495,7 @@ class Path extends NativeFieldWrapperClass1 {
   }
   void _addRRect(Float32List rrect) native 'Path_addRRect';
 
-  /// Adds a new sub-path that consists of the given `path` offset by the given
-  /// `offset`.
+  /// Adds the sub-paths of `path`, offset by `offset`, to this path.
   ///
   /// If `matrix4` is specified, the path will be transformed by this matrix
   /// after the matrix is translated by the given offset. The matrix is a 4x4
@@ -2514,8 +2513,9 @@ class Path extends NativeFieldWrapperClass1 {
   void _addPath(Path path, double dx, double dy) native 'Path_addPath';
   void _addPathWithMatrix(Path path, double dx, double dy, Float64List matrix) native 'Path_addPathWithMatrix';
 
-  /// Adds the given path to this path by extending the current segment of this
-  /// path with the first segment of the given path.
+  /// Adds the sub-paths of `path`, offset by `offset`, to this path.
+  /// The current sub-path is extended with the first sub-path
+  /// of `path`, connecting them with a lineTo if necessary.
   ///
   /// If `matrix4` is specified, the path will be transformed by this matrix
   /// after the matrix is translated by the given `offset`.  The matrix is a 4x4


### PR DESCRIPTION
The documentation used the word "segment" instead of "sub-path".
The documentation of Path.addPath described adding a Path as adding a single sub-path.
