### PR TITLE
Unskip iOS launch URL tests

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -25,9 +25,9 @@ FLUTTER_ASSERT_ARC
   FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
   OCMStub([engine navigationChannel]).andReturn(navigationChannel);
   OCMStub([viewController engine]).andReturn(engine);
-  // Set blockArg to a strong local to retain to end of scope.
-  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
-  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
+  // Set blockNoInvoker to a strong local to retain to end of scope.
+  id blockNoInvoker = [OCMArg invokeBlockWithArgs:@NO, nil];
+  OCMStub([engine waitForFirstFrame:3.0 callback:blockNoInvoker]);
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };
@@ -50,9 +50,9 @@ FLUTTER_ASSERT_ARC
   FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
   OCMStub([engine navigationChannel]).andReturn(navigationChannel);
   OCMStub([viewController engine]).andReturn(engine);
-  // Set blockArg to a strong local to retain to end of scope.
-  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
-  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
+  // Set blockNoInvoker to a strong local to retain to end of scope.
+  id blockNoInvoker = [OCMArg invokeBlockWithArgs:@NO, nil];
+  OCMStub([engine waitForFirstFrame:3.0 callback:blockNoInvoker]);
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };
@@ -76,9 +76,9 @@ FLUTTER_ASSERT_ARC
   FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
   OCMStub([engine navigationChannel]).andReturn(navigationChannel);
   OCMStub([viewController engine]).andReturn(engine);
-  // Set blockArg to a strong local to retain to end of scope.
-  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
-  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
+  // Set blockNoInvoker to a strong local to retain to end of scope.
+  id blockNoInvoker = [OCMArg invokeBlockWithArgs:@NO, nil];
+  OCMStub([engine waitForFirstFrame:3.0 callback:blockNoInvoker]);
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -18,15 +18,16 @@ FLUTTER_ASSERT_ARC
 
 @implementation FlutterAppDelegateTest
 
-// TODO(dnfield): https://github.com/flutter/flutter/issues/74267
-- (void)skip_testLaunchUrl {
+- (void)testLaunchUrl {
   FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
   FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
   FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
   FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
   OCMStub([engine navigationChannel]).andReturn(navigationChannel);
   OCMStub([viewController engine]).andReturn(engine);
-  OCMStub([engine waitForFirstFrame:3.0 callback:([OCMArg invokeBlockWithArgs:@(NO), nil])]);
+  // Set blockArg to a strong local to retain to end of scope.
+  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
+  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };
@@ -42,14 +43,16 @@ FLUTTER_ASSERT_ARC
   OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
 }
 
-- (void)skip_testLaunchUrlWithQueryParameterAndFragment {
+- (void)testLaunchUrlWithQueryParameterAndFragment {
   FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
   FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
   FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
   FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
   OCMStub([engine navigationChannel]).andReturn(navigationChannel);
   OCMStub([viewController engine]).andReturn(engine);
-  OCMStub([engine waitForFirstFrame:3.0 callback:([OCMArg invokeBlockWithArgs:@(NO), nil])]);
+  // Set blockArg to a strong local to retain to end of scope.
+  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
+  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };
@@ -66,14 +69,16 @@ FLUTTER_ASSERT_ARC
                                   arguments:@"/custom/route?query=test#fragment"]);
 }
 
