### PR TITLE
adjust naming of DisplayList methods, fields and parameters to match style guide

### DIFF
--- a/flow/display_list_canvas.cc
+++ b/flow/display_list_canvas.cc
@@ -55,19 +55,19 @@ void DisplayListCanvasDispatcher::transform3x3(SkScalar mxx,
 }
 
 void DisplayListCanvasDispatcher::clipRect(const SkRect& rect,
-                                           bool isAA,
-                                           SkClipOp clip_op) {
-  canvas_->clipRect(rect, clip_op, isAA);
+                                           SkClipOp clip_op,
+                                           bool is_aa) {
+  canvas_->clipRect(rect, clip_op, is_aa);
 }
 void DisplayListCanvasDispatcher::clipRRect(const SkRRect& rrect,
-                                            bool isAA,
-                                            SkClipOp clip_op) {
-  canvas_->clipRRect(rrect, clip_op, isAA);
+                                            SkClipOp clip_op,
+                                            bool is_aa) {
+  canvas_->clipRRect(rrect, clip_op, is_aa);
 }
 void DisplayListCanvasDispatcher::clipPath(const SkPath& path,
-                                           bool isAA,
-                                           SkClipOp clip_op) {
-  canvas_->clipPath(path, clip_op, isAA);
+                                           SkClipOp clip_op,
+                                           bool is_aa) {
+  canvas_->clipPath(path, clip_op, is_aa);
 }
 
 void DisplayListCanvasDispatcher::drawPaint() {
@@ -117,31 +117,38 @@ void DisplayListCanvasDispatcher::drawVertices(const sk_sp<SkVertices> vertices,
 }
 void DisplayListCanvasDispatcher::drawImage(const sk_sp<SkImage> image,
                                             const SkPoint point,
-                                            const SkSamplingOptions& sampling) {
-  canvas_->drawImage(image, point.fX, point.fY, sampling, &paint());
+                                            const SkSamplingOptions& sampling,
+                                            bool render_with_attributes) {
+  canvas_->drawImage(image, point.fX, point.fY, sampling,
+                     render_with_attributes ? &paint() : nullptr);
 }
 void DisplayListCanvasDispatcher::drawImageRect(
     const sk_sp<SkImage> image,
     const SkRect& src,
     const SkRect& dst,
     const SkSamplingOptions& sampling,
+    bool render_with_attributes,
     SkCanvas::SrcRectConstraint constraint) {
-  canvas_->drawImageRect(image, src, dst, sampling, &paint(), constraint);
+  canvas_->drawImageRect(image, src, dst, sampling,
+                         render_with_attributes ? &paint() : nullptr,
+                         constraint);
 }
 void DisplayListCanvasDispatcher::drawImageNine(const sk_sp<SkImage> image,
                                                 const SkIRect& center,
                                                 const SkRect& dst,
-                                                SkFilterMode filter) {
-  canvas_->drawImageNine(image.get(), center, dst, filter, &paint());
+                                                SkFilterMode filter,
+                                                bool render_with_attributes) {
+  canvas_->drawImageNine(image.get(), center, dst, filter,
+                         render_with_attributes ? &paint() : nullptr);
 }
 void DisplayListCanvasDispatcher::drawImageLattice(
     const sk_sp<SkImage> image,
     const SkCanvas::Lattice& lattice,
     const SkRect& dst,
     SkFilterMode filter,
-    bool with_paint) {
+    bool render_with_attributes) {
   canvas_->drawImageLattice(image.get(), lattice, dst, filter,
-                            with_paint ? &paint() : nullptr);
+                            render_with_attributes ? &paint() : nullptr);
 }
 void DisplayListCanvasDispatcher::drawAtlas(const sk_sp<SkImage> atlas,
                                             const SkRSXform xform[],
@@ -150,14 +157,16 @@ void DisplayListCanvasDispatcher::drawAtlas(const sk_sp<SkImage> atlas,
                                             int count,
                                             SkBlendMode mode,
                                             const SkSamplingOptions& sampling,
-                                            const SkRect* cullRect) {
+                                            const SkRect* cullRect,
+                                            bool render_with_attributes) {
   canvas_->drawAtlas(atlas.get(), xform, tex, colors, count, mode, sampling,
-                     cullRect, &paint());
+                     cullRect, render_with_attributes ? &paint() : nullptr);
 }
 void DisplayListCanvasDispatcher::drawPicture(const sk_sp<SkPicture> picture,
                                               const SkMatrix* matrix,
-                                              bool with_save_layer) {
-  canvas_->drawPicture(picture, matrix, with_save_layer ? &paint() : nullptr);
+                                              bool render_with_attributes) {
+  canvas_->drawPicture(picture, matrix,
+                       render_with_attributes ? &paint() : nullptr);
 }
 void DisplayListCanvasDispatcher::drawDisplayList(
     const sk_sp<DisplayList> display_list) {
@@ -176,10 +185,10 @@ void DisplayListCanvasDispatcher::drawTextBlob(const sk_sp<SkTextBlob> blob,
 void DisplayListCanvasDispatcher::drawShadow(const SkPath& path,
                                              const SkColor color,
                                              const SkScalar elevation,
-                                             bool transparentOccluder,
+                                             bool transparent_occluder,
                                              SkScalar dpr) {
   flutter::PhysicalShapeLayer::DrawShadow(canvas_, path, color, elevation,
-                                          transparentOccluder, dpr);
+                                          transparent_occluder, dpr);
 }
 
 DisplayListCanvasRecorder::DisplayListCanvasRecorder(const SkRect& bounds)
@@ -210,21 +219,21 @@ void DisplayListCanvasRecorder::didScale(SkScalar sx, SkScalar sy) {
 
 void DisplayListCanvasRecorder::onClipRect(const SkRect& rect,
                                            SkClipOp clip_op,
-                                           ClipEdgeStyle edgeStyle) {
-  builder_->clipRect(rect, edgeStyle == ClipEdgeStyle::kSoft_ClipEdgeStyle,
-                     clip_op);
+                                           ClipEdgeStyle edge_style) {
+  builder_->clipRect(rect, clip_op,
+                     edge_style == ClipEdgeStyle::kSoft_ClipEdgeStyle);
 }
 void DisplayListCanvasRecorder::onClipRRect(const SkRRect& rrect,
                                             SkClipOp clip_op,
-                                            ClipEdgeStyle edgeStyle) {
-  builder_->clipRRect(rrect, edgeStyle == ClipEdgeStyle::kSoft_ClipEdgeStyle,
-                      clip_op);
+                                            ClipEdgeStyle edge_style) {
+  builder_->clipRRect(rrect, clip_op,
+                      edge_style == ClipEdgeStyle::kSoft_ClipEdgeStyle);
 }
 void DisplayListCanvasRecorder::onClipPath(const SkPath& path,
                                            SkClipOp clip_op,
-                                           ClipEdgeStyle edgeStyle) {
-  builder_->clipPath(path, edgeStyle == ClipEdgeStyle::kSoft_ClipEdgeStyle,
-                     clip_op);
+                                           ClipEdgeStyle edge_style) {
+  builder_->clipPath(path, clip_op,
+                     edge_style == ClipEdgeStyle::kSoft_ClipEdgeStyle);
 }
 
 void DisplayListCanvasRecorder::willSave() {
@@ -311,8 +320,11 @@ void DisplayListCanvasRecorder::onDrawImage2(const SkImage* image,
                                              SkScalar dy,
                                              const SkSamplingOptions& sampling,
                                              const SkPaint* paint) {
-  RecordPaintAttributes(paint, DrawType::kImageOpType);
-  builder_->drawImage(sk_ref_sp(image), SkPoint::Make(dx, dy), sampling);
+  if (paint != nullptr) {
+    RecordPaintAttributes(paint, DrawType::kImageOpType);
+  }
+  builder_->drawImage(sk_ref_sp(image), SkPoint::Make(dx, dy), sampling,
+                      paint != nullptr);
 }
 void DisplayListCanvasRecorder::onDrawImageRect2(
     const SkImage* image,
@@ -321,8 +333,11 @@ void DisplayListCanvasRecorder::onDrawImageRect2(
     const SkSamplingOptions& sampling,
     const SkPaint* paint,
     SrcRectConstraint constraint) {
-  RecordPaintAttributes(paint, DrawType::kImageRectOpType);
-  builder_->drawImageRect(sk_ref_sp(image), src, dst, sampling, constraint);
+  if (paint != nullptr) {
+    RecordPaintAttributes(paint, DrawType::kImageRectOpType);
+  }
+  builder_->drawImageRect(sk_ref_sp(image), src, dst, sampling,
+                          paint != nullptr, constraint);
 }
 void DisplayListCanvasRecorder::onDrawImageLattice2(const SkImage* image,
                                                     const Lattice& lattice,
@@ -351,9 +366,11 @@ void DisplayListCanvasRecorder::onDrawAtlas2(const SkImage* image,
                                              const SkSamplingOptions& sampling,
                                              const SkRect* cull,
                                              const SkPaint* paint) {
-  RecordPaintAttributes(paint, DrawType::kImageOpType);
+  if (paint != nullptr) {
+    RecordPaintAttributes(paint, DrawType::kImageOpType);
+  }
   builder_->drawAtlas(sk_ref_sp(image), xform, src, colors, count, mode,
-                      sampling, cull);
+                      sampling, cull, paint != nullptr);
 }
 
 void DisplayListCanvasRecorder::onDrawTextBlob(const SkTextBlob* blob,
@@ -374,7 +391,7 @@ void DisplayListCanvasRecorder::onDrawShadowRec(const SkPath& path,
 void DisplayListCanvasRecorder::onDrawPicture(const SkPicture* picture,
                                               const SkMatrix* matrix,
                                               const SkPaint* paint) {
-  if (paint) {
+  if (paint != nullptr) {
     RecordPaintAttributes(paint, DrawType::kSaveLayerOpType);
   }
   builder_->drawPicture(sk_ref_sp(picture), matrix, paint != nullptr);
@@ -410,7 +427,7 @@ void DisplayListCanvasRecorder::RecordPaintAttributes(const SkPaint* paint,
     paint = new SkPaint();
   }
   if ((dataNeeded & kAaNeeded_) != 0 && current_aa_ != paint->isAntiAlias()) {
-    builder_->setAA(current_aa_ = paint->isAntiAlias());
+    builder_->setAntiAlias(current_aa_ = paint->isAntiAlias());
   }
   if ((dataNeeded & kDitherNeeded_) != 0 &&
       current_dither_ != paint->isDither()) {
@@ -444,7 +461,7 @@ void DisplayListCanvasRecorder::RecordPaintAttributes(const SkPaint* paint,
   // }
   if ((dataNeeded & kPaintStyleNeeded_) != 0) {
     if (current_style_ != paint->getStyle()) {
-      builder_->setDrawStyle(current_style_ = paint->getStyle());
+      builder_->setStyle(current_style_ = paint->getStyle());
     }
     if (current_style_ == SkPaint::Style::kStroke_Style) {
       dataNeeded |= kStrokeStyleNeeded_;
@@ -455,13 +472,13 @@ void DisplayListCanvasRecorder::RecordPaintAttributes(const SkPaint* paint,
       builder_->setStrokeWidth(current_stroke_width_ = paint->getStrokeWidth());
     }
     if (current_cap_ != paint->getStrokeCap()) {
-      builder_->setCaps(current_cap_ = paint->getStrokeCap());
+      builder_->setStrokeCap(current_cap_ = paint->getStrokeCap());
     }
     if (current_join_ != paint->getStrokeJoin()) {
-      builder_->setJoins(current_join_ = paint->getStrokeJoin());
+      builder_->setStrokeJoin(current_join_ = paint->getStrokeJoin());
     }
     if (current_miter_limit_ != paint->getStrokeMiter()) {
-      builder_->setMiterLimit(current_miter_limit_ = paint->getStrokeMiter());
+      builder_->setStrokeMiter(current_miter_limit_ = paint->getStrokeMiter());
     }
   }
   if ((dataNeeded & kShaderNeeded_) != 0 &&

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -53,9 +53,9 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                     SkScalar py,
                     SkScalar pt) override;
 
-  void clipRect(const SkRect& rect, bool isAA, SkClipOp clip_op) override;
-  void clipRRect(const SkRRect& rrect, bool isAA, SkClipOp clip_op) override;
-  void clipPath(const SkPath& path, bool isAA, SkClipOp clip_op) override;
+  void clipRect(const SkRect& rect, SkClipOp clip_op, bool isAA) override;
+  void clipRRect(const SkRRect& rrect, SkClipOp clip_op, bool isAA) override;
+  void clipPath(const SkPath& path, SkClipOp clip_op, bool isAA) override;
 
   void drawPaint() override;
   void drawColor(SkColor color, SkBlendMode mode) override;
@@ -77,21 +77,24 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                     SkBlendMode mode) override;
   void drawImage(const sk_sp<SkImage> image,
                  const SkPoint point,
-                 const SkSamplingOptions& sampling) override;
+                 const SkSamplingOptions& sampling,
+                 bool render_with_attributes) override;
   void drawImageRect(const sk_sp<SkImage> image,
                      const SkRect& src,
                      const SkRect& dst,
                      const SkSamplingOptions& sampling,
+                     bool render_with_attributes,
                      SkCanvas::SrcRectConstraint constraint) override;
   void drawImageNine(const sk_sp<SkImage> image,
                      const SkIRect& center,
                      const SkRect& dst,
-                     SkFilterMode filter) override;
+                     SkFilterMode filter,
+                     bool render_with_attributes) override;
   void drawImageLattice(const sk_sp<SkImage> image,
                         const SkCanvas::Lattice& lattice,
                         const SkRect& dst,
                         SkFilterMode filter,
-                        bool with_paint) override;
+                        bool render_with_attributes) override;
   void drawAtlas(const sk_sp<SkImage> atlas,
                  const SkRSXform xform[],
                  const SkRect tex[],
@@ -99,10 +102,11 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
                  int count,
                  SkBlendMode mode,
                  const SkSamplingOptions& sampling,
-                 const SkRect* cullRect) override;
+                 const SkRect* cullRect,
+                 bool render_with_attributes) override;
   void drawPicture(const sk_sp<SkPicture> picture,
                    const SkMatrix* matrix,
-                   bool with_save_layer) override;
+                   bool render_with_attributes) override;
   void drawDisplayList(const sk_sp<DisplayList> display_list) override;
   void drawTextBlob(const sk_sp<SkTextBlob> blob,
                     SkScalar x,
@@ -110,7 +114,7 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
   void drawShadow(const SkPath& path,
                   const SkColor color,
                   const SkScalar elevation,
-                  bool transparentOccluder,
+                  bool transparent_occluder,
                   SkScalar dpr) override;
 
  private:

--- a/flow/display_list_canvas_unittests.cc
+++ b/flow/display_list_canvas_unittests.cc
@@ -367,7 +367,7 @@ class CanvasCompareTester {
         },
         [=](DisplayListBuilder& b) {
           b.save();
-          b.clipRect(clip, false, SkClipOp::kIntersect);
+          b.clipRect(clip, SkClipOp::kIntersect, false);
           b.drawRect(rect);
           b.restore();
         },
@@ -472,11 +472,11 @@ class CanvasCompareTester {
                cv_renderer, dl_renderer, adjuster, tolerance, "Base Test");
 
     RenderWith([=](SkCanvas*, SkPaint& p) { p.setAntiAlias(true); },  //
-               [=](DisplayListBuilder& b) { b.setAA(true); },         //
+               [=](DisplayListBuilder& b) { b.setAntiAlias(true); },  //
                cv_renderer, dl_renderer, adjuster, tolerance,
                "AntiAlias == True");
     RenderWith([=](SkCanvas*, SkPaint& p) { p.setAntiAlias(false); },  //
-               [=](DisplayListBuilder& b) { b.setAA(false); },         //
+               [=](DisplayListBuilder& b) { b.setAntiAlias(false); },  //
                cv_renderer, dl_renderer, adjuster, tolerance,
                "AntiAlias == False");
 
@@ -649,7 +649,7 @@ class CanvasCompareTester {
               b.setStrokeWidth(5.0);
               // A Discrete(3, 5) effect produces miters that are near
               // maximal for a miter limit of 3.0.
-              b.setMiterLimit(3.0);
+              b.setStrokeMiter(3.0);
               b.setPathEffect(effect);
             },
             cv_renderer, dl_renderer, adjuster,
@@ -676,7 +676,7 @@ class CanvasCompareTester {
               b.setStrokeWidth(5.0);
               // A Discrete(2, 3) effect produces miters that are near
               // maximal for a miter limit of 2.5.
-              b.setMiterLimit(2.5);
+              b.setStrokeMiter(2.5);
               b.setPathEffect(effect);
             },
             cv_renderer, dl_renderer, adjuster,
@@ -766,13 +766,13 @@ class CanvasCompareTester {
     // by a couple of pixels so we will relax bounds testing for strokes by
     // a couple of pixels.
     BoundsTolerance tolerance = tolerance_in.addBoundsPadding(2, 2);
-    RenderWith(
+    RenderWith(  //
         [=](SkCanvas*, SkPaint& p) { p.setStyle(SkPaint::kFill_Style); },
-        [=](DisplayListBuilder& b) { b.setDrawStyle(SkPaint::kFill_Style); },
+        [=](DisplayListBuilder& b) { b.setStyle(SkPaint::kFill_Style); },
         cv_renderer, dl_renderer, adjuster, tolerance, "Fill");
     RenderWith(
         [=](SkCanvas*, SkPaint& p) { p.setStyle(SkPaint::kStroke_Style); },
-        [=](DisplayListBuilder& b) { b.setDrawStyle(SkPaint::kStroke_Style); },
+        [=](DisplayListBuilder& b) { b.setStyle(SkPaint::kStroke_Style); },
         cv_renderer, dl_renderer, adjuster, tolerance, "Stroke + defaults");
 
     RenderWith(
@@ -781,7 +781,7 @@ class CanvasCompareTester {
           p.setStrokeWidth(10.0);
         },
         [=](DisplayListBuilder& b) {
-          b.setDrawStyle(SkPaint::kFill_Style);
+          b.setStyle(SkPaint::kFill_Style);
           b.setStrokeWidth(10.0);
         },
         cv_renderer, dl_renderer, adjuster, tolerance,
@@ -793,7 +793,7 @@ class CanvasCompareTester {
           p.setStrokeWidth(10.0);
         },
         [=](DisplayListBuilder& b) {
-          b.setDrawStyle(SkPaint::kStroke_Style);
+          b.setStyle(SkPaint::kStroke_Style);
           b.setStrokeWidth(10.0);
         },
         cv_renderer, dl_renderer, adjuster, tolerance, "Stroke Width 10");
@@ -803,7 +803,7 @@ class CanvasCompareTester {
           p.setStrokeWidth(5.0);
         },
         [=](DisplayListBuilder& b) {
-          b.setDrawStyle(SkPaint::kStroke_Style);
+          b.setStyle(SkPaint::kStroke_Style);
           b.setStrokeWidth(5.0);
         },
         cv_renderer, dl_renderer, adjuster, tolerance, "Stroke Width 5");
@@ -815,9 +815,9 @@ class CanvasCompareTester {
           p.setStrokeCap(SkPaint::kButt_Cap);
         },
         [=](DisplayListBuilder& b) {
-          b.setDrawStyle(SkPaint::kStroke_Style);
+          b.setStyle(SkPaint::kStroke_Style);
           b.setStrokeWidth(5.0);
-          b.setCaps(SkPaint::kButt_Cap);
+          b.setStrokeCap(SkPaint::kButt_Cap);
         },
         cv_renderer, dl_renderer, adjuster, tolerance,
         "Stroke Width 5, Butt Cap");
@@ -828,9 +828,9 @@ class CanvasCompareTester {
           p.setStrokeCap(SkPaint::kRound_Cap);
         },
         [=](DisplayListBuilder& b) {
-          b.setDrawStyle(SkPaint::kStroke_Style);
+          b.setStyle(SkPaint::kStroke_Style);
           b.setStrokeWidth(5.0);
-          b.setCaps(SkPaint::kRound_Cap);
+          b.setStrokeCap(SkPaint::kRound_Cap);
         },
         cv_renderer, dl_renderer, adjuster, tolerance,
         "Stroke Width 5, Round Cap");
@@ -842,9 +842,9 @@ class CanvasCompareTester {
           p.setStrokeJoin(SkPaint::kBevel_Join);
         },
         [=](DisplayListBuilder& b) {
-          b.setDrawStyle(SkPaint::kStroke_Style);
+          b.setStyle(SkPaint::kStroke_Style);
           b.setStrokeWidth(5.0);
-          b.setJoins(SkPaint::kBevel_Join);
+          b.setStrokeJoin(SkPaint::kBevel_Join);
         },
         cv_renderer, dl_renderer, adjuster, tolerance,
         "Stroke Width 5, Bevel Join");
@@ -855,9 +855,9 @@ class CanvasCompareTester {
           p.setStrokeJoin(SkPaint::kRound_Join);
         },
         [=](DisplayListBuilder& b) {
-          b.setDrawStyle(SkPaint::kStroke_Style);
+          b.setStyle(SkPaint::kStroke_Style);
           b.setStrokeWidth(5.0);
-          b.setJoins(SkPaint::kRound_Join);
+          b.setStrokeJoin(SkPaint::kRound_Join);
         },
         cv_renderer, dl_renderer, adjuster, tolerance,
         "Stroke Width 5, Round Join");
@@ -873,13 +873,13 @@ class CanvasCompareTester {
           p.setAntiAlias(true);
         },
         [=](DisplayListBuilder& b) {
-          b.setDrawStyle(SkPaint::kStroke_Style);
+          b.setStyle(SkPaint::kStroke_Style);
           b.setStrokeWidth(5.0);
-          b.setMiterLimit(10.0);
-          b.setJoins(SkPaint::kMiter_Join);
+          b.setStrokeMiter(10.0);
+          b.setStrokeJoin(SkPaint::kMiter_Join);
           // AA helps fill in the peaks of the really thin miters better
           // for bounds accuracy testing
-          b.setAA(true);
+          b.setAntiAlias(true);
         },
         cv_renderer, dl_renderer, adjuster, tolerance,
         "Stroke Width 5, Miter 10");
@@ -892,10 +892,10 @@ class CanvasCompareTester {
           p.setStrokeJoin(SkPaint::kMiter_Join);
         },
         [=](DisplayListBuilder& b) {
-          b.setDrawStyle(SkPaint::kStroke_Style);
+          b.setStyle(SkPaint::kStroke_Style);
           b.setStrokeWidth(5.0);
-          b.setMiterLimit(0.0);
-          b.setJoins(SkPaint::kMiter_Join);
+          b.setStrokeMiter(0.0);
+          b.setStrokeJoin(SkPaint::kMiter_Join);
         },
         cv_renderer, dl_renderer, adjuster, tolerance,
         "Stroke Width 5, Miter 0");
@@ -915,7 +915,7 @@ class CanvasCompareTester {
             },
             [=](DisplayListBuilder& b) {
               // Need stroke style to see dashing properly
-              b.setDrawStyle(SkPaint::kStroke_Style);
+              b.setStyle(SkPaint::kStroke_Style);
               // Provide some non-trivial stroke size to get dashed
               b.setStrokeWidth(5.0);
               b.setPathEffect(effect);
@@ -936,7 +936,7 @@ class CanvasCompareTester {
             },
             [=](DisplayListBuilder& b) {
               // Need stroke style to see dashing properly
-              b.setDrawStyle(SkPaint::kStroke_Style);
+              b.setStyle(SkPaint::kStroke_Style);
               // Provide some non-trivial stroke size to get dashed
               b.setStrokeWidth(5.0);
               b.setPathEffect(effect);
@@ -1012,7 +1012,7 @@ class CanvasCompareTester {
           c->clipRect(r_clip, SkClipOp::kIntersect, false);
         },
         [=](DisplayListBuilder& b) {
-          b.clipRect(r_clip, false, SkClipOp::kIntersect);
+          b.clipRect(r_clip, SkClipOp::kIntersect, false);
         },
         cv_renderer, dl_renderer, intersect_adjuster, intersect_tolerance,
         "Hard ClipRect inset by 15.5");
@@ -1021,7 +1021,7 @@ class CanvasCompareTester {
           c->clipRect(r_clip, SkClipOp::kIntersect, true);
         },
         [=](DisplayListBuilder& b) {
-          b.clipRect(r_clip, true, SkClipOp::kIntersect);
+          b.clipRect(r_clip, SkClipOp::kIntersect, true);
         },
         cv_renderer, dl_renderer, intersect_adjuster, intersect_tolerance,
         "AntiAlias ClipRect inset by 15.5");
@@ -1030,7 +1030,7 @@ class CanvasCompareTester {
           c->clipRect(r_clip, SkClipOp::kDifference, false);
         },
         [=](DisplayListBuilder& b) {
-          b.clipRect(r_clip, false, SkClipOp::kDifference);
+          b.clipRect(r_clip, SkClipOp::kDifference, false);
         },
         cv_renderer, dl_renderer, diff_adjuster, diff_tolerance,
         "Hard ClipRect Diff, inset by 15.5");
