### PR TITLE
Started providing the GPU sync switch to Rasterizer.Draw()

### DIFF
--- a/flow/surface.cc
+++ b/flow/surface.cc
@@ -18,4 +18,8 @@ bool Surface::ClearRenderContext() {
   return false;
 }
 
+bool Surface::IsAllowDrawingToSurfaceWhenGpuDisabled() const {
+  return true;
+}
+
 }  // namespace flutter

--- a/flow/surface.h
+++ b/flow/surface.h
@@ -33,6 +33,8 @@ class Surface {
 
   virtual bool ClearRenderContext();
 
+  virtual bool IsAllowDrawingToSurfaceWhenGpuDisabled() const;
+
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(Surface);
 };

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -318,4 +318,9 @@ bool GPUSurfaceGL::ClearRenderContext() {
   return delegate_->GLContextClearCurrent();
 }
 
+// |Surface|
+bool GPUSurfaceGL::IsAllowDrawingToSurfaceWhenGpuDisabled() const {
+  return delegate_->IsAllowDrawingToSurfaceWhenGpuDisabled();
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -50,6 +50,9 @@ class GPUSurfaceGL : public Surface {
   // |Surface|
   bool ClearRenderContext() override;
 
+  // |Surface|
+  bool IsAllowDrawingToSurfaceWhenGpuDisabled() const override;
+
  private:
   GPUSurfaceGLDelegate* delegate_;
   sk_sp<GrDirectContext> context_;

--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -99,4 +99,8 @@ GPUSurfaceGLDelegate::GetDefaultPlatformGLInterface() {
   return CreateGLInterface(nullptr);
 }
 
+bool GPUSurfaceGLDelegate::IsAllowDrawingToSurfaceWhenGpuDisabled() const {
+  return true;
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -69,6 +69,9 @@ class GPUSurfaceGLDelegate {
   // instrumentation to specific GL calls can specify custom GL functions
   // here.
   virtual GLProcResolver GetGLProcResolver() const;
+
+  // Whether to allow drawing to the surface when the GPU is disabled
+  virtual bool IsAllowDrawingToSurfaceWhenGpuDisabled() const;
 };
 
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_metal.h
+++ b/shell/gpu/gpu_surface_metal.h
@@ -49,6 +49,9 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetal : public Surface {
   // |Surface|
   std::unique_ptr<GLContextResult> MakeRenderContextCurrent() override;
 
+  // |Surface|
+  bool IsAllowDrawingToSurfaceWhenGpuDisabled() const override;
+
   std::unique_ptr<SurfaceFrame> AcquireFrameFromCAMetalLayer(
       const SkISize& frame_info);
 

--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -184,6 +184,10 @@ std::unique_ptr<GLContextResult> GPUSurfaceMetal::MakeRenderContextCurrent() {
   return std::make_unique<GLContextDefaultResult>(true);
 }
 
+bool GPUSurfaceMetal::IsAllowDrawingToSurfaceWhenGpuDisabled() const {
+  return delegate_->IsAllowDrawingToSurfaceWhenGpuDisabled();
+}
+
 void GPUSurfaceMetal::ReleaseUnusedDrawableIfNecessary() {
   // If the previous surface frame was not submitted before  a new one is acquired, the old drawable
   // needs to be released. An RAII wrapper may not be used because this needs to interoperate with

--- a/shell/gpu/gpu_surface_metal_delegate.cc
+++ b/shell/gpu/gpu_surface_metal_delegate.cc
@@ -16,4 +16,8 @@ MTLRenderTargetType GPUSurfaceMetalDelegate::GetRenderTargetType() {
   return render_target_type_;
 }
 
+bool GPUSurfaceMetalDelegate::IsAllowDrawingToSurfaceWhenGpuDisabled() const {
+  return true;
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_metal_delegate.h
+++ b/shell/gpu/gpu_surface_metal_delegate.h
@@ -89,6 +89,11 @@ class GPUSurfaceMetalDelegate {
   ///
   virtual bool PresentTexture(GPUMTLTextureInfo texture) const = 0;
 
+  //------------------------------------------------------------------------------
+  /// @brief Whether to allow drawing to the surface when the GPU is disabled
+  ///
+  virtual bool IsAllowDrawingToSurfaceWhenGpuDisabled() const;
+
   MTLRenderTargetType GetRenderTargetType();
 
  private:

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -46,6 +46,9 @@ class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
   // |GPUSurfaceGLDelegate|
   bool SurfaceSupportsReadback() const override;
 
+  // |GPUSurfaceGLDelegate|
+  bool IsAllowDrawingToSurfaceWhenGpuDisabled() const override;
+
  private:
   std::unique_ptr<IOSRenderTargetGL> render_target_;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -89,4 +89,9 @@ bool IOSSurfaceGL::GLContextPresent(uint32_t fbo_id) {
   return IsValid() && render_target_->PresentRenderBuffer();
 }
 
+// |GPUSurfaceGLDelegate|
+bool IOSSurfaceGL::IsAllowDrawingToSurfaceWhenGpuDisabled() const {
+  return false;
+}
+
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_metal.h
+++ b/shell/platform/darwin/ios/ios_surface_metal.h
@@ -49,6 +49,9 @@ class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetal final : public IOSSurface,
   // |GPUSurfaceMetalDelegate|
   bool PresentTexture(GPUMTLTextureInfo texture) const override;
 
+  // |GPUSurfaceMetalDelegate|
+  bool IsAllowDrawingToSurfaceWhenGpuDisabled() const override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceMetal);
 };
 

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -98,4 +98,9 @@ bool IOSSurfaceMetal::PresentTexture(GPUMTLTextureInfo texture) const {
   return false;
 }
 
+// |GPUSurfaceMetalDelegate|
+bool IOSSurfaceMetal::IsAllowDrawingToSurfaceWhenGpuDisabled() const {
+  return false;
+}
+
 }  // namespace flutter


### PR DESCRIPTION
1. Add new method `virtual bool IsAllowDrawingToSurfaceWhenGpuDisabled() const` to `flutter:Surface` to distinguish whether `Rasterizer.Draw` needs to use `gpu_disable_sync_switch`
2. `Rasterizer.Draw` uses `gpu_disable_sync_switch` on iOS's OpenGLES and Metal implementation. If `Rasterizer.Draw` is called in the background, this frame will be discarded.

Fixes issue: 
https://github.com/flutter/flutter/issues/89171

maybe can fix:  https://github.com/flutter/flutter/issues/89204

Note: This PR is a draft, if we confirm to use this patch, I can add tests

## Pre-launch Checklist
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

