### PR TITLE
Call DisplayListBuilder methods directly from flutter canvas

### DIFF
--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -1115,7 +1115,8 @@ void DisplayListBuilder::onSetMaskFilter(sk_sp<SkMaskFilter> filter) {
   current_mask_filter_ = filter;
   Push<SetMaskFilterOp>(0, std::move(filter));
 }
-void DisplayListBuilder::onSetMaskBlurFilter(SkBlurStyle style, SkScalar sigma) {
+void DisplayListBuilder::onSetMaskBlurFilter(SkBlurStyle style,
+                                             SkScalar sigma) {
   // Valid sigma is checked by setMaskBlurFilter
   FML_DCHECK(mask_sigma_valid(sigma));
   current_mask_filter_ = nullptr;

--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -9,8 +9,6 @@
 #include "flutter/flow/display_list_utils.h"
 #include "flutter/fml/logging.h"
 
-#include "third_party/skia/include/core/SkImageFilter.h"
-#include "third_party/skia/include/core/SkMaskFilter.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkRSXform.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
@@ -1054,121 +1052,88 @@ DisplayListBuilder::~DisplayListBuilder() {
   }
 }
 
-void DisplayListBuilder::setAA(bool aa) {
-  if (current_aa_ != aa) {
-    Push<SetAAOp>(0, current_aa_ = aa);
-  }
+void DisplayListBuilder::onSetAA(bool aa) {
+  Push<SetAAOp>(0, current_aa_ = aa);
 }
-void DisplayListBuilder::setDither(bool dither) {
-  if (current_dither_ != dither) {
-    Push<SetDitherOp>(0, current_dither_ = dither);
-  }
+void DisplayListBuilder::onSetDither(bool dither) {
+  Push<SetDitherOp>(0, current_dither_ = dither);
 }
-void DisplayListBuilder::setInvertColors(bool invert) {
-  if (current_invert_colors_ != invert) {
-    Push<SetInvertColorsOp>(0, current_invert_colors_ = invert);
-  }
+void DisplayListBuilder::onSetInvertColors(bool invert) {
+  Push<SetInvertColorsOp>(0, current_invert_colors_ = invert);
 }
-void DisplayListBuilder::setCaps(SkPaint::Cap cap) {
-  if (current_cap_ != cap) {
-    Push<SetCapsOp>(0, current_cap_ = cap);
-  }
+void DisplayListBuilder::onSetCaps(SkPaint::Cap cap) {
+  Push<SetCapsOp>(0, current_cap_ = cap);
 }
-void DisplayListBuilder::setJoins(SkPaint::Join join) {
-  if (current_join_ != join) {
-    Push<SetJoinsOp>(0, current_join_ = join);
-  }
+void DisplayListBuilder::onSetJoins(SkPaint::Join join) {
+  Push<SetJoinsOp>(0, current_join_ = join);
 }
-void DisplayListBuilder::setDrawStyle(SkPaint::Style style) {
-  if (current_style_ != style) {
-    Push<SetDrawStyleOp>(0, current_style_ = style);
-  }
+void DisplayListBuilder::onSetDrawStyle(SkPaint::Style style) {
+  Push<SetDrawStyleOp>(0, current_style_ = style);
 }
-void DisplayListBuilder::setStrokeWidth(SkScalar width) {
-  if (current_stroke_width_ != width) {
-    Push<SetStrokeWidthOp>(0, current_stroke_width_ = width);
-  }
+void DisplayListBuilder::onSetStrokeWidth(SkScalar width) {
+  Push<SetStrokeWidthOp>(0, current_stroke_width_ = width);
 }
-void DisplayListBuilder::setMiterLimit(SkScalar limit) {
-  if (current_miter_limit_ != limit) {
-    Push<SetMiterLimitOp>(0, current_miter_limit_ = limit);
-  }
+void DisplayListBuilder::onSetMiterLimit(SkScalar limit) {
+  Push<SetMiterLimitOp>(0, current_miter_limit_ = limit);
 }
-void DisplayListBuilder::setColor(SkColor color) {
-  if (current_color_ != color) {
-    Push<SetColorOp>(0, current_color_ = color);
-  }
+void DisplayListBuilder::onSetColor(SkColor color) {
+  Push<SetColorOp>(0, current_color_ = color);
 }
-void DisplayListBuilder::setBlendMode(SkBlendMode mode) {
-  if (current_blender_ || current_blend_ != mode) {
-    current_blender_ = nullptr;
-    Push<SetBlendModeOp>(0, current_blend_ = mode);
-  }
+void DisplayListBuilder::onSetBlendMode(SkBlendMode mode) {
+  current_blender_ = nullptr;
+  Push<SetBlendModeOp>(0, current_blend_ = mode);
 }
-void DisplayListBuilder::setBlender(sk_sp<SkBlender> blender) {
-  if (!blender) {
-    setBlendMode(SkBlendMode::kSrcOver);
-  } else if (current_blender_ != blender) {
-    (current_blender_ = blender)  //
-        ? Push<SetBlenderOp>(0, std::move(blender))
-        : Push<ClearBlenderOp>(0);
-  }
+void DisplayListBuilder::onSetBlender(sk_sp<SkBlender> blender) {
+  // setBlender(nullptr) should be redirected to setBlendMode(SrcOver)
+  FML_DCHECK(blender);
+  (current_blender_ = blender)  //
+      ? Push<SetBlenderOp>(0, std::move(blender))
+      : Push<ClearBlenderOp>(0);
 }
-void DisplayListBuilder::setShader(sk_sp<SkShader> shader) {
-  if (current_shader_ != shader) {
-    (current_shader_ = shader)  //
-        ? Push<SetShaderOp>(0, std::move(shader))
-        : Push<ClearShaderOp>(0);
-  }
+void DisplayListBuilder::onSetShader(sk_sp<SkShader> shader) {
+  (current_shader_ = shader)  //
+      ? Push<SetShaderOp>(0, std::move(shader))
+      : Push<ClearShaderOp>(0);
 }
-void DisplayListBuilder::setImageFilter(sk_sp<SkImageFilter> filter) {
-  if (current_image_filter_ != filter) {
-    (current_image_filter_ = filter)  //
-        ? Push<SetImageFilterOp>(0, std::move(filter))
-        : Push<ClearImageFilterOp>(0);
-  }
+void DisplayListBuilder::onSetImageFilter(sk_sp<SkImageFilter> filter) {
+  (current_image_filter_ = filter)  //
+      ? Push<SetImageFilterOp>(0, std::move(filter))
+      : Push<ClearImageFilterOp>(0);
 }
-void DisplayListBuilder::setColorFilter(sk_sp<SkColorFilter> filter) {
-  if (current_color_filter_ != filter) {
-    (current_color_filter_ = filter)  //
-        ? Push<SetColorFilterOp>(0, std::move(filter))
-        : Push<ClearColorFilterOp>(0);
-  }
+void DisplayListBuilder::onSetColorFilter(sk_sp<SkColorFilter> filter) {
+  (current_color_filter_ = filter)  //
+      ? Push<SetColorFilterOp>(0, std::move(filter))
+      : Push<ClearColorFilterOp>(0);
 }
-void DisplayListBuilder::setPathEffect(sk_sp<SkPathEffect> effect) {
-  if (current_path_effect_ != effect) {
-    (current_path_effect_ = effect)  //
-        ? Push<SetPathEffectOp>(0, std::move(effect))
-        : Push<ClearPathEffectOp>(0);
-  }
+void DisplayListBuilder::onSetPathEffect(sk_sp<SkPathEffect> effect) {
+  (current_path_effect_ = effect)  //
+      ? Push<SetPathEffectOp>(0, std::move(effect))
+      : Push<ClearPathEffectOp>(0);
 }
-void DisplayListBuilder::setMaskFilter(sk_sp<SkMaskFilter> filter) {
-  if (mask_sigma_valid(current_mask_sigma_) || current_mask_filter_ != filter) {
-    current_mask_sigma_ = kInvalidSigma;
-    current_mask_filter_ = filter;
-    Push<SetMaskFilterOp>(0, std::move(filter));
-  }
+void DisplayListBuilder::onSetMaskFilter(sk_sp<SkMaskFilter> filter) {
+  current_mask_sigma_ = kInvalidSigma;
+  current_mask_filter_ = filter;
+  Push<SetMaskFilterOp>(0, std::move(filter));
 }
-void DisplayListBuilder::setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) {
-  if (mask_sigma_valid(sigma) &&
-      (current_mask_sigma_ != sigma || current_mask_style_ != style)) {
-    current_mask_filter_ = nullptr;
-    current_mask_style_ = style;
-    current_mask_sigma_ = sigma;
-    switch (style) {
-      case kNormal_SkBlurStyle:
-        Push<SetMaskBlurFilterNormalOp>(0, sigma);
-        break;
-      case kSolid_SkBlurStyle:
-        Push<SetMaskBlurFilterSolidOp>(0, sigma);
-        break;
-      case kOuter_SkBlurStyle:
-        Push<SetMaskBlurFilterOuterOp>(0, sigma);
-        break;
-      case kInner_SkBlurStyle:
-        Push<SetMaskBlurFilterInnerOp>(0, sigma);
-        break;
-    }
+void DisplayListBuilder::onSetMaskBlurFilter(SkBlurStyle style, SkScalar sigma) {
+  // Valid sigma is checked by setMaskBlurFilter
+  FML_DCHECK(mask_sigma_valid(sigma));
+  current_mask_filter_ = nullptr;
+  current_mask_style_ = style;
+  current_mask_sigma_ = sigma;
+  switch (style) {
+    case kNormal_SkBlurStyle:
+      Push<SetMaskBlurFilterNormalOp>(0, sigma);
+      break;
+    case kSolid_SkBlurStyle:
+      Push<SetMaskBlurFilterSolidOp>(0, sigma);
+      break;
+    case kOuter_SkBlurStyle:
+      Push<SetMaskBlurFilterOuterOp>(0, sigma);
+      break;
+    case kInner_SkBlurStyle:
+      Push<SetMaskBlurFilterInnerOp>(0, sigma);
+      break;
   }
 }
 void DisplayListBuilder::setAttributesFromPaint(const SkPaint* paint,

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -423,7 +423,8 @@ class DisplayListBuilder final : public virtual Dispatcher, public SkRefCnt {
     }
   }
   void setMaskFilter(sk_sp<SkMaskFilter> filter) override {
-    if (mask_sigma_valid(current_mask_sigma_) || current_mask_filter_ != filter) {
+    if (mask_sigma_valid(current_mask_sigma_) ||
+        current_mask_filter_ != filter) {
       onSetMaskFilter(std::move(filter));
     }
   }

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -53,9 +53,9 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                     SkScalar py,
                     SkScalar pt) override;
 
-  void clipRect(const SkRect& rect, bool isAA, SkClipOp clip_op) override;
-  void clipRRect(const SkRRect& rrect, bool isAA, SkClipOp clip_op) override;
-  void clipPath(const SkPath& path, bool isAA, SkClipOp clip_op) override;
+  void clipRect(const SkRect& rect, SkClipOp clip_op, bool is_aa) override;
+  void clipRRect(const SkRRect& rrect, SkClipOp clip_op, bool is_aa) override;
+  void clipPath(const SkPath& path, SkClipOp clip_op, bool is_aa) override;
 
   void drawPaint() override;
   void drawColor(SkColor color, SkBlendMode mode) override;
@@ -77,21 +77,24 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                     SkBlendMode mode) override;
   void drawImage(const sk_sp<SkImage> image,
                  const SkPoint point,
-                 const SkSamplingOptions& sampling) override;
+                 const SkSamplingOptions& sampling,
+                 bool render_with_attributes) override;
   void drawImageRect(const sk_sp<SkImage> image,
                      const SkRect& src,
                      const SkRect& dst,
                      const SkSamplingOptions& sampling,
+                     bool render_with_attributes,
                      SkCanvas::SrcRectConstraint constraint) override;
   void drawImageNine(const sk_sp<SkImage> image,
                      const SkIRect& center,
                      const SkRect& dst,
-                     SkFilterMode filter) override;
+                     SkFilterMode filter,
+                     bool render_with_attributes) override;
   void drawImageLattice(const sk_sp<SkImage> image,
                         const SkCanvas::Lattice& lattice,
                         const SkRect& dst,
                         SkFilterMode filter,
-                        bool with_paint) override;
+                        bool render_with_attributes) override;
   void drawAtlas(const sk_sp<SkImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
@@ -99,10 +102,11 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                  int count,
                  SkBlendMode mode,
                  const SkSamplingOptions& sampling,
-                 const SkRect* cullRect) override;
+                 const SkRect* cullRect,
+                 bool render_with_attributes) override;
   void drawPicture(const sk_sp<SkPicture> picture,
                    const SkMatrix* matrix,
-                   bool with_save_layer) override;
+                   bool render_with_attributes) override;
   void drawDisplayList(const sk_sp<DisplayList> display_list) override;
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,
@@ -233,80 +237,8 @@ class DisplayListCanvasRecorder
                      const SkMatrix* matrix,
                      const SkPaint* paint) override;
 
-  enum class DrawType {
-    // The operation will be an image operation
-    kImageOpType,
-    // The operation will be an imageRect operation
-    kImageRectOpType,
-    // The operation will be a fill or stroke depending on the paint.style
-    kDrawOpType,
-    // The operation will be a fill (ignoring paint.style)
-    kFillOpType,
-    // The operation will be a stroke (ignoring paint.style)
-    kStrokeOpType,
-    // The operation will be a saveLayer with a paint object
-    kSaveLayerOpType,
-  };
-
-  void RecordPaintAttributes(const SkPaint* paint, DrawType type);
-
  private:
   sk_sp<DisplayListBuilder> builder_;
-
-  // Mask bits for the various attributes that might be needed for a given
-  // operation.
-  // clang-format off
-  static constexpr int kAaNeeded_            = 1 << 0;
-  static constexpr int kColorNeeded_         = 1 << 1;
-  static constexpr int kBlendNeeded_         = 1 << 2;
-  static constexpr int kInvertColorsNeeded_  = 1 << 3;
-  static constexpr int kPaintStyleNeeded_    = 1 << 4;
-  static constexpr int kStrokeStyleNeeded_   = 1 << 5;
-  static constexpr int kShaderNeeded_        = 1 << 6;
-  static constexpr int kColorFilterNeeded_   = 1 << 7;
-  static constexpr int kImageFilterNeeded_   = 1 << 8;
-  static constexpr int kPathEffectNeeded_    = 1 << 9;
-  static constexpr int kMaskFilterNeeded_    = 1 << 10;
-  static constexpr int kDitherNeeded_        = 1 << 11;
-  // clang-format on
-
-  // Combinations of the above mask bits that are common to typical "draw"
-  // calls.
-  // Note that the strokeStyle_ is handled conditionally depending on whether
-  // the paintStyle_ attribute value is synchronized. It can also be manually
-  // specified for operations that will be always stroking, like [drawLine].
-  static constexpr int kPaintMask_ = kAaNeeded_ | kColorNeeded_ |
-                                     kBlendNeeded_ | kInvertColorsNeeded_ |
-                                     kColorFilterNeeded_ | kShaderNeeded_ |
-                                     kDitherNeeded_ | kImageFilterNeeded_;
-  static constexpr int kDrawMask_ = kPaintMask_ | kPaintStyleNeeded_ |
-                                    kMaskFilterNeeded_ | kPathEffectNeeded_;
-  static constexpr int kStrokeMask_ = kPaintMask_ | kStrokeStyleNeeded_ |
-                                      kMaskFilterNeeded_ | kPathEffectNeeded_;
-  static constexpr int kImageMask_ = kColorNeeded_ | kBlendNeeded_ |
-                                     kInvertColorsNeeded_ |
-                                     kColorFilterNeeded_ | kDitherNeeded_ |
-                                     kImageFilterNeeded_ | kMaskFilterNeeded_;
-  static constexpr int kImageRectMask_ = kImageMask_ | kAaNeeded_;
-  static constexpr int kSaveLayerMask_ =
-      kColorNeeded_ | kBlendNeeded_ | kInvertColorsNeeded_ |
-      kColorFilterNeeded_ | kImageFilterNeeded_;
-
-  bool current_aa_ = false;
-  bool current_dither_ = false;
-  SkColor current_color_ = 0xFF000000;
-  SkBlendMode current_blend_ = SkBlendMode::kSrcOver;
-  SkPaint::Style current_style_ = SkPaint::Style::kFill_Style;
-  SkScalar current_stroke_width_ = 0.0;
-  SkScalar current_miter_limit_ = 4.0;
-  SkPaint::Cap current_cap_ = SkPaint::Cap::kButt_Cap;
-  SkPaint::Join current_join_ = SkPaint::Join::kMiter_Join;
-  sk_sp<SkBlender> current_blender_;
-  sk_sp<SkShader> current_shader_;
-  sk_sp<SkColorFilter> current_color_filter_;
-  sk_sp<SkImageFilter> current_image_filter_;
-  sk_sp<SkPathEffect> current_path_effect_;
-  sk_sp<SkMaskFilter> current_mask_filter_;
 };
 
 }  // namespace flutter

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -237,6 +237,8 @@ struct DisplayListInvocation {
     return (op_count == sk_op_count && byte_count == sk_byte_count);
   }
 
+  bool is_nop() { return op_count == 0; }
+
   sk_sp<DisplayList> Build() {
     DisplayListBuilder builder;
     invoker(builder);
@@ -251,97 +253,99 @@ struct DisplayListInvocationGroup {
 
 std::vector<DisplayListInvocationGroup> allGroups = {
   { "SetAA", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setAA(false);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setAA(true);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setAA(false);}},
     }
   },
   { "SetDither", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setDither(false);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setDither(true);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setDither(false);}},
     }
   },
   { "SetInvertColors", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setInvertColors(false);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setInvertColors(true);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setInvertColors(false);}},
     }
   },
   { "SetStrokeCap", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setCaps(SkPaint::kButt_Cap);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setCaps(SkPaint::kRound_Cap);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setCaps(SkPaint::kSquare_Cap);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setCaps(SkPaint::kButt_Cap);}},
     }
   },
   { "SetStrokeJoin", {
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setJoins(SkPaint::kBevel_Join);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setJoins(SkPaint::kRound_Join);}},
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setJoins(SkPaint::kMiter_Join);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setJoins(SkPaint::kMiter_Join);}},
     }
   },
   { "SetDrawStyle", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setDrawStyle(SkPaint::kFill_Style);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setDrawStyle(SkPaint::kStroke_Style);}},
