### PR TITLE
Use runtime checks for arguments, out directory

### DIFF
--- a/testing/symbols/verify_exported.dart
+++ b/testing/symbols/verify_exported.dart
@@ -21,10 +21,14 @@ import 'package:path/path.dart' as p;
 /// Takes the path to the out directory as the first argument, and the path to
 /// the buildtools directory as the second argument.
 ///
-/// If the second argument is not specified, it is assumed that it is the parent
-/// of the out directory (for backwards compatibility).
+/// If the second argument is not specified, for backwards compatibility, it is
+/// assumed that it is ../buildtools relative to the first parameter (the out
+/// directory).
 void main(List<String> arguments) {
-  assert(arguments.length == 2 || arguments.length == 1);
+  if (arguments.isEmpty || arguments.length > 2) {
+    print('usage: dart verify_exported.dart OUT_DIR [BUILDTOOLS]');
+    exit(1);
+  }
   final String outPath = arguments.first;
   final String buildToolsPath = arguments.length == 1
       ? p.join(p.dirname(outPath), 'buildtools')
@@ -39,7 +43,10 @@ void main(List<String> arguments) {
     throw UnimplementedError('Script only support running on Linux or MacOS.');
   }
   final String nmPath = p.join(buildToolsPath, platform, 'clang', 'bin', 'llvm-nm');
-  assert(Directory(outPath).existsSync());
+  if (!Directory(outPath).existsSync()) {
+    print('error: build out directory not found: $outPath');
+    exit(1);
+  }
 
   final Iterable<String> releaseBuilds = Directory(outPath).listSync()
       .whereType<Directory>()


### PR DESCRIPTION
Since verify_exported.dart is not run with assertions enabled, replace
the assertions with runtime checks and appropriate error messages:

* Adds a check for valid arguments and emits usage otherwise
* Adds a check for the presence of the out/ directory and exits with
  error if it does not exist.

Issue: https://github.com/flutter/flutter/issues/87960

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
