### PR TITLE
Allow android embedding to set frame rate more than once

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -214,15 +214,8 @@ public class FlutterJNI {
   }
 
   public static void setRefreshRateFPS(float refreshRateFPS) {
-    if (FlutterJNI.setRefreshRateFPSCalled) {
-      Log.w(TAG, "FlutterJNI.setRefreshRateFPS called more than once");
-    }
-
     FlutterJNI.refreshRateFPS = refreshRateFPS;
-    FlutterJNI.setRefreshRateFPSCalled = true;
   }
-
-  private static boolean setRefreshRateFPSCalled = false;
 
   // TODO(mattcarroll): add javadocs
   public static void setAsyncWaitForVsyncDelegate(@Nullable AsyncWaitForVsyncDelegate delegate) {

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -34,10 +34,10 @@ public class VsyncWaiter {
                     @Override
                     public void doFrame(long frameTimeNanos) {
                       float fps = windowManager.getDefaultDisplay().getRefreshRate();
-                      if (fps != lastFps) [
+                      if (fps != lastFps) {
                         lastFps = fps;
                         FlutterJNI.setRefreshRateFPS(fps);
-                      ]
+                      }
                       long refreshPeriodNanos = (long) (1000000000.0 / fps);
                       FlutterJNI.nativeOnVsync(
                           frameTimeNanos, frameTimeNanos + refreshPeriodNanos, cookie);

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -53,8 +53,8 @@ public class VsyncWaiter {
   public void init() {
     FlutterJNI.setAsyncWaitForVsyncDelegate(asyncWaitForVsyncDelegate);
 
-    lastFps = fps;
     float fps = windowManager.getDefaultDisplay().getRefreshRate();
+    lastFps = fps;
     FlutterJNI.setRefreshRateFPS(fps);
   }
 }

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -12,6 +12,7 @@ import io.flutter.embedding.engine.FlutterJNI;
 // TODO(mattcarroll): add javadoc.
 public class VsyncWaiter {
   private static VsyncWaiter instance;
+  private float lastFps;
 
   @NonNull
   public static VsyncWaiter getInstance(@NonNull WindowManager windowManager) {
@@ -33,6 +34,10 @@ public class VsyncWaiter {
                     @Override
                     public void doFrame(long frameTimeNanos) {
                       float fps = windowManager.getDefaultDisplay().getRefreshRate();
+                      if (fps != lastFps) [
+                        lastFps = fps;
+                        FlutterJNI.setRefreshRateFPS(fps);
+                      ]
                       long refreshPeriodNanos = (long) (1000000000.0 / fps);
                       FlutterJNI.nativeOnVsync(
                           frameTimeNanos, frameTimeNanos + refreshPeriodNanos, cookie);
@@ -48,7 +53,7 @@ public class VsyncWaiter {
   public void init() {
     FlutterJNI.setAsyncWaitForVsyncDelegate(asyncWaitForVsyncDelegate);
 
-    // TODO(mattcarroll): look into moving FPS reporting to a plugin
+    lastFps = fps;
     float fps = windowManager.getDefaultDisplay().getRefreshRate();
     FlutterJNI.setRefreshRateFPS(fps);
   }


### PR DESCRIPTION
Sometimes devtools reports 60fps for my pixel device. perhaps we get a different framerate query sometimes?
