### PR TITLE
[WIP]Fix OpenGL leak on Android and iOS

### DIFF
--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -57,6 +57,7 @@ std::unique_ptr<Surface> AndroidSurfaceGL::CreateGPUSurface(
     if (!main_skia_context) {
       main_skia_context = GPUSurfaceGL::MakeGLContext(this);
       GLContextPtr()->SetMainSkiaContext(main_skia_context);
+      return std::make_unique<GPUSurfaceGL>(main_skia_context, true);
     }
     return std::make_unique<GPUSurfaceGL>(main_skia_context, this, true);
   }

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -44,6 +44,7 @@ std::unique_ptr<Surface> IOSSurfaceGL::CreateGPUSurface(GrDirectContext* gr_cont
     if (!context) {
       context = GPUSurfaceGL::MakeGLContext(this);
       gl_context->SetMainContext(context);
+      return std::make_unique<GPUSurfaceGL>(context, true);
     }
 
     return std::make_unique<GPUSurfaceGL>(context, this, true);


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/89658

If the `GrDirectContext` is created by owned thread, [context_owner_](https://github.com/flutter/engine/blob/be8467ea6113d0811a3fb7bb4b2925f5cc310e92/shell/gpu/gpu_surface_gl.cc#L104) should be set to`true` to release OpenGL resources in destructor, otherwise `releaseResourcesAndAbandonContext()` will be called in the destructor of [AndroidContext](https://github.com/flutter/engine/blob/07896f7164204b58e0009ff62a6b14f25de8e20c/shell/platform/android/context/android_context.cc#L14) or [IOSContextGL](https://github.com/flutter/engine/blob/07896f7164204b58e0009ff62a6b14f25de8e20c/shell/platform/darwin/ios/ios_context_gl.mm#L30), both the destructor of  `AndroidContext` and `IOSContextGL` are called in the platform thread, which is a wrong thread to release OpenGL resources.

## Related PRs
- https://github.com/flutter/engine/pull/23798

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
