### PR TITLE
Fix wrong EGL value in AndroidEnvironmentGL

### DIFF
--- a/shell/platform/android/android_environment_gl.cc
+++ b/shell/platform/android/android_environment_gl.cc
@@ -24,7 +24,7 @@ AndroidEnvironmentGL::AndroidEnvironmentGL()
 }
 
 AndroidEnvironmentGL::~AndroidEnvironmentGL() {
-  // Diconnect the display if valid.
+  // Disconnect the display if valid.
   if (display_ != EGL_NO_DISPLAY) {
     eglTerminate(display_);
   }

--- a/shell/platform/android/android_environment_gl.cc
+++ b/shell/platform/android/android_environment_gl.cc
@@ -25,7 +25,7 @@ AndroidEnvironmentGL::AndroidEnvironmentGL()
 
 AndroidEnvironmentGL::~AndroidEnvironmentGL() {
   // Diconnect the display if valid.
-  if (display_ != EGL_NO_CONTEXT) {
+  if (display_ != EGL_NO_DISPLAY) {
     eglTerminate(display_);
   }
 }


### PR DESCRIPTION
Fix a wrong EGL value: EGL_NO_DISPLAY should be used here instead of EGL_NO_CONTEXT.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

