### PR TITLE
[UWP] Implement clipboard.

### DIFF
--- a/shell/platform/windows/platform_handler_winuwp.cc
+++ b/shell/platform/windows/platform_handler_winuwp.cc
@@ -4,8 +4,12 @@
 
 #include "flutter/shell/platform/windows/platform_handler_winuwp.h"
 
-#include "flutter/shell/platform/windows/flutter_windows_view.h"
+#include "third_party/cppwinrt/generated/winrt/Windows.ApplicationModel.DataTransfer.h"
+#include "third_party/cppwinrt/generated/winrt/Windows.Foundation.h"
+#include "third_party/cppwinrt/generated/winrt/Windows.UI.Core.h"
 
+#include "flutter/shell/platform/windows/flutter_windows_view.h"
+#include "flutter/shell/platform/windows/string_conversion.h"
 namespace flutter {
 
 // static
@@ -24,8 +28,42 @@ PlatformHandlerWinUwp::~PlatformHandlerWinUwp() = default;
 void PlatformHandlerWinUwp::GetPlainText(
     std::unique_ptr<MethodResult<rapidjson::Document>> result,
     std::string_view key) {
-  // TODO: Implement. See https://github.com/flutter/flutter/issues/70214.
-  result->NotImplemented();
+  auto activation_mode =
+      winrt::Windows::UI::Core::CoreWindow::GetForCurrentThread()
+          .ActivationMode();
+  // We call `Clipboard::GetContent()` when the application window is in
+  // focus, otherwise calling this will throw an error.
+  if (activation_mode == winrt::Windows::UI::Core::CoreWindowActivationMode::
+                             ActivatedInForeground) {
+    auto content =
+        winrt::Windows::ApplicationModel::DataTransfer::Clipboard::GetContent();
+    // Calling `DataPackageView::GetTextAsync()` when the clipboard has no text
+    // content will throw an error.
+    if (content.Contains(winrt::Windows::ApplicationModel::DataTransfer::
+                             StandardDataFormats::Text())) {
+      // Waiting `DataPackageView::GetTextAsync()` using `TResult.get()` on the
+      // platform thread will causes the application stop, so we continue
+      // response on this callback.
+      content.GetTextAsync().Completed([result = std::move(result), key](
+                                           auto async_info,
+                                           auto _async_status) {
+        auto clipboard_string = async_info.GetResults();
+
+        rapidjson::Document document;
+        document.SetObject();
+        rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
+        document.AddMember(
+            rapidjson::Value(key.data(), allocator),
+            rapidjson::Value(Utf8FromUtf16(clipboard_string), allocator),
+            allocator);
+        result->Success(document);
+      });
+    } else {
+      result->Success(rapidjson::Document());
+    }
+  } else {
+    result->Success(rapidjson::Document());
+  }
 }
 
 void PlatformHandlerWinUwp::GetHasStrings(
@@ -37,8 +75,12 @@ void PlatformHandlerWinUwp::GetHasStrings(
 void PlatformHandlerWinUwp::SetPlainText(
     const std::string& text,
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-  // TODO: Implement. See https://github.com/flutter/flutter/issues/70214.
-  result->NotImplemented();
+  winrt::Windows::ApplicationModel::DataTransfer::DataPackage content;
+  content.SetText(Utf16FromUtf8(text));
+  winrt::Windows::ApplicationModel::DataTransfer::Clipboard::SetContent(
+      content);
+
+  result->Success();
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/platform_handler_winuwp.cc
+++ b/shell/platform/windows/platform_handler_winuwp.cc
@@ -69,7 +69,8 @@ void PlatformHandlerWinUwp::GetPlainText(
       result->Success(rapidjson::Document());
     }
   } else {
-    result->Success(rapidjson::Document());
+    result->Error(kClipboardError,
+                  "Unable to read clipboard. The window is not focused.");
   }
 }
 


### PR DESCRIPTION
This PR will able to merge after:
- [X] #27749
- [X] The `hasString` implementation for UWP.

This PR implements clipboard in platform handler in UWP.
I tested it by these steps:
- Selecting `TextField` in flutter uwp app.
- Typing some characters.
- Performing right click and checking `Paste` behavior in the context menu.

|Clipboard content|`Paste` behavior|
|-|-|
|Text (copied from another app)|appeared, performing paste by clicking|
|Image (from Print Screen key)|disappeared|

Fixes one item in flutter/flutter#70214.

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.