### PR TITLE
Fix function definitions in SPIR-V transpiler.

### DIFF
--- a/lib/spirv/lib/src/transpiler.dart
+++ b/lib/spirv/lib/src/transpiler.dart
@@ -193,13 +193,11 @@ class _Transpiler {
   String resolveName(int id) {
     if (alias.containsKey(id)) {
       return resolveName(alias[id]!);
-    }
-    if (constantTrue > 0 && id == constantTrue) {
+    } else if (constantTrue > 0 && id == constantTrue) {
       return 'true';
     } else if (constantFalse > 0 && id == constantFalse) {
       return 'false';
-    }
-    if (id == colorOutput) {
+    } else if (id == colorOutput) {
       if (target == TargetLanguage.glslES) {
         return _glslESColorName;
       } else {

--- a/lib/spirv/lib/src/transpiler.dart
+++ b/lib/spirv/lib/src/transpiler.dart
@@ -198,7 +198,8 @@ class _Transpiler {
       return 'true';
     } else if (constantFalse > 0 && id == constantFalse) {
       return 'false';
-    } if (id == colorOutput) {
+    }
+    if (id == colorOutput) {
       if (target == TargetLanguage.glslES) {
         return _glslESColorName;
       } else {
@@ -664,19 +665,16 @@ class _Transpiler {
   void opFunctionParameter() {
     if (declaredParams > 0) {
       out.write(', ');
-      src.write(', ');
     }
 
     final int type = readWord();
     final int id = readWord();
     final String decl = resolveType(type) + ' ' + resolveName(id);
     out.write(decl);
-    src.write(decl);
     declaredParams++;
 
     if (declaredParams == currentFunctionType?.params.length) {
       out.write(') ');
-      src.writeln(');');
     }
   }
 

--- a/lib/spirv/test/general_shaders/BUILD.gn
+++ b/lib/spirv/test/general_shaders/BUILD.gn
@@ -10,6 +10,7 @@ if (enable_unittests) {
     tool = "//flutter/lib/spirv/test:glsl_to_spirv"
 
     sources = [
+      "functions.glsl",
       "simple.glsl",
       "uniforms.glsl",
     ]

--- a/lib/spirv/test/general_shaders/functions.glsl
+++ b/lib/spirv/test/general_shaders/functions.glsl
@@ -1,0 +1,34 @@
+#version 320 es
+
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+precision highp float;
+
+layout ( location = 0 ) out vec4 oColor;
+
+layout ( location = 0 ) uniform float a;  // should be 1.0
+
+float addA(float x) {
+  return x + a;
+}
+
+vec2 pairWithA(float x) {
+  return vec2(x, a);
+}
+
+vec3 composedFunction(float x) {
+  return vec3(addA(x), pairWithA(x));
+}
+
+float multiParam(float x, float y, float z) {
+  return x * y * z * a;
+}
+
+void main() {
+  float x = addA(0.0); // x = 0 + 1;
+  vec3 v3 = composedFunction(x); // v3 = vec3(2, 1, 1);
+  x = multiParam(v3.x, v3.y, v3.z); // x = 2 * 1 * 1 * 1;
+  oColor = vec4(0.0, x / 2.0, 0.0, 1.0); // vec4(0, 1, 0, 1);
+}

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -21,8 +21,7 @@ void main() {
   });
 
   test('simple shader renders correctly', () async {
-    final Uint8List shaderBytes =
-        await spvFile('general_shaders', 'functions.spv').readAsBytes();
+    final Uint8List shaderBytes = await spvFile('general_shaders', 'functions.spv').readAsBytes();
     final FragmentShader shader = FragmentShader(
       spirv: shaderBytes.buffer,
       floatUniforms: Float32List.fromList(<double>[1]),
@@ -31,8 +30,7 @@ void main() {
   });
 
   test('shader with functions renders green', () {
-    final ByteBuffer spirv =
-        spvFile('general_shaders', 'functions.spv').readAsBytesSync().buffer;
+    final ByteBuffer spirv = spvFile('general_shaders', 'functions.spv').readAsBytesSync().buffer;
     final FragmentShader shader = FragmentShader(
       spirv: spirv,
       floatUniforms: Float32List.fromList(<double>[1]),
@@ -41,8 +39,7 @@ void main() {
   });
 
   test('shader with uniforms renders and updates correctly', () async {
-    final Uint8List shaderBytes =
-        await spvFile('general_shaders', 'uniforms.spv').readAsBytes();
+    final Uint8List shaderBytes = await spvFile('general_shaders', 'uniforms.spv').readAsBytes();
     final FragmentShader shader = FragmentShader(spirv: shaderBytes.buffer);
 
     shader.update(

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -15,8 +15,7 @@ import 'shader_test_file_utils.dart';
 
 void main() {
   test('throws exception for invalid shader', () {
-    final ByteBuffer invalidBytes =
-        Uint8List.fromList(<int>[1, 2, 3, 4, 5]).buffer;
+    final ByteBuffer invalidBytes = Uint8List.fromList(<int>[1, 2, 3, 4, 5]).buffer;
     expect(() => FragmentShader(spirv: invalidBytes), throws);
   });
 

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -15,27 +15,45 @@ import 'shader_test_file_utils.dart';
 
 void main() {
   test('throws exception for invalid shader', () {
-    final ByteBuffer invalidBytes = Uint8List.fromList(<int>[1, 2, 3, 4, 5]).buffer;
+    final ByteBuffer invalidBytes =
+        Uint8List.fromList(<int>[1, 2, 3, 4, 5]).buffer;
     expect(() => FragmentShader(spirv: invalidBytes), throws);
   });
 
   test('simple shader renders correctly', () async {
-    final Uint8List shaderBytes = await spvFile('general_shaders', 'simple.spv').readAsBytes();
-    _expectShaderRendersGreen(shaderBytes.buffer.asUint32List());
+    final Uint8List shaderBytes =
+        await spvFile('general_shaders', 'functions.spv').readAsBytes();
+    final FragmentShader shader = FragmentShader(
+      spirv: shaderBytes.buffer,
+      floatUniforms: Float32List.fromList(<double>[1]),
+    );
+    _expectShaderRendersGreen(shader);
+  });
+
+  test('shader with functions renders green', () {
+    final ByteBuffer spirv =
+        spvFile('general_shaders', 'functions.spv').readAsBytesSync().buffer;
+    final FragmentShader shader = FragmentShader(
+      spirv: spirv,
+      floatUniforms: Float32List.fromList(<double>[1]),
+    );
+    _expectShaderRendersGreen(shader);
   });
 
   test('shader with uniforms renders and updates correctly', () async {
-    final Uint8List shaderBytes = await spvFile('general_shaders', 'uniforms.spv').readAsBytes();
+    final Uint8List shaderBytes =
+        await spvFile('general_shaders', 'uniforms.spv').readAsBytes();
     final FragmentShader shader = FragmentShader(spirv: shaderBytes.buffer);
 
-    shader.update(floatUniforms: Float32List.fromList(<double>[
-      0.0,  // iFloatUniform
+    shader.update(
+        floatUniforms: Float32List.fromList(<double>[
+      0.0, // iFloatUniform
       0.25, // iVec2Uniform.x
       0.75, // iVec2Uniform.y
-      0.0,    // iMat2Uniform[0][0]
-      0.0,    // iMat2Uniform[0][1]
-      0.0,    // iMat2Uniform[1][0]
-      1.0,    // iMat2Uniform[1][1]
+      0.0, // iMat2Uniform[0][0]
+      0.0, // iMat2Uniform[0][1]
+      0.0, // iMat2Uniform[1][0]
+      1.0, // iMat2Uniform[1][1]
     ]));
 
     final ByteData renderedBytes = (await _imageByteDataFromShader(
@@ -49,15 +67,15 @@ void main() {
   });
 
   // Test all supported GLSL ops. See lib/spirv/lib/src/constants.dart
-  final Map<String, Uint32List> supportedGLSLOpShaders =
-    _loadSpv('supported_glsl_op_shaders');
+  final Map<String, ByteBuffer> supportedGLSLOpShaders =
+      _loadSpv('supported_glsl_op_shaders');
   expect(supportedGLSLOpShaders.isNotEmpty, true);
   _expectShadersRenderGreen(supportedGLSLOpShaders);
   _expectShadersHaveOp(supportedGLSLOpShaders, true /* glsl ops */);
 
   // Test all supported instructions. See lib/spirv/lib/src/constants.dart
-  final Map<String, Uint32List> supportedOpShaders =
-    _loadSpv('supported_op_shaders');
+  final Map<String, ByteBuffer> supportedOpShaders =
+      _loadSpv('supported_op_shaders');
   expect(supportedOpShaders.isNotEmpty, true);
   _expectShadersRenderGreen(supportedOpShaders);
   _expectShadersHaveOp(supportedOpShaders, false /* glsl ops */);
@@ -66,15 +84,19 @@ void main() {
 // Expect that all of the spirv shaders in this folder render green.
 // Keeping the outer loop of the test synchronous allows for easy printing
 // of the file name within the test case.
-void _expectShadersRenderGreen(Map<String, Uint32List> shaders) {
+void _expectShadersRenderGreen(Map<String, ByteBuffer> shaders) {
   for (final String key in shaders.keys) {
     test('$key renders green', () {
-      _expectShaderRendersGreen(shaders[key]!);
+      final FragmentShader shader = FragmentShader(
+        spirv: shaders[key]!,
+        floatUniforms: Float32List.fromList(<double>[1]),
+      );
+      _expectShaderRendersGreen(shader);
     });
   }
 }
 
-void _expectShadersHaveOp(Map<String, Uint32List> shaders, bool glsl) {
+void _expectShadersHaveOp(Map<String, ByteBuffer> shaders, bool glsl) {
   for (final String key in shaders.keys) {
     test('$key contains opcode', () {
       _expectShaderHasOp(shaders[key]!, key, glsl);
@@ -85,7 +107,8 @@ void _expectShadersHaveOp(Map<String, Uint32List> shaders, bool glsl) {
 const int _opExtInst = 12;
 
 // Expects that a spirv shader has the op code identified by its file name.
-void _expectShaderHasOp(Uint32List words, String filename, bool glsl) {
+void _expectShaderHasOp(ByteBuffer spirv, String filename, bool glsl) {
+  final Uint32List words = spirv.asUint32List();
   final List<String> sections = filename.split('_');
   expect(sections.length, greaterThan(1));
   final int op = int.parse(sections.first);
@@ -98,7 +121,7 @@ void _expectShaderHasOp(Uint32List words, String filename, bool glsl) {
     final int word = words[position];
     final int currentOpCode = word & 0xFFFF;
     if (glsl) {
-      if (currentOpCode == _opExtInst && words[position+4] == op) {
+      if (currentOpCode == _opExtInst && words[position + 4] == op) {
         found = true;
         break;
       }
@@ -119,11 +142,7 @@ void _expectShaderHasOp(Uint32List words, String filename, bool glsl) {
 }
 
 // Expects that a spirv shader only outputs the color green.
-Future<void> _expectShaderRendersGreen(Uint32List spirv) async {
-  final FragmentShader shader = FragmentShader(
-    spirv: spirv.buffer,
-    floatUniforms: Float32List.fromList(<double>[1]),
-  );
+Future<void> _expectShaderRendersGreen(FragmentShader shader) async {
   final ByteData renderedBytes = (await _imageByteDataFromShader(
     shader: shader,
     imageDimension: _shaderImageDimension,
@@ -153,23 +172,23 @@ Future<ByteData?> _imageByteDataFromShader({
 // $FLUTTER_BUILD_DIRECTORY/gen/flutter/lib/spirv/test/$leafFolderName
 // This is synchronous so that tests can be inside of a loop with
 // the proper test name.
-Map<String, Uint32List> _loadSpv(String leafFolderName) {
-  final Map<String, Uint32List> out = SplayTreeMap<String, Uint32List>();
+Map<String, ByteBuffer> _loadSpv(String leafFolderName) {
+  final Map<String, ByteBuffer> out = SplayTreeMap<String, ByteBuffer>();
 
   final Directory directory = spvDirectory(leafFolderName);
   if (!directory.existsSync()) {
     return out;
   }
 
-  directory.listSync()
-    .where((FileSystemEntity entry) => path.extension(entry.path) == '.spv')
-    .forEach((FileSystemEntity entry) {
-      final String key = path.basenameWithoutExtension(entry.path);
-      out[key] = (entry as File).readAsBytesSync().buffer.asUint32List();
-    });
+  directory
+      .listSync()
+      .where((FileSystemEntity entry) => path.extension(entry.path) == '.spv')
+      .forEach((FileSystemEntity entry) {
+    final String key = path.basenameWithoutExtension(entry.path);
+    out[key] = (entry as File).readAsBytesSync().buffer;
+  });
   return out;
 }
-
 
 // Arbitrary, but needs to be greater than 1 for frag coord tests.
 const int _shaderImageDimension = 4;

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -146,7 +146,7 @@ Future<int> main(List<String> args) async {
       errSink: errBuffer,
     );
     final List<io.File> fileList = await clangTidy.computeChangedFiles();
-    expect(fileList.length, lessThan(300));
+    expect(fileList.length, lessThan(2000));
   });
 
   test('No Commands are produced when no files changed', () async {

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -146,7 +146,7 @@ Future<int> main(List<String> args) async {
       errSink: errBuffer,
     );
     final List<io.File> fileList = await clangTidy.computeChangedFiles();
-    expect(fileList.length, lessThan(2000));
+    expect(fileList.length, lessThan(300));
   });
 
   test('No Commands are produced when no files changed', () async {


### PR DESCRIPTION
Function calls were not tested and the definitions of function parameters were output separately, since the transpiler used to output function declarations before implementations.

https://github.com/flutter/flutter/issues/89083

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
