### PR TITLE
Avoid deadlock while creating platform views with multiple engines.

### DIFF
--- a/fml/raster_thread_merger.cc
+++ b/fml/raster_thread_merger.cc
@@ -23,8 +23,7 @@ RasterThreadMerger::RasterThreadMerger(
     fml::TaskQueueId gpu_queue_id)
     : platform_queue_id_(platform_queue_id),
       gpu_queue_id_(gpu_queue_id),
-      shared_merger_(shared_merger),
-      enabled_(true) {}
+      shared_merger_(shared_merger) {}
 
 void RasterThreadMerger::SetMergeUnmergeCallback(const fml::closure& callback) {
   merge_unmerge_callback_ = callback;
@@ -119,12 +118,12 @@ bool RasterThreadMerger::IsMerged() {
 
 void RasterThreadMerger::Enable() {
   std::scoped_lock lock(mutex_);
-  enabled_ = true;
+  shared_merger_->SetEnabledUnSafe(true);
 }
 
 void RasterThreadMerger::Disable() {
   std::scoped_lock lock(mutex_);
-  enabled_ = false;
+  shared_merger_->SetEnabledUnSafe(false);
 }
 
 bool RasterThreadMerger::IsEnabled() {
@@ -133,7 +132,7 @@ bool RasterThreadMerger::IsEnabled() {
 }
 
 bool RasterThreadMerger::IsEnabledUnSafe() const {
-  return enabled_;
+  return shared_merger_->IsEnabledUnSafe();
 }
 
 bool RasterThreadMerger::IsMergedUnSafe() const {

--- a/fml/raster_thread_merger.h
+++ b/fml/raster_thread_merger.h
@@ -127,7 +127,6 @@ class RasterThreadMerger
   std::condition_variable merged_condition_;
   std::mutex mutex_;
   fml::closure merge_unmerge_callback_;
-  bool enabled_;
 
   bool IsMergedUnSafe() const;
 

--- a/fml/raster_thread_merger_unittests.cc
+++ b/fml/raster_thread_merger_unittests.cc
@@ -361,6 +361,27 @@ TEST(RasterThreadMerger, IsEnabled) {
   ASSERT_TRUE(raster_thread_merger->IsEnabled());
 }
 
+TEST(RasterThreadMerger, TwoMergersWithSameThreadPairShareEnabledState) {
+  TaskQueueWrapper queue1;
+  TaskQueueWrapper queue2;
+  fml::TaskQueueId qid1 = queue1.GetTaskQueueId();
+  fml::TaskQueueId qid2 = queue2.GetTaskQueueId();
+  const auto merger1 =
+      RasterThreadMerger::CreateOrShareThreadMerger(nullptr, qid1, qid2);
+  const auto merger2 =
+      RasterThreadMerger::CreateOrShareThreadMerger(merger1, qid1, qid2);
+  ASSERT_TRUE(merger1->IsEnabled());
+  ASSERT_TRUE(merger2->IsEnabled());
+
+  merger1->Disable();
+  ASSERT_FALSE(merger1->IsEnabled());
+  ASSERT_FALSE(merger2->IsEnabled());
+
+  merger2->Enable();
+  ASSERT_TRUE(merger1->IsEnabled());
+  ASSERT_TRUE(merger2->IsEnabled());
+}
+
 TEST(RasterThreadMerger, RunExpiredTasksWhileFirstTaskMergesThreads) {
   fml::MessageLoop* loop_platform = nullptr;
   fml::AutoResetWaitableEvent latch1;

--- a/fml/shared_thread_merger.cc
+++ b/fml/shared_thread_merger.cc
@@ -14,7 +14,8 @@ SharedThreadMerger::SharedThreadMerger(fml::TaskQueueId owner,
                                        fml::TaskQueueId subsumed)
     : owner_(owner),
       subsumed_(subsumed),
-      task_queues_(fml::MessageLoopTaskQueues::GetInstance()) {}
+      task_queues_(fml::MessageLoopTaskQueues::GetInstance()),
+      enabled_(true) {}
 
 bool SharedThreadMerger::MergeWithLease(RasterThreadMergerId caller,
                                         size_t lease_term) {
@@ -83,6 +84,14 @@ void SharedThreadMerger::ExtendLeaseTo(RasterThreadMergerId caller,
 
 bool SharedThreadMerger::IsMergedUnSafe() const {
   return !IsAllLeaseTermsZeroUnSafe();
+}
+
+bool SharedThreadMerger::IsEnabledUnSafe() const {
+  return enabled_;
+}
+
+void SharedThreadMerger::SetEnabledUnSafe(bool enabled) {
+  enabled_ = enabled;
 }
 
 bool SharedThreadMerger::IsAllLeaseTermsZeroUnSafe() const {

--- a/fml/shared_thread_merger.h
+++ b/fml/shared_thread_merger.h
@@ -42,6 +42,14 @@ class SharedThreadMerger
   // See the doc of |RasterThreadMerger::IsMergedUnSafe|.
   bool IsMergedUnSafe() const;
 
+  // It's called by |RasterThreadMerger::IsEnabledUnSafe|.
+  // See the doc of |RasterThreadMerger::IsEnabledUnSafe|.
+  bool IsEnabledUnSafe() const;
+
+  // It's called by |RasterThreadMerger::Enable| or
+  // |RasterThreadMerger::Disable|.
+  void SetEnabledUnSafe(bool enabled);
+
   // It's called by |RasterThreadMerger::DecrementLease|.
   // See the doc of |RasterThreadMerger::DecrementLease|.
   bool DecrementLease(RasterThreadMergerId caller);
@@ -51,6 +59,7 @@ class SharedThreadMerger
   fml::TaskQueueId subsumed_;
   fml::RefPtr<fml::MessageLoopTaskQueues> task_queues_;
   std::mutex mutex_;
+  bool enabled_;
 
   /// The |MergeWithLease| or |ExtendLeaseTo| method will record the caller
   /// into this lease_term_by_caller_ map, |UnMergeNowIfLastOne|

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -709,9 +709,9 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
   //
   // This prevents false positives such as this method starts assuming that the
   // raster and platform queues have a given thread configuration, but then the
-  // configuration is changed by a task, and the asumption is not longer true.
+  // configuration is changed by a task, and the assumption is no longer true.
   //
-  // This incorrect assumption can lead to dead lock.
+  // This incorrect assumption can lead to deadlock.
   // See `should_post_raster_task` for more.
   rasterizer_->DisableThreadMergerIfNeeded();
 
@@ -719,7 +719,7 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
   // starting the sequence and waiting on the latch. Later the UI thread posts
   // raster_task to the raster thread which signals the latch. If the raster and
   // the platform threads are the same this results in a deadlock as the
-  // raster_task will never be posted to the plaform/raster thread that is
+  // raster_task will never be posted to the platform/raster thread that is
   // blocked on a latch. To avoid the described deadlock, if the raster and the
   // platform threads are the same, should_post_raster_task will be false, and
   // then instead of posting a task to the raster thread, the ui thread just
@@ -818,9 +818,9 @@ void Shell::OnPlatformViewDestroyed() {
   //
   // This prevents false positives such as this method starts assuming that the
   // raster and platform queues have a given thread configuration, but then the
-  // configuration is changed by a task, and the asumption is not longer true.
+  // configuration is changed by a task, and the assumption is no longer true.
   //
-  // This incorrect assumption can lead to dead lock.
+  // This incorrect assumption can lead to deadlock.
   // See `should_post_raster_task` for more.
   rasterizer_->DisableThreadMergerIfNeeded();
 
@@ -828,8 +828,8 @@ void Shell::OnPlatformViewDestroyed() {
   // starting the sequence and waiting on the latch. Later the UI thread posts
   // raster_task to the raster thread triggers signaling the latch(on the IO
   // thread). If the raster and the platform threads are the same this results
-  // in a deadlock as the raster_task will never be posted to the plaform/raster
-  // thread that is blocked on a latch.  To avoid the described deadlock, if the
+  // in a deadlock as the raster_task will never be posted to platform/raster
+  // thread that is blocked on a latch. To avoid the described deadlock, if the
   // raster and the platform threads are the same, should_post_raster_task will
   // be false, and then instead of posting a task to the raster thread, the ui
   // thread just signals the latch and the platform/raster thread follows with


### PR DESCRIPTION
When using multiple lightweight engines and multiple platform views, it sometimes will result in a **deadlock**.

The code in shell.cc:
```c++
void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
  TRACE_EVENT0("flutter", "Shell::OnPlatformViewCreated");
  FML_DCHECK(is_setup_);
  FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());

  // Prevent any request to change the thread configuration for raster and
  // platform queues while the platform view is being created.
  //
  // This prevents false positives such as this method starts assuming that the
  // raster and platform queues have a given thread configuration, but then the
  // configuration is changed by a task, and the assumption is no longer true.
  //
  // This incorrect assumption can lead to deadlock.
  // See `should_post_raster_task` for more.
  rasterizer_->DisableThreadMergerIfNeeded();

  // The normal flow executed by this method is that the platform thread is
  // starting the sequence and waiting on the latch. Later the UI thread posts
  // raster_task to the raster thread which signals the latch. If the raster and
  // the platform threads are the same this results in a deadlock as the
  // raster_task will never be posted to the platform/raster thread that is
  // blocked on a latch. To avoid the described deadlock, if the raster and the
  // platform threads are the same, should_post_raster_task will be false, and
  // then instead of posting a task to the raster thread, the ui thread just
  // signals the latch and the platform/raster thread follows with executing
  // raster_task.
  const bool should_post_raster_task =
      !task_runners_.GetRasterTaskRunner()->RunsTasksOnCurrentThread();

  // Note:
  // This is a synchronous operation because certain platforms depend on
  // setup/suspension of all activities that may be interacting with the GPU in
  // a synchronous fashion.
  fml::AutoResetWaitableEvent latch;
  auto raster_task =
      fml::MakeCopyable([&waiting_for_first_frame = waiting_for_first_frame_,
                         rasterizer = rasterizer_->GetWeakPtr(),  //
                         surface = std::move(surface),            //
                         &latch]() mutable {
        if (rasterizer) {
          // Enables the thread merger which may be used by the external view
          // embedder.
          rasterizer->EnableThreadMergerIfNeeded();
          rasterizer->Setup(std::move(surface));
        }

        waiting_for_first_frame.store(true);

        // Step 3: All done. Signal the latch that the platform thread is
        // waiting on.
        latch.Signal();
      });

  auto ui_task = [engine = engine_->GetWeakPtr(),                            //
                  raster_task_runner = task_runners_.GetRasterTaskRunner(),  //
                  raster_task, should_post_raster_task,
                  &latch  //
  ] {
    if (engine) {
      engine->OnOutputSurfaceCreated();
    }
    // Step 2: Next, tell the raster thread that it should create a surface for
    // its rasterizer.
    if (should_post_raster_task) {
      fml::TaskRunner::RunNowOrPostTask(raster_task_runner, raster_task);
    } else {
      // See comment on should_post_raster_task, in this case we just unblock
      // the platform thread.
      latch.Signal();
    }
  };

  // Threading: Capture platform view by raw pointer and not the weak pointer.
  // We are going to use the pointer on the IO thread which is not safe with a
  // weak pointer. However, we are preventing the platform view from being
  // collected by using a latch.
  auto* platform_view = platform_view_.get();

  FML_DCHECK(platform_view);

  auto io_task = [io_manager = io_manager_->GetWeakPtr(), platform_view,
                  ui_task_runner = task_runners_.GetUITaskRunner(), ui_task,
                  shared_resource_context = shared_resource_context_] {
    if (io_manager && !io_manager->GetResourceContext()) {
      sk_sp<GrDirectContext> resource_context;
      if (shared_resource_context) {
        resource_context = shared_resource_context;
      } else {
        resource_context = platform_view->CreateResourceContext();
      }
      io_manager->NotifyResourceContextAvailable(resource_context);
    }
    // Step 1: Next, post a task on the UI thread to tell the engine that it has
    // an output surface.
    fml::TaskRunner::RunNowOrPostTask(ui_task_runner, ui_task);
  };

  fml::TaskRunner::RunNowOrPostTask(task_runners_.GetIOTaskRunner(), io_task);

  latch.Wait();
  if (!should_post_raster_task) {
    // See comment on should_post_raster_task, in this case the raster_task
    // wasn't executed, and we just run it here as the platform thread
    // is the raster thread.
    raster_task();
  }
}
```

The variable `should_post_raster_task` in `OnPlatformViewCreated()` controls the raster_task should be post to platform/raster thread or runs directly.

Before this change, the method `DisableThreadMergerIfNeeded()` will set the enabled state into RasterThreadMerger instance and not shared when two same thread pair (lightweight engines use same raster and platform thread). So this change move the `enabled_` member from `RasterThreadMerger` class to `SharedThreadMerger` class.

It was my little negligence not move this value into the `SharedThreadMerger` class. 😂

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
