### PR TITLE
Fix some stack-use-after-scopes found by ASan

### DIFF
--- a/fml/memory/ref_counted_unittest.cc
+++ b/fml/memory/ref_counted_unittest.cc
@@ -472,13 +472,15 @@ TEST(RefCountedTest, SelfAssignment) {
 
 TEST(RefCountedTest, Swap) {
   MyClass* created1 = nullptr;
-  bool was_destroyed1 = false;
+  static bool was_destroyed1;
+  was_destroyed1 = false;
   RefPtr<MyClass> r1(MakeRefCounted<MyClass>(&created1, &was_destroyed1));
   EXPECT_TRUE(created1);
   EXPECT_EQ(created1, r1.get());
 
   MyClass* created2 = nullptr;
-  bool was_destroyed2 = false;
+  static bool was_destroyed2;
+  was_destroyed2 = false;
   RefPtr<MyClass> r2(MakeRefCounted<MyClass>(&created2, &was_destroyed2));
   EXPECT_TRUE(created2);
   EXPECT_EQ(created2, r2.get());

--- a/shell/platform/embedder/tests/embedder_unittests_gl.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_gl.cc
@@ -2018,7 +2018,8 @@ TEST_F(EmbedderTest,
 
   constexpr size_t frames_expected = 10;
   fml::CountDownLatch frame_latch(frames_expected);
-  size_t frames_seen = 0;
+  static size_t frames_seen;
+  frames_seen = 0;
   context.AddNativeCallback("SignalNativeTest",
                             CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
                               frames_seen++;
@@ -2056,7 +2057,8 @@ TEST_F(EmbedderTest,
 
   constexpr size_t frames_expected = 10;
   fml::CountDownLatch frame_latch(frames_expected);
-  size_t frames_seen = 0;
+  static size_t frames_seen;
+  frames_seen = 0;
   context.AddNativeCallback("SignalNativeTest",
                             CREATE_NATIVE_ENTRY([&](Dart_NativeArguments args) {
                               frames_seen++;

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -1992,8 +1992,7 @@ Paragraph::Range<size_t> ParagraphTxt::GetWordBoundary(size_t offset) {
       return Range<size_t>(0, 0);
   }
 
-  auto unicode_text = icu::UnicodeString(false, text_.data(), text_.size());
-  word_breaker_->setText(unicode_text);
+  word_breaker_->setText(icu::UnicodeString(false, text_.data(), text_.size()));
 
   int32_t prev_boundary = word_breaker_->preceding(offset + 1);
   int32_t next_boundary = word_breaker_->next();

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -1992,7 +1992,8 @@ Paragraph::Range<size_t> ParagraphTxt::GetWordBoundary(size_t offset) {
       return Range<size_t>(0, 0);
   }
 
-  word_breaker_->setText(icu::UnicodeString(false, text_.data(), text_.size()));
+  auto unicode_text = icu::UnicodeString(false, text_.data(), text_.size());
+  word_breaker_->setText(unicode_text);
 
   int32_t prev_boundary = word_breaker_->preceding(offset + 1);
   int32_t next_boundary = word_breaker_->next();


### PR DESCRIPTION
This particular sanitizer doesn't support runtime suppression, so made quick fixes for PushingMultipleFrames*, RefCounted, and Paragraph.