### PR TITLE
Use a relative path for the output when building a Dart kernel

### DIFF
--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -69,7 +69,7 @@ template("flutter_snapshot") {
       "--packages=" + rebase_path(package_config),
       "--target=flutter",
       "--sdk-root=" + flutter_patched_sdk,
-      "--output-dill=" + rebase_path(kernel_output),
+      "--output-dill=" + rebase_path(kernel_output, root_build_dir),
     ]
 
     if (is_aot) {


### PR DESCRIPTION
The output path is written into the depfile, and the Dart tools expect a
relative path when checking whether the depfile target is up to date.
