### PR TITLE
set pre-built dart sdk to default

### DIFF
--- a/tools/download_dart_sdk.py
+++ b/tools/download_dart_sdk.py
@@ -212,7 +212,7 @@ def Main():
   fail_loudly = 1 if args.fail_loudly else 0
   verbose = args.verbose
 
-  prebuilt_enabled = os.environ.get(FLUTTER_PREBUILTS_ENV_VAR, 'false')
+  prebuilt_enabled = os.environ.get(FLUTTER_PREBUILTS_ENV_VAR, 'true')
   if prebuilt_enabled == '0' or prebuilt_enabled.lower() == 'false':
     if verbose:
       print('Skipping prebuild Dart SDK download.')

--- a/tools/gn
+++ b/tools/gn
@@ -334,7 +334,8 @@ def to_gn_args(args):
         gn_args['dart_sdk_output'] = 'built-dart-sdk'
       else:
         print('Tried to download prebuilt Dart SDK but an appropriate version '
-              'could not be found! Either retry by running '
+                'could not be found!')
+        print('Either retry by running '
               'flutter/tools/download_dart_sdk.py manually or compile from '
               'source by setting `--no-prebuilt-dart-sdk` flag to tools/gn')
     elif args.target_os is None or args.target_os == 'linux':
@@ -484,7 +485,7 @@ def parse_args(args):
   parser.add_argument('--prebuilt-dart-sdk', default=True, action='store_true',
                       help='Whether to use a prebuilt Dart SDK instead of building one. This defaults to ' +
                       'true and is enabled on CI.')
-  parser.add_argument('--no-prebuilt-dart-sdk', dest='prebuilt-dart-sdk', action='store_false')
+  parser.add_argument('--no-prebuilt-dart-sdk', dest='prebuilt_dart_sdk', action='store_false')
 
   # Sanitizers.
   parser.add_argument('--asan', default=False, action='store_true')

--- a/tools/gn
+++ b/tools/gn
@@ -328,12 +328,15 @@ def to_gn_args(args):
     # use it instead of building a new one.
     if args.prebuilt_dart_sdk:
       if can_use_prebuilt_dart(args):
+        print('Using prebuilt Dart SDK binary. If you are editing Dart sources '
+              'and wish to compile the Dart SDK, set `--no-prebuilt-dart-sdk`.')
         gn_args['flutter_prebuilt_dart_sdk'] = True
         gn_args['dart_sdk_output'] = 'built-dart-sdk'
       else:
-        print('--prebuilt-dart-sdk was specified, but an appropriate prebuilt '
-              'could not be found! Try running '
-              'flutter/tools/download_dart_sdk.py manually.')
+        print('Tried to download prebuilt Dart SDK but an appropriate version '
+              'could not be found! Either retry by running '
+              'flutter/tools/download_dart_sdk.py manually or compile from '
+              'source by setting `--no-prebuilt-dart-sdk` flag to tools/gn')
     elif args.target_os is None or args.target_os == 'linux':
       # dart_platform_sdk is only defined for host builds, linux arm host builds
       # specify target_os=linux.
@@ -479,7 +482,9 @@ def parse_args(args):
   parser.add_argument('--no-stripped', dest='stripped', action='store_false')
 
   parser.add_argument('--prebuilt-dart-sdk', default=True, action='store_true',
-                      help='Whether to use a prebuilt Dart SDK instead of building one.')
+                      help='Whether to use a prebuilt Dart SDK instead of building one. This defaults to ' +
+                      'true and is enabled on CI.')
+  parser.add_argument('--no-prebuilt-dart-sdk', dest='prebuilt-dart-sdk', action='store_false')
 
   # Sanitizers.
   parser.add_argument('--asan', default=False, action='store_true')

--- a/tools/gn
+++ b/tools/gn
@@ -85,6 +85,14 @@ def cpu_for_target_arch(arch):
   if arch in ['x64', 'arm64', 'simarm64', 'simdbc64', 'armsimdbc64']:
     return 'x64'
 
+def is_host_build(args):
+    # If target_os == None, then this is a host build.
+    # However, for linux arm64 builds, we cross compile from x64 hosts, so the
+    # target_os='linux' and linux-cpu='arm64'
+    # TODO(fujino): make host platform explicit
+    #   https://github.com/flutter/flutter/issues/79403
+    return args.target_os is None or args.target_os == 'linux'
+
 # Determines whether a prebuilt Dart SDK can be used instead of building one.
 # We can use a prebuilt Dart SDK when:
 # 1. It is a host build, or a build targeting desktop
@@ -332,13 +340,13 @@ def to_gn_args(args):
               'and wish to compile the Dart SDK, set `--no-prebuilt-dart-sdk`.')
         gn_args['flutter_prebuilt_dart_sdk'] = True
         gn_args['dart_sdk_output'] = 'built-dart-sdk'
-      else:
+      elif is_host_build(args):
         print('Tried to download prebuilt Dart SDK but an appropriate version '
                 'could not be found!')
         print('Either retry by running '
               'flutter/tools/download_dart_sdk.py manually or compile from '
               'source by setting `--no-prebuilt-dart-sdk` flag to tools/gn')
-    elif args.target_os is None or args.target_os == 'linux':
+    elif is_host_build(args):
       # dart_platform_sdk is only defined for host builds, linux arm host builds
       # specify target_os=linux.
       # dart_platform_sdk=True means exclude web-related files, e.g. dart2js,

--- a/tools/gn
+++ b/tools/gn
@@ -478,7 +478,7 @@ def parse_args(args):
                       help='Strip debug symbols from the output. This defaults to true and has no effect on iOS.')
   parser.add_argument('--no-stripped', dest='stripped', action='store_false')
 
-  parser.add_argument('--prebuilt-dart-sdk', default=False, action='store_true',
+  parser.add_argument('--prebuilt-dart-sdk', default=True, action='store_true',
                       help='Whether to use a prebuilt Dart SDK instead of building one.')
 
   # Sanitizers.


### PR DESCRIPTION
Since https://flutter.googlesource.com/recipes/+/0b7c1983e68cc802926bff6bd2d61ebdf1231785 (5 weeks ago), we have been using pre-built Dart SDK packages in CI builds. This change sets the default local workflow to also use the pre-built Dart SDK.

The Dart SDK can still be compiled locally by providing the env var `FLUTTER_PREBUILT_DART_SDK=false`.

Default flow, prints warning:
```
$ flutter/tools/gn --unoptimized
Using prebuilt Dart SDK binary. If you are editing Dart sources and wish to compile the Dart SDK, set `--no-prebuilt-dart-sdk`.
Generating GN files in: out/host_debug_unopt
Generating compile_commands took 60ms
Done. Made 736 targets from 245 files in 3118ms
```

Can be explicitly opted out:
```
flutter/tools/gn --unoptimized --no-prebuilt-dart-sdk
Generating GN files in: out/host_debug_unopt
Generating compile_commands took 63ms
Done. Made 912 targets from 260 files in 2921ms
```

If prebuilts are not present locally:
```
$ ./flutter/tools/gn --unoptimized
Tried to download prebuilt Dart SDK but an appropriate version could not be found!
Either retry by running flutter/tools/download_dart_sdk.py manually or compile from source by setting `--no-prebuilt-dart-sdk` flag to tools/gn
Generating GN files in: out/host_debug_unopt
Generating compile_commands took 75ms
Done. Made 912 targets from 260 files in 4385ms
```