### PR TITLE
[Desktop][Linux] Add RUNPATH $ORIGIN to flutter_linux_gtk

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -219,6 +219,11 @@ executable("flutter_linux_unittests") {
 
 shared_library("flutter_linux_gtk") {
   deps = [ ":flutter_linux" ]
+  
+  if (is_linux) {
+    # Ensure we can dlopen bundled dlls in bundle/lib on Flutter Desktop.
+    ldflags = [ "-Wl,-rpath,\$ORIGIN/" ]
+  }
 
   public_configs = [ "//flutter:config" ]
 }

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -219,7 +219,7 @@ executable("flutter_linux_unittests") {
 
 shared_library("flutter_linux_gtk") {
   deps = [ ":flutter_linux" ]
-  
+
   if (is_linux) {
     # Ensure we can dlopen bundled dlls in bundle/lib on Flutter Desktop.
     ldflags = [ "-Wl,-rpath,\$ORIGIN/" ]

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -220,10 +220,7 @@ executable("flutter_linux_unittests") {
 shared_library("flutter_linux_gtk") {
   deps = [ ":flutter_linux" ]
 
-  if (is_linux) {
-    # Ensure we can dlopen bundled dlls in bundle/lib on Flutter Desktop.
-    ldflags = [ "-Wl,-rpath,\$ORIGIN/" ]
-  }
+  ldflags = [ "-Wl,-rpath,\$ORIGIN" ]
 
   public_configs = [ "//flutter:config" ]
 }


### PR DESCRIPTION
When using `dart:ffi`'s `DynamicLibrary.open(...)`, the `RUNPATH` of `bundle/lib/libflutter_linux_gtk.so` is used rather than `bundle/flutter_app`. `libflutter_linux_gtk.so` did not have a `RUNPATH` set, making `dlopen` only succeed on absolute paths and dynamically linked libraries. Setting `RUNPATH` enables us to _dynamically load_ shared libraries without _dynamically linking_ them upfront.

With this fix, the `${plugin}_bundled_libraries` can work without modifying a flutter app:

`${plugin}/linux/CMakeLists.txt`

```cmake
# List of absolute paths to libraries that should be bundled with the plugin
set(mylib_dylib_bundled_libraries
  "${CMAKE_CURRENT_SOURCE_DIR}/../native/lib/linux_x64/libmylib_dylib.so;${CMAKE_CURRENT_SOURCE_DIR}/../native/lib/linux_x64/libmylib_dylib_dependency.so"
  PARENT_SCOPE
)
```

Before this fix, we also needed to modify a `flutter_app` to dynamically link the libraries:

`${flutter_app}/linux/CMakeLists.txt`

```cmake
# Link bundled libraries from plugins into main executable to enable dlopen
# with only library name.
foreach(plugin ${FLUTTER_PLUGIN_LIST})
  if(${plugin}_bundled_libraries)
    target_link_libraries(
      ${BINARY_NAME}
      PUBLIC
      ${${plugin}_bundled_libraries}
    )
  endif()
endforeach(plugin)
```

This `flutter_app` modification is obsolete after this PR.

Tested locally with this patch and `flutter --local-engine=host_release --local-engine-src-path=$HOME/flt/engine/src run linux`.
Change can be observed with `readelf -d flutter_app/build/linux/x64/release/bundle/lib/libflutter_linux_gtk.so | grep RUNPATH`.

Relevant issues: https://github.com/flutter/flutter/issues/78819#issuecomment-912581009 and https://github.com/dart-lang/ffi/issues/118.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
