### PR TITLE
Windows: Add dark theme support.

### DIFF
--- a/shell/platform/windows/client_wrapper/flutter_engine.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine.cc
@@ -74,6 +74,10 @@ void FlutterEngine::ReloadSystemFonts() {
   FlutterDesktopEngineReloadSystemFonts(engine_);
 }
 
+void FlutterEngine::ReloadPlatformBrightness() {
+  FlutterDesktopEngineReloadPlatformBrightness(engine_);
+}
+
 FlutterDesktopPluginRegistrarRef FlutterEngine::GetRegistrarForPlugin(
     const std::string& plugin_name) {
   if (!engine_) {

--- a/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_engine_unittests.cc
@@ -49,6 +49,11 @@ class TestFlutterWindowsApi : public testing::StubFlutterWindowsApi {
   // |flutter::testing::StubFlutterWindowsApi|
   void EngineReloadSystemFonts() override { reload_fonts_called_ = true; }
 
+  // |flutter::testing::StubFlutterWindowsApi|
+  void EngineReloadPlatformBrightness() override {
+    reload_brightness_called_ = true;
+  }
+
   bool create_called() { return create_called_; }
 
   bool run_called() { return run_called_; }
@@ -56,6 +61,8 @@ class TestFlutterWindowsApi : public testing::StubFlutterWindowsApi {
   bool destroy_called() { return destroy_called_; }
 
   bool reload_fonts_called() { return reload_fonts_called_; }
+
+  bool reload_brightness_called() { return reload_brightness_called_; }
 
   const std::vector<std::string>& dart_entrypoint_arguments() {
     return dart_entrypoint_arguments_;
@@ -66,6 +73,7 @@ class TestFlutterWindowsApi : public testing::StubFlutterWindowsApi {
   bool run_called_ = false;
   bool destroy_called_ = false;
   bool reload_fonts_called_ = false;
+  bool reload_brightness_called_ = false;
   std::vector<std::string> dart_entrypoint_arguments_;
 };
 
@@ -122,6 +130,18 @@ TEST(FlutterEngineTest, ReloadFonts) {
 
   engine.ReloadSystemFonts();
   EXPECT_TRUE(test_api->reload_fonts_called());
+}
+
+TEST(FlutterEngineTest, ReloadBrightness) {
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
+      std::make_unique<TestFlutterWindowsApi>());
+  auto test_api = static_cast<TestFlutterWindowsApi*>(scoped_api_stub.stub());
+
+  FlutterEngine engine(DartProject(L"fake/project/path"));
+  engine.Run();
+
+  engine.ReloadPlatformBrightness();
+  EXPECT_TRUE(test_api->reload_brightness_called());
 }
 
 TEST(FlutterEngineTest, GetMessenger) {

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_engine.h
@@ -58,6 +58,11 @@ class FlutterEngine : public PluginRegistry {
   // Win32 application).
   void ReloadSystemFonts();
 
+  // Tells the engine that the platform brightness value has changed. Should be
+  // called by clients when OS-level theme changes happen (e.g.,
+  // WM_DWMCOLORIZATIONCOLORCHANGED in a Win32 application).
+  void ReloadPlatformBrightness();
+
   // flutter::PluginRegistry:
   FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
       const std::string& plugin_name) override;

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -117,6 +117,13 @@ void FlutterDesktopEngineReloadSystemFonts(FlutterDesktopEngineRef engine) {
   }
 }
 
+void FlutterDesktopEngineReloadPlatformBrightness(
+    FlutterDesktopEngineRef engine) {
+  if (s_stub_implementation) {
+    s_stub_implementation->EngineReloadPlatformBrightness();
+  }
+}
+
 FlutterDesktopPluginRegistrarRef FlutterDesktopEngineGetPluginRegistrar(
     FlutterDesktopEngineRef engine,
     const char* plugin_name) {

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
@@ -65,6 +65,9 @@ class StubFlutterWindowsApi {
   // Called for FlutterDesktopEngineReloadSystemFonts.
   virtual void EngineReloadSystemFonts() {}
 
+  // Called for FlutterDesktopEngineReloadPlatformBrightness.
+  virtual void EngineReloadPlatformBrightness() {}
+
   // Called for FlutterDesktopViewGetHWND.
   virtual HWND ViewGetHWND() { return reinterpret_cast<HWND>(1); }
 

--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -222,6 +222,7 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
                     int,
                     FlutterPointerDeviceKind,
                     int32_t));
+  MOCK_METHOD0(OnPlatformBrightnessChanged, void());
 };
 
 // A FlutterWindowsView that overrides the RegisterKeyboardHandlers function

--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -77,8 +77,6 @@ FlutterWindowWinUWP::FlutterWindowWinUWP(
   application_view_ = cav;
   window_ = application_view_.CoreWindow();
 
-  ui_settings_ = winrt::Windows::UI::ViewManagement::UISettings{};
-
   SetEventHandlers();
 
   display_helper_ = std::make_unique<DisplayHelperWinUWP>();

--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -77,6 +77,8 @@ FlutterWindowWinUWP::FlutterWindowWinUWP(
   application_view_ = cav;
   window_ = application_view_.CoreWindow();
 
+  ui_settings_ = winrt::Windows::UI::ViewManagement::UISettings{};
+
   SetEventHandlers();
 
   display_helper_ = std::make_unique<DisplayHelperWinUWP>();
@@ -155,6 +157,9 @@ void FlutterWindowWinUWP::SetEventHandlers() {
   window_.PointerMoved({this, &FlutterWindowWinUWP::OnPointerMoved});
   window_.PointerWheelChanged(
       {this, &FlutterWindowWinUWP::OnPointerWheelChanged});
+
+  ui_settings_.ColorValuesChanged(
+      {this, &FlutterWindowWinUWP::OnColorValuesChanged});
 
   // TODO(clarkezone) support mouse leave handling
   // https://github.com/flutter/flutter/issues/70199
@@ -353,6 +358,12 @@ void FlutterWindowWinUWP::OnCharacterReceived(
     std::u16string text({keycode});
     binding_handler_delegate_->OnText(text);
   }
+}
+
+void FlutterWindowWinUWP::OnColorValuesChanged(
+    winrt::Windows::Foundation::IInspectable const&,
+    winrt::Windows::Foundation::IInspectable const&) {
+  binding_handler_delegate_->OnPlatformBrightnessChanged();
 }
 
 bool FlutterWindowWinUWP::OnBitmapSurfaceUpdated(const void* allocation,

--- a/shell/platform/windows/flutter_window_winuwp.h
+++ b/shell/platform/windows/flutter_window_winuwp.h
@@ -159,7 +159,7 @@ class FlutterWindowWinUWP : public WindowBindingHandler {
   winrt::Windows::UI::Composition::SpriteVisual render_target_{nullptr};
 
   // UISettings for observing the color change.
-  winrt::Windows::UI::ViewManagement::UISettings ui_settings_{nullptr};
+  winrt::Windows::UI::ViewManagement::UISettings ui_settings_;
 
   // GamepadCursorWinUWP object used to manage an emulated cursor visual driven
   // by gamepad.

--- a/shell/platform/windows/flutter_window_winuwp.h
+++ b/shell/platform/windows/flutter_window_winuwp.h
@@ -114,6 +114,11 @@ class FlutterWindowWinUWP : public WindowBindingHandler {
       winrt::Windows::Foundation::IInspectable const&,
       winrt::Windows::UI::Core::CharacterReceivedEventArgs const& args);
 
+  // Notifies current |WindowBindingHandlerDelegate| of color values changed
+  // events.
+  void OnColorValuesChanged(winrt::Windows::Foundation::IInspectable const&,
+                            winrt::Windows::Foundation::IInspectable const&);
+
   // Converts from logical point to physical X value.
   double GetPosX(winrt::Windows::UI::Core::PointerEventArgs const& args);
 
@@ -152,6 +157,9 @@ class FlutterWindowWinUWP : public WindowBindingHandler {
   // Compositor object that represents the render target binding the backing
   // SwapChain to the CoreWindow.
   winrt::Windows::UI::Composition::SpriteVisual render_target_{nullptr};
+
+  // UISettings for observing the color change.
+  winrt::Windows::UI::ViewManagement::UISettings ui_settings_{nullptr};
 
   // GamepadCursorWinUWP object used to manage an emulated cursor visual driven
   // by gamepad.

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -107,6 +107,10 @@ void FlutterDesktopEngineReloadSystemFonts(FlutterDesktopEngineRef engine) {
   EngineFromHandle(engine)->ReloadSystemFonts();
 }
 
+void FlutterDesktopEngineReloadPlatformBrightness(FlutterDesktopEngineRef engine) {
+  EngineFromHandle(engine)->ReloadPlatformBrightness();
+}
+
 FlutterDesktopPluginRegistrarRef FlutterDesktopEngineGetPluginRegistrar(
     FlutterDesktopEngineRef engine,
     const char* plugin_name) {

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -107,7 +107,8 @@ void FlutterDesktopEngineReloadSystemFonts(FlutterDesktopEngineRef engine) {
   EngineFromHandle(engine)->ReloadSystemFonts();
 }
 
-void FlutterDesktopEngineReloadPlatformBrightness(FlutterDesktopEngineRef engine) {
+void FlutterDesktopEngineReloadPlatformBrightness(
+    FlutterDesktopEngineRef engine) {
   EngineFromHandle(engine)->ReloadPlatformBrightness();
 }
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -413,8 +413,6 @@ void FlutterWindowsEngine::SendSystemSettings() {
   settings.AddMember("alwaysUse24HourFormat",
                      Prefer24HourTime(GetUserTimeFormat()), allocator);
   settings.AddMember("textScaleFactor", 1.0, allocator);
-  // TODO: Implement dark mode support.
-  // https://github.com/flutter/flutter/issues/54612
   settings.AddMember("platformBrightness", GetPreferredBrightness(), allocator);
   settings_channel_->Send(settings);
 }

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -391,6 +391,12 @@ void FlutterWindowsEngine::ReloadSystemFonts() {
   embedder_api_.ReloadSystemFonts(engine_);
 }
 
+void FlutterWindowsEngine::ReloadPlatformBrightness() {
+  if (engine_) {
+    SendSystemSettings();
+  }
+}
+
 void FlutterWindowsEngine::SendSystemSettings() {
   std::vector<LanguageInfo> languages = GetPreferredLanguageInfo();
   std::vector<FlutterLocale> flutter_locales;

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -415,7 +415,7 @@ void FlutterWindowsEngine::SendSystemSettings() {
   settings.AddMember("textScaleFactor", 1.0, allocator);
   // TODO: Implement dark mode support.
   // https://github.com/flutter/flutter/issues/54612
-  settings.AddMember("platformBrightness", "light", allocator);
+  settings.AddMember("platformBrightness", GetPreferredBrightness(), allocator);
   settings_channel_->Send(settings);
 }
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -419,7 +419,7 @@ void FlutterWindowsEngine::SendSystemSettings() {
   settings.AddMember("alwaysUse24HourFormat",
                      Prefer24HourTime(GetUserTimeFormat()), allocator);
   settings.AddMember("textScaleFactor", 1.0, allocator);
-  settings.AddMember("platformBrightness", GetPreferredBrightness(), allocator);
+  settings.AddMember("platformBrightness", Utf8FromUtf16(GetPreferredBrightness()), allocator);
   settings_channel_->Send(settings);
 }
 

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -419,7 +419,8 @@ void FlutterWindowsEngine::SendSystemSettings() {
   settings.AddMember("alwaysUse24HourFormat",
                      Prefer24HourTime(GetUserTimeFormat()), allocator);
   settings.AddMember("textScaleFactor", 1.0, allocator);
-  settings.AddMember("platformBrightness", Utf8FromUtf16(GetPreferredBrightness()), allocator);
+  settings.AddMember("platformBrightness",
+                     Utf8FromUtf16(GetPreferredBrightness()), allocator);
   settings_channel_->Send(settings);
 }
 

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -131,6 +131,9 @@ class FlutterWindowsEngine {
   // Informs the engine that the system font list has changed.
   void ReloadSystemFonts();
 
+  // Informs the engine that the platform brightness has changed.
+  void ReloadPlatformBrightness();
+
   // Attempts to register the texture with the given |texture_id|.
   bool RegisterExternalTexture(int64_t texture_id);
 

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -249,6 +249,10 @@ void FlutterWindowsView::OnScroll(double x,
              device_id);
 }
 
+void FlutterWindowsView::OnPlatformBrightnessChanged() {
+  SendPlatformBrightnessChanged();
+}
+
 void FlutterWindowsView::OnCursorRectUpdated(const Rect& rect) {
   binding_handler_->OnCursorRectUpdated(rect);
 }
@@ -464,6 +468,11 @@ void FlutterWindowsView::SendPointerEventWithData(
     }
   }
 }
+
+void FlutterWindowsView::SendPlatformBrightnessChanged() {
+  engine_->task_runner()->RunNowOrPostTask(
+      [this]() { engine_->ReloadPlatformBrightness(); });
+};
 
 bool FlutterWindowsView::MakeCurrent() {
   return engine_->surface_manager()->MakeCurrent();

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -149,6 +149,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
                 FlutterPointerDeviceKind device_kind,
                 int32_t device_id) override;
 
+  // |WindowBindingHandlerDelegate|
+  void OnPlatformBrightnessChanged() override;
+
   // |TextInputPluginDelegate|
   void OnCursorRectUpdated(const Rect& rect) override;
 
@@ -283,6 +286,9 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   // needed before passing on to engine.
   void SendPointerEventWithData(const FlutterPointerEvent& event_data,
                                 PointerState* state);
+
+  // Reports platform brightness change to Flutter engine.
+  void SendPlatformBrightnessChanged();
 
   // Currently configured WindowsRenderTarget for this view used by
   // surface_manager for creation of render surfaces and bound to the physical

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -174,6 +174,9 @@ FlutterDesktopEngineProcessMessages(FlutterDesktopEngineRef engine);
 FLUTTER_EXPORT void FlutterDesktopEngineReloadSystemFonts(
     FlutterDesktopEngineRef engine);
 
+FLUTTER_EXPORT void FlutterDesktopEngineReloadPlatformBrightness(
+    FlutterDesktopEngineRef engine);
+
 // Returns the plugin registrar handle for the plugin with the given name.
 //
 // The name must be unique across the application.

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -12,6 +12,11 @@
 
 namespace flutter {
 
+namespace {
+static constexpr char kBrightnessLight[] = "light";
+static constexpr char kBrightnessDark[] = "dark";
+}  // namespace
+
 // Components of a system language/locale.
 struct LanguageInfo {
   std::string language;
@@ -36,6 +41,9 @@ std::wstring GetUserTimeFormat();
 
 // Returns true if the time_format is set to use 24 hour time.
 bool Prefer24HourTime(std::wstring time_format);
+
+// Returns the user-preferred brightness.
+std::string GetPreferredBrightness();
 
 }  // namespace flutter
 

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -13,8 +13,8 @@
 namespace flutter {
 
 namespace {
-static constexpr char kBrightnessLight[] = "light";
-static constexpr char kBrightnessDark[] = "dark";
+static constexpr char kPlatformBrightnessLight[] = "light";
+static constexpr char kPlatformBrightnessDark[] = "dark";
 }  // namespace
 
 // Components of a system language/locale.

--- a/shell/platform/windows/system_utils.h
+++ b/shell/platform/windows/system_utils.h
@@ -13,8 +13,8 @@
 namespace flutter {
 
 namespace {
-static constexpr char kPlatformBrightnessLight[] = "light";
-static constexpr char kPlatformBrightnessDark[] = "dark";
+static constexpr wchar_t kPlatformBrightnessLight[] = L"light";
+static constexpr wchar_t kPlatformBrightnessDark[] = L"dark";
 }  // namespace
 
 // Components of a system language/locale.
@@ -43,7 +43,7 @@ std::wstring GetUserTimeFormat();
 bool Prefer24HourTime(std::wstring time_format);
 
 // Returns the user-preferred brightness.
-std::string GetPreferredBrightness();
+std::wstring GetPreferredBrightness();
 
 }  // namespace flutter
 

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -89,8 +89,8 @@ TEST(SystemUtils, Prefer24HourTimeHandles24Hour) {
 }
 
 TEST(SystemUtils, GetPreferredBrightness) {
-  std::string brightness = GetPreferredBrightness();
-  EXPECT_TRUE(brightness == "light" || brightness == "dark");
+  std::wstring brightness = GetPreferredBrightness();
+  EXPECT_TRUE(brightness == L"light" || brightness == L"dark");
 }
 
 }  // namespace testing

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -88,5 +88,10 @@ TEST(SystemUtils, Prefer24HourTimeHandles24Hour) {
   EXPECT_TRUE(Prefer24HourTime(L"HH:mm:ss"));
 }
 
+TEST(SystemUtils, GetPreferredBrightness) {
+  std::string brightness = GetPreferredBrightness();
+  EXPECT_TRUE(brightness == kBrightnessLight || brightness == kBrightnessDark);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/system_utils_unittests.cc
+++ b/shell/platform/windows/system_utils_unittests.cc
@@ -90,7 +90,7 @@ TEST(SystemUtils, Prefer24HourTimeHandles24Hour) {
 
 TEST(SystemUtils, GetPreferredBrightness) {
   std::string brightness = GetPreferredBrightness();
-  EXPECT_TRUE(brightness == kBrightnessLight || brightness == kBrightnessDark);
+  EXPECT_TRUE(brightness == "light" || brightness == "dark");
 }
 
 }  // namespace testing

--- a/shell/platform/windows/system_utils_win32.cc
+++ b/shell/platform/windows/system_utils_win32.cc
@@ -117,14 +117,14 @@ std::string GetPreferredBrightness() {
 
   if (result == 0) {
     if (use_light_theme == 1) {
-      return kBrightnessLight;
+      return kPlatformBrightnessLight;
     } else {
-      return kBrightnessDark;
+      return kPlatformBrightnessDark;
     }
   } else {
     // The current OS does not support dark mode. (Older Windows 10 or before
     // Windows 10)
-    return kBrightnessLight;
+    return kPlatformBrightnessLight;
   }
 }
 

--- a/shell/platform/windows/system_utils_win32.cc
+++ b/shell/platform/windows/system_utils_win32.cc
@@ -116,11 +116,7 @@ std::wstring GetPreferredBrightness() {
       &use_light_theme_size);
 
   if (result == 0) {
-    if (use_light_theme == 1) {
-      return kPlatformBrightnessLight;
-    } else {
-      return kPlatformBrightnessDark;
-    }
+    return use_light_theme ? kPlatformBrightnessLight : kPlatformBrightnessDark;
   } else {
     // The current OS does not support dark mode. (Older Windows 10 or before
     // Windows 10)

--- a/shell/platform/windows/system_utils_win32.cc
+++ b/shell/platform/windows/system_utils_win32.cc
@@ -106,4 +106,26 @@ bool Prefer24HourTime(std::wstring time_format) {
   return time_format.find(L"H") != std::wstring::npos;
 }
 
+std::string GetPreferredBrightness() {
+  DWORD use_light_theme;
+  DWORD use_light_theme_size = sizeof(use_light_theme);
+  LONG result = RegGetValue(
+      HKEY_CURRENT_USER,
+      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+      L"AppsUseLightTheme", RRF_RT_REG_DWORD, nullptr, &use_light_theme,
+      &use_light_theme_size);
+
+  if (result == 0) {
+    if (use_light_theme == 1) {
+      return kBrightnessLight;
+    } else {
+      return kBrightnessDark;
+    }
+  } else {
+    // The current OS does not support dark mode. (Older Windows 10 or before
+    // Windows 10)
+    return kBrightnessLight;
+  }
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/system_utils_win32.cc
+++ b/shell/platform/windows/system_utils_win32.cc
@@ -106,7 +106,7 @@ bool Prefer24HourTime(std::wstring time_format) {
   return time_format.find(L"H") != std::wstring::npos;
 }
 
-std::string GetPreferredBrightness() {
+std::wstring GetPreferredBrightness() {
   DWORD use_light_theme;
   DWORD use_light_theme_size = sizeof(use_light_theme);
   LONG result = RegGetValue(

--- a/shell/platform/windows/system_utils_winuwp.cc
+++ b/shell/platform/windows/system_utils_winuwp.cc
@@ -88,9 +88,9 @@ std::string GetPreferredBrightness() {
       winrt::Windows::UI::ViewManagement::UIColorType::Background);
   // Assuming that Windows return `Colors::Black` when being dark theme.
   if (background_color == winrt::Windows::UI::Colors::Black()) {
-    return kBrightnessDark;
+    return kPlatformBrightnessDark;
   } else {
-    return kBrightnessLight;
+    return kPlatformBrightnessLight;
   }
 }
 

--- a/shell/platform/windows/system_utils_winuwp.cc
+++ b/shell/platform/windows/system_utils_winuwp.cc
@@ -10,6 +10,8 @@
 
 #include "third_party/cppwinrt/generated/winrt/Windows.Foundation.Collections.h"
 #include "third_party/cppwinrt/generated/winrt/Windows.System.UserProfile.h"
+#include "third_party/cppwinrt/generated/winrt/Windows.UI.ViewManagement.h"
+#include "third_party/cppwinrt/generated/winrt/Windows.UI.h"
 
 #include "flutter/shell/platform/windows/string_conversion.h"
 
@@ -78,6 +80,18 @@ std::wstring GetUserTimeFormat() {
 
 bool Prefer24HourTime(std::wstring time_format) {
   return time_format.find(L"H") != std::wstring::npos;
+}
+
+std::string GetPreferredBrightness() {
+  winrt::Windows::UI::ViewManagement::UISettings ui_settings;
+  auto background_color = ui_settings.GetColorValue(
+      winrt::Windows::UI::ViewManagement::UIColorType::Background);
+  // Assuming that Windows return `Colors::Black` when being dark theme.
+  if (background_color == winrt::Windows::UI::Colors::Black()) {
+    return kBrightnessDark;
+  } else {
+    return kBrightnessLight;
+  }
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/system_utils_winuwp.cc
+++ b/shell/platform/windows/system_utils_winuwp.cc
@@ -82,7 +82,7 @@ bool Prefer24HourTime(std::wstring time_format) {
   return time_format.find(L"H") != std::wstring::npos;
 }
 
-std::string GetPreferredBrightness() {
+std::wstring GetPreferredBrightness() {
   winrt::Windows::UI::ViewManagement::UISettings ui_settings;
   auto background_color = ui_settings.GetColorValue(
       winrt::Windows::UI::ViewManagement::UIColorType::Background);

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -95,6 +95,9 @@ class WindowBindingHandlerDelegate {
                         int scroll_offset_multiplier,
                         FlutterPointerDeviceKind device_kind,
                         int32_t device_id) = 0;
+
+  // Notifies delegate that backing window has received brightness change event.
+  virtual void OnPlatformBrightnessChanged() = 0;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
This PR adds the dark theme support for both `windows` and `winuwp` engine, based on flutter/flutter#54612.

On Win32: using a registry value that is not documented. (I tested on Windows 10.0.19043.1165)
On UWP: using default background color. (I couldn't find WinRT API that returns dark/light directly, without xaml package.)

TODO:
- [X] Provide the theme value
- [X] Notify when the theme value is changed.

Flutter PR for win32: flutter/flutter#88520.
This PR will close flutter/flutter#54612.
This PR will complete one item in flutter/flutter#70214.

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.