### PR TITLE
Improve DisplayList bounds calculations

### DIFF
--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -823,7 +823,7 @@ DEFINE_DRAW_SHADOW_OP(ShadowOccludes, true)
 #pragma pack(pop, DLOp_Alignment)
 
 void DisplayList::ComputeBounds() {
-  DisplayListBoundsCalculator calculator(bounds_cull_);
+  DisplayListBoundsCalculator calculator(&bounds_cull_);
   Dispatch(calculator);
   bounds_ = calculator.getBounds();
 }

--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -797,27 +797,27 @@ struct DrawTextBlobOp final : DLOp {
 };
 
 // 4 byte header + 28 byte payload packs evenly into 32 bytes
-#define DEFINE_DRAW_SHADOW_OP(name, occludes)                         \
-  struct Draw##name##Op final : DLOp {                                \
-    static const auto kType = DisplayListOpType::kDraw##name;         \
-                                                                      \
-    Draw##name##Op(const SkPath& path,                                \
-                   SkColor color,                                     \
-                   SkScalar elevation,                                \
-                   SkScalar dpr)                                      \
-        : color(color), elevation(elevation), dpr(dpr), path(path) {} \
-                                                                      \
-    const SkColor color;                                              \
-    const SkScalar elevation;                                         \
-    const SkScalar dpr;                                               \
-    const SkPath path;                                                \
-                                                                      \
-    void dispatch(Dispatcher& dispatcher) const {                     \
-      dispatcher.drawShadow(path, color, elevation, occludes, dpr);   \
-    }                                                                 \
+#define DEFINE_DRAW_SHADOW_OP(name, nonoccluding)                       \
+  struct Draw##name##Op final : DLOp {                                  \
+    static const auto kType = DisplayListOpType::kDraw##name;           \
+                                                                        \
+    Draw##name##Op(const SkPath& path,                                  \
+                   SkColor color,                                       \
+                   SkScalar elevation,                                  \
+                   SkScalar dpr)                                        \
+        : color(color), elevation(elevation), dpr(dpr), path(path) {}   \
+                                                                        \
+    const SkColor color;                                                \
+    const SkScalar elevation;                                           \
+    const SkScalar dpr;                                                 \
+    const SkPath path;                                                  \
+                                                                        \
+    void dispatch(Dispatcher& dispatcher) const {                       \
+      dispatcher.drawShadow(path, color, elevation, nonoccluding, dpr); \
+    }                                                                   \
   };
 DEFINE_DRAW_SHADOW_OP(Shadow, false)
-DEFINE_DRAW_SHADOW_OP(ShadowOccludes, true)
+DEFINE_DRAW_SHADOW_OP(NonOccludingShadow, true)
 #undef DEFINE_DRAW_SHADOW_OP
 
 #pragma pack(pop, DLOp_Alignment)
