### PR TITLE
Fix regression in system UI colors

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -374,15 +374,17 @@ public class PlatformPlugin {
     // If transparent, SDK 29 and higher may apply a translucent scrim behind the bar to ensure
     // proper contrast. This can be overridden with
     // SystemChromeStyle.systemStatusBarContrastEnforced.
-    if (systemChromeStyle.statusBarIconBrightness != null && Build.VERSION.SDK_INT >= 23) {
-      switch (systemChromeStyle.statusBarIconBrightness) {
-        case DARK:
-          // View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-          flags |= 0x2000;
-          break;
-        case LIGHT:
-          flags &= ~0x2000;
-          break;
+    if (Build.VERSION.SDK_INT >= 23) {
+      if (systemChromeStyle.statusBarIconBrightness != null) {
+        switch (systemChromeStyle.statusBarIconBrightness) {
+          case DARK:
+            // View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            flags |= 0x2000;
+            break;
+          case LIGHT:
+            flags &= ~0x2000;
+            break;
+        }
       }
 
       if (systemChromeStyle.statusBarColor != null) {
@@ -403,16 +405,17 @@ public class PlatformPlugin {
     // If transparent, SDK 29 and higher may apply a translucent scrim behind 2/3 button navigation
     // bars to ensure proper contrast. This can be overridden with
     // SystemChromeStyle.systemNavigationBarContrastEnforced.
-    if (systemChromeStyle.systemNavigationBarIconBrightness != null
-        && Build.VERSION.SDK_INT >= 26) {
-      switch (systemChromeStyle.systemNavigationBarIconBrightness) {
-        case DARK:
-          // View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-          flags |= 0x10;
-          break;
-        case LIGHT:
-          flags &= ~0x10;
-          break;
+    if (Build.VERSION.SDK_INT >= 26) {
+      if (systemChromeStyle.systemNavigationBarIconBrightness != null) {
+        switch (systemChromeStyle.systemNavigationBarIconBrightness) {
+          case DARK:
+            // View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+            flags |= 0x10;
+            break;
+          case LIGHT:
+            flags &= ~0x10;
+            break;
+        }
       }
 
       if (systemChromeStyle.systemNavigationBarColor != null) {

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -162,15 +162,42 @@ public class PlatformPluginTest {
     when(fakeActivity.getWindow()).thenReturn(fakeWindow);
     PlatformChannel fakePlatformChannel = mock(PlatformChannel.class);
     PlatformPlugin platformPlugin = new PlatformPlugin(fakeActivity, fakePlatformChannel);
+    // Default style test
     SystemChromeStyle style =
-        new SystemChromeStyle(0XFF000000, null, true, 0XFFC70039, null, 0XFF006DB3, true);
+        new SystemChromeStyle(
+            0XFF000000, // statusBarColor
+            null, // statusBarIconBrightness
+            true, // systemStatusBarContrastEnforced
+            0XFFC70039, // systemNavigationBarColor
+            null, // systemNavigationBarIconBrightness
+            0XFF006DB3, // systemNavigationBarDividerColor
+            true, // systemNavigationBarContrastEnforced
+        );
 
     if (Build.VERSION.SDK_INT >= 28) {
       platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
 
+      assertEquals(0XFF000000, fakeActivity.getWindow().getStatusBarColor());
+      assertEquals(0XFFC70039, fakeActivity.getWindow().getNavigationBarColor());
       assertEquals(0XFF006DB3, fakeActivity.getWindow().getNavigationBarDividerColor());
+
+      // Regression test for https://github.com/flutter/flutter/issues/88431
+      // A null brightness should not affect changing color settings.
+      style = new SystemChromeStyle(
+          0XFF006DB3, // statusBarColor
+          null, // statusBarIconBrightness
+          true, // systemStatusBarContrastEnforced
+          0XFF000000, // systemNavigationBarColor
+          null, // systemNavigationBarIconBrightness
+          0XFF006DB3, // systemNavigationBarDividerColor
+          true, // systemNavigationBarContrastEnforced
+      );
+
+      platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
+
       assertEquals(0XFFC70039, fakeActivity.getWindow().getStatusBarColor());
       assertEquals(0XFF000000, fakeActivity.getWindow().getNavigationBarColor());
+      assertEquals(0XFF006DB3, fakeActivity.getWindow().getNavigationBarDividerColor());
     }
   }
 

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -171,8 +171,7 @@ public class PlatformPluginTest {
             0XFFC70039, // systemNavigationBarColor
             null, // systemNavigationBarIconBrightness
             0XFF006DB3, // systemNavigationBarDividerColor
-            true, // systemNavigationBarContrastEnforced
-        );
+            true); // systemNavigationBarContrastEnforced
 
     if (Build.VERSION.SDK_INT >= 28) {
       platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
@@ -183,15 +182,15 @@ public class PlatformPluginTest {
 
       // Regression test for https://github.com/flutter/flutter/issues/88431
       // A null brightness should not affect changing color settings.
-      style = new SystemChromeStyle(
-          0XFF006DB3, // statusBarColor
-          null, // statusBarIconBrightness
-          true, // systemStatusBarContrastEnforced
-          0XFF000000, // systemNavigationBarColor
-          null, // systemNavigationBarIconBrightness
-          0XFF006DB3, // systemNavigationBarDividerColor
-          true, // systemNavigationBarContrastEnforced
-      );
+      style =
+          new SystemChromeStyle(
+              0XFF006DB3, // statusBarColor
+              null, // statusBarIconBrightness
+              true, // systemStatusBarContrastEnforced
+              0XFF000000, // systemNavigationBarColor
+              null, // systemNavigationBarIconBrightness
+              0XFF006DB3, // systemNavigationBarDividerColor
+              true); // systemNavigationBarContrastEnforced
 
       platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/88431

This fixes a regression introduced in https://github.com/flutter/engine/pull/27018. The refactored style portion made color changes dependent on brightness not being null.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
