### PR TITLE
Specify string encoding in git revision

### DIFF
--- a/build/git_revision.py
+++ b/build/git_revision.py
@@ -27,7 +27,7 @@ def GetRepositoryVersion(repository):
     'HEAD',
   ])
 
-  return version.strip()
+  return str(version.strip(), 'utf-8')
 
 def main():
   parser = argparse.ArgumentParser()


### PR DESCRIPTION
This is the actual culprit of https://github.com/flutter/flutter/issues/87514.

With this change:
```
$ ./git_revision.py --repository ..
f2ff4c28e7aff8b3155d1557e81ddc20256c6ae2
```