### PR TITLE
 Factor out a task synchronization help function for unit tests

### DIFF
--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -135,7 +135,7 @@ TEST_F(ImageDecoderFixtureTest, CanCreateImageDecoder) {
 
   );
 
-  PostIOTaskSync(runners, [&]() {
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() {
     TestIOManager manager(runners.GetIOTaskRunner());
     ImageDecoder decoder(std::move(runners), loop->GetTaskRunner(),
                          manager.GetWeakIOManager());
@@ -399,12 +399,12 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   std::unique_ptr<ImageDecoder> image_decoder;
 
   // Setup the IO manager.
-  PostIOTaskSync(runners, [&]() {
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
   });
 
   // Setup the image decoder.
-  PostUITaskSync(runners, [&]() {
+  PostTaskSync(runners.GetUITaskRunner(), [&]() {
     image_decoder = std::make_unique<ImageDecoder>(
         runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
   });
@@ -444,10 +444,10 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   ASSERT_EQ(decoded_size(100, 100), SkISize::Make(100, 100));
 
   // Destroy the IO manager
-  PostIOTaskSync(runners, [&]() { io_manager.reset(); });
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() { io_manager.reset(); });
 
   // Destroy the image decoder
-  PostUITaskSync(runners, [&]() { image_decoder.reset(); });
+  PostTaskSync(runners.GetUITaskRunner(), [&]() { image_decoder.reset(); });
 }
 
 // TODO(https://github.com/flutter/flutter/issues/81232) - disabled due to
@@ -491,12 +491,12 @@ TEST_F(ImageDecoderFixtureTest, DISABLED_CanResizeWithoutDecode) {
   std::unique_ptr<ImageDecoder> image_decoder;
 
   // Setup the IO manager.
-  PostIOTaskSync(runners, [&]() {
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
   });
 
   // Setup the image decoder.
-  PostUITaskSync(runners, [&]() {
+  PostTaskSync(runners.GetUITaskRunner(), [&]() {
     image_decoder = std::make_unique<ImageDecoder>(
         runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
   });
@@ -529,10 +529,10 @@ TEST_F(ImageDecoderFixtureTest, DISABLED_CanResizeWithoutDecode) {
   ASSERT_EQ(decoded_size(100, 100), SkISize::Make(100, 100));
 
   // Destroy the IO manager
-  PostIOTaskSync(runners, [&]() { io_manager.reset(); });
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() { io_manager.reset(); });
 
   // Destroy the image decoder
-  PostUITaskSync(runners, [&]() { image_decoder.reset(); });
+  PostTaskSync(runners.GetUITaskRunner(), [&]() { image_decoder.reset(); });
 }
 
 // Verifies https://skia-review.googlesource.com/c/skia/+/259161 is present in
@@ -649,7 +649,7 @@ TEST_F(ImageDecoderFixtureTest,
   std::unique_ptr<TestIOManager> io_manager;
 
   // Setup the IO manager.
-  PostIOTaskSync(runners, [&]() {
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
   });
 
@@ -660,7 +660,7 @@ TEST_F(ImageDecoderFixtureTest,
   // Latch the IO task runner.
   runners.GetIOTaskRunner()->PostTask([&]() { io_latch.Wait(); });
 
-  PostUITaskSync(runners, [&]() {
+  PostTaskSync(runners.GetUITaskRunner(), [&]() {
     fml::AutoResetWaitableEvent isolate_latch;
     fml::RefPtr<MultiFrameCodec> codec;
     EXPECT_TRUE(isolate->RunInIsolateScope([&]() -> bool {
@@ -690,7 +690,7 @@ TEST_F(ImageDecoderFixtureTest,
   });
 
   // Destroy the IO manager
-  PostIOTaskSync(runners, [&]() { io_manager.reset(); });
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() { io_manager.reset(); });
 }
 
 TEST_F(ImageDecoderFixtureTest, MultiFrameCodecDidAccessGpuDisabledSyncSwitch) {
@@ -718,7 +718,7 @@ TEST_F(ImageDecoderFixtureTest, MultiFrameCodecDidAccessGpuDisabledSyncSwitch) {
   fml::RefPtr<MultiFrameCodec> codec;
 
   // Setup the IO manager.
-  PostIOTaskSync(runners, [&]() {
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
   });
 
@@ -726,7 +726,7 @@ TEST_F(ImageDecoderFixtureTest, MultiFrameCodecDidAccessGpuDisabledSyncSwitch) {
                                       GetDefaultKernelFilePath(),
                                       io_manager->GetWeakIOManager());
 
-  PostUITaskSync(runners, [&]() {
+  PostTaskSync(runners.GetUITaskRunner(), [&]() {
     fml::AutoResetWaitableEvent isolate_latch;
 
     EXPECT_TRUE(isolate->RunInIsolateScope([&]() -> bool {
@@ -751,7 +751,7 @@ TEST_F(ImageDecoderFixtureTest, MultiFrameCodecDidAccessGpuDisabledSyncSwitch) {
     isolate_latch.Wait();
   });
 
-  PostIOTaskSync(runners, [&]() {
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() {
     EXPECT_TRUE(io_manager->did_access_is_gpu_disabled_sync_switch_);
   });
 
@@ -759,10 +759,10 @@ TEST_F(ImageDecoderFixtureTest, MultiFrameCodecDidAccessGpuDisabledSyncSwitch) {
   isolate = nullptr;
 
   // Destroy the MultiFrameCodec
-  PostUITaskSync(runners, [&]() { codec = nullptr; });
+  PostTaskSync(runners.GetUITaskRunner(), [&]() { codec = nullptr; });
 
   // Destroy the IO manager
-  PostIOTaskSync(runners, [&]() { io_manager.reset(); });
+  PostTaskSync(runners.GetIOTaskRunner(), [&]() { io_manager.reset(); });
 }
 
 }  // namespace testing

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -13,6 +13,7 @@
 #include "flutter/testing/dart_isolate_runner.h"
 #include "flutter/testing/elf_loader.h"
 #include "flutter/testing/fixture_test.h"
+#include "flutter/testing/post_task_sync.h"
 #include "flutter/testing/test_dart_native_resolver.h"
 #include "flutter/testing/test_gl_surface.h"
 #include "flutter/testing/testing.h"
@@ -134,14 +135,11 @@ TEST_F(ImageDecoderFixtureTest, CanCreateImageDecoder) {
 
   );
 
-  fml::AutoResetWaitableEvent latch;
-  runners.GetIOTaskRunner()->PostTask([&]() {
+  PostIOTaskSync(runners, [&]() {
     TestIOManager manager(runners.GetIOTaskRunner());
     ImageDecoder decoder(std::move(runners), loop->GetTaskRunner(),
                          manager.GetWeakIOManager());
-    latch.Signal();
   });
-  latch.Wait();
 }
 
 /// An Image generator that pretends it can't recognize the data it was given.
@@ -401,20 +399,15 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   std::unique_ptr<ImageDecoder> image_decoder;
 
   // Setup the IO manager.
-  runners.GetIOTaskRunner()->PostTask([&]() {
+  PostIOTaskSync(runners, [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
-    latch.Signal();
   });
-  latch.Wait();
 
   // Setup the image decoder.
-  runners.GetUITaskRunner()->PostTask([&]() {
+  PostUITaskSync(runners, [&]() {
     image_decoder = std::make_unique<ImageDecoder>(
         runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
-
-    latch.Signal();
   });
-  latch.Wait();
 
   // Setup a generic decoding utility that gives us the final decoded size.
   auto decoded_size = [&](uint32_t target_width,
@@ -451,18 +444,10 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   ASSERT_EQ(decoded_size(100, 100), SkISize::Make(100, 100));
 
   // Destroy the IO manager
-  runners.GetIOTaskRunner()->PostTask([&]() {
-    io_manager.reset();
-    latch.Signal();
-  });
-  latch.Wait();
+  PostIOTaskSync(runners, [&]() { io_manager.reset(); });
 
   // Destroy the image decoder
-  runners.GetUITaskRunner()->PostTask([&]() {
-    image_decoder.reset();
-    latch.Signal();
-  });
-  latch.Wait();
+  PostUITaskSync(runners, [&]() { image_decoder.reset(); });
 }
 
 // TODO(https://github.com/flutter/flutter/issues/81232) - disabled due to
@@ -506,20 +491,15 @@ TEST_F(ImageDecoderFixtureTest, DISABLED_CanResizeWithoutDecode) {
   std::unique_ptr<ImageDecoder> image_decoder;
 
   // Setup the IO manager.
-  runners.GetIOTaskRunner()->PostTask([&]() {
+  PostIOTaskSync(runners, [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
-    latch.Signal();
   });
-  latch.Wait();
 
   // Setup the image decoder.
-  runners.GetUITaskRunner()->PostTask([&]() {
+  PostUITaskSync(runners, [&]() {
     image_decoder = std::make_unique<ImageDecoder>(
         runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
-
-    latch.Signal();
   });
-  latch.Wait();
 
   // Setup a generic decoding utility that gives us the final decoded size.
   auto decoded_size = [&](uint32_t target_width,
@@ -549,18 +529,10 @@ TEST_F(ImageDecoderFixtureTest, DISABLED_CanResizeWithoutDecode) {
   ASSERT_EQ(decoded_size(100, 100), SkISize::Make(100, 100));
 
   // Destroy the IO manager
-  runners.GetIOTaskRunner()->PostTask([&]() {
-    io_manager.reset();
-    latch.Signal();
-  });
-  latch.Wait();
+  PostIOTaskSync(runners, [&]() { io_manager.reset(); });
 
   // Destroy the image decoder
-  runners.GetUITaskRunner()->PostTask([&]() {
-    image_decoder.reset();
-    latch.Signal();
-  });
-  latch.Wait();
+  PostUITaskSync(runners, [&]() { image_decoder.reset(); });
 }
 
 // Verifies https://skia-review.googlesource.com/c/skia/+/259161 is present in
@@ -673,16 +645,13 @@ TEST_F(ImageDecoderFixtureTest,
                       CreateNewThread("io")         // io
   );
 
-  fml::AutoResetWaitableEvent latch;
   fml::AutoResetWaitableEvent io_latch;
   std::unique_ptr<TestIOManager> io_manager;
 
   // Setup the IO manager.
-  runners.GetIOTaskRunner()->PostTask([&]() {
+  PostIOTaskSync(runners, [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
-    latch.Signal();
   });
-  latch.Wait();
 
   auto isolate = RunDartCodeInIsolate(vm_ref, settings, runners, "main", {},
                                       GetDefaultKernelFilePath(),
@@ -691,7 +660,7 @@ TEST_F(ImageDecoderFixtureTest,
   // Latch the IO task runner.
   runners.GetIOTaskRunner()->PostTask([&]() { io_latch.Wait(); });
 
-  runners.GetUITaskRunner()->PostTask([&]() {
+  PostUITaskSync(runners, [&]() {
     fml::AutoResetWaitableEvent isolate_latch;
     fml::RefPtr<MultiFrameCodec> codec;
     EXPECT_TRUE(isolate->RunInIsolateScope([&]() -> bool {
@@ -718,17 +687,10 @@ TEST_F(ImageDecoderFixtureTest,
     EXPECT_FALSE(codec);
 
     io_latch.Signal();
-
-    latch.Signal();
   });
-  latch.Wait();
 
   // Destroy the IO manager
-  runners.GetIOTaskRunner()->PostTask([&]() {
-    io_manager.reset();
-    latch.Signal();
-  });
-  latch.Wait();
+  PostIOTaskSync(runners, [&]() { io_manager.reset(); });
 }
 
 TEST_F(ImageDecoderFixtureTest, MultiFrameCodecDidAccessGpuDisabledSyncSwitch) {
@@ -752,22 +714,19 @@ TEST_F(ImageDecoderFixtureTest, MultiFrameCodecDidAccessGpuDisabledSyncSwitch) {
                       CreateNewThread("io")         // io
   );
 
-  fml::AutoResetWaitableEvent latch;
   std::unique_ptr<TestIOManager> io_manager;
   fml::RefPtr<MultiFrameCodec> codec;
 
   // Setup the IO manager.
-  runners.GetIOTaskRunner()->PostTask([&]() {
+  PostIOTaskSync(runners, [&]() {
     io_manager = std::make_unique<TestIOManager>(runners.GetIOTaskRunner());
-    latch.Signal();
   });
-  latch.Wait();
 
   auto isolate = RunDartCodeInIsolate(vm_ref, settings, runners, "main", {},
                                       GetDefaultKernelFilePath(),
                                       io_manager->GetWeakIOManager());
 
-  runners.GetUITaskRunner()->PostTask([&]() {
+  PostUITaskSync(runners, [&]() {
     fml::AutoResetWaitableEvent isolate_latch;
 
     EXPECT_TRUE(isolate->RunInIsolateScope([&]() -> bool {
@@ -790,34 +749,20 @@ TEST_F(ImageDecoderFixtureTest, MultiFrameCodecDidAccessGpuDisabledSyncSwitch) {
       return true;
     }));
     isolate_latch.Wait();
-
-    latch.Signal();
   });
-  latch.Wait();
 
-  runners.GetIOTaskRunner()->PostTask([&]() {
+  PostIOTaskSync(runners, [&]() {
     EXPECT_TRUE(io_manager->did_access_is_gpu_disabled_sync_switch_);
-    latch.Signal();
   });
-  latch.Wait();
 
   // Destroy the Isolate
   isolate = nullptr;
 
   // Destroy the MultiFrameCodec
-  runners.GetUITaskRunner()->PostTask([&]() {
-    codec = nullptr;
-    latch.Signal();
-  });
-  latch.Wait();
+  PostUITaskSync(runners, [&]() { codec = nullptr; });
 
   // Destroy the IO manager
-  runners.GetIOTaskRunner()->PostTask([&]() {
-    io_manager.reset();
-    latch.Signal();
-  });
-
-  latch.Wait();
+  PostIOTaskSync(runners, [&]() { io_manager.reset(); });
 }
 
 }  // namespace testing

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -17,6 +17,8 @@ source_set("testing_lib") {
 
   sources = [
     "assertions.h",
+    "post_task_sync.cc",
+    "post_task_sync.h",
     "testing.cc",
     "testing.h",
     "thread_test.cc",
@@ -24,6 +26,7 @@ source_set("testing_lib") {
   ]
 
   public_deps = [
+    "//flutter/common:common",
     "//flutter/fml",
     "//third_party/googletest:gmock",
     "//third_party/googletest:gtest",

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -26,7 +26,6 @@ source_set("testing_lib") {
   ]
 
   public_deps = [
-    "//flutter/common:common",
     "//flutter/fml",
     "//third_party/googletest:gmock",
     "//third_party/googletest:gtest",

--- a/testing/post_task_sync.cc
+++ b/testing/post_task_sync.cc
@@ -9,30 +9,10 @@
 namespace flutter {
 namespace testing {
 
-void PostPlatformTaskSync(const TaskRunners& task_runners,
-                          const std::function<void()>& function) {
-  PostTaskSync(*task_runners.GetPlatformTaskRunner(), function);
-}
-
-void PostUITaskSync(const TaskRunners& task_runners,
-                    const std::function<void()>& function) {
-  PostTaskSync(*task_runners.GetUITaskRunner(), function);
-}
-
-void PostRasterTaskSync(const TaskRunners& task_runners,
-                        const std::function<void()>& function) {
-  PostTaskSync(*task_runners.GetRasterTaskRunner(), function);
-}
-
-void PostIOTaskSync(const TaskRunners& task_runners,
-                    const std::function<void()>& function) {
-  PostTaskSync(*task_runners.GetIOTaskRunner(), function);
-}
-
-void PostTaskSync(fml::TaskRunner& task_runner,
+void PostTaskSync(fml::RefPtr<fml::TaskRunner> task_runner,
                   const std::function<void()>& function) {
   fml::AutoResetWaitableEvent latch;
-  task_runner.PostTask([&] {
+  task_runner->PostTask([&] {
     function();
     latch.Signal();
   });

--- a/testing/post_task_sync.cc
+++ b/testing/post_task_sync.cc
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/post_task_sync.h"
+
+#include "flutter/fml/synchronization/waitable_event.h"
+
+namespace flutter {
+namespace testing {
+
+void PostPlatformTaskSync(const TaskRunners& task_runners,
+                          const std::function<void()>& function) {
+  PostTaskSync(*task_runners.GetPlatformTaskRunner(), function);
+}
+
+void PostUITaskSync(const TaskRunners& task_runners,
+                    const std::function<void()>& function) {
+  PostTaskSync(*task_runners.GetUITaskRunner(), function);
+}
+
+void PostRasterTaskSync(const TaskRunners& task_runners,
+                        const std::function<void()>& function) {
+  PostTaskSync(*task_runners.GetRasterTaskRunner(), function);
+}
+
+void PostIOTaskSync(const TaskRunners& task_runners,
+                    const std::function<void()>& function) {
+  PostTaskSync(*task_runners.GetIOTaskRunner(), function);
+}
+
+void PostTaskSync(fml::TaskRunner& task_runner,
+                  const std::function<void()>& function) {
+  fml::AutoResetWaitableEvent latch;
+  task_runner.PostTask([&] {
+    function();
+    latch.Signal();
+  });
+  latch.Wait();
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/testing/post_task_sync.h
+++ b/testing/post_task_sync.h
@@ -11,19 +11,7 @@
 namespace flutter {
 namespace testing {
 
-void PostPlatformTaskSync(const TaskRunners& task_runners,
-                          const std::function<void()>& function);
-
-void PostUITaskSync(const TaskRunners& task_runners,
-                    const std::function<void()>& function);
-
-void PostRasterTaskSync(const TaskRunners& task_runners,
-                        const std::function<void()>& function);
-
-void PostIOTaskSync(const TaskRunners& task_runners,
-                    const std::function<void()>& function);
-
-void PostTaskSync(fml::TaskRunner& task_runner,
+void PostTaskSync(fml::RefPtr<fml::TaskRunner> task_runner,
                   const std::function<void()>& function);
 
 }  // namespace testing

--- a/testing/post_task_sync.h
+++ b/testing/post_task_sync.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_TESTING_POST_TASK_SYNC_H_
 #define FLUTTER_TESTING_POST_TASK_SYNC_H_
 
-#include "flutter/common/task_runners.h"
 #include "flutter/fml/task_runner.h"
 
 namespace flutter {

--- a/testing/post_task_sync.h
+++ b/testing/post_task_sync.h
@@ -1,0 +1,32 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_TESTING_POST_TASK_SYNC_H_
+#define FLUTTER_TESTING_POST_TASK_SYNC_H_
+
+#include "flutter/common/task_runners.h"
+#include "flutter/fml/task_runner.h"
+
+namespace flutter {
+namespace testing {
+
+void PostPlatformTaskSync(const TaskRunners& task_runners,
+                          const std::function<void()>& function);
+
+void PostUITaskSync(const TaskRunners& task_runners,
+                    const std::function<void()>& function);
+
+void PostRasterTaskSync(const TaskRunners& task_runners,
+                        const std::function<void()>& function);
+
+void PostIOTaskSync(const TaskRunners& task_runners,
+                    const std::function<void()>& function);
+
+void PostTaskSync(fml::TaskRunner& task_runner,
+                  const std::function<void()>& function);
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_TESTING_POST_TASK_SYNC_H_


### PR DESCRIPTION
The pattern of synchronously executing a task happens multiple times in tests. Pulled out helper functions can make tests are easier to parse/maintain

fixes: https://github.com/flutter/flutter/issues/89493

detail:  https://github.com/flutter/engine/pull/28159#discussion_r694177326

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.