### PR TITLE
[web] set aria-live on a11y placeholder to "polite"

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
@@ -189,7 +189,7 @@ class DesktopSemanticsEnabler extends SemanticsEnabler {
     // to the assistive technology user.
     placeholder
       ..setAttribute('role', 'button')
-      ..setAttribute('aria-live', 'true')
+      ..setAttribute('aria-live', 'polite')
       ..setAttribute('tabindex', '0')
       ..setAttribute('aria-label', placeholderMessage);
 

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -37,7 +37,7 @@ void testMain() {
 
     test('prepare accesibility placeholder', () async {
       expect(_placeholder!.getAttribute('role'), 'button');
-      expect(_placeholder!.getAttribute('aria-live'), 'true');
+      expect(_placeholder!.getAttribute('aria-live'), 'polite');
       expect(_placeholder!.getAttribute('tabindex'), '0');
 
       html.document.body!.append(_placeholder!);


### PR DESCRIPTION
"true" is not a valid value for `aria-live`.

Fixes https://github.com/flutter/flutter/issues/87939.