### PR TITLE
Specify the root directory for Dart frontend server sources

### DIFF
--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -13,7 +13,7 @@ frontend_server_files =
     exec_script("//third_party/dart/tools/list_dart_files.py",
                 [
                   "absolute",
-                  rebase_path("."),
+                  rebase_path("//flutter/flutter_frontend_server"),
                 ],
                 "list lines")
 
@@ -21,7 +21,7 @@ frontend_server_files +=
     exec_script("//third_party/dart/tools/list_dart_files.py",
                 [
                   "absolute",
-                  rebase_path("../../third_party/dart/pkg"),
+                  rebase_path("//third_party/dart/pkg"),
                 ],
                 "list lines")
 


### PR DESCRIPTION
The current directory where the frontend_server_files list is calculated
may not be the location of the frontend server.
