### PR TITLE
Fixes FlutterSemanticsScrollView to not implement accessibility conta…

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterSemanticsScrollView.mm
@@ -106,33 +106,4 @@
   return [[_semanticsObject children] count];
 }
 
-- (id)accessibilityElementAtIndex:(NSInteger)index {
-  SemanticsObject* child = [_semanticsObject children][index];
-
-  // Swap the original `SemanticsObject` to a `PlatformViewSemanticsContainer`
-  if (child.node.IsPlatformViewNode()) {
-    child.platformViewSemanticsContainer.index = index;
-    return child.platformViewSemanticsContainer;
-  }
-
-  if ([child hasChildren])
-    return [child accessibilityContainer];
-  return [child nativeAccessibility];
-}
-
-- (NSInteger)indexOfAccessibilityElement:(id)element {
-  if ([element isKindOfClass:[FlutterPlatformViewSemanticsContainer class]]) {
-    return ((FlutterPlatformViewSemanticsContainer*)element).index;
-  }
-
-  NSArray<SemanticsObject*>* children = [_semanticsObject children];
-  for (size_t i = 0; i < [children count]; i++) {
-    SemanticsObject* child = children[i];
-    if ((![child hasChildren] && child == element) ||
-        ([child hasChildren] && [child accessibilityContainer] == element))
-      return i;
-  }
-  return NSNotFound;
-}
-
 @end


### PR DESCRIPTION
…iner API

Implementing the accessibility contain API makes voiceover confused since we have our own way of handling accessibility container

fixes https://github.com/flutter/flutter/issues/90681

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
