### PR TITLE
Windows host builds don't need android SDK

### DIFF
--- a/ci/builders/windows_host_engine.json
+++ b/ci/builders/windows_host_engine.json
@@ -5,6 +5,9 @@
             "device_type=none",
             "os=Windows-10"
         ],
+        "gclient_custom_vars": {
+          "download_android_deps": false
+        },
         "gn": [
             "--runtime-mode",
             "debug",
@@ -37,6 +40,9 @@
             "device_type=none",
             "os=Windows-10"
         ],
+        "gclient_custom_vars": {
+          "download_android_deps": false
+        },
         "gn": [
             "--runtime-mode",
             "profile",
@@ -58,6 +64,9 @@
             "device_type=none",
             "os=Windows-10"
         ],
+        "gclient_custom_vars": {
+          "download_android_deps": false
+        },
         "generators": [],
         "gn": [
             "--runtime-mode",


### PR DESCRIPTION
Along with https://flutter-review.googlesource.com/c/recipes/+/16760 fixes part of https://github.com/flutter/flutter/issues/87947