### PR TITLE
Revert Fuchsia SDK rolls

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -630,7 +630,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/mac-amd64',
-        'version': '4p8By4CDlDzoooMi_rl5eaBEAFQNwPdTc63UV4nPQ4sC'
+        'version': '9xK8HkMEIni83bdI7XnHhSIoNK5pO5oc9gUy8gUGwk0C'
        }
      ],
      'condition': 'host_os == "mac"',
@@ -640,7 +640,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': 'F0f_c0znoGr1RowRXCEyUM7emgo5ENK9FPfW8_SnunQC'
+        'version': 'ZSqn1OAt7c1-5F9FrxDRL9MgJZ-rjGOPCmVfomq2-VoC'
        }
      ],
      'condition': 'host_os == "linux"',

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: 97d60977d3defe4a9a192781c5d86776
+Signature: da44635f0f4bb49575199fe893a6cf7e
 
 UNUSED LICENSES:
 
@@ -3420,7 +3420,6 @@ FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic/lib/src/scenic_context.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/src/focus_state.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/src/fuchsia_views_service.dart
 FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/trace_processing/metrics/camera_metrics.dart
-FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/virtual_camera.dart
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.accessibility.virtualkeyboard/virtual_keyboard.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.gatt2/client.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.gatt2/constants.fidl


### PR DESCRIPTION
The Fuchsia Linux/Mac SDK autorollers were paused due to
https://github.com/flutter/flutter/issues/88999 which, as far as we're
aware, has not yet been resolved upstream. Until we hear otherwise,
we've re-paused the rollers and are reverting to the last Fuchsia SDK
confirmed not to have the observatory port issue described in #88999.

This is a revert of both the Linux and Mac SDK rolls:
* Revert "Roll Fuchsia Linux SDK from ZSqn1OAt7... to F0f_c0zno... (#28325)"
  This reverts commit 8a89e93aa10dd2e81e2f0d66e9bcee09ad94ff3b.
* Revert "Roll Fuchsia Mac SDK from 9xK8HkMEI... to 4p8By4CDl... (#28324)"
  This reverts commit bc0ea465aa60bbe3b2330aa374f1844b50d95b06.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