+      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setDrawStyle(SkPaint::kStrokeAndFill_Style);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setDrawStyle(SkPaint::kFill_Style);}},
     }
   },
   { "SetStrokeWidth", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeWidth(0.0);}},
+      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeWidth(1.0);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeWidth(5.0);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setStrokeWidth(0.0);}},
     }
   },
   { "SetMiterLimit", {
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setMiterLimit(0.0);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setMiterLimit(5.0);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setMiterLimit(4.0);}},
     }
   },
   { "SetColor", {
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setColor(SK_ColorGREEN);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setColor(SK_ColorBLUE);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setColor(SK_ColorBLACK);}},
     }
   },
-  { "SetBlendMode", {
+  { "SetBlendModeOrBlender", {
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setBlendMode(SkBlendMode::kSrcIn);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setBlendMode(SkBlendMode::kDstIn);}},
-    }
-  },
-  { "SetBlender", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setBlender(nullptr);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(TestBlender1);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(TestBlender2);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setBlender(TestBlender3);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setBlendMode(SkBlendMode::kSrcOver);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setBlender(nullptr);}},
     }
   },
   { "SetShader", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setShader(nullptr);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setShader(TestShader1);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setShader(TestShader2);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setShader(TestShader3);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setShader(nullptr);}},
     }
   },
   { "SetImageFilter", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(nullptr);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(TestImageFilter1);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(TestImageFilter2);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setImageFilter(nullptr);}},
     }
   },
   { "SetColorFilter", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(nullptr);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(TestColorFilter1);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(TestColorFilter2);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setColorFilter(nullptr);}},
     }
   },
   { "SetPathEffect", {
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(nullptr);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(TestPathEffect1);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(TestPathEffect2);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setPathEffect(nullptr);}},
     }
   },
   { "SetMaskFilter", {
-      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(nullptr);}},
       {1, 16, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(TestMaskFilter);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setMaskBlurFilter(kNormal_SkBlurStyle, 3.0);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setMaskBlurFilter(kNormal_SkBlurStyle, 5.0);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setMaskBlurFilter(kSolid_SkBlurStyle, 3.0);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setMaskBlurFilter(kInner_SkBlurStyle, 3.0);}},
       {1, 8, 0, 0, [](DisplayListBuilder& b) {b.setMaskBlurFilter(kOuter_SkBlurStyle, 3.0);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.setMaskFilter(nullptr);}},
     }
   },
   { "Save(Layer)+Restore", {
@@ -355,76 +359,75 @@ std::vector<DisplayListInvocationGroup> allGroups = {
   },
   { "Translate", {
       // cv.translate(0, 0) is ignored
-      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.translate(0, 0);}},
       {1, 16, 1, 16, [](DisplayListBuilder& b) {b.translate(10, 10);}},
       {1, 16, 1, 16, [](DisplayListBuilder& b) {b.translate(10, 15);}},
       {1, 16, 1, 16, [](DisplayListBuilder& b) {b.translate(15, 10);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.translate(0, 0);}},
     }
   },
   { "Scale", {
       // cv.scale(1, 1) is ignored
-      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.scale(1, 1);}},
       {1, 16, 1, 16, [](DisplayListBuilder& b) {b.scale(2, 2);}},
       {1, 16, 1, 16, [](DisplayListBuilder& b) {b.scale(2, 3);}},
       {1, 16, 1, 16, [](DisplayListBuilder& b) {b.scale(3, 2);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.scale(1, 1);}},
     }
   },
   { "Rotate", {
       // cv.rotate(0) is ignored, otherwise expressed as concat(rotmatrix)
-      {1, 8, 0, 0, [](DisplayListBuilder& b) {b.rotate(0);}},
       {1, 8, 1, 32, [](DisplayListBuilder& b) {b.rotate(30);}},
       {1, 8, 1, 32, [](DisplayListBuilder& b) {b.rotate(45);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.rotate(0);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.rotate(360);}},
     }
   },
   { "Skew", {
       // cv.skew(0, 0) is ignored, otherwise expressed as concat(skewmatrix)
-      {1, 16, 0, 0, [](DisplayListBuilder& b) {b.skew(0, 0);}},
       {1, 16, 1, 32, [](DisplayListBuilder& b) {b.skew(0.1, 0.1);}},
       {1, 16, 1, 32, [](DisplayListBuilder& b) {b.skew(0.1, 0.2);}},
       {1, 16, 1, 32, [](DisplayListBuilder& b) {b.skew(0.2, 0.1);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.skew(0, 0);}},
     }
   },
   { "Transform2x3", {
       // cv.transform(identity) is ignored
-      {1, 32, 0, 0, [](DisplayListBuilder& b) {b.transform2x3(1, 0, 0, 0, 1, 0);}},
       {1, 32, 1, 32, [](DisplayListBuilder& b) {b.transform2x3(0, 1, 12, 1, 0, 33);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transform2x3(1, 0, 0, 0, 1, 0);}},
     }
   },
   { "Transform3x3", {
       // cv.transform(identity) is ignored
-      {1, 40, 0, 0, [](DisplayListBuilder& b) {b.transform3x3(1, 0, 0, 0, 1, 0, 0, 0, 1);}},
       {1, 40, 1, 40, [](DisplayListBuilder& b) {b.transform3x3(0, 1, 12, 1, 0, 33, 0, 0, 12);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transform3x3(1, 0, 0, 0, 1, 0, 0, 0, 1);}},
     }
   },
   { "ClipRect", {
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, true, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds.makeOffset(1, 1),
-                                                           true, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, false, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, true, SkClipOp::kDifference);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, false, SkClipOp::kDifference);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds.makeOffset(1, 1), SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kIntersect, false);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kDifference, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kDifference, false);}},
     }
   },
   { "ClipRRect", {
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, true, SkClipOp::kIntersect);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect.makeOffset(1, 1),
-                                                            true, SkClipOp::kIntersect);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, false, SkClipOp::kIntersect);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, true, SkClipOp::kDifference);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, false, SkClipOp::kDifference);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kIntersect, true);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect.makeOffset(1, 1), SkClipOp::kIntersect, true);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kIntersect, false);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kDifference, true);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kDifference, false);}},
     }
   },
   { "ClipPath", {
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, true, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath2, true, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath3, true, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, false, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, true, SkClipOp::kDifference);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, false, SkClipOp::kDifference);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath2, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath3, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kIntersect, false);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kDifference, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kDifference, false);}},
       // clipPath(rect) becomes clipRect
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPathRect, true, SkClipOp::kIntersect);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPathRect, SkClipOp::kIntersect, true);}},
       // clipPath(oval) becomes clipRRect
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipPath(TestPathOval, true, SkClipOp::kIntersect);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipPath(TestPathOval, SkClipOp::kIntersect, true);}},
     }
   },
   { "DrawPaint", {
@@ -520,41 +523,52 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "DrawImage", {
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::NearestSampling);}},
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {20, 10}, DisplayList::NearestSampling);}},
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 20}, DisplayList::NearestSampling);}},
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::LinearSampling);}},
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage2, {10, 10}, DisplayList::NearestSampling);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::NearestSampling, false);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {20, 10}, DisplayList::NearestSampling, false);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 20}, DisplayList::NearestSampling, false);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::LinearSampling, false);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::NearestSampling, true);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage2, {10, 10}, DisplayList::NearestSampling, false);}},
     }
   },
   { "DrawImageRect", {
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                DisplayList::NearestSampling);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                DisplayList::NearestSampling,
-                                                                SkCanvas::SrcRectConstraint::kStrict_SrcRectConstraint);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
-                                                                DisplayList::NearestSampling);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
-                                                                DisplayList::NearestSampling);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                DisplayList::LinearSampling);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
-                                                                DisplayList::NearestSampling);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, false,
+                                                                SkCanvas::kFast_SrcRectConstraint);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, true,
+                                                                SkCanvas::kFast_SrcRectConstraint);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, false,
+                                                                SkCanvas::kStrict_SrcRectConstraint);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, false,
+                                                                SkCanvas::kFast_SrcRectConstraint);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
+                                                                DisplayList::NearestSampling, false,
+                                                                SkCanvas::kFast_SrcRectConstraint);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                DisplayList::LinearSampling, false,
+                                                                SkCanvas::kFast_SrcRectConstraint);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, false,
+                                                                SkCanvas::kFast_SrcRectConstraint);}},
     }
   },
   { "DrawImageNine", {
       // SkVanvas::drawImageNine is immediately converted to drawImageLattice
       {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                SkFilterMode::kNearest);}},
