### PR TITLE
Update DEPS to rev to the latest DevTools CIPD package

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -47,7 +47,7 @@ vars = {
   'dart_boringssl_rev': '1607f54fed72c6589d560254626909a64124f091',
   'dart_clock_rev': 'a494269254ba978e7ef8f192c5f7fec3fc05b9d3',
   'dart_collection_rev': '75a7a5510979a3cd70143af85bcc1667ee233674',
-  'dart_devtools_rev': '64cffbed6366329ad05e44d48fa2298367643bb6',
+  'dart_devtools_rev': '2b47d9ed486479153ca2fd038000950674ed1beb',
   'dart_http_throttle_tag': '1.0.2',
   'dart_intl_tag': '0.17.0-nullsafety',
   'dart_linter_tag': '1.9.0',
@@ -172,7 +172,7 @@ deps = {
   # WARNING: Unused Dart dependencies in the list below till "WARNING:" marker are removed automatically - see create_updated_flutter_deps.py.
 
   'src/third_party/dart/third_party/devtools':
-   {'packages': [{'version': 'git_revision:64cffbed6366329ad05e44d48fa2298367643bb6', 'package': 'dart/third_party/flutter/devtools'}], 'dep_type': 'cipd'},
+   {'packages': [{'version': 'git_revision:2b47d9ed486479153ca2fd038000950674ed1beb', 'package': 'dart/third_party/flutter/devtools'}], 'dep_type': 'cipd'},
 
   'src/third_party/dart/third_party/pkg/args':
    Var('dart_git') + '/args.git@bf4c8796881b62fd5d3f6d86ab43014f9651eb20',


### PR DESCRIPTION
This updates the engine repo to the latest version of the devtools CIPD package.

*List which issues are fixed by this PR. You must list at least one issue.*

This is necessary as the dep has rev'd upstream in the sdk repo (see https://dart-review.googlesource.com/c/sdk/+/210423).

