### PR TITLE
Set MinimumOSVersion to iOS 9 in Info.plist

### DIFF
--- a/shell/platform/darwin/ios/framework/Info.plist
+++ b/shell/platform/darwin/ios/framework/Info.plist
@@ -21,7 +21,7 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
   <key>FlutterEngine</key>
   <string>{0}</string>
   <key>ClangVersion</key>


### PR DESCRIPTION
The Flutter.framework minimum version was bumped to 9.0 as of flutter/engine#28572 / flutter/buildroot#509.  However, the framework's Info.plist was not updated, which causes App Store "Invalid bundle" submission failures.  Updated it to 9.0.

The "right" fix is https://github.com/flutter/engine/pull/28743 to set the value based on the iOS version buildroot setting.  That PR also has tests, but is riskier and has a higher likelihood of being reverted.

This PR is a targeted fix to resolve the P1 ASAP.

Fixes https://github.com/flutter/flutter/issues/90209

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