@@ -1040,7 +1040,7 @@ class CanvasCompareTester {
           c->clipRRect(rr_clip, SkClipOp::kIntersect, false);
         },
         [=](DisplayListBuilder& b) {
-          b.clipRRect(rr_clip, false, SkClipOp::kIntersect);
+          b.clipRRect(rr_clip, SkClipOp::kIntersect, false);
         },
         cv_renderer, dl_renderer, intersect_adjuster, intersect_tolerance,
         "Hard ClipRRect inset by 15.5");
@@ -1049,7 +1049,7 @@ class CanvasCompareTester {
           c->clipRRect(rr_clip, SkClipOp::kIntersect, true);
         },
         [=](DisplayListBuilder& b) {
-          b.clipRRect(rr_clip, true, SkClipOp::kIntersect);
+          b.clipRRect(rr_clip, SkClipOp::kIntersect, true);
         },
         cv_renderer, dl_renderer, intersect_adjuster, intersect_tolerance,
         "AntiAlias ClipRRect inset by 15.5");
@@ -1058,7 +1058,7 @@ class CanvasCompareTester {
           c->clipRRect(rr_clip, SkClipOp::kDifference, false);
         },
         [=](DisplayListBuilder& b) {
-          b.clipRRect(rr_clip, false, SkClipOp::kDifference);
+          b.clipRRect(rr_clip, SkClipOp::kDifference, false);
         },
         cv_renderer, dl_renderer, diff_adjuster, diff_tolerance,
         "Hard ClipRRect Diff, inset by 15.5");
