### PR TITLE
Fix typo in FlMethodResponse docs

### DIFF
--- a/shell/platform/linux/public/flutter_linux/fl_method_response.h
+++ b/shell/platform/linux/public/flutter_linux/fl_method_response.h
@@ -85,7 +85,7 @@ G_DECLARE_FINAL_TYPE(FlMethodNotImplementedResponse,
  *                   fl_method_error_response_get_message (error_response),
  *                   fl_method_error_response_get_details (error_response));
  *   }
- *   else if (FL_IS_METHOD_ERROR_RESPONSE (response)) {
+ *   else if (FL_IS_METHOD_NOT_IMPLEMENTED_RESPONSE (response)) {
  *     handle_not_implemented ();
  *   }
  * }


### PR DESCRIPTION
The sample code in the comment uses the wrong macro for the last branch.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
