### PR TITLE
Don't use Build.VERSION_CODES.S in test

### DIFF
--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -456,7 +456,8 @@ public class FlutterActivityTest {
           "reportFullyDrawn isn't used in API level " + version, flutterActivity.isFullyDrawn());
     }
 
-    for (int version = Build.VERSION_CODES.Q; version < Build.VERSION_CODES.S; version++) {
+    final int versionCodeS = 31;
+    for (int version = Build.VERSION_CODES.Q; version < versionCodeS; version++) {
       TestUtils.setApiVersion(version);
       flutterActivity.onFlutterUiDisplayed();
       assertTrue(


### PR DESCRIPTION
This change makes the cherry-pick of https://github.com/flutter/engine/pull/28593 easier.

Issue: https://github.com/flutter/flutter/issues/90144