### PR TITLE
Use `android_virtual_device` dep in Linux Scenarios LUCI test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -128,7 +128,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "android_avd", "version": "31"}
+          {"dependency": "android_virtual_device", "version": "31"}
         ]
       upload_packages: "true"
       clobber: "true"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -126,6 +126,10 @@ targets:
     bringup: true # Recipe issue https://github.com/flutter/flutter/issues/86427
     recipe: engine/scenarios
     properties:
+      dependencies: >-
+        [
+          {"dependency": "android_avd", "version": "31"}
+        ]
       upload_packages: "true"
       clobber: "true"
     timeout: 60


### PR DESCRIPTION
This PR adds the android_avd dependency introduced in https://flutter-review.googlesource.com/c/recipes/+/17280 to `Linux
scenarios`.

This needs to land after the recipes CL is landed to keep Linux scenarios green.

Pending approval of the recipes CL

Related framework-side PR: https://github.com/flutter/flutter/pull/89306