### PR TITLE
Revert "Sets focus before sending a11y focus event in Android"

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1020,32 +1020,27 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         }
       case AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS:
         {
-          // Focused semantics node must be reset before sending the
-          // TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED event. Otherwise,
-          // TalkBack may think the node is still focused.
-          accessibilityFocusedSemanticsNode = null;
-          embeddedAccessibilityFocusedNodeId = null;
           accessibilityChannel.dispatchSemanticsAction(
               virtualViewId, Action.DID_LOSE_ACCESSIBILITY_FOCUS);
           sendAccessibilityEvent(
               virtualViewId, AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED);
+          accessibilityFocusedSemanticsNode = null;
+          embeddedAccessibilityFocusedNodeId = null;
           return true;
         }
       case AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS:
         {
+          accessibilityChannel.dispatchSemanticsAction(
+              virtualViewId, Action.DID_GAIN_ACCESSIBILITY_FOCUS);
+          sendAccessibilityEvent(virtualViewId, AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
+
           if (accessibilityFocusedSemanticsNode == null) {
             // When Android focuses a node, it doesn't invalidate the view.
             // (It does when it sends ACTION_CLEAR_ACCESSIBILITY_FOCUS, so
             // we only have to worry about this when the focused node is null.)
             rootAccessibilityView.invalidate();
           }
-          // Focused semantics node must be set before sending the TYPE_VIEW_ACCESSIBILITY_FOCUSED
-          // event. Otherwise, TalkBack may think the node is not focused yet.
           accessibilityFocusedSemanticsNode = semanticsNode;
-
-          accessibilityChannel.dispatchSemanticsAction(
-              virtualViewId, Action.DID_GAIN_ACCESSIBILITY_FOCUS);
-          sendAccessibilityEvent(virtualViewId, AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
 
           if (semanticsNode.hasAction(Action.INCREASE)
               || semanticsNode.hasAction(Action.DECREASE)) {

--- a/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
+++ b/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java
@@ -5,7 +5,6 @@
 package io.flutter.view;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -47,7 +46,6 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.invocation.InvocationOnMock;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
@@ -798,122 +796,6 @@ public class AccessibilityBridgeTest {
     AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(1);
     assertEquals(nodeInfo.getTextSelectionStart(), expectedStart);
     assertEquals(nodeInfo.getTextSelectionEnd(), expectedEnd);
-  }
-
-  @Test
-  public void itSetsFocusedNodeBeforeSendingEvent() {
-    AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
-    AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
-    AccessibilityManager mockManager = mock(AccessibilityManager.class);
-    View mockRootView = mock(View.class);
-    Context context = mock(Context.class);
-    when(mockRootView.getContext()).thenReturn(context);
-    when(context.getPackageName()).thenReturn("test");
-    AccessibilityBridge accessibilityBridge =
-        setUpBridge(
-            /*rootAccessibilityView=*/ mockRootView,
-            /*accessibilityChannel=*/ mockChannel,
-            /*accessibilityManager=*/ mockManager,
-            /*contentResolver=*/ null,
-            /*accessibilityViewEmbedder=*/ mockViewEmbedder,
-            /*platformViewsAccessibilityDelegate=*/ null);
-
-    ViewParent mockParent = mock(ViewParent.class);
-    when(mockRootView.getParent()).thenReturn(mockParent);
-    when(mockManager.isEnabled()).thenReturn(true);
-
-    TestSemanticsNode root = new TestSemanticsNode();
-    root.id = 0;
-    root.label = "root";
-
-    TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
-    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
-
-    class Verifier {
-      public Verifier(AccessibilityBridge accessibilityBridge) {
-        this.accessibilityBridge = accessibilityBridge;
-      }
-
-      public AccessibilityBridge accessibilityBridge;
-      public boolean verified = false;
-
-      public boolean verify(InvocationOnMock invocation) {
-        AccessibilityEvent event = (AccessibilityEvent) invocation.getArguments()[1];
-        assertEquals(event.getEventType(), AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUSED);
-        // The accessibility focus must be set before sending out
-        // the TYPE_VIEW_ACCESSIBILITY_FOCUSED event.
-        AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
-        assertTrue(nodeInfo.isAccessibilityFocused());
-        verified = true;
-        return true;
-      }
-    };
-    Verifier verifier = new Verifier(accessibilityBridge);
-    when(mockParent.requestSendAccessibilityEvent(eq(mockRootView), any(AccessibilityEvent.class)))
-        .thenAnswer(invocation -> verifier.verify(invocation));
-    accessibilityBridge.performAction(0, AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS, null);
-    assertTrue(verifier.verified);
-  }
-
-  @Test
-  public void itClearsFocusedNodeBeforeSendingEvent() {
-    AccessibilityChannel mockChannel = mock(AccessibilityChannel.class);
-    AccessibilityViewEmbedder mockViewEmbedder = mock(AccessibilityViewEmbedder.class);
-    AccessibilityManager mockManager = mock(AccessibilityManager.class);
-    View mockRootView = mock(View.class);
-    Context context = mock(Context.class);
-    when(mockRootView.getContext()).thenReturn(context);
-    when(context.getPackageName()).thenReturn("test");
-    AccessibilityBridge accessibilityBridge =
-        setUpBridge(
-            /*rootAccessibilityView=*/ mockRootView,
-            /*accessibilityChannel=*/ mockChannel,
-            /*accessibilityManager=*/ mockManager,
-            /*contentResolver=*/ null,
-            /*accessibilityViewEmbedder=*/ mockViewEmbedder,
-            /*platformViewsAccessibilityDelegate=*/ null);
-
-    ViewParent mockParent = mock(ViewParent.class);
-    when(mockRootView.getParent()).thenReturn(mockParent);
-    when(mockManager.isEnabled()).thenReturn(true);
-
-    TestSemanticsNode root = new TestSemanticsNode();
-    root.id = 0;
-    root.label = "root";
-
-    TestSemanticsUpdate testSemanticsUpdate = root.toUpdate();
-    testSemanticsUpdate.sendUpdateToBridge(accessibilityBridge);
-    // Set the focus on root.
-    accessibilityBridge.performAction(0, AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS, null);
-    AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
-    assertTrue(nodeInfo.isAccessibilityFocused());
-
-    class Verifier {
-      public Verifier(AccessibilityBridge accessibilityBridge) {
-        this.accessibilityBridge = accessibilityBridge;
-      }
-
-      public AccessibilityBridge accessibilityBridge;
-      public boolean verified = false;
-
-      public boolean verify(InvocationOnMock invocation) {
-        AccessibilityEvent event = (AccessibilityEvent) invocation.getArguments()[1];
-        assertEquals(
-            event.getEventType(), AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED);
-        // The accessibility focus must be cleared before sending out
-        // the TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED event.
-        AccessibilityNodeInfo nodeInfo = accessibilityBridge.createAccessibilityNodeInfo(0);
-        assertFalse(nodeInfo.isAccessibilityFocused());
-        verified = true;
-        return true;
-      }
-    };
-    Verifier verifier = new Verifier(accessibilityBridge);
-    when(mockParent.requestSendAccessibilityEvent(eq(mockRootView), any(AccessibilityEvent.class)))
-        .thenAnswer(invocation -> verifier.verify(invocation));
-    accessibilityBridge.performAction(
-        0, AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS, null);
-    assertTrue(verifier.verified);
   }
 
   @Test


### PR DESCRIPTION
Reverts flutter/engine#27992

It looks like this change caused a failure in

https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20android_semantics_integration_test/2203/overview

```
[android_semantics_integration_test] [STDOUT] stdout: [ +856 ms] 00:15 [32m+1[0m[31m -1[0m: AccessibilityBridge TextField password TextField has correct Android semantics [1m[31m[E][0m[0m
[android_semantics_integration_test] [STDOUT] stdout: [        ]   Expected: AndroidSemanticsNode with className: android.widget.EditText with actions: [AndroidSemanticsAction.clearAccessibilityFocus, AndroidSemanticsAction.click, AndroidSemanticsAction.copy, AndroidSemanticsAction.setSelection, AndroidSemanticsAction.setText] with flag isEditable: true with flag isFocusable: true with flag isFocused: true with flag isPassword: true
[android_semantics_integration_test] [STDOUT] stdout: [        ]     Actual: AndroidSemanticsNode:<{flags: {isEditable: true, isEnabled: true, isDismissible: false, isCheckable: false, isChecked: false, isFocused: true, isLongClickable: false, isFocusable: true, isPassword: true}, id: 30, text: null, rect: {height: 144, width: 1080, bottom: 592.0, top: 544.0, left: 0.0, right: 360.0}, actions: [131072, 32768, 2097152, 16, 64], className: android.widget.EditText, liveRegion: 0, contentDescription: null}>
[android_semantics_integration_test] [STDOUT] stdout: [        ]      Which: Expected actions: [AndroidSemanticsAction.clearAccessibilityFocus, AndroidSemanticsAction.click, AndroidSemanticsAction.copy, AndroidSemanticsAction.setSelection, AndroidSemanticsAction.setText]
[android_semantics_integration_test] [STDOUT] stdout: [        ]             Actual actions: [AndroidSemanticsAction.accessibilityFocus, AndroidSemanticsAction.click, AndroidSemanticsAction.copy, AndroidSemanticsAction.setSelection, AndroidSemanticsAction.setText]
[android_semantics_integration_test] [STDOUT] stdout: [        ]             Unexpected: {AndroidSemanticsAction.accessibilityFocus}
[android_semantics_integration_test] [STDOUT] stdout: [        ]             Missing: {AndroidSemanticsAction.clearAccessibilityFocus}
```

Reverting this to get the Engine roll moving again.