### PR TITLE
Fix getLineBoundary for TextAffinity

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3258,12 +3258,19 @@ class Paragraph extends NativeFieldWrapperClass1 {
     // _getLineBoundary only considers the offset and assumes that the
     // TextAffinity is upstream. In the case that TextPosition is just after a
     // wordwrap (downstream), we need to get the line for the next offset.
+    // Otherwise, we're done.
     if (position.offset != line.end || position.affinity == TextAffinity.upstream) {
       return line;
     }
 
     final List<int> nextBoundary = _getLineBoundary(position.offset + 1);
-    return TextRange(start: boundary[0], end: boundary[1]);
+    final TextRange nextLine = TextRange(start: nextBoundary[0], end: nextBoundary[1]);
+    // If there is no next line, because we're at the end of the field, return
+    // line.
+    if (!nextLine.isValid) {
+      return line;
+    }
+    return nextLine;
   }
   List<int> _getLineBoundary(int offset) native 'Paragraph_getLineBoundary';
 

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3253,6 +3253,16 @@ class Paragraph extends NativeFieldWrapperClass1 {
   /// metrics, so use it sparingly.
   TextRange getLineBoundary(TextPosition position) {
     final List<int> boundary = _getLineBoundary(position.offset);
+    final TextRange line = TextRange(start: boundary[0], end: boundary[1]);
+
+    // _getLineBoundary only considers the offset and assumes that the
+    // TextAffinity is upstream. In the case that TextPosition is just after a
+    // wordwrap (downstream), we need to get the line for the next offset.
+    if (position.offset != line.end || position.affinity == TextAffinity.upstream) {
+      return line;
+    }
+
+    final List<int> nextBoundary = _getLineBoundary(position.offset + 1);
     return TextRange(start: boundary[0], end: boundary[1]);
   }
   List<int> _getLineBoundary(int offset) native 'Paragraph_getLineBoundary';

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -3255,14 +3255,6 @@ class Paragraph extends NativeFieldWrapperClass1 {
     final List<int> boundary = _getLineBoundary(position.offset);
     final TextRange line = TextRange(start: boundary[0], end: boundary[1]);
 
-    // _getLineBoundary only considers the offset and assumes that the
-    // TextAffinity is upstream. In the case that TextPosition is just after a
-    // wordwrap (downstream), we need to get the line for the next offset.
-    // Otherwise, we're done.
-    if (position.offset != line.end || position.affinity == TextAffinity.upstream) {
-      return line;
-    }
-
     final List<int> nextBoundary = _getLineBoundary(position.offset + 1);
     final TextRange nextLine = TextRange(start: nextBoundary[0], end: nextBoundary[1]);
     // If there is no next line, because we're at the end of the field, return
@@ -3270,7 +3262,16 @@ class Paragraph extends NativeFieldWrapperClass1 {
     if (!nextLine.isValid) {
       return line;
     }
-    return nextLine;
+
+    // _getLineBoundary only considers the offset and assumes that the
+    // TextAffinity is upstream. In the case that TextPosition is just after a
+    // wordwrap (downstream), we need to return the line for the next offset.
+    if (position.affinity == TextAffinity.downstream && line != nextLine
+        && position.offset == line.end && line.end == nextLine.start) {
+      final List<int> nextBoundary = _getLineBoundary(position.offset + 1);
+      return TextRange(start: nextBoundary[0], end: nextBoundary[1]);
+    }
+    return line;
   }
   List<int> _getLineBoundary(int offset) native 'Paragraph_getLineBoundary';
 

--- a/testing/dart/paragraph_test.dart
+++ b/testing/dart/paragraph_test.dart
@@ -72,6 +72,9 @@ void main() {
     final Paragraph paragraph = builder.build();
     paragraph.layout(ParagraphConstraints(width: fontSize * 5.0));
 
+    // Wraps to two lines.
+    expect(paragraph.height, closeTo(fontSize * 2.0, 0.001));
+
     final TextPosition wrapPositionDown = TextPosition(
       offset: 5,
       affinity: TextAffinity.downstream,
@@ -103,5 +106,54 @@ void main() {
     line = paragraph.getLineBoundary(wrapPositionEnd);
     expect(line.start, 5);
     expect(line.end, 9);
+  });
+
+  test('getLineBoundary RTL', () {
+    const double fontSize = 10.0;
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+      fontFamily: 'Ahem',
+      fontStyle: FontStyle.normal,
+      fontWeight: FontWeight.normal,
+      fontSize: fontSize,
+      textDirection: TextDirection.rtl,
+    ));
+    builder.addText('القاهرةالقاهرة');
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(ParagraphConstraints(width: fontSize * 5.0));
+
+      // Wraps to three lines.
+      expect(paragraph.height, closeTo(fontSize * 3.0, 0.001));
+
+    final TextPosition wrapPositionDown = TextPosition(
+      offset: 5,
+      affinity: TextAffinity.downstream,
+    );
+    TextRange line = paragraph.getLineBoundary(wrapPositionDown);
+    expect(line.start, 5);
+    expect(line.end, 10);
+
+    final TextPosition wrapPositionUp = TextPosition(
+      offset: 5,
+      affinity: TextAffinity.upstream,
+    );
+    line = paragraph.getLineBoundary(wrapPositionUp);
+    expect(line.start, 0);
+    expect(line.end, 5);
+
+    final TextPosition wrapPositionStart = TextPosition(
+      offset: 0,
+      affinity: TextAffinity.downstream,
+    );
+    line = paragraph.getLineBoundary(wrapPositionStart);
+    expect(line.start, 0);
+    expect(line.end, 5);
+
+    final TextPosition wrapPositionEnd = TextPosition(
+      offset: 9,
+      affinity: TextAffinity.downstream,
+    );
+    line = paragraph.getLineBoundary(wrapPositionEnd);
+    expect(line.start, 5);
+    expect(line.end, 10);
   });
 }

