### PR TITLE
Add GestureSettings and configure touch slop from Android ViewConfiguration

### DIFF
--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -339,7 +339,7 @@ void hooksTests() {
     window.onMetricsChanged!();
     _callHook(
       '_updateWindowMetrics',
-      16,
+      17,
       0, // window Id
       0.1234, // device pixel ratio
       0.0,    // width
@@ -355,7 +355,8 @@ void hooksTests() {
       0.0,    // system gesture inset top
       0.0,    // system gesture inset right
       0.0,    // system gesture inset bottom
-      0.0,    // system gesture inset left
+      0.0,    // system gesture inset left,
+      22.0,  // physical touch slop
     );
 
     expectIdentical(originalZone, callbackZone);
@@ -402,7 +403,7 @@ void hooksTests() {
   test('Window padding/insets/viewPadding/systemGestureInsets', () {
     _callHook(
       '_updateWindowMetrics',
-      16,
+      17,
       0, // window Id
       1.0, // devicePixelRatio
       800.0, // width
@@ -419,6 +420,7 @@ void hooksTests() {
       0.0, // systemGestureInsetRight
       0.0, // systemGestureInsetBottom
       0.0, // systemGestureInsetLeft
+      22.0, // physical touch slop
     );
 
     expectEquals(window.viewInsets.bottom, 0.0);
@@ -428,7 +430,7 @@ void hooksTests() {
 
     _callHook(
       '_updateWindowMetrics',
-      16,
+      17,
       0, // window Id
       1.0, // devicePixelRatio
       800.0, // width
@@ -445,12 +447,90 @@ void hooksTests() {
       0.0, // systemGestureInsetRight
       44.0, // systemGestureInsetBottom
       0.0, // systemGestureInsetLeft
+      22.0, // physical touch slop
     );
 
     expectEquals(window.viewInsets.bottom, 400.0);
     expectEquals(window.viewPadding.bottom, 40.0);
     expectEquals(window.padding.bottom, 0.0);
     expectEquals(window.systemGestureInsets.bottom, 44.0);
+  });
+
+   test('Window physical touch slop', () {
+    _callHook(
+      '_updateWindowMetrics',
+      17,
+      0, // window Id
+      1.0, // devicePixelRatio
+      800.0, // width
+      600.0, // height
+      50.0, // paddingTop
+      0.0, // paddingRight
+      40.0, // paddingBottom
+      0.0, // pattingLeft
+      0.0, // insetTop
+      0.0, // insetRight
+      0.0, // insetBottom
+      0.0, // insetLeft
+      0.0, // systemGestureInsetTop
+      0.0, // systemGestureInsetRight
+      0.0, // systemGestureInsetBottom
+      0.0, // systemGestureInsetLeft
+      11.0, // physical touch slop
+    );
+
+    expectEquals(window.viewConfiguration.gestureSettings,
+      GestureSettings(physicalTouchSlop: 11.0));
+
+    _callHook(
+      '_updateWindowMetrics',
+      17,
+      0, // window Id
+      1.0, // devicePixelRatio
+      800.0, // width
+      600.0, // height
+      50.0, // paddingTop
+      0.0, // paddingRight
+      40.0, // paddingBottom
+      0.0, // pattingLeft
+      0.0, // insetTop
+      0.0, // insetRight
+      400.0, // insetBottom
+      0.0, // insetLeft
+      0.0, // systemGestureInsetTop
+      0.0, // systemGestureInsetRight
+      44.0, // systemGestureInsetBottom
+      0.0, // systemGestureInsetLeft
+      -1.0, // physical touch slop
+    );
+
+    expectEquals(window.viewConfiguration.gestureSettings,
+      GestureSettings(physicalTouchSlop: null));
+
+    _callHook(
+      '_updateWindowMetrics',
+      17,
+      0, // window Id
+      1.0, // devicePixelRatio
+      800.0, // width
+      600.0, // height
+      50.0, // paddingTop
+      0.0, // paddingRight
+      40.0, // paddingBottom
+      0.0, // pattingLeft
+      0.0, // insetTop
+      0.0, // insetRight
+      400.0, // insetBottom
+      0.0, // insetLeft
+      0.0, // systemGestureInsetTop
+      0.0, // systemGestureInsetRight
+      44.0, // systemGestureInsetBottom
+      0.0, // systemGestureInsetLeft
+      22.0, // physical touch slop
+    );
+
+    expectEquals(window.viewConfiguration.gestureSettings,
+      GestureSettings(physicalTouchSlop: 22.0));
   });
 
   test('onLocaleChanged preserves callback zone', () {
@@ -671,4 +751,5 @@ void _callHook(
   Object? arg14,
   Object? arg15,
   Object? arg16,
+  Object? arg17,
 ]) native 'CallHook';

--- a/lib/ui/fixtures/ui_test.dart
+++ b/lib/ui/fixtures/ui_test.dart
@@ -356,7 +356,7 @@ void hooksTests() {
       0.0,    // system gesture inset right
       0.0,    // system gesture inset bottom
       0.0,    // system gesture inset left,
-      22.0,  // physical touch slop
+      22.0,   // physicalTouchSlop
     );
 
     expectIdentical(originalZone, callbackZone);
@@ -411,7 +411,7 @@ void hooksTests() {
       50.0, // paddingTop
       0.0, // paddingRight
       40.0, // paddingBottom
-      0.0, // pattingLeft
+      0.0, // paddingLeft
       0.0, // insetTop
       0.0, // insetRight
       0.0, // insetBottom
@@ -420,7 +420,7 @@ void hooksTests() {
       0.0, // systemGestureInsetRight
       0.0, // systemGestureInsetBottom
       0.0, // systemGestureInsetLeft
-      22.0, // physical touch slop
+      22.0, // physicalTouchSlop
     );
 
     expectEquals(window.viewInsets.bottom, 0.0);
@@ -438,7 +438,7 @@ void hooksTests() {
       50.0, // paddingTop
       0.0, // paddingRight
       40.0, // paddingBottom
-      0.0, // pattingLeft
+      0.0, // paddingLeft
       0.0, // insetTop
       0.0, // insetRight
       400.0, // insetBottom
@@ -447,7 +447,7 @@ void hooksTests() {
       0.0, // systemGestureInsetRight
       44.0, // systemGestureInsetBottom
       0.0, // systemGestureInsetLeft
-      22.0, // physical touch slop
+      22.0, // physicalTouchSlop
     );
 
     expectEquals(window.viewInsets.bottom, 400.0);
@@ -467,7 +467,7 @@ void hooksTests() {
       50.0, // paddingTop
       0.0, // paddingRight
       40.0, // paddingBottom
-      0.0, // pattingLeft
+      0.0, // paddingLeft
       0.0, // insetTop
       0.0, // insetRight
       0.0, // insetBottom
@@ -476,7 +476,7 @@ void hooksTests() {
       0.0, // systemGestureInsetRight
       0.0, // systemGestureInsetBottom
       0.0, // systemGestureInsetLeft
-      11.0, // physical touch slop
+      11.0, // physicalTouchSlop
     );
 
     expectEquals(window.viewConfiguration.gestureSettings,
@@ -492,7 +492,7 @@ void hooksTests() {
       50.0, // paddingTop
       0.0, // paddingRight
       40.0, // paddingBottom
-      0.0, // pattingLeft
+      0.0, // paddingLeft
       0.0, // insetTop
       0.0, // insetRight
       400.0, // insetBottom
@@ -501,7 +501,7 @@ void hooksTests() {
       0.0, // systemGestureInsetRight
       44.0, // systemGestureInsetBottom
       0.0, // systemGestureInsetLeft
-      -1.0, // physical touch slop
+      -1.0, // physicalTouchSlop
     );
 
     expectEquals(window.viewConfiguration.gestureSettings,
@@ -517,7 +517,7 @@ void hooksTests() {
       50.0, // paddingTop
       0.0, // paddingRight
       40.0, // paddingBottom
-      0.0, // pattingLeft
+      0.0, // paddingLeft
       0.0, // insetTop
       0.0, // insetRight
       400.0, // insetBottom
@@ -526,7 +526,7 @@ void hooksTests() {
       0.0, // systemGestureInsetRight
       44.0, // systemGestureInsetBottom
       0.0, // systemGestureInsetLeft
-      22.0, // physical touch slop
+      22.0, // physicalTouchSlop
     );
 
     expectEquals(window.viewConfiguration.gestureSettings,

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -27,6 +27,7 @@ void _updateWindowMetrics(
   double systemGestureInsetRight,
   double systemGestureInsetBottom,
   double systemGestureInsetLeft,
+  double physicalTouchSlop,
 ) {
   PlatformDispatcher.instance._updateWindowMetrics(
     id,
@@ -45,6 +46,7 @@ void _updateWindowMetrics(
     systemGestureInsetRight,
     systemGestureInsetBottom,
     systemGestureInsetLeft,
+    physicalTouchSlop,
   );
 }
 

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -56,6 +56,9 @@ typedef _SetNeedsReportTimingsFunc = void Function(bool value);
 /// Signature for [PlatformDispatcher.onConfigurationChanged].
 typedef PlatformConfigurationChangedCallback = void Function(PlatformConfiguration configuration);
 
+// A gesture setting value that indicates it has not been set by the engine.
+const double _kUnsetGestureSetting = -1.0;
+
 /// Platform event dispatcher singleton.
 ///
 /// The most basic interface to the host operating system's interface.
@@ -216,7 +219,7 @@ class PlatformDispatcher {
       ),
       // -1 is used as a sentinel for an undefined touch slop
       gestureSettings: GestureSettings(
-        physicalTouchSlop: physicalTouchSlop < 0 ? null : physicalTouchSlop,
+        physicalTouchSlop: physicalTouchSlop == _kUnsetGestureSetting ? null : physicalTouchSlop,
       ),
     );
     _invoke(onMetricsChanged, _onMetricsChangedZone);

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -1131,7 +1131,11 @@ class ViewConfiguration {
   /// phone sensor housings).
   final WindowPadding padding;
 
-  /// The view specific gesture settings.
+  /// Additional configuration for touch gestures performed on this view.
+  ///
+  /// For example, the touch slop defined in physical pixels may be provided
+  /// by the gesture settings and should be preferred over the framework
+  /// touch slop constant.
   final GestureSettings gestureSettings;
 
   @override

--- a/lib/ui/platform_dispatcher.dart
+++ b/lib/ui/platform_dispatcher.dart
@@ -179,6 +179,7 @@ class PlatformDispatcher {
     double systemGestureInsetRight,
     double systemGestureInsetBottom,
     double systemGestureInsetLeft,
+    double physicalTouchSlop,
   ) {
     final ViewConfiguration previousConfiguration =
         _viewConfigurations[id] ?? const ViewConfiguration();
@@ -212,6 +213,10 @@ class PlatformDispatcher {
         right: math.max(0.0, systemGestureInsetRight),
         bottom: math.max(0.0, systemGestureInsetBottom),
         left: math.max(0.0, systemGestureInsetLeft),
+      ),
+      // -1 is used as a sentinel for an undefined touch slop
+      gestureSettings: GestureSettings(
+        physicalTouchSlop: physicalTouchSlop < 0 ? null : physicalTouchSlop,
       ),
     );
     _invoke(onMetricsChanged, _onMetricsChangedZone);
@@ -1026,6 +1031,7 @@ class ViewConfiguration {
     this.viewPadding = WindowPadding.zero,
     this.systemGestureInsets = WindowPadding.zero,
     this.padding = WindowPadding.zero,
+    this.gestureSettings = const GestureSettings(),
   });
 
   /// Copy this configuration with some fields replaced.
@@ -1038,6 +1044,7 @@ class ViewConfiguration {
     WindowPadding? viewPadding,
     WindowPadding? systemGestureInsets,
     WindowPadding? padding,
+    GestureSettings? gestureSettings
   }) {
     return ViewConfiguration(
       window: window ?? this.window,
@@ -1048,6 +1055,7 @@ class ViewConfiguration {
       viewPadding: viewPadding ?? this.viewPadding,
       systemGestureInsets: systemGestureInsets ?? this.systemGestureInsets,
       padding: padding ?? this.padding,
+      gestureSettings: gestureSettings ?? this.gestureSettings,
     );
   }
 
@@ -1119,6 +1127,9 @@ class ViewConfiguration {
   /// intrusions in the display (e.g. overscan regions on television screens or
   /// phone sensor housings).
   final WindowPadding padding;
+
+  /// The view specific gesture settings.
+  final GestureSettings gestureSettings;
 
   @override
   String toString() {

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -898,6 +898,9 @@ class GestureSettings {
 
   /// The number of physical pixels that the first and second tap of a double tap
   /// can drift apart to still be recognized as a double tap.
+  ///
+  /// If `null`, the framework's default double tap slop configuration should be used
+  /// instead.
   final double? physicalDoubleTapSlop;
 
   /// Create a new [GestureSetting]s object from an existing value, overwriting
@@ -925,5 +928,5 @@ class GestureSettings {
   int get hashCode => hashValues(physicalTouchSlop, physicalDoubleTapSlop);
 
   @override
-  String toString() => 'GestureSettings{physicalTouchSlop: $physicalTouchSlop, physicalDoubleTapSlop: $physicalDoubleTapSlop}';
+  String toString() => 'GestureSettings(physicalTouchSlop: $physicalTouchSlop, physicalDoubleTapSlop: $physicalDoubleTapSlop)';
 }

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -873,11 +873,14 @@ class FrameData {
 }
 
 /// Platform specific configuration for gesture behavior, such as touch slop.
+///
+/// These settings are provided via [ViewConfiguration] to each window, and should
+/// be favored for configuring gesture behavior over the framework constants.
+///
+/// A `null` field indicates that the platform or view does not have a preference
+/// and the fallback constants should be used instead.
 class GestureSettings {
   /// Create a new [GestureSettings] value.
-  ///
-  /// All values are optional and default to `null` if unset, which signals to
-  /// the framework that it must use a fallback value.
   ///
   /// Consider using [GestureSettings.copyWith] on an existing settings object
   /// to ensure that newly added fields are correctly set.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -874,9 +874,17 @@ class FrameData {
 
 /// Platform specific configuration for gesture behavior, such as touch slop.
 class GestureSettings {
-
   /// Create a new [GestureSettings] value.
-  const GestureSettings({this.physicalTouchSlop});
+  ///
+  /// All values are optional and default to `null` if unset, which signals to
+  /// the framework that it must use a fallback value.
+  ///
+  /// Consider using [GestureSettings.copyWith] on an existing settings object
+  /// to ensure that newly added fields are correctly set.
+  const GestureSettings({
+    this.physicalTouchSlop,
+    this.physicalDoubleTapSlop,
+  });
 
   /// The number of physical pixels a pointer is allowed to drift before it is
   /// considered an intentional movement.
@@ -885,17 +893,34 @@ class GestureSettings {
   /// instead.
   final double? physicalTouchSlop;
 
+  /// The number of physical pixels that the first and second tap of a double tap
+  /// can drift apart to still be recognized as a double tap.
+  final double? physicalDoubleTapSlop;
+
+  /// Create a new [GestureSetting]s object from an existing value, overwriting
+  /// all of the provided fields.
+  GestureSettings copyWith({
+    double? physicalTouchSlop,
+    double? physicalDoubleTapSlop,
+  }) {
+    return GestureSettings(
+      physicalTouchSlop: physicalTouchSlop ?? this.physicalTouchSlop,
+      physicalDoubleTapSlop: physicalDoubleTapSlop ?? this.physicalDoubleTapSlop,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType)
       return false;
     return other is GestureSettings &&
-      other.physicalTouchSlop == physicalTouchSlop;
+      other.physicalTouchSlop == physicalTouchSlop &&
+      other.physicalDoubleTapSlop == physicalDoubleTapSlop;
   }
 
   @override
-  int get hashCode => physicalTouchSlop.hashCode;
+  int get hashCode => hashValues(physicalTouchSlop, physicalDoubleTapSlop);
 
   @override
-  String toString() => 'GestureSettings{physicalTouchSlop: $physicalTouchSlop}';
+  String toString() => 'GestureSettings{physicalTouchSlop: $physicalTouchSlop, physicalDoubleTapSlop: $physicalDoubleTapSlop}';
 }

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -871,3 +871,31 @@ class FrameData {
   /// If not provided, defaults to -1.
   final int frameNumber;
 }
+
+/// Platform specific configuration for gesture behavior, such as touch slop.
+class GestureSettings {
+
+  /// Create a new [GestureSettings] value.
+  const GestureSettings({this.physicalTouchSlop});
+
+  /// The number of physical pixels a pointer is allowed to drift before it is
+  /// considered an intentional movement.
+  ///
+  /// If `null`, the framework's default touch slop configuration should be used
+  /// instead.
+  final double? physicalTouchSlop;
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is GestureSettings &&
+      other.physicalTouchSlop == physicalTouchSlop;
+  }
+
+  @override
+  int get hashCode => physicalTouchSlop.hashCode;
+
+  @override
+  String toString() => 'GestureSettings{physicalTouchSlop: $physicalTouchSlop}';
+}

--- a/lib/ui/window/platform_configuration.cc
+++ b/lib/ui/window/platform_configuration.cc
@@ -232,8 +232,9 @@ void PlatformConfiguration::DidCreateIsolate() {
                   Dart_GetField(library, tonic::ToDart("_drawFrame")));
   report_timings_.Set(tonic::DartState::Current(),
                       Dart_GetField(library, tonic::ToDart("_reportTimings")));
-  windows_.insert(std::make_pair(0, std::unique_ptr<Window>(new Window{
-                                        0, ViewportMetrics{1.0, 0.0, 0.0}})));
+  windows_.insert(
+      std::make_pair(0, std::unique_ptr<Window>(new Window{
+                            0, ViewportMetrics{1.0, 0.0, 0.0, -1}})));
 }
 
 void PlatformConfiguration::UpdateLocales(

--- a/lib/ui/window/platform_configuration_unittests.cc
+++ b/lib/ui/window/platform_configuration_unittests.cc
@@ -103,7 +103,7 @@ TEST_F(ShellTest, PlatformConfigurationWindowMetricsUpdate) {
 
     ASSERT_NE(configuration->get_window(0), nullptr);
     configuration->get_window(0)->UpdateWindowMetrics(
-        ViewportMetrics{2.0, 10.0, 20.0});
+        ViewportMetrics{2.0, 10.0, 20.0, 22});
     ASSERT_EQ(
         configuration->get_window(0)->viewport_metrics().device_pixel_ratio,
         2.0);
@@ -111,6 +111,9 @@ TEST_F(ShellTest, PlatformConfigurationWindowMetricsUpdate) {
               10.0);
     ASSERT_EQ(configuration->get_window(0)->viewport_metrics().physical_height,
               20.0);
+    ASSERT_EQ(
+        configuration->get_window(0)->viewport_metrics().physical_touch_slop,
+        22);
 
     message_latch->Signal();
   };

--- a/lib/ui/window/viewport_metrics.cc
+++ b/lib/ui/window/viewport_metrics.cc
@@ -12,10 +12,12 @@ ViewportMetrics::ViewportMetrics() = default;
 
 ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
                                  double p_physical_width,
-                                 double p_physical_height)
+                                 double p_physical_height,
+                                 double p_physical_touch_slop)
     : device_pixel_ratio(p_device_pixel_ratio),
       physical_width(p_physical_width),
-      physical_height(p_physical_height) {}
+      physical_height(p_physical_height),
+      physical_touch_slop(p_physical_touch_slop) {}
 
 ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
                                  double p_physical_width,
@@ -31,7 +33,8 @@ ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
                                  double p_physical_system_gesture_inset_top,
                                  double p_physical_system_gesture_inset_right,
                                  double p_physical_system_gesture_inset_bottom,
-                                 double p_physical_system_gesture_inset_left)
+                                 double p_physical_system_gesture_inset_left,
+                                 double p_physical_touch_slop)
     : device_pixel_ratio(p_device_pixel_ratio),
       physical_width(p_physical_width),
       physical_height(p_physical_height),
@@ -48,8 +51,8 @@ ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
           p_physical_system_gesture_inset_right),
       physical_system_gesture_inset_bottom(
           p_physical_system_gesture_inset_bottom),
-      physical_system_gesture_inset_left(p_physical_system_gesture_inset_left) {
-}
+      physical_system_gesture_inset_left(p_physical_system_gesture_inset_left),
+      physical_touch_slop(p_physical_touch_slop) {}
 
 bool operator==(const ViewportMetrics& a, const ViewportMetrics& b) {
   return a.device_pixel_ratio == b.device_pixel_ratio &&
@@ -70,7 +73,8 @@ bool operator==(const ViewportMetrics& a, const ViewportMetrics& b) {
          a.physical_system_gesture_inset_bottom ==
              b.physical_system_gesture_inset_bottom &&
          a.physical_system_gesture_inset_left ==
-             b.physical_system_gesture_inset_left;
+             b.physical_system_gesture_inset_left &&
+         a.physical_touch_slop == b.physical_touch_slop;
 }
 
 std::ostream& operator<<(std::ostream& os, const ViewportMetrics& a) {

--- a/lib/ui/window/viewport_metrics.h
+++ b/lib/ui/window/viewport_metrics.h
@@ -13,7 +13,8 @@ struct ViewportMetrics {
   ViewportMetrics();
   ViewportMetrics(double p_device_pixel_ratio,
                   double p_physical_width,
-                  double p_physical_height);
+                  double p_physical_height,
+                  double p_physical_touch_slop);
   ViewportMetrics(double p_device_pixel_ratio,
                   double p_physical_width,
                   double p_physical_height,
@@ -28,7 +29,8 @@ struct ViewportMetrics {
                   double p_physical_system_gesture_inset_top,
                   double p_physical_system_gesture_inset_right,
                   double p_physical_system_gesture_inset_bottom,
-                  double p_physical_system_gesture_inset_left);
+                  double p_physical_system_gesture_inset_left,
+                  double p_physical_touch_slop);
 
   double device_pixel_ratio = 1.0;
   double physical_width = 0;
@@ -45,6 +47,7 @@ struct ViewportMetrics {
   double physical_system_gesture_inset_right = 0;
   double physical_system_gesture_inset_bottom = 0;
   double physical_system_gesture_inset_left = 0;
+  double physical_touch_slop = -1.0;
 };
 
 bool operator==(const ViewportMetrics& a, const ViewportMetrics& b);

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -64,24 +64,22 @@ void Window::UpdateWindowMetrics(const ViewportMetrics& metrics) {
   tonic::DartState::Scope scope(dart_state);
   tonic::LogIfError(tonic::DartInvokeField(
       library_.value(), "_updateWindowMetrics",
-      {
-          tonic::ToDart(window_id_),
-          tonic::ToDart(metrics.device_pixel_ratio),
-          tonic::ToDart(metrics.physical_width),
-          tonic::ToDart(metrics.physical_height),
-          tonic::ToDart(metrics.physical_padding_top),
-          tonic::ToDart(metrics.physical_padding_right),
-          tonic::ToDart(metrics.physical_padding_bottom),
-          tonic::ToDart(metrics.physical_padding_left),
-          tonic::ToDart(metrics.physical_view_inset_top),
-          tonic::ToDart(metrics.physical_view_inset_right),
-          tonic::ToDart(metrics.physical_view_inset_bottom),
-          tonic::ToDart(metrics.physical_view_inset_left),
-          tonic::ToDart(metrics.physical_system_gesture_inset_top),
-          tonic::ToDart(metrics.physical_system_gesture_inset_right),
-          tonic::ToDart(metrics.physical_system_gesture_inset_bottom),
-          tonic::ToDart(metrics.physical_system_gesture_inset_left),
-      }));
+      {tonic::ToDart(window_id_), tonic::ToDart(metrics.device_pixel_ratio),
+       tonic::ToDart(metrics.physical_width),
+       tonic::ToDart(metrics.physical_height),
+       tonic::ToDart(metrics.physical_padding_top),
+       tonic::ToDart(metrics.physical_padding_right),
+       tonic::ToDart(metrics.physical_padding_bottom),
+       tonic::ToDart(metrics.physical_padding_left),
+       tonic::ToDart(metrics.physical_view_inset_top),
+       tonic::ToDart(metrics.physical_view_inset_right),
+       tonic::ToDart(metrics.physical_view_inset_bottom),
+       tonic::ToDart(metrics.physical_view_inset_left),
+       tonic::ToDart(metrics.physical_system_gesture_inset_top),
+       tonic::ToDart(metrics.physical_system_gesture_inset_right),
+       tonic::ToDart(metrics.physical_system_gesture_inset_bottom),
+       tonic::ToDart(metrics.physical_system_gesture_inset_left),
+       tonic::ToDart(metrics.physical_touch_slop)}));
 }
 
 }  // namespace flutter

--- a/lib/web_ui/lib/src/ui/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/ui/platform_dispatcher.dart
@@ -155,6 +155,7 @@ class ViewConfiguration {
     this.viewPadding = WindowPadding.zero,
     this.systemGestureInsets = WindowPadding.zero,
     this.padding = WindowPadding.zero,
+    this.gestureSettings = const GestureSettings(),
   });
 
   ViewConfiguration copyWith({
@@ -166,6 +167,7 @@ class ViewConfiguration {
     WindowPadding? viewPadding,
     WindowPadding? systemGestureInsets,
     WindowPadding? padding,
+    GestureSettings? gestureSettings,
   }) {
     return ViewConfiguration(
       window: window ?? this.window,
@@ -176,6 +178,7 @@ class ViewConfiguration {
       viewPadding: viewPadding ?? this.viewPadding,
       systemGestureInsets: systemGestureInsets ?? this.systemGestureInsets,
       padding: padding ?? this.padding,
+      gestureSettings: gestureSettings ?? this.gestureSettings,
     );
   }
 
@@ -187,6 +190,7 @@ class ViewConfiguration {
   final WindowPadding viewPadding;
   final WindowPadding systemGestureInsets;
   final WindowPadding padding;
+  final GestureSettings? gestureSettings;
 
   @override
   String toString() {

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -265,8 +265,9 @@ class GestureSettings {
 
   @override
   bool operator ==(Object other) {
-    if (other.runtimeType != runtimeType)
+    if (other.runtimeType != runtimeType) {
       return false;
+    }
     return other is GestureSettings &&
       other.physicalTouchSlop == physicalTouchSlop;
   }

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -257,3 +257,23 @@ class FrameData {
 
   final int frameNumber;
 }
+
+class GestureSettings {
+  const GestureSettings({this.physicalTouchSlop});
+
+  final double? physicalTouchSlop;
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is GestureSettings &&
+      other.physicalTouchSlop == physicalTouchSlop;
+  }
+
+  @override
+  int get hashCode => physicalTouchSlop.hashCode;
+
+  @override
+  String toString() => 'GestureSettings{physicalTouchSlop: $physicalTouchSlop}';
+}

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -292,5 +292,5 @@ class GestureSettings {
   int get hashCode => hashValues(physicalTouchSlop, physicalDoubleTapSlop);
 
   @override
-  String toString() => 'GestureSettings{physicalTouchSlop: $physicalTouchSlop, physicalDoubleTapSlop: $physicalDoubleTapSlop}';
+  String toString() => 'GestureSettings(physicalTouchSlop: $physicalTouchSlop, physicalDoubleTapSlop: $physicalDoubleTapSlop)';
 }

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -259,9 +259,24 @@ class FrameData {
 }
 
 class GestureSettings {
-  const GestureSettings({this.physicalTouchSlop});
+  const GestureSettings({
+    this.physicalTouchSlop,
+    this.physicalDoubleTapSlop,
+  });
 
   final double? physicalTouchSlop;
+
+  final double? physicalDoubleTapSlop;
+
+  GestureSettings copyWith({
+    double? physicalTouchSlop,
+    double? physicalDoubleTapSlop,
+  }) {
+    return GestureSettings(
+      physicalTouchSlop: physicalTouchSlop ?? this.physicalTouchSlop,
+      physicalDoubleTapSlop: physicalDoubleTapSlop ?? this.physicalDoubleTapSlop,
+    );
+  }
 
   @override
   bool operator ==(Object other) {
@@ -269,12 +284,13 @@ class GestureSettings {
       return false;
     }
     return other is GestureSettings &&
-      other.physicalTouchSlop == physicalTouchSlop;
+      other.physicalTouchSlop == physicalTouchSlop &&
+      other.physicalDoubleTapSlop == physicalDoubleTapSlop;
   }
 
   @override
-  int get hashCode => physicalTouchSlop.hashCode;
+  int get hashCode => hashValues(physicalTouchSlop, physicalDoubleTapSlop);
 
   @override
-  String toString() => 'GestureSettings{physicalTouchSlop: $physicalTouchSlop}';
+  String toString() => 'GestureSettings{physicalTouchSlop: $physicalTouchSlop, physicalDoubleTapSlop: $physicalDoubleTapSlop}';
 }

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -125,7 +125,8 @@ void ShellTest::SetViewportMetrics(Shell* shell, double width, double height) {
       0,       // gesture inset top
       0,       // gesture inset right
       0,       // gesture inset bottom
-      0        // gesture inset left
+      0,       // gesture inset left
+      22       // physical touch slop
   };
   // Set viewport to nonempty, and call Animator::BeginFrame to make the layer
   // tree pipeline nonempty. Without either of this, the layer tree below
@@ -164,7 +165,7 @@ void ShellTest::PumpOneFrame(Shell* shell,
                              double width,
                              double height,
                              LayerTreeBuilder builder) {
-  PumpOneFrame(shell, {1.0, width, height}, std::move(builder));
+  PumpOneFrame(shell, {1.0, width, height, 22}, std::move(builder));
 }
 
 void ShellTest::PumpOneFrame(Shell* shell,

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1363,7 +1363,7 @@ TEST_F(ShellTest, WaitForFirstFrameZeroSizeFrame) {
   configuration.SetEntrypoint("emptyMain");
 
   RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get(), {1.0, 0.0, 0.0});
+  PumpOneFrame(shell.get(), {1.0, 0.0, 0.0, 22});
   fml::Status result = shell->WaitForFirstFrame(fml::TimeDelta::Zero());
   ASSERT_FALSE(result.ok());
   ASSERT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
@@ -1484,7 +1484,7 @@ TEST_F(ShellTest, SetResourceCacheSize) {
 
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {
-        shell->GetPlatformView()->SetViewportMetrics({1.0, 400, 200});
+        shell->GetPlatformView()->SetViewportMetrics({1.0, 400, 200, 22});
       });
   PumpOneFrame(shell.get());
 
@@ -1504,7 +1504,7 @@ TEST_F(ShellTest, SetResourceCacheSize) {
 
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {
-        shell->GetPlatformView()->SetViewportMetrics({1.0, 800, 400});
+        shell->GetPlatformView()->SetViewportMetrics({1.0, 800, 400, 22});
       });
   PumpOneFrame(shell.get());
 
@@ -1522,7 +1522,7 @@ TEST_F(ShellTest, SetResourceCacheSizeEarly) {
 
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {
-        shell->GetPlatformView()->SetViewportMetrics({1.0, 400, 200});
+        shell->GetPlatformView()->SetViewportMetrics({1.0, 400, 200, 22});
       });
   PumpOneFrame(shell.get());
 
@@ -1550,7 +1550,7 @@ TEST_F(ShellTest, SetResourceCacheSizeNotifiesDart) {
 
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {
-        shell->GetPlatformView()->SetViewportMetrics({1.0, 400, 200});
+        shell->GetPlatformView()->SetViewportMetrics({1.0, 400, 200, 22});
       });
   PumpOneFrame(shell.get());
 
@@ -2234,7 +2234,7 @@ TEST_F(ShellTest, DiscardLayerTreeOnResize) {
       [&shell, &expected_size]() {
         shell->GetPlatformView()->SetViewportMetrics(
             {1.0, static_cast<double>(expected_size.width()),
-             static_cast<double>(expected_size.height())});
+             static_cast<double>(expected_size.height()), 22});
       });
 
   auto configuration = RunConfiguration::InferFromSettings(settings);
@@ -2307,13 +2307,13 @@ TEST_F(ShellTest, IgnoresInvalidMetrics) {
   RunEngine(shell.get(), std::move(configuration));
 
   task_runner->PostTask([&]() {
-    shell->GetPlatformView()->SetViewportMetrics({0.0, 400, 200});
+    shell->GetPlatformView()->SetViewportMetrics({0.0, 400, 200, 22});
     task_runner->PostTask([&]() {
-      shell->GetPlatformView()->SetViewportMetrics({0.8, 0.0, 200});
+      shell->GetPlatformView()->SetViewportMetrics({0.8, 0.0, 200, 22});
       task_runner->PostTask([&]() {
-        shell->GetPlatformView()->SetViewportMetrics({0.8, 400, 0.0});
+        shell->GetPlatformView()->SetViewportMetrics({0.8, 400, 0.0, 22});
         task_runner->PostTask([&]() {
-          shell->GetPlatformView()->SetViewportMetrics({0.8, 400, 200.0});
+          shell->GetPlatformView()->SetViewportMetrics({0.8, 400, 200.0, 22});
         });
       });
     });
@@ -2325,7 +2325,7 @@ TEST_F(ShellTest, IgnoresInvalidMetrics) {
   latch.Reset();
 
   task_runner->PostTask([&]() {
-    shell->GetPlatformView()->SetViewportMetrics({1.2, 600, 300});
+    shell->GetPlatformView()->SetViewportMetrics({1.2, 600, 300, 22});
   });
   latch.Wait();
   ASSERT_EQ(last_device_pixel_ratio, 1.2);

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -20,6 +20,7 @@ import android.view.MotionEvent;
 import android.view.PointerIcon;
 import android.view.Surface;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.ViewStructure;
 import android.view.WindowInsets;
@@ -1262,6 +1263,7 @@ public class FlutterView extends FrameLayout implements MouseCursorPlugin.MouseC
     }
 
     viewportMetrics.devicePixelRatio = getResources().getDisplayMetrics().density;
+    viewportMetrics.physicalTouchSlop = ViewConfiguration.get(getContext()).getScaledTouchSlop();
     flutterEngine.getRenderer().setViewportMetrics(viewportMetrics);
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -562,7 +562,8 @@ public class FlutterJNI {
       int systemGestureInsetTop,
       int systemGestureInsetRight,
       int systemGestureInsetBottom,
-      int systemGestureInsetLeft) {
+      int systemGestureInsetLeft,
+      int physicalTouchSlop) {
     ensureRunningOnMainThread();
     ensureAttachedToNative();
     nativeSetViewportMetrics(
@@ -581,7 +582,8 @@ public class FlutterJNI {
         systemGestureInsetTop,
         systemGestureInsetRight,
         systemGestureInsetBottom,
-        systemGestureInsetLeft);
+        systemGestureInsetLeft,
+        physicalTouchSlop);
   }
 
   private native void nativeSetViewportMetrics(
@@ -600,7 +602,8 @@ public class FlutterJNI {
       int systemGestureInsetTop,
       int systemGestureInsetRight,
       int systemGestureInsetBottom,
-      int systemGestureInsetLeft);
+      int systemGestureInsetLeft,
+      int physicalTouchSlop);
   // ----- End Render Surface Support -----
 
   // ------ Start Touch Interaction Support ---

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -358,9 +358,7 @@ public class FlutterRenderer implements TextureRegistry {
    * pixels, not logical pixels.
    */
   public static final class ViewportMetrics {
-    /**
-     * A value that indicates the setting has not been set.
-     */
+    /** A value that indicates the setting has not been set. */
     public static final int unsetValue = -1;
 
     public float devicePixelRatio = 1.0f;

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -300,7 +300,8 @@ public class FlutterRenderer implements TextureRegistry {
         viewportMetrics.systemGestureInsetTop,
         viewportMetrics.systemGestureInsetRight,
         viewportMetrics.systemGestureInsetBottom,
-        viewportMetrics.systemGestureInsetLeft);
+        viewportMetrics.systemGestureInsetLeft,
+        viewportMetrics.physicalTouchSlop);
   }
 
   // TODO(mattcarroll): describe the native behavior that this invokes
@@ -372,6 +373,7 @@ public class FlutterRenderer implements TextureRegistry {
     public int systemGestureInsetRight = 0;
     public int systemGestureInsetBottom = 0;
     public int systemGestureInsetLeft = 0;
+    public int physicalTouchSlop = -1;
 
     /**
      * Whether this instance contains valid metrics for the Flutter application.

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -358,6 +358,11 @@ public class FlutterRenderer implements TextureRegistry {
    * pixels, not logical pixels.
    */
   public static final class ViewportMetrics {
+    /**
+     * A value that indicates the setting has not been set.
+     */
+    public static final int unsetValue = -1;
+
     public float devicePixelRatio = 1.0f;
     public int width = 0;
     public int height = 0;
@@ -373,7 +378,7 @@ public class FlutterRenderer implements TextureRegistry {
     public int systemGestureInsetRight = 0;
     public int systemGestureInsetBottom = 0;
     public int systemGestureInsetLeft = 0;
-    public int physicalTouchSlop = -1;
+    public int physicalTouchSlop = unsetValue;
 
     /**
      * Whether this instance contains valid metrics for the Flutter application.

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -27,6 +27,7 @@ import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.View;
+import android.view.ViewConfiguration;
 import android.view.ViewStructure;
 import android.view.WindowInsets;
 import android.view.WindowManager;
@@ -115,6 +116,7 @@ public class FlutterView extends SurfaceView
     int systemGestureInsetRight = 0;
     int systemGestureInsetBottom = 0;
     int systemGestureInsetLeft = 0;
+    int physicalTouchSlop = -1;
   }
 
   private final DartExecutor dartExecutor;
@@ -178,6 +180,7 @@ public class FlutterView extends SurfaceView
     mIsSoftwareRenderingEnabled = mNativeView.getFlutterJNI().getIsSoftwareRenderingEnabled();
     mMetrics = new ViewportMetrics();
     mMetrics.devicePixelRatio = context.getResources().getDisplayMetrics().density;
+    mMetrics.physicalTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
     setFocusable(true);
     setFocusableInTouchMode(true);
 
@@ -762,7 +765,8 @@ public class FlutterView extends SurfaceView
             mMetrics.systemGestureInsetTop,
             mMetrics.systemGestureInsetRight,
             mMetrics.systemGestureInsetBottom,
-            mMetrics.systemGestureInsetLeft);
+            mMetrics.systemGestureInsetLeft,
+            mMetrics.physicalTouchSlop);
   }
 
   // Called by FlutterNativeView to notify first Flutter frame rendered.

--- a/shell/platform/android/platform_view_android_jni_impl.cc
+++ b/shell/platform/android/platform_view_android_jni_impl.cc
@@ -276,7 +276,8 @@ static void SetViewportMetrics(JNIEnv* env,
                                jint systemGestureInsetTop,
                                jint systemGestureInsetRight,
                                jint systemGestureInsetBottom,
-                               jint systemGestureInsetLeft) {
+                               jint systemGestureInsetLeft,
+                               jint physicalTouchSlop) {
   const flutter::ViewportMetrics metrics{
       static_cast<double>(devicePixelRatio),
       static_cast<double>(physicalWidth),
@@ -293,6 +294,7 @@ static void SetViewportMetrics(JNIEnv* env,
       static_cast<double>(systemGestureInsetRight),
       static_cast<double>(systemGestureInsetBottom),
       static_cast<double>(systemGestureInsetLeft),
+      static_cast<double>(physicalTouchSlop),
   };
 
   ANDROID_SHELL_HOLDER->GetPlatformView()->SetViewportMetrics(metrics);
@@ -682,7 +684,7 @@ bool RegisterApi(JNIEnv* env) {
       },
       {
           .name = "nativeSetViewportMetrics",
-          .signature = "(JFIIIIIIIIIIIIII)V",
+          .signature = "(JFIIIIIIIIIIIIIII)V",
           .fnPtr = reinterpret_cast<void*>(&SetViewportMetrics),
       },
       {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -792,6 +792,22 @@ public class FlutterViewTest {
     assertEquals(null, flutterView.findViewByAccessibilityIdTraversal(accessibilityViewId));
   }
 
+  public void ViewportMetrics_initializedPhysicalTouchSlop() {
+    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
+    FlutterEngine flutterEngine =
+        spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
+    when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
+
+
+    flutterView.attachToFlutterEngine(flutterEngine);
+    ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
+        ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
+    verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
+
+    assertNotEquals(-1, viewportMetricsCaptor.getValue().physicalTouchSlop);
+  }
+
   /*
    * A custom shadow that reports fullscreen flag for system UI visibility
    */

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -805,7 +805,7 @@ public class FlutterViewTest {
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);
     verify(flutterRenderer).setViewportMetrics(viewportMetricsCaptor.capture());
 
-    assertNotEquals(-1, viewportMetricsCaptor.getValue().physicalTouchSlop);
+    assertFalse(-1 == viewportMetricsCaptor.getValue().physicalTouchSlop);
   }
 
   /*

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -799,7 +799,6 @@ public class FlutterViewTest {
     FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
     when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
 
-
     flutterView.attachToFlutterEngine(flutterEngine);
     ArgumentCaptor<FlutterRenderer.ViewportMetrics> viewportMetricsCaptor =
         ArgumentCaptor.forClass(FlutterRenderer.ViewportMetrics.class);

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformViewsControllerTest.java
@@ -850,7 +850,8 @@ public class PlatformViewsControllerTest {
         int systemGestureInsetTop,
         int systemGestureInsetRight,
         int systemGestureInsetBottom,
-        int systemGestureInsetLeft) {}
+        int systemGestureInsetLeft,
+        int physicalTouchSlop) {}
 
     @Implementation
     public void invokePlatformMessageResponseCallback(

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -417,7 +417,8 @@ void PlatformView::OnScenicEvent(
         0.0f,                           // p_physical_system_gesture_inset_top
         0.0f,                           // p_physical_system_gesture_inset_right
         0.0f,  // p_physical_system_gesture_inset_bottom
-        0.0f,  // p_physical_system_gesture_inset_left
+        0.0f,  // p_physical_system_gesture_inset_left,
+        -1.0,  // p_physical_touch_slop,
     });
   }
 }

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -588,9 +588,9 @@ TEST_F(PlatformViewTests, SetViewportMetrics) {
   session_listener->OnScenicEvent(std::move(events));
   RunLoopUntilIdle();
   EXPECT_EQ(delegate.metrics(),
-            flutter::ViewportMetrics(valid_pixel_ratio,
-                                     valid_pixel_ratio * valid_max_bound,
-                                     valid_pixel_ratio * valid_max_bound));
+            flutter::ViewportMetrics(
+                valid_pixel_ratio, valid_pixel_ratio * valid_max_bound,
+                valid_pixel_ratio * valid_max_bound, -1.0));
 }
 
 // This test makes sure that the PlatformView correctly registers semantics

--- a/testing/dart/BUILD.gn
+++ b/testing/dart/BUILD.gn
@@ -14,6 +14,7 @@ tests = [
   "dart_test.dart",
   "encoding_test.dart",
   "geometry_test.dart",
+  "gesture_settings_test.dart",
   "gradient_test.dart",
   "http_allow_http_connections_test.dart",
   "http_disallow_http_connections_test.dart",

--- a/testing/dart/gesture_settings_test.dart
+++ b/testing/dart/gesture_settings_test.dart
@@ -10,16 +10,15 @@ void main() {
   test('GestureSettings has a reasonable toString', () {
     const GestureSettings gestureSettings = GestureSettings(physicalDoubleTapSlop: 2.0, physicalTouchSlop: 1.0);
 
-    expect(gestureSettings.toString(), 'GestureSettings{physicalTouchSlop: 1.0, physicalDoubleTapSlop: 2.0}');
+    expect(gestureSettings.toString(), 'GestureSettings(physicalTouchSlop: 1.0, physicalDoubleTapSlop: 2.0)');
   });
 
   test('GestureSettings has a correct equality', () {
     // don't refactor these to be const, that defeats the point!
-    double value = 2.0;
+    final double value = nonconst(2.0);
     final GestureSettings settingsA = GestureSettings(physicalDoubleTapSlop: value, physicalTouchSlop: 1.0);
     final GestureSettings settingsB = GestureSettings(physicalDoubleTapSlop: value, physicalTouchSlop: 3.0);
     final GestureSettings settingsC = GestureSettings(physicalDoubleTapSlop: value, physicalTouchSlop: 1.0);
-    value++;
 
     expect(settingsA, equals(settingsC));
     expect(settingsC, equals(settingsA));
@@ -52,3 +51,7 @@ void main() {
     expect(settings.physicalTouchSlop, null);
   });
 }
+
+// Prevent the linter from complaining about a const value so that
+// non-identical equality can be tested.
+T nonconst<T>(T value) => value;

--- a/testing/dart/gesture_settings_test.dart
+++ b/testing/dart/gesture_settings_test.dart
@@ -1,0 +1,54 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:litetest/litetest.dart';
+
+void main() {
+  test('GestureSettings has a reasonable toString', () {
+    const GestureSettings gestureSettings = GestureSettings(physicalDoubleTapSlop: 2.0, physicalTouchSlop: 1.0);
+
+    expect(gestureSettings.toString(), '{physicalTouchSlop: 1.0, physicalDoubleTapSlop: 2.0}');
+  });
+
+  test('GestureSettings has a correct equality', () {
+    // don't refactor these to be const, that defeats the point!
+    double value = 2.0;
+    final GestureSettings settingsA = GestureSettings(physicalDoubleTapSlop: value, physicalTouchSlop: 1.0);
+    final GestureSettings settingsB = GestureSettings(physicalDoubleTapSlop: value, physicalTouchSlop: 3.0);
+    final GestureSettings settingsC = GestureSettings(physicalDoubleTapSlop: value, physicalTouchSlop: 1.0);
+    value++;
+
+    expect(settingsA, equals(settingsC));
+    expect(settingsC, equals(settingsA));
+
+    expect(settingsA, notEquals(settingsB));
+    expect(settingsC, notEquals(settingsB));
+
+    expect(settingsB, notEquals(settingsA));
+    expect(settingsB, notEquals(settingsC));
+  });
+
+  test('GestureSettings copyWith preserves already set values', () {
+    const GestureSettings initial = GestureSettings(physicalDoubleTapSlop: 1.0, physicalTouchSlop: 1.0);
+
+    final GestureSettings copyA = initial.copyWith();
+
+    expect(copyA.physicalDoubleTapSlop, 1.0);
+    expect(copyA.physicalTouchSlop, 1.0);
+
+    final GestureSettings copyB = copyA.copyWith(physicalDoubleTapSlop: 2.0, physicalTouchSlop: 2.0);
+
+    expect(copyB.physicalDoubleTapSlop, 2.0);
+    expect(copyB.physicalTouchSlop, 2.0);
+  });
+
+   test('GestureSettings constructor defaults to null', () {
+    const GestureSettings settings = GestureSettings();
+
+    expect(settings.physicalDoubleTapSlop, null);
+    expect(settings.physicalTouchSlop, null);
+  });
+}

--- a/testing/dart/gesture_settings_test.dart
+++ b/testing/dart/gesture_settings_test.dart
@@ -10,7 +10,7 @@ void main() {
   test('GestureSettings has a reasonable toString', () {
     const GestureSettings gestureSettings = GestureSettings(physicalDoubleTapSlop: 2.0, physicalTouchSlop: 1.0);
 
-    expect(gestureSettings.toString(), '{physicalTouchSlop: 1.0, physicalDoubleTapSlop: 2.0}');
+    expect(gestureSettings.toString(), 'GestureSettings{physicalTouchSlop: 1.0, physicalDoubleTapSlop: 2.0}');
   });
 
   test('GestureSettings has a correct equality', () {


### PR DESCRIPTION
Implements the engine side support for flutter/flutter#87322

Adds a new member to view configuration: GestureSettings. This should contain platform specified defaults/settings for common touch/gestures - for now only touch slop for android.

The intention is to use this to allow flutter to conform much more closely to the exact native behavior
