### PR TITLE
Allow collapsed compositing range

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -722,7 +722,7 @@ public class TextInputChannel {
       }
 
       if ((composingStart != -1 || composingEnd != -1)
-          && (composingStart < 0 || composingStart >= composingEnd)) {
+          && (composingStart < 0 || composingStart > composingEnd)) {
         throw new IndexOutOfBoundsException(
             "invalid composing range: ("
                 + String.valueOf(composingStart)

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -429,8 +429,6 @@ public class TextInputPluginTest {
     assertThrows(IndexOutOfBoundsException.class, () -> new TextEditState("Text", 0, 0, -1, -9));
     assertThrows(IndexOutOfBoundsException.class, () -> new TextEditState("Text", 0, 0, -9, -9));
     assertThrows(IndexOutOfBoundsException.class, () -> new TextEditState("Text", 0, 0, 2, 1));
-    // A collapsed composing range is invalid.
-    assertThrows(IndexOutOfBoundsException.class, () -> new TextEditState("Text", 0, 0, 1, 1));
 
     // Valid values (does not throw):
     // Nothing selected/composing:
@@ -448,6 +446,13 @@ public class TextInputPluginTest {
     state = new TextEditState("REEEE", 4, 2, -1, -1);
     assertEquals(4, state.selectionStart);
     assertEquals(2, state.selectionEnd);
+    // A collapsed selection and composing range.
+    state = new TextEditState("text", 0, 0, 0, 0);
+    assertEquals("text", state.text);
+    assertEquals(0, state.selectionStart);
+    assertEquals(0, state.selectionEnd);
+    assertEquals(0, state.composingStart);
+    assertEquals(0, state.composingEnd);
   }
 
   @Test


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/87017

@LongCatIsLooong this was considered an invalid state in https://github.com/blasten/engine/commit/778eb844d48f3902223a61dd02a6f994e564b586.  
Is this a requirement of the framework? 

As far as Android is concerned, collapsed compositing ranges are allowed.