### PR TITLE
Implement a default font manager for Fuchsia.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -187,6 +187,9 @@ struct Settings {
   // Selects the DisplayList for storage of rendering operations.
   bool enable_display_list = false;
 
+  // Data set by platform-specific embedders for use in font initialization.
+  uint32_t font_initialization_data = 0;
+
   // All shells in the process share the same VM. The last shell to shutdown
   // should typically shut down the VM as well. However, applications depend on
   // the behavior of "warming-up" the VM by creating a shell that does not do

--- a/lib/ui/text/font_collection.cc
+++ b/lib/ui/text/font_collection.cc
@@ -68,8 +68,9 @@ std::shared_ptr<txt::FontCollection> FontCollection::GetFontCollection() const {
   return collection_;
 }
 
-void FontCollection::SetupDefaultFontManager() {
-  collection_->SetupDefaultFontManager();
+void FontCollection::SetupDefaultFontManager(
+    uint32_t font_initialization_data) {
+  collection_->SetupDefaultFontManager(font_initialization_data);
 }
 
 void FontCollection::RegisterFonts(

--- a/lib/ui/text/font_collection.h
+++ b/lib/ui/text/font_collection.h
@@ -29,7 +29,7 @@ class FontCollection {
 
   std::shared_ptr<txt::FontCollection> GetFontCollection() const;
 
-  void SetupDefaultFontManager();
+  void SetupDefaultFontManager(uint32_t font_initialization_data);
 
   void RegisterFonts(std::shared_ptr<AssetManager> asset_manager);
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -144,7 +144,7 @@ fml::WeakPtr<Engine> Engine::GetWeakPtr() const {
 
 void Engine::SetupDefaultFontManager() {
   TRACE_EVENT0("flutter", "Engine::SetupDefaultFontManager");
-  font_collection_->SetupDefaultFontManager();
+  font_collection_->SetupDefaultFontManager(settings_.font_initialization_data);
 }
 
 std::shared_ptr<AssetManager> Engine::GetAssetManager() {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1831,7 +1831,7 @@ bool Shell::ReloadSystemFonts() {
   if (!engine_) {
     return false;
   }
-  engine_->GetFontCollection().GetFontCollection()->SetupDefaultFontManager();
+  engine_->SetupDefaultFontManager();
   engine_->GetFontCollection().GetFontCollection()->ClearFontFamilyCache();
   // After system fonts are reloaded, we send a system channel message
   // to notify flutter framework.

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build/fuchsia/sdk.gni")
 import("//flutter/common/config.gni")
 import("//flutter/testing/testing.gni")
 
@@ -174,6 +175,7 @@ source_set("txt") {
     sources += [ "src/txt/platform_linux.cc" ]
   } else if (is_fuchsia) {
     sources += [ "src/txt/platform_fuchsia.cc" ]
+    deps += [ "$fuchsia_sdk_root/fidl:fuchsia.fonts" ]
   } else if (is_win) {
     sources += [ "src/txt/platform_windows.cc" ]
   } else {
@@ -348,5 +350,13 @@ if (enable_unittests) {
              "//flutter/testing:testing_lib",
              ":txt_fixtures",
            ] + txt_common_executable_deps
+
+    if (is_fuchsia) {
+      sources += [ "tests/platform_fuchsia_unittests.cc" ]
+      deps += [
+        "$fuchsia_sdk_root/fidl:fuchsia.fonts",
+        "$fuchsia_sdk_root/pkg:async-testing",
+      ]
+    }
   }
 }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -97,8 +97,9 @@ size_t FontCollection::GetFontManagersCount() const {
   return GetFontManagerOrder().size();
 }
 
-void FontCollection::SetupDefaultFontManager() {
-  default_font_manager_ = GetDefaultFontManager();
+void FontCollection::SetupDefaultFontManager(
+    uint32_t font_initialization_data) {
+  default_font_manager_ = GetDefaultFontManager(font_initialization_data);
 }
 
 void FontCollection::SetDefaultFontManager(sk_sp<SkFontMgr> font_manager) {

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -45,7 +45,7 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
 
   size_t GetFontManagersCount() const;
 
-  void SetupDefaultFontManager();
+  void SetupDefaultFontManager(uint32_t font_initialization_data);
   void SetDefaultFontManager(sk_sp<SkFontMgr> font_manager);
   void SetAssetFontManager(sk_sp<SkFontMgr> font_manager);
   void SetDynamicFontManager(sk_sp<SkFontMgr> font_manager);

--- a/third_party/txt/src/txt/platform.cc
+++ b/third_party/txt/src/txt/platform.cc
@@ -10,7 +10,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
   return {"Arial"};
 }
 
-sk_sp<SkFontMgr> GetDefaultFontManager() {
+sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
   return SkFontMgr::RefDefault();
 }
 

--- a/third_party/txt/src/txt/platform.h
+++ b/third_party/txt/src/txt/platform.h
@@ -15,7 +15,7 @@ namespace txt {
 
 std::vector<std::string> GetDefaultFontFamilies();
 
-sk_sp<SkFontMgr> GetDefaultFontManager();
+sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data);
 
 }  // namespace txt
 

--- a/third_party/txt/src/txt/platform_android.cc
+++ b/third_party/txt/src/txt/platform_android.cc
@@ -10,7 +10,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
   return {"sans-serif"};
 }
 
-sk_sp<SkFontMgr> GetDefaultFontManager() {
+sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
   return SkFontMgr::RefDefault();
 }
 

--- a/third_party/txt/src/txt/platform_fuchsia.cc
+++ b/third_party/txt/src/txt/platform_fuchsia.cc
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <lib/zx/channel.h>
+
+#include "third_party/skia/include/ports/SkFontMgr_fuchsia.h"
 #include "txt/platform.h"
 
 namespace txt {
@@ -10,8 +13,14 @@ std::vector<std::string> GetDefaultFontFamilies() {
   return {"Roboto"};
 }
 
-sk_sp<SkFontMgr> GetDefaultFontManager() {
-  return SkFontMgr::RefDefault();
+sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
+  if (font_initialization_data) {
+    fuchsia::fonts::ProviderSyncPtr sync_font_provider;
+    sync_font_provider.Bind(zx::channel(font_initialization_data));
+    return SkFontMgr_New_Fuchsia(std::move(sync_font_provider));
+  } else {
+    return SkFontMgr::RefDefault();
+  }
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -16,7 +16,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
   return {"Ubuntu", "Cantarell", "DejaVu Sans", "Liberation Sans", "Arial"};
 }
 
-sk_sp<SkFontMgr> GetDefaultFontManager() {
+sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
 #ifdef FLUTTER_USE_FONTCONFIG
   return SkFontMgr_New_FontConfig(nullptr);
 #else

--- a/third_party/txt/src/txt/platform_mac.mm
+++ b/third_party/txt/src/txt/platform_mac.mm
@@ -25,7 +25,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
   }
 }
 
-sk_sp<SkFontMgr> GetDefaultFontManager() {
+sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
   return SkFontMgr::RefDefault();
 }
 

--- a/third_party/txt/src/txt/platform_windows.cc
+++ b/third_party/txt/src/txt/platform_windows.cc
@@ -11,7 +11,7 @@ std::vector<std::string> GetDefaultFontFamilies() {
   return {"Segoe UI", "Arial"};
 }
 
-sk_sp<SkFontMgr> GetDefaultFontManager() {
+sk_sp<SkFontMgr> GetDefaultFontManager(uint32_t font_initialization_data) {
   return SkFontMgr_New_DirectWrite();
 }
 

--- a/third_party/txt/tests/fake_provider.h
+++ b/third_party/txt/tests/fake_provider.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fuchsia/fonts/cpp/fidl_test_base.h>
+#include <lib/fidl/cpp/binding.h>
+#include <lib/fidl/cpp/interface_handle.h>
+
+#include "flutter/fml/logging.h"
+
+namespace txt {
+
+class FakeProvider : public fuchsia::fonts::testing::Provider_TestBase {
+ public:
+  FakeProvider() : binding_(this) {}
+
+  fidl::InterfaceHandle<fuchsia::fonts::Provider> Bind(
+      async_dispatcher_t* dispatcher) {
+    FML_CHECK(!binding_.is_bound());
+
+    fidl::InterfaceHandle<fuchsia::fonts::Provider> provider;
+    binding_.Bind(provider.NewRequest(), dispatcher);
+
+    return provider;
+  }
+
+  virtual void NotImplemented_(const std::string& name) override {
+    FML_LOG(ERROR) << "A fidl call for " << name
+                   << " on fake_provider is not implemented! This likely means"
+                      "that your test will hang.";
+  }
+
+  void GetFontFamilyInfo(fuchsia::fonts::FamilyName family,
+                         GetFontFamilyInfoCallback callback) override {
+    was_invoked_ = true;
+    callback(fuchsia::fonts::FontFamilyInfo());
+  }
+
+  bool WasInvoked() { return was_invoked_; }
+
+ private:
+  fidl::Binding<fuchsia::fonts::Provider> binding_;
+  bool was_invoked_ = false;
+};
+
+}  // namespace txt

--- a/third_party/txt/tests/platform_fuchsia_unittests.cc
+++ b/third_party/txt/tests/platform_fuchsia_unittests.cc
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <lib/async-loop/cpp/loop.h>
+#include <lib/async-loop/default.h>
+#include <lib/async-testing/test_loop.h>
+
+#include "fake_provider.h"
+#include "gtest/gtest.h"
+#include "txt/platform.h"
+
+namespace txt {
+
+class PlatformFuchsiaTest : public ::testing::Test {
+ protected:
+  PlatformFuchsiaTest() : loop_(&kAsyncLoopConfigNoAttachToCurrentThread) {
+    loop_.StartThread();
+  }
+
+  async::Loop& loop() { return loop_; }
+
+  FakeProvider& fake_provider() { return fake_provider_; }
+
+  fidl::InterfaceHandle<fuchsia::fonts::Provider> GetProvider() {
+    return fake_provider_.Bind(loop_.dispatcher());
+  }
+
+  void TearDown() override {
+    loop_.Quit();
+    loop_.JoinThreads();
+  }
+
+ private:
+  async::Loop loop_;  // Must come before FIDL bindings.
+  FakeProvider fake_provider_;
+};
+
+TEST_F(PlatformFuchsiaTest, GetDefaultFontManager) {
+  zx_handle_t handle = GetProvider().TakeChannel().release();
+  auto font_manager = GetDefaultFontManager(handle);
+
+  // Nonnull font initialization data should not create SkFontMgr::RefDefault().
+  EXPECT_NE(font_manager, SkFontMgr::RefDefault());
+
+  // Check to see that our font provider was called.
+  EXPECT_FALSE(fake_provider().WasInvoked());
+  font_manager->matchFamily("Invalid font.");
+  EXPECT_TRUE(fake_provider().WasInvoked());
+}
+
+TEST_F(PlatformFuchsiaTest, GetDefaultFontManagerFail) {
+  // Null font initialization data should create SkFontMgr::RefDefault().
+  EXPECT_EQ(GetDefaultFontManager(0), SkFontMgr::RefDefault());
+}
+
+}  // namespace txt


### PR DESCRIPTION
This helps us get rid of our hacky font switch after engine initialization.

Test: Added to txt_unittests
Bug: https://fxbug.dev/76406
Bug: flutter/flutter#82202.