### PR TITLE
Add archive configurations for web engine builder.

### DIFF
--- a/ci/builders/web_engine.json
+++ b/ci/builders/web_engine.json
@@ -1,6 +1,15 @@
 [
     {
-        "archives": [],
+        "archives": [
+             {
+                     "name": "windows_host_debug_unopt",
+                     "include_paths": ["out/host_debug_unopt"],
+                     "exclude_paths": [
+			     "out/host_debug_unopt/obj",
+                             "out/host_debug_unopt/exe.unstripped"
+                     ]
+              }
+        ],
         "drone_dimensions": [
             "device_type=none",
             "os=Windows-10"
@@ -21,7 +30,24 @@
         "tests": []
     },
     {
-        "archives": [],
+        "archives": [
+		{
+			"name": "linux_host_debug_unopt",
+			"include_paths": ["out/host_debug_unopt"],
+			"exclude_paths": [
+				"out/host_debug_unopt/obj",
+				"out/host_debug_unopt/exe.unstripped"
+			]
+		},
+		{
+			"name": "javascript_tests",
+			"include_paths": [
+				"flutter/lib/web_ui/build/test",
+				"flutter/web_sdk/web_engine_tester/lib/static"
+			],
+			"exclude_paths": []
+		}
+	],
         "drone_dimensions": [
             "device_type=none",
             "os=Linux"
@@ -77,7 +103,16 @@
         "tests": []
     },
     {
-        "archives": [],
+        "archives": [
+            {
+                "name": "mac_host_debug_unopt",
+                "include_paths": ["out/host_debug_unopt"],
+                "exclude_paths": [
+                    "out/host_debug_unopt/obj",
+                    "out/host_debug_unopt/exe.unstripped"
+                ]
+            }
+        ],
         "drone_dimensions": [
             "device_type=none",
             "os=Mac"


### PR DESCRIPTION
Archives to CAS has been implemented in the recipes and we are ready to
start archiving artifacts from the builders.

Bug: https://github.com/flutter/flutter/issues/81855

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
