### PR TITLE
Roll buildroot to c37164f39300c6e42560a5853e16a919688f7b86

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -97,7 +97,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'bab43eb08cff63e71de5e7fe816ccf2aea3576a4',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'c37164f39300c6e42560a5853e16a919688f7b86',
 
    # Fuchsia compatibility
    #
@@ -631,17 +631,6 @@ deps = {
 }
 
 hooks = [
-  {
-    # This clobbers when necessary (based on get_landmines.py). It must be the
-    # first hook so that other things that get/generate into the output
-    # directory will not subsequently be clobbered.
-    'name': 'landmines',
-    'pattern': '.',
-    'action': [
-        'python3',
-        'src/build/landmines.py',
-    ],
-  },
   {
     # Update the Windows toolchain if necessary.
     'name': 'win_toolchain',


### PR DESCRIPTION
This eliminates the landmines hook.

build/landmines.py writes out a .landmines file at the root of the
buildroot. The first step of a `gclient sync` is to check for diffs
between that file and the new one, and if found, a clobber is performed.

We never actually use this functionality, and the code calls rmtree()
which (at least on macos) appears to choke on symlinks.

This deletes these scripts, and will be paired with the deletion of the
first gclient hook in the DEPS file in flutter/engine during the roll.

If we ever need this functionality, it's relatively straightforward to
add it back.

Issue: flutter/flutter#87960

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