@@ -1071,7 +1071,7 @@ class CanvasCompareTester {
           c->clipPath(path_clip, SkClipOp::kIntersect, false);
         },
         [=](DisplayListBuilder& b) {
-          b.clipPath(path_clip, false, SkClipOp::kIntersect);
+          b.clipPath(path_clip, SkClipOp::kIntersect, false);
         },
         cv_renderer, dl_renderer, intersect_adjuster, intersect_tolerance,
         "Hard ClipPath inset by 15.5");
@@ -1080,7 +1080,7 @@ class CanvasCompareTester {
           c->clipPath(path_clip, SkClipOp::kIntersect, true);
         },
         [=](DisplayListBuilder& b) {
-          b.clipPath(path_clip, true, SkClipOp::kIntersect);
+          b.clipPath(path_clip, SkClipOp::kIntersect, true);
         },
         cv_renderer, dl_renderer, intersect_adjuster, intersect_tolerance,
         "AntiAlias ClipPath inset by 15.5");
@@ -1089,7 +1089,7 @@ class CanvasCompareTester {
           c->clipPath(path_clip, SkClipOp::kDifference, false);
         },
         [=](DisplayListBuilder& b) {
-          b.clipPath(path_clip, false, SkClipOp::kDifference);
+          b.clipPath(path_clip, SkClipOp::kDifference, false);
         },
         cv_renderer, dl_renderer, diff_adjuster, diff_tolerance,
         "Hard ClipPath Diff, inset by 15.5");
