### PR TITLE
Add --asan-options flag to run_tests.py

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -545,6 +545,8 @@ def main():
       help='Generate coverage reports for each unit test framework run.')
   parser.add_argument('--engine-capture-core-dump', dest='engine_capture_core_dump', action='store_true',
       default=False, help='Capture core dumps from crashes of engine tests.')
+  parser.add_argument('--asan-options', dest='asan_options', action='store', type=str, default='',
+      help='Runtime AddressSanitizer flags to use if built wth asan (example: "verbosity=1:detect_leaks=0')
 
   args = parser.parse_args()
 
@@ -556,6 +558,9 @@ def main():
   build_dir = os.path.join(out_dir, args.variant)
   if args.type != 'java':
     assert os.path.exists(build_dir), 'Build variant directory %s does not exist!' % build_dir
+
+  if args.asan_options:
+    os.environ['ASAN_OPTIONS'] = args.asan_options
 
   engine_filter = args.engine_filter.split(',') if args.engine_filter else None
   if 'engine' in types:


### PR DESCRIPTION
Add a flag to configure asan via ASAN_OPTIONS when running from LUCI. I added this due to trouble getting the environment variable to propagate on the CI side.

Currently using it here: https://flutter-review.googlesource.com/c/recipes/+/16364