### PR TITLE
Share the GrContext between lightweight engines

### DIFF
--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -194,7 +194,7 @@ AndroidContextGL::~AndroidContextGL() {
   sk_sp<GrDirectContext> main_context = GetMainSkiaContext();
   SetMainSkiaContext(nullptr);
   fml::AutoResetWaitableEvent latch;
-  task_runners_.GetRasterTaskRunner()->PostTask([&] {
+  fml::TaskRunner::RunNowOrPostTask(task_runners_.GetRasterTaskRunner(), [&] {
     if (main_context) {
       std::unique_ptr<AndroidEGLSurface> pbuffer_surface =
           CreateOffscreenSurface();
@@ -208,6 +208,7 @@ AndroidContextGL::~AndroidContextGL() {
     latch.Signal();
   });
   latch.Wait();
+
   if (!TeardownContext(environment_->Display(), context_)) {
     FML_LOG(ERROR)
         << "Could not tear down the EGL context. Possible resource leak.";

--- a/shell/platform/android/android_context_gl.h
+++ b/shell/platform/android/android_context_gl.h
@@ -72,7 +72,8 @@ class AndroidEGLSurface {
 class AndroidContextGL : public AndroidContext {
  public:
   AndroidContextGL(AndroidRenderingAPI rendering_api,
-                   fml::RefPtr<AndroidEnvironmentGL> environment);
+                   fml::RefPtr<AndroidEnvironmentGL> environment,
+                   const TaskRunners& taskRunners);
 
   ~AndroidContextGL();
 
@@ -131,6 +132,7 @@ class AndroidContextGL : public AndroidContext {
   EGLContext context_;
   EGLContext resource_context_;
   bool valid_ = false;
+  TaskRunners task_runners_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidContextGL);
 };

--- a/shell/platform/android/android_context_gl_unittests.cc
+++ b/shell/platform/android/android_context_gl_unittests.cc
@@ -1,11 +1,67 @@
+#define FML_USED_ON_EMBEDDER
+
 #include <memory>
+#include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/platform/android/android_context_gl.h"
 #include "flutter/shell/platform/android/android_environment_gl.h"
 #include "gtest/gtest.h"
 
-TEST(AndroidContextGl, Create) {
-  auto environment = fml::MakeRefCounted<flutter::AndroidEnvironmentGL>();
-  auto context = std::make_unique<flutter::AndroidContextGL>(
-      flutter::AndroidRenderingAPI::kOpenGLES, environment);
-  EXPECT_NE(context.get(), nullptr);
+namespace flutter {
+namespace testing {
+namespace android {
+namespace {
+TaskRunners MakeTaskRunners(const std::string& thread_label,
+                            const ThreadHost& thread_host) {
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  fml::RefPtr<fml::TaskRunner> platform_runner =
+      fml::MessageLoop::GetCurrent().GetTaskRunner();
+
+  return TaskRunners(thread_label, platform_runner,
+                     thread_host.raster_thread->GetTaskRunner(),
+                     thread_host.ui_thread->GetTaskRunner(),
+                     thread_host.io_thread->GetTaskRunner());
 }
+}  // namespace
+
+TEST(AndroidContextGl, Create) {
+  GrMockOptions main_context_options;
+  sk_sp<GrDirectContext> main_context =
+      GrDirectContext::MakeMock(&main_context_options);
+  auto environment = fml::MakeRefCounted<AndroidEnvironmentGL>();
+  std::string thread_label =
+      ::testing::UnitTest::GetInstance()->current_test_info()->name();
+  ThreadHost thread_host(thread_label, ThreadHost::Type::UI |
+                                           ThreadHost::Type::RASTER |
+                                           ThreadHost::Type::IO);
+  TaskRunners task_runners = MakeTaskRunners(thread_label, thread_host);
+  auto context = std::make_unique<AndroidContextGL>(
+      AndroidRenderingAPI::kOpenGLES, environment, task_runners);
+  context->SetMainSkiaContext(main_context);
+  EXPECT_NE(context.get(), nullptr);
+  context.reset();
+  EXPECT_TRUE(main_context->abandoned());
+}
+
+TEST(AndroidContextGl, CreateSingleThread) {
+  GrMockOptions main_context_options;
+  sk_sp<GrDirectContext> main_context =
+      GrDirectContext::MakeMock(&main_context_options);
+  auto environment = fml::MakeRefCounted<AndroidEnvironmentGL>();
+  std::string thread_label =
+      ::testing::UnitTest::GetInstance()->current_test_info()->name();
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  fml::RefPtr<fml::TaskRunner> platform_runner =
+      fml::MessageLoop::GetCurrent().GetTaskRunner();
+  TaskRunners task_runners =
+      TaskRunners(thread_label, platform_runner, platform_runner,
+                  platform_runner, platform_runner);
+  auto context = std::make_unique<AndroidContextGL>(
+      AndroidRenderingAPI::kOpenGLES, environment, task_runners);
+  context->SetMainSkiaContext(main_context);
+  EXPECT_NE(context.get(), nullptr);
+  context.reset();
+  EXPECT_TRUE(main_context->abandoned());
+}
+}  // namespace android
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -52,7 +52,13 @@ std::unique_ptr<Surface> AndroidSurfaceGL::CreateGPUSurface(
   if (gr_context) {
     return std::make_unique<GPUSurfaceGL>(sk_ref_sp(gr_context), this, true);
   } else {
-    return std::make_unique<GPUSurfaceGL>(this, true);
+    sk_sp<GrDirectContext> main_skia_context =
+        GLContextPtr()->GetMainSkiaContext();
+    if (!main_skia_context) {
+      main_skia_context = GPUSurfaceGL::MakeGLContext(this);
+      GLContextPtr()->SetMainSkiaContext(main_skia_context);
+    }
+    return std::make_unique<GPUSurfaceGL>(main_skia_context, this, true);
   }
 }
 
@@ -171,7 +177,14 @@ AndroidContextGL* AndroidSurfaceGL::GLContextPtr() const {
 
 std::unique_ptr<Surface> AndroidSurfaceGL::CreatePbufferSurface() {
   onscreen_surface_ = GLContextPtr()->CreatePbufferSurface();
-  return std::make_unique<GPUSurfaceGL>(this, true);
+  sk_sp<GrDirectContext> main_skia_context =
+      GLContextPtr()->GetMainSkiaContext();
+  if (!main_skia_context) {
+    main_skia_context = GPUSurfaceGL::MakeGLContext(this);
+    GLContextPtr()->SetMainSkiaContext(main_skia_context);
+  }
+
+  return std::make_unique<GPUSurfaceGL>(main_skia_context, this, true);
 }
 
 }  // namespace flutter

--- a/shell/platform/android/context/android_context.cc
+++ b/shell/platform/android/context/android_context.cc
@@ -9,7 +9,11 @@ namespace flutter {
 AndroidContext::AndroidContext(AndroidRenderingAPI rendering_api)
     : rendering_api_(rendering_api) {}
 
-AndroidContext::~AndroidContext() = default;
+AndroidContext::~AndroidContext() {
+  if (main_context_) {
+    main_context_->releaseResourcesAndAbandonContext();
+  }
+};
 
 AndroidRenderingAPI AndroidContext::RenderingApi() const {
   return rendering_api_;
@@ -17,6 +21,15 @@ AndroidRenderingAPI AndroidContext::RenderingApi() const {
 
 bool AndroidContext::IsValid() const {
   return true;
+}
+
+void AndroidContext::SetMainSkiaContext(
+    const sk_sp<GrDirectContext>& main_context) {
+  main_context_ = main_context;
+}
+
+sk_sp<GrDirectContext> AndroidContext::GetMainSkiaContext() const {
+  return main_context_;
 }
 
 }  // namespace flutter

--- a/shell/platform/android/context/android_context.h
+++ b/shell/platform/android/context/android_context.h
@@ -6,6 +6,7 @@
 #define FLUTTER_SHELL_PLATFORM_ANDROID_ANDROID_CONTEXT_H_
 
 #include "flutter/fml/macros.h"
+#include "flutter/fml/task_runner.h"
 #include "third_party/skia/include/gpu/GrDirectContext.h"
 
 namespace flutter {

--- a/shell/platform/android/context/android_context.h
+++ b/shell/platform/android/context/android_context.h
@@ -28,8 +28,36 @@ class AndroidContext {
 
   virtual bool IsValid() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Setter for the Skia context to be used by subsequent
+  ///             AndroidSurfaces.
+  /// @details    This is useful to reduce memory consumption when creating
+  ///             multiple AndroidSurfaces for the same AndroidContext.
+  ///
+  ///             The first AndroidSurface should set this for the
+  ///             AndroidContext if the AndroidContext does not yet have a
+  ///             Skia context to share via GetMainSkiaContext.
+  ///
+  void SetMainSkiaContext(const sk_sp<GrDirectContext>& main_context);
+
+  //----------------------------------------------------------------------------
+  /// @brief      Accessor for the Skia context associated with AndroidSurfaces
+  ///             and the raster thread.
+  /// @details    This context is created lazily by the AndroidSurface based
+  ///             on their respective rendering backend and set on this
+  ///             AndroidContext to share via SetMainSkiaContext.
+  /// @returns    `nullptr` when no Skia context has been set yet by its
+  ///             AndroidSurface via SetMainSkiaContext.
+  /// @attention  The software context doesn't have a Skia context, so this
+  ///             value will be nullptr.
+  ///
+  sk_sp<GrDirectContext> GetMainSkiaContext() const;
+
  private:
   const AndroidRenderingAPI rendering_api_;
+
+  // This is the Skia context used for on-screen rendering.
+  sk_sp<GrDirectContext> main_context_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidContext);
 };

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -46,13 +46,14 @@ std::unique_ptr<AndroidSurface> AndroidSurfaceFactoryImpl::CreateSurface() {
 }
 
 static std::shared_ptr<flutter::AndroidContext> CreateAndroidContext(
-    bool use_software_rendering) {
+    bool use_software_rendering,
+    const flutter::TaskRunners task_runners) {
   if (use_software_rendering) {
     return std::make_shared<AndroidContext>(AndroidRenderingAPI::kSoftware);
   }
   return std::make_unique<AndroidContextGL>(
       AndroidRenderingAPI::kOpenGLES,
-      fml::MakeRefCounted<AndroidEnvironmentGL>());
+      fml::MakeRefCounted<AndroidEnvironmentGL>(), task_runners);
 }
 
 PlatformViewAndroid::PlatformViewAndroid(
@@ -63,7 +64,8 @@ PlatformViewAndroid::PlatformViewAndroid(
     : PlatformViewAndroid(delegate,
                           std::move(task_runners),
                           std::move(jni_facade),
-                          CreateAndroidContext(use_software_rendering)) {}
+                          CreateAndroidContext(use_software_rendering,
+                                               task_runners)) {}
 
 PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -286,7 +286,8 @@ std::unique_ptr<Surface> PlatformViewAndroid::CreateRenderingSurface() {
   if (!android_surface_) {
     return nullptr;
   }
-  return android_surface_->CreateGPUSurface();
+  return android_surface_->CreateGPUSurface(
+      android_context_->GetMainSkiaContext().get());
 }
 
 // |PlatformView|

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -61,11 +61,11 @@ PlatformViewAndroid::PlatformViewAndroid(
     flutter::TaskRunners task_runners,
     std::shared_ptr<PlatformViewAndroidJNI> jni_facade,
     bool use_software_rendering)
-    : PlatformViewAndroid(delegate,
-                          std::move(task_runners),
-                          std::move(jni_facade),
-                          CreateAndroidContext(use_software_rendering,
-                                               task_runners)) {}
+    : PlatformViewAndroid(
+          delegate,
+          std::move(task_runners),
+          std::move(jni_facade),
+          CreateAndroidContext(use_software_rendering, task_runners)) {}
 
 PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,


### PR DESCRIPTION
Reverts https://github.com/flutter/engine/commit/27281c426f22c50e3cd339f62c32511922fa17b0, reenabling sharing of GrContexts.  It also takes advantage of the new test harness to ensure it is safe.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
