### PR TITLE
Prevent a race between SurfaceTexture.release and attachToGLContext

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/SurfaceTextureWrapper.java
@@ -52,7 +52,11 @@ public class SurfaceTextureWrapper {
   // Called by native.
   @SuppressWarnings("unused")
   public void attachToGLContext(int texName) {
-    surfaceTexture.attachToGLContext(texName);
+    synchronized (this) {
+      if (!released) {
+        surfaceTexture.attachToGLContext(texName);
+      }
+    }
   }
 
   // Called by native.


### PR DESCRIPTION
SurfaceTexture.release is called on the platform thread, but attachToGLContext is called on the raster thread. An attachToGLContext call that happens after the texture is released will fail.

related pr:
https://github.com/flutter/engine/pull/21777 

related issue : 
https://github.com/flutter/flutter/issues/87635

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

about test：
According to @jason-simmons said at review of https://github.com/flutter/engine/pull/21777 .
SurfaceTextureWrapper doesn't contain any logic - it just forwards calls to SurfaceTexture with synchronization on the method called on the raster thread. The overall Java/JNI interaction will be verified by end-to-end tests.


