### PR TITLE
VSync callback support for Linux

### DIFF
--- a/shell/platform/linux/fl_engine_private.h
+++ b/shell/platform/linux/fl_engine_private.h
@@ -244,15 +244,6 @@ GBytes* fl_engine_send_platform_message_finish(FlEngine* engine,
  */
 FlTaskRunner* fl_engine_get_task_runner(FlEngine* engine);
 
-/**
- * fl_engine_execute_task:
- * @engine: an #FlEngine.
- * @task: a #FlutterTask to execute.
- *
- * Executes given Flutter task.
- */
-void fl_engine_execute_task(FlEngine* engine, FlutterTask* task);
-
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_ENGINE_PRIVATE_H_

--- a/shell/platform/linux/fl_renderer.cc
+++ b/shell/platform/linux/fl_renderer.cc
@@ -179,3 +179,10 @@ gboolean fl_renderer_present_layers(FlRenderer* self,
   return FL_RENDERER_GET_CLASS(self)->present_layers(self, layers,
                                                      layers_count);
 }
+
+gboolean fl_renderer_is_blocking_main_thread(FlRenderer* self) {
+  FlRendererPrivate* priv = reinterpret_cast<FlRendererPrivate*>(
+      fl_renderer_get_instance_private(self));
+
+  return priv->blocking_main_thread;
+}

--- a/shell/platform/linux/fl_renderer.h
+++ b/shell/platform/linux/fl_renderer.h
@@ -256,6 +256,15 @@ void fl_renderer_wait_for_frame(FlRenderer* renderer,
                                 int target_width,
                                 int target_height);
 
+/**
+ * fl_renderer_is_blocking_main_thread:
+ * @renderer: an #FlRenderer.
+ *
+ * Returns %TRUE if we are currently blocking the main thread waiting for a
+ * frame to arrive.
+ */
+gboolean fl_renderer_is_blocking_main_thread(FlRenderer* self);
+
 G_END_DECLS
 
 #endif  // FLUTTER_SHELL_PLATFORM_LINUX_FL_RENDERER_H_

--- a/shell/platform/linux/fl_task_runner.h
+++ b/shell/platform/linux/fl_task_runner.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_LINUX_FL_TASK_RUNNER_H_
 
 #include <glib-object.h>
+#include <functional>
 
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/linux/public/flutter_linux/fl_engine.h"
@@ -27,14 +28,14 @@ FlTaskRunner* fl_task_runner_new(FlEngine* engine);
 /**
  * fl_task_runner_post_task:
  * @task_runner: an #FlTaskRunner.
- * @task: Flutter task being scheduled
+ * @delegate: The callback to be scheduled
  * @target_time_nanos: absolute time in nanoseconds
  *
  * Posts a Flutter task to be executed on main thread. This function is thread
  * safe and may be called from any thread.
  */
 void fl_task_runner_post_task(FlTaskRunner* task_runner,
-                              FlutterTask task,
+                              std::function<void()> delegate,
                               uint64_t target_time_nanos);
 
 /**


### PR DESCRIPTION
This change adds support for VSync callbacks on Linux, making it possible
to run at high refresh rates. The heavy lifting is done by GDK; and so the
implementation just wires the Flutter internals to it.

Unresolved: the implementation conflicts with "smooth resizing" support
(#25884). Smooth resizing blocks the main thread until a frame is rendered,
but this also blocks the VSync callbacks necessary to make progress in
rendering, resulting in a livelock. The smooth resizing is commented out
for now.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- **N/A** I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
