### PR TITLE
Remove references to deprecated SkClipOps

### DIFF
--- a/testing/assertions_skia.cc
+++ b/testing/assertions_skia.cc
@@ -15,33 +15,9 @@ std::ostream& operator<<(std::ostream& os, const SkClipOp& o) {
     case SkClipOp::kIntersect:
       os << "ClipOpIntersect";
       break;
-#ifdef SK_SUPPORT_DEPRECATED_CLIPOPS
-    case SkClipOp::kUnion_deprecated:
-      os << "ClipOpUnion_deprecated";
+    default:
+      os << "ClipOpUnknown" << static_cast<int>(o);
       break;
-    case SkClipOp::kXOR_deprecated:
-      os << "ClipOpXOR_deprecated";
-      break;
-    case SkClipOp::kReverseDifference_deprecated:
-      os << "ClipOpReverseDifference_deprecated";
-      break;
-    case SkClipOp::kReplace_deprecated:
-      os << "ClipOpReplace_deprectaed";
-      break;
-#else
-    case SkClipOp::kExtraEnumNeedInternallyPleaseIgnoreWillGoAway2:
-      os << "ClipOpReserved2";
-      break;
-    case SkClipOp::kExtraEnumNeedInternallyPleaseIgnoreWillGoAway3:
-      os << "ClipOpReserved3";
-      break;
-    case SkClipOp::kExtraEnumNeedInternallyPleaseIgnoreWillGoAway4:
-      os << "ClipOpReserved4";
-      break;
-    case SkClipOp::kExtraEnumNeedInternallyPleaseIgnoreWillGoAway5:
-      os << "ClipOpReserved5";
-      break;
-#endif
   }
   return os;
 }


### PR DESCRIPTION
SK_SUPPORT_DEPRECATED_CLIPOPS is slated for removal.
As part of this removal SkClipOp will be defined as just intersect and difference.
This means the _deprecated values and the PleaseIgnoreWillGoAway values will finally go away.
This is needed to unblock the Skia change https://skia-review.googlesource.com/c/skia/+/436565, which will resolve https://skbug.com/10209

*List which issues are fixed by this PR. You must list at least one issue.*

https://skbug.com/10209

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
