### PR TITLE
Do not generate keydown event for empty modifier flags

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -50,7 +50,8 @@
     case NSEventTypeFlagsChanged:
       if (event.modifierFlags < _previouslyPressedFlags) {
         type = @"keyup";
-      } else if (event.modifierFlags > _previouslyPressedFlags) {
+      } else if (event.modifierFlags > _previouslyPressedFlags &&
+                 event.modifierFlags > 0x100) {  // 0x100 is empty modifierFlags
         type = @"keydown";
       } else {
         // ignore duplicate modifiers; This can happen in situations like switching

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -39,7 +39,7 @@
 }
 
 - (void)handleEvent:(NSEvent*)event callback:(FlutterAsyncKeyCallback)callback {
-  // Remove the 0x100 bit set by Cocoa when no modifiers are pressed.
+  // Remove the modifier bits that Flutter is not interested in.
   NSEventModifierFlags modifierFlags = event.modifierFlags & ~0x100;
   NSString* type;
   switch (event.type) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponder.mm
@@ -39,6 +39,8 @@
 }
 
 - (void)handleEvent:(NSEvent*)event callback:(FlutterAsyncKeyCallback)callback {
+  // Remove the 0x100 bit set by Cocoa when no modifiers are pressed.
+  NSEventModifierFlags modifierFlags = event.modifierFlags & ~0x100;
   NSString* type;
   switch (event.type) {
     case NSEventTypeKeyDown:
@@ -48,10 +50,9 @@
       type = @"keyup";
       break;
     case NSEventTypeFlagsChanged:
-      if (event.modifierFlags < _previouslyPressedFlags) {
+      if (modifierFlags < _previouslyPressedFlags) {
         type = @"keyup";
-      } else if (event.modifierFlags > _previouslyPressedFlags &&
-                 event.modifierFlags > 0x100) {  // 0x100 is empty modifierFlags
+      } else if (modifierFlags > _previouslyPressedFlags) {
         type = @"keydown";
       } else {
         // ignore duplicate modifiers; This can happen in situations like switching
@@ -62,7 +63,7 @@
     default:
       NSAssert(false, @"Unexpected key event type (got %lu).", event.type);
   }
-  _previouslyPressedFlags = event.modifierFlags;
+  _previouslyPressedFlags = modifierFlags;
   NSMutableDictionary* keyMessage = [@{
     @"keymap" : @"macos",
     @"type" : type,

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
@@ -52,9 +52,18 @@ TEST(FlutterChannelKeyResponderUnittests, BasicKeyEvent) {
         callback(keyMessage);
       }));
 
-  // Key down
   FlutterChannelKeyResponder* responder =
       [[FlutterChannelKeyResponder alloc] initWithChannel:mockKeyEventChannel];
+
+  // Empty modifiers. Shouldn't result in any event
+  [responder handleEvent:keyEvent(NSEventTypeFlagsChanged, 0x100, @"", @"", FALSE, 60)
+                callback:^(BOOL handled) {
+                  [responses addObject:@(handled)];
+                }];
+
+  EXPECT_EQ([messages count], 0u);
+
+  // Key down
   [responder handleEvent:keyEvent(NSEventTypeKeyDown, 0x100, @"a", @"a", FALSE, 0)
                 callback:^(BOOL handled) {
                   [responses addObject:@(handled)];

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
@@ -55,8 +55,8 @@ TEST(FlutterChannelKeyResponderUnittests, BasicKeyEvent) {
   FlutterChannelKeyResponder* responder =
       [[FlutterChannelKeyResponder alloc] initWithChannel:mockKeyEventChannel];
 
-  // Initial empty modifiers. This can happen when user opens window while modifier key is present
-  // and then releases the modifier. Shouldn't result in any event being sent.
+  // Initial empty modifiers. This can happen when user opens window while modifier key is pressed
+  // and then releases the modifier. Shouldn't result in an event being sent.
   [responder handleEvent:keyEvent(NSEventTypeFlagsChanged, 0x100, @"", @"", FALSE, 60)
                 callback:^(BOOL handled) {
                   [responses addObject:@(handled)];

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
@@ -55,7 +55,8 @@ TEST(FlutterChannelKeyResponderUnittests, BasicKeyEvent) {
   FlutterChannelKeyResponder* responder =
       [[FlutterChannelKeyResponder alloc] initWithChannel:mockKeyEventChannel];
 
-  // Empty modifiers. Shouldn't result in any event
+  // Initial empty modifiers. This can happen when user opens window while modifier key is present
+  // and then releases the modifier. Shouldn't result in any event being sent.
   [responder handleEvent:keyEvent(NSEventTypeFlagsChanged, 0x100, @"", @"", FALSE, 60)
                 callback:^(BOOL handled) {
                   [responses addObject:@(handled)];

--- a/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterChannelKeyResponderUnittests.mm
@@ -57,6 +57,7 @@ TEST(FlutterChannelKeyResponderUnittests, BasicKeyEvent) {
 
   // Initial empty modifiers. This can happen when user opens window while modifier key is pressed
   // and then releases the modifier. Shouldn't result in an event being sent.
+  // Regression test for https://github.com/flutter/flutter/issues/87339.
   [responder handleEvent:keyEvent(NSEventTypeFlagsChanged, 0x100, @"", @"", FALSE, 60)
                 callback:^(BOOL handled) {
                   [responses addObject:@(handled)];


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/87339

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
