### PR TITLE
Eliminate Mac Android Debug Engine shard

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -185,15 +185,6 @@ targets:
     timeout: 60
     scheduler: luci
 
-  - name: Mac Android Debug Engine
-    recipe: engine
-    properties:
-      android_sdk_license: \n24333f8a63b6825ea9c5514f83c2829b004d1fee
-      android_sdk_preview_license: \n84831b9409646a918e30573bab4c9c91346d8abd
-      build_android_debug: "true"
-    timeout: 60
-    scheduler: luci
-
   - name: Mac Host Engine
     recipe: engine
     properties:


### PR DESCRIPTION
At one point, this shard built the Android Vulkan binaries, but during
the migration to ci.yaml-based recipes, the gn and build steps for that
build were accidentally removed. As such, this shard no longer builds
anything.

This was detected when a buildroot roll triggered a clobber build which
caused the verify_exported.dart script to fail due to a missing 'out'
directory, which caused several of us to wonder why we were:
1. Checking that we strip release binaries on a debug bot, and
2. Why we're checking that we strip release binaries before we actually
   build anything at all.

It appears that we used to build android vulkan binaries, such as in
steps 14-16 of Build 11130:
* https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20Android%20Debug%20Engine/11130/overview

We migrated to ci.yaml-based infra in this commit:
* https://flutter-review.googlesource.com/c/infra/+/15660

A no-op rebuild was triggered in commmit:
* https://github.com/flutter/engine/pull/27599

Which triggered the following buikld, Build 11131:
* https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20Android%20Debug%20Engine/11131/overview

That build does not contain the gn or build steps for the Android Vulkan
binaries.

HOWEVER... we have no users actually using Android Vulkan binaries, so
rather than update the build to fix this, we delete the shard altogether
and save some CPU.

This will be followed by a patch that removes the --enable-vulkan flag
from gn and throughout our build.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
