### PR TITLE
[web_ui] Fixed aria-live attribute on web

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,3 +20,4 @@ Hidenori Matsubayashi <Hidenori.Matsubayashi@sony.com>
 Sarbagya Dhaubanjar <mail@sarbagyastha.com.np>
 Callum Moffat <callum@moffatman.com>
 Koutaro Mori <koutaro.mo@gmail.com>
+TheOneWithTheBraid <the-one@with-the-braid.cf>

--- a/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
@@ -174,7 +174,8 @@ class DesktopSemanticsEnabler extends SemanticsEnabler {
 
   @override
   html.Element prepareAccessibilityPlaceholder() {
-    final html.Element placeholder = _semanticsPlaceholder = html.Element.tag('flt-semantics-placeholder');
+    final html.Element placeholder =
+        _semanticsPlaceholder = html.Element.tag('flt-semantics-placeholder');
 
     // Only listen to "click" because other kinds of events are reported via
     // PointerBinding.
@@ -189,7 +190,7 @@ class DesktopSemanticsEnabler extends SemanticsEnabler {
     // to the assistive technology user.
     placeholder
       ..setAttribute('role', 'button')
-      ..setAttribute('aria-live', 'true')
+      ..setAttribute('aria-live', 'polite')
       ..setAttribute('tabindex', '0')
       ..setAttribute('aria-label', placeholderMessage);
 
@@ -372,7 +373,8 @@ class MobileSemanticsEnabler extends SemanticsEnabler {
 
   @override
   html.Element prepareAccessibilityPlaceholder() {
-    final html.Element placeholder = _semanticsPlaceholder = html.Element.tag('flt-semantics-placeholder');
+    final html.Element placeholder =
+        _semanticsPlaceholder = html.Element.tag('flt-semantics-placeholder');
 
     // Only listen to "click" because other kinds of events are reported via
     // PointerBinding.

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -37,7 +37,7 @@ void testMain() {
 
     test('prepare accesibility placeholder', () async {
       expect(_placeholder!.getAttribute('role'), 'button');
-      expect(_placeholder!.getAttribute('aria-live'), 'true');
+      expect(_placeholder!.getAttribute('aria-live'), 'polite');
       expect(_placeholder!.getAttribute('tabindex'), '0');
 
       html.document.body!.append(_placeholder!);

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -35,7 +35,7 @@ void testMain() {
       EngineSemanticsOwner.instance.semanticsEnabled = false;
     });
 
-    test('prepare accesibility placeholder', () async {
+    test('prepare accessibility placeholder', () async {
       expect(_placeholder!.getAttribute('role'), 'button');
       expect(_placeholder!.getAttribute('aria-live'), 'polite');
       expect(_placeholder!.getAttribute('tabindex'), '0');
@@ -72,7 +72,7 @@ void testMain() {
     });
 
     test(
-        'Relevants events targeting placeholder should not be forwarded to the framework',
+        'Relevant events targeting placeholder should not be forwarded to the framework',
         () async {
       final html.Event event = html.MouseEvent('mousedown');
       _placeholder!.dispatchEvent(event);
@@ -110,15 +110,15 @@ void testMain() {
         EngineSemanticsOwner.instance.semanticsEnabled = false;
       });
 
-      test('prepare accesibility placeholder', () async {
+      test('prepare accessibility placeholder', () async {
         expect(_placeholder!.getAttribute('role'), 'button');
 
         // Placeholder should cover all the screen on a mobile device.
         final num bodyHeight = html.window.innerHeight!;
-        final num bodyWidht = html.window.innerWidth!;
+        final num bodyWidth = html.window.innerWidth!;
 
         expect(_placeholder!.getBoundingClientRect().height, bodyHeight);
-        expect(_placeholder!.getBoundingClientRect().width, bodyWidht);
+        expect(_placeholder!.getBoundingClientRect().width, bodyWidth);
       });
 
       test('Non-relevant events should be forwarded to the framework',


### PR DESCRIPTION
This PR fixes the incorrectly set `aria-live` attribute in the web's semantics. Up to now, it has been set to `true`, which is an invalid value. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions), it should be set to `polite`, `assertive` or `off`.

Moreover, several typos in the semantics test have been fixed.

*List which issues are fixed by this PR. You must list at least one issue.*
- https://github.com/flutter/flutter/issues/87939

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
- I don't think so.

Please note, there was an existing test I modified. Unfortunately, this test was expecting the incorrect value.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