+                                                                SkFilterMode::kNearest, false);}},
       {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
-                                                                SkFilterMode::kNearest);}},
+                                                                SkFilterMode::kNearest, false);}},
       {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
-                                                                SkFilterMode::kNearest);}},
+                                                                SkFilterMode::kNearest, false);}},
       {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                SkFilterMode::kLinear);}},
+                                                                SkFilterMode::kLinear, false);}},
+      {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                SkFilterMode::kNearest, true);}},
       {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
-                                                                SkFilterMode::kNearest);}},
+                                                                SkFilterMode::kNearest, false);}},
     }
   },
   { "DrawImageLattice", {
@@ -605,46 +619,51 @@ std::vector<DisplayListInvocationGroup> allGroups = {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
+      {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
+        static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
+        static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
+        b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
+                    DisplayList::NearestSampling, nullptr, true);}},
       {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {0, 1, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
       {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 25, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
       {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::LinearSampling, nullptr);}},
+                    DisplayList::LinearSampling, nullptr, false);}},
       {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kDstIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
       {1, 56 + 32 + 32, 1, 56 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         static SkRect cullRect = { 0, 0, 200, 200 };
         b.drawAtlas(TestImage2, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, &cullRect);}},
+                    DisplayList::NearestSampling, &cullRect, false);}},
       {1, 40 + 32 + 32 + 8, 1, 40 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         static SkColor colors[] = { SK_ColorBLUE, SK_ColorGREEN };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
       {1, 56 + 32 + 32 + 8, 1, 56 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         static SkColor colors[] = { SK_ColorBLUE, SK_ColorGREEN };
         static SkRect cullRect = { 0, 0, 200, 200 };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, &cullRect);}},
