### PR TITLE
added unit tests for the android embedder that run on android devices

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -145,6 +145,11 @@ group("flutter") {
       "//flutter/third_party/txt:txt_unittests",
     ]
 
+    if (is_android) {
+      public_deps +=
+          [ "//flutter/shell/platform/android:flutter_shell_native_unittests" ]
+    }
+
     # The accessibility library only supports Mac and Windows at the moment.
     if (is_mac || is_win) {
       public_deps +=

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -770,6 +770,7 @@ FILE: ../../../flutter/shell/gpu/gpu_surface_vulkan_delegate.h
 FILE: ../../../flutter/shell/platform/android/AndroidManifest.xml
 FILE: ../../../flutter/shell/platform/android/android_context_gl.cc
 FILE: ../../../flutter/shell/platform/android/android_context_gl.h
+FILE: ../../../flutter/shell/platform/android/android_context_gl_unittests.cc
 FILE: ../../../flutter/shell/platform/android/android_environment_gl.cc
 FILE: ../../../flutter/shell/platform/android/android_environment_gl.h
 FILE: ../../../flutter/shell/platform/android/android_exports.lst
@@ -779,6 +780,7 @@ FILE: ../../../flutter/shell/platform/android/android_image_generator.cc
 FILE: ../../../flutter/shell/platform/android/android_image_generator.h
 FILE: ../../../flutter/shell/platform/android/android_shell_holder.cc
 FILE: ../../../flutter/shell/platform/android/android_shell_holder.h
+FILE: ../../../flutter/shell/platform/android/android_shell_holder_unittests.cc
 FILE: ../../../flutter/shell/platform/android/android_surface_gl.cc
 FILE: ../../../flutter/shell/platform/android/android_surface_gl.h
 FILE: ../../../flutter/shell/platform/android/android_surface_software.cc
@@ -795,6 +797,7 @@ FILE: ../../../flutter/shell/platform/android/external_view_embedder/surface_poo
 FILE: ../../../flutter/shell/platform/android/external_view_embedder/surface_pool_unittests.cc
 FILE: ../../../flutter/shell/platform/android/flutter_main.cc
 FILE: ../../../flutter/shell/platform/android/flutter_main.h
+FILE: ../../../flutter/shell/platform/android/flutter_shell_native_unittests.cc
 FILE: ../../../flutter/shell/platform/android/io/flutter/FlutterInjector.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/Log.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterActivity.java

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -8,9 +8,9 @@
 #include <functional>
 #include <memory>
 
-#include "flow/embedded_views.h"
 #include "flutter/common/graphics/texture.h"
 #include "flutter/common/task_runners.h"
+#include "flutter/flow/embedded_views.h"
 #include "flutter/flow/surface.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -35,10 +35,30 @@ source_set("image_generator") {
   ]
 }
 
