### PR TITLE
Fix flaky stack-use-after-scope in PushingMutlipleFramesSetsUpNewReco…

### DIFF
--- a/shell/platform/embedder/tests/embedder_unittests_gl.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_gl.cc
@@ -2028,6 +2028,8 @@ TEST_F(EmbedderTest,
   frame_latch.Wait();
 
   ASSERT_EQ(frames_expected, frames_seen);
+
+  FlutterEngineShutdown(engine.release());
 }
 
 TEST_F(EmbedderTest,
@@ -2067,6 +2069,8 @@ TEST_F(EmbedderTest,
   frame_latch.Wait();
 
   ASSERT_EQ(frames_expected, frames_seen);
+
+  FlutterEngineShutdown(engine.release());
 }
 
 TEST_F(EmbedderTest, PlatformViewMutatorsAreValid) {


### PR DESCRIPTION
Speculative fix for flake in https://github.com/flutter/flutter/issues/88713

Shutdown the engine at the end of `PushingMutlipleFramesSetsUpNewRecordingCanvasWith*CustomCompositor` to prevent another frame from getting processed after scope free prior to engine destruct.