### PR TITLE
Implement hashCode and == for FragmentShader

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3826,10 +3826,13 @@ class FragmentShader extends Shader {
     );
     _uniformFloatCount = result.uniformFloatCount;
     _init(result.src, debugPrint);
+    _spirvHash = hashList(spirv.asUint32List());
     update(floatUniforms: floatUniforms ?? Float32List(_uniformFloatCount));
   }
 
   late final int _uniformFloatCount;
+  late final int _spirvHash;
+  int _hashCode = 0;
 
   void _constructor() native 'FragmentShader_constructor';
   void _init(String sksl, bool debugPrint) native 'FragmentShader_init';
@@ -3850,7 +3853,19 @@ class FragmentShader extends Shader {
         'FragmentShader floatUniforms size: ${floatUniforms.length} must match given shader uniform count: $_uniformFloatCount.');
     }
     _update(floatUniforms);
+    _hashCode = hashValues(_spirvHash, hashList(floatUniforms));
   }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+    return other is FragmentShader && other._hashCode == _hashCode;
+  }
+
+  @override
+  int get hashCode => _hashCode;
 
   void _update(Float32List floatUniforms) native 'FragmentShader_update';
 }

--- a/testing/dart/fragment_shader_test.dart
+++ b/testing/dart/fragment_shader_test.dart
@@ -19,6 +19,43 @@ void main() {
     expect(() => FragmentShader(spirv: invalidBytes), throws);
   });
 
+  test('equality depends on floatUniforms', () {
+    final ByteBuffer spirv = spvFile('general_shaders', 'simple.spv')
+        .readAsBytesSync().buffer;
+    final FragmentShader a = FragmentShader(spirv: spirv);
+    final FragmentShader b = FragmentShader(spirv: spirv);
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+    b.update(floatUniforms: Float32List.fromList(<double>[1]));
+    expect(a, notEquals(b));
+    expect(a.hashCode, notEquals(b.hashCode));
+    b.update(floatUniforms: Float32List.fromList(<double>[0]));
+    expect(a, b);
+    expect(a.hashCode, b.hashCode);
+  });
+
+  test('equality depends on spirv', () {
+     final ByteBuffer spirvA = spvFile('general_shaders', 'simple.spv')
+         .readAsBytesSync().buffer;
+     final ByteBuffer spirvB = spvFile('general_shaders', 'uniforms.spv')
+         .readAsBytesSync().buffer;
+    final FragmentShader a = FragmentShader(spirv: spirvA);
+    final FragmentShader b = FragmentShader(spirv: spirvB);
+    expect(a, notEquals(b));
+    expect(a.hashCode, notEquals(b.hashCode));
+   });
+
+  test('hashCode changes with floatUniforms', () {
+    final ByteBuffer spirv = spvFile('general_shaders', 'simple.spv')
+        .readAsBytesSync().buffer;
+    final FragmentShader shader = FragmentShader(spirv: spirv);
+    final firstHash = shader.hashCode;
+    shader.update(floatUniforms: Float32List.fromList(<double>[1]));
+    expect(shader.hashCode, notEquals(firstHash));
+    shader.update(floatUniforms: Float32List.fromList(<double>[0]));
+    expect(shader.hashCode, firstHash);
+  });
+
   test('simple shader renders correctly', () async {
     final Uint8List shaderBytes = await spvFile('general_shaders', 'simple.spv').readAsBytes();
     _expectShaderRendersGreen(shaderBytes.buffer.asUint32List());


### PR DESCRIPTION
FragmentShader now implements hashCode and the `==` operator.

https://github.com/flutter/flutter/issues/89082

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
