### PR TITLE
Reset viewport_metrics when spawn new Engine

### DIFF
--- a/lib/ui/window/viewport_metrics.cc
+++ b/lib/ui/window/viewport_metrics.cc
@@ -54,6 +54,11 @@ ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
       physical_system_gesture_inset_left(p_physical_system_gesture_inset_left),
       physical_touch_slop(p_physical_touch_slop) {}
 
+void ViewportMetrics::ResetForSpawn() {
+  physical_width = 0;
+  physical_height = 0;
+}
+
 bool operator==(const ViewportMetrics& a, const ViewportMetrics& b) {
   return a.device_pixel_ratio == b.device_pixel_ratio &&
          a.physical_width == b.physical_width &&

--- a/lib/ui/window/viewport_metrics.h
+++ b/lib/ui/window/viewport_metrics.h
@@ -32,6 +32,8 @@ struct ViewportMetrics {
                   double p_physical_system_gesture_inset_left,
                   double p_physical_touch_slop);
 
+  void ResetForSpawn();
+
   double device_pixel_ratio = 1.0;
   double physical_width = 0;
   double physical_height = 0;

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -60,6 +60,7 @@ std::unique_ptr<RuntimeController> RuntimeController::Spawn(
                                           p_persistent_isolate_data,     //
                                           context_);                     //
   result->spawning_isolate_ = root_isolate_;
+  result->platform_data_.viewport_metrics.ResetForSpawn();
   return result;
 }
 


### PR DESCRIPTION
physical_width and physical_height should be reset to 0 when spawn new Engine. Otherwise, flutter will use the wrong width and height for layout, and if the developer uses SizeChangedLayoutNotifier, the wrong width and height will be obtained before onSizeChanged is called.