### PR TITLE
Revert "Build dart:zircon and dart:zircon_ffi (#28071)"

### DIFF
--- a/shell/platform/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/BUILD.gn
@@ -77,7 +77,6 @@ group("fuchsia") {
   deps = [
     ":dart_binaries",
     ":flutter_binaries",
-    "dart-pkg",
     "dart_runner:dart_aot_${product_suffix}runner",
     "dart_runner:dart_jit_${product_suffix}runner",
     "flutter:flutter_aot_${product_suffix}runner",

--- a/shell/platform/fuchsia/dart-pkg/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/BUILD.gn
@@ -1,7 +1,0 @@
-# Copyright 2013 The Flutter Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
-group("dart-pkg") {
-  deps = [ "zircon:dart_zircon" ]
-}

--- a/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import("//build/fuchsia/sdk.gni")
-import("//flutter/tools/fuchsia/dart/dart_library.gni")
 
 config("zircon_config") {
   include_dirs = [ "." ]
@@ -35,19 +34,4 @@ source_set("zircon") {
     "//flutter/fml",
     "//flutter/third_party/tonic",
   ]
-}
-
-dart_library("dart_zircon") {
-  package_name = "zircon"
-
-  sources = [
-    "src/handle.dart",
-    "src/handle_disposition.dart",
-    "src/handle_waiter.dart",
-    "src/init.dart",
-    "src/system.dart",
-    "zircon.dart",
-  ]
-
-  deps = [ "../zircon_ffi:dart_zircon_ffi" ]
 }

--- a/shell/platform/fuchsia/dart-pkg/zircon_ffi/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/zircon_ffi/BUILD.gn
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import("//build/fuchsia/sdk.gni")
-import("//flutter/tools/fuchsia/dart/dart_library.gni")
 
 config("zircon_ffi_config") {
   include_dirs = [ "." ]
@@ -31,10 +30,4 @@ shared_library("zircon_ffi") {
     "//flutter/fml",
     "//third_party/dart/runtime:dart_api",
   ]
-}
-
-dart_library("dart_zircon_ffi") {
-  package_name = "zircon_ffi"
-
-  sources = [ "zircon_ffi.dart" ]
 }

--- a/tools/.vpython
+++ b/tools/.vpython
@@ -1,4 +1,0 @@
-wheel: <
-  name: "infra/python/wheels/pyyaml/${vpython_platform}"
-  version: "version:3.12"
->

--- a/tools/.vpython3
+++ b/tools/.vpython3
@@ -1,5 +1,0 @@
-python_version: "3.8"
-wheel: <
-  name: "infra/python/wheels/pyyaml-py3"
-  version: "version:5.3.1"
->

--- a/tools/fuchsia/dart/dart_package_config.gni
+++ b/tools/fuchsia/dart/dart_package_config.gni
@@ -77,7 +77,9 @@ template("dart_package_config") {
                              "visibility",
                            ])
 
-    script = "//flutter/tools/fuchsia/dart/gen_dart_package_config.py"
+    script =
+        get_label_info("//flutter/tools/fuchsia/dart:gen_dart_package_config",
+                       "target_out_dir") + "/gen_dart_package_config.pyz"
 
     inputs = [ intermediate_file ]
     outputs = [ package_config_file ]

--- a/tools/fuchsia/dart/gen_dart_package_config.py
+++ b/tools/fuchsia/dart/gen_dart_package_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env vpython3
+#!/usr/bin/env python3.8
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/fuchsia/sdk/find_dart_libraries.py
+++ b/tools/fuchsia/sdk/find_dart_libraries.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env vpython3
+#!/usr/bin/env python3
 #
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be

--- a/tools/gn
+++ b/tools/gn
@@ -1,4 +1,4 @@
-#!/usr/bin/env vpython3
+#!/usr/bin/env python3
 # Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.

--- a/tools/python/run_python3_action.py
+++ b/tools/python/run_python3_action.py
@@ -1,10 +1,10 @@
-#!/usr/bin/env vpython3
+#!/usr/bin/env python
 #
 # Copyright 2021 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import os
 import sys
-import subprocess
 
-subprocess.run(['vpython3'] + sys.argv[1:])
+os.execv('/usr/bin/python3', ['python3'] + sys.argv[1:])


### PR DESCRIPTION
This reverts commit fa053625ac59f8ade72c7b18aca613d599f758ab.

Reverting in order to land revert of the gn script_executable from
python3 to vpython3, which is causing flakes on Windows. This revert is
required because the original patch introduced a dependency on the `yaml`
module, which ships with `vpython3` but not as part of the CIPD package
that includes `python3`.

Issue: https://github.com/flutter/flutter/issues/88719

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
