### PR TITLE
Support iOS universal links route deep linking

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -132,17 +132,11 @@ static NSString* const kRestorationStateAppModificationKey = @"mod-date";
   }
 }
 
-static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
-  NSNumber* isEnabled = [infoDictionary objectForKey:@"FlutterDeepLinkingEnabled"];
-  if (isEnabled) {
-    return [isEnabled boolValue];
-  } else {
-    return NO;
-  }
-}
-
-- (BOOL)openURL:(NSURL*)url infoPlistGetter:(NSDictionary* (^)())infoPlistGetter {
-  if (!IsDeepLinkingEnabled(infoPlistGetter())) {
+- (BOOL)openURL:(NSURL*)url {
+  NSNumber* isDeepLinkingEnabled =
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"];
+  if (!isDeepLinkingEnabled.boolValue) {
+    // Not set or NO.
     return NO;
   } else {
     FlutterViewController* flutterViewController = [self rootFlutterViewController];
@@ -179,10 +173,7 @@ static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
   if ([_lifeCycleDelegate application:application openURL:url options:options]) {
     return YES;
   }
-  return [self openURL:url
-       infoPlistGetter:^NSDictionary*() {
-         return [[NSBundle mainBundle] infoDictionary];
-       }];
+  return [self openURL:url];
 }
 
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {
@@ -233,10 +224,7 @@ static BOOL IsDeepLinkingEnabled(NSDictionary* infoDictionary) {
   if (userActivity.activityType == NSUserActivityTypeBrowsingWeb) {
     return NO;
   }
-  return [self openURL:userActivity.webpageURL
-       infoPlistGetter:^NSDictionary*() {
-         return [[NSBundle mainBundle] infoDictionary];
-       }];
+  return [self openURL:userActivity.webpageURL];
 }
 
 #pragma mark - FlutterPluginRegistry methods. All delegating to the rootViewController

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -221,9 +221,6 @@ static NSString* const kRestorationStateAppModificationKey = @"mod-date";
                    restorationHandler:restorationHandler]) {
     return YES;
   }
-  if (userActivity.activityType == NSUserActivityTypeBrowsingWeb) {
-    return NO;
-  }
   return [self openURL:userActivity.webpageURL];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -32,13 +32,10 @@ FLUTTER_ASSERT_ARC
     return viewController;
   };
   NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
-  NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
-  BOOL result = [appDelegate application:[UIApplication sharedApplication]
-                                 openURL:url
-                                 options:options
-                         infoPlistGetter:^NSDictionary*() {
-                           return @{@"FlutterDeepLinkingEnabled" : @(YES)};
-                         }];
+  BOOL result = [appDelegate openURL:url
+                     infoPlistGetter:^NSDictionary*() {
+                       return @{@"FlutterDeepLinkingEnabled" : @YES};
+                     }];
   XCTAssertTrue(result);
   OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
 }
@@ -57,13 +54,10 @@ FLUTTER_ASSERT_ARC
     return viewController;
   };
   NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test#fragment"];
-  NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
-  BOOL result = [appDelegate application:[UIApplication sharedApplication]
-                                 openURL:url
-                                 options:options
-                         infoPlistGetter:^NSDictionary*() {
-                           return @{@"FlutterDeepLinkingEnabled" : @(YES)};
-                         }];
+  BOOL result = [appDelegate openURL:url
+                     infoPlistGetter:^NSDictionary*() {
+                       return @{@"FlutterDeepLinkingEnabled" : @YES};
+                     }];
   XCTAssertTrue(result);
   OCMVerify([navigationChannel invokeMethod:@"pushRoute"
                                   arguments:@"/custom/route?query=test#fragment"]);
@@ -83,15 +77,69 @@ FLUTTER_ASSERT_ARC
     return viewController;
   };
   NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route#fragment"];
-  NSDictionary<UIApplicationOpenURLOptionsKey, id>* options = @{};
-  BOOL result = [appDelegate application:[UIApplication sharedApplication]
-                                 openURL:url
-                                 options:options
-                         infoPlistGetter:^NSDictionary*() {
-                           return @{@"FlutterDeepLinkingEnabled" : @(YES)};
-                         }];
+  BOOL result = [appDelegate openURL:url
+                     infoPlistGetter:^NSDictionary*() {
+                       return @{@"FlutterDeepLinkingEnabled" : @YES};
+                     }];
   XCTAssertTrue(result);
   OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route#fragment"]);
