### PR TITLE
Windows: FlutterDesktopPixelBuffer: Add optional release callback

### DIFF
--- a/shell/platform/common/public/flutter_texture_registrar.h
+++ b/shell/platform/common/public/flutter_texture_registrar.h
@@ -34,6 +34,10 @@ typedef struct {
   size_t width;
   // Height of the pixel buffer.
   size_t height;
+  // An optional callback that gets invoked when the |buffer| can be released.
+  void (*release_callback)(void* release_context);
+  // Opaque data passed to |release_callback|.
+  void* release_context;
 } FlutterDesktopPixelBuffer;
 
 // The pixel buffer copy callback definition provided to

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -227,6 +227,7 @@ executable("flutter_windows_unittests") {
     "string_conversion_unittests.cc",
     "system_utils_unittests.cc",
     "testing/engine_modifier.h",
+    "testing/mock_gl_functions.h",
   ]
 
   # Target-specific sources.

--- a/shell/platform/windows/external_texture_gl.cc
+++ b/shell/platform/windows/external_texture_gl.cc
@@ -125,6 +125,9 @@ bool ExternalTextureGL::CopyPixelBuffer(size_t& width, size_t& height) {
   gl.glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pixel_buffer->width,
                   pixel_buffer->height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
                   pixel_buffer->buffer);
+  if (pixel_buffer->release_callback) {
+    pixel_buffer->release_callback(pixel_buffer->release_context);
+  }
   return true;
 }
 

--- a/shell/platform/windows/external_texture_gl.cc
+++ b/shell/platform/windows/external_texture_gl.cc
@@ -4,61 +4,6 @@
 
 #include "flutter/shell/platform/windows/external_texture_gl.h"
 
