### PR TITLE
[ci.yaml] Add gradle cache

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -30,6 +30,7 @@ platform_properties:
       caches: >-
         [
           {"name":"builder_linux_engine","path":"builder"},
+          {"name":"gradle","path":"gradle"},
           {"name":"openjdk","path":"java"}
         ]
       # CIPD flutter_internal/java/openjdk/$platform


### PR DESCRIPTION
Enable gradle cache on LUCI to allow reuse. Minimizes network flakes in builds because of gradle reuse.

https://github.com/flutter/flutter/issues/88717

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
