### PR TITLE
Remove parameter ignore_raster_cache, which is not really used. (#88323)

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -68,10 +68,9 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
 }
 
 RasterStatus CompositorContext::ScopedFrame::Raster(
-    flutter::LayerTree& layer_tree,
-    bool ignore_raster_cache) {
+    flutter::LayerTree& layer_tree) {
   TRACE_EVENT0("flutter", "CompositorContext::ScopedFrame::Raster");
-  bool root_needs_readback = layer_tree.Preroll(*this, ignore_raster_cache);
+  bool root_needs_readback = layer_tree.Preroll(*this);
   bool needs_save_layer = root_needs_readback && !surface_supports_readback();
   PostPrerollResult post_preroll_result = PostPrerollResult::kSuccess;
   if (view_embedder_ && raster_thread_merger_) {
@@ -97,7 +96,7 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
     }
     canvas()->clear(SK_ColorTRANSPARENT);
   }
-  layer_tree.Paint(*this, ignore_raster_cache);
+  layer_tree.Paint(*this);
   if (canvas() && needs_save_layer) {
     canvas()->restore();
   }

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -83,8 +83,7 @@ class CompositorContext {
 
     GrDirectContext* gr_context() const { return gr_context_; }
 
-    virtual RasterStatus Raster(LayerTree& layer_tree,
-                                bool ignore_raster_cache);
+    virtual RasterStatus Raster(LayerTree& layer_tree);
 
    private:
     CompositorContext& context_;

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -22,8 +22,7 @@ LayerTree::LayerTree(const SkISize& frame_size, float device_pixel_ratio)
   FML_CHECK(device_pixel_ratio_ != 0.0f);
 }
 
-bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
-                        bool ignore_raster_cache) {
+bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame) {
   TRACE_EVENT0("flutter", "LayerTree::Preroll");
 
   if (!root_layer_) {
@@ -37,7 +36,7 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       checkerboard_raster_cache_images_);
   MutatorsStack stack;
   PrerollContext context = {
-      ignore_raster_cache ? nullptr : &frame.context().raster_cache(),
+      &frame.context().raster_cache(),
       frame.gr_context(),
       frame.view_embedder(),
       stack,
@@ -54,8 +53,7 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
   return context.surface_needs_readback;
 }
 
-void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
-                      bool ignore_raster_cache) const {
+void LayerTree::Paint(CompositorContext::ScopedFrame& frame) const {
   TRACE_EVENT0("flutter", "LayerTree::Paint");
 
   if (!root_layer_) {
@@ -81,7 +79,7 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
       frame.context().raster_time(),
       frame.context().ui_time(),
       frame.context().texture_registry(),
-      ignore_raster_cache ? nullptr : &frame.context().raster_cache(),
+      &frame.context().raster_cache(),
       checkerboard_offscreen_layers_,
       device_pixel_ratio_};
 


### PR DESCRIPTION
Removed ignore_raster_cache, which was always set to false and was not really used.

*fixed by this PR*
- https://github.com/flutter/flutter/issues/88323


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
