### PR TITLE
Fix lint that shows up in manual builds

### DIFF
--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -63,8 +63,8 @@ class CustomEncodableValue {
   ~CustomEncodableValue() = default;
 
   // Allow implicit conversion to std::any to allow direct use of any_cast.
-  operator std::any &() { return value_; }
-  operator const std::any &() const { return value_; }
+  operator std::any&() { return value_; }
+  operator const std::any&() const { return value_; }
 
 #if defined(FLUTTER_ENABLE_RTTI) && FLUTTER_ENABLE_RTTI
   // Passthrough to std::any's type().


### PR DESCRIPTION
Fix a lint that shows up when manually triggering single targets on LUCI: https://logs.chromium.org/logs/flutter/led/bdero_google.com/99df41994bd16dd3d5cdcd53023e14896cde9f87a29ecf97895a6b3dd041061a/+/u/format_and_dart_test/stdout

Not sure why it's not showing up during full CI runs, though.