### PR TITLE
Reland using preDraw for the Android embedding

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -542,7 +542,8 @@ public class FlutterActivity extends Activity
         /* inflater=*/ null,
         /* container=*/ null,
         /* savedInstanceState=*/ null,
-        /*flutterViewId=*/ FLUTTER_VIEW_ID);
+        /*flutterViewId=*/ FLUTTER_VIEW_ID,
+        /*shouldDelayFirstAndroidViewDraw=*/ getRenderMode() == RenderMode.surface);
   }
 
   private void configureStatusBarForFullscreenFlutterExperience() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -15,6 +15,7 @@ import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewTreeObserver.OnPreDrawListener;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -67,15 +68,17 @@ import java.util.Arrays;
   private static final String TAG = "FlutterActivityAndFragmentDelegate";
   private static final String FRAMEWORK_RESTORATION_BUNDLE_KEY = "framework";
   private static final String PLUGINS_RESTORATION_BUNDLE_KEY = "plugins";
+  private static final int FLUTTER_SPLASH_VIEW_FALLBACK_ID = 486947586;
 
   // The FlutterActivity or FlutterFragment that is delegating most of its calls
   // to this FlutterActivityAndFragmentDelegate.
   @NonNull private Host host;
   @Nullable private FlutterEngine flutterEngine;
-  @Nullable private FlutterSplashView flutterSplashView;
   @Nullable private FlutterView flutterView;
   @Nullable private PlatformPlugin platformPlugin;
+  @VisibleForTesting @Nullable OnPreDrawListener activePreDrawListener;
   private boolean isFlutterEngineFromHost;
+  private boolean isFlutterUiDisplayed;
 
   @NonNull
   private final FlutterUiDisplayListener flutterUiDisplayListener =
@@ -83,11 +86,13 @@ import java.util.Arrays;
         @Override
         public void onFlutterUiDisplayed() {
           host.onFlutterUiDisplayed();
+          isFlutterUiDisplayed = true;
         }
 
         @Override
         public void onFlutterUiNoLongerDisplayed() {
           host.onFlutterUiNoLongerDisplayed();
+          isFlutterUiDisplayed = false;
         }
       };
 
@@ -254,6 +259,16 @@ import java.util.Arrays;
    *
    * <p>{@code inflater} and {@code container} may be null when invoked from an {@code Activity}.
    *
