### PR TITLE
Make benchmark parsing pre-submit non-bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -148,7 +148,6 @@ targets:
     scheduler: luci
 
   - name: Linux Benchmarks (no-upload)
-    bringup: true
     recipe: engine/engine_metrics
     properties:
       build_host: "true"


### PR DESCRIPTION
This has been passing as post-submit from inception
