### PR TITLE
Turn compressed pointers on Android for 64 bit architectures.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -380,6 +380,10 @@ def to_gn_args(args):
     # on Android.
     gn_args['bssl_use_clang_integrated_as'] = True
 
+    # Enable pointer compression on 64-bit mobile targets.
+    if args.target_os in ['android'] and gn_args['target_cpu'] in ['x64' , 'arm64']:
+      gn_args['dart_use_compressed_pointers'] = True
+
     return gn_args
 
 def parse_args(args):


### PR DESCRIPTION
This CL attempts to turn on compressed pointers in the Dart VM on Android for 64 bit architectures.