### PR TITLE
Python 3 compatibility fix for running Java tests using run_tests.py

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -321,6 +321,7 @@ def AssertExpectedJavaVersion():
   EXPECTED_VERSION = '1.8'
   # `java -version` is output to stderr. https://bugs.java.com/bugdatabase/view_bug.do?bug_id=4380614
   version_output = subprocess.check_output(['java', '-version'], stderr=subprocess.STDOUT)
+  version_output = version_output.decode('utf-8')
   match = bool(re.compile('version "%s' % EXPECTED_VERSION).search(version_output))
   message = "JUnit tests need to be run with Java %s. Check the `java -version` on your PATH." % EXPECTED_VERSION
   assert match, message


### PR DESCRIPTION
(Note that LUCI is currently still running this script using Python 2)
