### PR TITLE
Add bundletool to DEPS and remove outdated header comment

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -435,7 +435,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/bundletool',
-        'version': 'version:1.7.1'
+        'version': 'version:1.7.1.1'
        }
      ],
      'dep_type': 'cipd',

--- a/DEPS
+++ b/DEPS
@@ -1,21 +1,7 @@
-# This file is automatically processed to create .DEPS.git which is the file
-# that gclient uses under git.
+# This file contains the dependencies used by the Engine repo.
 #
-# See http://code.google.com/p/chromium/wiki/UsingGit
-#
-# To test manually, run:
-#   python tools/deps2git/deps2git.py -o .DEPS.git -w <gclientdir>
-# where <gcliendir> is the absolute path to the directory containing the
-# .gclient file (the parent of 'src').
-#
-# Then commit .DEPS.git locally (gclient doesn't like dirty trees) and run
-#   gclient sync..
-# Verify the thing happened you wanted. Then revert your .DEPS.git change
-# DO NOT CHECK IN CHANGES TO .DEPS.git upstream. It will be automatically
-# updated by a bot when you modify this one.
-#
-# When adding a new dependency, please update the top-level .gitignore file
-# to list the dependency's destination directory.
+# Use the `gclient sync` command to download and sync local checkouts
+# with the versions listed in this file.
 
 vars = {
   'chromium_git': 'https://chromium.googlesource.com',
@@ -444,6 +430,16 @@ deps = {
 
   'src/third_party/pkg/when':
   Var('dart_git') + '/when.git' + '@' + '0.2.0',
+
+  'src/third_party/bundletool': {
+     'packages': [
+       {
+        'package': 'flutter/android/bundletool',
+        'version': 'version:1.7.1'
+       }
+     ],
+     'dep_type': 'cipd',
+   },
 
   'src/third_party/android_tools/ndk': {
      'packages': [

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: ba62ed10d5e046f90a397663d6c9d5d2
+Signature: c74d92f352b4f0ae5ef7f45d2358846f
 

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: c74d92f352b4f0ae5ef7f45d2358846f
+Signature: 8657ee54922fa27c46d6c88773a1431d
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1497,6 +1497,16 @@ class _RepositoryIcuDirectory extends _RepositoryDirectory {
   }
 }
 
+class _RepositoryBundletoolDirectory extends _RepositoryDirectory {
+  _RepositoryBundletoolDirectory(_RepositoryDirectory parent, fs.Directory io) : super(parent, io);
+
+  @override
+  bool shouldRecurse(fs.IoNode entry) {
+    return entry.name != 'bundletool.jar' // redundant with LICENSE file
+        && super.shouldRecurse(entry);
+  }
+}
+
 class _RepositoryHarfbuzzDirectory extends _RepositoryDirectory {
   _RepositoryHarfbuzzDirectory(_RepositoryDirectory parent, fs.Directory io) : super(parent, io);
 
@@ -1858,6 +1868,8 @@ class _RepositoryRootThirdPartyDirectory extends _RepositoryGenericThirdPartyDir
       return _RepositoryHarfbuzzDirectory(this, entry);
     if (entry.name == 'icu')
       return _RepositoryIcuDirectory(this, entry);
+    if (entry.name == 'bundletool')
+      return _RepositoryBundletoolDirectory(this, entry);
     if (entry.name == 'jsr-305')
       return _RepositoryJSR305Directory(this, entry);
     if (entry.name == 'libcxx')


### PR DESCRIPTION
Bundletool is needed to run integration tests for deferred components such as https://github.com/flutter/flutter/pull/88030

Also removes the outdated header at the top of DEPS.
