### PR TITLE
winuwp: Add multi-touch support

### DIFF
--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -12,10 +12,10 @@ namespace flutter {
 static constexpr double kControllerScrollMultiplier = 3;
 
 // Minimum pointer ID that gets emitted by the pointer ID generator.
-static constexpr auto kMinPointerId = 0;
+static constexpr uint32_t kMinPointerId = 0;
 
 // Maximum pointer ID that gets emitted by the pointer ID generator.
-static constexpr auto kMaxPointerId = 128;
+static constexpr uint32_t kMaxPointerId = 128;
 
 // Maps a Flutter cursor name to a CoreCursor.
 //

--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -11,10 +11,11 @@ namespace flutter {
 // Multipler used to map controller velocity to an appropriate scroll input.
 static constexpr double kControllerScrollMultiplier = 3;
 
-// TODO(clarkezone): Determine pointer ID in
-// OnPointerPressed/OnPointerReleased/OnPointerMoved in order to support multi
-// touch. See https://github.com/flutter/flutter/issues/70201
-static constexpr int32_t kDefaultPointerDeviceId = 0;
+// Minimum pointer ID that gets emitted by the pointer ID generator.
+static constexpr auto kMinPointerId = 0;
+
+// Maximum pointer ID that gets emitted by the pointer ID generator.
+static constexpr auto kMaxPointerId = 128;
 
 // Maps a Flutter cursor name to a CoreCursor.
 //
@@ -69,8 +70,8 @@ winrt::Windows::UI::Core::CoreCursor GetCursorByName(
 }  // namespace
 
 FlutterWindowWinUWP::FlutterWindowWinUWP(
-    ABI::Windows::ApplicationModel::Core::CoreApplicationView*
-        applicationview) {
+    ABI::Windows::ApplicationModel::Core::CoreApplicationView* applicationview)
+    : pointer_id_generator_(kMinPointerId, kMaxPointerId) {
   winrt::Windows::ApplicationModel::Core::CoreApplicationView cav{nullptr};
   winrt::copy_from_abi(cav, applicationview);
 
@@ -206,9 +207,10 @@ void FlutterWindowWinUWP::OnPointerPressed(
   double y = GetPosY(args);
   FlutterPointerDeviceKind device_kind = GetPointerDeviceKind(args);
   FlutterPointerMouseButtons mouse_button = GetPointerMouseButton(args);
+  auto pointer_id = GetPointerId(args);
 
-  binding_handler_delegate_->OnPointerDown(
-      x, y, device_kind, kDefaultPointerDeviceId, mouse_button);
+  binding_handler_delegate_->OnPointerDown(x, y, device_kind, pointer_id,
+                                           mouse_button);
 }
 
 void FlutterWindowWinUWP::OnPointerReleased(
@@ -218,9 +220,11 @@ void FlutterWindowWinUWP::OnPointerReleased(
   double y = GetPosY(args);
   FlutterPointerDeviceKind device_kind = GetPointerDeviceKind(args);
   FlutterPointerMouseButtons mouse_button = GetPointerMouseButton(args);
+  auto pointer_id = GetPointerId(args);
 
-  binding_handler_delegate_->OnPointerUp(x, y, device_kind,
-                                         kDefaultPointerDeviceId, mouse_button);
+  binding_handler_delegate_->OnPointerUp(x, y, device_kind, pointer_id,
+                                         mouse_button);
+  ReleasePointer(args);
 }
 
 void FlutterWindowWinUWP::OnPointerMoved(
@@ -229,9 +233,9 @@ void FlutterWindowWinUWP::OnPointerMoved(
   double x = GetPosX(args);
   double y = GetPosY(args);
   FlutterPointerDeviceKind device_kind = GetPointerDeviceKind(args);
+  auto pointer_id = GetPointerId(args);
 
-  binding_handler_delegate_->OnPointerMove(x, y, device_kind,
-                                           kDefaultPointerDeviceId);
+  binding_handler_delegate_->OnPointerMove(x, y, device_kind, pointer_id);
 }
 
 void FlutterWindowWinUWP::OnPointerWheelChanged(
@@ -240,9 +244,10 @@ void FlutterWindowWinUWP::OnPointerWheelChanged(
   double x = GetPosX(args);
   double y = GetPosY(args);
   FlutterPointerDeviceKind device_kind = GetPointerDeviceKind(args);
+  auto pointer_id = GetPointerId(args);
   int delta = args.CurrentPoint().Properties().MouseWheelDelta();
   binding_handler_delegate_->OnScroll(x, y, 0, -delta, 1, device_kind,
-                                      kDefaultPointerDeviceId);
+                                      pointer_id);
 }
 
 double FlutterWindowWinUWP::GetPosX(
@@ -297,6 +302,17 @@ FlutterPointerMouseButtons FlutterWindowWinUWP::GetPointerMouseButton(
       return kFlutterPointerButtonMousePrimary;
   }
   return kFlutterPointerButtonMousePrimary;
+}
+
+void FlutterWindowWinUWP::ReleasePointer(
+    winrt::Windows::UI::Core::PointerEventArgs const& args) {
+  pointer_id_generator_.ReleaseNumber(args.CurrentPoint().PointerId());
+}
+
+uint32_t FlutterWindowWinUWP::GetPointerId(
+    winrt::Windows::UI::Core::PointerEventArgs const& args) {
+  // Generate a mapped ID in the interval [kMinPointerId, kMaxPointerId].
+  return pointer_id_generator_.GetGeneratedId(args.CurrentPoint().PointerId());
 }
 
 void FlutterWindowWinUWP::OnBoundsChanged(

--- a/shell/platform/windows/flutter_window_winuwp.h
+++ b/shell/platform/windows/flutter_window_winuwp.h
@@ -17,6 +17,7 @@
 #include "flutter/shell/platform/windows/display_helper_winuwp.h"
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/game_pad_cursor_winuwp.h"
+#include "flutter/shell/platform/windows/sequential_id_generator.h"
 
 namespace flutter {
 
@@ -129,6 +130,12 @@ class FlutterWindowWinUWP : public WindowBindingHandler {
   FlutterPointerDeviceKind GetPointerDeviceKind(
       winrt::Windows::UI::Core::PointerEventArgs const& args);
 
+  // Gets the pointer ID.
+  uint32_t GetPointerId(winrt::Windows::UI::Core::PointerEventArgs const& args);
+
+  // Releases the pointer from the ID generator.
+  void ReleasePointer(winrt::Windows::UI::Core::PointerEventArgs const& args);
+
   // Gets the mouse button.
   FlutterPointerMouseButtons GetPointerMouseButton(
       winrt::Windows::UI::Core::PointerEventArgs const& args);
@@ -167,6 +174,9 @@ class FlutterWindowWinUWP : public WindowBindingHandler {
 
   // DisplayHelper object used to determine window bounds, DPI etc.
   std::unique_ptr<DisplayHelperWinUWP> display_helper_ = {nullptr};
+
+  // Generates pointer IDs for pointer events.
+  SequentialIdGenerator pointer_id_generator_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -310,7 +310,7 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   std::unique_ptr<FlutterWindowsEngine> engine_;
 
   // Keeps track of pointer states in relation to the window.
-  std::map<int32_t, std::unique_ptr<PointerState>> pointer_states_;
+  std::unordered_map<int32_t, std::unique_ptr<PointerState>> pointer_states_;
 
   // The plugin registrar managing internal plugins.
   std::unique_ptr<flutter::PluginRegistrar> internal_plugin_registrar_;


### PR DESCRIPTION
Now that multi touch is supported for Win32, it's time to implement it for UWP as well. This PR does so.

Fixes https://github.com/flutter/flutter/issues/70201

Linked issues:
- https://github.com/flutter/flutter/issues/70201
- #27863 

Tested with flutter_gallery.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
