### PR TITLE
Add --verbose flag to gn wrapper

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -493,6 +493,9 @@ def parse_args(args):
   parser.add_argument('--trace-gn', default=False, action='store_true',
                        help='Write a GN trace log (gn_trace.json) in the Chromium tracing format in the build directory.')
 
+  # Verbose output.
+  parser.add_argument('--verbose', default=False, action='store_true')
+
   return parser.parse_args(args)
 
 def main(argv):
@@ -525,6 +528,9 @@ def main(argv):
 
   if args.trace_gn:
     command.append('--tracelog=%s/gn_trace.json' % out_dir)
+
+  if args.verbose:
+    command.append('-v')
 
   print("Generating GN files in: %s" % out_dir)
   try:


### PR DESCRIPTION
When debugging gn invocations, it's useful to be able to run the
underlying `gn` tool in verbose mode. This adds a `--verbose` flag that
passes the `-v` flag on the underlying `gn` invocation.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
