### PR TITLE
Do not share the GrDirectContext across engine instances on Android

### DIFF
--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -52,13 +52,7 @@ std::unique_ptr<Surface> AndroidSurfaceGL::CreateGPUSurface(
   if (gr_context) {
     return std::make_unique<GPUSurfaceGL>(sk_ref_sp(gr_context), this, true);
   } else {
-    sk_sp<GrDirectContext> main_skia_context =
-        GLContextPtr()->GetMainSkiaContext();
-    if (!main_skia_context) {
-      main_skia_context = GPUSurfaceGL::MakeGLContext(this);
-      GLContextPtr()->SetMainSkiaContext(main_skia_context);
-    }
-    return std::make_unique<GPUSurfaceGL>(main_skia_context, this, true);
+    return std::make_unique<GPUSurfaceGL>(this, true);
   }
 }
 
@@ -177,14 +171,7 @@ AndroidContextGL* AndroidSurfaceGL::GLContextPtr() const {
 
 std::unique_ptr<Surface> AndroidSurfaceGL::CreatePbufferSurface() {
   onscreen_surface_ = GLContextPtr()->CreatePbufferSurface();
-  sk_sp<GrDirectContext> main_skia_context =
-      GLContextPtr()->GetMainSkiaContext();
-  if (!main_skia_context) {
-    main_skia_context = GPUSurfaceGL::MakeGLContext(this);
-    GLContextPtr()->SetMainSkiaContext(main_skia_context);
-  }
-
-  return std::make_unique<GPUSurfaceGL>(main_skia_context, this, true);
+  return std::make_unique<GPUSurfaceGL>(this, true);
 }
 
 }  // namespace flutter

--- a/shell/platform/android/context/android_context.cc
+++ b/shell/platform/android/context/android_context.cc
@@ -9,11 +9,7 @@ namespace flutter {
 AndroidContext::AndroidContext(AndroidRenderingAPI rendering_api)
     : rendering_api_(rendering_api) {}
 
-AndroidContext::~AndroidContext() {
-  if (main_context_) {
-    main_context_->releaseResourcesAndAbandonContext();
-  }
-};
+AndroidContext::~AndroidContext() = default;
 
 AndroidRenderingAPI AndroidContext::RenderingApi() const {
   return rendering_api_;
@@ -21,15 +17,6 @@ AndroidRenderingAPI AndroidContext::RenderingApi() const {
 
 bool AndroidContext::IsValid() const {
   return true;
-}
-
-void AndroidContext::SetMainSkiaContext(
-    const sk_sp<GrDirectContext>& main_context) {
-  main_context_ = main_context;
-}
-
-sk_sp<GrDirectContext> AndroidContext::GetMainSkiaContext() const {
-  return main_context_;
 }
 
 }  // namespace flutter

--- a/shell/platform/android/context/android_context.h
+++ b/shell/platform/android/context/android_context.h
@@ -28,36 +28,8 @@ class AndroidContext {
 
   virtual bool IsValid() const;
 
-  //----------------------------------------------------------------------------
-  /// @brief      Setter for the Skia context to be used by subsequent
-  ///             AndroidSurfaces.
-  /// @details    This is useful to reduce memory consumption when creating
-  ///             multiple AndroidSurfaces for the same AndroidContext.
-  ///
-  ///             The first AndroidSurface should set this for the
-  ///             AndroidContext if the AndroidContext does not yet have a
-  ///             Skia context to share via GetMainSkiaContext.
-  ///
-  void SetMainSkiaContext(const sk_sp<GrDirectContext>& main_context);
-
-  //----------------------------------------------------------------------------
-  /// @brief      Accessor for the Skia context associated with AndroidSurfaces
-  ///             and the raster thread.
-  /// @details    This context is created lazily by the AndroidSurface based
-  ///             on their respective rendering backend and set on this
-  ///             AndroidContext to share via SetMainSkiaContext.
-  /// @returns    `nullptr` when no Skia context has been set yet by its
-  ///             AndroidSurface via SetMainSkiaContext.
-  /// @attention  The software context doesn't have a Skia context, so this
-  ///             value will be nullptr.
-  ///
-  sk_sp<GrDirectContext> GetMainSkiaContext() const;
-
  private:
   const AndroidRenderingAPI rendering_api_;
-
-  // This is the Skia context used for on-screen rendering.
-  sk_sp<GrDirectContext> main_context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidContext);
 };

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -293,8 +293,7 @@ std::unique_ptr<Surface> PlatformViewAndroid::CreateRenderingSurface() {
   if (!android_surface_) {
     return nullptr;
   }
-  return android_surface_->CreateGPUSurface(
-      android_context_->GetMainSkiaContext().get());
+  return android_surface_->CreateGPUSurface();
 }
 
 // |PlatformView|


### PR DESCRIPTION
The AndroidContext is owned by the PlatformViewAndroid and is
destructed on the platform thread.  If the AndroidContext owns the
GrDirectContext, then the GrDirectContext will also be destructed on
the platform thread.

This is unsafe because the platform thread does not have the EGL
context required to invoke OpenGL ES APIs.

See https://github.com/flutter/flutter/issues/87937
See https://github.com/flutter/flutter/issues/89658
