### PR TITLE
Correct the return value of the method RunInIsolateScope

### DIFF
--- a/testing/dart_isolate_runner.cc
+++ b/testing/dart_isolate_runner.cc
@@ -59,7 +59,7 @@ void AutoIsolateShutdown::Shutdown() {
         latch.Signal();
       });
   latch.Wait();
-  return true;
+  return result;
 }
 
 std::unique_ptr<AutoIsolateShutdown> RunDartCodeInIsolateOnUITaskRunner(


### PR DESCRIPTION
I found that the return value of the method `RunInIsolateScope` was incorrect when I wrote a new test, , so I decided to fix it.

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
