### PR TITLE
fix leak of DisplayList storage

### DIFF
--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -951,17 +951,19 @@ bool DisplayList::Equals(const DisplayList& other) const {
   if (used_ != other.used_ || op_count_ != other.op_count_) {
     return false;
   }
-  if (ptr_ == other.ptr_) {
+  uint8_t* ptr = storage_.get();
+  uint8_t* o_ptr = other.storage_.get();
+  if (ptr == o_ptr) {
     return true;
   }
-  return CompareOps(ptr_, ptr_ + used_, other.ptr_, other.ptr_ + other.used_);
+  return CompareOps(ptr, ptr + used_, o_ptr, o_ptr + other.used_);
 }
 
 DisplayList::DisplayList(uint8_t* ptr,
                          size_t used,
                          int op_count,
                          const SkRect& cull)
-    : ptr_(ptr),
+    : storage_(ptr),
       used_(used),
       op_count_(op_count),
       bounds_({0, 0, -1, -1}),
@@ -973,7 +975,8 @@ DisplayList::DisplayList(uint8_t* ptr,
 }
 
 DisplayList::~DisplayList() {
-  DisposeOps(ptr_, ptr_ + used_);
+  uint8_t* ptr = storage_.get();
+  DisposeOps(ptr, ptr + used_);
 }
 
 #define DL_BUILDER_PAGE 4096

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -168,8 +168,7 @@ class DisplayList : public SkRefCnt {
   static const SkSamplingOptions CubicSampling;
 
   DisplayList()
-      : ptr_(nullptr),
-        used_(0),
+      : used_(0),
         op_count_(0),
         unique_id_(0),
         bounds_({0, 0, 0, 0}),
@@ -177,7 +176,10 @@ class DisplayList : public SkRefCnt {
 
   ~DisplayList();
 
-  void Dispatch(Dispatcher& ctx) const { Dispatch(ctx, ptr_, ptr_ + used_); }
+  void Dispatch(Dispatcher& ctx) const {
+    uint8_t* ptr = storage_.get();
+    Dispatch(ctx, ptr, ptr + used_);
+  }
 
   void RenderTo(SkCanvas* canvas) const;
 
@@ -199,7 +201,7 @@ class DisplayList : public SkRefCnt {
  private:
   DisplayList(uint8_t* ptr, size_t used, int op_count, const SkRect& cull_rect);
 
-  uint8_t* ptr_;
+  std::unique_ptr<uint8_t, SkFunctionWrapper<void(void*), sk_free>> storage_;
   size_t used_;
   int op_count_;
 


### PR DESCRIPTION
Switch to a unique_ptr to ensure that the memory is freed. The type used here for DisplayList::storage_ here is taken from the internal memory holder of the SkAutoTMalloc that was used to allocate and grow the array. SkAutoTMalloc manages a pointer that should be freed with sk_free (which is just a null protected wrapper around free).