@@ -1365,10 +1365,10 @@ void DisplayListBuilder::drawTextBlob(const sk_sp<SkTextBlob> blob,
 void DisplayListBuilder::drawShadow(const SkPath& path,
                                     const SkColor color,
                                     const SkScalar elevation,
-                                    bool occludes,
+                                    bool transparentOccluder,
                                     SkScalar dpr) {
-  occludes  //
-      ? Push<DrawShadowOccludesOp>(0, 1, path, color, elevation, dpr)
+  transparentOccluder  //
+      ? Push<DrawNonOccludingShadowOp>(0, 1, path, color, elevation, dpr)
       : Push<DrawShadowOp>(0, 1, path, color, elevation, dpr);
 }
 

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -148,7 +148,7 @@ namespace flutter {
   V(DrawTextBlob)                   \
                                     \
   V(DrawShadow)                     \
-  V(DrawShadowOccludes)
+  V(DrawNonOccludingShadow)
 
 #define DL_OP_TO_ENUM_VALUE(name) k##name,
 enum class DisplayListOpType { FOR_EACH_DISPLAY_LIST_OP(DL_OP_TO_ENUM_VALUE) };
@@ -325,7 +325,7 @@ class Dispatcher {
   virtual void drawShadow(const SkPath& path,
                           const SkColor color,
                           const SkScalar elevation,
-                          bool occludes,
+                          bool transparentOccluder,
                           SkScalar dpr) = 0;
 };
 
@@ -440,7 +440,7 @@ class DisplayListBuilder final : public virtual Dispatcher, public SkRefCnt {
   void drawShadow(const SkPath& path,
                   const SkColor color,
                   const SkScalar elevation,
-                  bool occludes,
+                  bool transparentOccluder,
                   SkScalar dpr) override;
 
   sk_sp<DisplayList> Build();

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -245,8 +245,8 @@ class Dispatcher {
   virtual void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) = 0;
 
   virtual void save() = 0;
-  virtual void restore() = 0;
   virtual void saveLayer(const SkRect* bounds, bool restoreWithPaint) = 0;
+  virtual void restore() = 0;
 
   virtual void translate(SkScalar tx, SkScalar ty) = 0;
   virtual void scale(SkScalar sx, SkScalar sy) = 0;
@@ -358,8 +358,8 @@ class DisplayListBuilder final : public virtual Dispatcher, public SkRefCnt {
   void setMaskBlurFilter(SkBlurStyle style, SkScalar sigma) override;
 
   void save() override;
-  void restore() override;
   void saveLayer(const SkRect* bounds, bool restoreWithPaint) override;
+  void restore() override;
 
   void translate(SkScalar tx, SkScalar ty) override;
   void scale(SkScalar sx, SkScalar sy) override;

--- a/flow/display_list_canvas.cc
+++ b/flow/display_list_canvas.cc
@@ -176,10 +176,10 @@ void DisplayListCanvasDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
 void DisplayListCanvasDispatcher::drawShadow(const SkPath& path,
                                              const SkColor color,
                                              const SkScalar elevation,
-                                             bool occludes,
+                                             bool transparentOccluder,
                                              SkScalar dpr) {
   flutter::PhysicalShapeLayer::DrawShadow(canvas_, path, color, elevation,
-                                          occludes, dpr);
+                                          transparentOccluder, dpr);
 }
 
 DisplayListCanvasRecorder::DisplayListCanvasRecorder(const SkRect& bounds)

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -110,7 +110,7 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
   void drawShadow(const SkPath& path,
                   const SkColor color,
                   const SkScalar elevation,
-                  bool occludes,
+                  bool transparentOccluder,
                   SkScalar dpr) override;
 
  private:

--- a/flow/display_list_canvas_unittests.cc
+++ b/flow/display_list_canvas_unittests.cc
@@ -50,7 +50,10 @@ constexpr SkRect RenderBounds =
 // The tests try 3 miter limit values, 0.0, 4.0 (the default), and 10.0
 // These values will allow us to construct a diamond that spans the
 // width or height of the render box and still show the miter for 4.0
-// and 10.0
+// and 10.0.
+// These values were discovered by drawing a diamond path in Skia fiddle
+// and then playing with the cross-axis size until the miter was about
+// as large as it could get before it got cut off.
 
 // The X offsets which will be used for tall vertical diamonds are
 // expressed in terms of the rendering height to obtain the proper angle
@@ -436,7 +439,8 @@ class CanvasCompareTester {
             cv_restored, dl_restored, adjuster, blur5Tolerance,
             "saveLayer ImageFilter, no bounds");
       }
-      ASSERT_TRUE(filter->unique()) << "SL with IF no bounds Cleanup";
+      ASSERT_TRUE(filter->unique())
+          << "saveLayer ImageFilter, no bounds Cleanup";
       {
         RenderWith(
             [=](SkCanvas* cv, SkPaint& p) {
@@ -454,7 +458,8 @@ class CanvasCompareTester {
             cv_restored, dl_restored, adjuster, blur5Tolerance,
             "saveLayer ImageFilter and bounds");
       }
-      ASSERT_TRUE(filter->unique()) << "SL with IF and bounds Cleanup";
+      ASSERT_TRUE(filter->unique())
+          << "saveLayer ImageFilter and bounds Cleanup";
     }
   }
 
@@ -468,10 +473,12 @@ class CanvasCompareTester {
 
     RenderWith([=](SkCanvas*, SkPaint& p) { p.setAntiAlias(true); },  //
                [=](DisplayListBuilder& b) { b.setAA(true); },         //
-               cv_renderer, dl_renderer, adjuster, tolerance, "AA == True");
+               cv_renderer, dl_renderer, adjuster, tolerance,
+               "AntiAlias == True");
     RenderWith([=](SkCanvas*, SkPaint& p) { p.setAntiAlias(false); },  //
                [=](DisplayListBuilder& b) { b.setAA(false); },         //
-               cv_renderer, dl_renderer, adjuster, tolerance, "AA == False");
+               cv_renderer, dl_renderer, adjuster, tolerance,
+               "AntiAlias == False");
 
     RenderWith([=](SkCanvas*, SkPaint& p) { p.setDither(true); },  //
                [=](DisplayListBuilder& b) { b.setDither(true); },  //
@@ -606,7 +613,7 @@ class CanvasCompareTester {
             cv_renderer, dl_renderer, adjuster, tolerance,
             "ColorFilter == RotateRGB", &bg);
       }
-      ASSERT_TRUE(filter->unique()) << "ColorFilter Cleanup";
+      ASSERT_TRUE(filter->unique()) << "ColorFilter == RotateRGB Cleanup";
       filter = SkColorFilters::Matrix(invert_color_matrix);
       {
         SkColor bg = SK_ColorWHITE;
@@ -622,7 +629,7 @@ class CanvasCompareTester {
             cv_renderer, dl_renderer, adjuster, tolerance,
             "ColorFilter == Invert", &bg);
       }
-      ASSERT_TRUE(filter->unique()) << "ColorFilter Cleanup";
+      ASSERT_TRUE(filter->unique()) << "ColorFilter == Invert Cleanup";
     }
 
     {
@@ -654,7 +661,7 @@ class CanvasCompareTester {
                 .addBoundsPadding(2, 2),
             "PathEffect == Discrete-3-5");
       }
-      ASSERT_TRUE(effect->unique()) << "PathEffect Cleanup";
+      ASSERT_TRUE(effect->unique()) << "PathEffect == Discrete-3-5 Cleanup";
       effect = SkDiscretePathEffect::Make(2, 3);
       {
         RenderWith(
@@ -681,7 +688,7 @@ class CanvasCompareTester {
                 .addBoundsPadding(2, 2),
             "PathEffect == Discrete-2-3");
       }
-      ASSERT_TRUE(effect->unique()) << "PathEffect Cleanup";
+      ASSERT_TRUE(effect->unique()) << "PathEffect == Discrete-2-3 Cleanup";
     }
 
     {
@@ -703,7 +710,7 @@ class CanvasCompareTester {
             cv_renderer, dl_renderer, adjuster, blur5Tolerance,
             "MaskFilter == Blur 5");
       }
-      ASSERT_TRUE(filter->unique()) << "MaskFilter Cleanup";
+      ASSERT_TRUE(filter->unique()) << "MaskFilter == Blur 5 Cleanup";
       {
         RenderWith(
             [=](SkCanvas*, SkPaint& p) {
@@ -719,7 +726,8 @@ class CanvasCompareTester {
             cv_renderer, dl_renderer, adjuster, blur5Tolerance,
             "MaskFilter == Blur(Normal, 5.0)");
       }
-      ASSERT_TRUE(filter->unique()) << "MaskFilter Cleanup";
+      ASSERT_TRUE(filter->unique())
+          << "MaskFilter == Blur(Normal, 5.0) Cleanup";
     }
 
     {
@@ -745,7 +753,7 @@ class CanvasCompareTester {
                    cv_renderer, dl_renderer, adjuster, tolerance,
                    "LinearGradient GYB");
       }
-      ASSERT_TRUE(shader->unique()) << "Shader Cleanup";
+      ASSERT_TRUE(shader->unique()) << "LinearGradient GYB Cleanup";
     }
   }
 
@@ -915,7 +923,7 @@ class CanvasCompareTester {
             cv_renderer, dl_renderer, adjuster, tolerance,
             "PathEffect == Dash-29-2");
       }
