### PR TITLE
Don't use Dart's application_snapshot() rule

### DIFF
--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -10,11 +10,12 @@ import("//flutter/common/config.gni")
 import("//third_party/dart/build/dart/dart_action.gni")
 
 # Creates a dart kernel (dill) file suitable for use with gen_snapshot, as well
-# as the app-jit, aot-elf, or aot-assembly snapshot for Android or iOS.
+# as the app-jit, aot-elf, or aot-assembly snapshot for targeting Flutter on
+# Android or iOS.
 #
 # Invoker must supply dart_main and package_config. Invoker may optionally
 # supply aot as a boolean and product as a boolean.
-template("dart_snapshot") {
+template("flutter_snapshot") {
   assert(!is_fuchsia)
   assert(defined(invoker.main_dart), "main_dart is a required parameter.")
   assert(defined(invoker.package_config),
@@ -168,7 +169,129 @@ template("dart_snapshot") {
   }
 }
 
-template("dart_pkg_helper") {
+# Creates an app-jit snapshot for a command-line Dart program based on a
+# training run.
+#
+# Parameters:
+#  main_dart (required):
+#    The entrypoint to the Dart application.
+#
+#  training_args (required):
+#    Arguments to pass to the Dart application for the training run.
+#
+#  vm_args (optional):
+#    Additional arguments to the Dart VM.
+#
+#  deps (optional):
+#    Any build dependencies.
+#
+#  package_config (required):
+#    The .packages file for the app. Defaults to the $_dart_root/.packages.
+#
+#  output (optional):
+#    Overrides the full output path.
+#
+#  snapshot_kind (optional)
+#    Either an "app-jit" snapshot (default) or a "kernel" snapshot
+template("application_snapshot") {
+  assert(defined(invoker.main_dart), "Must specify 'main_dart'")
+  assert(defined(invoker.training_args), "Must specify 'training_args'")
+  assert(defined(invoker.package_config), "Must specify 'package_config'")
+
+  main_dart = invoker.main_dart
+  training_args = invoker.training_args
+  package_config = rebase_path(invoker.package_config)
+  name = target_name
+
+  extra_deps = []
+  if (defined(invoker.deps)) {
+    extra_deps += invoker.deps
+  }
+  extra_inputs = [ main_dart ]
+  if (defined(invoker.inputs)) {
+    extra_inputs += invoker.inputs
+  }
+  output = "$root_gen_dir/$name.dart.snapshot"
+  if (defined(invoker.output)) {
+    output = invoker.output
+  }
+
+  depfile = output + ".d"
+  abs_depfile = rebase_path(depfile)
+  abs_output = rebase_path(output)
+  rel_output = rebase_path(output, root_build_dir)
+  snapshot_vm_args = [
+    "--disable-dart-dev",
+    "--deterministic",
+    "--packages=$package_config",
+    "--snapshot=$abs_output",
+    "--snapshot-depfile=$abs_depfile",
+    "--depfile-output-filename=$rel_output",
+  ]
+  if (defined(invoker.vm_args)) {
+    snapshot_vm_args += invoker.vm_args
+  }
+
+  snapshot_kind = "app-jit"
+  if (target_cpu != host_cpu) {
+    snapshot_kind = "kernel"
+  }
+  if (defined(invoker.snapshot_kind)) {
+    snapshot_kind = invoker.snapshot_kind
+  }
+  if (snapshot_kind == "kernel") {
+    snapshot_vm_args += [ "--snapshot-kind=kernel" ]
+  } else if (snapshot_kind == "app-jit") {
+    snapshot_vm_args += [ "--snapshot-kind=app-jit" ]
+  } else {
+    assert(false, "Bad snapshot_kind: '$snapshot_kind'")
+  }
+
+  if (flutter_prebuilt_dart_sdk) {
+    action(target_name) {
+      forward_variables_from(invoker,
+                             [
+                               "testonly",
+                               "visibility",
+                             ])
+      deps = extra_deps + [ "//flutter:dart_sdk" ]
+      script = "//build/gn_run_binary.py"
+      inputs = extra_inputs
+      outputs = [ output ]
+      depfile = depfile
+      pool = "//flutter/build/dart:dart_pool"
+
+      ext = ""
+      if (is_win) {
+        ext = ".exe"
+      }
+      dart = rebase_path("$host_prebuilt_dart_sdk/bin/dart$ext", root_out_dir)
+
+      args = [ dart ]
+      args += snapshot_vm_args
+      args += [ rebase_path(main_dart) ]
+      args += training_args
+    }
+  } else {
+    dart_action(target_name) {
+      forward_variables_from(invoker,
+                             [
+                               "testonly",
+                               "visibility",
+                             ])
+      script = main_dart
+      pool = "//flutter/build/dart:dart_pool"
+      deps = extra_deps
+      inputs = extra_inputs
+      outputs = [ output ]
+      depfile = depfile
+      vm_args = snapshot_vm_args
+      args = training_args
+    }
+  }
+}
+
+template("_dart_pkg_helper") {
   assert(defined(invoker.package_name))
   package_name = invoker.package_name
   pkg_directory = rebase_path("$root_gen_dir/dart-pkg")
@@ -284,7 +407,7 @@ template("dart_pkg") {
                                   [ pubspec_yaml_path ])
 
   dart_pkg_target_name = "${target_name}_pkg_helper"
-  dart_pkg_helper(dart_pkg_target_name) {
+  _dart_pkg_helper(dart_pkg_target_name) {
     package_name = dart_package_name
     if (defined(invoker.sources)) {
       sources = invoker.sources
@@ -342,53 +465,6 @@ template("dart_pkg") {
         dartx_target_name = "${app_name}_dart_app"
         deps += [ ":$dartx_target_name" ]
       }
-    }
-  }
-}
-
-# Used to create dart_pkgs from a directory populated by fetch_dart_packages.py
-#
-# This build rule will result in a many packages under $root_gen_dir/dart-pkg/.
-#
-#   base_dir (optional)
-#       Directory populated by fetch_dart_packages.py. Defaults to BUILD.gn
-#       directory.
-template("dart_packages") {
-  base_dir = "."
-  if (defined(invoker.base_dir)) {
-    base_dir = invoker.base_dir
-  }
-
-  # Determine list of packages.
-  list_script =
-      rebase_path("build/dart/dart/tools/fetch_dart_packages.py", ".", "//")
-  packages = exec_script(list_script,
-                         [
-                           "--directory",
-                           rebase_path(base_dir),
-                           "--list",
-                         ],
-                         "list lines",
-                         [
-                           rebase_path("pubspec.yaml"),
-                           rebase_path("pubspec.lock"),
-                         ])
-
-  # Generate dart_pkg for each package.
-  foreach(package_dir, packages) {
-    dart_pkg("$package_dir") {
-      pkg_dir = rebase_path("$package_dir")
-    }
-  }
-
-  # Generate target group.
-  group(target_name) {
-    deps = []
-    foreach(package_dir, packages) {
-      deps += [ ":$package_dir" ]
-    }
-    if (defined(invoker.deps)) {
-      deps += invoker.deps
     }
   }
 }

--- a/flutter_frontend_server/BUILD.gn
+++ b/flutter_frontend_server/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//third_party/dart/utils/application_snapshot.gni")
+import("//flutter/build/dart/rules.gni")
 
 frontend_server_files =
     exec_script("//third_party/dart/tools/list_dart_files.py",
@@ -23,9 +23,8 @@ frontend_server_files +=
 application_snapshot("frontend_server") {
   main_dart = "bin/starter.dart"
   deps = [ "//flutter/lib/snapshot:kernel_platform_files" ]
-  pool = "//flutter/build/dart:dart_pool"
 
-  dot_packages = rebase_path(".dart_tool/package_config.json")
+  package_config = rebase_path(".dart_tool/package_config.json")
   flutter_patched_sdk = rebase_path("$root_out_dir/flutter_patched_sdk")
   training_args = [
     "--train",

--- a/flutter_frontend_server/test/to_string_test.dart
+++ b/flutter_frontend_server/test/to_string_test.dart
@@ -8,22 +8,23 @@ import 'package:litetest/litetest.dart';
 import 'package:path/path.dart' as path;
 
 Future<void> main(List<String> args) async {
-  if (args.length != 2) {
-    stderr.writeln('The first argument must be the path to the frontend server dill.');
-    stderr.writeln('The second argument must be the path to the flutter_patched_sdk');
+  if (args.length != 3) {
+    stderr.writeln('The first argument must be the path to the build output.');
+    stderr.writeln('The second argument must be the path to the frontend server dill.');
+    stderr.writeln('The third argument must be the path to the flutter_patched_sdk');
     exit(-1);
   }
 
   final String dart = Platform.resolvedExecutable;
-  final String frontendServer = args[0];
-  final String sdkRoot = args[1];
+  final String buildDir = args[0];
+  final String frontendServer = args[1];
+  final String sdkRoot = args[2];
   final String basePath = path.canonicalize(path.join(path.dirname(Platform.script.path), '..'));
   final String fixtures = path.join(basePath, 'test', 'fixtures');
   final String mainDart = path.join(fixtures, 'lib', 'main.dart');
   final String packageConfig = path.join(fixtures, '.dart_tool', 'package_config.json');
   final String regularDill = path.join(fixtures, 'toString.dill');
   final String transformedDill = path.join(fixtures, 'toStringTransformed.dill');
-
 
   void _checkProcessResult(ProcessResult result) {
     if (result.exitCode != 0) {
@@ -45,7 +46,7 @@ Future<void> main(List<String> args) async {
     final ProcessResult runResult = Process.runSync(dart, <String>[regularDill]);
     _checkProcessResult(runResult);
     String paintString = '"Paint.toString":"Paint(Color(0xffffffff))"';
-    if (const bool.fromEnvironment('dart.vm.product', defaultValue: false)) {
+    if (buildDir.contains('release')) {
       paintString = '"Paint.toString":"Instance of \'Paint\'"';
     }
 

--- a/shell/platform/fuchsia/dart/BUILD.gn
+++ b/shell/platform/fuchsia/dart/BUILD.gn
@@ -2,17 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/build/dart/rules.gni")
 import("//flutter/tools/fuchsia/dart/dart_library.gni")
-import("//third_party/dart/build/dart/dart_action.gni")
-import("//third_party/dart/utils/application_snapshot.gni")
-import("//third_party/dart/utils/compile_platform.gni")
 
 application_snapshot("kernel_compiler") {
   main_dart = "compiler.dart"
 
   deps = [ "../flutter/kernel:kernel_platform_files($host_toolchain)" ]
 
-  dot_packages =
+  package_config =
       rebase_path("//third_party/dart/.dart_tool/package_config.json")
 
   training_args = [
@@ -39,14 +37,24 @@ application_snapshot("kernel_compiler") {
   inputs = kernel_compiler_files
 }
 
-application_snapshot("list_libraries") {
+application_snapshot("_list_libraries_kernel") {
+  visibility = [ ":*" ]
+  snapshot_kind = "kernel"
   main_dart = "//third_party/dart/pkg/vm/bin/list_libraries.dart"
+  package_config =
+      rebase_path("//third_party/dart/.dart_tool/package_config.json")
+  training_args = []
+  output = "$target_gen_dir/list_libraries.dart.dill"
+}
+
+application_snapshot("list_libraries") {
+  deps = [ ":_list_libraries_kernel" ]
+  main_dart = "//third_party/dart/pkg/vm/bin/list_libraries.dart"
+  package_config =
+      rebase_path("//third_party/dart/.dart_tool/package_config.json")
   training_args = [
-    # train against the dill file which is generated for this snapshot. If this build file
-    # changes location this path will need to be updated.
-    rebase_path(
-        root_gen_dir +
-        "/flutter/shell/platform/fuchsia/dart/list_libraries.dart.dill"),
+    # train against the dill file which is generated for this snapshot.
+    rebase_path("$target_gen_dir/list_libraries.dart.dill"),
   ]
 }
 

--- a/testing/android_background_image/BUILD.gn
+++ b/testing/android_background_image/BUILD.gn
@@ -7,7 +7,7 @@ import("//flutter/testing/rules/runtime_mode.gni")
 
 assert(is_android)
 
-dart_snapshot("android_background_image_snapshot") {
+flutter_snapshot("android_background_image_snapshot") {
   main_dart = "lib/main.dart"
   package_config = ".dart_tool/package_config.json"
 }

--- a/testing/dart/compile_test.gni
+++ b/testing/dart/compile_test.gni
@@ -2,6 +2,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//build/compiled_action.gni")
+import("//flutter/common/config.gni")
+import("//third_party/dart/build/dart/dart_action.gni")
+import("//third_party/dart/sdk_args.gni")
+
 import("//third_party/dart/build/dart/dart_action.gni")
 
 # Generates a Dart kernel snapshot using flutter_frontend_server.
@@ -20,43 +25,67 @@ template("compile_flutter_dart_test") {
   assert(defined(invoker.packages),
          "The path to the .packages file must be specified.")
 
-  dart_action(target_name) {
-    testonly = true
-    deps = []
-    if (defined(invoker.deps)) {
-      deps += invoker.deps
+  common_deps = [
+    "//flutter/flutter_frontend_server:frontend_server",
+    "//flutter/lib/snapshot:strong_platform",
+  ]
+  if (defined(invoker.deps)) {
+    common_deps += invoker.deps
+  }
+
+  snapshot_depfile =
+      "$root_gen_dir/flutter/testing/snapshot_$target_name.depfile.d"
+
+  common_vm_args = [ "--disable-dart-dev" ]
+
+  flutter_patched_sdk = rebase_path("$root_out_dir/flutter_patched_sdk")
+
+  common_args = [
+    "--sound-null-safety",
+    "--sdk-root",
+    flutter_patched_sdk,
+    "--target=flutter",
+    "--packages",
+    rebase_path(invoker.packages),
+    "--depfile",
+    rebase_path(snapshot_depfile),
+    "--output-dill",
+    rebase_path(invoker.dart_kernel, root_out_dir),
+    rebase_path(invoker.dart_file),
+  ]
+
+  if (flutter_prebuilt_dart_sdk) {
+    action(target_name) {
+      testonly = true
+      deps = common_deps + [ "//flutter:dart_sdk" ]
+      pool = "//flutter/build/dart:dart_pool"
+      script = "//build/gn_run_binary.py"
+      inputs = [ invoker.dart_file ]
+      outputs = [ invoker.dart_kernel ]
+      depfile = snapshot_depfile
+
+      ext = ""
+      if (is_win) {
+        ext = ".exe"
+      }
+      dart = rebase_path("$host_prebuilt_dart_sdk/bin/dart$ext", root_out_dir)
+      frontend_server =
+          rebase_path("$root_gen_dir/frontend_server.dart.snapshot")
+
+      args = [ dart ] + common_vm_args + [ frontend_server ] + common_args
     }
-    deps += [
-      "//flutter/flutter_frontend_server:frontend_server",
-      "//flutter/lib/snapshot:strong_platform",
-    ]
-    pool = "//flutter/build/dart:dart_pool"
-    script = "$root_gen_dir/frontend_server.dart.snapshot"
-    packages = rebase_path(invoker.packages)  # rebase_path(".packages")
-
-    inputs = [ invoker.dart_file ]
-    outputs = [ invoker.dart_kernel ]
-
-    snapshot_depfile =
-        "$root_gen_dir/flutter/testing/snapshot_$target_name.depfile.d"
-    depfile = snapshot_depfile
-
-    flutter_patched_sdk = rebase_path("$root_out_dir/flutter_patched_sdk")
-
-    vm_args = [ "--disable-dart-dev" ]
-
-    args = [
-      "--sound-null-safety",
-      "--sdk-root",
-      flutter_patched_sdk,
-      "--target=flutter",
-      "--packages",
-      packages,
-      "--depfile",
-      rebase_path(snapshot_depfile),
-      "--output-dill",
-      rebase_path(invoker.dart_kernel, root_out_dir),
-      rebase_path(invoker.dart_file),
-    ]
+  } else {
+    dart_action(target_name) {
+      testonly = true
+      deps = common_deps
+      pool = "//flutter/build/dart:dart_pool"
+      script = "$root_gen_dir/frontend_server.dart.snapshot"
+      packages = rebase_path(invoker.packages)
+      inputs = [ invoker.dart_file ]
+      outputs = [ invoker.dart_kernel ]
+      depfile = snapshot_depfile
+      vm_args = common_vm_args
+      args = common_args
+    }
   }
 }

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -428,11 +428,12 @@ def RunFrontEndServerTests(build_dir):
     opts = [
       '--disable-dart-dev',
       dart_test_file,
+      build_dir,
       os.path.join(build_dir, 'gen', 'frontend_server.dart.snapshot'),
       os.path.join(build_dir, 'flutter_patched_sdk')]
     RunEngineExecutable(
       build_dir,
-      'dart',
+      os.path.join('dart-sdk', 'bin', 'dart'),
       None,
       flags=opts,
       cwd=test_dir)
@@ -445,7 +446,12 @@ def RunConstFinderTests(build_dir):
     os.path.join(test_dir, 'const_finder_test.dart'),
     os.path.join(build_dir, 'gen', 'frontend_server.dart.snapshot'),
     os.path.join(build_dir, 'flutter_patched_sdk')]
-  RunEngineExecutable(build_dir, 'dart', None, flags=opts, cwd=test_dir)
+  RunEngineExecutable(
+    build_dir,
+    os.path.join('dart-sdk', 'bin', 'dart'),
+    None,
+    flags=opts,
+    cwd=test_dir)
 
 
 def RunLitetestTests(build_dir):
@@ -457,7 +463,7 @@ def RunLitetestTests(build_dir):
       dart_test_file]
     RunEngineExecutable(
       build_dir,
-      'dart',
+      os.path.join('dart-sdk', 'bin', 'dart'),
       None,
       flags=opts,
       cwd=test_dir)
@@ -472,7 +478,7 @@ def RunBenchmarkTests(build_dir):
       dart_test_file]
     RunEngineExecutable(
       build_dir,
-      'dart',
+      os.path.join('dart-sdk', 'bin', 'dart'),
       None,
       flags=opts,
       cwd=test_dir)
@@ -487,7 +493,7 @@ def RunGithooksTests(build_dir):
       dart_test_file]
     RunEngineExecutable(
       build_dir,
-      'dart',
+      os.path.join('dart-sdk', 'bin', 'dart'),
       None,
       flags=opts,
       cwd=test_dir)
@@ -504,7 +510,7 @@ def RunClangTidyTests(build_dir):
       os.path.join(buildroot_dir, 'flutter')]
     RunEngineExecutable(
       build_dir,
-      'dart',
+      os.path.join('dart-sdk', 'bin', 'dart'),
       None,
       flags=opts,
       cwd=test_dir)

--- a/testing/scenario_app/BUILD.gn
+++ b/testing/scenario_app/BUILD.gn
@@ -5,7 +5,7 @@
 import("//flutter/build/dart/rules.gni")
 import("//flutter/testing/rules/runtime_mode.gni")
 
-dart_snapshot("scenario_app_snapshot") {
+flutter_snapshot("scenario_app_snapshot") {
   main_dart = "lib/main.dart"
   package_config = ".dart_tool/package_config.json"
 }

--- a/tools/const_finder/BUILD.gn
+++ b/tools/const_finder/BUILD.gn
@@ -2,13 +2,12 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//third_party/dart/utils/application_snapshot.gni")
+import("//flutter/build/dart/rules.gni")
 
 application_snapshot("const_finder") {
   main_dart = "bin/main.dart"
-  dot_packages = ".dart_tool/package_config.json"
-  dart_snapshot_kind = "kernel"
-  pool = "//flutter/build/dart:dart_pool"
+  package_config = ".dart_tool/package_config.json"
+  snapshot_kind = "kernel"
 
   training_args = [ "--help" ]
 


### PR DESCRIPTION
This PR stops using the `application_snapshot()` template from the Dart build files, and replaces it with a similar template that produces the same results but behaves a little differently.

First, instead of unconditionally depending directly on a built Dart VM, it can use the Dart VM from a prebuilt Dart SDK. This will cut down on host build times a little bit.

Second, since the Flutter build will rarely-if-ever be generating snapshots using a `-O0` or "simulator" build of the Dart VM, there's no need to pull out a separate kernel compilation step as an optimization, and the whole thing can be done directly with either the built or prebuilt Dart VM.

This PR also removes other uses of the `dart_action()` template so that we can usually avoid building a Dart VM when using a prebuilt Dart SDK, and renames Flutter's `dart_snapshot()` template to `flutter_snapshot()` to try to avoid confusion.

This also fixes https://github.com/flutter/flutter/issues/88921