### PR TITLE
Declare flutter_gdb as a Python 2 script

### DIFF
--- a/ci/licenses_golden/licenses_skia
+++ b/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: 84d0a762b7ddb7d5817405df71c998dc
+Signature: 29d7ebca3e5cdc5e122f260a9ade4964
 
 UNUSED LICENSES:
 
@@ -3346,8 +3346,6 @@ FILE: ../../../third_party/skia/bench/ClipMaskBench.cpp
 FILE: ../../../third_party/skia/bench/ClipStrategyBench.cpp
 FILE: ../../../third_party/skia/bench/PathTextBench.cpp
 FILE: ../../../third_party/skia/bench/ShadowBench.cpp
-FILE: ../../../third_party/skia/bin/gerrit-number
-FILE: ../../../third_party/skia/bin/sysopen
 FILE: ../../../third_party/skia/dm/DMGpuTestProcs.cpp
 FILE: ../../../third_party/skia/example/HelloWorld.cpp
 FILE: ../../../third_party/skia/example/HelloWorld.h

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: ba62ed10d5e046f90a397663d6c9d5d2
+Signature: 2b08c736bc3af2c5d770099c53112c83
 

--- a/sky/tools/flutter_gdb
+++ b/sky/tools/flutter_gdb
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 #
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -77,7 +77,7 @@ class _RepositorySourceFile extends _RepositoryLicensedFile {
 
   fs.TextFile get ioTextFile => super.io as fs.TextFile;
 
-  static final RegExp _hashBangPattern = RegExp(r'^#! *(?:/bin/sh|/bin/bash|/usr/bin/env +(?:python|python3|bash))\b');
+  static final RegExp _hashBangPattern = RegExp(r'^#! *(?:/bin/sh|/bin/bash|/usr/bin/env +(?:python[23]?|bash))\b');
 
   @override
   bool get isShellScript {


### PR DESCRIPTION
The script has not been ported to Python 3.  The environment required by
Python 3 (e.g. PYTHONHOME) may conflict with the environment expected by
the Python 2 runtime linked into the version of GDB launched by the script.
