### PR TITLE
Fix memory leak in FlutterSwitchSemanticsObject

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -96,7 +96,7 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
                            uid:(int32_t)uid {
   self = [super initWithBridge:bridge uid:uid];
   if (self) {
-    _nativeSwitch = [[[UISwitch alloc] init] retain];
+    _nativeSwitch = [[UISwitch alloc] init];
   }
   return self;
 }


### PR DESCRIPTION

```
_nativeSwitch = [[[UISwitch alloc] init] retain];
```
Both methods `alloc` and `retain` will increase the reference count of `_nativeSwitch`,so its reference count is 2

```
- (void)dealloc {
  [_nativeSwitch release];
  [super dealloc];
}
```
After the `dealloc` method is called, reference count of `_nativeSwitch` is 1 instead of 0, so it will not be destroyed

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

