### PR TITLE
Set MinimumOSVersion in iOS Info.plist based on buildroot setting

### DIFF
--- a/build/copy_info_plist.py
+++ b/build/copy_info_plist.py
@@ -10,14 +10,12 @@ engine.
 
 Precondition: $CWD/../../flutter is the path to the flutter engine repo.
 
-usage: copy_info_plist.py <src_path> <dest_path> --bitcode=<enable_bitcode>
+usage: copy_info_plist.py --source <src_path> --destination <dest_path> --bitcode --minversion=<deployment_target>
 """
-
-
-
 
 import subprocess
 
+import argparse
 import sys
 import git_revision
 import os
@@ -30,13 +28,25 @@ def GetClangVersion(bitcode) :
   return version.splitlines()[0]
 
 def main():
-  text = open(sys.argv[1]).read()
+
+  parser = argparse.ArgumentParser(
+      description='Copies the Info.plist and adds extra fields to it like the git hash of the engine')
+
+  parser.add_argument('--source', help='Path to Info.plist source template', type=str, required=True)
+  parser.add_argument('--destination', help='Path to destination Info.plist', type=str, required=True)
+  parser.add_argument('--bitcode', help='Built with bitcode', action='store_true')
+  parser.add_argument('--minversion', help='Minimum device OS version like "9.0"', type=str)
+
+  args = parser.parse_args()
+
+  text = open(args.source).read()
   engine_path = os.path.join(os.getcwd(), "..", "..", "flutter")
   revision = git_revision.GetRepositoryVersion(engine_path)
-  clang_version = GetClangVersion(sys.argv[3] == "--bitcode=true")
-  text = text.format(revision, clang_version)
+  bitcode = args.bitcode is not None;
+  clang_version = GetClangVersion(bitcode)
+  text = text.format(revision = revision, clang_version = clang_version, min_version = args.minversion)
 
-  with open(sys.argv[2], "w") as outfile:
+  with open(args.destination, "w") as outfile:
     outfile.write(text)
 
 if __name__ == "__main__":

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -259,7 +259,6 @@ shared_library("ios_test_flutter") {
     ":flutter_framework_source",
     ":ios_gpu_configuration",
     ":ios_test_flutter_mrc",
-    ":universal_flutter_framework",
     "//flutter/common:common",
     "//flutter/lib/ui:ui",
     "//flutter/shell/platform/darwin/common:framework_shared",

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -259,6 +259,7 @@ shared_library("ios_test_flutter") {
     ":flutter_framework_source",
     ":ios_gpu_configuration",
     ":ios_test_flutter_mrc",
+    ":universal_flutter_framework",
     "//flutter/common:common",
     "//flutter/lib/ui:ui",
     "//flutter/shell/platform/darwin/common:framework_shared",
@@ -323,10 +324,16 @@ action("copy_framework_info_plist") {
   sources = [ "framework/Info.plist" ]
   outputs = [ "$_flutter_framework_dir/Info.plist" ]
   args = [
+    "--source",
     rebase_path(sources[0]),
+    "--destination",
     rebase_path(outputs[0]),
-    "--bitcode=$enable_bitcode",
+    "--minversion",
+    ios_deployment_target,
   ]
+  if (enable_bitcode) {
+    args += [ "--bitcode" ]
+  }
 }
 
 copy("copy_framework_module_map") {

--- a/shell/platform/darwin/ios/framework/Info.plist
+++ b/shell/platform/darwin/ios/framework/Info.plist
@@ -21,10 +21,10 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>{min_version}</string>
   <key>FlutterEngine</key>
-  <string>{0}</string>
+  <string>{revision}</string>
   <key>ClangVersion</key>
-  <string>{1}</string>
+  <string>{clang_version}</string>
 </dict>
 </plist>

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#import <Foundation/Foundation.h>
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
@@ -28,6 +29,21 @@ FLUTTER_ASSERT_ARC
   id project = OCMClassMock([FlutterDartProject class]);
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
   XCTAssertNotNil(engine);
+}
+
+- (void)testInfoPlist {
+  NSBundle* flutterBundle = [NSBundle bundleForClass:[FlutterEngine class]];
+  XCTAssertEqualObjects(flutterBundle.bundleIdentifier, @"io.flutter.flutter");
+  NSDictionary<NSString*, id>* infoDictionary = flutterBundle.infoDictionary;
+  XCTAssertEqualObjects(infoDictionary[@"MinimumOSVersion"], @"9.0");
+
+  // SHA length is 40.
+  XCTAssertEqual(((NSString*)infoDictionary[@"FlutterEngine"]).length, 40);
+
+  // {clang_version} placeholder is 15 characters. The clang string version
+  // is longer than that, so check if the placeholder has been replaced, without
+  // actually checking a literal string, which could be different on various machines.
+  XCTAssertTrue(((NSString*)infoDictionary[@"ClangVersion"]).length > 15);
 }
 
 - (void)testDeallocated {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -38,12 +38,12 @@ FLUTTER_ASSERT_ARC
   XCTAssertEqualObjects(infoDictionary[@"MinimumOSVersion"], @"9.0");
 
   // SHA length is 40.
-  XCTAssertEqual(((NSString*)infoDictionary[@"FlutterEngine"]).length, 40);
+  XCTAssertEqual(((NSString*)infoDictionary[@"FlutterEngine"]).length, 40UL);
 
   // {clang_version} placeholder is 15 characters. The clang string version
   // is longer than that, so check if the placeholder has been replaced, without
   // actually checking a literal string, which could be different on various machines.
-  XCTAssertTrue(((NSString*)infoDictionary[@"ClangVersion"]).length > 15);
+  XCTAssertTrue(((NSString*)infoDictionary[@"ClangVersion"]).length > 15UL);
 }
 
 - (void)testDeallocated {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -32,8 +32,11 @@ FLUTTER_ASSERT_ARC
 }
 
 - (void)testInfoPlist {
-  NSBundle* flutterBundle = [NSBundle bundleForClass:[FlutterEngine class]];
-  XCTAssertEqualObjects(flutterBundle.bundleIdentifier, @"io.flutter.flutter");
+  // Check the embedded Flutter.framework Info.plist, not the linked dylib.
+  NSURL* flutterFrameworkURL =
+      [NSBundle.mainBundle.privateFrameworksURL URLByAppendingPathComponent:@"Flutter.framework"];
+  NSBundle* flutterBundle = [NSBundle bundleWithURL:flutterFrameworkURL];
+
   NSDictionary<NSString*, id>* infoDictionary = flutterBundle.infoDictionary;
   XCTAssertEqualObjects(infoDictionary[@"MinimumOSVersion"], @"9.0");
 

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -320,10 +320,14 @@ if (is_mac && !embedder_for_target) {
     outputs =
         [ "$_flutter_embedder_framework_dir/Versions/A/Resources/Info.plist" ]
     args = [
+      "--source",
       rebase_path(sources[0]),
+      "--destination",
       rebase_path(outputs[0]),
-      "--bitcode=$enable_bitcode",
     ]
+    if (enable_bitcode) {
+      args += [ "--bitcode" ]
+    }
   }
 
   copy("copy_module_map") {

--- a/shell/platform/embedder/assets/EmbedderInfo.plist
+++ b/shell/platform/embedder/assets/EmbedderInfo.plist
@@ -25,8 +25,8 @@
   <key>NSHumanReadableCopyright</key>
   <string>Copyright 2013 The Flutter Authors. All rights reserved.</string>
   <key>FlutterEngine</key>
-  <string>{0}</string>
+  <string>{revision}</string>
   <key>ClangVersion</key>
-  <string>{1}</string>
+  <string>{clang_version}</string>
 </dict>
 </plist>

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -14,9 +14,9 @@
 		0D6AB6BE22BB05E200EEE540 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0D6AB6BD22BB05E200EEE540 /* Assets.xcassets */; };
 		0D6AB6C122BB05E200EEE540 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0D6AB6BF22BB05E200EEE540 /* LaunchScreen.storyboard */; };
 		0D6AB6C422BB05E200EEE540 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D6AB6C322BB05E200EEE540 /* main.m */; };
-		0D6AB73F22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */; };
 		F7521D7826BB68BC005F15C5 /* libios_test_flutter.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = F7521D7226BB671E005F15C5 /* libios_test_flutter.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		F7521D7926BB68BC005F15C5 /* libocmock_shared.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = F7521D7526BB673E005F15C5 /* libocmock_shared.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		F77E081926FA9CE6003E6E4C /* Flutter.framework in Embed Libraries */ = {isa = PBXBuildFile; fileRef = F77E081726FA9CE6003E6E4C /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,6 +37,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				F7521D7826BB68BC005F15C5 /* libios_test_flutter.dylib in Embed Libraries */,
+				F77E081926FA9CE6003E6E4C /* Flutter.framework in Embed Libraries */,
 				F7521D7926BB68BC005F15C5 /* libocmock_shared.dylib in Embed Libraries */,
 			);
 			name = "Embed Libraries";
@@ -70,6 +71,7 @@
 		0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FlutterEngineConfig.xcconfig; sourceTree = "<group>"; };
 		F7521D7226BB671E005F15C5 /* libios_test_flutter.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libios_test_flutter.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libios_test_flutter.dylib"; sourceTree = "<group>"; };
 		F7521D7526BB673E005F15C5 /* libocmock_shared.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libocmock_shared.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libocmock_shared.dylib"; sourceTree = "<group>"; };
+		F77E081726FA9CE6003E6E4C /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = "../../../../out/$(FLUTTER_ENGINE)/Flutter.framework"; sourceTree = "<group>"; };
 		F7A3FDE026B9E0A300EADD61 /* FlutterAppDelegateTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterAppDelegateTest.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -167,6 +169,7 @@
 		0D6AB6FC22BC1BC300EEE540 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F77E081726FA9CE6003E6E4C /* Flutter.framework */,
 				F7521D7226BB671E005F15C5 /* libios_test_flutter.dylib */,
 				F7521D7526BB673E005F15C5 /* libocmock_shared.dylib */,
 			);
@@ -264,7 +267,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0D6AB73F22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
The Flutter.framework minimum version was bumped to 9.0 as of flutter/engine#28572 / flutter/buildroot#509.  However, the framework's Info.plist was not updated, which causes App Store "Invalid bundle" submission failures.

1. Adopt `argparse` in copy_info_plist.py to make it easier to add new arguments to the script
2. Add `--minversion` to the script, to be used as the `MinimumOSVersion` value in the iOS Info.plist to keep the value in sync with the buildroot setting.
3. Add a test to validate the Info.plist values. Embed (but do not link) the Flutter.framework in the test so it can be parsed.

Follow up to https://github.com/flutter/engine/pull/28783, would have also fixed https://github.com/flutter/flutter/issues/90209

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
