### PR TITLE
Avoid crashing when FlutterImageView is resized to zero dimension

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -24,6 +24,7 @@ import io.flutter.Log;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.RenderSurface;
 import java.nio.ByteBuffer;
+import java.util.Locale;
 
 /**
  * Paints a Flutter UI provided by an {@link android.media.ImageReader} onto a {@link
@@ -93,15 +94,19 @@ public class FlutterImageView extends View implements RenderSurface {
     setAlpha(0.0f);
   }
 
+  private static void logW(String format, Object... args) {
+    Log.w(TAG, String.format(Locale.US, format, args));
+  }
+
   @TargetApi(19)
   @NonNull
   private static ImageReader createImageReader(int width, int height) {
     if (width <= 0) {
-      Log.w(TAG, "ImageReader dimensions must > 0, but given width=" + width + ", set width=1");
+      logW("ImageReader width must be greater than 0, but given width=%d, set width=1", width);
       width = 1;
     }
     if (height <= 0) {
-      Log.w(TAG, "ImageReader dimensions must > 0, but given height=" + height + ", set height=1");
+      logW("ImageReader height must be greater than 0, but given height=%d, set height=1", height);
       height = 1;
     }
     if (android.os.Build.VERSION.SDK_INT >= 29) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -20,6 +20,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import io.flutter.Log;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.RenderSurface;
 import java.nio.ByteBuffer;
@@ -38,6 +39,8 @@ import java.nio.ByteBuffer;
  */
 @TargetApi(19)
 public class FlutterImageView extends View implements RenderSurface {
+  private static final String TAG = "FlutterImageView";
+
   @NonNull private ImageReader imageReader;
   @Nullable private Image currentImage;
   @Nullable private Bitmap currentBitmap;
@@ -89,6 +92,14 @@ public class FlutterImageView extends View implements RenderSurface {
   @TargetApi(19)
   @NonNull
   private static ImageReader createImageReader(int width, int height) {
+    if (width <= 0) {
+      Log.w(TAG, "ImageReader dimensions must > 0, but given width=" + width + ", set width=1");
+      width = 1;
+    }
+    if (height <= 0) {
+      Log.w(TAG, "ImageReader dimensions must > 0, but given height=" + height + ", set height=1");
+      height = 1;
+    }
     if (android.os.Build.VERSION.SDK_INT >= 29) {
       return ImageReader.newInstance(
           width,

--- a/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterImageView.java
@@ -46,6 +46,10 @@ public class FlutterImageView extends View implements RenderSurface {
   @Nullable private Bitmap currentBitmap;
   @Nullable private FlutterRenderer flutterRenderer;
 
+  public ImageReader getImageReader() {
+    return imageReader;
+  }
+
   public enum SurfaceKind {
     /** Displays the background canvas. */
     background,

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -735,6 +735,31 @@ public class FlutterViewTest {
   }
 
   @Test
+  public void flutterImageView_workaroundWithOnePixelWhenResizeWithZero() {
+    final ImageReader mockReader = mock(ImageReader.class);
+    when(mockReader.getMaxImages()).thenReturn(2);
+
+    final FlutterImageView imageView =
+        spy(
+            new FlutterImageView(
+                RuntimeEnvironment.application,
+                mockReader,
+                FlutterImageView.SurfaceKind.background));
+
+    final FlutterJNI jni = mock(FlutterJNI.class);
+    imageView.attachToRenderer(new FlutterRenderer(jni));
+
+    final Image mockImage = mock(Image.class);
+    when(mockReader.acquireLatestImage()).thenReturn(mockImage);
+
+    final int incorrectWidth = 0;
+    final int incorrectHeight = -100;
+    imageView.resizeIfNeeded(incorrectWidth, incorrectHeight);
+    assertEquals(1, imageView.getImageReader().getWidth());
+    assertEquals(1, imageView.getImageReader().getHeight());
+  }
+
+  @Test
   public void flutterSurfaceView_GathersTransparentRegion() {
     final Region mockRegion = mock(Region.class);
     final FlutterSurfaceView surfaceView = new FlutterSurfaceView(RuntimeEnvironment.application);


### PR DESCRIPTION
This PR fixes a Android crash when using WebView and when keyboard shows, flutter area was resized to a zero height.
Java crash stack:

```java

E/AndroidRuntime(24165): Process: io.flutter.plugins.webviewflutterexample, PID: 24165
E/AndroidRuntime(24165): java.lang.IllegalArgumentException: The image dimensions must be positive
E/AndroidRuntime(24165): 	at android.media.ImageReader.<init>(ImageReader.java:247)
E/AndroidRuntime(24165): 	at android.media.ImageReader.newInstance(ImageReader.java:135)
E/AndroidRuntime(24165): 	at io.flutter.embedding.android.FlutterImageView.createImageReader(FlutterImageView.java:124)
E/AndroidRuntime(24165): 	at io.flutter.embedding.android.FlutterImageView.resizeIfNeeded(FlutterImageView.java:266)
E/AndroidRuntime(24165): 	at io.flutter.embedding.android.FlutterImageView.onSizeChanged(FlutterImageView.java:345)
E/AndroidRuntime(24165): 	at android.view.View.sizeChange(View.java:22113)
E/AndroidRuntime(24165): 	at android.view.View.setFrame(View.java:22065)
E/AndroidRuntime(24165): 	at android.view.View.layout(View.java:21924)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
E/AndroidRuntime(24165): 	at android.view.View.layout(View.java:21927)
E/AndroidRuntime(24165): 	at android.view.ViewGroup.layout(ViewGroup.java:6260)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
E/AndroidRuntime(24165): 	at android.view.View.layout(View.java:21927)
E/AndroidRuntime(24165): 	at android.view.ViewGroup.layout(ViewGroup.java:6260)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
E/AndroidRuntime(24165): 	at android.view.View.layout(View.java:21927)
E/AndroidRuntime(24165): 	at android.view.ViewGroup.layout(ViewGroup.java:6260)
E/AndroidRuntime(24165): 	at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1829)
E/AndroidRuntime(24165): 	at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1673)
E/AndroidRuntime(24165): 	at android.widget.LinearLayout.onLayout(LinearLayout.java:1582)
E/AndroidRuntime(24165): 	at android.view.View.layout(View.java:21927)
E/AndroidRuntime(24165): 	at android.view.ViewGroup.layout(ViewGroup.java:6260)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
E/AndroidRuntime(24165): 	at android.view.View.layout(View.java:21927)
E/AndroidRuntime(24165): 	at android.view.ViewGroup.layout(ViewGroup.java:6260)
E/AndroidRuntime(24165): 	at android.widget.LinearLayout.setChildFrame(LinearLayout.java:1829)
E/AndroidRuntime(24165): 	at android.widget.LinearLayout.layoutVertical(LinearLayout.java:1673)
E/AndroidRuntime(24165): 	at android.widget.LinearLayout.onLayout(LinearLayout.java:1582)
E/AndroidRuntime(24165): 	at android.view.View.layout(View.java:21927)
E/AndroidRuntime(24165): 	at android.view.ViewGroup.layout(ViewGroup.java:6260)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
E/AndroidRuntime(24165): 	at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
E/AndroidRuntime(24165): 	at com.android.internal.policy.DecorView.onLayout(DecorView.java:779)
E/AndroidRuntime(24165): 	at android.view.View.layout(View.java:21927)
E/AndroidRuntime(24165): 	at android.view.ViewGroup.layout(ViewGroup.java:6260)
E/AndroidRuntime(24165): 	at android.view.ViewRootImpl.performLayout(ViewRootImpl.java:3080)
E/AndroidRuntime(24165): 	at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2590)
E/AndroidRuntime(24165): 	at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1721)
E/AndroidRuntime(24165): 	at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7598)
E/AndroidRuntime(24165): 	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:966)
E/AndroidRuntime(24165): 	at android.view.Choreographer.doCallbacks(Choreographer.java:790)
E/AndroidRuntime(24165): 	at android.view.Choreographer.doFrame(Choreographer.java:725)
E/AndroidRuntime(24165): 	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:951)
E/AndroidRuntime(24165): 	at android.os.Handler.handleCallback(Handler.java:883)
E/AndroidRuntime(24165): 	at android.os.Handler.dispatchMessage(Handler.java:100)
E/AndroidRuntime(24165): 	at android.os.Looper.loop(Looper.java:214)
E/AndroidRuntime(24165): 	at android.app.ActivityThread.main(ActivityThread.java:7356)
E/AndroidRuntime(24165): 	at java.lang.reflect.Method.invoke(Native Method)
E/AndroidRuntime(24165): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
E/AndroidRuntime(24165): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
I/Process (24165): Sending signal. PID: 24165 SIG: 9

```
It fixed: https://github.com/flutter/flutter/issues/87858

This is a workaround and stay the same with this logic of `FlutterImageView`'s constructors, they take 1 pixel as default:
```java
  /**
   * Constructs a {@code FlutterImageView} with an {@link android.media.ImageReader} that provides
   * the Flutter UI.
   */
  public FlutterImageView(@NonNull Context context, int width, int height, SurfaceKind kind) {
    this(context, createImageReader(width, height), kind);
  }

  public FlutterImageView(@NonNull Context context) {
    this(context, 1, 1, SurfaceKind.background);
  }

  public FlutterImageView(@NonNull Context context, @NonNull AttributeSet attrs) {
    this(context, 1, 1, SurfaceKind.background);
  }
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

