### PR TITLE
Fix StandardMessageCodec test leaks

### DIFF
--- a/shell/platform/common/client_wrapper/standard_codec.cc
+++ b/shell/platform/common/client_wrapper/standard_codec.cc
@@ -295,8 +295,8 @@ const StandardMessageCodec& StandardMessageCodec::GetInstance(
   if (!serializer) {
     serializer = &StandardCodecSerializer::GetInstance();
   }
-  auto* sInstances = new std::map<const StandardCodecSerializer*,
-                                  std::unique_ptr<StandardMessageCodec>>;
+  static auto* sInstances = new std::map<const StandardCodecSerializer*,
+                                         std::unique_ptr<StandardMessageCodec>>;
   auto it = sInstances->find(serializer);
   if (it == sInstances->end()) {
     // Uses new due to private constructor (to prevent API clients from
@@ -342,8 +342,8 @@ const StandardMethodCodec& StandardMethodCodec::GetInstance(
   if (!serializer) {
     serializer = &StandardCodecSerializer::GetInstance();
   }
-  auto* sInstances = new std::map<const StandardCodecSerializer*,
-                                  std::unique_ptr<StandardMethodCodec>>;
+  static auto* sInstances = new std::map<const StandardCodecSerializer*,
+                                         std::unique_ptr<StandardMethodCodec>>;
   auto it = sInstances->find(serializer);
   if (it == sInstances->end()) {
     // Uses new due to private constructor (to prevent API clients from

--- a/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
+++ b/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
@@ -76,6 +76,14 @@ static void CheckEncodeDecodeWithEncodePrefix(
   EXPECT_EQ(value, *decoded);
 }
 
+TEST(StandardMessageCodec, GetInstanceCachesInstance) {
+  const StandardMessageCodec& codec_a =
+      StandardMessageCodec::GetInstance(nullptr);
+  const StandardMessageCodec& codec_b =
+      StandardMessageCodec::GetInstance(nullptr);
+  EXPECT_EQ(&codec_a, &codec_b);
+}
+
 TEST(StandardMessageCodec, CanEncodeAndDecodeNull) {
   std::vector<uint8_t> bytes = {0x00};
   CheckEncodeDecode(EncodableValue(), bytes);

--- a/shell/platform/common/client_wrapper/standard_method_codec_unittests.cc
+++ b/shell/platform/common/client_wrapper/standard_method_codec_unittests.cc
@@ -32,6 +32,14 @@ bool MethodCallsAreEqual(const MethodCall<>& a, const MethodCall<>& b) {
 
 }  // namespace
 
+TEST(StandardMethodCodec, GetInstanceCachesInstance) {
+  const StandardMethodCodec& codec_a =
+      StandardMethodCodec::GetInstance(nullptr);
+  const StandardMethodCodec& codec_b =
+      StandardMethodCodec::GetInstance(nullptr);
+  EXPECT_EQ(&codec_a, &codec_b);
+}
+
 TEST(StandardMethodCodec, HandlesMethodCallsWithNullArguments) {
   const StandardMethodCodec& codec = StandardMethodCodec::GetInstance();
   MethodCall<> call("hello", nullptr);


### PR DESCRIPTION
Fix a memory leak that triggers asan traces in the codec tests.