### PR TITLE
Switch to structured logging for Fuchsia

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -195,6 +195,7 @@ source_set("fml") {
       "$fuchsia_sdk_root/pkg:async-loop-cpp",
       "$fuchsia_sdk_root/pkg:async-loop-default",
       "$fuchsia_sdk_root/pkg:syslog",
+      "$fuchsia_sdk_root/pkg:syslog_structured_backend",
       "$fuchsia_sdk_root/pkg:trace",
       "$fuchsia_sdk_root/pkg:trace-engine",
       "$fuchsia_sdk_root/pkg:zx",

--- a/shell/platform/fuchsia/dart_runner/main.cc
+++ b/shell/platform/fuchsia/dart_runner/main.cc
@@ -34,9 +34,16 @@ static void RegisterProfilerSymbols(const char* symbols_path,
 }
 #endif  // !defined(DART_PRODUCT)
 
+#if defined(OS_FUCHSIA)
+void init_fuchsia_logging();
+#endif
+
+
 int main(int argc, const char** argv) {
   async::Loop loop(&kAsyncLoopConfigAttachToCurrentThread);
-
+  #if defined(OS_FUCHSIA)
+  init_fuchsia_logging();
+  #endif
   // Create our component context which is served later.
   auto context = sys::ComponentContext::Create();
 

--- a/shell/platform/fuchsia/flutter/main.cc
+++ b/shell/platform/fuchsia/flutter/main.cc
@@ -17,9 +17,15 @@
 #include "runtime/dart/utils/root_inspect_node.h"
 #include "runtime/dart/utils/tempfs.h"
 
+#if defined(OS_FUCHSIA)
+void init_fuchsia_logging();
+#endif
+
 int main(int argc, char const* argv[]) {
   fml::MessageLoop::EnsureInitializedForCurrentThread();
-
+  #if defined(OS_FUCHSIA)
+  init_fuchsia_logging();
+  #endif
   // Create our component context which is served later.
   auto context = sys::ComponentContext::Create();
   dart_utils::RootInspectNode::Initialize(context.get());


### PR DESCRIPTION
This patch switches Flutter to structured logging on Fuchsia.
*List which issues are fixed by this PR. You must list at least one issue.*
fxbug.dev/80147
*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides]. -- unclear how to run the formatter
- [x ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA]
- [ ] All existing and new tests are passing -- no applicable tests as this is Fuchsia platform code.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
