### PR TITLE
[web] Support raw straight RGBA format in Image.toByteData() in Html

### DIFF
--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -172,7 +172,8 @@ class HtmlImage implements ui.Image {
 
   @override
   Future<ByteData?> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) {
-    if (format == ui.ImageByteFormat.rawRgba) {
+    // TODO(ColdPaleLight): https://github.com/flutter/flutter/issues/89128
+    if (format == ui.ImageByteFormat.rawRgba || format == ui.ImageByteFormat.rawStraightRgba) {
       final html.CanvasElement canvas = html.CanvasElement()
         ..width = width
         ..height = height;
@@ -180,10 +181,6 @@ class HtmlImage implements ui.Image {
       ctx.drawImage(imgElement, 0, 0);
       final html.ImageData imageData = ctx.getImageData(0, 0, width, height);
       return Future<ByteData?>.value(imageData.data.buffer.asByteData());
-    } else if (format == ui.ImageByteFormat.rawStraightRgba) {
-      // TODO(ColdPaleLight): https://github.com/flutter/flutter/issues/89094
-      throw UnsupportedError(
-        'Image.toByteData(format: ui.ImageByteFormat.rawStraightRgba) not yet implemented for HTML');
     }
     if (imgElement.src?.startsWith('data:') == true) {
       final UriData data = UriData.fromUri(Uri.parse(imgElement.src!));

--- a/lib/web_ui/lib/src/engine/html_image_codec.dart
+++ b/lib/web_ui/lib/src/engine/html_image_codec.dart
@@ -172,21 +172,25 @@ class HtmlImage implements ui.Image {
 
   @override
   Future<ByteData?> toByteData({ui.ImageByteFormat format = ui.ImageByteFormat.rawRgba}) {
-    // TODO(ColdPaleLight): https://github.com/flutter/flutter/issues/89128
-    if (format == ui.ImageByteFormat.rawRgba || format == ui.ImageByteFormat.rawStraightRgba) {
-      final html.CanvasElement canvas = html.CanvasElement()
-        ..width = width
-        ..height = height;
-      final html.CanvasRenderingContext2D ctx = canvas.context2D;
-      ctx.drawImage(imgElement, 0, 0);
-      final html.ImageData imageData = ctx.getImageData(0, 0, width, height);
-      return Future<ByteData?>.value(imageData.data.buffer.asByteData());
-    }
-    if (imgElement.src?.startsWith('data:') == true) {
-      final UriData data = UriData.fromUri(Uri.parse(imgElement.src!));
-      return Future<ByteData?>.value(data.contentAsBytes().buffer.asByteData());
-    } else {
-      return Future<ByteData?>.value(null);
+    switch (format) {
+      // TODO(ColdPaleLight): https://github.com/flutter/flutter/issues/89128
+      // The format rawRgba always returns straight rather than premul currently.
+      case ui.ImageByteFormat.rawRgba:
+      case ui.ImageByteFormat.rawStraightRgba:
+        final html.CanvasElement canvas = html.CanvasElement()
+          ..width = width
+          ..height = height;
+        final html.CanvasRenderingContext2D ctx = canvas.context2D;
+        ctx.drawImage(imgElement, 0, 0);
+        final html.ImageData imageData = ctx.getImageData(0, 0, width, height);
+        return Future<ByteData?>.value(imageData.data.buffer.asByteData());
+      default:
+        if (imgElement.src?.startsWith('data:') == true) {
+          final UriData data = UriData.fromUri(Uri.parse(imgElement.src!));
+          return Future<ByteData?>.value(data.contentAsBytes().buffer.asByteData());
+        } else {
+          return Future<ByteData?>.value(null);
+        }
     }
   }
 

--- a/lib/web_ui/test/engine/image_to_byte_data_test.dart
+++ b/lib/web_ui/test/engine/image_to_byte_data_test.dart
@@ -62,6 +62,4 @@ Future<void> testMain() async {
       <int>[0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF],
     );
   });
-
-
 }

--- a/lib/web_ui/test/engine/image_to_byte_data_test.dart
+++ b/lib/web_ui/test/engine/image_to_byte_data_test.dart
@@ -20,13 +20,19 @@ Future<void> testMain() async {
     await webOnlyFontCollection.ensureFontsLoaded();
   });
 
-  test('Picture.toImage().toByteData()', () async {
+  Future<Image> createTestImageByColor(Color color) async {
     final EnginePictureRecorder recorder = EnginePictureRecorder();
     final RecordingCanvas canvas =
         recorder.beginRecording(const Rect.fromLTRB(0, 0, 2, 2));
-    canvas.drawColor(const Color(0xFFCCDD00), BlendMode.srcOver);
+    canvas.drawColor(color, BlendMode.srcOver);
     final Picture testPicture = recorder.endRecording();
     final Image testImage = await testPicture.toImage(2, 2);
+    return testImage;
+  }
+
+  test('Picture.toImage().toByteData()', () async {
+    final Image testImage = await createTestImageByColor(const Color(0xFFCCDD00));
+
     final ByteData bytes =
         (await testImage.toByteData(format: ImageByteFormat.rawRgba))!;
     expect(
@@ -45,4 +51,17 @@ Future<void> testMain() async {
       pngHeader,
     );
   });
+
+  test('Image.toByteData(format: ImageByteFormat.rawStraightRgba)', () async {
+    final Image testImage = await createTestImageByColor(const Color(0xAAFFFF00));
+
+    final ByteData bytes =
+        (await testImage.toByteData(format: ImageByteFormat.rawStraightRgba))!;
+    expect(
+      bytes.buffer.asUint32List(),
+      <int>[0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF, 0xAA00FFFF],
+    );
+  });
+
+
 }


### PR DESCRIPTION
Fix issue : https://github.com/flutter/flutter/issues/89094

Detail: https://github.com/flutter/engine/pull/28339#discussion_r698009629

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
