### PR TITLE
Add test for web platform environment defines

### DIFF
--- a/lib/web_ui/test/platform_environment_define_test.dart
+++ b/lib/web_ui/test/platform_environment_define_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/lib/web_ui/test/platform_environment_define_test.dart
+++ b/lib/web_ui/test/platform_environment_define_test.dart
@@ -1,0 +1,17 @@
+// Copyright 2021 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/bootstrap/browser.dart';
+import 'package:test/test.dart';
+
+void main() {
+  internalBootstrapBrowserTest(() => testMain);
+}
+
+void testMain() {
+  test('Web library environment define exists', () {
+    expect(const bool.fromEnvironment('dart.library.html'), isTrue);
+    expect(const bool.fromEnvironment('dart.library.someFooLibrary'), isFalse);
+  });
+}


### PR DESCRIPTION
Adds a regression test for https://github.com/dart-lang/sdk/issues/47207. This is tested in the Dart SDK but since Flutter web has its own integration of the DDC compiler through a frontend server it makes sense to test here as well.

This test requires https://github.com/dart-lang/sdk/commit/6c4593929f067af259113eae5dc1b3b1c04f1035 from the Dart SDK to pass.
