### PR TITLE
fuchsia: Fix thread names + add test

### DIFF
--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -21,6 +21,10 @@ shell_gpu_configuration("fuchsia_gpu_configuration") {
   enable_metal = false
 }
 
+config("runner_base_config") {
+  defines = [ "FML_USED_ON_EMBEDDER" ]
+}
+
 config("runner_debug_config") {
   defines = [ "DEBUG" ]  # Needed due to direct dart dependencies.
 }
@@ -36,7 +40,7 @@ config("runner_product_config") {
 template("runner_sources") {
   assert(defined(invoker.product), "runner_sources must define product")
 
-  runner_configs = []
+  runner_configs = [ ":runner_base_config" ]
   if (is_debug) {
     runner_configs += [ ":runner_debug_config" ]
   }

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define FML_USED_ON_EMBEDDER
-
 #include "component.h"
 
 #include <dlfcn.h>

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define FML_USED_ON_EMBEDDER
-
 #include "engine.h"
 
 #include <lib/async/cpp/task.h>
@@ -43,6 +41,13 @@ std::unique_ptr<flutter::PlatformMessage> MakeLocalizationPlatformMessage(
 
 }  // namespace
 
+flutter::ThreadHost Engine::CreateThreadHost(const std::string& name_prefix) {
+  fml::Thread::SetCurrentThreadName(name_prefix + ".platform");
+  return flutter::ThreadHost(name_prefix, flutter::ThreadHost::Type::RASTER |
+                                              flutter::ThreadHost::Type::UI |
+                                              flutter::ThreadHost::Type::IO);
+}
+
 Engine::Engine(Delegate& delegate,
                std::string thread_label,
                std::shared_ptr<sys::ServiceDirectory> svc,
@@ -55,10 +60,7 @@ Engine::Engine(Delegate& delegate,
                FlutterRunnerProductConfiguration product_config)
     : delegate_(delegate),
       thread_label_(std::move(thread_label)),
-      thread_host_(thread_label_ + ".",
-                   flutter::ThreadHost::Type::RASTER |
-                       flutter::ThreadHost::Type::UI |
-                       flutter::ThreadHost::Type::IO),
+      thread_host_(CreateThreadHost(thread_label_)),
       intercept_all_input_(product_config.get_intercept_all_input()),
       weak_factory_(this) {
   // Get the task runners from the managed threads. The current thread will be

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -45,6 +45,8 @@ class Engine final {
     virtual void OnEngineTerminate(const Engine* holder) = 0;
   };
 
+  static flutter::ThreadHost CreateThreadHost(const std::string& name_prefix);
+
   Engine(Delegate& delegate,
          std::string thread_label,
          std::shared_ptr<sys::ServiceDirectory> svc,

--- a/shell/platform/fuchsia/flutter/main.cc
+++ b/shell/platform/fuchsia/flutter/main.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define FML_USED_ON_EMBEDDER
-
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/sys/inspect/cpp/component.h>
 #include <lib/trace-provider/provider.h>

--- a/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
+++ b/shell/platform/fuchsia/flutter/tests/engine_unittests.cc
@@ -12,6 +12,7 @@
 #include "flutter/fml/message_loop_impl.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/shell/common/serialization_callbacks.h"
+#include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/platform/fuchsia/flutter/gfx_session_connection.h"
 #include "flutter/shell/platform/fuchsia/flutter/logging.h"
 #include "flutter/shell/platform/fuchsia/flutter/runner.h"
@@ -25,6 +26,13 @@ using namespace flutter;
 
 namespace flutter_runner {
 namespace testing {
+namespace {
+
+std::string GetCurrentTestName() {
+  return ::testing::UnitTest::GetInstance()->current_test_info()->name();
+}
+
+}  // namespace
 
 class MockTaskRunner : public fml::BasicTaskRunner {
  public:
@@ -82,6 +90,41 @@ class EngineTest : public ::testing::Test {
   fuchsia::ui::scenic::ScenicPtr scenic_;
   std::optional<scenic::Session> session_;
 };
+
+TEST_F(EngineTest, ThreadNames) {
+  std::string prefix = GetCurrentTestName();
+  flutter::ThreadHost engine_thread_host = Engine::CreateThreadHost(prefix);
+
+  char thread_name[ZX_MAX_NAME_LEN];
+  zx::thread::self()->get_property(ZX_PROP_NAME, thread_name,
+                                   sizeof(thread_name));
+  EXPECT_EQ(std::string(thread_name), prefix + std::string(".platform"));
+  EXPECT_EQ(engine_thread_host.platform_thread, nullptr);
+
+  engine_thread_host.raster_thread->GetTaskRunner()->PostTask([&prefix]() {
+    char thread_name[ZX_MAX_NAME_LEN];
+    zx::thread::self()->get_property(ZX_PROP_NAME, thread_name,
+                                     sizeof(thread_name));
+    EXPECT_EQ(std::string(thread_name), prefix + std::string(".raster"));
+  });
+  engine_thread_host.raster_thread->Join();
+
+  engine_thread_host.ui_thread->GetTaskRunner()->PostTask([&prefix]() {
+    char thread_name[ZX_MAX_NAME_LEN];
+    zx::thread::self()->get_property(ZX_PROP_NAME, thread_name,
+                                     sizeof(thread_name));
+    EXPECT_EQ(std::string(thread_name), prefix + std::string(".ui"));
+  });
+  engine_thread_host.ui_thread->Join();
+
+  engine_thread_host.io_thread->GetTaskRunner()->PostTask([&prefix]() {
+    char thread_name[ZX_MAX_NAME_LEN];
+    zx::thread::self()->get_property(ZX_PROP_NAME, thread_name,
+                                     sizeof(thread_name));
+    EXPECT_EQ(std::string(thread_name), prefix + std::string(".io"));
+  });
+  engine_thread_host.io_thread->Join();
+}
 
 TEST_F(EngineTest, SkpWarmup) {
   SkISize draw_size = SkISize::Make(100, 100);


### PR DESCRIPTION
Unfortunately https://github.com/flutter/engine/pull/27455 inadvertantly changed our thread names which breaks internal tests that rely on profiling/tracing.

Test: Added test case to engine_unittests
Fixes: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=82001
Fixes: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=82002
Fixes: https://buganizer.corp.google.com/issues/195412484