### PR TITLE
Symbolize ASan traces when using `run_tests.py`

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -569,7 +569,7 @@ def main():
     ]
     process = subprocess.Popen(command, stdout=subprocess.PIPE)
     for line in process.stdout:
-      key, _, value = str(line).partition("=")
+      key, _, value = line.decode('ascii').strip().partition("=")
       os.environ[key] = value
     process.communicate() # Avoid pipe deadlock while waiting for termination.
 

--- a/testing/sanitizer_suppressions.sh
+++ b/testing/sanitizer_suppressions.sh
@@ -1,5 +1,9 @@
 TESTING_DIRECTORY=$(dirname "${BASH_SOURCE[0]}")
 
+pushd $TESTING_DIRECTORY/../.. >/dev/null
+ENGINE_BUILDROOT=$(pwd)
+popd >/dev/null
+
 TSAN_SUPPRESSIONS_FILE="${TESTING_DIRECTORY}/tsan_suppressions.txt"
 export TSAN_OPTIONS="suppressions=${TSAN_SUPPRESSIONS_FILE}"
 echo "Using Thread Sanitizer suppressions in ${TSAN_SUPPRESSIONS_FILE}"
@@ -13,4 +17,5 @@ export UBSAN_OPTIONS="suppressions=${UBSAN_SUPPRESSIONS_FILE}"
 echo "Using Undefined Behavior suppressions in ${UBSAN_SUPPRESSIONS_FILE}"
 
 
-export ASAN_OPTIONS="detect_leaks=0:detect_container_overflow=0"
+export ASAN_OPTIONS="symbolize=1:detect_leaks=0:detect_container_overflow=0"
+export ASAN_SYMBOLIZER_PATH=$ENGINE_BUILDROOT/buildtools/linux-x64/clang/bin/llvm-symbolizer

--- a/testing/sanitizer_suppressions.sh
+++ b/testing/sanitizer_suppressions.sh
@@ -1,8 +1,14 @@
-TESTING_DIRECTORY=$(dirname "${BASH_SOURCE[0]}")
+TESTING_DIRECTORY=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd -P)
+ENGINE_BUILDROOT=$(cd $TESTING_DIRECTORY/../..; pwd -P)
 
-pushd $TESTING_DIRECTORY/../.. >/dev/null
-ENGINE_BUILDROOT=$(pwd)
-popd >/dev/null
+case "$(uname -s)" in
+  Linux)
+    BUILDTOOLS_DIRECTORY="${ENGINE_BUILDROOT}/buildtools/linux-x64"
+    ;;
+  Darwin)
+    BUILDTOOLS_DIRECTORY="${ENGINE_BUILDROOT}/buildtools/mac-x64"
+    ;;
+esac
 
 TSAN_SUPPRESSIONS_FILE="${TESTING_DIRECTORY}/tsan_suppressions.txt"
 export TSAN_OPTIONS="suppressions=${TSAN_SUPPRESSIONS_FILE}"
@@ -18,4 +24,4 @@ echo "Using Undefined Behavior suppressions in ${UBSAN_SUPPRESSIONS_FILE}"
 
 
 export ASAN_OPTIONS="symbolize=1:detect_leaks=0:detect_container_overflow=0"
-export ASAN_SYMBOLIZER_PATH=$ENGINE_BUILDROOT/buildtools/linux-x64/clang/bin/llvm-symbolizer
+export ASAN_SYMBOLIZER_PATH="${BUILDTOOLS_DIRECTORY}/clang/bin/llvm-symbolizer"


### PR DESCRIPTION
We noticed the traces weren't getting symbolized when running in LUCI here: flutter/flutter#88713.

* Set `ASAN_SYMBOLIZER_PATH` when running tests via `run_tests.py`.
* Also changes `run_tests.py` to remove the newlines appearing at the end of the sourced variables from `sanitizer_suppressions.sh`, which was breaking the path.