### PR TITLE
Replace jcenter() for mavenCentral()

### DIFF
--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath "com.android.tools.build:gradle:7.0.0"
@@ -10,7 +10,7 @@ buildscript {
 
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 apply plugin: "com.android.library"

--- a/testing/android_background_image/android/build.gradle
+++ b/testing/android_background_image/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/testing/scenario_app/android/build.gradle
+++ b/testing/scenario_app/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/tools/cipd/android_embedding_bundle/build.gradle
+++ b/tools/cipd/android_embedding_bundle/build.gradle
@@ -12,7 +12,7 @@ def destinationDir = "lib"
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:3.5.0"
@@ -22,7 +22,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
The jcenter repo is deprecated.

Related issue: https://github.com/flutter/flutter/issues/88717