### PR TITLE
Delay matrix call in Preroll of picture layer 

### DIFF
--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -92,13 +92,7 @@ void DisplayListLayer::Preroll(PrerollContext* context,
   if (context->raster_cache && context->raster_cache->PreCheckWillCache(
                                    disp_list, is_complex_, will_change_)) {
     TRACE_EVENT0("flutter", "DisplayListLayer::RasterCache (Preroll)");
-
-    SkMatrix ctm = matrix;
-    ctm.preTranslate(offset_.x(), offset_.y());
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-    ctm = RasterCache::GetIntegralTransCTM(ctm);
-#endif
-    context->raster_cache->Prepare(context, disp_list, ctm);
+    context->raster_cache->Prepare(context, disp_list, matrix, offset_);
   }
 
   SkRect bounds = disp_list->bounds().makeOffset(offset_.x(), offset_.y());

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -89,7 +89,8 @@ void DisplayListLayer::Preroll(PrerollContext* context,
 
   DisplayList* disp_list = display_list();
 
-  if (auto* cache = context->raster_cache) {
+  if (context->raster_cache && context->raster_cache->PreCheckWillCache(
+                                   disp_list, is_complex_, will_change_)) {
     TRACE_EVENT0("flutter", "DisplayListLayer::RasterCache (Preroll)");
 
     SkMatrix ctm = matrix;
@@ -97,8 +98,7 @@ void DisplayListLayer::Preroll(PrerollContext* context,
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
     ctm = RasterCache::GetIntegralTransCTM(ctm);
 #endif
-    cache->Prepare(context->gr_context, disp_list, ctm,
-                   context->dst_color_space, is_complex_, will_change_);
+    context->raster_cache->Prepare(context, disp_list, ctm);
   }
 
   SkRect bounds = disp_list->bounds().makeOffset(offset_.x(), offset_.y());

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -89,10 +89,10 @@ void DisplayListLayer::Preroll(PrerollContext* context,
 
   DisplayList* disp_list = display_list();
 
-  if (context->raster_cache && context->raster_cache->PreCheckWillCache(
-                                   disp_list, is_complex_, will_change_)) {
+  if (auto* cache = context->raster_cache) {
     TRACE_EVENT0("flutter", "DisplayListLayer::RasterCache (Preroll)");
-    context->raster_cache->Prepare(context, disp_list, matrix, offset_);
+    cache->Prepare(context, disp_list, is_complex_, will_change_, matrix,
+                   offset_);
   }
 
   SkRect bounds = disp_list->bounds().makeOffset(offset_.x(), offset_.y());

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -111,10 +111,10 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   SkPicture* sk_picture = picture();
 
-  if (context->raster_cache && context->raster_cache->PreCheckWillCache(
-                                   sk_picture, is_complex_, will_change_)) {
+  if (auto* cache = context->raster_cache) {
     TRACE_EVENT0("flutter", "PictureLayer::RasterCache (Preroll)");
-    context->raster_cache->Prepare(context, sk_picture, matrix, offset_);
+    cache->Prepare(context, sk_picture, is_complex_, will_change_, matrix,
+                   offset_);
   }
 
   SkRect bounds = sk_picture->cullRect().makeOffset(offset_.x(), offset_.y());

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -111,7 +111,8 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   SkPicture* sk_picture = picture();
 
-  if (auto* cache = context->raster_cache) {
+  if (context->raster_cache && context->raster_cache->PreCheckWillCache(
+                                   sk_picture, is_complex_, will_change_)) {
     TRACE_EVENT0("flutter", "PictureLayer::RasterCache (Preroll)");
 
     SkMatrix ctm = matrix;
@@ -119,8 +120,7 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
     ctm = RasterCache::GetIntegralTransCTM(ctm);
 #endif
-    cache->Prepare(context->gr_context, sk_picture, ctm,
-                   context->dst_color_space, is_complex_, will_change_);
+    context->raster_cache->Prepare(context, sk_picture, ctm);
   }
 
   SkRect bounds = sk_picture->cullRect().makeOffset(offset_.x(), offset_.y());

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -114,13 +114,7 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   if (context->raster_cache && context->raster_cache->PreCheckWillCache(
                                    sk_picture, is_complex_, will_change_)) {
     TRACE_EVENT0("flutter", "PictureLayer::RasterCache (Preroll)");
-
-    SkMatrix ctm = matrix;
-    ctm.preTranslate(offset_.x(), offset_.y());
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-    ctm = RasterCache::GetIntegralTransCTM(ctm);
-#endif
-    context->raster_cache->Prepare(context, sk_picture, ctm);
+    context->raster_cache->Prepare(context, sk_picture, matrix, offset_);
   }
 
   SkRect bounds = sk_picture->cullRect().makeOffset(offset_.x(), offset_.y());

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -43,34 +43,7 @@ RasterCache::RasterCache(size_t access_threshold,
           picture_and_display_list_cache_limit_per_frame),
       checkerboard_images_(false) {}
 
-static bool CanRasterizePicture(SkPicture* picture) {
-  if (picture == nullptr) {
-    return false;
-  }
-
-  const SkRect cull_rect = picture->cullRect();
-
-  if (cull_rect.isEmpty()) {
-    // No point in ever rasterizing an empty picture.
-    return false;
-  }
-
-  if (!cull_rect.isFinite()) {
-    // Cannot attempt to rasterize into an infinitely large surface.
-    FML_LOG(INFO) << "Attempted to raster cache non-finite picture";
-    return false;
-  }
-
-  return true;
-}
-
-static bool CanRasterizeDisplayList(DisplayList* display_list) {
-  if (display_list == nullptr) {
-    return false;
-  }
-
-  const SkRect cull_rect = display_list->bounds();
-
+static bool CanRasterizeRect(const SkRect& cull_rect) {
   if (cull_rect.isEmpty()) {
     // No point in ever rasterizing an empty display list.
     return false;
@@ -94,7 +67,7 @@ static bool IsPictureWorthRasterizing(SkPicture* picture,
     return false;
   }
 
-  if (!CanRasterizePicture(picture)) {
+  if (picture == nullptr || !CanRasterizeRect(picture->cullRect())) {
     // No point in deciding whether the picture is worth rasterizing if it
     // cannot be rasterized at all.
     return false;
@@ -120,7 +93,7 @@ static bool IsDisplayListWorthRasterizing(DisplayList* display_list,
     return false;
   }
 
-  if (!CanRasterizeDisplayList(display_list)) {
+  if (display_list == nullptr || !CanRasterizeRect(display_list->bounds())) {
     // No point in deciding whether the display list is worth rasterizing if it
     // cannot be rasterized at all.
     return false;
@@ -239,10 +212,13 @@ std::unique_ptr<RasterCacheResult> RasterCache::RasterizeLayer(
       });
 }
 
-bool RasterCache::PreCheckWillCache(SkPicture* picture,
-                                    bool is_complex,
-                                    bool will_change) {
-  if (!GenerateNewCacheInthisFrame()) {
+bool RasterCache::Prepare(PrerollContext* context,
+                          SkPicture* picture,
+                          bool is_complex,
+                          bool will_change,
+                          const SkMatrix& untranslated_matrix,
+                          const SkPoint& offset) {
+  if (!GenerateNewCacheInThisFrame()) {
     return false;
   }
 
@@ -251,38 +227,19 @@ bool RasterCache::PreCheckWillCache(SkPicture* picture,
     return false;
   }
 
-  return true;
-}
+  SkMatrix transformation_matrix = untranslated_matrix;
+  transformation_matrix.preTranslate(offset.x(), offset.y());
 
-bool RasterCache::PreCheckWillCache(DisplayList* display_list,
-                                    bool is_complex,
-                                    bool will_change) {
-  if (!GenerateNewCacheInthisFrame()) {
-    return false;
-  }
-
-  if (!IsDisplayListWorthRasterizing(display_list, will_change, is_complex)) {
-    // We only deal with display lists that are worthy of rasterization.
-    return false;
-  }
-
-  return true;
-}
-
-bool RasterCache::Prepare(PrerollContext* context,
-                          SkPicture* picture,
-                          const SkMatrix& untranslated_matrix,
-                          const SkPoint& offset) {
   // Decompose the matrix (once) for all subsequent operations. We want to make
   // sure to avoid volumetric distortions while accounting for scaling.
-  const MatrixDecomposition matrix(untranslated_matrix);
+  const MatrixDecomposition matrix(transformation_matrix);
 
   if (!matrix.IsValid()) {
     // The matrix was singular. No point in going further.
     return false;
   }
 
-  PictureRasterCacheKey cache_key(picture->uniqueID(), untranslated_matrix);
+  PictureRasterCacheKey cache_key(picture->uniqueID(), transformation_matrix);
 
   // Creates an entry, if not present prior.
   Entry& entry = picture_cache_[cache_key];
@@ -292,15 +249,14 @@ bool RasterCache::Prepare(PrerollContext* context,
   }
 
   if (!entry.image) {
-    // Translate won't affect cache result, so we apply it only before
-    // rasterizing.
-    SkMatrix ctm = untranslated_matrix;
-    ctm.preTranslate(offset.x(), offset.y());
+    // GetIntegralTransCTM effect for matrix which only contains scale,
+    // translate, so it won't affect result of matrix decomposition and cache
+    // key.
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
-    ctm = GetIntegralTransCTM(ctm);
+    transformation_matrix = GetIntegralTransCTM(transformation_matrix);
 #endif
     entry.image =
-        RasterizePicture(picture, context->gr_context, ctm,
+        RasterizePicture(picture, context->gr_context, transformation_matrix,
                          context->dst_color_space, checkerboard_images_);
     picture_cached_this_frame_++;
   }
@@ -309,11 +265,25 @@ bool RasterCache::Prepare(PrerollContext* context,
 
 bool RasterCache::Prepare(PrerollContext* context,
                           DisplayList* display_list,
+                          bool is_complex,
+                          bool will_change,
                           const SkMatrix& untranslated_matrix,
                           const SkPoint& offset) {
+  if (!GenerateNewCacheInThisFrame()) {
+    return false;
+  }
+
+  if (!IsDisplayListWorthRasterizing(display_list, will_change, is_complex)) {
+    // We only deal with display lists that are worthy of rasterization.
+    return false;
+  }
+
+  SkMatrix transformation_matrix = untranslated_matrix;
+  transformation_matrix.preTranslate(offset.x(), offset.y());
+
   // Decompose the matrix (once) for all subsequent operations. We want to make
   // sure to avoid volumetric distortions while accounting for scaling.
-  const MatrixDecomposition matrix(untranslated_matrix);
+  const MatrixDecomposition matrix(transformation_matrix);
 
   if (!matrix.IsValid()) {
     // The matrix was singular. No point in going further.
@@ -321,7 +291,7 @@ bool RasterCache::Prepare(PrerollContext* context,
   }
 
   DisplayListRasterCacheKey cache_key(display_list->unique_id(),
-                                      untranslated_matrix);
+                                      transformation_matrix);
 
   // Creates an entry, if not present prior.
   Entry& entry = display_list_cache_[cache_key];
@@ -331,16 +301,15 @@ bool RasterCache::Prepare(PrerollContext* context,
   }
 
   if (!entry.image) {
-    // Translate won't affect cache result, so we apply it only before
-    // rasterizing.
-    SkMatrix ctm = untranslated_matrix;
-    ctm.preTranslate(offset.x(), offset.y());
+    // GetIntegralTransCTM effect for matrix which only contains scale,
+    // translate, so it won't affect result of matrix decomposition and cache
+    // key.
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
-    ctm = GetIntegralTransCTM(ctm);
+    transformation_matrix = GetIntegralTransCTM(transformation_matrix);
 #endif
-    entry.image =
-        RasterizeDisplayList(display_list, context->gr_context, ctm,
-                             context->dst_color_space, checkerboard_images_);
+    entry.image = RasterizeDisplayList(
+        display_list, context->gr_context, transformation_matrix,
+        context->dst_color_space, checkerboard_images_);
     display_list_cached_this_frame_++;
   }
   return true;

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -149,10 +149,12 @@ class RasterCache {
   // 2. the picture is accessed too few times.
   bool Prepare(PrerollContext* context,
                SkPicture* picture,
-               const SkMatrix& transformation_matrix);
+               const SkMatrix& untranslated_matrix,
+               const SkPoint& offset = SkPoint());
   bool Prepare(PrerollContext* context,
                DisplayList* display_list,
-               const SkMatrix& transformation_matrix);
+               const SkMatrix& untranslated_matrix,
+               const SkPoint& offset = SkPoint());
 
   void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -131,28 +131,24 @@ class RasterCache {
     return result;
   }
 
-  // Check picture/display_list is worth to cache without generate cache entry.
-  // Raster result is not worth to cache if
-  // 1. There are too many results to be cached in the current frame.
-  //    (See also kDefaultPictureAndDispLayListCacheLimitPerFrame.)
-  // 2. The result is not worth rasterizing
-  bool PreCheckWillCache(SkPicture* picture, bool is_complex, bool will_change);
-  bool PreCheckWillCache(DisplayList* display_list,
-                         bool is_complex,
-                         bool will_change);
-
-  // Return true if the cache is generated. Makesure call this after
-  // PreCheckWillCache returns true
+  // Return true if the cache is generated.
   //
   // We may return false and not generate the cache if
-  // 1. The matrix is singular
-  // 2. the picture is accessed too few times.
+  // 1. There are too many pictures to be cached in the current frame.
+  //    (See also kDefaultPictureAndDispLayListCacheLimitPerFrame.)
+  // 2. The picture is not worth rasterizing
+  // 3. The matrix is singular
+  // 4. The picture is accessed too few times
   bool Prepare(PrerollContext* context,
                SkPicture* picture,
+               bool is_complex,
+               bool will_change,
                const SkMatrix& untranslated_matrix,
                const SkPoint& offset = SkPoint());
   bool Prepare(PrerollContext* context,
                DisplayList* display_list,
+               bool is_complex,
+               bool will_change,
                const SkMatrix& untranslated_matrix,
                const SkPoint& offset = SkPoint());
 
@@ -254,7 +250,7 @@ class RasterCache {
     }
   }
 
-  bool GenerateNewCacheInthisFrame() const {
+  bool GenerateNewCacheInThisFrame() const {
     // Disabling caching when access_threshold is zero is historic behavior.
     return access_threshold_ != 0 &&
            picture_cached_this_frame_ + display_list_cached_this_frame_ <

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -4,7 +4,6 @@
 
 #include "flutter/flow/testing/mock_raster_cache.h"
 
-#include "flutter/flow/layers/layer.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 
 namespace flutter {
@@ -57,11 +56,37 @@ void MockRasterCache::AddMockPicture(int width, int height) {
       SkRect::MakeLTRB(0, 0, 200 + width, 200 + height), &rtree_factory);
   recorder_canvas->drawPath(path, SkPaint());
   sk_sp<SkPicture> picture = skp_recorder.finishRecordingAsPicture();
+  PrerollContextHolder holder = GetSamplePrerollContextHolder();
+  holder.preroll_context.dst_color_space = color_space_;
   for (int i = 0; i < access_threshold(); i++) {
-    Prepare(nullptr, picture.get(), ctm, color_space_, true, false);
+    Prepare(&holder.preroll_context, picture.get(), ctm);
     Draw(*picture, mock_canvas_);
   }
-  Prepare(nullptr, picture.get(), ctm, color_space_, true, false);
+  Prepare(&holder.preroll_context, picture.get(), ctm);
+}
+
+PrerollContextHolder GetSamplePrerollContextHolder() {
+  Stopwatch raster_time;
+  Stopwatch ui_time;
+  MutatorsStack mutators_stack;
+  TextureRegistry texture_registry;
+  sk_sp<SkColorSpace> srgb = SkColorSpace::MakeSRGB();
+  PrerollContextHolder holder = {
+      {
+          nullptr,                    /* raster_cache */
+          nullptr,                    /* gr_context */
+          nullptr,                    /* external_view_embedder */
+          mutators_stack, srgb.get(), /* color_space */
+          kGiantRect,                 /* cull_rect */
+          false,                      /* layer reads from surface */
+          raster_time, ui_time, texture_registry,
+          false, /* checkerboard_offscreen_layers */
+          1.0f,  /* frame_device_pixel_ratio */
+          false, /* has_platform_view */
+      },
+      srgb};
+
+  return holder;
 }
 
 }  // namespace testing

--- a/flow/testing/mock_raster_cache.cc
+++ b/flow/testing/mock_raster_cache.cc
@@ -59,10 +59,10 @@ void MockRasterCache::AddMockPicture(int width, int height) {
   PrerollContextHolder holder = GetSamplePrerollContextHolder();
   holder.preroll_context.dst_color_space = color_space_;
   for (int i = 0; i < access_threshold(); i++) {
-    Prepare(&holder.preroll_context, picture.get(), ctm);
+    Prepare(&holder.preroll_context, picture.get(), true, false, ctm);
     Draw(*picture, mock_canvas_);
   }
-  Prepare(&holder.preroll_context, picture.get(), ctm);
+  Prepare(&holder.preroll_context, picture.get(), true, false, ctm);
 }
 
 PrerollContextHolder GetSamplePrerollContextHolder() {

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -5,6 +5,7 @@
 #ifndef FLOW_TESTING_MOCK_RASTER_CACHE_H_
 #define FLOW_TESTING_MOCK_RASTER_CACHE_H_
 
+#include "flutter/flow/layers/layer.h"
 #include "flutter/flow/raster_cache.h"
 #include "flutter/flow/testing/mock_layer.h"
 #include "flutter/testing/mock_canvas.h"
@@ -46,9 +47,9 @@ class MockRasterCacheResult : public RasterCacheResult {
  */
 class MockRasterCache : public RasterCache {
  public:
-  explicit MockRasterCache(
-      size_t access_threshold = 3,
-      size_t picture_cache_limit_per_frame = kDefaultPictureCacheLimitPerFrame)
+  explicit MockRasterCache(size_t access_threshold = 3,
+                           size_t picture_cache_limit_per_frame =
+                               kDefaultPictureAndDispLayListCacheLimitPerFrame)
       : RasterCache(access_threshold, picture_cache_limit_per_frame) {}
 
   std::unique_ptr<RasterCacheResult> RasterizePicture(
@@ -91,6 +92,13 @@ class MockRasterCache : public RasterCache {
       false,             /* has_texture_layer */
   };
 };
+
+struct PrerollContextHolder {
+  PrerollContext preroll_context;
+  sk_sp<SkColorSpace> srgb;
+};
+
+PrerollContextHolder GetSamplePrerollContextHolder();
 
 }  // namespace testing
 }  // namespace flutter

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -47,10 +47,12 @@ class MockRasterCacheResult : public RasterCacheResult {
  */
 class MockRasterCache : public RasterCache {
  public:
-  explicit MockRasterCache(size_t access_threshold = 3,
-                           size_t picture_cache_limit_per_frame =
-                               kDefaultPictureAndDispLayListCacheLimitPerFrame)
-      : RasterCache(access_threshold, picture_cache_limit_per_frame) {}
+  explicit MockRasterCache(
+      size_t access_threshold = 3,
+      size_t picture_and_display_list_cache_limit_per_frame =
+          kDefaultPictureAndDispLayListCacheLimitPerFrame)
+      : RasterCache(access_threshold,
+                    picture_and_display_list_cache_limit_per_frame) {}
 
   std::unique_ptr<RasterCacheResult> RasterizePicture(
       SkPicture* picture,


### PR DESCRIPTION
1. Unify the interface of RasterCache::Prepare
2. Avoid create of `SkMatrix` and `preTranslate` call when raster result isn't worth to cache at all.
3. Rename `picture_cache_limit_per_frame_` into `picture_and_display_list_cache_limit_per_frame_`