### PR TITLE
merge accounting of the picture and dl cache entries in reported statistics

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -413,11 +413,7 @@ size_t RasterCache::GetLayerCachedEntriesCount() const {
 }
 
 size_t RasterCache::GetPictureCachedEntriesCount() const {
-  return picture_cache_.size();
-}
-
-size_t RasterCache::GetDisplayListCachedEntriesCount() const {
-  return display_list_cache_.size();
+  return picture_cache_.size() + display_list_cache_.size();
 }
 
 void RasterCache::SetCheckboardCacheImages(bool checkerboard) {
@@ -434,14 +430,13 @@ void RasterCache::SetCheckboardCacheImages(bool checkerboard) {
 
 void RasterCache::TraceStatsToTimeline() const {
 #if !FLUTTER_RELEASE
-  FML_TRACE_COUNTER("flutter", "RasterCache", reinterpret_cast<int64_t>(this),
-                    "LayerCount", layer_cache_.size(), "LayerMBytes",
-                    EstimateLayerCacheByteSize() / kMegaByteSizeInBytes,
-                    "PictureCount", picture_cache_.size(), "PictureMBytes",
-                    EstimatePictureCacheByteSize() / kMegaByteSizeInBytes,
-                    "DisplayListCount", display_list_cache_.size(),
-                    "DisplayListMBytes",
-                    EstimateDisplayListCacheByteSize() / kMegaByteSizeInBytes);
+  FML_TRACE_COUNTER(
+      "flutter",                                                           //
+      "RasterCache", reinterpret_cast<int64_t>(this),                      //
+      "LayerCount", GetLayerCachedEntriesCount(),                          //
+      "LayerMBytes", EstimateLayerCacheByteSize() / kMegaByteSizeInBytes,  //
+      "PictureCount", GetPictureCachedEntriesCount(),                      //
+      "PictureMBytes", EstimatePictureCacheByteSize() / kMegaByteSizeInBytes);
 
 #endif  // !FLUTTER_RELEASE
 }
@@ -463,17 +458,12 @@ size_t RasterCache::EstimatePictureCacheByteSize() const {
       picture_cache_bytes += item.second.image->image_bytes();
     }
   }
-  return picture_cache_bytes;
-}
-
-size_t RasterCache::EstimateDisplayListCacheByteSize() const {
-  size_t display_list_cache_bytes = 0;
   for (const auto& item : display_list_cache_) {
     if (item.second.image) {
-      display_list_cache_bytes += item.second.image->image_bytes();
+      picture_cache_bytes += item.second.image->image_bytes();
     }
   }
-  return display_list_cache_bytes;
+  return picture_cache_bytes;
 }
 
 }  // namespace flutter

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -186,27 +186,16 @@ class RasterCache {
 
   size_t GetPictureCachedEntriesCount() const;
 
-  size_t GetDisplayListCachedEntriesCount() const;
-
   /**
    * @brief Estimate how much memory is used by picture raster cache entries in
-   * bytes.
+   * bytes, including cache entries in the SkPicture cache and the DisplayList
+   * cache.
    *
    * Only SkImage's memory usage is counted as other objects are often much
    * smaller compared to SkImage. SkImageInfo::computeMinByteSize is used to
    * estimate the SkImage memory usage.
    */
   size_t EstimatePictureCacheByteSize() const;
-
-  /**
-   * @brief Estimate how much memory is used by display list raster cache
-   * entries in bytes.
-   *
-   * Only SkImage's memory usage is counted as other objects are often much
-   * smaller compared to SkImage. SkImageInfo::computeMinByteSize is used to
-   * estimate the SkImage memory usage.
-   */
-  size_t EstimateDisplayListCacheByteSize() const;
 
   /**
    * @brief Estimate how much memory is used by layer raster cache entries in

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1707,9 +1707,6 @@ bool Shell::OnServiceProtocolEstimateRasterCacheMemory(
   response->AddMember<uint64_t>("pictureBytes",
                                 raster_cache.EstimatePictureCacheByteSize(),
                                 response->GetAllocator());
-  response->AddMember<uint64_t>("displayListBytes",
-                                raster_cache.EstimateDisplayListCacheByteSize(),
-                                response->GetAllocator());
   return true;
 }
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -2185,7 +2185,7 @@ TEST_F(ShellTest, OnServiceProtocolEstimateRasterCacheMemoryWorks) {
   document.Accept(writer);
   std::string expected_json =
       "{\"type\":\"EstimateRasterCacheMemory\",\"layerBytes\":40000,\"picture"
-      "Bytes\":400,\"displayListBytes\":0}";
+      "Bytes\":400}";
   std::string actual_json = buffer.GetString();
   ASSERT_EQ(actual_json, expected_json);
 


### PR DESCRIPTION
We used to report separate statistics for the Picture cache and the DisplayList cache, but really they are somewhat mutually exclusive caches that are used for the same purpose. I've merged our reporting of statistics on those caches for a number of reasons:

- Flutter developers only see the Dart "Picture" class and though we sometimes implement it using an SkPicture and sometimes using a DisplayList, that implementation detail will not be important to them
- Developers are likely familiar with looking for picture cache statistics in various tools and may miss the DL cache statistics or misunderstand why the picture cache statistics would suddenly be different when DisplayList is enabled
- devtools only looks for the picture cache statistics and so is not reporting any statistics for the DL cache

Now both cache statistics will be consolidated and reported under the single "picture cache" set of metrics.