### PR TITLE
fuchsia: Add child views to flatland engine

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -147,16 +147,24 @@ class Engine final : public fuchsia::memorypressure::Watcher {
   void Terminate();
 
   void DebugWireframeSettingsChanged(bool enabled);
-  void CreateView(int64_t view_id,
-                  ViewCallback on_view_created,
-                  ViewIdCallback on_view_bound,
-                  bool hit_testable,
-                  bool focusable);
+  void CreateGfxView(int64_t view_id,
+                     ViewCallback on_view_created,
+                     GfxViewIdCallback on_view_bound,
+                     bool hit_testable,
+                     bool focusable);
+  void CreateFlatlandView(int64_t view_id,
+                          ViewCallback on_view_created,
+                          FlatlandViewCreatedCallback on_view_bound,
+                          bool hit_testable,
+                          bool focusable);
   void UpdateView(int64_t view_id,
                   SkRect occlusion_hint,
                   bool hit_testable,
-                  bool focusable);
-  void DestroyView(int64_t view_id, ViewIdCallback on_view_unbound);
+                  bool focusable,
+                  bool use_flatland);
+  void DestroyGfxView(int64_t view_id, GfxViewIdCallback on_view_unbound);
+  void DestroyFlatlandView(int64_t view_id,
+                           FlatlandViewIdCallback on_view_unbound);
 
   // |fuchsia::memorypressure::Watcher|
   void OnLevelChanged(fuchsia::memorypressure::Level level,

--- a/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/flatland_external_view_embedder.h
@@ -30,7 +30,10 @@
 
 namespace flutter_runner {
 
-using FlatlandViewCallback = std::function<void()>;
+using ViewCallback = std::function<void()>;
+using FlatlandViewCreatedCallback = std::function<void(
+    fuchsia::ui::composition::ContentId,
+    fuchsia::ui::composition::ChildViewWatcherPtr child_view_watcher)>;
 using FlatlandViewIdCallback =
     std::function<void(fuchsia::ui::composition::ContentId)>;
 
@@ -95,8 +98,8 @@ class FlatlandExternalViewEmbedder final
   // |SetViewProperties| doesn't manipulate the view directly -- it sets pending
   // properties for the next |UpdateView| call.
   void CreateView(int64_t view_id,
-                  FlatlandViewCallback on_view_created,
-                  FlatlandViewIdCallback on_view_bound);
+                  ViewCallback on_view_created,
+                  FlatlandViewCreatedCallback on_view_bound);
   void DestroyView(int64_t view_id, FlatlandViewIdCallback on_view_unbound);
   void SetViewProperties(int64_t view_id,
                          const SkRect& occlusion_hint,
@@ -153,7 +156,6 @@ class FlatlandExternalViewEmbedder final
   struct FlatlandView {
     fuchsia::ui::composition::TransformId transform_id;
     fuchsia::ui::composition::ContentId viewport_id;
-    fuchsia::ui::composition::ChildViewWatcherPtr content_link;
     ViewMutators mutators;
     SkSize size = SkSize::MakeEmpty();
   };

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.cc
@@ -578,7 +578,7 @@ void FuchsiaExternalViewEmbedder::EnableWireframe(bool enable) {
 
 void FuchsiaExternalViewEmbedder::CreateView(int64_t view_id,
                                              ViewCallback on_view_created,
-                                             ViewIdCallback on_view_bound) {
+                                             GfxViewIdCallback on_view_bound) {
   FML_CHECK(scenic_views_.find(view_id) == scenic_views_.end());
 
   ScenicView new_view = {
@@ -602,8 +602,9 @@ void FuchsiaExternalViewEmbedder::CreateView(int64_t view_id,
   scenic_views_.emplace(std::make_pair(view_id, std::move(new_view)));
 }
 
-void FuchsiaExternalViewEmbedder::DestroyView(int64_t view_id,
-                                              ViewIdCallback on_view_unbound) {
+void FuchsiaExternalViewEmbedder::DestroyView(
+    int64_t view_id,
+    GfxViewIdCallback on_view_unbound) {
   auto scenic_view = scenic_views_.find(view_id);
   FML_CHECK(scenic_view != scenic_views_.end());
   scenic::ResourceId resource_id = scenic_view->second.view_holder.id();

--- a/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_external_view_embedder.h
@@ -33,7 +33,7 @@
 namespace flutter_runner {
 
 using ViewCallback = std::function<void()>;
-using ViewIdCallback = std::function<void(scenic::ResourceId)>;
+using GfxViewIdCallback = std::function<void(scenic::ResourceId)>;
 
 // This struct represents a transformed clip rect.
 struct TransformedClip {
@@ -126,8 +126,8 @@ class FuchsiaExternalViewEmbedder final : public flutter::ExternalViewEmbedder {
   void EnableWireframe(bool enable);
   void CreateView(int64_t view_id,
                   ViewCallback on_view_created,
-                  ViewIdCallback on_view_bound);
-  void DestroyView(int64_t view_id, ViewIdCallback on_view_unbound);
+                  GfxViewIdCallback on_view_bound);
+  void DestroyView(int64_t view_id, GfxViewIdCallback on_view_unbound);
   void SetViewProperties(int64_t view_id,
                          const SkRect& occlusion_hint,
                          bool hit_testable,

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -64,9 +64,7 @@ PlatformView::PlatformView(
     fidl::InterfaceRequest<fuchsia::ui::input3::KeyboardListener>
         keyboard_listener_request,
     OnEnableWireframe wireframe_enabled_callback,
-    OnCreateView on_create_view_callback,
     OnUpdateView on_update_view_callback,
-    OnDestroyView on_destroy_view_callback,
     OnCreateSurface on_create_surface_callback,
     OnSemanticsNodeUpdate on_semantics_node_update_callback,
     OnRequestAnnounce on_request_announce_callback,
@@ -83,9 +81,7 @@ PlatformView::PlatformView(
       pointer_delegate_(
           std::make_shared<PointerDelegate>(std::move(touch_source))),
       wireframe_enabled_callback_(std::move(wireframe_enabled_callback)),
-      on_create_view_callback_(std::move(on_create_view_callback)),
       on_update_view_callback_(std::move(on_update_view_callback)),
-      on_destroy_view_callback_(std::move(on_destroy_view_callback)),
       on_create_surface_callback_(std::move(on_create_surface_callback)),
       on_semantics_node_update_callback_(
           std::move(on_semantics_node_update_callback)),
@@ -253,82 +249,6 @@ void PlatformView::OnAction(fuchsia::ui::input::InputMethodAction action) {
       fml::MallocMapping::Copy(data, buffer.GetSize()),  // message
       nullptr)                                           // response
   );
-}
-
-bool PlatformView::OnChildViewConnected(scenic::ResourceId view_holder_id) {
-  auto view_id_mapping = child_view_ids_.find(view_holder_id);
-  if (view_id_mapping == child_view_ids_.end()) {
-    return false;
-  }
-
-  std::ostringstream out;
-  out << "{"
-      << "\"method\":\"View.viewConnected\","
-      << "\"args\":{"
-      << "  \"viewId\":" << view_id_mapping->second  // ViewHolderToken handle
-      << "  }"
-      << "}";
-  auto call = out.str();
-
-  std::unique_ptr<flutter::PlatformMessage> message =
-      std::make_unique<flutter::PlatformMessage>(
-          "flutter/platform_views",
-          fml::MallocMapping::Copy(call.c_str(), call.size()), nullptr);
-  DispatchPlatformMessage(std::move(message));
-
-  return true;
-}
-
-bool PlatformView::OnChildViewDisconnected(scenic::ResourceId view_holder_id) {
-  auto view_id_mapping = child_view_ids_.find(view_holder_id);
-  if (view_id_mapping == child_view_ids_.end()) {
-    return false;
-  }
-
-  std::ostringstream out;
-  out << "{"
-      << "\"method\":\"View.viewDisconnected\","
-      << "\"args\":{"
-      << "  \"viewId\":" << view_id_mapping->second  // ViewHolderToken handle
-      << "  }"
-      << "}";
-  auto call = out.str();
-
-  std::unique_ptr<flutter::PlatformMessage> message =
-      std::make_unique<flutter::PlatformMessage>(
-          "flutter/platform_views",
-          fml::MallocMapping::Copy(call.c_str(), call.size()), nullptr);
-  DispatchPlatformMessage(std::move(message));
-
-  return true;
-}
-
-bool PlatformView::OnChildViewStateChanged(scenic::ResourceId view_holder_id,
-                                           bool is_rendering) {
-  auto view_id_mapping = child_view_ids_.find(view_holder_id);
-  if (view_id_mapping == child_view_ids_.end()) {
-    return false;
-  }
-
-  const std::string is_rendering_str = is_rendering ? "true" : "false";
-  std::ostringstream out;
-  out << "{"
-      << "\"method\":\"View.viewStateChanged\","
-      << "\"args\":{"
-      << "  \"viewId\":" << view_id_mapping->second << ","  // ViewHolderToken
-      << "  \"is_rendering\":" << is_rendering_str << ","   // IsViewRendering
-      << "  \"state\":" << is_rendering_str                 // IsViewRendering
-      << "  }"
-      << "}";
-  auto call = out.str();
-
-  std::unique_ptr<flutter::PlatformMessage> message =
-      std::make_unique<flutter::PlatformMessage>(
-          "flutter/platform_views",
-          fml::MallocMapping::Copy(call.c_str(), call.size()), nullptr);
-  DispatchPlatformMessage(std::move(message));
-
-  return true;
 }
 
 static flutter::PointerData::Change GetChangeFromPointerEventPhase(
@@ -800,7 +720,6 @@ bool PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
       return false;
     }
 
-    const int64_t view_id_raw = view_id->value.GetUint64();
     auto on_view_created = fml::MakeCopyable(
         [platform_task_runner = task_runners_.GetPlatformTaskRunner(),
          message = std::move(message)]() {
@@ -811,25 +730,8 @@ bool PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
                 std::vector<uint8_t>({'[', '0', ']'})));
           }
         });
-    auto on_view_bound =
-        [weak = weak_factory_.GetWeakPtr(),
-         platform_task_runner = task_runners_.GetPlatformTaskRunner(),
-         view_id = view_id_raw](scenic::ResourceId resource_id) {
-          platform_task_runner->PostTask([weak, view_id, resource_id]() {
-            if (!weak) {
-              FML_LOG(WARNING)
-                  << "ViewHolder bound to PlatformView after PlatformView was "
-                     "destroyed; ignoring.";
-              return;
-            }
-
-            FML_DCHECK(weak->child_view_ids_.count(resource_id) == 0);
-            weak->child_view_ids_[resource_id] = view_id;
-          });
-        };
-    on_create_view_callback_(
-        view_id_raw, std::move(on_view_created), std::move(on_view_bound),
-        hit_testable->value.GetBool(), focusable->value.GetBool());
+    OnCreateView(std::move(on_view_created), view_id->value.GetUint64(),
+                 hit_testable->value.GetBool(), focusable->value.GetBool());
     return true;
   } else if (method == "View.update") {
     auto args_it = root.FindMember("args");
@@ -917,24 +819,7 @@ bool PlatformView::HandleFlutterPlatformViewsChannelPlatformMessage(
       return false;
     }
 
-    const int64_t view_id_raw = view_id->value.GetUint64();
-    auto on_view_unbound =
-        [weak = weak_factory_.GetWeakPtr(),
-         platform_task_runner = task_runners_.GetPlatformTaskRunner()](
-            scenic::ResourceId resource_id) {
-          platform_task_runner->PostTask([weak, resource_id]() {
-            if (!weak) {
-              FML_LOG(WARNING)
-                  << "ViewHolder unbound from PlatformView after PlatformView"
-                     "was destroyed; ignoring.";
-              return;
-            }
-
-            FML_DCHECK(weak->child_view_ids_.count(resource_id) == 1);
-            weak->child_view_ids_.erase(resource_id);
-          });
-        };
-    on_destroy_view_callback_(view_id_raw, std::move(on_view_unbound));
+    OnDisposeView(view_id->value.GetUint64());
     if (message->response()) {
       message->response()->Complete(std::make_unique<fml::DataMapping>(
           std::vector<uint8_t>({'[', '0', ']'})));

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -215,7 +215,7 @@ class PlatformViewBuilder {
     return *this;
   }
 
-  PlatformViewBuilder& SetDestroyViewCallback(OnDestroyView callback) {
+  PlatformViewBuilder& SetDestroyViewCallback(OnDestroyGfxView callback) {
     on_destroy_view_callback_ = std::move(callback);
     return *this;
   }
@@ -230,7 +230,7 @@ class PlatformViewBuilder {
     return *this;
   }
 
-  PlatformViewBuilder& SetCreateViewCallback(OnCreateView callback) {
+  PlatformViewBuilder& SetCreateViewCallback(OnCreateGfxView callback) {
     on_create_view_callback_ = std::move(callback);
     return *this;
   }
@@ -310,9 +310,9 @@ class PlatformViewBuilder {
       keyboard_listener_{nullptr};
   fit::closure on_session_listener_error_callback_{nullptr};
   OnEnableWireframe wireframe_enabled_callback_{nullptr};
-  OnCreateView on_create_view_callback_{nullptr};
+  OnCreateGfxView on_create_view_callback_{nullptr};
   OnUpdateView on_update_view_callback_{nullptr};
-  OnDestroyView on_destroy_view_callback_{nullptr};
+  OnDestroyGfxView on_destroy_view_callback_{nullptr};
   OnCreateSurface on_create_surface_callback_{nullptr};
   OnSemanticsNodeUpdate on_semantics_node_update_callback_{nullptr};
   OnRequestAnnounce on_request_announce_callback_{nullptr};
@@ -706,7 +706,7 @@ TEST_F(PlatformViewTests, CreateViewTest) {
   auto CreateViewCallback = [&create_view_called](
                                 int64_t view_id,
                                 flutter_runner::ViewCallback on_view_created,
-                                flutter_runner::ViewIdCallback on_view_bound,
+                                flutter_runner::GfxViewIdCallback on_view_bound,
                                 bool hit_testable, bool focusable) {
     create_view_called = true;
     on_view_created();
@@ -883,8 +883,8 @@ TEST_F(PlatformViewTests, DestroyViewTest) {
   // setting |wireframe_enabled| to true.
   bool destroy_view_called = false;
   auto DestroyViewCallback =
-      [&destroy_view_called](int64_t view_id,
-                             flutter_runner::ViewIdCallback on_view_unbound) {
+      [&destroy_view_called](
+          int64_t view_id, flutter_runner::GfxViewIdCallback on_view_unbound) {
         destroy_view_called = true;
         on_view_unbound(0);
       };
@@ -942,14 +942,14 @@ TEST_F(PlatformViewTests, ViewEventsTest) {
                            nullptr                               // io
       );
 
-  auto on_create_view = [kViewId](int64_t view_id,
-                                  flutter_runner::ViewCallback on_view_created,
-                                  flutter_runner::ViewIdCallback on_view_bound,
-                                  bool hit_testable, bool focusable) {
-    ASSERT_EQ(view_id, kViewId);
-    on_view_created();
-    on_view_bound(kViewHolderId);
-  };
+  auto on_create_view =
+      [kViewId](int64_t view_id, flutter_runner::ViewCallback on_view_created,
+                flutter_runner::GfxViewIdCallback on_view_bound,
+                bool hit_testable, bool focusable) {
+        ASSERT_EQ(view_id, kViewId);
+        on_view_created();
+        on_view_bound(kViewHolderId);
+      };
 
   flutter_runner::GfxPlatformView platform_view =
       PlatformViewBuilder(delegate, std::move(task_runners),


### PR DESCRIPTION
This PR adds the flatland specific child creation code to engine. We still use int64 hack for passing token down to engine from dart, but we interpret it as zx::channel(Flatland's ViewCreationToken) if ViewProvider code established a flatland connection. 

There are strong-typed callbacks for Flatland specific code. Events are captured in FlatlandPlatformView and scene changes are in FlatlandExternalViewEmbedder. 

See https://fuchsia-review.googlesource.com/c/fuchsia/+/584563 for dart sdk changes. We are waiting for Screenshot capability to add flutter-embedder-test cases.

Bug: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=64201