### PR TITLE
Use the suppressions script to source runtime suppressions in `run_tests.py`

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -563,7 +563,7 @@ def main():
     file_dir = os.path.dirname(os.path.abspath(__file__))
     command = [
       "env", "-i", "bash",
-      "-c", f"source {file_dir}/sanitizer_suppressions.sh >/dev/null && env"
+      "-c", "source {}/sanitizer_suppressions.sh >/dev/null && env".format(file_dir)
     ]
     process = subprocess.Popen(command, stdout=subprocess.PIPE)
     for line in process.stdout:

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -545,8 +545,8 @@ def main():
       help='Generate coverage reports for each unit test framework run.')
   parser.add_argument('--engine-capture-core-dump', dest='engine_capture_core_dump', action='store_true',
       default=False, help='Capture core dumps from crashes of engine tests.')
-  parser.add_argument('--asan-options', dest='asan_options', action='store', type=str, default='',
-      help='Runtime AddressSanitizer flags to use if built wth asan (example: "verbosity=1:detect_leaks=0')
+  parser.add_argument('--use-sanitizer-suppressions', dest='sanitizer_suppressions', action='store_true',
+      default=False, help='Provide the sanitizer suppressions lists to the via environment to the tests.')
 
   args = parser.parse_args()
 
@@ -559,8 +559,17 @@ def main():
   if args.type != 'java':
     assert os.path.exists(build_dir), 'Build variant directory %s does not exist!' % build_dir
 
-  if args.asan_options:
-    os.environ['ASAN_OPTIONS'] = args.asan_options
+  if args.sanitizer_suppressions:
+    file_dir = os.path.dirname(os.path.abspath(__file__))
+    command = [
+      "env", "-i", "bash",
+      "-c", f"source {file_dir}/sanitizer_suppressions.sh >/dev/null && env"
+    ]
+    process = subprocess.Popen(command, stdout=subprocess.PIPE)
+    for line in process.stdout:
+      key, _, value = str(line).partition("=")
+      os.environ[key] = value
+    process.communicate() # Avoid pipe deadlock while waiting for termination.
 
   engine_filter = args.engine_filter.split(',') if args.engine_filter else None
   if 'engine' in types:

--- a/testing/sanitizer_suppressions.sh
+++ b/testing/sanitizer_suppressions.sh
@@ -13,4 +13,4 @@ export UBSAN_OPTIONS="suppressions=${UBSAN_SUPPRESSIONS_FILE}"
 echo "Using Undefined Behavior suppressions in ${UBSAN_SUPPRESSIONS_FILE}"
 
 
-export ASAN_OPTIONS="detect_leaks=1"
+export ASAN_OPTIONS="detect_leaks=0"

--- a/testing/sanitizer_suppressions.sh
+++ b/testing/sanitizer_suppressions.sh
@@ -13,4 +13,4 @@ export UBSAN_OPTIONS="suppressions=${UBSAN_SUPPRESSIONS_FILE}"
 echo "Using Undefined Behavior suppressions in ${UBSAN_SUPPRESSIONS_FILE}"
 
 
-export ASAN_OPTIONS="detect_leaks=0"
+export ASAN_OPTIONS="detect_leaks=0:detect_container_overflow=0"

--- a/testing/sanitizer_suppressions.sh
+++ b/testing/sanitizer_suppressions.sh
@@ -1,14 +1,14 @@
-CURRENT_DIRECTORY="$(pwd)/$(dirname "$0")"
+TESTING_DIRECTORY=$(dirname "${BASH_SOURCE[0]}")
 
-TSAN_SUPPRESSIONS_FILE="${CURRENT_DIRECTORY}/tsan_suppressions.txt"
+TSAN_SUPPRESSIONS_FILE="${TESTING_DIRECTORY}/tsan_suppressions.txt"
 export TSAN_OPTIONS="suppressions=${TSAN_SUPPRESSIONS_FILE}"
 echo "Using Thread Sanitizer suppressions in ${TSAN_SUPPRESSIONS_FILE}"
 
-LSAN_SUPPRESSIONS_FILE="${CURRENT_DIRECTORY}/lsan_suppressions.txt"
+LSAN_SUPPRESSIONS_FILE="${TESTING_DIRECTORY}/lsan_suppressions.txt"
 export LSAN_OPTIONS="suppressions=${LSAN_SUPPRESSIONS_FILE}"
 echo "Using Leak Sanitizer suppressions in ${LSAN_SUPPRESSIONS_FILE}"
 
-UBSAN_SUPPRESSIONS_FILE="${CURRENT_DIRECTORY}/ubsan_suppressions.txt"
+UBSAN_SUPPRESSIONS_FILE="${TESTING_DIRECTORY}/ubsan_suppressions.txt"
 export UBSAN_OPTIONS="suppressions=${UBSAN_SUPPRESSIONS_FILE}"
 echo "Using Undefined Behavior suppressions in ${UBSAN_SUPPRESSIONS_FILE}"
 


### PR DESCRIPTION
Follow-up to https://github.com/flutter/engine/pull/28082.

CI commands are declarative & deferred, and so it's not easy to source this environment on the CI side.

Let me know if `run_tests.py` is currently/should remain runnable on Windows. If so, I can change this to set the environment in a less invasive way.