### PR TITLE
Fix a bug in the Base32 encoder that can cause improper encoding of the first byte

### DIFF
--- a/fml/base32.cc
+++ b/fml/base32.cc
@@ -25,7 +25,7 @@ std::pair<bool, std::string> Base32Encode(std::string_view input) {
   output.reserve(encoded_length);
 
   Base32EncodeConverter converter;
-  converter.Append(input[0]);
+  converter.Append(static_cast<uint8_t>(input[0]));
   size_t next_byte_index = 1;
 
   while (converter.CanExtract()) {

--- a/fml/base32.h
+++ b/fml/base32.h
@@ -16,7 +16,7 @@ template <int from_length, int to_length, int buffer_length>
 class BitConverter {
  public:
   void Append(int bits) {
-    FML_DCHECK(bits < (1 << from_length));
+    FML_DCHECK(bits >= 0 && bits < (1 << from_length));
     FML_DCHECK(CanAppend());
     lower_free_bits_ -= from_length;
     buffer_ |= (bits << lower_free_bits_);

--- a/fml/base32_unittest.cc
+++ b/fml/base32_unittest.cc
@@ -38,6 +38,12 @@ TEST(Base32Test, CanEncode) {
     ASSERT_TRUE(result.first);
     ASSERT_EQ(result.second, "NBSWYTDP");
   }
+
+  {
+    auto result = fml::Base32Encode("\xff\xfe\x7f\x80\x81");
+    ASSERT_TRUE(result.first);
+    ASSERT_EQ(result.second, "777H7AEB");
+  }
 }
 
 TEST(Base32Test, CanEncodeDecodeStrings) {


### PR DESCRIPTION
A negative value passed to BitConverter::Append will overwrite the upper bits of
the BitConverter's buffer.  Base32Encode was not casting the first input char to
an unsigned byte, and Append was not checking for negative inputs.