### PR TITLE
[ci.yaml] Remove deprecated builder field

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -57,7 +57,6 @@ platform_properties:
 
 targets:
   - name: Linux Android AOT Engine
-    builder: Linux Android AOT Engine
     recipe: engine
     properties:
       add_recipes_cq: "true"
@@ -68,7 +67,6 @@ targets:
     scheduler: luci
 
   - name: Linux Android Debug Engine
-    builder: Linux Android Debug Engine
     recipe: engine
     properties:
       add_recipes_cq: "true"
@@ -81,7 +79,6 @@ targets:
     scheduler: luci
 
   - name: Linux Android Scenarios
-    builder: Linux Android Scenarios
     bringup: true # Recipe issue https://github.com/flutter/flutter/issues/86427
     recipe: engine/scenarios
     properties:
@@ -91,7 +88,6 @@ targets:
     scheduler: luci
 
   - name: Linux Benchmarks
-    builder: Linux Benchmarks
     enabled_branches:
       - master
     recipe: engine/engine_metrics
@@ -102,7 +98,6 @@ targets:
     scheduler: luci
 
   - name: Linux Fuchsia
-    builder: Linux Fuchsia
     recipe: engine
     properties:
       add_recipes_cq: "true"
@@ -112,7 +107,6 @@ targets:
     scheduler: luci
 
   - name: Linux Fuchsia FEMU
-    builder: Linux Fuchsia FEMU
     recipe: femu_test
     properties:
       add_recipes_cq: "true"
@@ -122,13 +116,11 @@ targets:
     scheduler: luci
 
   - name: Linux Framework Smoke Tests
-    builder: Linux Framework Smoke Tests
     recipe: engine/framework_smoke
     timeout: 60
     scheduler: luci
 
   - name: Linux Host Engine
-    builder: Linux Host Engine
     recipe: engine
     properties:
       add_recipes_cq: "true"
@@ -137,7 +129,6 @@ targets:
     scheduler: luci
 
   - name: Linux Unopt
-    builder: Linux Unopt
     recipe: engine_unopt
     properties:
       add_recipes_cq: "true"
@@ -145,7 +136,6 @@ targets:
     scheduler: luci
 
   - name: Linux Arm Host Engine
-    builder: Linux Arm Host Engine
     recipe: engine/engine_arm
     properties:
       add_recipes_cq: "true"
@@ -154,7 +144,6 @@ targets:
     scheduler: luci
 
   - name: Linux Web Engine
-    builder: Linux Web Engine
     recipe: web_engine
     properties:
       add_recipes_cq: "true"
@@ -170,7 +159,6 @@ targets:
       - flutter_frontend_server/**
 
   - name: Linux Web Framework tests
-    builder: Linux Web Framework tests
     recipe: engine/web_engine_framework
     properties:
       add_recipes_cq: "true"
@@ -189,7 +177,6 @@ targets:
       - flutter_frontend_server/**
 
   - name: Mac Android AOT Engine
-    builder: Mac Android AOT Engine
     recipe: engine
     properties:
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
@@ -199,7 +186,6 @@ targets:
     scheduler: luci
 
   - name: Mac Android Debug Engine
-    builder: Mac Android Debug Engine
     recipe: engine
     properties:
       android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
@@ -209,7 +195,6 @@ targets:
     scheduler: luci
 
   - name: Mac Host Engine
-    builder: Mac Host Engine
     recipe: engine
     properties:
       add_recipes_cq: "true"
@@ -218,7 +203,6 @@ targets:
     scheduler: luci
 
   - name: Mac Unopt
-    builder: Mac Unopt
     recipe: engine_unopt
     properties:
       add_recipes_cq: "true"
@@ -227,7 +211,6 @@ targets:
     scheduler: luci
 
   - name: Mac iOS Engine
-    builder: Mac iOS Engine
     recipe: engine
     properties:
       build_ios: "true"
@@ -237,7 +220,6 @@ targets:
     scheduler: luci
 
   - name: Mac Web Engine
-    builder: Mac Web Engine
     recipe: web_engine
     properties:
       gcs_goldens_bucket: flutter_logs
@@ -252,7 +234,6 @@ targets:
       - flutter_frontend_server/**
 
   - name: Windows Android AOT Engine
-    builder: Windows Android AOT Engine
     recipe: engine
     properties:
       build_android_aot: "true"
@@ -262,7 +243,6 @@ targets:
     scheduler: luci
 
   - name: Windows Host Engine
-    builder: Windows Host Engine
     recipe: engine
     timeout: 60
     properties:
@@ -271,7 +251,6 @@ targets:
     scheduler: luci
 
   - name: Windows Unopt
-    builder: Windows Unopt
     recipe: engine_unopt
     properties:
       add_recipes_cq: "true"
@@ -279,7 +258,6 @@ targets:
     scheduler: luci
 
   - name: Windows UWP Engine
-    builder: Windows UWP Engine
     recipe: engine
     properties:
       build_windows_uwp: "true"
@@ -287,7 +265,6 @@ targets:
     scheduler: luci
 
   - name: Windows Web Engine
-    builder: Windows Web Engine
     recipe: web_engine
     properties:
       gcs_goldens_bucket: flutter_logs
@@ -299,7 +276,6 @@ targets:
       - web_sdk/**
 
   - name: Mac iOS Engine Profile
-    builder: Mac iOS Engine Profile
     presubmit: false
     recipe: engine
     properties:
@@ -310,7 +286,6 @@ targets:
     scheduler: luci
 
   - name: Mac iOS Engine Release
-    builder: Mac iOS Engine Release
     presubmit: false
     recipe: engine
     properties:
@@ -321,7 +296,6 @@ targets:
     scheduler: luci
 
   - name: Linux ci_yaml engine roller
-    builder: Linux ci_yaml engine roller
     bringup: true
     presubmit: false
     recipe: infra/ci_yaml


### PR DESCRIPTION
This is some cleanup to remove the deprecated field. It's a no-op to remove as everything has switched over to use name