### PR TITLE
Ensure that unregisterTexture is called when forget to call SurfaceTextureEntry.release

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -177,20 +177,29 @@ public class FlutterRenderer implements TextureRegistry {
           return;
         }
 
-        handler.post(
-            new Runnable() {
-              public void run() {
-                if (released || !flutterJNI.isAttached()) {
-                  return;
-                }
-                Log.v(TAG, "Releasing a SurfaceTexture (" + id + ").");
-                unregisterTexture(id);
-                released = true;
-              }
-            });
+        handler.post(new SurfaceTextureFinalizerRunnable(id, flutterJNI));
       } finally {
         super.finalize();
       }
+    }
+  }
+
+  static final class SurfaceTextureFinalizerRunnable implements Runnable {
+    private final long id;
+    private final FlutterJNI flutterJNI;
+
+    SurfaceTextureFinalizerRunnable(long id, @NonNull FlutterJNI flutterJNI) {
+      this.id = id;
+      this.flutterJNI = flutterJNI;
+    }
+
+    @Override
+    public void run() {
+      if (!flutterJNI.isAttached()) {
+        return;
+      }
+      Log.v(TAG, "Releasing a SurfaceTexture (" + id + ").");
+      flutterJNI.unregisterTexture(id);
     }
   }
   // ------ END TextureRegistry IMPLEMENTATION ----

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -4,9 +4,14 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
 
+import android.os.Looper;
 import android.view.Surface;
 import io.flutter.embedding.engine.FlutterJNI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -115,5 +120,79 @@ public class FlutterRendererTest {
 
     // Verify behavior under test.
     verify(fakeFlutterJNI, times(0)).markTextureFrameAvailable(eq(entry.id()));
+  }
+
+  @Test
+  public void itUnregistersTextureWhenSurfaceTextureFinalized() {
+    // Setup the test.
+    FlutterJNI fakeFlutterJNI = mock(FlutterJNI.class);
+    when(fakeFlutterJNI.isAttached()).thenReturn(true);
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+
+    fakeFlutterJNI.detachFromNativeAndReleaseResources();
+
+    FlutterRenderer.SurfaceTextureRegistryEntry entry =
+        (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
+    long id = entry.id();
+
+    flutterRenderer.startRenderingToSurface(fakeSurface);
+
+    // Execute the behavior under test.
+    runFinalization(entry);
+
+    shadowOf(Looper.getMainLooper()).idle();
+
+    flutterRenderer.stopRenderingToSurface();
+
+    // Verify behavior under test.
+    verify(fakeFlutterJNI, times(1)).unregisterTexture(eq(id));
+  }
+
+  @Test
+  public void itStopsUnregisteringTextureWhenDetached() {
+    // Setup the test.
+    FlutterJNI fakeFlutterJNI = mock(FlutterJNI.class);
+    when(fakeFlutterJNI.isAttached()).thenReturn(false);
+    FlutterRenderer flutterRenderer = new FlutterRenderer(fakeFlutterJNI);
+
+    fakeFlutterJNI.detachFromNativeAndReleaseResources();
+
+    FlutterRenderer.SurfaceTextureRegistryEntry entry =
+        (FlutterRenderer.SurfaceTextureRegistryEntry) flutterRenderer.createSurfaceTexture();
+    long id = entry.id();
+
+    flutterRenderer.startRenderingToSurface(fakeSurface);
+
+    flutterRenderer.stopRenderingToSurface();
+
+    // Execute the behavior under test.
+    runFinalization(entry);
+
+    shadowOf(Looper.getMainLooper()).idle();
+
+    // Verify behavior under test.
+    verify(fakeFlutterJNI, times(0)).unregisterTexture(eq(id));
+  }
+
+  void runFinalization(FlutterRenderer.SurfaceTextureRegistryEntry entry) {
+    CountDownLatch latch = new CountDownLatch(1);
+    Thread fakeFinalizer =
+        new Thread(
+            new Runnable() {
+              public void run() {
+                try {
+                  entry.finalize();
+                  latch.countDown();
+                } catch (Throwable e) {
+                  // do nothing
+                }
+              }
+            });
+    fakeFinalizer.start();
+    try {
+      latch.await(5L, TimeUnit.SECONDS);
+    } catch (Throwable e) {
+      // do nothing
+    }
   }
 }


### PR DESCRIPTION
Fix the issue : https://github.com/flutter/flutter/issues/88571

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.