### PR TITLE
fuchsia: Fix renderer destructor

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -90,16 +90,14 @@ class Engine final {
   const std::string thread_label_;
   flutter::ThreadHost thread_host_;
 
-  std::optional<VulkanSurfaceProducer> surface_producer_;
-
-  // Gfx specific classes.
   fuchsia::ui::views::ViewToken view_token_;
-  std::shared_ptr<GfxSessionConnection> session_connection_;
-  std::shared_ptr<FuchsiaExternalViewEmbedder> external_view_embedder_;
-
-  // Flatland specific classes.
   fuchsia::ui::views::ViewCreationToken view_creation_token_;
-  std::shared_ptr<FlatlandConnection> flatland_connection_;
+  std::shared_ptr<GfxSessionConnection>
+      session_connection_;  // Must come before surface_producer_
+  std::shared_ptr<FlatlandConnection>
+      flatland_connection_;  // Must come before surface_producer_
+  std::optional<VulkanSurfaceProducer> surface_producer_;
+  std::shared_ptr<FuchsiaExternalViewEmbedder> external_view_embedder_;
   std::shared_ptr<FlatlandExternalViewEmbedder> flatland_view_embedder_;
 
   scenic::ViewRefPair view_ref_pair_;


### PR DESCRIPTION
https://github.com/flutter/engine/pull/27423 introduced a regression even in the non-flatland code because of a member/destruction-order issue.  This crash occurs when a flutter app is terminated and the engine instance is shutting down.

While debugging that, I discovered another underlying issue -- all render objects like FuchsiaExternalViewEmbedder are created on raster but destroyed on platform!  This is very problematic, especially re: FIDL bindings which must only be accessed on one thread (the destructor logic sends FIDL commands).

Fix both issues.
@uysalere 

Tests:  Manual testing with workstation (launch simple_browser then quit) and smart_display (session_ctl restart)
Fixes:  https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=83473