### PR TITLE
Fix: modifier keys not recognized on macOS Web

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -128,6 +128,7 @@ class Keyboard {
       'keymap': 'web',
       'code': keyboardEvent.code,
       'key': keyboardEvent.key,
+      'location': keyboardEvent.location,
       'metaState': _lastMetaState,
     };
 
@@ -151,6 +152,7 @@ class Keyboard {
       'keymap': 'web',
       'code': event.code,
       'key': event.key,
+      'location': event.location,
       'metaState': _lastMetaState,
     };
 

--- a/lib/web_ui/test/keyboard_test.dart
+++ b/lib/web_ui/test/keyboard_test.dart
@@ -61,6 +61,7 @@ void testMain() {
         'type': 'keyup',
         'keymap': 'web',
         'code': 'SomeCode',
+        'location': 0,
         'key': 'SomeKey',
         'metaState': 0x0,
       });
@@ -92,6 +93,7 @@ void testMain() {
         'keymap': 'web',
         'code': 'SomeCode',
         'key': 'SomeKey',
+        'location': 0,
         'metaState': 0x0,
       });
       expect(event.defaultPrevented, isFalse);
@@ -124,6 +126,7 @@ void testMain() {
         'keymap': 'web',
         'code': 'SomeCode',
         'key': 'SomeKey',
+        'location': 0,
         //          ctrl
         'metaState': 0x4,
       });
@@ -142,6 +145,7 @@ void testMain() {
         'keymap': 'web',
         'code': 'SomeCode',
         'key': 'SomeKey',
+        'location': 0,
         //          shift  alt   meta
         'metaState': 0x1 | 0x2 | 0x8,
       });
@@ -191,6 +195,7 @@ void testMain() {
         'keymap': 'web',
         'code': 'SomeCode',
         'key': 'SomeKey',
+        'location': 0,
         'metaState': 0,
       };
       expect(messages, <Map<String, dynamic>>[
@@ -346,12 +351,14 @@ void testMain() {
           'keydown',
           key: 'Meta',
           code: 'MetaLeft',
+          location: 1,
           isMetaPressed: true,
         );
         dispatchKeyboardEvent(
           'keydown',
           key: 'Alt',
           code: 'AltLeft',
+          location: 1,
           isMetaPressed: true,
           isAltPressed: true,
         );
@@ -367,9 +374,15 @@ void testMain() {
           'keyup',
           key: 'Meta',
           code: 'MetaLeft',
+          location: 1,
           isAltPressed: true,
         );
-        dispatchKeyboardEvent('keyup', key: 'Alt', code: 'AltLeft');
+        dispatchKeyboardEvent(
+          'keyup',
+          key: 'Alt',
+          code: 'AltLeft',
+          location: 1,
+        );
         // Notice no `keyup` for "i".
 
         expect(messages, <Map<String, dynamic>>[
@@ -378,6 +391,7 @@ void testMain() {
             'keymap': 'web',
             'key': 'Meta',
             'code': 'MetaLeft',
+            'location': 1,
             //           meta
             'metaState': 0x8,
           },
@@ -386,6 +400,7 @@ void testMain() {
             'keymap': 'web',
             'key': 'Alt',
             'code': 'AltLeft',
+            'location': 1,
             //           alt   meta
             'metaState': 0x2 | 0x8,
           },
@@ -394,6 +409,7 @@ void testMain() {
             'keymap': 'web',
             'key': 'i',
             'code': 'KeyI',
+            'location': 0,
             //           alt   meta
             'metaState': 0x2 | 0x8,
           },
@@ -402,6 +418,7 @@ void testMain() {
             'keymap': 'web',
             'key': 'Meta',
             'code': 'MetaLeft',
+            'location': 1,
             //           alt
             'metaState': 0x2,
           },
@@ -410,6 +427,7 @@ void testMain() {
             'keymap': 'web',
             'key': 'Alt',
             'code': 'AltLeft',
+            'location': 1,
             'metaState': 0x0,
           },
         ]);
@@ -426,6 +444,7 @@ void testMain() {
             'keymap': 'web',
             'key': 'i',
             'code': 'KeyI',
+            'location': 0,
             'metaState': 0x0,
           }
         ]);
@@ -449,12 +468,14 @@ void testMain() {
           'keydown',
           key: 'Meta',
           code: 'MetaLeft',
+          location: 1,
           isMetaPressed: true,
         );
         dispatchKeyboardEvent(
           'keydown',
           key: 'Alt',
           code: 'AltLeft',
+          location: 1,
           isMetaPressed: true,
           isAltPressed: true,
         );
@@ -470,9 +491,15 @@ void testMain() {
           'keyup',
           key: 'Meta',
           code: 'MetaLeft',
+          location: 1,
           isAltPressed: true,
         );
-        dispatchKeyboardEvent('keyup', key: 'Alt', code: 'AltLeft');
+        dispatchKeyboardEvent(
+          'keyup',
+          key: 'Alt',
+          code: 'AltLeft',
+          location: 1,
+        );
         // Notice no `keyup` for "i".
 
         messages.clear();
@@ -497,6 +524,7 @@ void testMain() {
             'keymap': 'web',
             'key': 'i',
             'code': 'KeyI',
+            'location': 0,
             'metaState': 0x0,
           });
         }
@@ -551,12 +579,14 @@ void testMain() {
         'keydown',
         key: 'Meta',
         code: 'MetaLeft',
+        location: 1,
         isMetaPressed: true,
       );
       dispatchKeyboardEvent(
         'keydown',
         key: 'Alt',
         code: 'AltLeft',
+        location: 1,
         isMetaPressed: true,
         isAltPressed: true,
       );
@@ -572,6 +602,7 @@ void testMain() {
         'keyup',
         key: 'Meta',
         code: 'MetaLeft',
+        location: 1,
         isAltPressed: true,
       );
       // Notice no `keyup` for "AltLeft" and "i".
@@ -587,6 +618,7 @@ void testMain() {
           'keymap': 'web',
           'key': 'i',
           'code': 'KeyI',
+          'location': 0,
           //           alt
           'metaState': 0x2,
         }
@@ -616,6 +648,7 @@ html.KeyboardEvent dispatchKeyboardEvent(
   html.EventTarget? target,
   String? key,
   String? code,
+  int location = 0,
   bool repeat = false,
   bool isShiftPressed = false,
   bool isAltPressed = false,
@@ -631,6 +664,7 @@ html.KeyboardEvent dispatchKeyboardEvent(
     <String, dynamic>{
       'key': key,
       'code': code,
+      'location': location,
       'repeat': repeat,
       'shiftKey': isShiftPressed,
       'altKey': isAltPressed,


### PR DESCRIPTION
The framework has started using `KeyboardEvent.location` to recognize modifiers on Web, but the engine is not sending this field at all, which makes all modifiers unrecognized. This PR fixes that by adding this field.

Fixes https://github.com/flutter/flutter/issues/87951.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
