### PR TITLE
added log statement to timerfd_settime failure

### DIFF
--- a/fml/platform/linux/timerfd.cc
+++ b/fml/platform/linux/timerfd.cc
@@ -8,6 +8,7 @@
 #include <unistd.h>
 
 #include "flutter/fml/eintr_wrapper.h"
+#include "flutter/fml/logging.h"
 
 #if FML_TIMERFD_AVAILABLE == 0
 
@@ -48,6 +49,9 @@ bool TimerRearm(int fd, fml::TimePoint time_point) {
   spec.it_interval = spec.it_value;  // single expiry.
 
   int result = ::timerfd_settime(fd, TFD_TIMER_ABSTIME, &spec, nullptr);
+  if (result != 0) {
+    FML_DLOG(ERROR) << "timerfd_settime err:" << strerror(errno);
+  }
   return result == 0;
 }
 


### PR DESCRIPTION
This should help debug issue https://github.com/flutter/flutter/issues/87815#issuecomment-895419760

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
