### PR TITLE
[web] fix the last matrix element in CkPath.shift

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/path.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/path.dart
@@ -257,12 +257,16 @@ class CkPath extends ManagedSkiaObject<SkPath> implements ui.Path {
   }
 
   @override
-  ui.Path shift(ui.Offset offset) {
-    // Since CanvasKit does not expose `SkPath.offset`, create a copy of this
-    // path and call `transform` on it.
-    final SkPath newPath = skiaObject.copy();
-    newPath.transform(1.0, 0.0, offset.dx, 0.0, 1.0, offset.dy, 0.0, 0.0, 0.0);
-    return CkPath.fromSkPath(newPath, _fillType);
+  CkPath shift(ui.Offset offset) {
+    // `SkPath.transform` mutates the existing path, so create a copy and call
+    // `transform` on the copy.
+    final SkPath shiftedPath = skiaObject.copy();
+    shiftedPath.transform(
+      1.0, 0.0, offset.dx,
+      0.0, 1.0, offset.dy,
+      0.0, 0.0, 1.0,
+    );
+    return CkPath.fromSkPath(shiftedPath, _fillType);
   }
 
   static CkPath combine(

--- a/lib/web_ui/test/canvaskit/path_test.dart
+++ b/lib/web_ui/test/canvaskit/path_test.dart
@@ -85,6 +85,21 @@ void testMain() {
       expect(path.contains(const ui.Offset(5, 5)), isFalse);
     });
 
+    test('CkPath.shift creates a shifted copy of the path', () {
+      const ui.Rect testRect = ui.Rect.fromLTRB(0, 0, 10, 10);
+      final CkPath path = CkPath();
+      path.addRect(testRect);
+      expect(path.getBounds(), testRect);
+
+      expect(
+        path.shift(const ui.Offset(20, 20)).getBounds(),
+        testRect.shift(const ui.Offset(20, 20)),
+      );
+
+      // Make sure the original path wasn't mutated.
+      expect(path.getBounds(), testRect);
+    });
+
     test('CkPath resurrection', () {
       const ui.Rect rect = ui.Rect.fromLTRB(0, 0, 10, 10);
       final CkPath path = CkPath();


### PR DESCRIPTION
We were passing zero as the last matrix element, which is wrong. Although it doesn't cause an issue when rendering in wasm CanvasKit, it did show up in cobalt.
