### PR TITLE
fuchsia: Convert vulkan headers to DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -396,9 +396,13 @@ deps = {
   'src/third_party/pyyaml':
    Var('fuchsia_git') + '/third_party/pyyaml.git' + '@' + '25e97546488eee166b1abb229a27856cecd8b7ac',
 
-   # Headers for Vulkan 1.1
+   # Upstream Khronos Vulkan Headers (v1.1.91)
    'src/third_party/vulkan':
    Var('github_git') + '/KhronosGroup/Vulkan-Docs.git' + '@' + 'v1.1.91',
+
+   # Downstream Fuchsia Vulkan Headers (v1.2.148)
+  'src/third_party/fuchsia-vulkan':
+   Var('fuchsia_git') + '/third_party/Vulkan-Headers.git' + '@' + '651810b2fb877d819feaa00273035bfa16dec94b',
 
    'src/third_party/swiftshader':
    Var('swiftshader_git') + '/SwiftShader.git' + '@' + '5d1e8540407c138f47028d64684f3da599430aa4',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 3888099f467312adecd9d1ee4b26ce62
+Signature: c659eddfed39c5a418591dc1ae335f48
 
 UNUSED LICENSES:
 
@@ -254,6 +254,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: abseil-cpp
 LIBRARY: angle
 LIBRARY: boringssl
+LIBRARY: fuchsia-vulkan
 LIBRARY: khronos
 LIBRARY: libwebp
 LIBRARY: vulkan
@@ -1197,6 +1198,30 @@ FILE: ../../../third_party/boringssl/src/third_party/wycheproof_testvectors/x448
 FILE: ../../../third_party/boringssl/src/third_party/wycheproof_testvectors/x448_pem_test.json
 FILE: ../../../third_party/boringssl/src/third_party/wycheproof_testvectors/x448_test.json
 FILE: ../../../third_party/boringssl/src/third_party/wycheproof_testvectors/xchacha20_poly1305_test.json
+FILE: ../../../third_party/fuchsia-vulkan/cmake/cmake_uninstall.cmake.in
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vk_icd.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vk_layer.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vk_platform.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vk_sdk_platform.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan.hpp
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_android.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_beta.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_core.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_directfb.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_fuchsia.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_ggp.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_ios.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_macos.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_metal.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_vi.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_wayland.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_win32.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_xcb.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_xlib.h
+FILE: ../../../third_party/fuchsia-vulkan/include/vulkan/vulkan_xlib_xrandr.h
+FILE: ../../../third_party/fuchsia-vulkan/registry/validusage.json
+FILE: ../../../third_party/fuchsia-vulkan/registry/vk.xml
 FILE: ../../../third_party/khronos/GLES2/gl2platform.h
 FILE: ../../../third_party/khronos/GLES3/gl3platform.h
 FILE: ../../../third_party/libwebp/gradlew

--- a/common/graphics/BUILD.gn
+++ b/common/graphics/BUILD.gn
@@ -27,5 +27,8 @@ source_set("graphics") {
     "//third_party/skia",
   ]
 
-  public_configs = [ "//flutter:config" ]
+  public_configs = [
+    "//flutter:config",
+    "//flutter/vulkan:vulkan_config",
+  ]
 }

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -80,7 +80,10 @@ source_set("flow") {
     "surface_frame.h",
   ]
 
-  public_configs = [ "//flutter:config" ]
+  public_configs = [
+    "//flutter:config",
+    "//flutter/vulkan:vulkan_config",
+  ]
 
   deps = [
     "//flutter/common",

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -128,12 +128,14 @@ source_set("ui") {
 
   public_configs = [ "//flutter:config" ]
 
-  public_deps = [ "//flutter/third_party/txt" ]
+  public_deps = [
+    "//flutter/flow",
+    "//flutter/third_party/txt",
+  ]
 
   deps = [
     "//flutter/assets",
     "//flutter/common",
-    "//flutter/flow",
     "//flutter/fml",
     "//flutter/runtime:test_font",
     "//flutter/third_party/tonic",

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -75,7 +75,10 @@ source_set("runtime") {
     sources += [ "ptrace_check.cc" ]
   }
 
-  public_deps = [ "//third_party/rapidjson" ]
+  public_deps = [
+    "//flutter/lib/ui",
+    "//third_party/rapidjson",
+  ]
 
   public_configs = [ "//flutter:config" ]
 
@@ -86,7 +89,6 @@ source_set("runtime") {
     "//flutter/flow",
     "//flutter/fml",
     "//flutter/lib/io",
-    "//flutter/lib/ui",
     "//flutter/third_party/tonic",
     "//flutter/third_party/txt",
     "//third_party/dart/runtime:dart_api",

--- a/vulkan/BUILD.gn
+++ b/vulkan/BUILD.gn
@@ -8,7 +8,7 @@ config("vulkan_config") {
   include_dirs = []
   defines = []
   if (is_fuchsia) {
-    include_dirs += [ "$fuchsia_sdk_root/vulkan/include" ]
+    include_dirs += [ "//third_party/fuchsia-vulkan/include" ]
     defines += [ "VK_USE_PLATFORM_FUCHSIA=1" ]
   } else {
     include_dirs += [


### PR DESCRIPTION
These headers must be manually updated from time-to-time to stay in sync with fuchsia-specific extensions.  They exist in a public repository, so there is no need to maintain a vendored copy of them.

Once we move the fuchsia embedding out of flutter/engine, this dep will go away (the engine can use upstream vulkan headers only).

Functionally this PR is a no-op.  The headers are identical to those in //build/fuchsia/vulkan.  Follow-up PRs will update the headers to Vulkan 1.2.174 for Fuchsia and delete the buildroot copy of the headers.

Test:  Ran workstation in fuchsia tree
Bug: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=82397