--- a/testing/dart/paragraph_test.dart
+++ b/testing/dart/paragraph_test.dart
@@ -121,8 +121,8 @@ void main() {
     final Paragraph paragraph = builder.build();
     paragraph.layout(ParagraphConstraints(width: fontSize * 5.0));
 
-      // Wraps to three lines.
-      expect(paragraph.height, closeTo(fontSize * 3.0, 0.001));
+    // Wraps to three lines.
+    expect(paragraph.height, closeTo(fontSize * 3.0, 0.001));
 
     final TextPosition wrapPositionDown = TextPosition(
       offset: 5,
@@ -154,6 +154,56 @@ void main() {
     );
     line = paragraph.getLineBoundary(wrapPositionEnd);
     expect(line.start, 5);
+    expect(line.end, 10);
+  });
+
+  test('getLineBoundary empty line', () {
+    const double fontSize = 10.0;
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+      fontFamily: 'Ahem',
+      fontStyle: FontStyle.normal,
+      fontWeight: FontWeight.normal,
+      fontSize: fontSize,
+      textDirection: TextDirection.rtl,
+    ));
+    builder.addText('Test\n\nAhem');
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(ParagraphConstraints(width: fontSize * 5.0));
+
+    // Three lines due to line breaks, with the middle line being empty.
+    expect(paragraph.height, closeTo(fontSize * 3.0, 0.001));
+
+    final TextPosition emptyLinePosition = TextPosition(
+      offset: 5,
+      affinity: TextAffinity.downstream,
+    );
+    TextRange line = paragraph.getLineBoundary(emptyLinePosition);
+    expect(line.start, 5);
+    expect(line.end, 5);
+
+    // Since these are hard newlines, TextAffinity has no effect here.
+    final TextPosition emptyLinePositionUpstream = TextPosition(
+      offset: 5,
+      affinity: TextAffinity.upstream,
+    );
+    line = paragraph.getLineBoundary(emptyLinePositionUpstream);
+    expect(line.start, 5);
+    expect(line.end, 5);
+
+    final TextPosition endOfFirstLinePosition = TextPosition(
+      offset: 4,
+      affinity: TextAffinity.downstream,
+    );
+    line = paragraph.getLineBoundary(endOfFirstLinePosition);
+    expect(line.start, 0);
+    expect(line.end, 4);
+
+    final TextPosition startOfLastLinePosition = TextPosition(
+      offset: 6,
+      affinity: TextAffinity.downstream,
+    );
+    line = paragraph.getLineBoundary(startOfLastLinePosition);
+    expect(line.start, 6);
     expect(line.end, 10);
   });
 }

--- a/testing/dart/paragraph_test.dart
+++ b/testing/dart/paragraph_test.dart
@@ -59,4 +59,49 @@ void main() {
       );
     }
   });
+
+  test('getLineBoundary', () {
+    const double fontSize = 10.0;
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+      fontFamily: 'Ahem',
+      fontStyle: FontStyle.normal,
+      fontWeight: FontWeight.normal,
+      fontSize: fontSize,
+    ));
+    builder.addText('Test Ahem');
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(ParagraphConstraints(width: fontSize * 5.0));
+
+    final TextPosition wrapPositionDown = TextPosition(
+      offset: 5,
+      affinity: TextAffinity.downstream,
+    );
+    TextRange line = paragraph.getLineBoundary(wrapPositionDown);
+    expect(line.start, 5);
+    expect(line.end, 9);
+
+    final TextPosition wrapPositionUp = TextPosition(
+      offset: 5,
+      affinity: TextAffinity.upstream,
+    );
+    line = paragraph.getLineBoundary(wrapPositionUp);
+    expect(line.start, 0);
+    expect(line.end, 5);
+
+    final TextPosition wrapPositionStart = TextPosition(
+      offset: 0,
+      affinity: TextAffinity.downstream,
+    );
+    line = paragraph.getLineBoundary(wrapPositionStart);
+    expect(line.start, 0);
+    expect(line.end, 5);
+
+    final TextPosition wrapPositionEnd = TextPosition(
+      offset: 9,
+      affinity: TextAffinity.downstream,
+    );
+    line = paragraph.getLineBoundary(wrapPositionEnd);
+    expect(line.start, 5);
+    expect(line.end, 9);
+  });
 }


### PR DESCRIPTION
Paragraph.getLineBoundary accepts a TextPosition, but it disregards the included TextAffinity.  This causes it to give the wrong answer at downstream wordwrap boundaries (see the linked issue for an example).

This PR makes it give the right response for all TextAffinities.

Fixes https://github.com/flutter/flutter/issues/87970