### PR TITLE
[flutter_releases] apply patches to flutter-2.5-candidate.8

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -10,6 +10,7 @@ enabled_branches:
   - dev
   - beta
   - stable
+  - flutter-2.5-candidate.8
 
 platform_properties:
   linux:

--- a/DEPS
+++ b/DEPS
@@ -27,7 +27,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   # OCMock is for testing only so there is no google clone
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
-  'skia_revision': '9a6f3990aff79e826e6c5b7c11c384e4ea19b89f',
+  'skia_revision': 'e835a74ea80e00c90ec0bf3281c09d01eda32311',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/ci/licenses_golden/licenses_skia
+++ b/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: f1dd52ab83ce37340bbe5f8c4f35bb5e
+Signature: eed272ad3db69cb88daa5be046a86122
 
 UNUSED LICENSES:
 

--- a/common/settings.h
+++ b/common/settings.h
@@ -166,7 +166,7 @@ struct Settings {
   bool enable_skparagraph = false;
 
   // Selects the DisplayList for storage of rendering operations.
-  bool enable_display_list = true;
+  bool enable_display_list = false;
 
   // All shells in the process share the same VM. The last shell to shutdown
   // should typically shut down the VM as well. However, applications depend on

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -46,8 +46,12 @@ enum class RasterStatus {
   kEnqueuePipeline,
   // Failed to rasterize the frame.
   kFailed,
-  // Layer tree was discarded due to LayerTreeDiscardCallback
-  kDiscarded
+  // Layer tree was discarded due to LayerTreeDiscardCallback or inability to
+  // access the GPU.
+  kDiscarded,
+  // Drawing was yielded to allow the correct thread to draw as a result of the
+  // RasterThreadMerger.
+  kYielded,
 };
 
 class CompositorContext {

--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -6,10 +6,8 @@
 
 namespace flutter {
 
-void ExternalViewEmbedder::SubmitFrame(
-    GrDirectContext* context,
-    std::unique_ptr<SurfaceFrame> frame,
-    const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch) {
+void ExternalViewEmbedder::SubmitFrame(GrDirectContext* context,
+                                       std::unique_ptr<SurfaceFrame> frame) {
   frame->Submit();
 };
 

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -10,7 +10,6 @@
 #include "flutter/flow/surface_frame.h"
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/raster_thread_merger.h"
-#include "flutter/fml/synchronization/sync_switch.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkPoint.h"
@@ -313,10 +312,8 @@ class ExternalViewEmbedder {
   // This method can mutate the root Skia canvas before submitting the frame.
   //
   // It can also allocate frames for overlay surfaces to compose hybrid views.
-  virtual void SubmitFrame(
-      GrDirectContext* context,
-      std::unique_ptr<SurfaceFrame> frame,
-      const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch);
+  virtual void SubmitFrame(GrDirectContext* context,
+                           std::unique_ptr<SurfaceFrame> frame);
 
   // This method provides the embedder a way to do additional tasks after
   // |SubmitFrame|. For example, merge task runners if `should_resubmit_frame`

--- a/flow/surface.cc
+++ b/flow/surface.cc
@@ -18,4 +18,8 @@ bool Surface::ClearRenderContext() {
   return false;
 }
 
+bool Surface::AllowsDrawingWhenGpuDisabled() const {
+  return true;
+}
+
 }  // namespace flutter

--- a/flow/surface.h
+++ b/flow/surface.h
@@ -33,6 +33,8 @@ class Surface {
 
   virtual bool ClearRenderContext();
 
+  virtual bool AllowsDrawingWhenGpuDisabled() const;
+
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(Surface);
 };

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -233,9 +233,10 @@ class Rasterizer final : public SnapshotDelegate {
   /// @param[in]  discardCallback if specified and returns true, the layer tree
   ///                             is discarded instead of being rendered
   ///
-  void Draw(std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder,
-            std::shared_ptr<Pipeline<flutter::LayerTree>> pipeline,
-            LayerTreeDiscardCallback discardCallback = NoDiscard);
+  RasterStatus Draw(
+      std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder,
+      std::shared_ptr<Pipeline<flutter::LayerTree>> pipeline,
+      LayerTreeDiscardCallback discardCallback = NoDiscard);
 
   //----------------------------------------------------------------------------
   /// @brief      The type of the screenshot to obtain of the previously
@@ -491,6 +492,9 @@ class Rasterizer final : public SnapshotDelegate {
 
   RasterStatus DrawToSurface(FrameTimingsRecorder& frame_timings_recorder,
                              flutter::LayerTree& layer_tree);
+
+  RasterStatus DrawToSurfaceUnsafe(FrameTimingsRecorder& frame_timings_recorder,
+                                   flutter::LayerTree& layer_tree);
 
   void FireNextFrameCallbackIfPresent();
 

--- a/shell/common/shell_test_external_view_embedder.cc
+++ b/shell/common/shell_test_external_view_embedder.cc
@@ -63,8 +63,7 @@ SkCanvas* ShellTestExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
 // |ExternalViewEmbedder|
 void ShellTestExternalViewEmbedder::SubmitFrame(
     GrDirectContext* context,
-    std::unique_ptr<SurfaceFrame> frame,
-    const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch) {
+    std::unique_ptr<SurfaceFrame> frame) {
   frame->Submit();
   if (frame && frame->SkiaSurface()) {
     last_submitted_frame_size_ = SkISize::Make(frame->SkiaSurface()->width(),

--- a/shell/common/shell_test_external_view_embedder.h
+++ b/shell/common/shell_test_external_view_embedder.h
@@ -63,9 +63,7 @@ class ShellTestExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void SubmitFrame(GrDirectContext* context,
-                   std::unique_ptr<SurfaceFrame> frame,
-                   const std::shared_ptr<const fml::SyncSwitch>&
-                       gpu_disable_sync_switch) override;
+                   std::unique_ptr<SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|
   void EndFrame(

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -318,4 +318,9 @@ bool GPUSurfaceGL::ClearRenderContext() {
   return delegate_->GLContextClearCurrent();
 }
 
+// |Surface|
+bool GPUSurfaceGL::AllowsDrawingWhenGpuDisabled() const {
+  return delegate_->AllowsDrawingWhenGpuDisabled();
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -50,6 +50,9 @@ class GPUSurfaceGL : public Surface {
   // |Surface|
   bool ClearRenderContext() override;
 
+  // |Surface|
+  bool AllowsDrawingWhenGpuDisabled() const override;
+
  private:
   GPUSurfaceGLDelegate* delegate_;
   sk_sp<GrDirectContext> context_;

--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -99,4 +99,8 @@ GPUSurfaceGLDelegate::GetDefaultPlatformGLInterface() {
   return CreateGLInterface(nullptr);
 }
 
+bool GPUSurfaceGLDelegate::AllowsDrawingWhenGpuDisabled() const {
+  return true;
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -69,6 +69,9 @@ class GPUSurfaceGLDelegate {
   // instrumentation to specific GL calls can specify custom GL functions
   // here.
   virtual GLProcResolver GetGLProcResolver() const;
+
+  // Whether to allow drawing to the surface when the GPU is disabled
+  virtual bool AllowsDrawingWhenGpuDisabled() const;
 };
 
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_metal.h
+++ b/shell/gpu/gpu_surface_metal.h
@@ -49,6 +49,9 @@ class SK_API_AVAILABLE_CA_METAL_LAYER GPUSurfaceMetal : public Surface {
   // |Surface|
   std::unique_ptr<GLContextResult> MakeRenderContextCurrent() override;
 
+  // |Surface|
+  bool AllowsDrawingWhenGpuDisabled() const override;
+
   std::unique_ptr<SurfaceFrame> AcquireFrameFromCAMetalLayer(
       const SkISize& frame_info);
 

--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -184,6 +184,10 @@ std::unique_ptr<GLContextResult> GPUSurfaceMetal::MakeRenderContextCurrent() {
   return std::make_unique<GLContextDefaultResult>(true);
 }
 
+bool GPUSurfaceMetal::AllowsDrawingWhenGpuDisabled() const {
+  return delegate_->AllowsDrawingWhenGpuDisabled();
+}
+
 void GPUSurfaceMetal::ReleaseUnusedDrawableIfNecessary() {
   // If the previous surface frame was not submitted before  a new one is acquired, the old drawable
   // needs to be released. An RAII wrapper may not be used because this needs to interoperate with

--- a/shell/gpu/gpu_surface_metal_delegate.cc
+++ b/shell/gpu/gpu_surface_metal_delegate.cc
@@ -16,4 +16,8 @@ MTLRenderTargetType GPUSurfaceMetalDelegate::GetRenderTargetType() {
   return render_target_type_;
 }
 
+bool GPUSurfaceMetalDelegate::AllowsDrawingWhenGpuDisabled() const {
+  return true;
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_metal_delegate.h
+++ b/shell/gpu/gpu_surface_metal_delegate.h
@@ -89,6 +89,11 @@ class GPUSurfaceMetalDelegate {
   ///
   virtual bool PresentTexture(GPUMTLTextureInfo texture) const = 0;
 
+  //------------------------------------------------------------------------------
+  /// @brief Whether to allow drawing to the surface when the GPU is disabled
+  ///
+  virtual bool AllowsDrawingWhenGpuDisabled() const;
+
   MTLRenderTargetType GetRenderTargetType();
 
  private:

--- a/shell/platform/android/external_view_embedder/external_view_embedder.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.cc
@@ -75,8 +75,7 @@ SkRect AndroidExternalViewEmbedder::GetViewRect(int view_id) const {
 // |ExternalViewEmbedder|
 void AndroidExternalViewEmbedder::SubmitFrame(
     GrDirectContext* context,
-    std::unique_ptr<SurfaceFrame> frame,
-    const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch) {
+    std::unique_ptr<SurfaceFrame> frame) {
   TRACE_EVENT0("flutter", "AndroidExternalViewEmbedder::SubmitFrame");
 
   if (!FrameHasPlatformLayers()) {

--- a/shell/platform/android/external_view_embedder/external_view_embedder.h
+++ b/shell/platform/android/external_view_embedder/external_view_embedder.h
@@ -47,9 +47,7 @@ class AndroidExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void SubmitFrame(GrDirectContext* context,
-                   std::unique_ptr<SurfaceFrame> frame,
-                   const std::shared_ptr<const fml::SyncSwitch>&
-                       gpu_disable_sync_switch) override;
+                   std::unique_ptr<SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|
   PostPrerollResult PostPrerollAction(

--- a/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
+++ b/shell/platform/android/external_view_embedder/external_view_embedder_unittests.cc
@@ -334,7 +334,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame) {
           return true;
         });
 
-    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame), nullptr);
+    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
     // Submits frame if no Android view in the current frame.
     EXPECT_TRUE(did_submit_frame);
     // Doesn't resubmit frame.
@@ -401,7 +401,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame) {
           return true;
         });
 
-    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame), nullptr);
+    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
     // Doesn't submit frame if there aren't Android views in the previous frame.
     EXPECT_FALSE(did_submit_frame);
     // Resubmits frame.
@@ -465,7 +465,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame) {
           }
           return true;
         });
-    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame), nullptr);
+    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
     // Submits frame if there are Android views in the previous frame.
     EXPECT_TRUE(did_submit_frame);
     // Doesn't resubmit frame.
@@ -573,7 +573,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame__overlayComposition) {
         return true;
       });
 
-  embedder->SubmitFrame(gr_context.get(), std::move(surface_frame), nullptr);
+  embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
   EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
   embedder->EndFrame(/*should_resubmit_frame=*/false, raster_thread_merger);
@@ -640,7 +640,7 @@ TEST(AndroidExternalViewEmbedder, SubmitFrame__platformViewWithoutAnyOverlay) {
         return true;
       });
 
-  embedder->SubmitFrame(gr_context.get(), std::move(surface_frame), nullptr);
+  embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
   EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
   embedder->EndFrame(/*should_resubmit_frame=*/false, raster_thread_merger);
@@ -734,7 +734,7 @@ TEST(AndroidExternalViewEmbedder, DestroyOverlayLayersOnSizeChange) {
         std::make_unique<SurfaceFrame>(SkSurface::MakeNull(1000, 1000), false,
                                        [](const SurfaceFrame& surface_frame,
                                           SkCanvas* canvas) { return true; });
-    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame), nullptr);
+    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
     EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
     embedder->EndFrame(/*should_resubmit_frame=*/false, raster_thread_merger);
@@ -816,7 +816,7 @@ TEST(AndroidExternalViewEmbedder, DoesNotDestroyOverlayLayersOnSizeChange) {
         std::make_unique<SurfaceFrame>(SkSurface::MakeNull(1000, 1000), false,
                                        [](const SurfaceFrame& surface_frame,
                                           SkCanvas* canvas) { return true; });
-    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame), nullptr);
+    embedder->SubmitFrame(gr_context.get(), std::move(surface_frame));
 
     EXPECT_CALL(*jni_mock, FlutterViewEndFrame());
     embedder->EndFrame(/*should_resubmit_frame=*/false, raster_thread_merger);

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -462,22 +462,9 @@ SkRect FlutterPlatformViewsController::GetPlatformViewRect(int view_id) {
   );
 }
 
-bool FlutterPlatformViewsController::SubmitFrame(
-    GrDirectContext* gr_context,
-    std::shared_ptr<IOSContext> ios_context,
-    std::unique_ptr<SurfaceFrame> frame,
-    const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch) {
-  bool result = false;
-  gpu_disable_sync_switch->Execute(
-      fml::SyncSwitch::Handlers().SetIfTrue([&] { result = false; }).SetIfFalse([&] {
-        result = SubmitFrameGpuSafe(gr_context, ios_context, std::move(frame));
-      }));
-  return result;
-}
-
-bool FlutterPlatformViewsController::SubmitFrameGpuSafe(GrDirectContext* gr_context,
-                                                        std::shared_ptr<IOSContext> ios_context,
-                                                        std::unique_ptr<SurfaceFrame> frame) {
+bool FlutterPlatformViewsController::SubmitFrame(GrDirectContext* gr_context,
+                                                 std::shared_ptr<IOSContext> ios_context,
+                                                 std::unique_ptr<SurfaceFrame> frame) {
   // Any UIKit related code has to run on main thread.
   FML_DCHECK([[NSThread currentThread] isMainThread]);
   if (flutter_view_ == nullptr) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViewsTest.mm
@@ -968,10 +968,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto mock_surface = std::make_unique<flutter::SurfaceFrame>(
       nullptr, true,
       [](const flutter::SurfaceFrame& surface_frame, SkCanvas* canvas) { return false; });
-  auto is_gpu_disabled = std::make_shared<fml::SyncSwitch>();
-  is_gpu_disabled->SetSwitch(false);
-  XCTAssertFalse(flutterPlatformViewsController->SubmitFrame(
-      nullptr, nullptr, std::move(mock_surface), is_gpu_disabled));
+  XCTAssertFalse(
+      flutterPlatformViewsController->SubmitFrame(nullptr, nullptr, std::move(mock_surface)));
 
   auto embeddedViewParams_2 =
       std::make_unique<flutter::EmbeddedViewParams>(finalMatrix, SkSize::Make(300, 300), stack);
@@ -980,10 +978,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto mock_surface_submit_false = std::make_unique<flutter::SurfaceFrame>(
       nullptr, true,
       [](const flutter::SurfaceFrame& surface_frame, SkCanvas* canvas) { return true; });
-  auto gpu_is_disabled = std::make_shared<fml::SyncSwitch>();
-  gpu_is_disabled->SetSwitch(false);
-  XCTAssertTrue(flutterPlatformViewsController->SubmitFrame(
-      nullptr, nullptr, std::move(mock_surface_submit_false), gpu_is_disabled));
+  XCTAssertTrue(flutterPlatformViewsController->SubmitFrame(nullptr, nullptr,
+                                                            std::move(mock_surface_submit_false)));
 }
 
 - (void)

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -173,8 +173,7 @@ class FlutterPlatformViewsController {
 
   bool SubmitFrame(GrDirectContext* gr_context,
                    std::shared_ptr<IOSContext> ios_context,
-                   std::unique_ptr<SurfaceFrame> frame,
-                   const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch);
+                   std::unique_ptr<SurfaceFrame> frame);
 
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 
@@ -299,10 +298,6 @@ class FlutterPlatformViewsController {
 
   // Commit a CATransaction if |BeginCATransaction| has been called during the frame.
   void CommitCATransactionIfNeeded();
-
-  bool SubmitFrameGpuSafe(GrDirectContext* gr_context,
-                          std::shared_ptr<IOSContext> ios_context,
-                          std::unique_ptr<SurfaceFrame> frame);
 
   // Resets the state of the frame.
   void ResetFrameState();

--- a/shell/platform/darwin/ios/ios_external_view_embedder.h
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.h
@@ -54,9 +54,7 @@ class IOSExternalViewEmbedder : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void SubmitFrame(GrDirectContext* context,
-                   std::unique_ptr<SurfaceFrame> frame,
-                   const std::shared_ptr<const fml::SyncSwitch>&
-                       gpu_disable_sync_switch) override;
+                   std::unique_ptr<SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|
   void EndFrame(

--- a/shell/platform/darwin/ios/ios_external_view_embedder.mm
+++ b/shell/platform/darwin/ios/ios_external_view_embedder.mm
@@ -72,14 +72,11 @@ SkCanvas* IOSExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
 }
 
 // |ExternalViewEmbedder|
-void IOSExternalViewEmbedder::SubmitFrame(
-    GrDirectContext* context,
-    std::unique_ptr<SurfaceFrame> frame,
-    const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch) {
+void IOSExternalViewEmbedder::SubmitFrame(GrDirectContext* context,
+                                          std::unique_ptr<SurfaceFrame> frame) {
   TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::SubmitFrame");
   FML_CHECK(platform_views_controller_);
-  platform_views_controller_->SubmitFrame(std::move(context), ios_context_, std::move(frame),
-                                          gpu_disable_sync_switch);
+  platform_views_controller_->SubmitFrame(std::move(context), ios_context_, std::move(frame));
   TRACE_EVENT0("flutter", "IOSExternalViewEmbedder::DidSubmitFrame");
 }
 

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -46,6 +46,9 @@ class IOSSurfaceGL final : public IOSSurface, public GPUSurfaceGLDelegate {
   // |GPUSurfaceGLDelegate|
   bool SurfaceSupportsReadback() const override;
 
+  // |GPUSurfaceGLDelegate|
+  bool AllowsDrawingWhenGpuDisabled() const override;
+
  private:
   std::unique_ptr<IOSRenderTargetGL> render_target_;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -89,4 +89,9 @@ bool IOSSurfaceGL::GLContextPresent(uint32_t fbo_id) {
   return IsValid() && render_target_->PresentRenderBuffer();
 }
 
+// |GPUSurfaceGLDelegate|
+bool IOSSurfaceGL::AllowsDrawingWhenGpuDisabled() const {
+  return false;
+}
+
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_metal.h
+++ b/shell/platform/darwin/ios/ios_surface_metal.h
@@ -49,6 +49,9 @@ class SK_API_AVAILABLE_CA_METAL_LAYER IOSSurfaceMetal final : public IOSSurface,
   // |GPUSurfaceMetalDelegate|
   bool PresentTexture(GPUMTLTextureInfo texture) const override;
 
+  // |GPUSurfaceMetalDelegate|
+  bool AllowsDrawingWhenGpuDisabled() const override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceMetal);
 };
 

--- a/shell/platform/darwin/ios/ios_surface_metal.mm
+++ b/shell/platform/darwin/ios/ios_surface_metal.mm
@@ -98,4 +98,9 @@ bool IOSSurfaceMetal::PresentTexture(GPUMTLTextureInfo texture) const {
   return false;
 }
 
+// |GPUSurfaceMetalDelegate|
+bool IOSSurfaceMetal::AllowsDrawingWhenGpuDisabled() const {
+  return false;
+}
+
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -135,8 +135,7 @@ static FlutterBackingStoreConfig MakeBackingStoreConfig(
 // |ExternalViewEmbedder|
 void EmbedderExternalViewEmbedder::SubmitFrame(
     GrDirectContext* context,
-    std::unique_ptr<SurfaceFrame> frame,
-    const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch) {
+    std::unique_ptr<SurfaceFrame> frame) {
   auto [matched_render_targets, pending_keys] =
       render_target_cache_.GetExistingTargetsInCache(pending_views_);
 

--- a/shell/platform/embedder/embedder_external_view_embedder.h
+++ b/shell/platform/embedder/embedder_external_view_embedder.h
@@ -98,9 +98,7 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void SubmitFrame(GrDirectContext* context,
-                   std::unique_ptr<SurfaceFrame> frame,
-                   const std::shared_ptr<const fml::SyncSwitch>&
-                       gpu_disable_sync_switch) override;
+                   std::unique_ptr<SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|
   SkCanvas* GetRootCanvas() override;

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.cc
@@ -244,8 +244,7 @@ void FuchsiaExternalViewEmbedder::EndFrame(
 
 void FuchsiaExternalViewEmbedder::SubmitFrame(
     GrDirectContext* context,
-    std::unique_ptr<flutter::SurfaceFrame> frame,
-    const std::shared_ptr<const fml::SyncSwitch>& gpu_disable_sync_switch) {
+    std::unique_ptr<flutter::SurfaceFrame> frame) {
   TRACE_EVENT0("flutter", "FuchsiaExternalViewEmbedder::SubmitFrame");
   std::vector<std::unique_ptr<SurfaceProducerSurface>> frame_surfaces;
   std::unordered_map<EmbedderLayerId, size_t> frame_surface_indices;

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
@@ -104,9 +104,7 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
 
   // |ExternalViewEmbedder|
   void SubmitFrame(GrDirectContext* context,
-                   std::unique_ptr<flutter::SurfaceFrame> frame,
-                   const std::shared_ptr<const fml::SyncSwitch>&
-                       gpu_disable_sync_switch) override;
+                   std::unique_ptr<flutter::SurfaceFrame> frame) override;
 
   // |ExternalViewEmbedder|
   void CancelFrame() override { Reset(); }

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -53,9 +53,7 @@ class MockExternalViewEmbedder : public flutter::ExternalViewEmbedder {
       double device_pixel_ratio,
       fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger) override {}
   void SubmitFrame(GrDirectContext* context,
-                   std::unique_ptr<flutter::SurfaceFrame> frame,
-                   const std::shared_ptr<const fml::SyncSwitch>&
-                       gpu_disable_sync_switch) override {
+                   std::unique_ptr<flutter::SurfaceFrame> frame) override {
     return;
   }
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/89598

- "crash in GrMtlCommandBuffer::getBlitCommandEncoder()"
  - Tracking issues: https://github.com/flutter/flutter/issues/89171, [b/197827241](http://b/197827241)
  - CP request: [b/198731189](http://b/198731189)
  - Fix PR: [Started providing the GPU sync switch to Rasterizer.DrawToSurface() #28383
](https://github.com/flutter/engine/pull/28383)
- "iOS crash in GrMtlAttachment::onRelease()"
  - Tracking issues: https://github.com/flutter/flutter/issues/89204, [b/198231043](http://b/198231043)
  - Fix: https://skia.googlesource.com/skia/+/98ef6cc8b1407111013c7531b554e86d4c5c4ff6 will need to be reverted on Flutter's Skia branch(es)
- Memory usage regression
  - Tracking issues: https://github.com/flutter/flutter/issues/88745, [b/197437240](http://b/197437240)
  - Fix PR: https://github.com/flutter/engine/pull/28308