-- (void)skip_testLaunchUrlWithFragmentNoQueryParameter {
+- (void)testLaunchUrlWithFragmentNoQueryParameter {
   FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
   FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
   FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
   FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
   OCMStub([engine navigationChannel]).andReturn(navigationChannel);
   OCMStub([viewController engine]).andReturn(engine);
-  OCMStub([engine waitForFirstFrame:3.0 callback:([OCMArg invokeBlockWithArgs:@(NO), nil])]);
+  // Set blockArg to a strong local to retain to end of scope.
+  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
+  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -44,11 +44,11 @@
 		0AC232F424BA71D300A85907 /* SemanticsObjectTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SemanticsObjectTest.mm; sourceTree = "<group>"; };
 		0AC232F724BA71D300A85907 /* FlutterEngineTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterEngineTest.mm; sourceTree = "<group>"; };
 		0AC2330324BA71D300A85907 /* accessibility_bridge_test.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = accessibility_bridge_test.mm; sourceTree = "<group>"; };
-		0AC2330B24BA71D300A85907 /* FlutterTextInputPluginTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FlutterTextInputPluginTest.m; sourceTree = "<group>"; };
+		0AC2330B24BA71D300A85907 /* FlutterTextInputPluginTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterTextInputPluginTest.mm; sourceTree = "<group>"; };
 		0AC2330F24BA71D300A85907 /* FlutterBinaryMessengerRelayTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterBinaryMessengerRelayTest.mm; sourceTree = "<group>"; };
 		0AC2331024BA71D300A85907 /* connection_collection_test.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = connection_collection_test.mm; sourceTree = "<group>"; };
 		0AC2331224BA71D300A85907 /* FlutterEnginePlatformViewTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterEnginePlatformViewTest.mm; sourceTree = "<group>"; };
-		0AC2331924BA71D300A85907 /* FlutterPluginAppLifeCycleDelegateTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FlutterPluginAppLifeCycleDelegateTest.m; sourceTree = "<group>"; };
+		0AC2331924BA71D300A85907 /* FlutterPluginAppLifeCycleDelegateTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterPluginAppLifeCycleDelegateTest.mm; sourceTree = "<group>"; };
 		0AC2332124BA71D300A85907 /* FlutterViewControllerTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterViewControllerTest.mm; sourceTree = "<group>"; };
 		0D1CE5D7233430F400E5D880 /* FlutterChannelsTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FlutterChannelsTest.m; sourceTree = "<group>"; };
 		0D6AB6B122BB05E100EEE540 /* IosUnitTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IosUnitTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -90,11 +90,11 @@
 				0AC232F424BA71D300A85907 /* SemanticsObjectTest.mm */,
 				0AC232F724BA71D300A85907 /* FlutterEngineTest.mm */,
 				0AC2330324BA71D300A85907 /* accessibility_bridge_test.mm */,
-				0AC2330B24BA71D300A85907 /* FlutterTextInputPluginTest.m */,
+				0AC2330B24BA71D300A85907 /* FlutterTextInputPluginTest.mm */,
 				0AC2330F24BA71D300A85907 /* FlutterBinaryMessengerRelayTest.mm */,
 				0AC2331024BA71D300A85907 /* connection_collection_test.mm */,
 				0AC2331224BA71D300A85907 /* FlutterEnginePlatformViewTest.mm */,
-				0AC2331924BA71D300A85907 /* FlutterPluginAppLifeCycleDelegateTest.m */,
+				0AC2331924BA71D300A85907 /* FlutterPluginAppLifeCycleDelegateTest.mm */,
 				0AC2332124BA71D300A85907 /* FlutterViewControllerTest.mm */,
 			);
 			name = Source;
@@ -209,8 +209,8 @@
 		0D6AB6A922BB05E100EEE540 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
-				ORGANIZATIONNAME = "Aaron Clarke";
+				LastUpgradeCheck = 1300;
+				ORGANIZATIONNAME = "The Flutter Authors";
 				TargetAttributes = {
 					0D6AB6B022BB05E100EEE540 = {
 						CreatedOnToolsVersion = 10.2.1;

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/xcshareddata/xcschemes/IosUnitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
https://github.com/flutter/engine/pull/27777 turned these back on, but they were failing with the log:
```
IosUnitTests[2454:799223] *** -[OCMBlockArgCaller isProxy]: message sent to deallocated instance 0x600000e3c720
```
The dealloced instance was the block passed into the `-[FlutterEngine waitForFirstFrame::]` stub.  Pull it into a strong local to retain it until the end of scope (the test uses ARC).  

Minor Xcode project file cleanup.

Fixes https://github.com/flutter/flutter/issues/74267

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
