### PR TITLE
organize snapshot/BUILD.gn targets and fix create_arm_gen_snapshot

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -76,9 +76,7 @@ group("flutter") {
 
   # If enbaled, compile the SDK / snapshot.
   if (!is_fuchsia) {
-    public_deps += [
-      "//flutter/lib/snapshot:generate_snapshot_bins",
-    ]
+    public_deps += [ "//flutter/lib/snapshot:generate_snapshot_bins" ]
 
     if (_build_engine_artifacts) {
       public_deps += [

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -77,8 +77,7 @@ group("flutter") {
   # If enbaled, compile the SDK / snapshot.
   if (!is_fuchsia) {
     public_deps += [
-      "//flutter/lib/snapshot:generate_snapshot_bin",
-      "//flutter/lib/snapshot:kernel_platform_files",
+      "//flutter/lib/snapshot:generate_snapshot_bins",
     ]
 
     if (_build_engine_artifacts) {

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -9,7 +9,7 @@ import("//flutter/lib/ui/dart_ui.gni")
 import("//third_party/dart/utils/compile_platform.gni")
 
 group("generate_snapshot_bins") {
-  deps = [":generate_snapshot_bin"]
+  deps = [ ":generate_snapshot_bin" ]
   if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]
   }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -9,7 +9,7 @@ import("//flutter/lib/ui/dart_ui.gni")
 import("//third_party/dart/utils/compile_platform.gni")
 
 group("generate_snapshot_bins") {
-  deps = [:"generate_snapshot_bin"]
+  deps = [":generate_snapshot_bin"]
   if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]
   }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -11,7 +11,7 @@ import("//third_party/dart/utils/compile_platform.gni")
 group("generate_snapshot_bins") {
   deps = [
     ":generate_snapshot_bin",
-    kernel_platform_files
+    ":kernel_platform_files"
   ]
   if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -8,6 +8,13 @@ import("//flutter/common/config.gni")
 import("//flutter/lib/ui/dart_ui.gni")
 import("//third_party/dart/utils/compile_platform.gni")
 
+group("generate_snapshot_bins") {
+  deps = [:"generate_snapshot_bin"]
+  if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
+    deps += [ ":create_arm_gen_snapshot" ]
+  }
+}
+
 compiled_action("generate_snapshot_bin") {
   if (target_cpu == "x86" && host_os == "linux") {
     # By default Dart will create a 32-bit gen_snapshot host binary if the target
@@ -22,7 +29,7 @@ compiled_action("generate_snapshot_bin") {
   platform_kernel = "$root_out_dir/flutter_patched_sdk/platform_strong.dill"
 
   inputs = [ platform_kernel ]
-  deps = [ ":kernel_platform_files" ]
+  deps = [ ":strong_platform" ]
 
   vm_snapshot_data = "$target_gen_dir/vm_isolate_snapshot.bin"
   vm_snapshot_instructions = "$target_gen_dir/vm_snapshot_instructions.bin"
@@ -221,9 +228,6 @@ source_set("snapshot") {
     ":vm_snapshot_data_linkable",
     ":vm_snapshot_instructions_linkable",
   ]
-  if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [ ":create_arm_gen_snapshot" ]
-  }
 
   sources = get_target_outputs(":isolate_snapshot_data_linkable") +
             get_target_outputs(":isolate_snapshot_instructions_linkable") +
@@ -254,9 +258,4 @@ compile_platform("strong_platform") {
     "-Ddart.isVM=true",
     "dart:core",
   ]
-}
-
-# Fuchsia's snapshot requires a different platform with extra dart: libraries.
-group("kernel_platform_files") {
-  public_deps = [ ":strong_platform" ]
 }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -11,7 +11,7 @@ import("//third_party/dart/utils/compile_platform.gni")
 group("generate_snapshot_bins") {
   deps = [
     ":generate_snapshot_bin",
-    ":kernel_platform_files"
+    ":kernel_platform_files",
   ]
   if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -9,7 +9,10 @@ import("//flutter/lib/ui/dart_ui.gni")
 import("//third_party/dart/utils/compile_platform.gni")
 
 group("generate_snapshot_bins") {
-  deps = [ ":generate_snapshot_bin" ]
+  deps = [
+    ":generate_snapshot_bin",
+    kernel_platform_files
+  ]
   if (host_os == "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]
   }
@@ -29,7 +32,7 @@ compiled_action("generate_snapshot_bin") {
   platform_kernel = "$root_out_dir/flutter_patched_sdk/platform_strong.dill"
 
   inputs = [ platform_kernel ]
-  deps = [ ":strong_platform" ]
+  deps = [ ":kernel_platform_files" ]
 
   vm_snapshot_data = "$target_gen_dir/vm_isolate_snapshot.bin"
   vm_snapshot_instructions = "$target_gen_dir/vm_snapshot_instructions.bin"
@@ -258,4 +261,9 @@ compile_platform("strong_platform") {
     "-Ddart.isVM=true",
     "dart:core",
   ]
+}
+
+# Fuchsia's snapshot requires a different platform with extra dart: libraries.
+group("kernel_platform_files") {
+  public_deps = [ ":strong_platform" ]
 }


### PR DESCRIPTION
1. Make all the public_deps in snapshot/BUILD.gn into one single group target, adding `create_arm_gen_snapshot` into this new group target.
2. From BUILD.gn, refer to the new group target instead.

This also fixes https://github.com/flutter/flutter/issues/38933

The current code has `create_arm_gen_snapshot` inside `source_set("snapshot")`, which doesn't seem to be run at all.

**I couldn't find any deps to `source_set("snapshot")` in the code base. Maybe we should just remove `source_set("snapshot")`?** @zanderso 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
