### PR TITLE
vsync_waiter_fallback should schedule firecallback for future

### DIFF
--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -98,7 +98,6 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
                                fml::TimePoint frame_target_time,
                                bool pause_secondary_tasks) {
   FML_DCHECK(fml::TimePoint::Now() >= frame_start_time);
-  FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   Callback callback;
   std::vector<fml::closure> secondary_callbacks;

--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -7,8 +7,10 @@
 #include "flow/frame_timings.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/fml/trace_event.h"
+#include "fml/logging.h"
 #include "fml/message_loop_task_queues.h"
 #include "fml/task_queue_id.h"
+#include "fml/time/time_point.h"
 
 namespace flutter {
 
@@ -95,6 +97,9 @@ void VsyncWaiter::ScheduleSecondaryCallback(uintptr_t id,
 void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
                                fml::TimePoint frame_target_time,
                                bool pause_secondary_tasks) {
+  FML_DCHECK(fml::TimePoint::Now() >= frame_start_time);
+  FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
+
   Callback callback;
   std::vector<fml::closure> secondary_callbacks;
 
@@ -137,7 +142,7 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
       ui_task_queue_id = task_runners_.GetUITaskRunner()->GetTaskQueueId();
     }
 
-    task_runners_.GetUITaskRunner()->PostTaskForTime(
+    task_runners_.GetUITaskRunner()->PostTask(
         [ui_task_queue_id, callback, flow_identifier, frame_start_time,
          frame_target_time, pause_secondary_tasks]() {
           FML_TRACE_EVENT("flutter", kVsyncTraceName, "StartTime",
@@ -151,8 +156,7 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
           if (pause_secondary_tasks) {
             ResumeDartMicroTasks(ui_task_queue_id);
           }
-        },
-        frame_start_time);
+        });
   }
 
   for (auto& secondary_callback : secondary_callbacks) {

--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -65,6 +65,8 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
   // as AwaitVSync().
   virtual void AwaitVSyncForSecondaryCallback() { AwaitVSync(); }
 
+  // Schedules the callback on the UI task runner. Needs to be invoked as close
+  // to the `frame_start_time` as possible.
   void FireCallback(fml::TimePoint frame_start_time,
                     fml::TimePoint frame_target_time,
                     bool pause_secondary_tasks = true);

--- a/shell/common/vsync_waiter_fallback.cc
+++ b/shell/common/vsync_waiter_fallback.cc
@@ -35,11 +35,15 @@ void VsyncWaiterFallback::AwaitVSync() {
 
   constexpr fml::TimeDelta kSingleFrameInterval =
       fml::TimeDelta::FromSecondsF(1.0 / 60.0);
-
-  auto next =
+  auto frame_start_time =
       SnapToNextTick(fml::TimePoint::Now(), phase_, kSingleFrameInterval);
+  auto frame_target_time = frame_start_time + kSingleFrameInterval;
 
-  FireCallback(next, next + kSingleFrameInterval, !for_testing_);
+  task_runners_.GetPlatformTaskRunner()->PostTaskForTime(
+      [frame_start_time, frame_target_time, this]() {
+        FireCallback(frame_start_time, frame_target_time, !for_testing_);
+      },
+      frame_start_time);
 }
 
 }  // namespace flutter

--- a/shell/common/vsync_waiter_fallback.cc
+++ b/shell/common/vsync_waiter_fallback.cc
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#define FML_USED_ON_EMBEDDER
-
 #include "flutter/shell/common/vsync_waiter_fallback.h"
 
 #include <memory>
@@ -46,8 +44,7 @@ void VsyncWaiterFallback::AwaitVSync() {
   std::weak_ptr<VsyncWaiterFallback> weak_this =
       std::static_pointer_cast<VsyncWaiterFallback>(shared_from_this());
 
-  auto current_task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
-  current_task_runner->PostTaskForTime(
+  task_runners_.GetUITaskRunner()->PostTaskForTime(
       [frame_start_time, frame_target_time, weak_this]() {
         if (auto vsync_waiter = weak_this.lock()) {
           vsync_waiter->FireCallback(frame_start_time, frame_target_time,


### PR DESCRIPTION
This makes the impl consistent with how other platforms implement
vsyncs. This also ensures that we always pause the microtasks for the
minimal time possible.

Fixes: https://github.com/flutter/flutter/issues/89786
