### PR TITLE
Use separate io_manager when spawn engine

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -48,7 +48,9 @@ std::unique_ptr<RuntimeController> RuntimeController::Spawn(
     const std::function<void(int64_t)>& p_idle_notification_callback,
     const fml::closure& p_isolate_create_callback,
     const fml::closure& p_isolate_shutdown_callback,
-    std::shared_ptr<const fml::Mapping> p_persistent_isolate_data) const {
+    std::shared_ptr<const fml::Mapping> p_persistent_isolate_data,
+    fml::WeakPtr<IOManager> io_manager,
+    fml::WeakPtr<ImageDecoder> image_decoder) const {
   auto result =
       std::make_unique<RuntimeController>(p_client,                      //
                                           vm_,                           //
@@ -59,6 +61,8 @@ std::unique_ptr<RuntimeController> RuntimeController::Spawn(
                                           p_isolate_shutdown_callback,   //
                                           p_persistent_isolate_data,     //
                                           context_);                     //
+  result->context_.io_manager = std::move(io_manager);
+  result->context_.image_decoder = std::move(image_decoder);
   result->spawning_isolate_ = root_isolate_;
   return result;
 }

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -102,7 +102,9 @@ class RuntimeController : public PlatformConfigurationClient {
       const std::function<void(int64_t)>& idle_notification_callback,
       const fml::closure& isolate_create_callback,
       const fml::closure& isolate_shutdown_callback,
-      std::shared_ptr<const fml::Mapping> persistent_isolate_data) const;
+      std::shared_ptr<const fml::Mapping> persistent_isolate_data,
+      fml::WeakPtr<IOManager> io_manager,
+      fml::WeakPtr<ImageDecoder> image_decoder) const;
 
   // |PlatformConfigurationClient|
   ~RuntimeController() override;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -112,7 +112,8 @@ std::unique_ptr<Engine> Engine::Spawn(
     Delegate& delegate,
     const PointerDataDispatcherMaker& dispatcher_maker,
     Settings settings,
-    std::unique_ptr<Animator> animator) const {
+    std::unique_ptr<Animator> animator,
+    fml::WeakPtr<IOManager> io_manager) const {
   auto result = std::make_unique<Engine>(
       /*delegate=*/delegate,
       /*dispatcher_maker=*/dispatcher_maker,
@@ -121,7 +122,7 @@ std::unique_ptr<Engine> Engine::Spawn(
       /*task_runners=*/task_runners_,
       /*settings=*/settings,
       /*animator=*/std::move(animator),
-      /*io_manager=*/runtime_controller_->GetIOManager(),
+      /*io_manager=*/io_manager,
       /*font_collection=*/font_collection_,
       /*runtime_controller=*/nullptr);
   result->runtime_controller_ = runtime_controller_->Spawn(
@@ -131,7 +132,9 @@ std::unique_ptr<Engine> Engine::Spawn(
       settings_.idle_notification_callback,  // idle notification callback
       settings_.isolate_create_callback,     // isolate create callback
       settings_.isolate_shutdown_callback,   // isolate shutdown callback
-      settings_.persistent_isolate_data      // persistent isolate data
+      settings_.persistent_isolate_data,     // persistent isolate data
+      io_manager,                            // io_manager
+      result->GetImageDecoderWeakPtr()       // imageDecoder
   );
   return result;
 }
@@ -149,6 +152,10 @@ void Engine::SetupDefaultFontManager() {
 
 std::shared_ptr<AssetManager> Engine::GetAssetManager() {
   return asset_manager_;
+}
+
+fml::WeakPtr<ImageDecoder> Engine::GetImageDecoderWeakPtr() {
+  return image_decoder_.GetWeakPtr();
 }
 
 fml::WeakPtr<ImageGeneratorRegistry> Engine::GetImageGeneratorRegistry() {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -375,7 +375,8 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
       Delegate& delegate,
       const PointerDataDispatcherMaker& dispatcher_maker,
       Settings settings,
-      std::unique_ptr<Animator> animator) const;
+      std::unique_ptr<Animator> animator,
+      fml::WeakPtr<IOManager> io_manager) const;
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys the engine engine. Called by the shell on the UI task
@@ -804,6 +805,9 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
 
   // Return the asset manager associated with the current engine, or nullptr.
   std::shared_ptr<AssetManager> GetAssetManager();
+
+  // Return the weak_ptr of ImageDecoder.
+  fml::WeakPtr<ImageDecoder> GetImageDecoderWeakPtr();
 
   //----------------------------------------------------------------------------
   /// @brief      Get the `ImageGeneratorRegistry` associated with the current

--- a/shell/common/engine_unittests.cc
+++ b/shell/common/engine_unittests.cc
@@ -268,8 +268,8 @@ TEST_F(EngineTest, SpawnSharesFontLibrary) {
         /*font_collection=*/std::make_shared<FontCollection>(),
         /*runtime_controller=*/std::move(mock_runtime_controller));
 
-    auto spawn =
-        engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr);
+    auto spawn = engine->Spawn(delegate_, dispatcher_maker_, settings_, nullptr,
+                               io_manager_);
     EXPECT_TRUE(spawn != nullptr);
     EXPECT_EQ(&engine->GetFontCollection(), &spawn->GetFontCollection());
   });

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -500,7 +500,8 @@ std::unique_ptr<Shell> Shell::Spawn(
           return engine->Spawn(/*delegate=*/delegate,
                                /*dispatcher_maker=*/dispatcher_maker,
                                /*settings=*/settings,
-                               /*animator=*/std::move(animator));
+                               /*animator=*/std::move(animator),
+                               /*io_manager=*/std::move(io_manager));
         },
         is_gpu_disabled));
     return result;


### PR DESCRIPTION
Each Engine should use its own io_manager when spawn new engine. The current situation is that when a new Engine is spawned from an old Engine, the new Engine will use the io_manager of the old Engine. the new Engine will be crash when the old Engine is destroyed.
For example:
![device-2021-08-20-195426](https://user-images.githubusercontent.com/5997059/130229456-ecb0f24e-d879-4920-96a2-f0e06f0b1827.png)
In this case, two engines are used to display GIF images on the same page, when I remove the top flutterView and destroy the engine, the bottomEngine will continue to decode pictures, but it will be crash because io_manager is null 
![image](https://user-images.githubusercontent.com/5997059/130229800-1f778a0d-7895-40d2-8b8d-98049afcfcbe.png)

In addition, when I modified the code, I found that ImageDeocoder also had the same problem. In other words, there will be similar crash in certain situations ,please take a look