@@ -1872,7 +1872,20 @@ TEST(DisplayListCanvas, DrawImageNearest) {
       [=](DisplayListBuilder& builder) {  //
         builder.drawImage(CanvasCompareTester::testImage,
                           SkPoint::Make(RenderLeft, RenderTop),
-                          DisplayList::NearestSampling);
+                          DisplayList::NearestSampling, true);
+      });
+}
+
+TEST(DisplayListCanvas, DrawImageNearestNoPaint) {
+  CanvasCompareTester::RenderAll(
+      [=](SkCanvas* canvas, SkPaint& paint) {  //
+        canvas->drawImage(CanvasCompareTester::testImage, RenderLeft, RenderTop,
+                          DisplayList::NearestSampling, nullptr);
+      },
+      [=](DisplayListBuilder& builder) {  //
+        builder.drawImage(CanvasCompareTester::testImage,
+                          SkPoint::Make(RenderLeft, RenderTop),
+                          DisplayList::NearestSampling, false);
       });
 }
 
@@ -1885,7 +1898,7 @@ TEST(DisplayListCanvas, DrawImageLinear) {
       [=](DisplayListBuilder& builder) {  //
         builder.drawImage(CanvasCompareTester::testImage,
                           SkPoint::Make(RenderLeft, RenderTop),
-                          DisplayList::LinearSampling);
+                          DisplayList::LinearSampling, true);
       });
 }
 
@@ -1900,7 +1913,22 @@ TEST(DisplayListCanvas, DrawImageRectNearest) {
       },
       [=](DisplayListBuilder& builder) {  //
         builder.drawImageRect(CanvasCompareTester::testImage, src, dst,
-                              DisplayList::NearestSampling);
+                              DisplayList::NearestSampling, true);
+      });
+}
+
+TEST(DisplayListCanvas, DrawImageRectNearestNoPaint) {
+  SkRect src = SkRect::MakeIWH(RenderWidth, RenderHeight).makeInset(5, 5);
+  SkRect dst = RenderBounds.makeInset(15.5, 10.5);
+  CanvasCompareTester::RenderAll(
+      [=](SkCanvas* canvas, SkPaint& paint) {  //
+        canvas->drawImageRect(CanvasCompareTester::testImage, src, dst,
+                              DisplayList::NearestSampling, nullptr,
+                              SkCanvas::kFast_SrcRectConstraint);
+      },
+      [=](DisplayListBuilder& builder) {  //
+        builder.drawImageRect(CanvasCompareTester::testImage, src, dst,
+                              DisplayList::NearestSampling, false);
       });
 }
 
@@ -1915,7 +1943,7 @@ TEST(DisplayListCanvas, DrawImageRectLinear) {
       },
       [=](DisplayListBuilder& builder) {  //
         builder.drawImageRect(CanvasCompareTester::testImage, src, dst,
-                              DisplayList::LinearSampling);
+                              DisplayList::LinearSampling, true);
       });
 }
 
@@ -1929,7 +1957,21 @@ TEST(DisplayListCanvas, DrawImageNineNearest) {
       },
       [=](DisplayListBuilder& builder) {  //
         builder.drawImageNine(CanvasCompareTester::testImage, src, dst,
-                              SkFilterMode::kNearest);
+                              SkFilterMode::kNearest, true);
+      });
+}
+
+TEST(DisplayListCanvas, DrawImageNineNearestNoPaint) {
+  SkIRect src = SkIRect::MakeWH(RenderWidth, RenderHeight).makeInset(5, 5);
+  SkRect dst = RenderBounds.makeInset(15.5, 10.5);
+  CanvasCompareTester::RenderAll(
+      [=](SkCanvas* canvas, SkPaint& paint) {  //
+        canvas->drawImageNine(CanvasCompareTester::testImage.get(), src, dst,
+                              SkFilterMode::kNearest, nullptr);
+      },
+      [=](DisplayListBuilder& builder) {  //
+        builder.drawImageNine(CanvasCompareTester::testImage, src, dst,
+                              SkFilterMode::kNearest, false);
       });
 }
 
@@ -1943,7 +1985,7 @@ TEST(DisplayListCanvas, DrawImageNineLinear) {
       },
       [=](DisplayListBuilder& builder) {  //
         builder.drawImageNine(CanvasCompareTester::testImage, src, dst,
-                              SkFilterMode::kLinear);
+                              SkFilterMode::kLinear, true);
       });
 }
 
