### PR TITLE
adjust opacity layer raster cache heuristics

### DIFF
--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -55,7 +55,9 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
     child_matrix = RasterCache::GetIntegralTransCTM(child_matrix);
 #endif
-    TryToPrepareRasterCache(context, GetCacheableChild(), child_matrix);
+    if (ShouldRasterCache()) {
+      TryToPrepareRasterCache(context, GetCacheableChild(), child_matrix);
+    }
   }
 
   // Restore cull_rect
@@ -77,7 +79,7 @@ void OpacityLayer::Paint(PaintContext& context) const {
       context.leaf_nodes_canvas->getTotalMatrix()));
 #endif
 
-  if (context.raster_cache &&
+  if (context.raster_cache && ShouldRasterCache() &&
       context.raster_cache->Draw(GetCacheableChild(),
                                  *context.leaf_nodes_canvas, &paint)) {
     return;
@@ -99,6 +101,10 @@ void OpacityLayer::Paint(PaintContext& context) const {
   Layer::AutoSaveLayer save_layer =
       Layer::AutoSaveLayer::Create(context, saveLayerBounds, &paint);
   PaintChildren(context);
+}
+
+bool OpacityLayer::ShouldRasterCache() const {
+  return alpha_ != 255 && alpha_ != 0;
 }
 
 }  // namespace flutter

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -79,9 +79,12 @@ void OpacityLayer::Paint(PaintContext& context) const {
       context.leaf_nodes_canvas->getTotalMatrix()));
 #endif
 
-  if (context.raster_cache && ShouldRasterCache() &&
+  // If the opacity layer has become fully opaque, attempt to reuse an available
+  // raster but do not retain the cache entry.
+  if (context.raster_cache &&
       context.raster_cache->Draw(GetCacheableChild(),
-                                 *context.leaf_nodes_canvas, &paint)) {
+                                 *context.leaf_nodes_canvas, &paint,
+                                 ShouldRasterCache())) {
     return;
   }
 
@@ -104,7 +107,7 @@ void OpacityLayer::Paint(PaintContext& context) const {
 }
 
 bool OpacityLayer::ShouldRasterCache() const {
-  return alpha_ != 255 && alpha_ != 0;
+  return alpha_ != 255;
 }
 
 }  // namespace flutter

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -41,6 +41,11 @@ class OpacityLayer : public MergedContainerLayer {
   SkAlpha alpha_;
   SkPoint offset_;
 
+  // Do not raster cache excessively if alpha is 0 or 255. This allows the
+  // framework to skip dropping the opacity layer in order to remove the raster
+  // cache memory overhead.
+  bool ShouldRasterCache() const;
+
   FML_DISALLOW_COPY_AND_ASSIGN(OpacityLayer);
 };
 

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -41,7 +41,7 @@ class OpacityLayer : public MergedContainerLayer {
   SkAlpha alpha_;
   SkPoint offset_;
 
-  // Do not raster cache excessively if alpha is 0 or 255. This allows the
+  // Do not raster cache excessively if alpha is 255. This allows the
   // framework to skip dropping the opacity layer in order to remove the raster
   // cache memory overhead.
   bool ShouldRasterCache() const;

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -126,7 +126,7 @@ TEST_F(OpacityLayerTest, ChildIsNotCachedWhenFullyOpaque) {
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
   EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), other_canvas));
-  EXPECT_TRUE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
 }
 
 TEST_F(OpacityLayerTest, ChildIsNotCachedWhenFullyTransparent) {
@@ -155,7 +155,7 @@ TEST_F(OpacityLayerTest, ChildIsNotCachedWhenFullyTransparent) {
 
   EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
   EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), other_canvas));
-  EXPECT_TRUE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
 }
 
 TEST_F(OpacityLayerTest, ChildrenNotCached) {

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -389,6 +389,30 @@ bool RasterCache::Draw(const Layer* layer,
   return false;
 }
 
+bool RasterCache::Draw(const Layer* layer,
+                       SkCanvas& canvas,
+                       SkPaint* paint,
+                       bool retain_cache) const {
+  LayerRasterCacheKey cache_key(layer->unique_id(), canvas.getTotalMatrix());
+  auto it = layer_cache_.find(cache_key);
+  if (it == layer_cache_.end()) {
+    return false;
+  }
+
+  Entry& entry = it->second;
+  if (retain_cache) {
+    entry.access_count++;
+    entry.used_this_frame = true;
+  }
+
+  if (entry.image) {
+    entry.image->draw(canvas, paint);
+    return true;
+  }
+
+  return false;
+}
+
 void RasterCache::SweepAfterFrame() {
   SweepOneCacheAfterFrame(picture_cache_);
   SweepOneCacheAfterFrame(display_list_cache_);

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -174,6 +174,20 @@ class RasterCache {
             SkCanvas& canvas,
             SkPaint* paint = nullptr) const;
 
+  // Find the raster cache for the layer and draw it to the canvas.
+  //
+  // Additional paint can be given to change how the raster cache is drawn
+  // (e.g., draw the raster cache with some opacity).
+  //
+  // Return true if the layer raster cache is found and drawn.
+  //
+  // If retain_cache is false, the cache entry will not be marked as used,
+  // allowing it to be reclaimed.
+  bool Draw(const Layer* layer,
+                       SkCanvas& canvas,
+                       SkPaint* paint,
+                       bool retain_cache) const;
+
   void SweepAfterFrame();
 
   void Clear();

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -184,9 +184,9 @@ class RasterCache {
   // If retain_cache is false, the cache entry will not be marked as used,
   // allowing it to be reclaimed.
   bool Draw(const Layer* layer,
-                       SkCanvas& canvas,
-                       SkPaint* paint,
-                       bool retain_cache) const;
+            SkCanvas& canvas,
+            SkPaint* paint,
+            bool retain_cache) const;
 
   void SweepAfterFrame();
 


### PR DESCRIPTION
Currently flutter appears to unconditionally raster cache layers beneath an opacity layer. The primary reason this does not heavily impact the framework is that the framework tends to remove opacity layers from the tree if they hit `255`.

Nevertheless, removing the layer can cause pixel snapping on low DPI screens. We had previously investigated fixing this with the animated opacity widget but this was reverted due to increased memory usage. After this change, it should be "safe" (from the perspective of memory usage) to leave an opacity layer in the tree. We also do not risk any obvious regressions from changing the raster cache performance at `255` since the framework does not currently create opacity layers with these values today.

Issue: https://github.com/flutter/flutter/issues/71008

Previous attempt: https://github.com/flutter/flutter/pull/83145