### PR TITLE
[web] rename watcher.dart to pipeline.dart

### DIFF
--- a/lib/web_ui/dev/build.dart
+++ b/lib/web_ui/dev/build.dart
@@ -10,8 +10,8 @@ import 'package:path/path.dart' as path;
 import 'package:watcher/src/watch_event.dart';
 
 import 'environment.dart';
+import 'pipeline.dart';
 import 'utils.dart';
-import 'watcher.dart';
 
 class BuildCommand extends Command<bool> with ArgUtils<bool> {
   BuildCommand() {

--- a/lib/web_ui/dev/pipeline.dart
+++ b/lib/web_ui/dev/pipeline.dart
@@ -87,13 +87,16 @@ abstract class ProcessStep implements PipelineStep {
   }
 }
 
-/// Represents a sequence of asynchronous tasks to be executed.
+/// Executes a sequence of asynchronous tasks, typically as part of a build/test
+/// process.
 ///
 /// The pipeline can be executed by calling [start] and stopped by calling
 /// [stop].
 ///
 /// When a pipeline is stopped, it switches to the [PipelineStatus.stopping]
-/// state and waits until the current task finishes.
+/// state. If [PipelineStep.isSafeToInterrupt] is true, interrupts the currently
+/// running step and skips the rest. Otherwise, waits until the current task
+/// finishes and skips the rest.
 class Pipeline {
   Pipeline({required this.steps});
 

--- a/lib/web_ui/dev/run.dart
+++ b/lib/web_ui/dev/run.dart
@@ -8,10 +8,10 @@ import 'dart:io' as io;
 import 'package:args/command_runner.dart';
 
 import 'common.dart';
+import 'pipeline.dart';
 import 'steps/compile_tests_step.dart';
 import 'steps/run_tests_step.dart';
 import 'utils.dart';
-import 'watcher.dart';
 
 /// Runs build and test steps.
 ///

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -10,8 +10,8 @@ import 'package:web_test_utils/goldens.dart';
 
 import '../environment.dart';
 import '../exceptions.dart';
+import '../pipeline.dart';
 import '../utils.dart';
-import '../watcher.dart';
 
 /// Compiles web tests and their dependencies.
 ///

--- a/lib/web_ui/dev/steps/run_tests_step.dart
+++ b/lib/web_ui/dev/steps/run_tests_step.dart
@@ -19,9 +19,9 @@ import 'package:test_core/src/runner/reporter.dart' as hack;
 import '../browser.dart';
 import '../environment.dart';
 import '../exceptions.dart';
+import '../pipeline.dart';
 import '../test_platform.dart';
 import '../utils.dart';
-import '../watcher.dart';
 
 // Maximum number of tests that run concurrently.
 const int _testConcurrency = int.fromEnvironment('FELT_TEST_CONCURRENCY', defaultValue: 10);

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -12,10 +12,10 @@ import 'package:watcher/src/watch_event.dart';
 
 import 'browser.dart';
 import 'common.dart';
+import 'pipeline.dart';
 import 'steps/compile_tests_step.dart';
 import 'steps/run_tests_step.dart';
 import 'utils.dart';
-import 'watcher.dart';
 
 /// Runs tests.
 class TestCommand extends Command<bool> with ArgUtils<bool> {


### PR DESCRIPTION
Executing pipelines of build steps is the library's primary purpose. Watching is one feature among others. `felt run` doesn't use the watching functionality, so it's weird that it imports `watcher.dart`. So I think `pipeline.dart` is a more logical name for the library.