### PR TITLE
Reland "RTM must to acquire lock before called IsMergedUnsafe (#28514)"

### DIFF
--- a/fml/raster_thread_merger.cc
+++ b/fml/raster_thread_merger.cc
@@ -91,7 +91,9 @@ bool RasterThreadMerger::IsOnPlatformThread() const {
   return MessageLoop::GetCurrentTaskQueueId() == platform_queue_id_;
 }
 
-bool RasterThreadMerger::IsOnRasterizingThread() const {
+bool RasterThreadMerger::IsOnRasterizingThread() {
+  std::scoped_lock lock(mutex_);
+
   if (IsMergedUnSafe()) {
     return IsOnPlatformThread();
   } else {

--- a/fml/raster_thread_merger.h
+++ b/fml/raster_thread_merger.h
@@ -89,7 +89,7 @@ class RasterThreadMerger
   // Returns true if the current thread owns rasterizing.
   // When the threads are merged, platform thread owns rasterizing.
   // When un-merged, raster thread owns rasterizing.
-  bool IsOnRasterizingThread() const;
+  bool IsOnRasterizingThread();
 
   // Returns true if the current thread is the platform thread.
   bool IsOnPlatformThread() const;


### PR DESCRIPTION
This reverts commit 011c0f5f8ed62333df041e21003abb9307818e4e.

This was reverted because if was deemed to potentially cause a framework
test flake: https://github.com/flutter/flutter/issues/89757, but was not
the cause of it.
