### PR TITLE
Normalize the path that we set the ANDROID_HOME environment variable to

### DIFF
--- a/testing/rules/run_gradle.py
+++ b/testing/rules/run_gradle.py
@@ -14,12 +14,15 @@ import subprocess
 import platform
 
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
-ANDROID_HOME = os.path.join(SCRIPT_PATH, '..', '..', '..', 'third_party', 'android_tools', 'sdk')
+ANDROID_HOME = os.path.normpath(os.path.join(SCRIPT_PATH, '..', '..', '..',
+    'third_party', 'android_tools', 'sdk'))
 
 if platform.system() == 'Darwin':
-  JAVA_HOME = os.path.join(SCRIPT_PATH, '..', '..', '..', 'third_party', 'java', 'openjdk', 'Contents', 'Home')
+  JAVA_HOME = os.path.normpath(os.path.join(SCRIPT_PATH, '..', '..', '..',
+      'third_party', 'java', 'openjdk', 'Contents', 'Home'))
 else:
-  JAVA_HOME = os.path.join(SCRIPT_PATH, '..', '..', '..', 'third_party', 'java', 'openjdk')
+  JAVA_HOME = os.path.normpath(os.path.join(SCRIPT_PATH, '..', '..', '..',
+      'third_party', 'java', 'openjdk'))
 
 def main():
   if not os.path.isdir(ANDROID_HOME):


### PR DESCRIPTION
The gradle/android tooling will validate that ANDROID_HOME and
ANDROID_SDK_ROOT are precisely the same. So if they point to the same
directory but are not normalized this check will fail.

Fixes Dart-Flutter Head-Head-Head bot.