@@ -1970,6 +2012,32 @@ TEST(DisplayListCanvas, DrawImageLatticeNearest) {
       [=](DisplayListBuilder& builder) {                                   //
         builder.drawImageLattice(CanvasCompareTester::testImage, lattice,  //
                                  dst, SkFilterMode::kNearest, true);
+      });
+}
+
+TEST(DisplayListCanvas, DrawImageLatticeNearestNoPaint) {
+  const SkRect dst = RenderBounds.makeInset(15.5, 10.5);
+  const int divX[] = {
+      (RenderLeft + RenderCenterX) / 2,
+      RenderCenterX,
+      (RenderRight + RenderCenterX) / 2,
+  };
+  const int divY[] = {
+      (RenderTop + RenderCenterY) / 2,
+      RenderCenterY,
+      (RenderBottom + RenderCenterY) / 2,
+  };
+  SkCanvas::Lattice lattice = {
+      divX, divY, nullptr, 3, 3, nullptr, nullptr,
+  };
+  CanvasCompareTester::RenderAll(
+      [=](SkCanvas* canvas, SkPaint& paint) {  //
+        canvas->drawImageLattice(CanvasCompareTester::testImage.get(), lattice,
+                                 dst, SkFilterMode::kNearest, nullptr);
+      },
+      [=](DisplayListBuilder& builder) {                                   //
+        builder.drawImageLattice(CanvasCompareTester::testImage, lattice,  //
+                                 dst, SkFilterMode::kNearest, false);
       });
 }
 
@@ -2032,7 +2100,44 @@ TEST(DisplayListCanvas, DrawAtlasNearest) {
       [=](DisplayListBuilder& builder) {
         builder.drawAtlas(image, xform, tex, colors, 4,  //
                           SkBlendMode::kSrcOver, DisplayList::NearestSampling,
-                          nullptr);
+                          nullptr, true);
+      });
+}
+
+TEST(DisplayListCanvas, DrawAtlasNearestNoPaint) {
+  const SkRSXform xform[] = {
+      // clang-format off
+      { 1.2f,  0.0f, RenderLeft,  RenderTop},
+      { 0.0f,  1.2f, RenderRight, RenderTop},
+      {-1.2f,  0.0f, RenderRight, RenderBottom},
+      { 0.0f, -1.2f, RenderLeft,  RenderBottom},
+      // clang-format on
+  };
+  const SkRect tex[] = {
+      // clang-format off
+      {0,               0,                RenderHalfWidth, RenderHalfHeight},
+      {RenderHalfWidth, 0,                RenderWidth,     RenderHalfHeight},
+      {RenderHalfWidth, RenderHalfHeight, RenderWidth,     RenderHeight},
+      {0,               RenderHalfHeight, RenderHalfWidth, RenderHeight},
+      // clang-format on
+  };
+  const SkColor colors[] = {
+      SK_ColorBLUE,
+      SK_ColorGREEN,
+      SK_ColorYELLOW,
+      SK_ColorMAGENTA,
+  };
+  const sk_sp<SkImage> image = CanvasCompareTester::testImage;
+  CanvasCompareTester::RenderAtlas(
+      [=](SkCanvas* canvas, SkPaint& paint) {
+        canvas->drawAtlas(image.get(), xform, tex, colors, 4,
+                          SkBlendMode::kSrcOver, DisplayList::NearestSampling,
+                          nullptr, nullptr);
+      },
+      [=](DisplayListBuilder& builder) {
+        builder.drawAtlas(image, xform, tex, colors, 4,  //
+                          SkBlendMode::kSrcOver, DisplayList::NearestSampling,
+                          nullptr, false);
       });
 }
 
@@ -2069,7 +2174,7 @@ TEST(DisplayListCanvas, DrawAtlasLinear) {
       [=](DisplayListBuilder& builder) {
         builder.drawAtlas(image, xform, tex, colors, 2,  //
                           SkBlendMode::kSrcOver, DisplayList::LinearSampling,
-                          nullptr);
+                          nullptr, true);
       });
 }
 
@@ -2149,7 +2254,7 @@ TEST(DisplayListCanvas, DrawPictureWithPaint) {
 
 TEST(DisplayListCanvas, DrawDisplayList) {
   DisplayListBuilder builder;
-  builder.setDrawStyle(SkPaint::kFill_Style);
+  builder.setStyle(SkPaint::kFill_Style);
   builder.setColor(SK_ColorBLUE);
   builder.drawOval(RenderBounds);
   sk_sp<DisplayList> display_list = builder.Build();
@@ -2227,7 +2332,7 @@ TEST(DisplayListCanvas, DrawShadow) {
       CanvasCompareTester::DefaultTolerance.addBoundsPadding(3, 3));
 }
 
-TEST(DisplayListCanvas, DrawNonOccludedShadow) {
+TEST(DisplayListCanvas, DrawShadowTransparentOccluder) {
   SkPath path;
   path.addRoundRect(
       {

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -251,8 +251,8 @@ struct DisplayListInvocationGroup {
 
 std::vector<DisplayListInvocationGroup> allGroups = {
   { "SetAA", {
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setAA(false);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setAA(true);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setAntiAlias(false);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setAntiAlias(true);}},
     }
   },
   { "SetDither", {
@@ -266,20 +266,20 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "SetStrokeCap", {
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setCaps(SkPaint::kButt_Cap);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setCaps(SkPaint::kRound_Cap);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setCaps(SkPaint::kSquare_Cap);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeCap(SkPaint::kButt_Cap);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeCap(SkPaint::kRound_Cap);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeCap(SkPaint::kSquare_Cap);}},
     }
   },
   { "SetStrokeJoin", {
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setJoins(SkPaint::kBevel_Join);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setJoins(SkPaint::kRound_Join);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setJoins(SkPaint::kMiter_Join);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(SkPaint::kBevel_Join);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(SkPaint::kRound_Join);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(SkPaint::kMiter_Join);}},
     }
   },
   { "SetDrawStyle", {
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setDrawStyle(SkPaint::kFill_Style);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setDrawStyle(SkPaint::kStroke_Style);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStyle(SkPaint::kFill_Style);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStyle(SkPaint::kStroke_Style);}},
     }
   },
   { "SetStrokeWidth", {
@@ -288,8 +288,8 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "SetMiterLimit", {
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setMiterLimit(0.0);}},
-      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setMiterLimit(5.0);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeMiter(0.0);}},
+      {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeMiter(5.0);}},
     }
   },
   { "SetColor", {
@@ -397,34 +397,34 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "ClipRect", {
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, true, SkClipOp::kIntersect);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kIntersect, true);}},
       {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds.makeOffset(1, 1),
-                                                           true, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, false, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, true, SkClipOp::kDifference);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, false, SkClipOp::kDifference);}},
+                                                           SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kIntersect, false);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kDifference, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipRect(TestBounds, SkClipOp::kDifference, false);}},
     }
   },
   { "ClipRRect", {
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, true, SkClipOp::kIntersect);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kIntersect, true);}},
       {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect.makeOffset(1, 1),
-                                                            true, SkClipOp::kIntersect);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, false, SkClipOp::kIntersect);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, true, SkClipOp::kDifference);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, false, SkClipOp::kDifference);}},
+                                                            SkClipOp::kIntersect, true);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kIntersect, false);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kDifference, true);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipRRect(TestRRect, SkClipOp::kDifference, false);}},
     }
   },
   { "ClipPath", {
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, true, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath2, true, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath3, true, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, false, SkClipOp::kIntersect);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, true, SkClipOp::kDifference);}},
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, false, SkClipOp::kDifference);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath2, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath3, SkClipOp::kIntersect, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kIntersect, false);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kDifference, true);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPath1, SkClipOp::kDifference, false);}},
       // clipPath(rect) becomes clipRect
