### PR TITLE
[web] clear surfaces on hot restart

### DIFF
--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -361,6 +361,17 @@ void registerHotRestartListener(ui.VoidCallback listener) {
   _hotRestartListeners.add(listener);
 }
 
+/// Pretends that hot restart is about to happen.
+///
+/// Useful in tests to check that the engine performs appropriate clean-ups,
+/// such as removing static DOM listeners, prior to allowing the Dart runtime
+/// to re-initialize the program.
+void debugEmulateHotRestart() {
+  for (final ui.VoidCallback listener in _hotRestartListeners) {
+    listener();
+  }
+}
+
 /// This method performs one-time initialization of the Web environment that
 /// supports the Flutter framework.
 ///

--- a/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
@@ -4,6 +4,7 @@
 
 import 'package:meta/meta.dart';
 
+import '../../engine.dart';
 import '../util.dart';
 import 'embedded_views.dart';
 import 'surface.dart';
@@ -16,7 +17,11 @@ class SurfaceFactory {
 
   SurfaceFactory(this.maximumSurfaces)
       : assert(maximumSurfaces >= 1,
-            'The maximum number of surfaces must be at least 1');
+            'The maximum number of surfaces must be at least 1') {
+    if (assertionsEnabled) {
+      registerHotRestartListener(debugClear);
+    }
+  }
 
   /// The base surface to paint on. This is the default surface which will be
   /// painted to. If there are no platform views, then this surface will receive

--- a/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
@@ -17,6 +17,11 @@ class SurfaceFactory {
   static SurfaceFactory get instance =>
       _instance ??= SurfaceFactory(HtmlViewEmbedder.maximumSurfaces);
 
+  /// Returns the raw (potentially uninitialized) value of the singleton.
+  ///
+  /// Useful in tests for checking the lifecycle of this class.
+  static SurfaceFactory? get debugUninitializedInstance => _instance;
+
   static SurfaceFactory? _instance;
 
   SurfaceFactory(this.maximumSurfaces)

--- a/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/surface_factory.dart
@@ -11,9 +11,13 @@ import 'surface.dart';
 
 /// Caches surfaces used to overlay platform views.
 class SurfaceFactory {
-  /// The cache singleton.
-  static final SurfaceFactory instance =
-      SurfaceFactory(HtmlViewEmbedder.maximumSurfaces);
+  /// The lazy-initialized singleton surface factory.
+  ///
+  /// [debugClear] causes this singleton to be reinitialized.
+  static SurfaceFactory get instance =>
+      _instance ??= SurfaceFactory(HtmlViewEmbedder.maximumSurfaces);
+
+  static SurfaceFactory? _instance;
 
   SurfaceFactory(this.maximumSurfaces)
       : assert(maximumSurfaces >= 1,
@@ -173,7 +177,10 @@ class SurfaceFactory {
     for (final Surface surface in _liveSurfaces) {
       surface.dispose();
     }
+    baseSurface.dispose();
+    backupSurface.dispose();
     _liveSurfaces.clear();
     _cache.clear();
+    _instance = null;
   }
 }


### PR DESCRIPTION
Surfaces register DOM event listeners, which need to be cleaned up before hot restarting, lest they are triggered after the hot restart and attempt to operate on discarded objects.

Fixes https://github.com/flutter/flutter/issues/90236.