### PR TITLE
Fix Android T deprecated WindowManager INCORRECT_CONTEXT_USAGE

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -10,13 +10,11 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.hardware.display.DisplayManager;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.view.Display;
-import android.view.WindowManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.BuildConfig;
@@ -109,7 +107,6 @@ public class FlutterLoader {
   private FlutterApplicationInfo flutterApplicationInfo;
   private FlutterJNI flutterJNI;
   private ExecutorService executorService;
-  private WindowManager windowManager;
 
   private static class InitResult {
     final String appStoragePath;
@@ -162,19 +159,9 @@ public class FlutterLoader {
     initStartTimestampMillis = SystemClock.uptimeMillis();
     flutterApplicationInfo = ApplicationInfoLoader.load(appContext);
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-      final DisplayManager dm = appContext.getSystemService(DisplayManager.class);
-      final Display primaryDisplay = dm.getDisplay(Display.DEFAULT_DISPLAY);
-      final Context windowContext =
-          appContext.createWindowContext(
-              primaryDisplay, WindowManager.LayoutParams.TYPE_APPLICATION, null);
-      VsyncWaiter.getInstance(
-              (WindowManager) windowContext.getSystemService(Context.WINDOW_SERVICE))
-          .init();
-    } else {
-      VsyncWaiter.getInstance((WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE))
-          .init();
-    }
+    final DisplayManager dm = appContext.getSystemService(DisplayManager.class);
+    final Display primaryDisplay = dm.getDisplay(Display.DEFAULT_DISPLAY);
+    VsyncWaiter.getInstance(primaryDisplay).init();
 
     // Use a background thread for initialization tasks that require disk access.
     Callable<InitResult> initTask =

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -10,6 +10,7 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.hardware.display.DisplayManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -9,10 +9,12 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
+import android.hardware.display.DisplayManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
+import android.view.Display;
 import android.view.WindowManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -158,8 +160,20 @@ public class FlutterLoader {
 
     initStartTimestampMillis = SystemClock.uptimeMillis();
     flutterApplicationInfo = ApplicationInfoLoader.load(appContext);
-    VsyncWaiter.getInstance((WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE))
-        .init();
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      final DisplayManager dm = appContext.getSystemService(DisplayManager.class);
+      final Display primaryDisplay = dm.getDisplay(Display.DEFAULT_DISPLAY);
+      final Context windowContext =
+          appContext.createWindowContext(
+              primaryDisplay, WindowManager.LayoutParams.TYPE_APPLICATION, null);
+      VsyncWaiter.getInstance(
+              (WindowManager) windowContext.getSystemService(Context.WINDOW_SERVICE))
+          .init();
+    } else {
+      VsyncWaiter.getInstance((WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE))
+          .init();
+    }
 
     // Use a background thread for initialization tasks that require disk access.
     Callable<InitResult> initTask =

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -161,17 +161,18 @@ public class FlutterLoader {
     initStartTimestampMillis = SystemClock.uptimeMillis();
     flutterApplicationInfo = ApplicationInfoLoader.load(appContext);
 
+    float fps;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
       final DisplayManager dm = appContext.getSystemService(DisplayManager.class);
       final Display primaryDisplay = dm.getDisplay(Display.DEFAULT_DISPLAY);
-      VsyncWaiter.getInstance(primaryDisplay.getRefreshRate()).init();
+      fps = primaryDisplay.getRefreshRate();
     } else {
-      VsyncWaiter.getInstance(
-              ((WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE))
-                  .getDefaultDisplay()
-                  .getRefreshRate())
-          .init();
+      fps =
+          ((WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE))
+              .getDefaultDisplay()
+              .getRefreshRate();
     }
+    VsyncWaiter.getInstance(fps).init();
 
     // Use a background thread for initialization tasks that require disk access.
     Callable<InitResult> initTask =

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -10,11 +10,13 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.hardware.display.DisplayManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.view.Display;
+import android.view.WindowManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import io.flutter.BuildConfig;
@@ -159,9 +161,17 @@ public class FlutterLoader {
     initStartTimestampMillis = SystemClock.uptimeMillis();
     flutterApplicationInfo = ApplicationInfoLoader.load(appContext);
 
-    final DisplayManager dm = appContext.getSystemService(DisplayManager.class);
-    final Display primaryDisplay = dm.getDisplay(Display.DEFAULT_DISPLAY);
-    VsyncWaiter.getInstance(primaryDisplay).init();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      final DisplayManager dm = appContext.getSystemService(DisplayManager.class);
+      final Display primaryDisplay = dm.getDisplay(Display.DEFAULT_DISPLAY);
+      VsyncWaiter.getInstance(primaryDisplay.getRefreshRate()).init();
+    } else {
+      VsyncWaiter.getInstance(
+              ((WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE))
+                  .getDefaultDisplay()
+                  .getRefreshRate())
+          .init();
+    }
 
     // Use a background thread for initialization tasks that require disk access.
     Callable<InitResult> initTask =

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -5,7 +5,6 @@
 package io.flutter.view;
 
 import android.view.Choreographer;
-import android.view.Display;
 import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.FlutterJNI;
 
@@ -14,14 +13,14 @@ public class VsyncWaiter {
   private static VsyncWaiter instance;
 
   @NonNull
-  public static VsyncWaiter getInstance(@NonNull Display display) {
+  public static VsyncWaiter getInstance(@NonNull float fps) {
     if (instance == null) {
-      instance = new VsyncWaiter(display);
+      instance = new VsyncWaiter(fps);
     }
     return instance;
   }
 
-  @NonNull private final Display display;
+  @NonNull private final float fps;
 
   private final FlutterJNI.AsyncWaitForVsyncDelegate asyncWaitForVsyncDelegate =
       new FlutterJNI.AsyncWaitForVsyncDelegate() {
@@ -32,7 +31,6 @@ public class VsyncWaiter {
                   new Choreographer.FrameCallback() {
                     @Override
                     public void doFrame(long frameTimeNanos) {
-                      float fps = display.getRefreshRate();
                       long refreshPeriodNanos = (long) (1000000000.0 / fps);
                       FlutterJNI.nativeOnVsync(
                           frameTimeNanos, frameTimeNanos + refreshPeriodNanos, cookie);
@@ -41,15 +39,14 @@ public class VsyncWaiter {
         }
       };
 
-  private VsyncWaiter(@NonNull Display display) {
-    this.display = display;
+  private VsyncWaiter(@NonNull float fps) {
+    this.fps = fps;
   }
 
   public void init() {
     FlutterJNI.setAsyncWaitForVsyncDelegate(asyncWaitForVsyncDelegate);
 
     // TODO(mattcarroll): look into moving FPS reporting to a plugin
-    float fps = display.getRefreshRate();
     FlutterJNI.setRefreshRateFPS(fps);
   }
 }

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -5,7 +5,7 @@
 package io.flutter.view;
 
 import android.view.Choreographer;
-import android.view.WindowManager;
+import android.view.Display;
 import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.FlutterJNI;
 
@@ -14,14 +14,14 @@ public class VsyncWaiter {
   private static VsyncWaiter instance;
 
   @NonNull
-  public static VsyncWaiter getInstance(@NonNull WindowManager windowManager) {
+  public static VsyncWaiter getInstance(@NonNull Display display) {
     if (instance == null) {
-      instance = new VsyncWaiter(windowManager);
+      instance = new VsyncWaiter(display);
     }
     return instance;
   }
 
-  @NonNull private final WindowManager windowManager;
+  @NonNull private final Display display;
 
   private final FlutterJNI.AsyncWaitForVsyncDelegate asyncWaitForVsyncDelegate =
       new FlutterJNI.AsyncWaitForVsyncDelegate() {
@@ -32,7 +32,7 @@ public class VsyncWaiter {
                   new Choreographer.FrameCallback() {
                     @Override
                     public void doFrame(long frameTimeNanos) {
-                      float fps = windowManager.getDefaultDisplay().getRefreshRate();
+                      float fps = display.getRefreshRate();
                       long refreshPeriodNanos = (long) (1000000000.0 / fps);
                       FlutterJNI.nativeOnVsync(
                           frameTimeNanos, frameTimeNanos + refreshPeriodNanos, cookie);
@@ -41,15 +41,15 @@ public class VsyncWaiter {
         }
       };
 
-  private VsyncWaiter(@NonNull WindowManager windowManager) {
-    this.windowManager = windowManager;
+  private VsyncWaiter(@NonNull Display display) {
+    this.display = display;
   }
 
   public void init() {
     FlutterJNI.setAsyncWaitForVsyncDelegate(asyncWaitForVsyncDelegate);
 
     // TODO(mattcarroll): look into moving FPS reporting to a plugin
-    float fps = windowManager.getDefaultDisplay().getRefreshRate();
+    float fps = display.getRefreshRate();
     FlutterJNI.setRefreshRateFPS(fps);
   }
 }

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -5,7 +5,6 @@
 package io.flutter.view;
 
 import android.view.Choreographer;
-import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.FlutterJNI;
 
 // TODO(mattcarroll): add javadoc.
@@ -13,14 +12,14 @@ public class VsyncWaiter {
   private static VsyncWaiter instance;
 
   @NonNull
-  public static VsyncWaiter getInstance(@NonNull float fps) {
+  public static VsyncWaiter getInstance(float fps) {
     if (instance == null) {
       instance = new VsyncWaiter(fps);
     }
     return instance;
   }
 
-  @NonNull private final float fps;
+  private final float fps;
 
   private final FlutterJNI.AsyncWaitForVsyncDelegate asyncWaitForVsyncDelegate =
       new FlutterJNI.AsyncWaitForVsyncDelegate() {
@@ -39,7 +38,7 @@ public class VsyncWaiter {
         }
       };
 
-  private VsyncWaiter(@NonNull float fps) {
+  private VsyncWaiter(float fps) {
     this.fps = fps;
   }
 

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -5,6 +5,7 @@
 package io.flutter.view;
 
 import android.view.Choreographer;
+import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.FlutterJNI;
 
 // TODO(mattcarroll): add javadoc.

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -8,6 +8,7 @@ import static android.os.Looper.getMainLooper;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyFloat;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -8,11 +8,11 @@ import static android.os.Looper.getMainLooper;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyFloat;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -107,8 +107,7 @@ public class FlutterLoaderTest {
 
     assertFalse(flutterLoader.initialized());
     flutterLoader.startInitialization(appContextSpy);
-    verify(mockFlutterJNI, times(1)).setRefreshRateFPS(anyFloat());
-    verify(appContextSpy, times(0)).getSystemService(anyString());
+    verify(appContextSpy, never()).getSystemService(anyString());
   }
 
   @Test
@@ -120,6 +119,6 @@ public class FlutterLoaderTest {
 
     assertFalse(flutterLoader.initialized());
     flutterLoader.startInitialization(RuntimeEnvironment.application);
-    verify(mockFlutterJNI, times(1)).setRefreshRateFPS(anyFloat());
+    vverify(appContextSpy, times(1)).getSystemService(anyString());
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -92,4 +92,14 @@ public class FlutterLoaderTest {
     flutterLoader.startInitialization(RuntimeEnvironment.application);
     verify(mockExecutorService, times(1)).submit(any(Callable.class));
   }
+
+  @Test
+  public void itReportsFpsToVsyncWaiter() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
+
+    assertFalse(flutterLoader.initialized());
+    flutterLoader.startInitialization(RuntimeEnvironment.application);
+    verify(mockFlutterJNI, times(1)).setRefreshRateFPS(anyFloat());
+  }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -22,7 +22,6 @@ import android.annotation.TargetApi;
 import android.app.ActivityManager;
 import android.content.Context;
 import io.flutter.embedding.engine.FlutterJNI;
-import io.flutter.view.VsyncWaiter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -105,25 +105,9 @@ public class FlutterLoaderTest {
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 
     Context appContextSpy = spy(RuntimeEnvironment.application);
-    VsyncWaiter vsyncSpy = spy(VsyncWaiter.getInstance(60.0f));
 
     assertFalse(flutterLoader.initialized());
     flutterLoader.startInitialization(appContextSpy);
     verify(appContextSpy, never()).getSystemService(anyString());
-    verify(vsyncSpy, times(1)).init();
-  }
-
-  @Test
-  @TargetApi(22)
-  @Config(sdk = 22)
-  public void itReportsFpsToVsyncWaiterLegacy() {
-    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
-    FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
-
-    VsyncWaiter vsyncSpy = spy(VsyncWaiter.getInstance(60.0f));
-
-    assertFalse(flutterLoader.initialized());
-    flutterLoader.startInitialization(RuntimeEnvironment.application);
-    verify(vsyncSpy, times(1)).init();
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -102,9 +102,12 @@ public class FlutterLoaderTest {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 
+    Context appContextSpy = Mockito.spy(RuntimeEnvironment.application);
+
     assertFalse(flutterLoader.initialized());
-    flutterLoader.startInitialization(RuntimeEnvironment.application);
+    flutterLoader.startInitialization(appContextSpy);
     verify(mockFlutterJNI, times(1)).setRefreshRateFPS(anyFloat());
+    verify(appContextSpy, times(0)).getSystemService(anyString());
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -105,7 +105,7 @@ public class FlutterLoaderTest {
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 
     Context appContextSpy = spy(RuntimeEnvironment.application);
-    VsyncWaiter vsyncSpy = spy(VsyncWaiter.getInstance(60.0));
+    VsyncWaiter vsyncSpy = spy(VsyncWaiter.getInstance(60.0f));
 
     assertFalse(flutterLoader.initialized());
     flutterLoader.startInitialization(appContextSpy);
@@ -120,7 +120,7 @@ public class FlutterLoaderTest {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 
-    VsyncWaiter vsyncSpy = spy(VsyncWaiter.getInstance(60.0));
+    VsyncWaiter vsyncSpy = spy(VsyncWaiter.getInstance(60.0f));
 
     assertFalse(flutterLoader.initialized());
     flutterLoader.startInitialization(RuntimeEnvironment.application);

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -95,9 +95,9 @@ public class FlutterLoaderTest {
   }
 
   @Test
-  @TargetApi(30)
-  @Config(sdk = 30)
-  public void itReportsFpsToVsyncWaiter() {
+  @TargetApi(23)
+  @Config(sdk = 23)
+  public void itReportsFpsToVsyncWaiterAndroidM() {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 
@@ -107,9 +107,9 @@ public class FlutterLoaderTest {
   }
 
   @Test
-  @TargetApi(18)
-  @Config(sdk = 18)
-  public void itReportsFpsToVsyncWaiter() {
+  @TargetApi(22)
+  @Config(sdk = 22)
+  public void itReportsFpsToVsyncWaiterLegacy() {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.robolectric.Shadows.shadowOf;
 
+import android.annotation.TargetApi;
 import android.app.ActivityManager;
 import android.content.Context;
 import io.flutter.embedding.engine.FlutterJNI;
@@ -94,6 +95,20 @@ public class FlutterLoaderTest {
   }
 
   @Test
+  @TargetApi(30)
+  @Config(sdk = 30)
+  public void itReportsFpsToVsyncWaiter() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
+
+    assertFalse(flutterLoader.initialized());
+    flutterLoader.startInitialization(RuntimeEnvironment.application);
+    verify(mockFlutterJNI, times(1)).setRefreshRateFPS(anyFloat());
+  }
+
+  @Test
+  @TargetApi(18)
+  @Config(sdk = 18)
   public void itReportsFpsToVsyncWaiter() {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -117,8 +117,10 @@ public class FlutterLoaderTest {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 
+    Context appContextSpy = spy(RuntimeEnvironment.application);
+
     assertFalse(flutterLoader.initialized());
-    flutterLoader.startInitialization(RuntimeEnvironment.application);
-    vverify(appContextSpy, times(1)).getSystemService(anyString());
+    flutterLoader.startInitialization(appContextSpy);
+    verify(appContextSpy, times(1)).getSystemService(anyString());
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.robolectric.Shadows.shadowOf;
@@ -102,7 +103,7 @@ public class FlutterLoaderTest {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 
-    Context appContextSpy = Mockito.spy(RuntimeEnvironment.application);
+    Context appContextSpy = spy(RuntimeEnvironment.application);
 
     assertFalse(flutterLoader.initialized());
     flutterLoader.startInitialization(appContextSpy);

--- a/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/loader/FlutterLoaderTest.java
@@ -22,6 +22,7 @@ import android.annotation.TargetApi;
 import android.app.ActivityManager;
 import android.content.Context;
 import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.view.VsyncWaiter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -104,10 +105,12 @@ public class FlutterLoaderTest {
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 
     Context appContextSpy = spy(RuntimeEnvironment.application);
+    VsyncWaiter vsyncSpy = spy(VsyncWaiter.getInstance(60.0));
 
     assertFalse(flutterLoader.initialized());
     flutterLoader.startInitialization(appContextSpy);
     verify(appContextSpy, never()).getSystemService(anyString());
+    verify(vsyncSpy, times(1)).init();
   }
 
   @Test
@@ -117,10 +120,10 @@ public class FlutterLoaderTest {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
     FlutterLoader flutterLoader = new FlutterLoader(mockFlutterJNI);
 
-    Context appContextSpy = spy(RuntimeEnvironment.application);
+    VsyncWaiter vsyncSpy = spy(VsyncWaiter.getInstance(60.0));
 
     assertFalse(flutterLoader.initialized());
-    flutterLoader.startInitialization(appContextSpy);
-    verify(appContextSpy, times(1)).getSystemService(anyString());
+    flutterLoader.startInitialization(RuntimeEnvironment.application);
+    verify(vsyncSpy, times(1)).init();
   }
 }


### PR DESCRIPTION
Internal bug: b/199439780

Android T enforces not using an application context to get a WidowManager.