-      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPathRect, true, SkClipOp::kIntersect);}},
+      {1, 24, 1, 24, [](DisplayListBuilder& b) {b.clipPath(TestPathRect, SkClipOp::kIntersect, true);}},
       // clipPath(oval) becomes clipRRect
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipPath(TestPathOval, true, SkClipOp::kIntersect);}},
+      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.clipPath(TestPathOval, SkClipOp::kIntersect, true);}},
     }
   },
   { "DrawPaint", {
@@ -520,41 +520,46 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "DrawImage", {
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::NearestSampling);}},
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {20, 10}, DisplayList::NearestSampling);}},
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 20}, DisplayList::NearestSampling);}},
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::LinearSampling);}},
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage2, {10, 10}, DisplayList::NearestSampling);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::NearestSampling, false);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::NearestSampling, true);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {20, 10}, DisplayList::NearestSampling, false);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 20}, DisplayList::NearestSampling, false);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage1, {10, 10}, DisplayList::LinearSampling, false);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.drawImage(TestImage2, {10, 10}, DisplayList::NearestSampling, false);}},
     }
   },
   { "DrawImageRect", {
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                DisplayList::NearestSampling);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                DisplayList::NearestSampling,
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, false);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, true);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, false,
                                                                 SkCanvas::SrcRectConstraint::kStrict_SrcRectConstraint);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
-                                                                DisplayList::NearestSampling);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
-                                                                DisplayList::NearestSampling);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                DisplayList::LinearSampling);}},
-      {1, 64, 1, 64, [](DisplayListBuilder& b) {b.drawImageRect(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
-                                                                DisplayList::NearestSampling);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, false);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
+                                                                DisplayList::NearestSampling, false);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                DisplayList::LinearSampling, false);}},
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.drawImageRect(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
+                                                                DisplayList::NearestSampling, false);}},
     }
   },
   { "DrawImageNine", {
       // SkVanvas::drawImageNine is immediately converted to drawImageLattice
       {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                SkFilterMode::kNearest);}},
-      {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
-                                                                SkFilterMode::kNearest);}},
-      {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
-                                                                SkFilterMode::kNearest);}},
+                                                                SkFilterMode::kNearest, false);}},
       {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
-                                                                SkFilterMode::kLinear);}},
+                                                                SkFilterMode::kNearest, true);}},
+      {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 25, 20}, {10, 10, 80, 80},
+                                                                SkFilterMode::kNearest, false);}},
+      {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 85, 80},
+                                                                SkFilterMode::kNearest, false);}},
+      {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage1, {10, 10, 20, 20}, {10, 10, 80, 80},
+                                                                SkFilterMode::kLinear, false);}},
       {1, 48, 1, 80, [](DisplayListBuilder& b) {b.drawImageNine(TestImage2, {10, 10, 15, 15}, {10, 10, 80, 80},
-                                                                SkFilterMode::kNearest);}},
+                                                                SkFilterMode::kNearest, false);}},
     }
   },
   { "DrawImageLattice", {
@@ -605,46 +610,51 @@ std::vector<DisplayListInvocationGroup> allGroups = {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
+      {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
+        static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
+        static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
+        b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
+                    DisplayList::NearestSampling, nullptr, true);}},
       {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {0, 1, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
       {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 25, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
       {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::LinearSampling, nullptr);}},
+                    DisplayList::LinearSampling, nullptr, false);}},
       {1, 40 + 32 + 32, 1, 40 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         b.drawAtlas(TestImage1, xforms, texs, nullptr, 2, SkBlendMode::kDstIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
       {1, 56 + 32 + 32, 1, 56 + 32 + 32, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         static SkRect cullRect = { 0, 0, 200, 200 };
         b.drawAtlas(TestImage2, xforms, texs, nullptr, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, &cullRect);}},
+                    DisplayList::NearestSampling, &cullRect, false);}},
       {1, 40 + 32 + 32 + 8, 1, 40 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         static SkColor colors[] = { SK_ColorBLUE, SK_ColorGREEN };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, nullptr);}},
