### PR TITLE
Don't use rFD in pre-Q versions

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -1094,9 +1094,9 @@ public class FlutterActivity extends Activity
   public void onFlutterUiDisplayed() {
     // Notifies Android that we're fully drawn so that performance metrics can be collected by
     // Flutter performance tests. A few considerations:
-    // * rFD was supported in KitKat (API 19), but has a bug around requiring
+    // * reportFullyDrawn was supported in KitKat (API 19), but has a bug around requiring
     // permissions in some Android versions.
-    // * rFD behavior isn't tested on pre-Q versions.
+    // * reportFullyDrawn behavior isn't tested on pre-Q versions.
     // See https://github.com/flutter/flutter/issues/46172, and
     // https://github.com/flutter/flutter/issues/88767.
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -1093,10 +1093,13 @@ public class FlutterActivity extends Activity
   @Override
   public void onFlutterUiDisplayed() {
     // Notifies Android that we're fully drawn so that performance metrics can be collected by
-    // Flutter performance tests.
-    // This was supported in KitKat (API 19), but has a bug around requiring
-    // permissions. See https://github.com/flutter/flutter/issues/46172
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+    // Flutter performance tests. A few considerations:
+    // * rFD was supported in KitKat (API 19), but has a bug around requiring
+    // permissions in some Android versions.
+    // * rFD behavior isn't tested on pre-Q versions.
+    // See https://github.com/flutter/flutter/issues/46172, and
+    // https://github.com/flutter/flutter/issues/88767.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       reportFullyDrawn();
     }
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -438,6 +438,32 @@ public class FlutterActivityTest {
     assertNull(splashScreen);
   }
 
+  @Test
+  public void fullyDrawn() {
+    Intent intent =
+        FlutterActivityWithReportFullyDrawn.createDefaultIntent(RuntimeEnvironment.application);
+    ActivityController<FlutterActivityWithReportFullyDrawn> activityController =
+        Robolectric.buildActivity(FlutterActivityWithReportFullyDrawn.class, intent);
+    FlutterActivityWithReportFullyDrawn flutterActivity = activityController.get();
+
+    // See https://github.com/flutter/flutter/issues/46172, and
+    // https://github.com/flutter/flutter/issues/88767.
+    for (int version = Build.VERSION_CODES.JELLY_BEAN; version < Build.VERSION_CODES.Q; version++) {
+      TestUtils.setApiVersion(version);
+      flutterActivity.onFlutterUiDisplayed();
+      assertFalse(
+          "reportFullyDrawn isn't used in API level " + version, flutterActivity.isFullyDrawn());
+    }
+
+    for (int version = Build.VERSION_CODES.Q; version < Build.VERSION_CODES.S; version++) {
+      TestUtils.setApiVersion(version);
+      flutterActivity.onFlutterUiDisplayed();
+      assertTrue(
+          "reportFullyDrawn is used in API level " + version, flutterActivity.isFullyDrawn());
+      flutterActivity.resetFullyDrawn();
+    }
+  }
+
   static class FlutterActivityWithProvidedEngine extends FlutterActivity {
     @Override
     @SuppressLint("MissingSuperCall")
@@ -475,6 +501,23 @@ public class FlutterActivityTest {
     @Override
     public RenderMode getRenderMode() {
       return RenderMode.texture;
+    }
+  }
+
+  private static class FlutterActivityWithReportFullyDrawn extends FlutterActivity {
+    private boolean fullyDrawn = false;
+
+    @Override
+    public void reportFullyDrawn() {
+      fullyDrawn = true;
+    }
+
+    public boolean isFullyDrawn() {
+      return fullyDrawn;
+    }
+
+    public void resetFullyDrawn() {
+      fullyDrawn = false;
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/88767

We cannot safely rely on this API since there's no test in Android prior to Q.