### PR TITLE
Revert "RTM must to acquire lock before called IsMergedUnsafe (#28514)"

### DIFF
--- a/fml/raster_thread_merger.cc
+++ b/fml/raster_thread_merger.cc
@@ -91,9 +91,7 @@ bool RasterThreadMerger::IsOnPlatformThread() const {
   return MessageLoop::GetCurrentTaskQueueId() == platform_queue_id_;
 }
 
-bool RasterThreadMerger::IsOnRasterizingThread() {
-  std::scoped_lock lock(mutex_);
-
+bool RasterThreadMerger::IsOnRasterizingThread() const {
   if (IsMergedUnSafe()) {
     return IsOnPlatformThread();
   } else {

--- a/fml/raster_thread_merger.h
+++ b/fml/raster_thread_merger.h
@@ -89,7 +89,7 @@ class RasterThreadMerger
   // Returns true if the current thread owns rasterizing.
   // When the threads are merged, platform thread owns rasterizing.
   // When un-merged, raster thread owns rasterizing.
-  bool IsOnRasterizingThread();
+  bool IsOnRasterizingThread() const;
 
   // Returns true if the current thread is the platform thread.
   bool IsOnPlatformThread() const;


### PR DESCRIPTION
This reverts commit 6e478c72419e5af88203252953cb57483c4560cc.

This is causing https://github.com/flutter/flutter/issues/89757