### PR TITLE
Fix typo in a comment in #28098

### DIFF
--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -16,7 +16,7 @@ static constexpr double kControllerScrollMultiplier = 3;
 // touch. See https://github.com/flutter/flutter/issues/70201
 static constexpr int32_t kDefaultPointerDeviceId = 0;
 
-// Maps a Flutter cursor name to an CoreCursor.
+// Maps a Flutter cursor name to a CoreCursor.
 //
 // Returns the arrow cursor for unknown constants.
 //


### PR DESCRIPTION
Fixes `an` -> `a`

This is a cleanup patch from #28098.

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.
