### PR TITLE
Fix the SurfaceTexture related crash by replacing the JNI weak global reference with WeakReference

### DIFF
--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -13,7 +13,7 @@ namespace flutter {
 
 AndroidExternalTextureGL::AndroidExternalTextureGL(
     int64_t id,
-    const fml::jni::JavaObjectWeakGlobalRef& surface_texture,
+    const fml::jni::ScopedJavaGlobalRef<jobject>& surface_texture,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
     : Texture(id),
       jni_facade_(jni_facade),
@@ -74,7 +74,8 @@ void AndroidExternalTextureGL::Paint(SkCanvas& canvas,
 }
 
 void AndroidExternalTextureGL::UpdateTransform() {
-  jni_facade_->SurfaceTextureGetTransformMatrix(surface_texture_, transform);
+  jni_facade_->SurfaceTextureGetTransformMatrix(
+      fml::jni::ScopedJavaLocalRef<jobject>(surface_texture_), transform);
 }
 
 void AndroidExternalTextureGL::OnGrContextDestroyed() {
@@ -86,16 +87,19 @@ void AndroidExternalTextureGL::OnGrContextDestroyed() {
 }
 
 void AndroidExternalTextureGL::Attach(jint textureName) {
-  jni_facade_->SurfaceTextureAttachToGLContext(surface_texture_, textureName);
+  jni_facade_->SurfaceTextureAttachToGLContext(
+      fml::jni::ScopedJavaLocalRef<jobject>(surface_texture_), textureName);
 }
 
 void AndroidExternalTextureGL::Update() {
-  jni_facade_->SurfaceTextureUpdateTexImage(surface_texture_);
+  jni_facade_->SurfaceTextureUpdateTexImage(
+      fml::jni::ScopedJavaLocalRef<jobject>(surface_texture_));
   UpdateTransform();
 }
 
 void AndroidExternalTextureGL::Detach() {
-  jni_facade_->SurfaceTextureDetachFromGLContext(surface_texture_);
+  jni_facade_->SurfaceTextureDetachFromGLContext(
+      fml::jni::ScopedJavaLocalRef<jobject>(surface_texture_));
 }
 
 void AndroidExternalTextureGL::OnTextureUnregistered() {}

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -8,7 +8,6 @@
 #include <GLES/gl.h>
 
 #include "flutter/common/graphics/texture.h"
-#include "flutter/fml/platform/android/jni_weak_ref.h"
 #include "flutter/shell/platform/android/platform_view_android_jni_impl.h"
 
 namespace flutter {
@@ -17,7 +16,7 @@ class AndroidExternalTextureGL : public flutter::Texture {
  public:
   AndroidExternalTextureGL(
       int64_t id,
-      const fml::jni::JavaObjectWeakGlobalRef& surface_texture,
+      const fml::jni::ScopedJavaGlobalRef<jobject>& surface_texture,
       std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
 
   ~AndroidExternalTextureGL() override;
@@ -49,7 +48,7 @@ class AndroidExternalTextureGL : public flutter::Texture {
 
   std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
 
-  fml::jni::JavaObjectWeakGlobalRef surface_texture_;
+  fml::jni::ScopedJavaGlobalRef<jobject> surface_texture_;
 
   AttachmentState state_ = AttachmentState::uninitialized;
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -34,6 +34,7 @@ import io.flutter.util.Preconditions;
 import io.flutter.view.AccessibilityBridge;
 import io.flutter.view.FlutterCallbackInformation;
 import java.io.IOException;
+import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -756,11 +757,14 @@ public class FlutterJNI {
   public void registerTexture(long textureId, @NonNull SurfaceTextureWrapper textureWrapper) {
     ensureRunningOnMainThread();
     ensureAttachedToNative();
-    nativeRegisterTexture(nativeShellHolderId, textureId, textureWrapper);
+    nativeRegisterTexture(
+        nativeShellHolderId, textureId, new WeakReference<SurfaceTextureWrapper>(textureWrapper));
   }
 
   private native void nativeRegisterTexture(
-      long nativeShellHolderId, long textureId, @NonNull SurfaceTextureWrapper textureWrapper);
+      long nativeShellHolderId,
+      long textureId,
+      @NonNull WeakReference<SurfaceTextureWrapper> textureWrapper);
 
   /**
    * Call this method to inform Flutter that a texture previously registered with {@link

--- a/shell/platform/android/jni/jni_mock.h
+++ b/shell/platform/android/jni/jni_mock.h
@@ -46,22 +46,22 @@ class JNIMock final : public PlatformViewAndroidJNI {
 
   MOCK_METHOD(void,
               SurfaceTextureAttachToGLContext,
-              (JavaWeakGlobalRef surface_texture, int textureId),
+              (JavaLocalRef surface_texture, int textureId),
               (override));
 
   MOCK_METHOD(void,
               SurfaceTextureUpdateTexImage,
-              (JavaWeakGlobalRef surface_texture),
+              (JavaLocalRef surface_texture),
               (override));
 
   MOCK_METHOD(void,
               SurfaceTextureGetTransformMatrix,
-              (JavaWeakGlobalRef surface_texture, SkMatrix& transform),
+              (JavaLocalRef surface_texture, SkMatrix& transform),
               (override));
 
   MOCK_METHOD(void,
               SurfaceTextureDetachFromGLContext,
-              (JavaWeakGlobalRef surface_texture),
+              (JavaLocalRef surface_texture),
               (override));
 
   MOCK_METHOD(void,

--- a/shell/platform/android/jni/platform_view_android_jni.h
+++ b/shell/platform/android/jni/platform_view_android_jni.h
@@ -14,15 +14,15 @@
 #include "third_party/skia/include/core/SkMatrix.h"
 
 #if OS_ANDROID
-#include "flutter/fml/platform/android/jni_weak_ref.h"
+#include "flutter/fml/platform/android/scoped_java_ref.h"
 #endif
 
 namespace flutter {
 
 #if OS_ANDROID
-using JavaWeakGlobalRef = fml::jni::JavaObjectWeakGlobalRef;
+using JavaLocalRef = fml::jni::ScopedJavaLocalRef<jobject>;
 #else
-using JavaWeakGlobalRef = std::nullptr_t;
+using JavaLocalRef = std::nullptr_t;
 #endif
 
 //------------------------------------------------------------------------------
@@ -86,31 +86,28 @@ class PlatformViewAndroidJNI {
   /// @brief      Attach the SurfaceTexture to the OpenGL ES context that is
   ///             current on the calling thread.
   ///
-  virtual void SurfaceTextureAttachToGLContext(
-      JavaWeakGlobalRef surface_texture,
-      int textureId) = 0;
+  virtual void SurfaceTextureAttachToGLContext(JavaLocalRef surface_texture,
+                                               int textureId) = 0;
 
   //----------------------------------------------------------------------------
   /// @brief      Updates the texture image to the most recent frame from the
   ///             image stream.
   ///
-  virtual void SurfaceTextureUpdateTexImage(
-      JavaWeakGlobalRef surface_texture) = 0;
+  virtual void SurfaceTextureUpdateTexImage(JavaLocalRef surface_texture) = 0;
 
   //----------------------------------------------------------------------------
   /// @brief      Gets the transform matrix from the SurfaceTexture.
   ///             Then, it updates the `transform` matrix, so it fill the canvas
   ///             and preserve the aspect ratio.
   ///
-  virtual void SurfaceTextureGetTransformMatrix(
-      JavaWeakGlobalRef surface_texture,
-      SkMatrix& transform) = 0;
+  virtual void SurfaceTextureGetTransformMatrix(JavaLocalRef surface_texture,
+                                                SkMatrix& transform) = 0;
 
   //----------------------------------------------------------------------------
   /// @brief      Detaches a SurfaceTexture from the OpenGL ES context.
   ///
   virtual void SurfaceTextureDetachFromGLContext(
-      JavaWeakGlobalRef surface_texture) = 0;
+      JavaLocalRef surface_texture) = 0;
 
   //----------------------------------------------------------------------------
   /// @brief      Positions and sizes a platform view if using hybrid

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -291,7 +291,7 @@ void PlatformViewAndroid::UpdateSemantics(
 
 void PlatformViewAndroid::RegisterExternalTexture(
     int64_t texture_id,
-    const fml::jni::JavaObjectWeakGlobalRef& surface_texture) {
+    const fml::jni::ScopedJavaGlobalRef<jobject>& surface_texture) {
   RegisterTexture(std::make_shared<AndroidExternalTextureGL>(
       texture_id, surface_texture, std::move(jni_facade_)));
 }

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "flutter/fml/memory/weak_ptr.h"
-#include "flutter/fml/platform/android/jni_weak_ref.h"
 #include "flutter/fml/platform/android/scoped_java_ref.h"
 #include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/shell/common/platform_view.h"
@@ -97,7 +96,7 @@ class PlatformViewAndroid final : public PlatformView {
 
   void RegisterExternalTexture(
       int64_t texture_id,
-      const fml::jni::JavaObjectWeakGlobalRef& surface_texture);
+      const fml::jni::ScopedJavaGlobalRef<jobject>& surface_texture);
 
   // |PlatformView|
   void LoadDartDeferredLibrary(

--- a/shell/platform/android/platform_view_android_jni_impl.h
+++ b/shell/platform/android/platform_view_android_jni_impl.h
@@ -41,16 +41,15 @@ class PlatformViewAndroidJNIImpl final : public PlatformViewAndroidJNI {
 
   void FlutterViewOnPreEngineRestart() override;
 
-  void SurfaceTextureAttachToGLContext(JavaWeakGlobalRef surface_texture,
+  void SurfaceTextureAttachToGLContext(JavaLocalRef surface_texture,
                                        int textureId) override;
 
-  void SurfaceTextureUpdateTexImage(JavaWeakGlobalRef surface_texture) override;
+  void SurfaceTextureUpdateTexImage(JavaLocalRef surface_texture) override;
 
-  void SurfaceTextureGetTransformMatrix(JavaWeakGlobalRef surface_texture,
+  void SurfaceTextureGetTransformMatrix(JavaLocalRef surface_texture,
                                         SkMatrix& transform) override;
 
-  void SurfaceTextureDetachFromGLContext(
-      JavaWeakGlobalRef surface_texture) override;
+  void SurfaceTextureDetachFromGLContext(JavaLocalRef surface_texture) override;
 
   void FlutterViewOnDisplayPlatformView(int view_id,
                                         int x,


### PR DESCRIPTION
App crashed when SurfaceTexture.detachFromContext is called after SurfaceTexture.finalize，this pr will fix it

detail：
https://github.com/flutter/flutter/issues/83090#issuecomment-869973939

related issue：
https://github.com/flutter/flutter/issues/87807
https://github.com/flutter/flutter/issues/83090
https://github.com/flutter/flutter/issues/85196

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.
