### PR TITLE
fix LeakedCloseable violation

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -83,7 +83,13 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
           if (isAttachedToFlutterRenderer) {
             disconnectSurfaceFromRenderer();
           }
-
+          
+          // Definitively release the surface to avoid leaked closeables, just in case
+          if (renderSurface != null) {
+            renderSurface.release();
+            renderSurface = null;
+          }
+          
           // Return true to indicate that no further painting will take place
           // within this SurfaceTexture.
           return true;
@@ -192,7 +198,12 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
       throw new IllegalStateException(
           "connectSurfaceToRenderer() should only be called when flutterRenderer and getSurfaceTexture() are non-null.");
     }
-
+    
+    if (renderSurface != null) {
+      renderSurface.release();
+      renderSurface = null;
+    }
+    
     renderSurface = new Surface(getSurfaceTexture());
     flutterRenderer.startRenderingToSurface(renderSurface);
   }


### PR DESCRIPTION
StrictModePolicyViolation due to LEAKED_CLOSABLE
08-06 11:51:38.518  8199  8199 E AndroidRuntime: Caused by: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
08-06 11:51:38.518  8199  8199 E AndroidRuntime: 	... 7 more
08-06 11:51:38.518  8199  8199 E AndroidRuntime: Caused by: java.lang.Throwable: Explicit termination method 'release' not called
08-06 11:51:38.518  8199  8199 E AndroidRuntime: 	at dalvik.system.CloseGuard.open(CloseGuard.java:237)
08-06 11:51:38.518  8199  8199 E AndroidRuntime: 	at android.view.Surface.setNativeObjectLocked(Surface.java:679)
08-06 11:51:38.518  8199  8199 E AndroidRuntime: 	at android.view.Surface.<init>(Surface.java:255)
08-06 11:51:38.518  8199  8199 E AndroidRuntime: 	at io.flutter.embedding.android.FlutterTextureView.connectSurfaceToRenderer(FlutterTextureView.java:196)
08-06 11:51:38.518  8199  8199 E AndroidRuntime: 	at io.flutter.embedding.android.FlutterTextureView.-$$Nest$mconnectSurfaceToRenderer(Unknown Source:0)
08-06 11:51:38.518  8199  8199 E AndroidRuntime: 	at io.flutter.embedding.android.FlutterTextureView$1.onSurfaceTextureAvailable(FlutterTextureView.java:57)

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