+   * <p>{@code shouldDelayFirstAndroidViewDraw} determines whether to set up an {@link
+   * android.view.ViewTreeObserver.OnPreDrawListener}, which will defer the current drawing pass
+   * till after the Flutter UI has been displayed. This results in more accurate timings reported
+   * with Android tools, such as "Displayed" timing printed with `am start`.
+   *
+   * <p>Note that it should only be set to true when {@code Host#getRenderMode()} is {@code
+   * RenderMode.surface}. This parameter is also ignored, disabling the delay should the legacy
+   * {@code Host#provideSplashScreen()} be non-null. See <a
+   * href="https://flutter.dev/go/android-splash-migration">Android Splash Migration</a>.
+   *
    * <p>This method:
    *
    * <ol>
@@ -269,7 +284,8 @@ import java.util.Arrays;
       LayoutInflater inflater,
       @Nullable ViewGroup container,
       @Nullable Bundle savedInstanceState,
-      int flutterViewId) {
+      int flutterViewId,
+      boolean shouldDelayFirstAndroidViewDraw) {
     Log.v(TAG, "Creating FlutterView.");
     ensureAlive();
 
@@ -298,15 +314,28 @@ import java.util.Arrays;
     // Add listener to be notified when Flutter renders its first frame.
     flutterView.addOnFirstFrameRenderedListener(flutterUiDisplayListener);
 
-    flutterSplashView = new FlutterSplashView(host.getContext());
-    flutterSplashView.setId(ViewUtils.generateViewId(486947586));
-    flutterSplashView.displayFlutterViewWithSplash(flutterView, host.provideSplashScreen());
-
     Log.v(TAG, "Attaching FlutterEngine to FlutterView.");
     flutterView.attachToFlutterEngine(flutterEngine);
     flutterView.setId(flutterViewId);
 
-    return flutterSplashView;
+    SplashScreen splashScreen = host.provideSplashScreen();
+
+    if (splashScreen != null) {
+      Log.w(
+          TAG,
+          "A splash screen was provided to Flutter, but this is deprecated. See"
+              + " flutter.dev/go/android-splash-migration for migration steps.");
+      FlutterSplashView flutterSplashView = new FlutterSplashView(host.getContext());
+      flutterSplashView.setId(ViewUtils.generateViewId(FLUTTER_SPLASH_VIEW_FALLBACK_ID));
+      flutterSplashView.displayFlutterViewWithSplash(flutterView, splashScreen);
+
+      return flutterSplashView;
+    }
+
+    if (shouldDelayFirstAndroidViewDraw) {
+      delayFirstAndroidViewDraw(flutterView);
+    }
+    return flutterView;
   }
 
   void onRestoreInstanceState(@Nullable Bundle bundle) {
@@ -416,6 +445,38 @@ import java.util.Arrays;
   }
 
   /**
+   * Delays the first drawing of the {@code flutterView} until the Flutter first has been displayed.
+   */
+  private void delayFirstAndroidViewDraw(FlutterView flutterView) {
+    if (host.getRenderMode() != RenderMode.surface) {
+      // Using a TextureView will cause a deadlock, where the underlying SurfaceTexture is never
+      // available since it will wait for drawing to be completed first. At the same time, the
+      // preDraw listener keeps returning false since the Flutter Engine waits for the
+      // SurfaceTexture to be available.
+      throw new IllegalArgumentException(
+          "Cannot delay the first Android view draw when the render mode is not set to"
+              + " `RenderMode.surface`.");
+    }
+
+    if (activePreDrawListener != null) {
+      flutterView.getViewTreeObserver().removeOnPreDrawListener(activePreDrawListener);
+    }
+
+    activePreDrawListener =
+        new OnPreDrawListener() {
+          @Override
+          public boolean onPreDraw() {
+            if (isFlutterUiDisplayed && activePreDrawListener != null) {
+              flutterView.getViewTreeObserver().removeOnPreDrawListener(this);
+              activePreDrawListener = null;
+            }
+            return isFlutterUiDisplayed;
+          }
+        };
+    flutterView.getViewTreeObserver().addOnPreDrawListener(activePreDrawListener);
+  }
+
+  /**
    * Invoke this from {@code Activity#onResume()} or {@code Fragment#onResume()}.
    *
    * <p>This method notifies the running Flutter app that it is "resumed" as per the Flutter app
@@ -496,6 +557,10 @@ import java.util.Arrays;
     Log.v(TAG, "onDestroyView()");
     ensureAlive();
 
+    if (activePreDrawListener != null) {
+      flutterView.getViewTreeObserver().removeOnPreDrawListener(activePreDrawListener);
+      activePreDrawListener = null;
+    }
     flutterView.detachFromFlutterEngine();
     flutterView.removeOnFirstFrameRenderedListener(flutterUiDisplayListener);
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragmentActivity.java
@@ -424,6 +424,7 @@ public class FlutterFragmentActivity extends FragmentActivity
         backgroundMode == BackgroundMode.opaque
             ? TransparencyMode.opaque
             : TransparencyMode.transparent;
+    final boolean shouldDelayFirstAndroidViewDraw = renderMode == RenderMode.surface;
 
     if (getCachedEngineId() != null) {
       Log.v(
@@ -447,6 +448,7 @@ public class FlutterFragmentActivity extends FragmentActivity
           .handleDeeplinking(shouldHandleDeeplinking())
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
           .destroyEngineWithFragment(shouldDestroyEngineWithHost())
+          .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
           .build();
     } else {
       Log.v(
@@ -476,6 +478,7 @@ public class FlutterFragmentActivity extends FragmentActivity
           .renderMode(renderMode)
           .transparencyMode(transparencyMode)
           .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
+          .shouldDelayFirstAndroidViewDraw(shouldDelayFirstAndroidViewDraw)
           .build();
     }
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -292,6 +292,31 @@ public class FlutterActivityTest {
   }
 
   @Test
+  public void itDelaysDrawing() {
+    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController =
+        Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    flutterActivity.onCreate(null);
+
+    assertNotNull(flutterActivity.delegate.activePreDrawListener);
+  }
+
+  @Test
+  public void itDoesNotDelayDrawingwhenUsingTextureRendering() {
+    Intent intent =
+        FlutterActivityWithTextureRendering.createDefaultIntent(RuntimeEnvironment.application);
+    ActivityController<FlutterActivityWithTextureRendering> activityController =
+        Robolectric.buildActivity(FlutterActivityWithTextureRendering.class, intent);
+    FlutterActivityWithTextureRendering flutterActivity = activityController.get();
+
+    flutterActivity.onCreate(null);
+
+    assertNull(flutterActivity.delegate.activePreDrawListener);
+  }
+
+  @Test
   public void itRestoresPluginStateBeforePluginOnCreate() {
     FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
     FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
@@ -440,6 +465,13 @@ public class FlutterActivityTest {
 
     public static CachedEngineIntentBuilder withCachedEngine(@NonNull String cachedEngineId) {
       return new CachedEngineIntentBuilder(FlutterActivityWithIntentBuilders.class, cachedEngineId);
+    }
+  }
+
+  private static class FlutterActivityWithTextureRendering extends FlutterActivity {
+    @Override
+    public RenderMode getRenderMode() {
+      return RenderMode.texture;
     }
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -82,7 +82,7 @@ public class FlutterAndroidComponentTest {
     assertNotNull(binding.getPlatformViewRegistry());
 
     delegate.onRestoreInstanceState(null);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -156,7 +156,7 @@ public class FlutterAndroidComponentTest {
     // Verify that after Activity creation, the plugin was allowed to restore state.
     verify(mockSaveStateListener, times(1)).onRestoreInstanceState(any(Bundle.class));
 
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();
@@ -195,7 +195,7 @@ public class FlutterAndroidComponentTest {
     // Push the delegate through all lifecycle methods all the way to destruction.
     delegate.onAttach(RuntimeEnvironment.application);
     delegate.onRestoreInstanceState(null);
-    delegate.onCreateView(null, null, null, 0);
+    delegate.onCreateView(null, null, null, 0, true);
     delegate.onStart();
     delegate.onResume();
     delegate.onPause();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -3,6 +3,7 @@ package io.flutter.embedding.android;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -41,6 +42,7 @@ public class FlutterFragmentTest {
     assertTrue(fragment.shouldDestroyEngineWithHost());
     assertEquals(RenderMode.surface, fragment.getRenderMode());
     assertEquals(TransparencyMode.transparent, fragment.getTransparencyMode());
+    assertFalse(fragment.shouldDelayFirstAndroidViewDraw());
   }
 
   @Test
@@ -68,12 +70,21 @@ public class FlutterFragmentTest {
   }
 
   @Test
-  public void itCreatesCachedEngineFragmentThatDoesNotDestroyTheEngine() {
+  public void itCreatesNewEngineFragmentThatDelaysFirstDrawWhenRequested() {
+    FlutterFragment fragment =
+        FlutterFragment.withNewEngine().shouldDelayFirstAndroidViewDraw(true).build();
+
+    assertNotNull(fragment.shouldDelayFirstAndroidViewDraw());
+  }
+
+  @Test
+  public void itCreatesCachedEngineFragmentWithExpectedDefaults() {
     FlutterFragment fragment = FlutterFragment.withCachedEngine("my_cached_engine").build();
 
     assertTrue(fragment.shouldAttachEngineToActivity());
     assertEquals("my_cached_engine", fragment.getCachedEngineId());
     assertFalse(fragment.shouldDestroyEngineWithHost());
+    assertFalse(fragment.shouldDelayFirstAndroidViewDraw());
   }
 
   @Test
@@ -86,6 +97,16 @@ public class FlutterFragmentTest {
     assertTrue(fragment.shouldAttachEngineToActivity());
     assertEquals("my_cached_engine", fragment.getCachedEngineId());
     assertTrue(fragment.shouldDestroyEngineWithHost());
+  }
+
+  @Test
+  public void itCreatesCachedEngineFragmentThatDelaysFirstDrawWhenRequested() {
+    FlutterFragment fragment =
+        FlutterFragment.withCachedEngine("my_cached_engine")
+            .shouldDelayFirstAndroidViewDraw(true)
+            .build();
+
+    assertNotNull(fragment.shouldDelayFirstAndroidViewDraw());
   }
 
   @Test


### PR DESCRIPTION
Relands #27645 (with no additional changes)

The [previous breakage](https://github.com/flutter/flutter/issues/85292#issuecomment-889570248) of some devicelab tests were fixed in https://github.com/flutter/flutter/pull/87324

Related issue: https://github.com/flutter/flutter/issues/85292