### PR TITLE
[web] Support raw straight RGBA format in Image.toByteData() in CanvasKit

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -308,10 +308,11 @@ class CkImage implements ui.Image, StackTraceDebugger {
     ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba,
   }) {
     assert(_debugCheckIsNotDisposed());
+    SkAlphaType alphaType = format == ui.ImageByteFormat.rawStraightRgba ? canvasKit.AlphaType.Unpremul : canvasKit.AlphaType.Premul;
     final ByteData? data = _encodeImage(
       skImage: skImage,
       format: format,
-      alphaType: canvasKit.AlphaType.Premul,
+      alphaType: alphaType,
       colorType: canvasKit.ColorType.RGBA_8888,
       colorSpace: SkColorSpaceSRGB,
     );
@@ -331,7 +332,7 @@ class CkImage implements ui.Image, StackTraceDebugger {
   }) {
     Uint8List? bytes;
 
-    if (format == ui.ImageByteFormat.rawRgba) {
+    if (format == ui.ImageByteFormat.rawRgba || format == ui.ImageByteFormat.rawStraightRgba) {
       final SkImageInfo imageInfo = SkImageInfo(
         alphaType: alphaType,
         colorType: colorType,

--- a/lib/web_ui/lib/src/engine/canvaskit/image.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/image.dart
@@ -308,7 +308,7 @@ class CkImage implements ui.Image, StackTraceDebugger {
     ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba,
   }) {
     assert(_debugCheckIsNotDisposed());
-    SkAlphaType alphaType = format == ui.ImageByteFormat.rawStraightRgba ? canvasKit.AlphaType.Unpremul : canvasKit.AlphaType.Premul;
+    final SkAlphaType alphaType = format == ui.ImageByteFormat.rawStraightRgba ? canvasKit.AlphaType.Unpremul : canvasKit.AlphaType.Premul;
     final ByteData? data = _encodeImage(
       skImage: skImage,
       format: format,

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -181,6 +181,7 @@ class HtmlImage implements ui.Image {
       final html.ImageData imageData = ctx.getImageData(0, 0, width, height);
       return Future<ByteData?>.value(imageData.data.buffer.asByteData());
     } else if (format == ui.ImageByteFormat.rawStraightRgba) {
+      // TODO(ColdPaleLight): https://github.com/flutter/flutter/issues/89094
       throw UnsupportedError(
         'Image.toByteData(format: ui.ImageByteFormat.rawStraightRgba) not yet implemented for HTML');
     }

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -180,6 +180,9 @@ class HtmlImage implements ui.Image {
       ctx.drawImage(imgElement, 0, 0);
       final html.ImageData imageData = ctx.getImageData(0, 0, width, height);
       return Future<ByteData?>.value(imageData.data.buffer.asByteData());
+    } else if (format == ui.ImageByteFormat.rawStraightRgba) {
+      throw UnsupportedError(
+        'Image.toByteData(format: ui.ImageByteFormat.rawStraightRgba) not yet implemented for HTML');
     }
     if (imgElement.src?.startsWith('data:') == true) {
       final UriData data = UriData.fromUri(Uri.parse(imgElement.src!));

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -425,6 +425,7 @@ class ImageFilter {
 
 enum ImageByteFormat {
   rawRgba,
+  rawStraightRgba,
   rawUnmodified,
   png,
 }

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -1195,7 +1195,7 @@ void _canvasTests() {
         .beginRecording(Float32List.fromList(<double>[0, 0, 1, 1]));
     otherCanvas.drawRect(
       Float32List.fromList(<double>[0, 0, 1, 1]),
-      SkPaint(),
+      SkPaint()..setColorInt(0xAAFFFFFF),
     );
     final CkPicture picture =
         CkPicture(otherRecorder.finishRecordingAsPicture(), null, null);
@@ -1203,6 +1203,17 @@ void _canvasTests() {
     final ByteData rawData =
         await image.toByteData(format: ui.ImageByteFormat.rawRgba);
     expect(rawData.lengthInBytes, greaterThan(0));
+    expect(
+      rawData.buffer.asUint32List(),
+      <int>[0xAAAAAAAA],
+    );
+    final ByteData rawStraightData =
+        await image.toByteData(format: ui.ImageByteFormat.rawStraightRgba);
+    expect(rawStraightData.lengthInBytes, greaterThan(0));
+    expect(
+      rawStraightData.buffer.asUint32List(),
+      <int>[0xAAFFFFFF],
+    );
     final ByteData pngData =
         await image.toByteData(format: ui.ImageByteFormat.png);
     expect(pngData.lengthInBytes, greaterThan(0));


### PR DESCRIPTION
related issue: https://github.com/flutter/flutter/issues/86845
related pr: https://github.com/flutter/engine/pull/28293

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
