### PR TITLE
[UWP] Implement setting cursor icon.

### DIFF
--- a/shell/platform/windows/flutter_window_win32.cc
+++ b/shell/platform/windows/flutter_window_win32.cc
@@ -25,7 +25,7 @@ constexpr int kScrollOffsetMultiplier = 20;
 // Returns the arrow cursor for unknown constants.
 //
 // This map must be kept in sync with Flutter framework's
-// rendering/mouse_cursor.dart.
+// services/mouse_cursor.dart.
 static HCURSOR GetCursorByName(const std::string& cursor_name) {
   static auto* cursors = new std::map<std::string, const wchar_t*>{
       {"allScroll", IDC_SIZEALL},


### PR DESCRIPTION
This PR adds an implementation for setting cursor icon in UWP engine, and replace old `mouse_cursor.dart` path with new in a comment that in Win32 engine.

This PR will solve one item in flutter/flutter#70199.

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.