### PR TITLE
Allow iOS unit tests to run on Xcode 13

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -327,12 +327,11 @@ def AssertExpectedJavaVersion():
 
 
 def AssertExpectedXcodeVersion():
-  """Checks that the user has a recent version of Xcode installed"""
-  EXPECTED_MAJOR_VERSION = ['11', '12']
+  """Checks that the user has a version of Xcode installed"""
   version_output = subprocess.check_output(['xcodebuild', '-version'])
-  match = re.match("Xcode (\d+)", version_output)
+  match = re.match(b"Xcode (\d+)", version_output)
   message = "Xcode must be installed to run the iOS embedding unit tests"
-  assert match.group(1) in EXPECTED_MAJOR_VERSION, message
+  assert match, message
 
 
 def RunJavaTests(filter, android_variant='android_debug_unopt'):


### PR DESCRIPTION
1. Allow tests to run on Xcode 13 by remove any major version check, just make sure Xcode is installed.
2. Fix python3 `TypeError: cannot use a string pattern on a bytes-like object` error by matching the Regex by bytes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