+                    DisplayList::NearestSampling, nullptr, false);}},
       {1, 56 + 32 + 32 + 8, 1, 56 + 32 + 32 + 8, [](DisplayListBuilder& b) {
         static SkRSXform xforms[] = { {1, 0, 0, 0}, {0, 1, 0, 0} };
         static SkRect texs[] = { { 10, 10, 20, 20 }, {20, 20, 30, 30} };
         static SkColor colors[] = { SK_ColorBLUE, SK_ColorGREEN };
         static SkRect cullRect = { 0, 0, 200, 200 };
         b.drawAtlas(TestImage1, xforms, texs, colors, 2, SkBlendMode::kSrcIn,
-                    DisplayList::NearestSampling, &cullRect);}},
+                    DisplayList::NearestSampling, &cullRect, false);}},
     }
   },
   { "DrawPicture", {

--- a/flow/display_list_utils.cc
+++ b/flow/display_list_utils.cc
@@ -26,7 +26,7 @@ constexpr float invert_color_matrix[20] = {
 };
 // clang-format on
 
-void SkPaintDispatchHelper::setAA(bool aa) {
+void SkPaintDispatchHelper::setAntiAlias(bool aa) {
   paint_.setAntiAlias(aa);
 }
 void SkPaintDispatchHelper::setDither(bool dither) {
@@ -36,19 +36,19 @@ void SkPaintDispatchHelper::setInvertColors(bool invert) {
   invert_colors_ = invert;
   paint_.setColorFilter(makeColorFilter());
 }
-void SkPaintDispatchHelper::setCaps(SkPaint::Cap cap) {
+void SkPaintDispatchHelper::setStrokeCap(SkPaint::Cap cap) {
   paint_.setStrokeCap(cap);
 }
-void SkPaintDispatchHelper::setJoins(SkPaint::Join join) {
+void SkPaintDispatchHelper::setStrokeJoin(SkPaint::Join join) {
   paint_.setStrokeJoin(join);
 }
-void SkPaintDispatchHelper::setDrawStyle(SkPaint::Style style) {
+void SkPaintDispatchHelper::setStyle(SkPaint::Style style) {
   paint_.setStyle(style);
 }
 void SkPaintDispatchHelper::setStrokeWidth(SkScalar width) {
   paint_.setStrokeWidth(width);
 }
-void SkPaintDispatchHelper::setMiterLimit(SkScalar limit) {
+void SkPaintDispatchHelper::setStrokeMiter(SkScalar limit) {
   paint_.setStrokeMiter(limit);
 }
 void SkPaintDispatchHelper::setColor(SkColor color) {
@@ -137,22 +137,22 @@ void SkMatrixDispatchHelper::reset() {
 }
 
 void ClipBoundsDispatchHelper::clipRect(const SkRect& rect,
-                                        bool is_aa,
-                                        SkClipOp clip_op) {
+                                        SkClipOp clip_op,
+                                        bool is_aa) {
   if (clip_op == SkClipOp::kIntersect) {
     intersect(rect, is_aa);
   }
 }
 void ClipBoundsDispatchHelper::clipRRect(const SkRRect& rrect,
-                                         bool is_aa,
-                                         SkClipOp clip_op) {
+                                         SkClipOp clip_op,
+                                         bool is_aa) {
   if (clip_op == SkClipOp::kIntersect) {
     intersect(rrect.getBounds(), is_aa);
   }
 }
 void ClipBoundsDispatchHelper::clipPath(const SkPath& path,
-                                        bool is_aa,
-                                        SkClipOp clip_op) {
+                                        SkClipOp clip_op,
+                                        bool is_aa) {
   if (clip_op == SkClipOp::kIntersect) {
     intersect(path.getBounds(), is_aa);
   }
@@ -205,22 +205,22 @@ DisplayListBoundsCalculator::DisplayListBoundsCalculator(
     const SkRect* cull_rect)
     : ClipBoundsDispatchHelper(cull_rect) {
   layer_infos_.emplace_back(std::make_unique<RootLayerData>());
-  accumulator_ = layer_infos_.back()->accumulatorForLayer();
+  accumulator_ = layer_infos_.back()->layer_accumulator();
 }
-void DisplayListBoundsCalculator::setCaps(SkPaint::Cap cap) {
+void DisplayListBoundsCalculator::setStrokeCap(SkPaint::Cap cap) {
   cap_is_square_ = (cap == SkPaint::kSquare_Cap);
 }
-void DisplayListBoundsCalculator::setJoins(SkPaint::Join join) {
+void DisplayListBoundsCalculator::setStrokeJoin(SkPaint::Join join) {
   join_is_miter_ = (join == SkPaint::kMiter_Join);
 }
-void DisplayListBoundsCalculator::setDrawStyle(SkPaint::Style style) {
+void DisplayListBoundsCalculator::setStyle(SkPaint::Style style) {
   style_flag_ = (style == SkPaint::kFill_Style) ? kIsFilledGeometry  //
                                                 : kIsStrokedGeometry;
 }
 void DisplayListBoundsCalculator::setStrokeWidth(SkScalar width) {
   half_stroke_width_ = std::max(width * 0.5f, kMinStrokeWidth);
 }
-void DisplayListBoundsCalculator::setMiterLimit(SkScalar limit) {
+void DisplayListBoundsCalculator::setStrokeMiter(SkScalar limit) {
   miter_limit_ = std::max(limit, 1.0f);
 }
 void DisplayListBoundsCalculator::setBlendMode(SkBlendMode mode) {
@@ -253,7 +253,7 @@ void DisplayListBoundsCalculator::save() {
   SkMatrixDispatchHelper::save();
   ClipBoundsDispatchHelper::save();
   layer_infos_.emplace_back(std::make_unique<SaveData>(accumulator_));
-  accumulator_ = layer_infos_.back()->accumulatorForLayer();
+  accumulator_ = layer_infos_.back()->layer_accumulator();
 }
 void DisplayListBoundsCalculator::saveLayer(const SkRect* bounds,
                                             bool with_paint) {
@@ -261,12 +261,12 @@ void DisplayListBoundsCalculator::saveLayer(const SkRect* bounds,
   ClipBoundsDispatchHelper::save();
   if (with_paint) {
     layer_infos_.emplace_back(std::make_unique<SaveLayerData>(
-        accumulator_, image_filter_, paintNopsOnTransparenBlack()));
+        accumulator_, image_filter_, paint_nops_on_transparency()));
   } else {
     layer_infos_.emplace_back(
         std::make_unique<SaveLayerData>(accumulator_, nullptr, true));
   }
-  accumulator_ = layer_infos_.back()->accumulatorForLayer();
+  accumulator_ = layer_infos_.back()->layer_accumulator();
   // Accumulate the layer in its own coordinate system and then
   // filter and transform its bounds on restore.
   SkMatrixDispatchHelper::reset();
@@ -276,8 +276,8 @@ void DisplayListBoundsCalculator::restore() {
   if (layer_infos_.size() > 1) {
     SkMatrixDispatchHelper::restore();
     ClipBoundsDispatchHelper::restore();
-    accumulator_ = layer_infos_.back()->accumulatorForRestore();
-    SkRect layer_bounds = layer_infos_.back()->getLayerBounds();
+    accumulator_ = layer_infos_.back()->restore_accumulator();
+    SkRect layer_bounds = layer_infos_.back()->layer_bounds();
     // Must read unbounded state after layer_bounds
     bool layer_unbounded = layer_infos_.back()->is_unbounded();
     layer_infos_.pop_back();
@@ -290,19 +290,19 @@ void DisplayListBoundsCalculator::restore() {
       // modifications based on the attributes that were in place
       // when it was instantiated. Modifying it further base on the
       // current attributes would mix attribute states.
-      accumulateRect(layer_bounds, kIsUnfiltered);
+      AccumulateRect(layer_bounds, kIsUnfiltered);
     }
     if (layer_unbounded) {
-      accumulateUnbounded();
+      AccumulateUnbounded();
     }
   }
 }
 
 void DisplayListBoundsCalculator::drawPaint() {
-  accumulateUnbounded();
+  AccumulateUnbounded();
 }
 void DisplayListBoundsCalculator::drawColor(SkColor color, SkBlendMode mode) {
-  accumulateUnbounded();
+  AccumulateUnbounded();
 }
 void DisplayListBoundsCalculator::drawLine(const SkPoint& p0,
                                            const SkPoint& p1) {
@@ -311,32 +311,32 @@ void DisplayListBoundsCalculator::drawLine(const SkPoint& p0,
   if (bounds.width() > 0.0f && bounds.height() > 0.0f) {
     cap_flag |= kGeometryMayHaveDiagonalEndCaps;
   }
-  accumulateRect(bounds, cap_flag);
+  AccumulateRect(bounds, cap_flag);
 }
 void DisplayListBoundsCalculator::drawRect(const SkRect& rect) {
-  accumulateRect(rect, kIsDrawnGeometry);
+  AccumulateRect(rect, kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawOval(const SkRect& bounds) {
-  accumulateRect(bounds, kIsDrawnGeometry);
+  AccumulateRect(bounds, kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawCircle(const SkPoint& center,
                                              SkScalar radius) {
-  accumulateRect(SkRect::MakeLTRB(center.fX - radius, center.fY - radius,
+  AccumulateRect(SkRect::MakeLTRB(center.fX - radius, center.fY - radius,
                                   center.fX + radius, center.fY + radius),
                  kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawRRect(const SkRRect& rrect) {
-  accumulateRect(rrect.getBounds(), kIsDrawnGeometry);
+  AccumulateRect(rrect.getBounds(), kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawDRRect(const SkRRect& outer,
                                              const SkRRect& inner) {
-  accumulateRect(outer.getBounds(), kIsDrawnGeometry);
+  AccumulateRect(outer.getBounds(), kIsDrawnGeometry);
 }
 void DisplayListBoundsCalculator::drawPath(const SkPath& path) {
   if (path.isInverseFillType()) {
-    accumulateUnbounded();
+    AccumulateUnbounded();
   } else {
-    accumulateRect(path.getBounds(),                   //
+    AccumulateRect(path.getBounds(),                   //
                    (kIsDrawnGeometry |                 //
                     kGeometryMayHaveDiagonalEndCaps |  //
                     kGeometryMayHaveProblematicJoins));
@@ -349,7 +349,7 @@ void DisplayListBoundsCalculator::drawArc(const SkRect& bounds,
   // This could be tighter if we compute where the start and end
   // angles are and then also consider the quadrants swept and
   // the center if specified.
-  accumulateRect(bounds, kIsDrawnGeometry | kGeometryMayHaveDiagonalEndCaps);
+  AccumulateRect(bounds, kIsDrawnGeometry | kGeometryMayHaveDiagonalEndCaps);
 }
 void DisplayListBoundsCalculator::drawPoints(SkCanvas::PointMode mode,
                                              uint32_t count,
@@ -364,41 +364,50 @@ void DisplayListBoundsCalculator::drawPoints(SkCanvas::PointMode mode,
       flags |= kGeometryMayHaveDiagonalEndCaps;
       // Even Polygon mode just draws (count-1) separate lines, no joins
     }
-    accumulateRect(ptBounds.getBounds(), flags);
+    AccumulateRect(ptBounds.bounds(), flags);
   }
 }
 void DisplayListBoundsCalculator::drawVertices(const sk_sp<SkVertices> vertices,
                                                SkBlendMode mode) {
-  accumulateRect(vertices->bounds(), kIsNonGeometric);
+  AccumulateRect(vertices->bounds(), kIsNonGeometric);
 }
 void DisplayListBoundsCalculator::drawImage(const sk_sp<SkImage> image,
                                             const SkPoint point,
-                                            const SkSamplingOptions& sampling) {
+                                            const SkSamplingOptions& sampling,
+                                            bool render_with_attributes) {
   SkRect bounds = SkRect::MakeXYWH(point.fX, point.fY,  //
                                    image->width(), image->height());
-  accumulateRect(bounds, kIsNonGeometric | kApplyMaskFilter);
+  int flags = render_with_attributes ? kIsNonGeometric | kApplyMaskFilter
+                                     : kIsUnfiltered;
+  AccumulateRect(bounds, flags);
 }
 void DisplayListBoundsCalculator::drawImageRect(
     const sk_sp<SkImage> image,
     const SkRect& src,
     const SkRect& dst,
     const SkSamplingOptions& sampling,
+    bool render_with_attributes,
     SkCanvas::SrcRectConstraint constraint) {
-  accumulateRect(dst, kIsNonGeometric | kApplyMaskFilter);
+  int flags = render_with_attributes ? kIsNonGeometric | kApplyMaskFilter
+                                     : kIsUnfiltered;
+  AccumulateRect(dst, flags);
 }
 void DisplayListBoundsCalculator::drawImageNine(const sk_sp<SkImage> image,
                                                 const SkIRect& center,
                                                 const SkRect& dst,
-                                                SkFilterMode filter) {
-  accumulateRect(dst, kIsNonGeometric);
+                                                SkFilterMode filter,
+                                                bool render_with_attributes) {
+  AccumulateRect(dst, render_with_attributes ? kIsNonGeometric : kIsUnfiltered);
 }
 void DisplayListBoundsCalculator::drawImageLattice(
     const sk_sp<SkImage> image,
     const SkCanvas::Lattice& lattice,
     const SkRect& dst,
     SkFilterMode filter,
-    bool with_paint) {
-  accumulateRect(dst, kIsNonGeometric | kApplyMaskFilter);
+    bool render_with_attributes) {
+  int flags = render_with_attributes ? kIsNonGeometric | kApplyMaskFilter
+                                     : kIsUnfiltered;
+  AccumulateRect(dst, flags);
 }
 void DisplayListBoundsCalculator::drawAtlas(const sk_sp<SkImage> atlas,
                                             const SkRSXform xform[],
@@ -407,7 +416,8 @@ void DisplayListBoundsCalculator::drawAtlas(const sk_sp<SkImage> atlas,
                                             int count,
                                             SkBlendMode mode,
                                             const SkSamplingOptions& sampling,
-                                            const SkRect* cullRect) {
+                                            const SkRect* cullRect,
+                                            bool render_with_attributes) {
   SkPoint quad[4];
   BoundsAccumulator atlasBounds;
   for (int i = 0; i < count; i++) {
@@ -417,13 +427,14 @@ void DisplayListBoundsCalculator::drawAtlas(const sk_sp<SkImage> atlas,
       atlasBounds.accumulate(quad[j]);
     }
   }
-  if (atlasBounds.isNotEmpty()) {
-    accumulateRect(atlasBounds.getBounds(), kIsNonGeometric);
+  if (atlasBounds.is_not_empty()) {
+    int flags = render_with_attributes ? kIsNonGeometric : kIsUnfiltered;
+    AccumulateRect(atlasBounds.bounds(), flags);
   }
 }
 void DisplayListBoundsCalculator::drawPicture(const sk_sp<SkPicture> picture,
                                               const SkMatrix* pic_matrix,
-                                              bool with_save_layer) {
+                                              bool render_with_attributes) {
   // TODO(flar) cull rect really cannot be trusted in general, but it will
   // work for SkPictures generated from our own PictureRecorder or any
   // picture captured with an SkRTreeFactory or accurate bounds estimate.
@@ -431,29 +442,30 @@ void DisplayListBoundsCalculator::drawPicture(const sk_sp<SkPicture> picture,
   if (pic_matrix) {
     pic_matrix->mapRect(&bounds);
   }
-  accumulateRect(bounds, with_save_layer ? kIsNonGeometric : kIsUnfiltered);
+  AccumulateRect(bounds,
+                 render_with_attributes ? kIsNonGeometric : kIsUnfiltered);
 }
 void DisplayListBoundsCalculator::drawDisplayList(
     const sk_sp<DisplayList> display_list) {
-  accumulateRect(display_list->bounds(), kIsUnfiltered);
+  AccumulateRect(display_list->bounds(), kIsUnfiltered);
 }
 void DisplayListBoundsCalculator::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                                SkScalar x,
                                                SkScalar y) {
-  accumulateRect(blob->bounds().makeOffset(x, y), kIsFilledGeometry);
+  AccumulateRect(blob->bounds().makeOffset(x, y), kIsFilledGeometry);
 }
 void DisplayListBoundsCalculator::drawShadow(const SkPath& path,
                                              const SkColor color,
                                              const SkScalar elevation,
-                                             bool transparentOccluder,
+                                             bool transparent_occluder,
                                              SkScalar dpr) {
   SkRect shadow_bounds =
       PhysicalShapeLayer::ComputeShadowBounds(path, elevation, dpr, matrix());
-  accumulateRect(shadow_bounds, kIsUnfiltered);
+  AccumulateRect(shadow_bounds, kIsUnfiltered);
 }
 
-bool DisplayListBoundsCalculator::getFilteredBounds(SkRect& bounds,
-                                                    SkImageFilter* filter) {
+bool DisplayListBoundsCalculator::ComputeFilteredBounds(SkRect& bounds,
+                                                        SkImageFilter* filter) {
   if (filter) {
     if (!filter->canComputeFastBounds()) {
       return false;
@@ -463,7 +475,7 @@ bool DisplayListBoundsCalculator::getFilteredBounds(SkRect& bounds,
   return true;
 }
 
-bool DisplayListBoundsCalculator::adjustBoundsForPaint(SkRect& bounds,
+bool DisplayListBoundsCalculator::AdjustBoundsForPaint(SkRect& bounds,
                                                        int flags) {
   if ((flags & kIsUnfiltered) != 0) {
     FML_DCHECK(flags == kIsUnfiltered);
@@ -534,28 +546,28 @@ bool DisplayListBoundsCalculator::adjustBoundsForPaint(SkRect& bounds,
     }
   }
 
-  return getFilteredBounds(bounds, image_filter_.get());
+  return ComputeFilteredBounds(bounds, image_filter_.get());
 }
 
-void DisplayListBoundsCalculator::accumulateUnbounded() {
+void DisplayListBoundsCalculator::AccumulateUnbounded() {
   if (has_clip()) {
-    accumulator_->accumulate(getClipBounds());
+    accumulator_->accumulate(clip_bounds());
   } else {
     layer_infos_.back()->set_unbounded();
   }
 }
-void DisplayListBoundsCalculator::accumulateRect(SkRect& rect, int flags) {
-  if (adjustBoundsForPaint(rect, flags)) {
+void DisplayListBoundsCalculator::AccumulateRect(SkRect& rect, int flags) {
+  if (AdjustBoundsForPaint(rect, flags)) {
     matrix().mapRect(&rect);
-    if (!has_clip() || rect.intersect(getClipBounds())) {
+    if (!has_clip() || rect.intersect(clip_bounds())) {
       accumulator_->accumulate(rect);
     }
   } else {
-    accumulateUnbounded();
+    AccumulateUnbounded();
   }
 }
 
-bool DisplayListBoundsCalculator::paintNopsOnTransparenBlack() {
+bool DisplayListBoundsCalculator::paint_nops_on_transparency() {
   // SkImageFilter::canComputeFastBounds tests for transparency behavior
   // This test assumes that the blend mode checked down below will
   // NOP on transparent black.

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -392,7 +392,7 @@ void Canvas::drawImageNine(const CanvasImage* image,
     // simpler DrawImageNineOp record directly.
     display_list_recorder_->RecordPaintAttributes(
         paint.paint(), DisplayListCanvasRecorder::DrawType::kImageOpType);
-    builder()->drawImageNine(image->image(), icenter, dst, filter);
+    builder()->drawImageNine(image->image(), icenter, dst, filter, true);
   } else {
     canvas_->drawImageNine(image->image().get(), icenter, dst, filter,
                            paint.paint());


### PR DESCRIPTION
Addressing hopefully all of the concerns raised in https://github.com/flutter/engine/pull/28656 and https://github.com/flutter/flutter/issues/90232

Changes included in this update:

- Most method/field/parameter names should follow the style guide
- Dispatcher methods are still mixedCamel to match the Skia methods they are replacing
- Stroke Cap/Join nomenclature now matches Skia
- some abbreviations eliminated (notably, "aa" is left in parameter names as seen in `SkPaint::setAntiAlias(bool aa)`)
- some new parameters were added to make attributes optional for some calls (primarily drawImage variants) similar to the Skia convention of some methods taking a pointer to an SkPaint which is allowed to be null.
- I was going to change transparent Occluder, but that naming convention is used from the Flutter public API down through to Skia, so DisplayList will go with that flow, but the capitalization is modified for style guidelines

I may have made a bad call in a few places on what would be considered a getter/setter/accessor vs a method, so some feedback on those decisions would be welcome.