### PR TITLE
[UWP] Add modifier keys support

### DIFF
--- a/shell/platform/windows/keyboard_key_channel_handler.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler.cc
@@ -7,6 +7,7 @@
 #include <windows.h>
 
 #ifdef WINUWP
+#include "third_party/cppwinrt/generated/winrt/Windows.System.h"
 #include "third_party/cppwinrt/generated/winrt/Windows.UI.Core.h"
 #endif
 

--- a/shell/platform/windows/keyboard_key_channel_handler.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler.cc
@@ -6,6 +6,10 @@
 
 #include <windows.h>
 
+#ifdef WINUWP
+#include "third_party/cppwinrt/generated/winrt/Windows.UI.Core.h"
+#endif
+
 #include <iostream>
 
 #include "flutter/shell/platform/common/json_message_codec.h"
@@ -64,10 +68,48 @@ static constexpr int kScrollLock = 1 << 13;
 /// with the re-defined values declared above for compatibility with the Flutter
 /// framework.
 int GetModsForKeyState() {
-  // TODO(clarkezone) need to add support for get modifier state for UWP
-  // https://github.com/flutter/flutter/issues/70202
 #ifdef WINUWP
-  return 0;
+  using namespace winrt::Windows::System;
+  using namespace winrt::Windows::UI::Core;
+
+  auto window = CoreWindow::GetForCurrentThread();
+
+  auto key_is_down = [&window](VirtualKey key) {
+    auto state = window.GetKeyState(key);
+    return (state & CoreVirtualKeyStates::Down) == CoreVirtualKeyStates::Down;
+  };
+
+  int mods = 0;
+
+  if (key_is_down(VirtualKey::Shift))
+    mods |= kShift;
+  if (key_is_down(VirtualKey::LeftShift))
+    mods |= kShiftLeft;
+  if (key_is_down(VirtualKey::RightShift))
+    mods |= kShiftRight;
+  if (key_is_down(VirtualKey::Control))
+    mods |= kControl;
+  if (key_is_down(VirtualKey::LeftControl))
+    mods |= kControlLeft;
+  if (key_is_down(VirtualKey::RightControl))
+    mods |= kControlRight;
+  if (key_is_down(VirtualKey::Menu))
+    mods |= kAlt;
+  if (key_is_down(VirtualKey::LeftMenu))
+    mods |= kAltLeft;
+  if (key_is_down(VirtualKey::RightMenu))
+    mods |= kAltRight;
+  if (key_is_down(VirtualKey::LeftWindows))
+    mods |= kWinLeft;
+  if (key_is_down(VirtualKey::RightWindows))
+    mods |= kWinRight;
+  if (key_is_down(VirtualKey::CapitalLock))
+    mods |= kCapsLock;
+  if (key_is_down(VirtualKey::NumberKeyLock))
+    mods |= kNumLock;
+  if (key_is_down(VirtualKey::Scroll))
+    mods |= kScrollLock;
+  return mods;
 #else
   int mods = 0;
 


### PR DESCRIPTION
This PR adds modifier keys support by implementing GetModsForKeyState() in keyboard_key_channel_handler.cc.

This PR will fix flutter/flutter#82440.
This PR will complete one item in flutter/flutter#70202.

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.