### PR TITLE
RTM must acquire lock before called IsMergedUnsafe

### DIFF
--- a/fml/raster_thread_merger.cc
+++ b/fml/raster_thread_merger.cc
@@ -91,7 +91,9 @@ bool RasterThreadMerger::IsOnPlatformThread() const {
   return MessageLoop::GetCurrentTaskQueueId() == platform_queue_id_;
 }
 
-bool RasterThreadMerger::IsOnRasterizingThread() const {
+bool RasterThreadMerger::IsOnRasterizingThread() {
+  std::scoped_lock lock(mutex_);
+
   if (IsMergedUnSafe()) {
     return IsOnPlatformThread();
   } else {

--- a/fml/raster_thread_merger.h
+++ b/fml/raster_thread_merger.h
@@ -89,7 +89,7 @@ class RasterThreadMerger
   // Returns true if the current thread owns rasterizing.
   // When the threads are merged, platform thread owns rasterizing.
   // When un-merged, raster thread owns rasterizing.
-  bool IsOnRasterizingThread() const;
+  bool IsOnRasterizingThread();
 
   // Returns true if the current thread is the platform thread.
   bool IsOnPlatformThread() const;


### PR DESCRIPTION
I was able to reproduce this on a windows machine with 10000 runs
of this test semi-consistently prior to this fix. After this fix
it seems to have stopped happening.

Fixes: https://github.com/flutter/flutter/issues/88464