-shared_library("flutter_shell_native") {
-  visibility = [ ":*" ]
+executable("flutter_shell_native_unittests") {
+  visibility = [ "*" ]
+  testonly = true
+  sources = [
+    "android_context_gl_unittests.cc",
+    "android_shell_holder_unittests.cc",
+    "flutter_shell_native_unittests.cc",
+  ]
+  public_configs = [ "//flutter:config" ]
+  deps = [
+    ":flutter_shell_native_src",
+    "//third_party/googletest:gmock",
+    "//third_party/googletest:gtest",
+  ]
+}
 
+shared_library("flutter_shell_native") {
   output_name = "flutter"
+  deps = [ ":flutter_shell_native_src" ]
+  ldflags = [ "-Wl,--version-script=" + rebase_path("android_exports.lst") ]
+}
+
+source_set("flutter_shell_native_src") {
+  visibility = [ ":*" ]
 
   sources = [
     "$root_build_dir/flutter_icu/icudtl.o",
@@ -69,7 +89,7 @@ shared_library("flutter_shell_native") {
     "vsync_waiter_android.h",
   ]
 
-  deps = [
+  public_deps = [
     ":android_gpu_configuration",
     ":icudtl_object",
     ":image_generator",
@@ -100,8 +120,6 @@ shared_library("flutter_shell_native") {
     "EGL",
     "GLESv2",
   ]
-
-  ldflags = [ "-Wl,--version-script=" + rebase_path("android_exports.lst") ]
 }
 
 action("gen_android_build_config_java") {

--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -206,12 +206,19 @@ std::unique_ptr<AndroidEGLSurface> AndroidContextGL::CreateOnscreenSurface(
     fml::RefPtr<AndroidNativeWindow> window) const {
   EGLDisplay display = environment_->Display();
 
-  const EGLint attribs[] = {EGL_NONE};
+  if (window->IsOffscreen()) {
+    const EGLint attribs[] = {EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE};
 
-  EGLSurface surface = eglCreateWindowSurface(
-      display, config_, reinterpret_cast<EGLNativeWindowType>(window->handle()),
-      attribs);
-  return std::make_unique<AndroidEGLSurface>(surface, display, context_);
+    EGLSurface surface = eglCreatePbufferSurface(display, config_, attribs);
+    return std::make_unique<AndroidEGLSurface>(surface, display, context_);
+  } else {
+    const EGLint attribs[] = {EGL_NONE};
+
+    EGLSurface surface = eglCreateWindowSurface(
+        display, config_,
+        reinterpret_cast<EGLNativeWindowType>(window->handle()), attribs);
+    return std::make_unique<AndroidEGLSurface>(surface, display, context_);
+  }
 }
 
 std::unique_ptr<AndroidEGLSurface> AndroidContextGL::CreateOffscreenSurface()

--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -204,14 +204,11 @@ AndroidContextGL::~AndroidContextGL() {
 
 std::unique_ptr<AndroidEGLSurface> AndroidContextGL::CreateOnscreenSurface(
     fml::RefPtr<AndroidNativeWindow> window) const {
-  EGLDisplay display = environment_->Display();
-
   if (window->IsFakeWindow()) {
-    const EGLint attribs[] = {EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE};
-
-    EGLSurface surface = eglCreatePbufferSurface(display, config_, attribs);
-    return std::make_unique<AndroidEGLSurface>(surface, display, context_);
+    return CreatePbufferSurface();
   } else {
+    EGLDisplay display = environment_->Display();
+
     const EGLint attribs[] = {EGL_NONE};
 
     EGLSurface surface = eglCreateWindowSurface(

--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -206,7 +206,7 @@ std::unique_ptr<AndroidEGLSurface> AndroidContextGL::CreateOnscreenSurface(
     fml::RefPtr<AndroidNativeWindow> window) const {
   EGLDisplay display = environment_->Display();
 
-  if (window->IsOffscreen()) {
+  if (window->IsFakeWindow()) {
     const EGLint attribs[] = {EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE};
 
     EGLSurface surface = eglCreatePbufferSurface(display, config_, attribs);

--- a/shell/platform/android/android_context_gl_unittests.cc
+++ b/shell/platform/android/android_context_gl_unittests.cc
@@ -1,0 +1,11 @@
+#include <memory>
+#include "flutter/shell/platform/android/android_context_gl.h"
+#include "flutter/shell/platform/android/android_environment_gl.h"
+#include "gtest/gtest.h"
+
+TEST(AndroidContextGl, Create) {
+  auto environment = fml::MakeRefCounted<flutter::AndroidEnvironmentGL>();
+  auto context = std::make_unique<flutter::AndroidContextGL>(
+      flutter::AndroidRenderingAPI::kOpenGLES, environment);
+  EXPECT_NE(context.get(), nullptr);
+}

--- a/shell/platform/android/android_shell_holder_unittests.cc
+++ b/shell/platform/android/android_shell_holder_unittests.cc
@@ -1,0 +1,70 @@
+#include <memory>
+#include "flutter/shell/platform/android/android_shell_holder.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+namespace testing {
+namespace {
+class MockPlatformViewAndroidJNI : public PlatformViewAndroidJNI {
+  MOCK_METHOD2(FlutterViewHandlePlatformMessage,
+               void(std::unique_ptr<flutter::PlatformMessage> message,
+                    int responseId));
+  MOCK_METHOD2(FlutterViewHandlePlatformMessageResponse,
+               void(int responseId, std::unique_ptr<fml::Mapping> data));
+  MOCK_METHOD3(FlutterViewUpdateSemantics,
+               void(std::vector<uint8_t> buffer,
+                    std::vector<std::string> strings,
+                    std::vector<std::vector<uint8_t>> string_attribute_args));
+  MOCK_METHOD2(FlutterViewUpdateCustomAccessibilityActions,
+               void(std::vector<uint8_t> actions_buffer,
+                    std::vector<std::string> strings));
+  MOCK_METHOD0(FlutterViewOnFirstFrame, void());
+  MOCK_METHOD0(FlutterViewOnPreEngineRestart, void());
+  MOCK_METHOD2(SurfaceTextureAttachToGLContext,
+               void(JavaLocalRef surface_texture, int textureId));
+  MOCK_METHOD1(SurfaceTextureUpdateTexImage,
+               void(JavaLocalRef surface_texture));
+  MOCK_METHOD2(SurfaceTextureGetTransformMatrix,
+               void(JavaLocalRef surface_texture, SkMatrix& transform));
+  MOCK_METHOD1(SurfaceTextureDetachFromGLContext,
+               void(JavaLocalRef surface_texture));
+  MOCK_METHOD8(FlutterViewOnDisplayPlatformView,
+               void(int view_id,
+                    int x,
+                    int y,
+                    int width,
+                    int height,
+                    int viewWidth,
+                    int viewHeight,
+                    MutatorsStack mutators_stack));
+  MOCK_METHOD5(FlutterViewDisplayOverlaySurface,
+               void(int surface_id, int x, int y, int width, int height));
+  MOCK_METHOD0(FlutterViewBeginFrame, void());
+  MOCK_METHOD0(FlutterViewEndFrame, void());
+  MOCK_METHOD0(FlutterViewCreateOverlaySurface,
+               std::unique_ptr<PlatformViewAndroidJNI::OverlayMetadata>());
+  MOCK_METHOD0(FlutterViewDestroyOverlaySurfaces, void());
+  MOCK_METHOD1(FlutterViewComputePlatformResolvedLocale,
+               std::unique_ptr<std::vector<std::string>>(
+                   std::vector<std::string> supported_locales_data));
+  MOCK_METHOD0(GetDisplayRefreshRate, double());
+  MOCK_METHOD1(RequestDartDeferredLibrary, bool(int loading_unit_id));
+};
+}  // namespace
+
+TEST(AndroidShellHolder, Create) {
+  Settings settings;
+  settings.enable_software_rendering = false;
+  auto jni = std::make_shared<MockPlatformViewAndroidJNI>();
+  auto holder = std::make_unique<AndroidShellHolder>(
+      settings, jni, /*is_background_view=*/false);
+  EXPECT_NE(holder.get(), nullptr);
+  EXPECT_TRUE(holder->IsValid());
+  EXPECT_NE(holder->GetPlatformView().get(), nullptr);
+  auto window =
+      fml::MakeRefCounted<AndroidNativeWindow>(nullptr, /*is_offscreen=*/true);
+  holder->GetPlatformView()->NotifyCreated(window);
+}
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/android/flutter_shell_native_unittests.cc
+++ b/shell/platform/android/flutter_shell_native_unittests.cc
@@ -1,0 +1,6 @@
+#include "gtest/gtest.h"
+
+int main(int argc, char* argv[]) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/shell/platform/android/surface/android_native_window.cc
+++ b/shell/platform/android/surface/android_native_window.cc
@@ -6,11 +6,11 @@
 
 namespace flutter {
 
-AndroidNativeWindow::AndroidNativeWindow(Handle window, bool is_offscreen)
-    : window_(window), is_offscreen_(is_offscreen) {}
+AndroidNativeWindow::AndroidNativeWindow(Handle window, bool is_fake_window)
+    : window_(window), is_fake_window_(is_fake_window) {}
 
 AndroidNativeWindow::AndroidNativeWindow(Handle window)
-    : AndroidNativeWindow(window, /*is_offscreen=*/false) {}
+    : AndroidNativeWindow(window, /*is_fake_window=*/false) {}
 
 AndroidNativeWindow::~AndroidNativeWindow() {
   if (window_ != nullptr) {

--- a/shell/platform/android/surface/android_native_window.cc
+++ b/shell/platform/android/surface/android_native_window.cc
@@ -6,7 +6,11 @@
 
 namespace flutter {
 
-AndroidNativeWindow::AndroidNativeWindow(Handle window) : window_(window) {}
+AndroidNativeWindow::AndroidNativeWindow(Handle window, bool is_offscreen)
+    : window_(window), is_offscreen_(is_offscreen) {}
+
+AndroidNativeWindow::AndroidNativeWindow(Handle window)
+    : AndroidNativeWindow(window, /*is_offscreen=*/false) {}
 
 AndroidNativeWindow::~AndroidNativeWindow() {
   if (window_ != nullptr) {

--- a/shell/platform/android/surface/android_native_window.h
+++ b/shell/platform/android/surface/android_native_window.h
@@ -34,17 +34,17 @@ class AndroidNativeWindow
 
   /// Returns true when this AndroidNativeWindow is not backed by a real window
   /// (used for testing).
-  bool IsOffscreen() const { return is_offscreen_; }
+  bool IsFakeWindow() const { return is_fake_window_; }
 
  private:
   Handle window_;
-  const bool is_offscreen_;
+  const bool is_fake_window_;
 
   /// Creates a native window with the given handle. Handle ownership is assumed
   /// by this instance of the native window.
   explicit AndroidNativeWindow(Handle window);
 
-  explicit AndroidNativeWindow(Handle window, bool is_offscreen);
+  explicit AndroidNativeWindow(Handle window, bool is_fake_window);
 
   ~AndroidNativeWindow();
 

--- a/shell/platform/android/surface/android_native_window.h
+++ b/shell/platform/android/surface/android_native_window.h
@@ -32,12 +32,19 @@ class AndroidNativeWindow
 
   SkISize GetSize() const;
 
+  /// Returns true when this AndroidNativeWindow is not backed by a real window
+  /// (used for testing).
+  bool IsOffscreen() const { return is_offscreen_; }
+
  private:
   Handle window_;
+  const bool is_offscreen_;
 
   /// Creates a native window with the given handle. Handle ownership is assumed
   /// by this instance of the native window.
   explicit AndroidNativeWindow(Handle window);
+
+  explicit AndroidNativeWindow(Handle window, bool is_offscreen);
 
   ~AndroidNativeWindow();
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -351,6 +351,14 @@ def RunJavaTests(filter, android_variant='android_debug_unopt'):
   RunCmd(command, cwd=test_runner_dir, env=env)
 
 
+def RunAndroidTests(android_variant='android_debug_unopt'):
+  test_runner_name = 'flutter_shell_native_unittests'
+  tests_path = os.path.join(out_dir, android_variant, test_runner_name)
+  remote_path = '/data/local/tmp'
+  remote_tests_path = os.path.join(remote_path, test_runner_name)
+  RunCmd(['adb', 'push', tests_path, remote_path], cwd=buildroot_dir)
+  RunCmd(['adb', 'shell', remote_tests_path])
+
 def RunObjcTests(ios_variant='ios_debug_sim_unopt', test_filter=None):
   """Runs Objective-C XCTest unit tests for the iOS embedding"""
   AssertExpectedXcodeVersion()
@@ -591,6 +599,10 @@ def main():
       print('Can only filter JUnit4 tests by single entire class name, eg "io.flutter.SmokeTest". Ignoring filter=' + java_filter)
       java_filter = None
     RunJavaTests(java_filter, args.android_variant)
+
+  if 'android' in types:
+    assert not IsWindows(), "Android engine files can't be compiled on Windows."
+    RunAndroidTests(args.android_variant)
 
   if 'objc' in types:
     assert IsMac(), "iOS embedding tests can only be run on macOS."


### PR DESCRIPTION
Created a test runner that can execute Android embedder code on an Android device.  This matches the capabilities that we have for iOS with iOS with `IosUnitTests`.  Before this all c++ files in `shell/platform/android` were unable to be unit tested.  Since `scenario_app` isn't working for Android there is was no test coverage for these files in the engine repository.

This will be used to create the unit tests to resolve https://github.com/flutter/flutter/issues/90398.  The AndroidShellHolder test is hitting the code that we were concerned about.

We previously discussed something that would execute on the host platform with SwiftShader but that would be more work to get android code compiling for the host platform and be less useful since this actually runs on the target device.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
