### PR TITLE
Call `didFailToRegisterForRemoteNotificationsWithError` delegate methods in `FlutterPlugin`

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -85,6 +85,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)application:(UIApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
  *
  * @return `YES` if this handles the request.
  */

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -58,7 +58,7 @@ FLUTTER_DARWIN_EXPORT
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
 
 /**
- * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ * Calls all plugins registered for `UIApplicationDelegate` callbacks.
  */
 - (void)application:(UIApplication*)application
     didFailToRegisterForRemoteNotificationsWithError:(NSError*)error;

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -58,6 +58,12 @@ FLUTTER_DARWIN_EXPORT
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
 
 /**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)application:(UIApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error;
+
+/**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
  */
 - (void)application:(UIApplication*)application

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -95,6 +95,12 @@ static NSString* const kRestorationStateAppModificationKey = @"mod-date";
       didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
+- (void)application:(UIApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
+  [_lifeCycleDelegate application:application
+      didFailToRegisterForRemoteNotificationsWithError:error];
+}
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -249,6 +249,18 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 }
 
 - (void)application:(UIApplication*)application
+    didFailToRegisterForRemoteNotificationsWithError:(NSError*)error {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
+      continue;
+    }
+    if ([delegate respondsToSelector:_cmd]) {
+      [delegate application:application didFailToRegisterForRemoteNotificationsWithError:error];
+    }
+  }
+}
+
+- (void)application:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
   for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {


### PR DESCRIPTION
There is currently no way for plugins to know if [`registerForRemoteNotification`](https://developer.apple.com/documentation/uikit/uiapplication/1623078-registerforremotenotifications) **fails**. Push notification related plugins may want to handle this on behalf of the user. 
>  If registration fails, the app calls its app delegate’s [application(_:didFailToRegisterForRemoteNotificationsWithError:)](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622962-application) method instead. - [Apple docs](https://developer.apple.com/documentation/uikit/uiapplication/1623078-registerforremotenotifications)

This is because the `FlutterPluginAppLifeCycleDelegate` doesn't currently implement this method itself, and doesn't tell plugins about it. This is the last delegate method in UIApplicationDelegate that plugins were not informed by.

Regarding testing: the other delegate methods do not have tests. I don't see any way to test this at the moment 🙂

Closes https://github.com/flutter/flutter/issues/65365

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.