### PR TITLE
[Web text input] Make placeholder text invisible

### DIFF
--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -703,18 +703,22 @@ void applyGlobalCssRulesToSheet(
 
   // This undoes browser's default painting and layout attributes of range
   // input, which is used in semantics.
-  sheet.insertRule('''
-flt-semantics input[type=range] {
-appearance: none;
--webkit-appearance: none;
-width: 100%;
-position: absolute;
-border: none;
-top: 0;
-right: 0;
-bottom: 0;
-left: 0;
-}''', sheet.cssRules.length);
+  sheet.insertRule(
+    '''
+    flt-semantics input[type=range] {
+      appearance: none;
+      -webkit-appearance: none;
+      width: 100%;
+      position: absolute;
+      border: none;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
+    ''',
+    sheet.cssRules.length,
+  );
 
   if (isWebKit) {
     sheet.insertRule(
@@ -751,35 +755,45 @@ left: 0;
         sheet.cssRules.length);
   }
   sheet.insertRule('''
-flt-semantics input,
-flt-semantics textarea,
-flt-semantics [contentEditable="true"] {
-caret-color: transparent;
-}
-''', sheet.cssRules.length);
+    flt-semantics input,
+    flt-semantics textarea,
+    flt-semantics [contentEditable="true"] {
+    caret-color: transparent;
+  }
+  ''', sheet.cssRules.length);
 
   // By default on iOS, Safari would highlight the element that's being tapped
   // on using gray background. This CSS rule disables that.
   if (isWebKit) {
     sheet.insertRule('''
-$glassPaneTagName * {
--webkit-tap-highlight-color: transparent;
-}
-''', sheet.cssRules.length);
+      $glassPaneTagName * {
+      -webkit-tap-highlight-color: transparent;
+    }
+    ''', sheet.cssRules.length);
   }
+
+  // Hide placeholder text
+  sheet.insertRule(
+    '''
+    .flt-text-editing::placeholder {
+      opacity: 0;
+    }
+    ''',
+    sheet.cssRules.length,
+  );
 
   // This css prevents an autofill overlay brought by the browser during
   // text field autofill by delaying the transition effect.
   // See: https://github.com/flutter/flutter/issues/61132.
   if (browserHasAutofillOverlay()) {
     sheet.insertRule('''
-.transparentTextEditing:-webkit-autofill,
-.transparentTextEditing:-webkit-autofill:hover,
-.transparentTextEditing:-webkit-autofill:focus,
-.transparentTextEditing:-webkit-autofill:active {
-  -webkit-transition-delay: 99999s;
-}
-''', sheet.cssRules.length);
+      .transparentTextEditing:-webkit-autofill,
+      .transparentTextEditing:-webkit-autofill:hover,
+      .transparentTextEditing:-webkit-autofill:focus,
+      .transparentTextEditing:-webkit-autofill:active {
+        -webkit-transition-delay: 99999s;
+      }
+    ''', sheet.cssRules.length);
   }
 }
 

--- a/lib/web_ui/test/dom_renderer_test.dart
+++ b/lib/web_ui/test/dom_renderer_test.dart
@@ -169,6 +169,28 @@ void testMain() {
     renderer.removeResource(resource);
     expect(resourceRoot.childNodes.length, 0);
   });
+
+  test('hide placeholder text for textfield', () {
+    final DomRenderer renderer = DomRenderer();
+    final html.InputElement regularTextField = html.InputElement();
+    regularTextField.placeholder = 'Now you see me';
+    renderer.addResource(regularTextField);
+
+    renderer.focus(regularTextField);
+    html.CssStyleDeclaration? style = renderer.glassPaneShadow?.querySelector('input')?.getComputedStyle('::placeholder');
+    expect(style, isNotNull);
+    expect(style?.opacity, isNot('0'));
+
+    final html.InputElement textField = html.InputElement();
+    textField.placeholder = 'Now you dont';
+    renderer.addElementClass(textField, 'flt-text-editing');
+    renderer.addResource(textField);
+
+    renderer.focus(textField);
+    style = renderer.glassPaneShadow?.querySelector('input.flt-text-editing')?.getComputedStyle('::placeholder');
+    expect(style, isNotNull);
+    expect(style?.opacity, '0');
+  }, skip: browserEngine != BrowserEngine.firefox);
 }
 
 @JS('Element.prototype.attachShadow')


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/89568

Set the placeholder text's opacity to 0.


Not sure how best to test this. It seems
`getComputedStyle('::placeholder').opacity` only works on firefox? Will create
an issue if that's the case.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