-      ASSERT_TRUE(effect->unique()) << "PathEffect Cleanup";
+      ASSERT_TRUE(effect->unique()) << "PathEffect == Dash-29-2 Cleanup";
       effect = SkDashPathEffect::Make(TestDashes2, 2, 0.0f);
       {
         RenderWith(
@@ -936,7 +944,7 @@ class CanvasCompareTester {
             cv_renderer, dl_renderer, adjuster, tolerance,
             "PathEffect == Dash-17-1.5");
       }
-      ASSERT_TRUE(effect->unique()) << "PathEffect Cleanup";
+      ASSERT_TRUE(effect->unique()) << "PathEffect == Dash-17-1.5 Cleanup";
     }
   }
 
@@ -1016,7 +1024,7 @@ class CanvasCompareTester {
           b.clipRect(r_clip, true, SkClipOp::kIntersect);
         },
         cv_renderer, dl_renderer, intersect_adjuster, intersect_tolerance,
-        "AA ClipRect inset by 15.5");
+        "AntiAlias ClipRect inset by 15.5");
     RenderWith(
         [=](SkCanvas* c, SkPaint&) {
           c->clipRect(r_clip, SkClipOp::kDifference, false);
@@ -1044,7 +1052,7 @@ class CanvasCompareTester {
           b.clipRRect(rr_clip, true, SkClipOp::kIntersect);
         },
         cv_renderer, dl_renderer, intersect_adjuster, intersect_tolerance,
-        "AA ClipRRect inset by 15.5");
+        "AntiAlias ClipRRect inset by 15.5");
     RenderWith(
         [=](SkCanvas* c, SkPaint&) {
           c->clipRRect(rr_clip, SkClipOp::kDifference, false);
@@ -1075,7 +1083,7 @@ class CanvasCompareTester {
           b.clipPath(path_clip, true, SkClipOp::kIntersect);
         },
         cv_renderer, dl_renderer, intersect_adjuster, intersect_tolerance,
-        "AA ClipPath inset by 15.5");
+        "AntiAlias ClipPath inset by 15.5");
     RenderWith(
         [=](SkCanvas* c, SkPaint&) {
           c->clipPath(path_clip, SkClipOp::kDifference, false);
@@ -1121,7 +1129,7 @@ class CanvasCompareTester {
     ASSERT_EQ(ref_pixels.width(), TestWidth) << info;
     ASSERT_EQ(ref_pixels.height(), TestHeight) << info;
     ASSERT_EQ(ref_pixels.info().bytesPerPixel(), 4) << info;
-    checkPixels(&ref_pixels, ref_bounds, info, bg);
+    checkPixels(&ref_pixels, ref_bounds, info + " (Skia reference)", bg);
 
     {
       // This sequence plays the provided equivalently constructed
@@ -1159,7 +1167,8 @@ class CanvasCompareTester {
           << info;
 
       display_list->RenderTo(test_surface->getCanvas());
-      compareToReference(test_surface.get(), &ref_pixels, info + " (DL render)",
+      compareToReference(test_surface.get(), &ref_pixels,
+                         info + " (DisplayList built directly -> surface)",
                          &dl_bounds, &tolerance, bg);
     }
 
@@ -1176,7 +1185,8 @@ class CanvasCompareTester {
       cv_render(&dl_recorder, test_paint);
       dl_recorder.builder()->Build()->RenderTo(test_surface->getCanvas());
       compareToReference(test_surface.get(), &ref_pixels,
-                         info + " (Sk->DL render)", nullptr, nullptr, nullptr);
+                         info + " (Skia calls -> DisplayList -> surface)",
+                         nullptr, nullptr, nullptr);
     }
 
     {
@@ -1214,7 +1224,7 @@ class CanvasCompareTester {
       test_canvas->scale(TestScale, TestScale);
       display_list->RenderTo(test_canvas);
       compareToReference(test_surface.get(), &ref_pixels2,
-                         info + " (SKP/DL render scaled 2x)", nullptr, nullptr,
+                         info + " (Both rendered scaled 2x)", nullptr, nullptr,
                          nullptr, TestWidth2, TestHeight2, false);
     }
   }

--- a/flow/display_list_canvas_unittests.cc
+++ b/flow/display_list_canvas_unittests.cc
@@ -723,6 +723,9 @@ class CanvasCompareTester {
         if (!dl_bounds.contains(ref_bounds)) {
           FML_LOG(ERROR) << "DisplayList bounds are too small!";
         }
+        if (!ref_bounds.roundOut().contains(dl_bounds.roundOut())) {
+          FML_LOG(ERROR) << "###### DisplayList bounds are larger than reference!";
+        }
       }
 #endif  // DISPLAY_LIST_BOUNDS_ACCURACY_CHECKING
 

--- a/flow/display_list_utils.cc
+++ b/flow/display_list_utils.cc
@@ -137,103 +137,204 @@ void SkMatrixDispatchHelper::reset() {
 }
 
 void ClipBoundsDispatchHelper::clipRect(const SkRect& rect,
-                                        bool isAA,
+                                        bool is_aa,
                                         SkClipOp clip_op) {
   if (clip_op == SkClipOp::kIntersect) {
-    intersect(rect);
+    intersect(rect, is_aa);
   }
 }
 void ClipBoundsDispatchHelper::clipRRect(const SkRRect& rrect,
-                                         bool isAA,
+                                         bool is_aa,
                                          SkClipOp clip_op) {
   if (clip_op == SkClipOp::kIntersect) {
-    intersect(rrect.getBounds());
+    intersect(rrect.getBounds(), is_aa);
   }
 }
 void ClipBoundsDispatchHelper::clipPath(const SkPath& path,
-                                        bool isAA,
+                                        bool is_aa,
                                         SkClipOp clip_op) {
   if (clip_op == SkClipOp::kIntersect) {
-    intersect(path.getBounds());
+    intersect(path.getBounds(), is_aa);
   }
 }
-void ClipBoundsDispatchHelper::intersect(const SkRect& rect) {
+void ClipBoundsDispatchHelper::intersect(const SkRect& rect, bool is_aa) {
   SkRect devClipBounds = matrix().mapRect(rect);
-  if (!bounds_.intersect(devClipBounds)) {
-    bounds_.setEmpty();
+  if (is_aa) {
+    devClipBounds.roundOut(&devClipBounds);
+  }
+  if (has_clip_) {
+    if (!bounds_.intersect(devClipBounds)) {
+      bounds_.setEmpty();
+    }
+  } else {
+    has_clip_ = true;
+    if (devClipBounds.isEmpty()) {
+      bounds_.setEmpty();
+    } else {
+      bounds_ = devClipBounds;
+    }
   }
 }
 void ClipBoundsDispatchHelper::save() {
-  saved_.push_back(bounds_);
+  if (!has_clip_) {
+    saved_.push_back(SkRect::MakeLTRB(0, 0, -1, -1));
+  } else if (bounds_.isEmpty()) {
+    saved_.push_back(SkRect::MakeEmpty());
+  } else {
+    saved_.push_back(bounds_);
+  }
 }
 void ClipBoundsDispatchHelper::restore() {
   bounds_ = saved_.back();
   saved_.pop_back();
+  has_clip_ = (bounds_.fLeft <= bounds_.fRight &&  //
+               bounds_.fTop <= bounds_.fBottom);
+  if (!has_clip_) {
+    bounds_.setEmpty();
+  }
+}
+void ClipBoundsDispatchHelper::reset(const SkRect* cull_rect) {
+  if ((has_clip_ = cull_rect)) {
+    bounds_ = *cull_rect;
+  } else {
+    bounds_.setEmpty();
+  }
 }
 
-void DisplayListBoundsCalculator::saveLayer(const SkRect* bounds,
-                                            bool with_paint) {
-  SkMatrixDispatchHelper::save();
-  ClipBoundsDispatchHelper::save();
-  saved_infos_.emplace_back(
-      with_paint ? std::make_unique<SaveLayerWithPaintInfo>(
-                       this, accumulator_, matrix(), bounds, paint())
-                 : std::make_unique<SaveLayerInfo>(accumulator_, matrix()));
-  accumulator_ = saved_infos_.back()->save();
-  SkMatrixDispatchHelper::reset();
+DisplayListBoundsCalculator::DisplayListBoundsCalculator(
+    const SkRect* cull_rect)
+    : ClipBoundsDispatchHelper(cull_rect) {
+  layer_infos_.emplace_back(std::make_unique<RootLayerData>());
+  accumulator_ = layer_infos_.back()->accumulatorForLayer();
+}
+void DisplayListBoundsCalculator::setCaps(SkPaint::Cap cap) {
+  cap_is_square_ = (cap == SkPaint::kSquare_Cap);
+}
+void DisplayListBoundsCalculator::setJoins(SkPaint::Join join) {
+  join_is_miter_ = (join == SkPaint::kMiter_Join);
+}
+void DisplayListBoundsCalculator::setDrawStyle(SkPaint::Style style) {
+  style_flag_ = (style == SkPaint::kFill_Style) ? kIsFilledGeometry  //
+                                                : kIsStrokedGeometry;
+}
+void DisplayListBoundsCalculator::setStrokeWidth(SkScalar width) {
+  half_stroke_width_ = std::max(width * 0.5f, kMinStrokeWidth);
+}
+void DisplayListBoundsCalculator::setMiterLimit(SkScalar limit) {
+  miter_limit_ = std::max(limit, 1.0f);
+}
+void DisplayListBoundsCalculator::setBlendMode(SkBlendMode mode) {
+  blend_mode_ = mode;
+}
+void DisplayListBoundsCalculator::setBlender(sk_sp<SkBlender> blender) {
+  SkPaint paint;
+  paint.setBlender(std::move(blender));
+  blend_mode_ = paint.asBlendMode();
+}
+void DisplayListBoundsCalculator::setImageFilter(sk_sp<SkImageFilter> filter) {
+  image_filter_ = std::move(filter);
+}
+void DisplayListBoundsCalculator::setColorFilter(sk_sp<SkColorFilter> filter) {
+  color_filter_ = std::move(filter);
+}
+void DisplayListBoundsCalculator::setPathEffect(sk_sp<SkPathEffect> effect) {
+  path_effect_ = std::move(effect);
+}
+void DisplayListBoundsCalculator::setMaskFilter(sk_sp<SkMaskFilter> filter) {
+  mask_filter_ = std::move(filter);
+  mask_sigma_pad_ = 0.0f;
+}
+void DisplayListBoundsCalculator::setMaskBlurFilter(SkBlurStyle style,
+                                                    SkScalar sigma) {
+  mask_sigma_pad_ = std::max(3.0f * sigma, 0.0f);
+  mask_filter_ = nullptr;
 }
 void DisplayListBoundsCalculator::save() {
   SkMatrixDispatchHelper::save();
   ClipBoundsDispatchHelper::save();
-  saved_infos_.emplace_back(std::make_unique<SaveInfo>(accumulator_));
-  accumulator_ = saved_infos_.back()->save();
+  layer_infos_.emplace_back(std::make_unique<SaveData>(accumulator_));
+  accumulator_ = layer_infos_.back()->accumulatorForLayer();
+}
+void DisplayListBoundsCalculator::saveLayer(const SkRect* bounds,
+                                            bool with_paint) {
+  SkMatrixDispatchHelper::save();
+  ClipBoundsDispatchHelper::save();
+  if (with_paint) {
+    layer_infos_.emplace_back(std::make_unique<SaveLayerData>(
+        accumulator_, image_filter_, paintNopsOnTransparenBlack()));
+  } else {
+    layer_infos_.emplace_back(
+        std::make_unique<SaveLayerData>(accumulator_, nullptr, true));
+  }
+  accumulator_ = layer_infos_.back()->accumulatorForLayer();
+  // Accumulate the layer in its own coordinate system and then
+  // filter and transform its bounds on restore.
+  SkMatrixDispatchHelper::reset();
 }
 void DisplayListBoundsCalculator::restore() {
-  if (!saved_infos_.empty()) {
+  if (layer_infos_.size() > 1) {
     SkMatrixDispatchHelper::restore();
     ClipBoundsDispatchHelper::restore();
-    accumulator_ = saved_infos_.back()->restore();
-    saved_infos_.pop_back();
+    accumulator_ = layer_infos_.back()->accumulatorForRestore();
+    SkRect layer_bounds = layer_infos_.back()->getLayerBounds();
+    bool layer_flooded = layer_infos_.back()->is_flooded();
+    layer_infos_.pop_back();
+
+    // We accumulate the bounds even if the layer was flooded because
+    // the flooding may become a NOP, so we at least accumulate what
+    // we have.
+    if (!layer_bounds.isEmpty()) {
+      accumulateRect(layer_bounds, kIsNonGeometric);
+    }
+    if (layer_flooded) {
+      accumulateFlood();
+    }
   }
 }
 
 void DisplayListBoundsCalculator::drawPaint() {
-  if (!bounds_cull_.isEmpty()) {
-    root_accumulator_.accumulate(bounds_cull_);
-  }
+  accumulateFlood();
 }
 void DisplayListBoundsCalculator::drawColor(SkColor color, SkBlendMode mode) {
-  if (!bounds_cull_.isEmpty()) {
-    root_accumulator_.accumulate(bounds_cull_);
-  }
+  accumulateFlood();
 }
 void DisplayListBoundsCalculator::drawLine(const SkPoint& p0,
                                            const SkPoint& p1) {
   SkRect bounds = SkRect::MakeLTRB(p0.fX, p0.fY, p1.fX, p1.fY).makeSorted();
-  accumulateRect(bounds, kForceStroke | kIgnoreJoin);
+  int cap_flag = kIsStrokedGeometry;
+  if (bounds.width() > 0.0f && bounds.height() > 0.0f) {
+    cap_flag |= kGeometryMayHaveDiagonalEndCaps;
+  }
+  accumulateRect(bounds, cap_flag);
 }
 void DisplayListBoundsCalculator::drawRect(const SkRect& rect) {
-  // Right angle paths can ignore miter joins.
-  accumulateRect(rect, kIgnoreJoin | kIgnoreCap);
+  accumulateRect(rect, kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawOval(const SkRect& bounds) {
-  accumulateRect(bounds, kIgnoreJoin | kIgnoreCap);
+  accumulateRect(bounds, kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawCircle(const SkPoint& center,
                                              SkScalar radius) {
   accumulateRect(SkRect::MakeLTRB(center.fX - radius, center.fY - radius,
                                   center.fX + radius, center.fY + radius),
-                 kIgnoreJoin | kIgnoreCap);
+                 kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawRRect(const SkRRect& rrect) {
-  accumulateRect(rrect.getBounds(), kIgnoreJoin | kIgnoreCap);
+  accumulateRect(rrect.getBounds(), kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawDRRect(const SkRRect& outer,
                                              const SkRRect& inner) {
-  accumulateRect(outer.getBounds(), kIgnoreJoin | kIgnoreCap);
+  accumulateRect(outer.getBounds(), kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawPath(const SkPath& path) {
-  accumulateRect(path.getBounds());
+  if (path.isInverseFillType()) {
+    accumulateFlood();
+  } else {
+    accumulateRect(path.getBounds(),                   //
+                   (kIsDrawnGeometry |                 //
+                    kGeometryMayHaveDiagonalEndCaps |  //
+                    kGeometryMayHaveProblematicJoins));
+  }
 }
 void DisplayListBoundsCalculator::drawArc(const SkRect& bounds,
                                           SkScalar start,
@@ -242,7 +343,7 @@ void DisplayListBoundsCalculator::drawArc(const SkRect& bounds,
   // This could be tighter if we compute where the start and end
   // angles are and then also consider the quadrants swept and
   // the center if specified.
-  accumulateRect(bounds);
+  accumulateRect(bounds, kIsDrawnGeometry | kGeometryMayHaveDiagonalEndCaps);
 }
 void DisplayListBoundsCalculator::drawPoints(SkCanvas::PointMode mode,
                                              uint32_t count,
@@ -252,23 +353,26 @@ void DisplayListBoundsCalculator::drawPoints(SkCanvas::PointMode mode,
     for (size_t i = 0; i < count; i++) {
       ptBounds.accumulate(pts[i]);
     }
-    int flags = kForceStroke;
-    if (mode != SkCanvas::PointMode::kPolygon_PointMode) {
-      flags |= kIgnoreJoin;
+    int flags = kIsStrokedGeometry;
+    if (mode != SkCanvas::kPoints_PointMode) {
+      flags |= kGeometryMayHaveDiagonalEndCaps;
+      if (mode == SkCanvas::PointMode::kPolygon_PointMode) {
+        flags |= kGeometryMayHaveProblematicJoins;
+      }
     }
     accumulateRect(ptBounds.getBounds(), flags);
   }
 }
 void DisplayListBoundsCalculator::drawVertices(const sk_sp<SkVertices> vertices,
                                                SkBlendMode mode) {
-  accumulateRect(vertices->bounds(), kIgnoreStroke);
+  accumulateRect(vertices->bounds(), kIsFilledGeometry);
 }
 void DisplayListBoundsCalculator::drawImage(const sk_sp<SkImage> image,
                                             const SkPoint point,
                                             const SkSamplingOptions& sampling) {
-  SkRect bounds = SkRect::Make(image->bounds());
-  bounds.offset(point);
-  accumulateRect(bounds, kIgnoreStroke);
+  SkRect bounds = SkRect::MakeXYWH(point.fX, point.fY,  //
+                                   image->width(), image->height());
+  accumulateRect(bounds, kIsNonGeometric | kApplyMaskFilter);
 }
 void DisplayListBoundsCalculator::drawImageRect(
     const sk_sp<SkImage> image,
@@ -276,13 +380,13 @@ void DisplayListBoundsCalculator::drawImageRect(
     const SkRect& dst,
     const SkSamplingOptions& sampling,
     SkCanvas::SrcRectConstraint constraint) {
-  accumulateRect(dst, kIgnoreStroke);
+  accumulateRect(dst, kIsNonGeometric | kApplyMaskFilter);
 }
 void DisplayListBoundsCalculator::drawImageNine(const sk_sp<SkImage> image,
                                                 const SkIRect& center,
                                                 const SkRect& dst,
                                                 SkFilterMode filter) {
-  accumulateRect(dst, kIgnoreStroke);
+  accumulateRect(dst, kIsNonGeometric);
 }
 void DisplayListBoundsCalculator::drawImageLattice(
     const sk_sp<SkImage> image,
@@ -290,7 +394,7 @@ void DisplayListBoundsCalculator::drawImageLattice(
     const SkRect& dst,
     SkFilterMode filter,
     bool with_paint) {
-  accumulateRect(dst);
+  accumulateRect(dst, kIsNonGeometric | kApplyMaskFilter);
 }
 void DisplayListBoundsCalculator::drawAtlas(const sk_sp<SkImage> atlas,
                                             const SkRSXform xform[],
@@ -310,7 +414,7 @@ void DisplayListBoundsCalculator::drawAtlas(const sk_sp<SkImage> atlas,
     }
   }
   if (atlasBounds.isNotEmpty()) {
-    accumulateRect(atlasBounds.getBounds(), kIgnoreStroke);
+    accumulateRect(atlasBounds.getBounds(), kIsNonGeometric);
   }
 }
 void DisplayListBoundsCalculator::drawPicture(const sk_sp<SkPicture> picture,
@@ -323,125 +427,133 @@ void DisplayListBoundsCalculator::drawPicture(const sk_sp<SkPicture> picture,
   if (pic_matrix) {
     pic_matrix->mapRect(&bounds);
   }
-  if (with_save_layer) {
-    accumulateRect(bounds, kIgnoreStroke);
-  } else {
-    matrix().mapRect(&bounds);
-    accumulator_->accumulate(bounds);
-  }
+  accumulateRect(bounds, with_save_layer ? kIsFilledGeometry : kIsNonGeometric);
 }
 void DisplayListBoundsCalculator::drawDisplayList(
     const sk_sp<DisplayList> display_list) {
-  accumulateRect(display_list->bounds(), kIgnoreStroke);
+  accumulateRect(display_list->bounds(), kIsUnfiltered);
 }
 void DisplayListBoundsCalculator::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                                SkScalar x,
                                                SkScalar y) {
-  accumulateRect(blob->bounds().makeOffset(x, y));
+  accumulateRect(blob->bounds().makeOffset(x, y), kIsNonGeometric);
 }
 void DisplayListBoundsCalculator::drawShadow(const SkPath& path,
                                              const SkColor color,
                                              const SkScalar elevation,
                                              bool occludes,
                                              SkScalar dpr) {
-  accumulateRect(
-      PhysicalShapeLayer::ComputeShadowBounds(path, elevation, dpr, matrix()),
-      kIgnoreStroke);
+  SkRect shadow_bounds =
+      PhysicalShapeLayer::ComputeShadowBounds(path, elevation, dpr, matrix());
+  accumulateRect(shadow_bounds, kIsUnfiltered);
 }
 
-void DisplayListBoundsCalculator::accumulateRect(const SkRect& rect,
-                                                 int flags) {
-  SkRect dstRect = rect;
-  SkPaint p = paint();
-  if ((flags & kIgnoreStroke) != 0) {
-    FML_DCHECK((flags & kForceStroke) == 0);
-    p.setStyle(SkPaint::kFill_Style);
-  } else {
-    if ((flags & kForceStroke) != 0) {
-      p.setStyle(SkPaint::kStroke_Style);
-    }
-    if (p.getStyle() != SkPaint::kFill_Style) {
-      if ((flags & kIgnoreCap) != 0) {
-        p.setStrokeCap(SkPaint::kRound_Cap);
+bool DisplayListBoundsCalculator::adjustBoundsForPaint(SkRect& bounds,
+                                                       int flags) {
+  if ((flags & kIsUnfiltered) != 0) {
+    FML_DCHECK(flags == kIsUnfiltered);
+    return true;
+  }
+
+  if ((flags & kIsAnyGeometryMask) != 0) {
+    // Path effect occurs before stroking...
+    if (path_effect_) {
+      SkPaint p;
+      p.setPathEffect(path_effect_);
+      if (!p.canComputeFastBounds()) {
+        return false;
       }
-      if ((flags & kIgnoreJoin) != 0) {
-        p.setStrokeJoin(SkPaint::kRound_Join);
+      bounds = p.computeFastBounds(bounds, &bounds);
+    }
+
+    if ((flags & kIsDrawnGeometry) != 0) {
+      FML_DCHECK((flags & (kIsFilledGeometry | kIsStrokedGeometry)) == 0);
+      flags |= style_flag_;
+    }
+    if ((flags & kIsStrokedGeometry) != 0) {
+      FML_DCHECK((flags & kIsFilledGeometry) == 0);
+      // Determine the max multiplier to the stroke width first.
+      SkScalar pad = 1.0f;
+      if (join_is_miter_ && (flags & kGeometryMayHaveProblematicJoins) != 0) {
+        pad = std::max(pad, miter_limit_);
       }
+      if (cap_is_square_ && (flags & kGeometryMayHaveDiagonalEndCaps) != 0) {
+        pad = std::max(pad, SK_ScalarSqrt2);
+      }
+      pad *= half_stroke_width_;
+      bounds.outset(pad, pad);
+    } else {
+      FML_DCHECK((flags & kIsStrokedGeometry) == 0);
+    }
+    flags |= kApplyMaskFilter;
+  } else {
+    FML_DCHECK((flags & (kGeometryMayHaveDiagonalEndCaps |
+                         kGeometryMayHaveProblematicJoins)) == 0);
+  }
+
+  if ((flags & kApplyMaskFilter) != 0) {
+    if (mask_filter_) {
+      SkPaint p;
+      p.setMaskFilter(mask_filter_);
+      if (!p.canComputeFastBounds()) {
+        return false;
+      }
+      bounds = p.computeFastBounds(bounds, &bounds);
+    }
+    if (mask_sigma_pad_ > 0.0f) {
+      bounds.outset(mask_sigma_pad_, mask_sigma_pad_);
     }
   }
-  if (p.canComputeFastBounds()) {
-    dstRect = p.computeFastBounds(rect, &dstRect);
-    matrix().mapRect(&dstRect);
-    accumulator_->accumulate(dstRect);
+
+  if (image_filter_) {
+    if (!image_filter_->canComputeFastBounds()) {
+      FML_LOG(ERROR) << "ImageFilter cannot compute bounds";
+      return false;
+    }
+    bounds = image_filter_->computeFastBounds(bounds);
+  }
+
+  return true;
+}
+
+void DisplayListBoundsCalculator::accumulateFlood() {
+  if (has_clip()) {
+    accumulator_->accumulate(getClipBounds());
   } else {
-    root_accumulator_.accumulate(bounds_cull_);
+    layer_infos_.back()->set_flooded();
+  }
+}
+void DisplayListBoundsCalculator::accumulateRect(SkRect& rect, int flags) {
+  if (adjustBoundsForPaint(rect, flags)) {
+    matrix().mapRect(&rect);
+    if (!has_clip() || rect.intersect(getClipBounds())) {
+      accumulator_->accumulate(rect);
+    }
+  } else {
+    accumulateFlood();
   }
 }
 
-DisplayListBoundsCalculator::SaveInfo::SaveInfo(BoundsAccumulator* accumulator)
-    : saved_accumulator_(accumulator) {}
-BoundsAccumulator* DisplayListBoundsCalculator::SaveInfo::save() {
-  // No need to swap out the accumulator for a normal save
-  return saved_accumulator_;
-}
-BoundsAccumulator* DisplayListBoundsCalculator::SaveInfo::restore() {
-  return saved_accumulator_;
-}
-
-DisplayListBoundsCalculator::SaveLayerInfo::SaveLayerInfo(
-    BoundsAccumulator* accumulator,
-    const SkMatrix& matrix)
-    : SaveInfo(accumulator), matrix_(matrix) {}
-BoundsAccumulator* DisplayListBoundsCalculator::SaveLayerInfo::save() {
-  // Use the local layerAccumulator until restore is called and
-  // then transform (and adjust with paint if necessary) on restore()
-  return &layer_accumulator_;
-}
-BoundsAccumulator* DisplayListBoundsCalculator::SaveLayerInfo::restore() {
-  SkRect layer_bounds = layer_accumulator_.getBounds();
-  layer_bounds.roundOut(&layer_bounds);
-  matrix_.mapRect(&layer_bounds);
-  saved_accumulator_->accumulate(layer_bounds);
-  return saved_accumulator_;
-}
-
-DisplayListBoundsCalculator::SaveLayerWithPaintInfo::SaveLayerWithPaintInfo(
-    DisplayListBoundsCalculator* calculator,
-    BoundsAccumulator* accumulator,
-    const SkMatrix& saveMatrix,
-    const SkRect* saveBounds,
-    const SkPaint& savePaint)
-    : SaveLayerInfo(accumulator, saveMatrix),
-      calculator_(calculator),
-      paint_(savePaint) {
-  if (saveBounds) {
-    bounds_.emplace(*saveBounds);
-  }
-}
-
-static bool PaintNopsOnTransparenBlack(const SkPaint& paint) {
-  SkImageFilter* image_filter = paint.getImageFilter();
+bool DisplayListBoundsCalculator::paintNopsOnTransparenBlack() {
   // SkImageFilter::canComputeFastBounds tests for transparency behavior
   // This test assumes that the blend mode checked down below will
   // NOP on transparent black.
-  if (image_filter && !image_filter->canComputeFastBounds()) {
+  if (image_filter_ && !image_filter_->canComputeFastBounds()) {
     return false;
   }
 
-  SkColorFilter* color_filter = paint.getColorFilter();
   // We filter the transparent black that is used for the background of a
   // saveLayer and make sure it returns transparent black. If it does, then
   // the color filter will leave all area surrounding the contents of the
   // save layer untouched out to the edge of the output surface.
   // This test assumes that the blend mode checked down below will
   // NOP on transparent black.
-  if (color_filter &&
-      color_filter->filterColor(SK_ColorTRANSPARENT) != SK_ColorTRANSPARENT) {
+  if (color_filter_ &&
+      color_filter_->filterColor(SK_ColorTRANSPARENT) != SK_ColorTRANSPARENT) {
     return false;
   }
 
-  const auto blend_mode = paint.asBlendMode();
-  if (!blend_mode) {
+  if (!blend_mode_) {
     return false;  // can we query other blenders for this?
   }
   // Unusual blendmodes require us to process a saved layer
@@ -449,7 +561,7 @@ static bool PaintNopsOnTransparenBlack(const SkPaint& paint) {
   // For example, DstIn is used by masking layers.
   // https://code.google.com/p/skia/issues/detail?id=1291
   // https://crbug.com/401593
-  switch (blend_mode.value()) {
+  switch (blend_mode_.value()) {
     // For each of the following transfer modes, if the source
     // alpha is zero (our transparent black), the resulting
     // blended pixel is not necessarily equal to the original
@@ -496,32 +608,6 @@ static bool PaintNopsOnTransparenBlack(const SkPaint& paint) {
       return true;
       break;
   }
-}
-
-BoundsAccumulator*
-DisplayListBoundsCalculator::SaveLayerWithPaintInfo::restore() {
-  SkRect layer_bounds;
-  if (paint_.canComputeFastBounds() && PaintNopsOnTransparenBlack(paint_)) {
-    // The ideal situation. The paint can compute the bounds AND the
-    // surrounding transparent pixels will not affect the destination.
-    layer_bounds = layer_accumulator_.getBounds();
-    layer_bounds = paint_.computeFastBounds(layer_bounds, &layer_bounds);
-  } else if (bounds_.has_value()) {
-    // Bounds were provided by the save layer, the operation will affect
-    // all of those bounds.
-    layer_bounds = bounds_.value();
-  } else {
-    // Bounds were not provided for the save layer. We will fill to the
-    // cull bounds provided to the original DisplayList.
-    calculator_->root_accumulator_.accumulate(calculator_->bounds_cull_);
-    // There is no need to process the layer bounds further as we just
-    // expanded bounds to the cull rect of the DisplayList.
-    return saved_accumulator_;
-  }
-  layer_bounds.roundOut(&layer_bounds);
-  matrix_.mapRect(&layer_bounds);
-  saved_accumulator_->accumulate(layer_bounds);
-  return saved_accumulator_;
 }
 
 }  // namespace flutter

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -343,7 +343,7 @@ class DisplayListBoundsCalculator final
   void drawShadow(const SkPath& path,
                   const SkColor color,
                   const SkScalar elevation,
-                  bool occludes,
+                  bool transparentOccluder,
                   SkScalar dpr) override;
 
   bool isFlooded() {

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -387,7 +387,28 @@ class DisplayListBoundsCalculator final
 
   std::vector<std::unique_ptr<SaveInfo>> saved_infos_;
 
-  void accumulateRect(const SkRect& rect, bool force_stroke = false);
+  // Some operations are defined as stroking some geometry and
+  // need to always consider stroke attributes regardless of the
+  // setting of the drawing style in the paint.
+  static constexpr int kForceStroke = 1;
+
+  // Some operations are defined as filling some geometry and
+  // should never consider stroke attributes regardless of the
+  // setting of the drawing style in the paint.
+  static constexpr int kIgnoreStroke = 2;
+
+  // Some operations are defined as closed paths and will never
+  // have any segment end points which might be decorated with
+  // a square cap that expands the geometry.
+  static constexpr int kIgnoreCap = 4;
+
+  // Some operations are defined as smooth paths or paths that
+  // never exceed 90 degrees at the corners.  Such paths will
+  // never have a corner that extends outside of the box defined
+  // by (path_bounds + stroke_width/2).
+  static constexpr int kIgnoreJoin = 8;
+
+  void accumulateRect(const SkRect& rect, int flags = 0);
 };
 
 }  // namespace flutter


### PR DESCRIPTION
These changes are to help improve our bounds calculations - and thus our cache memory usage - for the DisplayList.

The effort was triggered by the regression documented in https://github.com/flutter/flutter/issues/88745 which resulted in disabling the DisplayList mechanism by default in the product. Rerunning the tests confirms that this PR fixes https://github.com/flutter/flutter/issues/88745

Testing locally with the Flutter Gallery transition benchmarks we could see that our cache usage was higher with DisplayList and we've taken a number of steps to reduce that usage back to the baseline, including this PR and https://github.com/flutter/engine/pull/28158 and https://github.com/flutter/engine/pull/28287.

Improving our bounds resulted in a whole new algorithm for the `DisplayListBoundsCalculator` class which now does all of its own work except for a few cases where we deal with opaque Skia objects which must be trusted as sources or modifiers of rendering bounds (SkTextBlob, ShadowUtils, SkImageFilter, SkMaskFilter, SkPathEffect). Some reasons for introducing the new architecture were:

- Avoiding having to translate the DisplayList data into an SkPaint to compute the bounds
- Avoiding the fact that SkPaint cannot distinguish between various operations which have reduced bounds considerations (some operations are always strokes, others are always fills, some cannot produce a miter or an end cap, some may not be governed by a MaskFilter or PathEffect during rendering, etc). The SkPaint bounds computation method does not allow the caller to specify these conditions and so it would often produce bounds that were unnecessarily conservative because it took action based on attributes that didn't apply. Trying to "patch up" an SkPaint to reflect these conditions ended up even more complicated than just avoiding it in the first place.
- Avoiding some bugs in Skia bounds computations (which have all been reported). Most of these issues were due to a heavy reliance on developers only setting "the right attributes" that belonged with a given operation, but some of them resulted in under-computing the proper bounds (triggering a test failure in the canvas unit tests heavily updated in this PR). These issues have workarounds and you can see a number of lines of code in that file that refer to Skia bugs on a line that works around the referenced bugs...

For this PR the bounds accuracy testing in `display_list_canvas_unittests.cc` have been enabled by default and they now verify what should be reasonably optimal bounds representing a tradeoff between time and area. More importantly, there is an assert that our bounds are never larger than the bounds computed by SkPicture/Recorder for the tested cases which are fairly extensive, representing:

- Every drawing operation we support
- Rendered with every Paint attribute we support
- Rendered with a variety of Clip options
- Rendered with a variety of transforms
- Rendered with a few cases of save/saveLayer/restore

The matrix of tests is quite large and the bounds returned are both encompassing of all pixels that were rendered (or else a hard test failure results) and no looser than those computed by the Skia mechanism (which, for now, just reports the condition as it does not represent a functional program bug). (Note that our bounds accuracy performance is already being tracked by the recent changes to report cache metrics for all benchmarks to Skia Perf so we should get perf failures if our cache usage regresses.)

The tests were modified in a couple of key ways to try to verify these conditions:

- Some tests were rendering a simple version of the primitive that didn't exhibit any corner cases (such as path join miters in particular). The tests were modified where possible to try to trigger any conditions that are covered by conservative estimates in the bounds calculations. Basically, they now try to "earn" their conservative bounds.
- A  "tolerance" object was added to the bounds tests to help account for cases where the bounds would be calculated with a conservative consideration that the test case cannot correct for. For example, the bounds calculation code might compute the bounds of a simple horizontal line as if it has an unruly assortment of geometry that triggers worst cases for joins, end caps, and path effects. Unfortunately, simple lines can never do that and the code to detect that case in the bounds calculations is outside of our current concept of a tradeoff between accuracy and computational speed - so we add a tolerance to the testing computations in some of those cases to overlook or forgive that extra bounds padding.
- Another tolerance case is an SkTextBlob for which we rely on Skia to tell us what the bounds of the glyphs are - but they return a dramatic overestimate of those bounds based on maximal typographic metrics and obscure glyphs present in the font. Even using the supposedly homogenous `ahem` font still produces wildly over-estimated bounds for a simple string. So, a tolerance for the base bounds of a text blob are recorded.
- Finally, some of the adjustments are attribute-specific. To that end, an adjuster function is allowed which can dynamically update the tolerances based on the final rendering attributes. This is used to dynamically handle path effect tolerances for lines as well as targeting a relaxation of tolerances for some operations under a perspective transform where the bounds computed are highly conservative.

A minor, seemingly unrelated, change in the code was made to rename one of the parameters to drawShadow which had a name that conflicted with its usage. It shouldn't have been causing problems because it was just passed along from source to destination as "that flag that the developer handed us and which we need to remember and eventually pass to Skia". Since we never interpreted its value ourselves, the name didn't really matter, but I noticed it was wrong when I was updating the shadow tests.