+                    DisplayList::NearestSampling, &cullRect, false);}},
     }
   },
   { "DrawPicture", {
@@ -704,10 +723,14 @@ TEST(DisplayList, SingleOpDisplayListsNotEqualEmpty) {
   for (auto& group : allGroups) {
     for (size_t i = 0; i < group.variants.size(); i++) {
       sk_sp<DisplayList> dl = group.variants[i].Build();
-      auto desc =
-          group.op_name + "(variant " + std::to_string(i + 1) + " != empty)";
-      ASSERT_FALSE(dl->Equals(*empty)) << desc;
-      ASSERT_FALSE(empty->Equals(*dl)) << desc;
+      auto desc = group.op_name + "(variant " + std::to_string(i + 1);
+      if (group.variants[i].is_nop()) {
+        ASSERT_TRUE(dl->Equals(*empty)) << desc + " == empty)";
+        ASSERT_TRUE(empty->Equals(*dl)) << desc + " == empty)";
+      } else {
+        ASSERT_FALSE(dl->Equals(*empty)) << desc + " != empty)";
+        ASSERT_FALSE(empty->Equals(*dl)) << desc + " != empty)";
+      }
     }
   }
 }
@@ -787,7 +810,9 @@ TEST(DisplayList, SingleOpDisplayListsCompareToEachOther) {
         sk_sp<DisplayList> listB = listsB[j];
         auto desc = group.op_name + "(variant " + std::to_string(i + 1) +
                     " ==? variant " + std::to_string(j + 1) + ")";
-        if (i == j) {
+        if (i == j ||
+            (group.variants[i].is_nop() && group.variants[j].is_nop())) {
+          // They are the same variant, or both variants are NOPs
           ASSERT_EQ(listA->op_count(), listB->op_count()) << desc;
           ASSERT_EQ(listA->bytes(), listB->bytes()) << desc;
           ASSERT_EQ(listA->bounds(), listB->bounds()) << desc;
@@ -824,7 +849,7 @@ static sk_sp<DisplayList> Build(size_t g_index, size_t v_index) {
     name = "Default";
   } else {
     name = allGroups[g_index].op_name;
-    if (v_index < 0) {
+    if (v_index >= allGroups[g_index].variants.size()) {
       name += " skipped";
     } else {
       name += " variant " + std::to_string(v_index + 1);
@@ -841,7 +866,7 @@ TEST(DisplayList, DisplayListsWithVaryingOpComparisons) {
   for (size_t gi = 0; gi < allGroups.size(); gi++) {
     DisplayListInvocationGroup& group = allGroups[gi];
     sk_sp<DisplayList> missing_dl = Build(gi, group.variants.size());
-    auto desc = "[Group " + std::to_string(gi + 1) + " omitted]";
+    auto desc = "[Group " + group.op_name + " omitted]";
     ASSERT_TRUE(missing_dl->Equals(*missing_dl)) << desc << " == itself";
     ASSERT_FALSE(missing_dl->Equals(*default_dl)) << desc << " != Default";
     ASSERT_FALSE(default_dl->Equals(*missing_dl)) << "Default != " << desc;
@@ -857,8 +882,13 @@ TEST(DisplayList, DisplayListsWithVaryingOpComparisons) {
         ASSERT_FALSE(variant_dl->Equals(*default_dl)) << desc << " != Default";
         ASSERT_FALSE(default_dl->Equals(*variant_dl)) << "Default != " << desc;
       }
-      ASSERT_FALSE(variant_dl->Equals(*missing_dl)) << desc << " != omitted";
-      ASSERT_FALSE(missing_dl->Equals(*variant_dl)) << "omitted != " << desc;
+      if (group.variants[vi].is_nop()) {
+        ASSERT_TRUE(variant_dl->Equals(*missing_dl)) << desc << " == omitted";
+        ASSERT_TRUE(missing_dl->Equals(*variant_dl)) << "omitted == " << desc;
+      } else {
+        ASSERT_FALSE(variant_dl->Equals(*missing_dl)) << desc << " != omitted";
+        ASSERT_FALSE(missing_dl->Equals(*variant_dl)) << "omitted != " << desc;
+      }
     }
   }
 }
@@ -986,6 +1016,182 @@ TEST(DisplayList, DisplayListSaveLayerBoundsWithAlphaFilter) {
     sk_sp<DisplayList> display_list = builder.Build();
     ASSERT_EQ(display_list->bounds(), build_bounds);
   }
+}
+
+class AttributeRefTester {
+ public:
+  virtual void setRefToPaint(SkPaint& paint) const = 0;
+  virtual void setRefToDisplayList(DisplayListBuilder& builder) const = 0;
+  virtual bool ref_is_unique() const = 0;
+
+  void testDisplayList() {
+    {
+      DisplayListBuilder builder;
+      setRefToDisplayList(builder);
+      builder.drawRect(SkRect::MakeLTRB(50, 50, 100, 100));
+      ASSERT_FALSE(ref_is_unique());
+    }
+    ASSERT_TRUE(ref_is_unique());
+  }
+  void testPaint() {
+    {
+      SkPaint paint;
+      setRefToPaint(paint);
+      ASSERT_FALSE(ref_is_unique());
+    }
+    ASSERT_TRUE(ref_is_unique());
+  }
+  void testCanvasRecorder() {
+    {
+      sk_sp<DisplayList> display_list;
+      {
+        DisplayListCanvasRecorder recorder(SkRect::MakeLTRB(0, 0, 200, 200));
+        {
+          {
+            SkPaint paint;
+            setRefToPaint(paint);
+            recorder.drawRect(SkRect::MakeLTRB(50, 50, 100, 100), paint);
+            ASSERT_FALSE(ref_is_unique());
+          }
+          ASSERT_FALSE(ref_is_unique());
+        }
+        display_list = recorder.Build();
+        ASSERT_FALSE(ref_is_unique());
+      }
+      ASSERT_FALSE(ref_is_unique());
+    }
+    ASSERT_TRUE(ref_is_unique());
+  }
+
+  void test() {
+    testDisplayList();
+    testPaint();
+    testCanvasRecorder();
+  }
+};
+
+TEST(DisplayList, DisplayListImageFilterRefHandling) {
+  class ImageFilterRefTester : public virtual AttributeRefTester {
+   public:
+    void setRefToPaint(SkPaint& paint) const override {
+      paint.setImageFilter(image_filter);
+    }
+    void setRefToDisplayList(DisplayListBuilder& builder) const override {
+      builder.setImageFilter(image_filter);
+    }
+    bool ref_is_unique() const override { return image_filter->unique(); }
+
+   private:
+    sk_sp<SkImageFilter> image_filter = SkImageFilters::Blur(2.0, 2.0, nullptr);
+  };
+
+  ImageFilterRefTester tester;
+  tester.test();
+  ASSERT_TRUE(tester.ref_is_unique());
+}
+
+TEST(DisplayList, DisplayListColorFilterRefHandling) {
+  class ColorFilterRefTester : public virtual AttributeRefTester {
+   public:
+    void setRefToPaint(SkPaint& paint) const override {
+      paint.setColorFilter(color_filter);
+    }
+    void setRefToDisplayList(DisplayListBuilder& builder) const override {
+      builder.setColorFilter(color_filter);
+    }
+    bool ref_is_unique() const override { return color_filter->unique(); }
+
+   private:
+    sk_sp<SkColorFilter> color_filter =
+        SkColorFilters::Blend(SK_ColorBLUE, SkBlendMode::kSrcIn);
+  };
+
+  ColorFilterRefTester tester;
+  tester.test();
+  ASSERT_TRUE(tester.ref_is_unique());
+}
+
+TEST(DisplayList, DisplayListMaskFilterRefHandling) {
+  class MaskFilterRefTester : public virtual AttributeRefTester {
+   public:
+    void setRefToPaint(SkPaint& paint) const override {
+      paint.setMaskFilter(mask_filter);
+    }
+    void setRefToDisplayList(DisplayListBuilder& builder) const override {
+      builder.setMaskFilter(mask_filter);
+    }
+    bool ref_is_unique() const override { return mask_filter->unique(); }
+
+   private:
+    sk_sp<SkMaskFilter> mask_filter =
+        SkMaskFilter::MakeBlur(SkBlurStyle::kNormal_SkBlurStyle, 2.0);
+  };
+
+  MaskFilterRefTester tester;
+  tester.test();
+  ASSERT_TRUE(tester.ref_is_unique());
+}
+
+TEST(DisplayList, DisplayListBlenderRefHandling) {
+  class BlenderRefTester : public virtual AttributeRefTester {
+   public:
+    void setRefToPaint(SkPaint& paint) const override {
+      paint.setBlender(blender);
+    }
+    void setRefToDisplayList(DisplayListBuilder& builder) const override {
+      builder.setBlender(blender);
+    }
+    bool ref_is_unique() const override { return blender->unique(); }
+
+   private:
+    sk_sp<SkBlender> blender =
+        SkBlenders::Arithmetic(0.25, 0.25, 0.25, 0.25, true);
+  };
+
+  BlenderRefTester tester;
+  tester.test();
+  ASSERT_TRUE(tester.ref_is_unique());
+}
+
+TEST(DisplayList, DisplayListShaderRefHandling) {
+  class ShaderRefTester : public virtual AttributeRefTester {
+   public:
+    void setRefToPaint(SkPaint& paint) const override {
+      paint.setShader(shader);
+    }
+    void setRefToDisplayList(DisplayListBuilder& builder) const override {
+      builder.setShader(shader);
+    }
+    bool ref_is_unique() const override { return shader->unique(); }
+
+   private:
+    sk_sp<SkShader> shader = SkShaders::Color(SK_ColorBLUE);
+  };
+
+  ShaderRefTester tester;
+  tester.test();
+  ASSERT_TRUE(tester.ref_is_unique());
+}
+
+TEST(DisplayList, DisplayListPathEffectRefHandling) {
+  class PathEffectRefTester : public virtual AttributeRefTester {
+   public:
+    void setRefToPaint(SkPaint& paint) const override {
+      paint.setPathEffect(path_effect);
+    }
+    void setRefToDisplayList(DisplayListBuilder& builder) const override {
+      builder.setPathEffect(path_effect);
+    }
+    bool ref_is_unique() const override { return path_effect->unique(); }
+
+   private:
+    sk_sp<SkPathEffect> path_effect =
+        SkDashPathEffect::Make(TestDashes1, 2, 0.0);
+  };
+
+  PathEffectRefTester tester;
+  tester.test();
+  ASSERT_TRUE(tester.ref_is_unique());
 }
 
 }  // namespace testing

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -65,9 +65,9 @@ class IgnoreAttributeDispatchHelper : public virtual Dispatcher {
 // A utility class that will ignore all Dispatcher methods relating
 // to setting a clip.
 class IgnoreClipDispatchHelper : public virtual Dispatcher {
-  void clipRect(const SkRect& rect, bool isAA, SkClipOp clip_op) override {}
-  void clipRRect(const SkRRect& rrect, bool isAA, SkClipOp clip_op) override {}
-  void clipPath(const SkPath& path, bool isAA, SkClipOp clip_op) override {}
+  void clipRect(const SkRect& rect, SkClipOp clip_op, bool is_aa) override {}
+  void clipRRect(const SkRRect& rrect, SkClipOp clip_op, bool is_aa) override {}
+  void clipPath(const SkPath& path, SkClipOp clip_op, bool is_aa) override {}
 };
 
 // A utility class that will ignore all Dispatcher methods relating
@@ -190,9 +190,9 @@ class SkMatrixDispatchHelper : public virtual Dispatcher,
 class ClipBoundsDispatchHelper : public virtual Dispatcher,
                                  private virtual SkMatrixSource {
  public:
-  void clipRect(const SkRect& rect, bool isAA, SkClipOp clip_op) override;
-  void clipRRect(const SkRRect& rrect, bool isAA, SkClipOp clip_op) override;
-  void clipPath(const SkPath& path, bool isAA, SkClipOp clip_op) override;
+  void clipRect(const SkRect& rect, SkClipOp clip_op, bool is_aa) override;
+  void clipRRect(const SkRRect& rrect, SkClipOp clip_op, bool is_aa) override;
+  void clipPath(const SkPath& path, SkClipOp clip_op, bool is_aa) override;
 
   void save() override;
   void restore() override;
@@ -257,7 +257,7 @@ class DisplayListBoundsCalculator final
   DisplayListBoundsCalculator(const SkRect& cull_rect = SkRect::MakeEmpty())
       : accumulator_(&root_accumulator_), bounds_cull_(cull_rect) {}
 
-  void saveLayer(const SkRect* bounds, bool with_paint) override;
+  void saveLayer(const SkRect* bounds, bool restore_with_paint) override;
   void save() override;
   void restore() override;
 
@@ -281,21 +281,24 @@ class DisplayListBoundsCalculator final
                     SkBlendMode mode) override;
   void drawImage(const sk_sp<SkImage> image,
                  const SkPoint point,
-                 const SkSamplingOptions& sampling) override;
+                 const SkSamplingOptions& sampling,
+                 bool render_with_attributes) override;
   void drawImageRect(const sk_sp<SkImage> image,
                      const SkRect& src,
                      const SkRect& dst,
                      const SkSamplingOptions& sampling,
+                     bool render_with_attributes,
                      SkCanvas::SrcRectConstraint constraint) override;
   void drawImageNine(const sk_sp<SkImage> image,
                      const SkIRect& center,
                      const SkRect& dst,
-                     SkFilterMode filter) override;
+                     SkFilterMode filter,
+                     bool render_with_attributes) override;
   void drawImageLattice(const sk_sp<SkImage> image,
                         const SkCanvas::Lattice& lattice,
                         const SkRect& dst,
                         SkFilterMode filter,
-                        bool with_paint) override;
+                        bool render_with_attributes) override;
   void drawAtlas(const sk_sp<SkImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
@@ -303,10 +306,11 @@ class DisplayListBoundsCalculator final
                  int count,
                  SkBlendMode mode,
                  const SkSamplingOptions& sampling,
-                 const SkRect* cullRect) override;
+                 const SkRect* cullRect,
+                 bool render_with_attributes) override;
   void drawPicture(const sk_sp<SkPicture> picture,
                    const SkMatrix* matrix,
-                   bool with_save_layer) override;
+                   bool render_with_attributes) override;
   void drawDisplayList(const sk_sp<DisplayList> display_list) override;
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,
@@ -387,6 +391,7 @@ class DisplayListBoundsCalculator final
 
   std::vector<std::unique_ptr<SaveInfo>> saved_infos_;
 
+  void accumulateImageBounds(const SkRect& bounds, bool with_attributes);
   void accumulateRect(const SkRect& rect, bool force_stroke = false);
 };
 

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -110,10 +110,9 @@ void Canvas::saveLayerWithoutBounds(const Paint& paint,
     return;
   }
   if (display_list_recorder_) {
-    if (paint.isNotNull()) {
-      paint.syncToDisplayList(builder(), DisplayListBuilder::kSaveLayerMask);
-    }
-    builder()->saveLayer(nullptr, paint.isNotNull());
+    bool with_attributes =
+        paint.syncToDisplayList(builder(), DisplayListBuilder::kSaveLayerMask);
+    builder()->saveLayer(nullptr, with_attributes);
   } else {
     SkPaint sk_paint;
     canvas_->saveLayer(nullptr, paint.paint(sk_paint));
@@ -131,10 +130,9 @@ void Canvas::saveLayer(double left,
   }
   SkRect bounds = SkRect::MakeLTRB(left, top, right, bottom);
   if (display_list_recorder_) {
-    if (paint.isNotNull()) {
-      paint.syncToDisplayList(builder(), DisplayListBuilder::kSaveLayerMask);
-    }
-    builder()->saveLayer(&bounds, paint.isNotNull());
+    bool with_attributes =
+        paint.syncToDisplayList(builder(), DisplayListBuilder::kSaveLayerMask);
+    builder()->saveLayer(&bounds, with_attributes);
   } else {
     SkPaint sk_paint;
     canvas_->saveLayer(&bounds, paint.paint(sk_paint));
@@ -292,8 +290,9 @@ void Canvas::drawLine(double x1,
   if (!canvas_) {
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
-    paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawRectMask);
+    paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawLineMask);
     builder()->drawLine(SkPoint::Make(x1, y1), SkPoint::Make(x2, y2));
   } else {
     SkPaint sk_paint;
@@ -305,6 +304,7 @@ void Canvas::drawPaint(const Paint& paint, const PaintData& paint_data) {
   if (!canvas_) {
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawPaintMask);
     builder()->drawPaint();
@@ -323,6 +323,7 @@ void Canvas::drawRect(double left,
   if (!canvas_) {
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawRectMask);
     builder()->drawRect(SkRect::MakeLTRB(left, top, right, bottom));
@@ -339,6 +340,7 @@ void Canvas::drawRRect(const RRect& rrect,
   if (!canvas_) {
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawRRectMask);
     builder()->drawRRect(rrect.sk_rrect);
@@ -355,6 +357,7 @@ void Canvas::drawDRRect(const RRect& outer,
   if (!canvas_) {
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawDRRectMask);
     builder()->drawDRRect(outer.sk_rrect, inner.sk_rrect);
@@ -373,6 +376,7 @@ void Canvas::drawOval(double left,
   if (!canvas_) {
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawOvalMask);
     builder()->drawOval(SkRect::MakeLTRB(left, top, right, bottom));
@@ -391,6 +395,7 @@ void Canvas::drawCircle(double x,
   if (!canvas_) {
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawCircleMask);
     builder()->drawCircle(SkPoint::Make(x, y), radius);
@@ -412,6 +417,7 @@ void Canvas::drawArc(double left,
   if (!canvas_) {
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawArcMask);
     builder()->drawArc(SkRect::MakeLTRB(left, top, right, bottom),
@@ -436,6 +442,7 @@ void Canvas::drawPath(const CanvasPath* path,
         ToDart("Canvas.drawPath called with non-genuine Path."));
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawPathMask);
     builder()->drawPath(path->path());
@@ -461,11 +468,10 @@ void Canvas::drawImage(const CanvasImage* image,
   }
   auto sampling = ImageFilter::SamplingFromIndex(filterQualityIndex);
   if (display_list_recorder_) {
-    if (paint.isNotNull()) {
-      paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawImageMask);
-    }
+    bool with_attributes =
+        paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawImageMask);
     builder()->drawImage(image->image(), SkPoint::Make(x, y), sampling,
-                         paint.isNotNull());
+                         with_attributes);
   } else {
     SkPaint sk_paint;
     canvas_->drawImage(image->image(), x, y, sampling, paint.paint(sk_paint));
@@ -496,12 +502,10 @@ void Canvas::drawImageRect(const CanvasImage* image,
   SkRect dst = SkRect::MakeLTRB(dst_left, dst_top, dst_right, dst_bottom);
   auto sampling = ImageFilter::SamplingFromIndex(filterQualityIndex);
   if (display_list_recorder_) {
-    if (paint.isNotNull()) {
-      paint.syncToDisplayList(builder(),
-                              DisplayListBuilder::kDrawImageRectMask);
-    }
+    bool with_attributes = paint.syncToDisplayList(
+        builder(), DisplayListBuilder::kDrawImageRectMask);
     builder()->drawImageRect(image->image(), src, dst, sampling,
-                             paint.isNotNull(),
+                             with_attributes,
                              SkCanvas::kFast_SrcRectConstraint);
   } else {
     SkPaint sk_paint;
@@ -538,12 +542,10 @@ void Canvas::drawImageNine(const CanvasImage* image,
   SkRect dst = SkRect::MakeLTRB(dst_left, dst_top, dst_right, dst_bottom);
   auto filter = ImageFilter::FilterModeFromIndex(bitmapSamplingIndex);
   if (display_list_recorder_) {
-    if (paint.isNotNull()) {
-      paint.syncToDisplayList(builder(),
-                              DisplayListBuilder::kDrawImageNineMask);
-    }
+    bool with_attributes = paint.syncToDisplayList(
+        builder(), DisplayListBuilder::kDrawImageNineMask);
     builder()->drawImageNine(image->image(), icenter, dst, filter,
-                             paint.isNotNull());
+                             with_attributes);
   } else {
     SkPaint sk_paint;
     canvas_->drawImageNine(image->image().get(), icenter, dst, filter,
@@ -588,6 +590,7 @@ void Canvas::drawPoints(const Paint& paint,
   static_assert(sizeof(SkPoint) == sizeof(float) * 2,
                 "SkPoint doesn't use floats.");
 
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawPointsMask);
     builder()->drawPoints(point_mode,
@@ -614,6 +617,7 @@ void Canvas::drawVertices(const Vertices* vertices,
         ToDart("Canvas.drawVertices called with non-genuine Vertices."));
     return;
   }
+  FML_DCHECK(paint.isNotNull());
   if (display_list_recorder_) {
     paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawVerticesMask);
     builder()->drawVertices(vertices->vertices(), blend_mode);
@@ -653,16 +657,15 @@ void Canvas::drawAtlas(const Paint& paint,
   auto sampling = ImageFilter::SamplingFromIndex(filterQualityIndex);
 
   if (display_list_recorder_) {
-    if (paint.isNotNull()) {
-      paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawAtlasMask);
-    }
+    bool with_attributes =
+        paint.syncToDisplayList(builder(), DisplayListBuilder::kDrawAtlasMask);
     builder()->drawAtlas(
         skImage, reinterpret_cast<const SkRSXform*>(transforms.data()),
         reinterpret_cast<const SkRect*>(rects.data()),
         reinterpret_cast<const SkColor*>(colors.data()),
         rects.num_elements() / 4,  // SkRect have 4 floats.
         blend_mode, sampling, reinterpret_cast<const SkRect*>(cull_rect.data()),
-        paint.isNotNull());
+        with_attributes);
   } else {
     SkPaint sk_paint;
     canvas_->drawAtlas(

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -188,8 +188,8 @@ class Canvas : public RefCountedDartWrappable<Canvas> {
   // paint attributes from an SkPaint and an operation type as well as access
   // to the raw DisplayListBuilder for emitting custom rendering operations.
   sk_sp<DisplayListCanvasRecorder> display_list_recorder_;
-  sk_sp<DisplayListBuilder> builder() {
-    return display_list_recorder_->builder();
+  DisplayListBuilder* builder() {
+    return display_list_recorder_->builder().get();
   }
 };
 

--- a/lib/ui/painting/paint.h
+++ b/lib/ui/painting/paint.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_PAINT_H_
 #define FLUTTER_LIB_UI_PAINTING_PAINT_H_
 
+#include "flow/display_list.h"
+
 #include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/tonic/converter/dart_converter.h"
 
@@ -15,13 +17,19 @@ class Paint {
   Paint() = default;
   Paint(Dart_Handle paint_objects, Dart_Handle paint_data);
 
-  const SkPaint* paint() const { return is_null_ ? nullptr : &paint_; }
+  const SkPaint* paint(SkPaint& paint) const;
+  void syncToDisplayList(
+      DisplayListBuilder* builder,
+      int attribute_mask = DisplayListBuilder::kAllAttributesMask) const;
+
+  bool isNull() const { return Dart_IsNull(paint_data_); }
+  bool isNotNull() const { return !Dart_IsNull(paint_data_); }
 
  private:
   friend struct tonic::DartConverter<Paint>;
 
-  SkPaint paint_;
-  bool is_null_ = true;
+  Dart_Handle paint_objects_;
+  Dart_Handle paint_data_;
 };
 
 // The PaintData argument is a placeholder to receive encoded data for Paint

--- a/lib/ui/painting/paint.h
+++ b/lib/ui/painting/paint.h
@@ -18,7 +18,14 @@ class Paint {
   Paint(Dart_Handle paint_objects, Dart_Handle paint_data);
 
   const SkPaint* paint(SkPaint& paint) const;
-  void syncToDisplayList(
+
+  /// Synchronize the Dart properties to the display list according
+  /// to the draw-op-specific mask of which properties are needed.
+  /// The return value indicates if the paint was non-null and can
+  /// either be DCHECKed or used to indicate to the DisplayList
+  /// draw operation whether or not to use the synchronized attributes
+  /// (mainly the drawImage and saveLayer methods).
+  bool syncToDisplayList(
       DisplayListBuilder* builder,
       int attribute_mask = DisplayListBuilder::kAllAttributesMask) const;
 

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -452,17 +452,19 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
 
   if (mask & tsBackgroundMask) {
     Paint background(background_objects, background_data);
-    if (background.paint()) {
+    if (background.isNotNull()) {
+      SkPaint paint;
       style.has_background = true;
-      style.background = *background.paint();
+      style.background = *background.paint(paint);
     }
   }
 
   if (mask & tsForegroundMask) {
     Paint foreground(foreground_objects, foreground_data);
-    if (foreground.paint()) {
+    if (foreground.isNotNull()) {
+      SkPaint paint;
       style.has_foreground = true;
-      style.foreground = *foreground.paint();
+      style.foreground = *foreground.paint(paint);
     }
   }
 


### PR DESCRIPTION
This is a cleanup task for the umbrella DisplayList Follow-on tasks. Specifically this change makes our Dart Canvas native method calls directly manipulate a DisplayList, bypassing the SkCanvas->DisplayList conversion adapter.

After this, deleting the old SkPicture code should involve nothing more than code deletion and removal of some flags because all of the code to independently rely directly on the DisplayList mechanism will be in place.

Note that some minor code cleanup happened as a result of this effort:
- Some DisplayListBuilder and Dispatcher methods (mainly the `clipFoo()` methods) had parameters reordered to match the SkCanvas versions
- The methods on SkCanvas that take an optional SkPaint and assume defaults in its absence (mainly `drawImage(.., SkPaint*)`) now all have a parameter on the associated DisplayList version to use or ignore the attributes while rendering (previously we would sync the attributes back to the defaults as an alternative, but it seems to be a common practice so providing a flag for that should be helpful and create less attribute churn, also Skia may optimize the case of `paint == nullptr` and we will indicate that condition to them more directly now).
- The various `DisplayListBuilder.set<Attribute>()` and `translate/scale/transform/etc()` methods now test for a state-NOP operation before pushing a record into the display list storage. The attribute setters do so in an inline friendly way as it seems to be common judging from benchmark tests before and after I added the inline friendly versions.
- Tests were updated to test the new "render_with_attributes" parameters
- drawTextBlob tests were updated to run with all attributes (it was an oversight to have them skip attribute testing before)