+}
+
+#pragma mark - Deep linking
+
+- (void)testUniversalLinkWebBrowserUrl {
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
+  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
+  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
+  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
+  OCMStub([viewController engine]).andReturn(engine);
+  // Set blockArg to a strong local to retain to end of scope.
+  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
+  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
+  appDelegate.rootFlutterViewControllerGetter = ^{
+    return viewController;
+  };
+  NSUserActivity* userActivity =
+      [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
+  userActivity.webpageURL = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
+  BOOL result = [appDelegate
+               application:[UIApplication sharedApplication]
+      continueUserActivity:userActivity
+        restorationHandler:^(NSArray<id<UIUserActivityRestoring>>* __nullable restorableObjects){
+        }];
+  XCTAssertFalse(result);
+  OCMReject([navigationChannel invokeMethod:OCMOCK_ANY arguments:OCMOCK_ANY]);
+}
+
+- (void)testUniversalLinkPushRoute {
+  id mockBundle = OCMClassMock([NSBundle class]);
+  OCMStub([mockBundle mainBundle]).andReturn(mockBundle);
+  OCMStub([mockBundle infoDictionary]).andReturn(@{@"FlutterDeepLinkingEnabled" : @YES});
+
+  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
+  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
+  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
+  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
+  OCMStub([viewController engine]).andReturn(engine);
+  // Set blockArg to a strong local to retain to end of scope.
+  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
+  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
+  appDelegate.rootFlutterViewControllerGetter = ^{
+    return viewController;
+  };
+  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
+  NSUserActivity* userActivity = [[NSUserActivity alloc] initWithActivityType:@"com.example.test"];
+  userActivity.webpageURL = url;
+  BOOL result = [appDelegate
+               application:[UIApplication sharedApplication]
+      continueUserActivity:userActivity
+        restorationHandler:^(NSArray<id<UIUserActivityRestoring>>* __nullable restorableObjects){
+        }];
+  XCTAssertTrue(result);
+  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
+  [mockBundle stopMocking];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -123,22 +123,6 @@ FLUTTER_ASSERT_ARC
 
 #pragma mark - Deep linking
 
-- (void)testUniversalLinkWebBrowserUrl {
-  OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
-      .andReturn(@YES);
-
-  NSUserActivity* userActivity =
-      [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
-  userActivity.webpageURL = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
-  BOOL result = [self.appDelegate
-               application:[UIApplication sharedApplication]
-      continueUserActivity:userActivity
-        restorationHandler:^(NSArray<id<UIUserActivityRestoring>>* __nullable restorableObjects){
-        }];
-  XCTAssertFalse(result);
-  OCMReject([self.mockNavigationChannel invokeMethod:OCMOCK_ANY arguments:OCMOCK_ANY]);
-}
-
 - (void)testUniversalLinkPushRoute {
   OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
       .andReturn(@YES);

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegateTest.mm
@@ -14,132 +14,145 @@
 FLUTTER_ASSERT_ARC
 
 @interface FlutterAppDelegateTest : XCTestCase
+@property(strong) FlutterAppDelegate* appDelegate;
+
+@property(strong) id mockMainBundle;
+@property(strong) id mockNavigationChannel;
+
+// Retain callback until the tests are done.
+// https://github.com/flutter/flutter/issues/74267
+@property(strong) id mockEngineFirstFrameCallback;
 @end
 
 @implementation FlutterAppDelegateTest
 
-- (void)testLaunchUrl {
+- (void)setUp {
+  [super setUp];
+
+  id mockMainBundle = OCMClassMock([NSBundle class]);
+  OCMStub([mockMainBundle mainBundle]).andReturn(mockMainBundle);
+  self.mockMainBundle = mockMainBundle;
+
   FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
+  self.appDelegate = appDelegate;
+
   FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
-  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
   FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
+  self.mockNavigationChannel = navigationChannel;
+
+  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
   OCMStub([engine navigationChannel]).andReturn(navigationChannel);
   OCMStub([viewController engine]).andReturn(engine);
-  // Set blockNoInvoker to a strong local to retain to end of scope.
-  id blockNoInvoker = [OCMArg invokeBlockWithArgs:@NO, nil];
-  OCMStub([engine waitForFirstFrame:3.0 callback:blockNoInvoker]);
+
+  id mockEngineFirstFrameCallback = [OCMArg invokeBlockWithArgs:@NO, nil];
+  self.mockEngineFirstFrameCallback = mockEngineFirstFrameCallback;
+  OCMStub([engine waitForFirstFrame:3.0 callback:mockEngineFirstFrameCallback]);
   appDelegate.rootFlutterViewControllerGetter = ^{
     return viewController;
   };
-  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
-  BOOL result = [appDelegate openURL:url
-                     infoPlistGetter:^NSDictionary*() {
-                       return @{@"FlutterDeepLinkingEnabled" : @YES};
-                     }];
+}
+
+- (void)tearDown {
+  // Explicitly stop mocking the NSBundle class property.
+  [self.mockMainBundle stopMocking];
+  [super tearDown];
+}
+
+- (void)testLaunchUrl {
+  OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
+      .andReturn(@YES);
+
+  BOOL result =
+      [self.appDelegate application:[UIApplication sharedApplication]
+                            openURL:[NSURL URLWithString:@"http://myApp/custom/route?query=test"]
+                            options:@{}];
   XCTAssertTrue(result);
-  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
+  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
+                                           arguments:@"/custom/route?query=test"]);
+}
+
+- (void)testLaunchUrlWithDeepLinkingNotSet {
+  OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
+      .andReturn(nil);
+
+  BOOL result =
+      [self.appDelegate application:[UIApplication sharedApplication]
+                            openURL:[NSURL URLWithString:@"http://myApp/custom/route?query=test"]
+                            options:@{}];
+  XCTAssertFalse(result);
+  OCMReject([self.mockNavigationChannel invokeMethod:OCMOCK_ANY arguments:OCMOCK_ANY]);
+}
+
+- (void)testLaunchUrlWithDeepLinkingDisabled {
+  OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
+      .andReturn(@NO);
+
+  BOOL result =
+      [self.appDelegate application:[UIApplication sharedApplication]
+                            openURL:[NSURL URLWithString:@"http://myApp/custom/route?query=test"]
+                            options:@{}];
+  XCTAssertFalse(result);
+  OCMReject([self.mockNavigationChannel invokeMethod:OCMOCK_ANY arguments:OCMOCK_ANY]);
 }
 
 - (void)testLaunchUrlWithQueryParameterAndFragment {
-  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
-  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
-  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
-  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
-  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
-  OCMStub([viewController engine]).andReturn(engine);
-  // Set blockNoInvoker to a strong local to retain to end of scope.
-  id blockNoInvoker = [OCMArg invokeBlockWithArgs:@NO, nil];
-  OCMStub([engine waitForFirstFrame:3.0 callback:blockNoInvoker]);
-  appDelegate.rootFlutterViewControllerGetter = ^{
-    return viewController;
-  };
-  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test#fragment"];
-  BOOL result = [appDelegate openURL:url
-                     infoPlistGetter:^NSDictionary*() {
-                       return @{@"FlutterDeepLinkingEnabled" : @YES};
-                     }];
+  OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
+      .andReturn(@YES);
+
+  BOOL result = [self.appDelegate
+      application:[UIApplication sharedApplication]
+          openURL:[NSURL URLWithString:@"http://myApp/custom/route?query=test#fragment"]
+          options:@{}];
   XCTAssertTrue(result);
-  OCMVerify([navigationChannel invokeMethod:@"pushRoute"
-                                  arguments:@"/custom/route?query=test#fragment"]);
+  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
+                                           arguments:@"/custom/route?query=test#fragment"]);
 }
 
 - (void)testLaunchUrlWithFragmentNoQueryParameter {
-  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
-  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
-  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
-  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
-  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
-  OCMStub([viewController engine]).andReturn(engine);
-  // Set blockNoInvoker to a strong local to retain to end of scope.
-  id blockNoInvoker = [OCMArg invokeBlockWithArgs:@NO, nil];
-  OCMStub([engine waitForFirstFrame:3.0 callback:blockNoInvoker]);
-  appDelegate.rootFlutterViewControllerGetter = ^{
-    return viewController;
-  };
-  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route#fragment"];
-  BOOL result = [appDelegate openURL:url
-                     infoPlistGetter:^NSDictionary*() {
-                       return @{@"FlutterDeepLinkingEnabled" : @YES};
-                     }];
+  OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
+      .andReturn(@YES);
+
+  BOOL result =
+      [self.appDelegate application:[UIApplication sharedApplication]
+                            openURL:[NSURL URLWithString:@"http://myApp/custom/route#fragment"]
+                            options:@{}];
   XCTAssertTrue(result);
-  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route#fragment"]);
+  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
+                                           arguments:@"/custom/route#fragment"]);
 }
 
 #pragma mark - Deep linking
 
 - (void)testUniversalLinkWebBrowserUrl {
-  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
-  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
-  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
-  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
-  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
-  OCMStub([viewController engine]).andReturn(engine);
-  // Set blockArg to a strong local to retain to end of scope.
-  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
-  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
-  appDelegate.rootFlutterViewControllerGetter = ^{
-    return viewController;
-  };
+  OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
+      .andReturn(@YES);
+
   NSUserActivity* userActivity =
       [[NSUserActivity alloc] initWithActivityType:NSUserActivityTypeBrowsingWeb];
   userActivity.webpageURL = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
-  BOOL result = [appDelegate
+  BOOL result = [self.appDelegate
                application:[UIApplication sharedApplication]
       continueUserActivity:userActivity
         restorationHandler:^(NSArray<id<UIUserActivityRestoring>>* __nullable restorableObjects){
         }];
   XCTAssertFalse(result);
-  OCMReject([navigationChannel invokeMethod:OCMOCK_ANY arguments:OCMOCK_ANY]);
+  OCMReject([self.mockNavigationChannel invokeMethod:OCMOCK_ANY arguments:OCMOCK_ANY]);
 }
 
 - (void)testUniversalLinkPushRoute {
-  id mockBundle = OCMClassMock([NSBundle class]);
-  OCMStub([mockBundle mainBundle]).andReturn(mockBundle);
-  OCMStub([mockBundle infoDictionary]).andReturn(@{@"FlutterDeepLinkingEnabled" : @YES});
+  OCMStub([self.mockMainBundle objectForInfoDictionaryKey:@"FlutterDeepLinkingEnabled"])
+      .andReturn(@YES);
 
-  FlutterAppDelegate* appDelegate = [[FlutterAppDelegate alloc] init];
-  FlutterViewController* viewController = OCMClassMock([FlutterViewController class]);
-  FlutterEngine* engine = OCMClassMock([FlutterEngine class]);
-  FlutterMethodChannel* navigationChannel = OCMClassMock([FlutterMethodChannel class]);
-  OCMStub([engine navigationChannel]).andReturn(navigationChannel);
-  OCMStub([viewController engine]).andReturn(engine);
-  // Set blockArg to a strong local to retain to end of scope.
-  id blockArg = [OCMArg invokeBlockWithArgs:@NO, nil];
-  OCMStub([engine waitForFirstFrame:3.0 callback:blockArg]);
-  appDelegate.rootFlutterViewControllerGetter = ^{
-    return viewController;
-  };
-  NSURL* url = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
   NSUserActivity* userActivity = [[NSUserActivity alloc] initWithActivityType:@"com.example.test"];
-  userActivity.webpageURL = url;
-  BOOL result = [appDelegate
+  userActivity.webpageURL = [NSURL URLWithString:@"http://myApp/custom/route?query=test"];
+  BOOL result = [self.appDelegate
                application:[UIApplication sharedApplication]
       continueUserActivity:userActivity
         restorationHandler:^(NSArray<id<UIUserActivityRestoring>>* __nullable restorableObjects){
         }];
   XCTAssertTrue(result);
-  OCMVerify([navigationChannel invokeMethod:@"pushRoute" arguments:@"/custom/route?query=test"]);
-  [mockBundle stopMocking];
+  OCMVerify([self.mockNavigationChannel invokeMethod:@"pushRoute"
+                                           arguments:@"/custom/route?query=test"]);
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
@@ -7,9 +7,6 @@
 @interface FlutterAppDelegate (Test)
 @property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
 
-- (BOOL)application:(UIApplication*)application
-            openURL:(NSURL*)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options
-    infoPlistGetter:(NSDictionary* (^)())infoPlistGetter;
+- (BOOL)openURL:(NSURL*)url infoPlistGetter:(NSDictionary* (^)())infoPlistGetter;
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate_Test.h
@@ -7,6 +7,4 @@
 @interface FlutterAppDelegate (Test)
 @property(nonatomic, copy) FlutterViewController* (^rootFlutterViewControllerGetter)(void);
 
-- (BOOL)openURL:(NSURL*)url infoPlistGetter:(NSDictionary* (^)())infoPlistGetter;
-
 @end

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FlutterEngineConfig.xcconfig; sourceTree = "<group>"; };
 		F7521D7226BB671E005F15C5 /* libios_test_flutter.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libios_test_flutter.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libios_test_flutter.dylib"; sourceTree = "<group>"; };
 		F7521D7526BB673E005F15C5 /* libocmock_shared.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libocmock_shared.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libocmock_shared.dylib"; sourceTree = "<group>"; };
+		F7A3FDE026B9E0A300EADD61 /* FlutterAppDelegateTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterAppDelegateTest.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,6 +94,7 @@
 		0AC232E924BA71D300A85907 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				F7A3FDE026B9E0A300EADD61 /* FlutterAppDelegateTest.mm */,
 				0AC232F424BA71D300A85907 /* SemanticsObjectTest.mm */,
 				0AC232F724BA71D300A85907 /* FlutterEngineTest.mm */,
 				0AC2330324BA71D300A85907 /* accessibility_bridge_test.mm */,


### PR DESCRIPTION
Support deep linking/route pushing via [universal links](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html), which are registered `http` and `https` scheme URLs, in addition to the [already-supported custom schemes](https://flutter.dev/docs/development/ui/navigation/deep-linking#enable-deep-linking-on-ios).

If the URL isn't handled by the life cycle delegate, and isn't from web browsing, send `pushRoute` to the app.
Share the open link/routing logic between `-application:continueUserActivity:restorationHandler:` and `-application:openURL:options:`.

Fixes https://github.com/flutter/flutter/issues/82550

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