-#include <EGL/egl.h>
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
-
-namespace {
-
-typedef void (*glGenTexturesProc)(GLsizei n, GLuint* textures);
-typedef void (*glDeleteTexturesProc)(GLsizei n, const GLuint* textures);
-typedef void (*glBindTextureProc)(GLenum target, GLuint texture);
-typedef void (*glTexParameteriProc)(GLenum target, GLenum pname, GLint param);
-typedef void (*glTexImage2DProc)(GLenum target,
-                                 GLint level,
-                                 GLint internalformat,
-                                 GLsizei width,
-                                 GLsizei height,
-                                 GLint border,
-                                 GLenum format,
-                                 GLenum type,
-                                 const void* data);
-
-// A struct containing pointers to resolved gl* functions.
-struct GlProcs {
-  glGenTexturesProc glGenTextures;
-  glDeleteTexturesProc glDeleteTextures;
-  glBindTextureProc glBindTexture;
-  glTexParameteriProc glTexParameteri;
-  glTexImage2DProc glTexImage2D;
-  bool valid;
-};
-
-static const GlProcs& GlProcs() {
-  static struct GlProcs procs = {};
-  static bool initialized = false;
-  if (!initialized) {
-    procs.glGenTextures =
-        reinterpret_cast<glGenTexturesProc>(eglGetProcAddress("glGenTextures"));
-    procs.glDeleteTextures = reinterpret_cast<glDeleteTexturesProc>(
-        eglGetProcAddress("glDeleteTextures"));
-    procs.glBindTexture =
-        reinterpret_cast<glBindTextureProc>(eglGetProcAddress("glBindTexture"));
-    procs.glTexParameteri = reinterpret_cast<glTexParameteriProc>(
-        eglGetProcAddress("glTexParameteri"));
-    procs.glTexImage2D =
-        reinterpret_cast<glTexImage2DProc>(eglGetProcAddress("glTexImage2D"));
-
-    procs.valid = procs.glGenTextures && procs.glDeleteTextures &&
-                  procs.glBindTexture && procs.glTexParameteri &&
-                  procs.glTexImage2D;
-    initialized = true;
-  }
-  return procs;
-}
-
-}  // namespace
-
 namespace flutter {
 
 struct ExternalTextureGLState {
@@ -67,15 +12,17 @@ struct ExternalTextureGLState {
 
 ExternalTextureGL::ExternalTextureGL(
     FlutterDesktopPixelBufferTextureCallback texture_callback,
-    void* user_data)
+    void* user_data,
+    const GlProcs& gl_procs)
     : state_(std::make_unique<ExternalTextureGLState>()),
       texture_callback_(texture_callback),
-      user_data_(user_data) {}
+      user_data_(user_data),
+      gl_(gl_procs) {}
 
 ExternalTextureGL::~ExternalTextureGL() {
   const auto& gl = GlProcs();
-  if (gl.valid && state_->gl_texture != 0) {
-    gl.glDeleteTextures(1, &state_->gl_texture);
+  if (state_->gl_texture != 0) {
+    gl_.glDeleteTextures(1, &state_->gl_texture);
   }
 }
 
@@ -101,30 +48,29 @@ bool ExternalTextureGL::PopulateTexture(size_t width,
 bool ExternalTextureGL::CopyPixelBuffer(size_t& width, size_t& height) {
   const FlutterDesktopPixelBuffer* pixel_buffer =
       texture_callback_(width, height, user_data_);
-  const auto& gl = GlProcs();
-  if (!gl.valid || !pixel_buffer || !pixel_buffer->buffer) {
+  if (!pixel_buffer || !pixel_buffer->buffer) {
     return false;
   }
   width = pixel_buffer->width;
   height = pixel_buffer->height;
 
   if (state_->gl_texture == 0) {
-    gl.glGenTextures(1, &state_->gl_texture);
+    gl_.glGenTextures(1, &state_->gl_texture);
 
-    gl.glBindTexture(GL_TEXTURE_2D, state_->gl_texture);
+    gl_.glBindTexture(GL_TEXTURE_2D, state_->gl_texture);
 
-    gl.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-    gl.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
 
-    gl.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-    gl.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    gl_.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
   } else {
-    gl.glBindTexture(GL_TEXTURE_2D, state_->gl_texture);
+    gl_.glBindTexture(GL_TEXTURE_2D, state_->gl_texture);
   }
-  gl.glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pixel_buffer->width,
-                  pixel_buffer->height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
-                  pixel_buffer->buffer);
+  gl_.glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pixel_buffer->width,
+                   pixel_buffer->height, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                   pixel_buffer->buffer);
   if (pixel_buffer->release_callback) {
     pixel_buffer->release_callback(pixel_buffer->release_context);
   }

--- a/shell/platform/windows/external_texture_gl.h
+++ b/shell/platform/windows/external_texture_gl.h
@@ -12,15 +12,43 @@
 #include "flutter/shell/platform/common/public/flutter_texture_registrar.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 
+#include <GLES2/gl2.h>
+#include <GLES2/gl2ext.h>
+
 namespace flutter {
 
 typedef struct ExternalTextureGLState ExternalTextureGLState;
+
+typedef void (*glGenTexturesProc)(GLsizei n, GLuint* textures);
+typedef void (*glDeleteTexturesProc)(GLsizei n, const GLuint* textures);
+typedef void (*glBindTextureProc)(GLenum target, GLuint texture);
+typedef void (*glTexParameteriProc)(GLenum target, GLenum pname, GLint param);
+typedef void (*glTexImage2DProc)(GLenum target,
+                                 GLint level,
+                                 GLint internalformat,
+                                 GLsizei width,
+                                 GLsizei height,
+                                 GLint border,
+                                 GLenum format,
+                                 GLenum type,
+                                 const void* data);
+
+// A struct containing pointers to resolved gl* functions.
+struct GlProcs {
+  glGenTexturesProc glGenTextures;
+  glDeleteTexturesProc glDeleteTextures;
+  glBindTextureProc glBindTexture;
+  glTexParameteriProc glTexParameteri;
+  glTexImage2DProc glTexImage2D;
+  bool valid;
+};
 
 // An abstraction of an OpenGL texture.
 class ExternalTextureGL {
  public:
   ExternalTextureGL(FlutterDesktopPixelBufferTextureCallback texture_callback,
-                    void* user_data);
+                    void* user_data,
+                    const GlProcs& gl_procs);
 
   virtual ~ExternalTextureGL();
 
@@ -49,6 +77,7 @@ class ExternalTextureGL {
   std::unique_ptr<ExternalTextureGLState> state_;
   FlutterDesktopPixelBufferTextureCallback texture_callback_ = nullptr;
   void* user_data_ = nullptr;
+  const GlProcs& gl_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -164,7 +164,10 @@ FlutterWindowsEngine::FlutterWindowsEngine(const FlutterProjectBundle& project)
   messenger_wrapper_ = std::make_unique<BinaryMessengerImpl>(messenger_.get());
   message_dispatcher_ =
       std::make_unique<IncomingMessageDispatcher>(messenger_.get());
-  texture_registrar_ = std::make_unique<FlutterWindowsTextureRegistrar>(this);
+
+  FlutterWindowsTextureRegistrar::ResolveGlFunctions(gl_procs_);
+  texture_registrar_ =
+      std::make_unique<FlutterWindowsTextureRegistrar>(this, gl_procs_);
   surface_manager_ = AngleSurfaceManager::Create();
 #ifndef WINUWP
   window_proc_delegate_manager_ =

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -182,6 +182,9 @@ class FlutterWindowsEngine {
   // The texture registrar.
   std::unique_ptr<FlutterWindowsTextureRegistrar> texture_registrar_;
 
+  // Resolved OpenGL functions used by external texture implementations.
+  GlProcs gl_procs_ = {};
+
   // An object used for intializing Angle and creating / destroying render
   // surfaces. Surface creation functionality requires a valid render_target.
   // May be nullptr if ANGLE failed to initialize.

--- a/shell/platform/windows/flutter_windows_texture_registrar.h
+++ b/shell/platform/windows/flutter_windows_texture_registrar.h
@@ -19,7 +19,8 @@ class FlutterWindowsEngine;
 // Thread safety: All member methods are thread safe.
 class FlutterWindowsTextureRegistrar {
  public:
-  explicit FlutterWindowsTextureRegistrar(FlutterWindowsEngine* engine);
+  explicit FlutterWindowsTextureRegistrar(FlutterWindowsEngine* engine,
+                                          const GlProcs& gl_procs);
 
   // Registers a texture described by the given |texture_info| object.
   // Returns the non-zero, positive texture id or -1 on error.
@@ -41,8 +42,12 @@ class FlutterWindowsTextureRegistrar {
                        size_t height,
                        FlutterOpenGLTexture* texture);
 
+  // Populates the OpenGL function pointers in |gl_procs|.
+  static void ResolveGlFunctions(GlProcs& gl_procs);
+
  private:
   FlutterWindowsEngine* engine_ = nullptr;
+  const GlProcs& gl_procs_;
 
   // All registered textures, keyed by their IDs.
   std::unordered_map<int64_t, std::unique_ptr<flutter::ExternalTextureGL>>

--- a/shell/platform/windows/testing/mock_gl_functions.h
+++ b/shell/platform/windows/testing/mock_gl_functions.h
@@ -1,0 +1,54 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_GL_FUNCTIONS_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_GL_FUNCTIONS_H_
+
+#include "flutter/shell/platform/windows/external_texture_gl.h"
+
+namespace flutter {
+namespace testing {
+
+// A class providing a mocked subset of OpenGL API functions.
+class MockGlFunctions {
+ public:
+  MockGlFunctions() {
+    gl_procs_.glGenTextures = &glGenTextures;
+    gl_procs_.glDeleteTextures = &glDeleteTextures;
+    gl_procs_.glBindTexture = &glBindTexture;
+    gl_procs_.glTexParameteri = &glTexParameteri;
+    gl_procs_.glTexImage2D = &glTexImage2D;
+    gl_procs_.valid = true;
+  }
+
+  const GlProcs& gl_procs() { return gl_procs_; }
+
+  static void glGenTextures(GLsizei n, GLuint* textures) {
+    // The minimum valid texture ID is 1
+    for (auto i = 0; i < n; i++) {
+      textures[i] = i + 1;
+    }
+  }
+
+  static void glDeleteTextures(GLsizei n, const GLuint* textures) {}
+  static void glBindTexture(GLenum target, GLuint texture) {}
+  static void glTexParameteri(GLenum target, GLenum pname, GLint param) {}
+  static void glTexImage2D(GLenum target,
+                           GLint level,
+                           GLint internalformat,
+                           GLsizei width,
+                           GLsizei height,
+                           GLint border,
+                           GLenum format,
+                           GLenum type,
+                           const void* data) {}
+
+ private:
+  GlProcs gl_procs_;
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_TESTING_MOCK_GL_FUNCTIONS_H_


### PR DESCRIPTION
This PR adds an optional callback to `FlutterDesktopPixelBuffer` that gets invoked when it's safe to release the backing buffer (or unlock a mutex protecting that buffer etc.).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
