### PR TITLE
[Keyboard] Send empty key events when no key data should (Windows)

### DIFF
--- a/shell/platform/windows/keyboard_key_embedder_handler.h
+++ b/shell/platform/windows/keyboard_key_embedder_handler.h
@@ -21,6 +21,12 @@ namespace {}  // namespace
 // converted |FlutterKeyEvent|s through the embedder API.
 //
 // This class communicates with the HardwareKeyboard API in the framework.
+//
+// Every key event must result in at least one FlutterKeyEvent, even an empty
+// one (both logical and physical IDs are 0). This ensures that raw key
+// messages are always preceded by key data so that the transit mode is
+// correctly inferred. (Technically only the first key event needs so, but for
+// simplicity.)
 class KeyboardKeyEmbedderHandler
     : public KeyboardKeyHandler::KeyboardKeyHandlerDelegate {
  public:
@@ -117,6 +123,11 @@ class KeyboardKeyEmbedderHandler
   static uint64_t GetLogicalKey(int key, bool extended, int scancode);
   static void HandleResponse(bool handled, void* user_data);
   static void ConvertUtf32ToUtf8_(char* out, char32_t ch);
+  // Create an empty event.
+  //
+  // This is used when no key data needs to be sent. For the reason, see the
+  // |KeyboardKeyEmbedderHandler| class.
+  static FlutterKeyEvent CreateEmptyEvent();
   static FlutterKeyEvent SynthesizeSimpleEvent(FlutterKeyEventType type,
                                                uint64_t physical,
                                                uint64_t logical,


### PR DESCRIPTION
The keyboard system on Windows now sends an empty key data instead of nothing if no key data should be sent.

This PR is fixes flutter/flutter#87230 for Windows, which suffers the most from this bug.

It depends on flutter/flutter#87152.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
