### PR TITLE
use all 16 matrix entries in Canvas.transform() to enable 3D matrix concatenation

### DIFF
--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -1204,6 +1204,7 @@ void DisplayListBuilder::skew(SkScalar sx, SkScalar sy) {
 }
 
 // clang-format off
+// 2x3 2D affine subset of a 4x4 transform in row major order
 void DisplayListBuilder::transform2x3(
     SkScalar mxx, SkScalar mxy, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myt) {
@@ -1214,6 +1215,7 @@ void DisplayListBuilder::transform2x3(
                         myx, myy, myt);
   }
 }
+// 3x3 non-Z subset of a 4x4 transform in row major order
 void DisplayListBuilder::transform3x3(
     SkScalar mxx, SkScalar mxy, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myt,
@@ -1228,6 +1230,7 @@ void DisplayListBuilder::transform3x3(
                          mwx, mwy, mwt);
   }
 }
+// full 4x4 transform in row major order
 void DisplayListBuilder::transform4x4(
     SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,

--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -309,50 +309,69 @@ struct SkewOp final : DLOp {
 struct Transform2x3Op final : DLOp {
   static const auto kType = DisplayListOpType::kTransform2x3;
 
-  Transform2x3Op(SkScalar mxx,
-                 SkScalar mxy,
-                 SkScalar mxt,
-                 SkScalar myx,
-                 SkScalar myy,
-                 SkScalar myt)
+  // clang-format off
+  Transform2x3Op(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                 SkScalar myx, SkScalar myy, SkScalar myt)
       : mxx(mxx), mxy(mxy), mxt(mxt), myx(myx), myy(myy), myt(myt) {}
+  // clang-format on
 
   const SkScalar mxx, mxy, mxt;
   const SkScalar myx, myy, myt;
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.transform2x3(mxx, mxy, mxt, myx, myy, myt);
+    dispatcher.transform2x3(mxx, mxy, mxt,  //
+                            myx, myy, myt);
   }
 };
 // 4 byte header + 36 byte payload packs evenly into 40 bytes
 struct Transform3x3Op final : DLOp {
   static const auto kType = DisplayListOpType::kTransform3x3;
 
-  Transform3x3Op(SkScalar mxx,
-                 SkScalar mxy,
-                 SkScalar mxt,
-                 SkScalar myx,
-                 SkScalar myy,
-                 SkScalar myt,
-                 SkScalar px,
-                 SkScalar py,
-                 SkScalar pt)
-      : mxx(mxx),
-        mxy(mxy),
-        mxt(mxt),
-        myx(myx),
-        myy(myy),
-        myt(myt),
-        px(px),
-        py(py),
-        pt(pt) {}
+  // clang-format off
+  Transform3x3Op(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                 SkScalar myx, SkScalar myy, SkScalar myt,
+                 SkScalar mwx, SkScalar mwy, SkScalar mwt)
+      : mxx(mxx), mxy(mxy), mxt(mxt),
+        myx(myx), myy(myy), myt(myt),
+        mwx(mwx), mwy(mwy), mwt(mwt) {}
+  // clang-format on
 
   const SkScalar mxx, mxy, mxt;
   const SkScalar myx, myy, myt;
-  const SkScalar px, py, pt;
+  const SkScalar mwx, mwy, mwt;
 
   void dispatch(Dispatcher& dispatcher) const {
-    dispatcher.transform3x3(mxx, mxy, mxt, myx, myy, myt, px, py, pt);
+    dispatcher.transform3x3(mxx, mxy, mxt,  //
+                            myx, myy, myt,  //
+                            mwx, mwy, mwt);
+  }
+};
+// 4 byte header + 64 byte payload uses 68 bytes which is rounded up to 72 bytes
+// (4 bytes unused)
+struct Transform4x4Op final : DLOp {
+  static const auto kType = DisplayListOpType::kTransform4x4;
+
+  // clang-format off
+  Transform4x4Op(SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+                 SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+                 SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+                 SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt)
+      : mxx(mxx), mxy(mxy), mxz(mxz), mxt(mxt),
+        myx(myx), myy(myy), myz(myz), myt(myt),
+        mzx(mzx), mzy(mzy), mzz(mzz), mzt(mzt),
+        mwx(mwx), mwy(mwy), mwz(mwz), mwt(mwt) {}
+  // clang-format on
+
+  const SkScalar mxx, mxy, mxz, mxt;
+  const SkScalar myx, myy, myz, myt;
+  const SkScalar mzx, mzy, mzz, mzt;
+  const SkScalar mwx, mwy, mwz, mwt;
+
+  void dispatch(Dispatcher& dispatcher) const {
+    dispatcher.transform4x4(mxx, mxy, mxz, mxt,  //
+                            myx, myy, myz, myt,  //
+                            mzx, mzy, mzz, mzt,  //
+                            mwx, mwy, mwz, mwt);
   }
 };
 
@@ -1183,25 +1202,53 @@ void DisplayListBuilder::rotate(SkScalar degrees) {
 void DisplayListBuilder::skew(SkScalar sx, SkScalar sy) {
   Push<SkewOp>(0, 1, sx, sy);
 }
-void DisplayListBuilder::transform2x3(SkScalar mxx,
-                                      SkScalar mxy,
-                                      SkScalar mxt,
-                                      SkScalar myx,
-                                      SkScalar myy,
-                                      SkScalar myt) {
-  Push<Transform2x3Op>(0, 1, mxx, mxy, mxt, myx, myy, myt);
+
+// clang-format off
+void DisplayListBuilder::transform2x3(
+    SkScalar mxx, SkScalar mxy, SkScalar mxt,
+    SkScalar myx, SkScalar myy, SkScalar myt) {
+  if (!(mxx == 1 && mxy == 0 && mxt == 0 &&
+        myx == 0 && myy == 1 && myt == 0)) {
+    Push<Transform2x3Op>(0, 1,
+                        mxx, mxy, mxt,
+                        myx, myy, myt);
+  }
 }
-void DisplayListBuilder::transform3x3(SkScalar mxx,
-                                      SkScalar mxy,
-                                      SkScalar mxt,
-                                      SkScalar myx,
-                                      SkScalar myy,
-                                      SkScalar myt,
-                                      SkScalar px,
-                                      SkScalar py,
-                                      SkScalar pt) {
-  Push<Transform3x3Op>(0, 1, mxx, mxy, mxt, myx, myy, myt, px, py, pt);
+void DisplayListBuilder::transform3x3(
+    SkScalar mxx, SkScalar mxy, SkScalar mxt,
+    SkScalar myx, SkScalar myy, SkScalar myt,
+    SkScalar mwx, SkScalar mwy, SkScalar mwt) {
+  if (mwx == 0 && mwy == 0 && mwt == 1) {
+    transform2x3(mxx, mxy, mxt,
+                 myx, myy, myt);
+  } else {
+    Push<Transform3x3Op>(0, 1,
+                         mxx, mxy, mxt,
+                         myx, myy, myt,
+                         mwx, mwy, mwt);
+  }
 }
+void DisplayListBuilder::transform4x4(
+    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
+  if (                        mxz == 0 &&
+                              myz == 0 &&
+      mzx == 0 && mzy == 0 && mzz == 1 && mzt == 0 &&
+                              mwz == 0) {
+    transform3x3(mxx, mxy, mxt,
+                 myx, myy, myt,
+                 mwx, mwy, mwt);
+  } else {
+    Push<Transform4x4Op>(0, 1,
+                         mxx, mxy, mxz, mxt,
+                         myx, myy, myz, myt,
+                         mzx, mzy, mzz, mzt,
+                         mwx, mwy, mwz, mwt);
+  }
+}
+// clang-format on
 
 void DisplayListBuilder::clipRect(const SkRect& rect,
                                   SkClipOp clip_op,

--- a/flow/display_list_canvas.cc
+++ b/flow/display_list_canvas.cc
@@ -35,6 +35,7 @@ void DisplayListCanvasDispatcher::skew(SkScalar sx, SkScalar sy) {
   canvas_->skew(sx, sy);
 }
 // clang-format off
+// 2x3 2D affine subset of a 4x4 transform in row major order
 void DisplayListCanvasDispatcher::transform2x3(
     SkScalar mxx, SkScalar mxy, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myt) {
@@ -45,6 +46,7 @@ void DisplayListCanvasDispatcher::transform2x3(
                          0,   0,  1,  0,
                          0,   0,  0,  1));
 }
+// 3x3 non-Z subset of a 4x4 transform in row major order
 void DisplayListCanvasDispatcher::transform3x3(
     SkScalar mxx, SkScalar mxy, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myt,
@@ -56,6 +58,7 @@ void DisplayListCanvasDispatcher::transform3x3(
                          0,   0,  1,  0,
                         mwx, mwy, 0, mwt));
 }
+// full 4x4 transform in row major order
 void DisplayListCanvasDispatcher::transform4x4(
     SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
@@ -217,6 +220,7 @@ sk_sp<DisplayList> DisplayListCanvasRecorder::Build() {
 
 // clang-format off
 void DisplayListCanvasRecorder::didConcat44(const SkM44& m44) {
+  // transform4x4 takes a full 4x4 transform in row major order
   builder_->transform4x4(
       m44.rc(0, 0), m44.rc(0, 1), m44.rc(0, 2), m44.rc(0, 3),
       m44.rc(1, 0), m44.rc(1, 1), m44.rc(1, 2), m44.rc(1, 3),

--- a/flow/display_list_canvas.cc
+++ b/flow/display_list_canvas.cc
@@ -36,7 +36,7 @@ void DisplayListCanvasDispatcher::skew(SkScalar sx, SkScalar sy) {
 }
 // clang-format off
 // 2x3 2D affine subset of a 4x4 transform in row major order
-void DisplayListCanvasDispatcher::transform2x3(
+void DisplayListCanvasDispatcher::transform2DAffine(
     SkScalar mxx, SkScalar mxy, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myt) {
   // Internally concat(SkMatrix) gets redirected to concat(SkM44)
@@ -46,20 +46,8 @@ void DisplayListCanvasDispatcher::transform2x3(
                          0,   0,  1,  0,
                          0,   0,  0,  1));
 }
-// 3x3 non-Z subset of a 4x4 transform in row major order
-void DisplayListCanvasDispatcher::transform3x3(
-    SkScalar mxx, SkScalar mxy, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myt,
-    SkScalar mwx, SkScalar mwy, SkScalar mwt) {
-  // Internally concat(SkMatrix) gets redirected to concat(SkM44)
-  // so we just jump directly to the SkM44 version
-  canvas_->concat(SkM44(mxx, mxy, 0, mxt,
-                        myx, myy, 0, myt,
-                         0,   0,  1,  0,
-                        mwx, mwy, 0, mwt));
-}
 // full 4x4 transform in row major order
-void DisplayListCanvasDispatcher::transform4x4(
+void DisplayListCanvasDispatcher::transformFullPerspective(
     SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
     SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
@@ -221,7 +209,7 @@ sk_sp<DisplayList> DisplayListCanvasRecorder::Build() {
 // clang-format off
 void DisplayListCanvasRecorder::didConcat44(const SkM44& m44) {
   // transform4x4 takes a full 4x4 transform in row major order
-  builder_->transform4x4(
+  builder_->transformFullPerspective(
       m44.rc(0, 0), m44.rc(0, 1), m44.rc(0, 2), m44.rc(0, 3),
       m44.rc(1, 0), m44.rc(1, 1), m44.rc(1, 2), m44.rc(1, 3),
       m44.rc(2, 0), m44.rc(2, 1), m44.rc(2, 2), m44.rc(2, 3),

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -37,21 +37,18 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
   void scale(SkScalar sx, SkScalar sy) override;
   void rotate(SkScalar degrees) override;
   void skew(SkScalar sx, SkScalar sy) override;
-  void transform2x3(SkScalar mxx,
-                    SkScalar mxy,
-                    SkScalar mxt,
-                    SkScalar myx,
-                    SkScalar myy,
-                    SkScalar myt) override;
-  void transform3x3(SkScalar mxx,
-                    SkScalar mxy,
-                    SkScalar mxt,
-                    SkScalar myx,
-                    SkScalar myy,
-                    SkScalar myt,
-                    SkScalar px,
-                    SkScalar py,
-                    SkScalar pt) override;
+  // clang-format off
+  void transform2x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                    SkScalar myx, SkScalar myy, SkScalar myt) override;
+  void transform3x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                    SkScalar myx, SkScalar myy, SkScalar myt,
+                    SkScalar mwx, SkScalar mwy, SkScalar mwt) override;
+  void transform4x4(
+      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+  // clang-format on
 
   void clipRect(const SkRect& rect, SkClipOp clip_op, bool isAA) override;
   void clipRRect(const SkRRect& rrect, SkClipOp clip_op, bool isAA) override;

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -39,14 +39,10 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
   void skew(SkScalar sx, SkScalar sy) override;
   // clang-format off
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void transform2x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                    SkScalar myx, SkScalar myy, SkScalar myt) override;
-  // 3x3 non-Z subset of a 4x4 transform in row major order
-  void transform3x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                    SkScalar myx, SkScalar myy, SkScalar myt,
-                    SkScalar mwx, SkScalar mwy, SkScalar mwt) override;
+  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                         SkScalar myx, SkScalar myy, SkScalar myt) override;
   // full 4x4 transform in row major order
-  void transform4x4(
+  void transformFullPerspective(
       SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
       SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
       SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -38,11 +38,14 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
   void rotate(SkScalar degrees) override;
   void skew(SkScalar sx, SkScalar sy) override;
   // clang-format off
+  // 2x3 2D affine subset of a 4x4 transform in row major order
   void transform2x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
                     SkScalar myx, SkScalar myy, SkScalar myt) override;
+  // 3x3 non-Z subset of a 4x4 transform in row major order
   void transform3x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
                     SkScalar myx, SkScalar myy, SkScalar myt,
                     SkScalar mwx, SkScalar mwy, SkScalar mwt) override;
+  // full 4x4 transform in row major order
   void transform4x4(
       SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
       SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,

--- a/flow/display_list_canvas_unittests.cc
+++ b/flow/display_list_canvas_unittests.cc
@@ -997,6 +997,25 @@ class CanvasCompareTester {
                  cv_renderer, dl_renderer, adjuster, skewed_tolerance,
                  "Transform 3x3");
     }
+    {
+      SkM44 m44 = SkM44(1, 0, 0, RenderCenterX,  //
+                        0, 1, 0, RenderCenterY,  //
+                        0, 0, 1, 0,              //
+                        0, 0, .001, 1);
+      m44.preConcat(SkM44::Rotate({1, 0, 0}, M_PI / 60));  // 3 degrees around X
+      m44.preConcat(SkM44::Rotate({0, 1, 0}, M_PI / 45));  // 4 degrees around Y
+      m44.preTranslate(-RenderCenterX, -RenderCenterY);
+      RenderWith([=](SkCanvas* c, SkPaint&) { c->concat(m44); },  //
+                 [=](DisplayListBuilder& b) {
+                   b.transform4x4(
+                       m44.rc(0, 0), m44.rc(0, 1), m44.rc(0, 2), m44.rc(0, 3),
+                       m44.rc(1, 0), m44.rc(1, 1), m44.rc(1, 2), m44.rc(1, 3),
+                       m44.rc(2, 0), m44.rc(2, 1), m44.rc(2, 2), m44.rc(2, 3),
+                       m44.rc(3, 0), m44.rc(3, 1), m44.rc(3, 2), m44.rc(3, 3));
+                 },  //
+                 cv_renderer, dl_renderer, adjuster, skewed_tolerance,
+                 "Transform 4x4");
+    }
   }
 
   static void RenderWithClips(CvRenderer& cv_renderer,

--- a/flow/display_list_canvas_unittests.cc
+++ b/flow/display_list_canvas_unittests.cc
@@ -978,24 +978,11 @@ class CanvasCompareTester {
                                       0, 0, 1);
       RenderWith([=](SkCanvas* c, SkPaint&) { c->concat(tx); },  //
                  [=](DisplayListBuilder& b) {
-                   b.transform2x3(tx[0], tx[1], tx[2],  //
-                                  tx[3], tx[4], tx[5]);
+                   b.transform2DAffine(tx[0], tx[1], tx[2],  //
+                                       tx[3], tx[4], tx[5]);
                  },  //
                  cv_renderer, dl_renderer, adjuster, skewed_tolerance,
-                 "Transform 2x3");
-    }
-    {
-      SkMatrix tx = SkMatrix::MakeAll(1.10, 0.10, 5,   //
-                                      0.05, 1.05, 10,  //
-                                      0, 0, 1.01);
-      RenderWith([=](SkCanvas* c, SkPaint&) { c->concat(tx); },  //
-                 [=](DisplayListBuilder& b) {
-                   b.transform3x3(tx[0], tx[1], tx[2],  //
-                                  tx[3], tx[4], tx[5],  //
-                                  tx[6], tx[7], tx[8]);
-                 },  //
-                 cv_renderer, dl_renderer, adjuster, skewed_tolerance,
-                 "Transform 3x3");
+                 "Transform 2D Affine");
     }
     {
       SkM44 m44 = SkM44(1, 0, 0, RenderCenterX,  //
@@ -1007,14 +994,14 @@ class CanvasCompareTester {
       m44.preTranslate(-RenderCenterX, -RenderCenterY);
       RenderWith([=](SkCanvas* c, SkPaint&) { c->concat(m44); },  //
                  [=](DisplayListBuilder& b) {
-                   b.transform4x4(
+                   b.transformFullPerspective(
                        m44.rc(0, 0), m44.rc(0, 1), m44.rc(0, 2), m44.rc(0, 3),
                        m44.rc(1, 0), m44.rc(1, 1), m44.rc(1, 2), m44.rc(1, 3),
                        m44.rc(2, 0), m44.rc(2, 1), m44.rc(2, 2), m44.rc(2, 3),
                        m44.rc(3, 0), m44.rc(3, 1), m44.rc(3, 2), m44.rc(3, 3));
                  },  //
                  cv_renderer, dl_renderer, adjuster, skewed_tolerance,
-                 "Transform 4x4");
+                 "Transform Full Perspective");
     }
   }
 

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -250,7 +250,7 @@ struct DisplayListInvocationGroup {
 };
 
 std::vector<DisplayListInvocationGroup> allGroups = {
-  { "SetAA", {
+  { "SetAntiAlias", {
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setAntiAlias(false);}},
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setAntiAlias(true);}},
     }
@@ -277,7 +277,7 @@ std::vector<DisplayListInvocationGroup> allGroups = {
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeJoin(SkPaint::kMiter_Join);}},
     }
   },
-  { "SetDrawStyle", {
+  { "SetStyle", {
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStyle(SkPaint::kFill_Style);}},
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStyle(SkPaint::kStroke_Style);}},
     }
@@ -287,7 +287,7 @@ std::vector<DisplayListInvocationGroup> allGroups = {
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeWidth(5.0);}},
     }
   },
-  { "SetMiterLimit", {
+  { "SetStrokeMiter", {
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeMiter(0.0);}},
       {0, 8, 0, 0, [](DisplayListBuilder& b) {b.setStrokeMiter(5.0);}},
     }
@@ -385,15 +385,40 @@ std::vector<DisplayListInvocationGroup> allGroups = {
     }
   },
   { "Transform2x3", {
-      // cv.transform(identity) is ignored
-      {1, 32, 0, 0, [](DisplayListBuilder& b) {b.transform2x3(1, 0, 0, 0, 1, 0);}},
       {1, 32, 1, 32, [](DisplayListBuilder& b) {b.transform2x3(0, 1, 12, 1, 0, 33);}},
+      // b.transform(identity) is ignored
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transform2x3(1, 0, 0, 0, 1, 0);}},
     }
   },
   { "Transform3x3", {
-      // cv.transform(identity) is ignored
-      {1, 40, 0, 0, [](DisplayListBuilder& b) {b.transform3x3(1, 0, 0, 0, 1, 0, 0, 0, 1);}},
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.transform3x3(1, 0, 0, 0, 1, 0, 0, .001, 1);}},
       {1, 40, 1, 40, [](DisplayListBuilder& b) {b.transform3x3(0, 1, 12, 1, 0, 33, 0, 0, 12);}},
+      // b.transform(2d affine) is reduced to 2x3
+      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.transform3x3(2, 0, 0, 0, 1, 0, 0, 0, 1);}},
+      // b.transform(identity) is ignored
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transform3x3(1, 0, 0, 0, 1, 0, 0, 0, 1);}},
+    }
+  },
+  { "Transform4x4", {
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.transform4x4(0, 1, 0, 12,
+                                                               1, 0, 0, 33,
+                                                               3, 2, 5, 29,
+                                                               0, 0, 0, 12);}},
+      // b.transform(identity-Z-entries) is reduced to 3x3
+      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.transform4x4(1, 0, 0, 0,
+                                                               0, 1, 0, 0,
+                                                               0, 0, 1, 0,
+                                                               0, 0, 0, 2);}},
+      // b.transform(2D affine) is reduced to 2x3
+      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.transform4x4(2, 0, 0, 0,
+                                                               0, 1, 0, 0,
+                                                               0, 0, 1, 0,
+                                                               0, 0, 0, 1);}},
+      // b.transform(identity) is ignored
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transform4x4(1, 0, 0, 0,
+                                                             0, 1, 0, 0,
+                                                             0, 0, 1, 0,
+                                                             0, 0, 0, 1);}},
     }
   },
   { "ClipRect", {
@@ -716,8 +741,13 @@ TEST(DisplayList, SingleOpDisplayListsNotEqualEmpty) {
       sk_sp<DisplayList> dl = group.variants[i].Build();
       auto desc =
           group.op_name + "(variant " + std::to_string(i + 1) + " != empty)";
-      ASSERT_FALSE(dl->Equals(*empty)) << desc;
-      ASSERT_FALSE(empty->Equals(*dl)) << desc;
+      if (group.variants[i].byte_count != 0) {
+        ASSERT_FALSE(dl->Equals(*empty)) << desc;
+        ASSERT_FALSE(empty->Equals(*dl)) << desc;
+      } else {
+        ASSERT_TRUE(dl->Equals(*empty)) << desc;
+        ASSERT_TRUE(empty->Equals(*dl)) << desc;
+      }
     }
   }
 }
@@ -867,8 +897,13 @@ TEST(DisplayList, DisplayListsWithVaryingOpComparisons) {
         ASSERT_FALSE(variant_dl->Equals(*default_dl)) << desc << " != Default";
         ASSERT_FALSE(default_dl->Equals(*variant_dl)) << "Default != " << desc;
       }
-      ASSERT_FALSE(variant_dl->Equals(*missing_dl)) << desc << " != omitted";
-      ASSERT_FALSE(missing_dl->Equals(*variant_dl)) << "omitted != " << desc;
+      if (group.variants[vi].byte_count != 0) {
+        ASSERT_FALSE(variant_dl->Equals(*missing_dl)) << desc << " != omitted";
+        ASSERT_FALSE(missing_dl->Equals(*variant_dl)) << "omitted != " << desc;
+      } else {
+        ASSERT_TRUE(variant_dl->Equals(*missing_dl)) << desc << " != omitted";
+        ASSERT_TRUE(missing_dl->Equals(*variant_dl)) << "omitted != " << desc;
+      }
     }
   }
 }

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -384,41 +384,27 @@ std::vector<DisplayListInvocationGroup> allGroups = {
       {1, 16, 1, 32, [](DisplayListBuilder& b) {b.skew(0.2, 0.1);}},
     }
   },
-  { "Transform2x3", {
-      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.transform2x3(0, 1, 12, 1, 0, 33);}},
+  { "Transform2DAffine", {
+      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.transform2DAffine(0, 1, 12, 1, 0, 33);}},
       // b.transform(identity) is ignored
-      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transform2x3(1, 0, 0, 0, 1, 0);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transform2DAffine(1, 0, 0, 0, 1, 0);}},
     }
   },
-  { "Transform3x3", {
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.transform3x3(1, 0, 0, 0, 1, 0, 0, .001, 1);}},
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.transform3x3(0, 1, 12, 1, 0, 33, 0, 0, 12);}},
-      // b.transform(2d affine) is reduced to 2x3
-      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.transform3x3(2, 0, 0, 0, 1, 0, 0, 0, 1);}},
-      // b.transform(identity) is ignored
-      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transform3x3(1, 0, 0, 0, 1, 0, 0, 0, 1);}},
-    }
-  },
-  { "Transform4x4", {
-      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.transform4x4(0, 1, 0, 12,
-                                                               1, 0, 0, 33,
-                                                               3, 2, 5, 29,
-                                                               0, 0, 0, 12);}},
-      // b.transform(identity-Z-entries) is reduced to 3x3
-      {1, 40, 1, 40, [](DisplayListBuilder& b) {b.transform4x4(1, 0, 0, 0,
-                                                               0, 1, 0, 0,
-                                                               0, 0, 1, 0,
-                                                               0, 0, 0, 2);}},
+  { "TransformFullPerspective", {
+      {1, 72, 1, 72, [](DisplayListBuilder& b) {b.transformFullPerspective(0, 1, 0, 12,
+                                                                           1, 0, 0, 33,
+                                                                           3, 2, 5, 29,
+                                                                           0, 0, 0, 12);}},
       // b.transform(2D affine) is reduced to 2x3
-      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.transform4x4(2, 0, 0, 0,
-                                                               0, 1, 0, 0,
-                                                               0, 0, 1, 0,
-                                                               0, 0, 0, 1);}},
+      {1, 32, 1, 32, [](DisplayListBuilder& b) {b.transformFullPerspective(2, 1, 0, 4,
+                                                                           1, 3, 0, 5,
+                                                                           0, 0, 1, 0,
+                                                                           0, 0, 0, 1);}},
       // b.transform(identity) is ignored
-      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transform4x4(1, 0, 0, 0,
-                                                             0, 1, 0, 0,
-                                                             0, 0, 1, 0,
-                                                             0, 0, 0, 1);}},
+      {0, 0, 0, 0, [](DisplayListBuilder& b) {b.transformFullPerspective(1, 0, 0, 0,
+                                                                         0, 1, 0, 0,
+                                                                         0, 0, 1, 0,
+                                                                         0, 0, 0, 1);}},
     }
   },
   { "ClipRect", {

--- a/flow/display_list_utils.cc
+++ b/flow/display_list_utils.cc
@@ -112,6 +112,7 @@ void SkMatrixDispatchHelper::skew(SkScalar sx, SkScalar sy) {
   matrix33_ = matrix_.asM33();
 }
 // clang-format off
+// 2x3 2D affine subset of a 4x4 transform in row major order
 void SkMatrixDispatchHelper::transform2x3(
     SkScalar mxx, SkScalar mxy, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myt) {
@@ -119,6 +120,7 @@ void SkMatrixDispatchHelper::transform2x3(
   matrix_.preConcat(matrix33_);
   matrix33_ = matrix_.asM33();
 }
+// 3x3 non-Z subset of a 4x4 transform in row major order
 void SkMatrixDispatchHelper::transform3x3(
     SkScalar mxx, SkScalar mxy, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myt,
@@ -127,6 +129,7 @@ void SkMatrixDispatchHelper::transform3x3(
   matrix_.preConcat(matrix33_);
   matrix33_ = matrix_.asM33();
 }
+// full 4x4 transform in row major order
 void SkMatrixDispatchHelper::transform4x4(
     SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,

--- a/flow/display_list_utils.cc
+++ b/flow/display_list_utils.cc
@@ -111,26 +111,23 @@ void SkMatrixDispatchHelper::skew(SkScalar sx, SkScalar sy) {
   matrix_.preConcat(matrix33_);
   matrix33_ = matrix_.asM33();
 }
+
 // clang-format off
+
 // 2x3 2D affine subset of a 4x4 transform in row major order
-void SkMatrixDispatchHelper::transform2x3(
+void SkMatrixDispatchHelper::transform2DAffine(
     SkScalar mxx, SkScalar mxy, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myt) {
-  matrix33_.setAll(mxx, mxy, mxt, myx, myy, myt, 0, 0, 1);
-  matrix_.preConcat(matrix33_);
-  matrix33_ = matrix_.asM33();
-}
-// 3x3 non-Z subset of a 4x4 transform in row major order
-void SkMatrixDispatchHelper::transform3x3(
-    SkScalar mxx, SkScalar mxy, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myt,
-    SkScalar mwx, SkScalar mwy, SkScalar mwt) {
-  matrix33_.setAll(mxx, mxy, mxt, myx, myy, myt, mwx, mwy, mwt);
-  matrix_.preConcat(matrix33_);
+  matrix_.preConcat({
+      mxx, mxy,  0 , mxt,
+      myx, myy,  0 , myt,
+       0 ,  0 ,  1 ,  0 ,
+       0 ,  0 ,  0 ,  1 ,
+  });
   matrix33_ = matrix_.asM33();
 }
 // full 4x4 transform in row major order
-void SkMatrixDispatchHelper::transform4x4(
+void SkMatrixDispatchHelper::transformFullPerspective(
     SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
     SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
@@ -143,7 +140,9 @@ void SkMatrixDispatchHelper::transform4x4(
   });
   matrix33_ = matrix_.asM33();
 }
+
 // clang-format on
+
 void SkMatrixDispatchHelper::save() {
   saved_.push_back(matrix_);
 }

--- a/flow/display_list_utils.cc
+++ b/flow/display_list_utils.cc
@@ -95,45 +95,63 @@ sk_sp<SkColorFilter> SkPaintDispatchHelper::makeColorFilter() {
 
 void SkMatrixDispatchHelper::translate(SkScalar tx, SkScalar ty) {
   matrix_.preTranslate(tx, ty);
+  matrix33_ = matrix_.asM33();
 }
 void SkMatrixDispatchHelper::scale(SkScalar sx, SkScalar sy) {
   matrix_.preScale(sx, sy);
+  matrix33_ = matrix_.asM33();
 }
 void SkMatrixDispatchHelper::rotate(SkScalar degrees) {
-  matrix_.preRotate(degrees);
+  matrix33_.setRotate(degrees);
+  matrix_.preConcat(matrix33_);
+  matrix33_ = matrix_.asM33();
 }
 void SkMatrixDispatchHelper::skew(SkScalar sx, SkScalar sy) {
-  matrix_.preSkew(sx, sy);
+  matrix33_.setSkew(sx, sy);
+  matrix_.preConcat(matrix33_);
+  matrix33_ = matrix_.asM33();
 }
-void SkMatrixDispatchHelper::transform2x3(SkScalar mxx,
-                                          SkScalar mxy,
-                                          SkScalar mxt,
-                                          SkScalar myx,
-                                          SkScalar myy,
-                                          SkScalar myt) {
-  matrix_.preConcat(SkMatrix::MakeAll(mxx, mxy, mxt, myx, myy, myt, 0, 0, 1));
+// clang-format off
+void SkMatrixDispatchHelper::transform2x3(
+    SkScalar mxx, SkScalar mxy, SkScalar mxt,
+    SkScalar myx, SkScalar myy, SkScalar myt) {
+  matrix33_.setAll(mxx, mxy, mxt, myx, myy, myt, 0, 0, 1);
+  matrix_.preConcat(matrix33_);
+  matrix33_ = matrix_.asM33();
 }
-void SkMatrixDispatchHelper::transform3x3(SkScalar mxx,
-                                          SkScalar mxy,
-                                          SkScalar mxt,
-                                          SkScalar myx,
-                                          SkScalar myy,
-                                          SkScalar myt,
-                                          SkScalar px,
-                                          SkScalar py,
-                                          SkScalar pt) {
-  matrix_.preConcat(
-      SkMatrix::MakeAll(mxx, mxy, mxt, myx, myy, myt, px, py, pt));
+void SkMatrixDispatchHelper::transform3x3(
+    SkScalar mxx, SkScalar mxy, SkScalar mxt,
+    SkScalar myx, SkScalar myy, SkScalar myt,
+    SkScalar mwx, SkScalar mwy, SkScalar mwt) {
+  matrix33_.setAll(mxx, mxy, mxt, myx, myy, myt, mwx, mwy, mwt);
+  matrix_.preConcat(matrix33_);
+  matrix33_ = matrix_.asM33();
 }
+void SkMatrixDispatchHelper::transform4x4(
+    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) {
+  matrix_.preConcat({
+      mxx, mxy, mxz, mxt,
+      myx, myy, myz, myt,
+      mzx, mzy, mzz, mzt,
+      mwx, mwy, mwz, mwt,
+  });
+  matrix33_ = matrix_.asM33();
+}
+// clang-format on
 void SkMatrixDispatchHelper::save() {
   saved_.push_back(matrix_);
 }
 void SkMatrixDispatchHelper::restore() {
   matrix_ = saved_.back();
+  matrix33_ = matrix_.asM33();
   saved_.pop_back();
 }
 void SkMatrixDispatchHelper::reset() {
-  matrix_.reset();
+  matrix_.setIdentity();
+  matrix33_ = matrix_.asM33();
 }
 
 void ClipBoundsDispatchHelper::clipRect(const SkRect& rect,

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -78,21 +78,18 @@ class IgnoreTransformDispatchHelper : public virtual Dispatcher {
   void scale(SkScalar sx, SkScalar sy) override {}
   void rotate(SkScalar degrees) override {}
   void skew(SkScalar sx, SkScalar sy) override {}
-  void transform2x3(SkScalar mxx,
-                    SkScalar mxy,
-                    SkScalar mxt,
-                    SkScalar myx,
-                    SkScalar myy,
-                    SkScalar myt) override {}
-  void transform3x3(SkScalar mxx,
-                    SkScalar mxy,
-                    SkScalar mxt,
-                    SkScalar myx,
-                    SkScalar myy,
-                    SkScalar myt,
-                    SkScalar px,
-                    SkScalar py,
-                    SkScalar pt) override {}
+  // clang-format off
+  void transform2x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                    SkScalar myx, SkScalar myy, SkScalar myt) override {}
+  void transform3x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                    SkScalar myx, SkScalar myy, SkScalar myt,
+                    SkScalar mwx, SkScalar mwy, SkScalar mwt) override {}
+  void transform4x4(
+    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override {}
+  // clang-format on
 };
 
 // A utility class that will monitor the Dispatcher methods relating
@@ -130,6 +127,14 @@ class SkPaintDispatchHelper : public virtual Dispatcher {
 
 class SkMatrixSource {
  public:
+  // The current full 4x4 transform matrix. Not generally needed
+  // for 2D operations. See |matrix|.
+  virtual const SkM44& m44() const = 0;
+
+  // The current matrix expressed as an SkMatrix. The data held
+  // in an SkMatrix is enough to perform point and rect transforms
+  // assuming input coordinates have only an X and Y and an assumed
+  // Z of 0 and an assumed W of 1.
   virtual const SkMatrix& matrix() const = 0;
 };
 
@@ -147,33 +152,32 @@ class SkMatrixDispatchHelper : public virtual Dispatcher,
   void scale(SkScalar sx, SkScalar sy) override;
   void rotate(SkScalar degrees) override;
   void skew(SkScalar sx, SkScalar sy) override;
-  void transform2x3(SkScalar mxx,
-                    SkScalar mxy,
-                    SkScalar mxt,
-                    SkScalar myx,
-                    SkScalar myy,
-                    SkScalar myt) override;
-  void transform3x3(SkScalar mxx,
-                    SkScalar mxy,
-                    SkScalar mxt,
-                    SkScalar myx,
-                    SkScalar myy,
-                    SkScalar myt,
-                    SkScalar px,
-                    SkScalar py,
-                    SkScalar pt) override;
+  // clang-format off
+  void transform2x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                    SkScalar myx, SkScalar myy, SkScalar myt) override;
+  void transform3x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                    SkScalar myx, SkScalar myy, SkScalar myt,
+                    SkScalar mwx, SkScalar mwy, SkScalar mwt) override;
+  void transform4x4(
+    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+  // clang-format on
 
   void save() override;
   void restore() override;
 
-  const SkMatrix& matrix() const override { return matrix_; }
+  const SkM44& m44() const override { return matrix_; }
+  const SkMatrix& matrix() const override { return matrix33_; }
 
  protected:
   void reset();
 
  private:
-  SkMatrix matrix_;
-  std::vector<SkMatrix> saved_;
+  SkM44 matrix_;
+  SkMatrix matrix33_;
+  std::vector<SkM44> saved_;
 };
 
 // A utility class that will monitor the Dispatcher methods relating

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -80,18 +80,14 @@ class IgnoreTransformDispatchHelper : public virtual Dispatcher {
   void skew(SkScalar sx, SkScalar sy) override {}
   // clang-format off
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void transform2x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                    SkScalar myx, SkScalar myy, SkScalar myt) override {}
-  // 3x3 non-Z subset of a 4x4 transform in row major order
-  void transform3x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                    SkScalar myx, SkScalar myy, SkScalar myt,
-                    SkScalar mwx, SkScalar mwy, SkScalar mwt) override {}
+  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                         SkScalar myx, SkScalar myy, SkScalar myt) override {}
   // full 4x4 transform in row major order
-  void transform4x4(
-    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override {}
+  void transformFullPerspective(
+      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override {}
   // clang-format on
 };
 
@@ -157,20 +153,19 @@ class SkMatrixDispatchHelper : public virtual Dispatcher,
   void scale(SkScalar sx, SkScalar sy) override;
   void rotate(SkScalar degrees) override;
   void skew(SkScalar sx, SkScalar sy) override;
+
   // clang-format off
+
   // 2x3 2D affine subset of a 4x4 transform in row major order
-  void transform2x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                    SkScalar myx, SkScalar myy, SkScalar myt) override;
-  // 3x3 non-Z subset of a 4x4 transform in row major order
-  void transform3x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
-                    SkScalar myx, SkScalar myy, SkScalar myt,
-                    SkScalar mwx, SkScalar mwy, SkScalar mwt) override;
+  void transform2DAffine(SkScalar mxx, SkScalar mxy, SkScalar mxt,
+                         SkScalar myx, SkScalar myy, SkScalar myt) override;
   // full 4x4 transform in row major order
-  void transform4x4(
-    SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
-    SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
-    SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
-    SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+  void transformFullPerspective(
+      SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
+      SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
+      SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
+      SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override;
+
   // clang-format on
 
   void save() override;

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -79,11 +79,14 @@ class IgnoreTransformDispatchHelper : public virtual Dispatcher {
   void rotate(SkScalar degrees) override {}
   void skew(SkScalar sx, SkScalar sy) override {}
   // clang-format off
+  // 2x3 2D affine subset of a 4x4 transform in row major order
   void transform2x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
                     SkScalar myx, SkScalar myy, SkScalar myt) override {}
+  // 3x3 non-Z subset of a 4x4 transform in row major order
   void transform3x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
                     SkScalar myx, SkScalar myy, SkScalar myt,
                     SkScalar mwx, SkScalar mwy, SkScalar mwt) override {}
+  // full 4x4 transform in row major order
   void transform4x4(
     SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,
@@ -135,6 +138,8 @@ class SkMatrixSource {
   // in an SkMatrix is enough to perform point and rect transforms
   // assuming input coordinates have only an X and Y and an assumed
   // Z of 0 and an assumed W of 1.
+  // See the block comment on the transform methods in |Dispatcher|
+  // for a detailed explanation.
   virtual const SkMatrix& matrix() const = 0;
 };
 
@@ -153,11 +158,14 @@ class SkMatrixDispatchHelper : public virtual Dispatcher,
   void rotate(SkScalar degrees) override;
   void skew(SkScalar sx, SkScalar sy) override;
   // clang-format off
+  // 2x3 2D affine subset of a 4x4 transform in row major order
   void transform2x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
                     SkScalar myx, SkScalar myy, SkScalar myt) override;
+  // 3x3 non-Z subset of a 4x4 transform in row major order
   void transform3x3(SkScalar mxx, SkScalar mxy, SkScalar mxt,
                     SkScalar myx, SkScalar myy, SkScalar myt,
                     SkScalar mwx, SkScalar mwy, SkScalar mwt) override;
+  // full 4x4 transform in row major order
   void transform4x4(
     SkScalar mxx, SkScalar mxy, SkScalar mxz, SkScalar mxt,
     SkScalar myx, SkScalar myy, SkScalar myz, SkScalar myt,

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -167,7 +167,10 @@ void Canvas::transform(const tonic::Float64List& matrix4) {
   if (!canvas_) {
     return;
   }
-  canvas_->concat(ToSkMatrix(matrix4));
+  canvas_->concat(SkM44(matrix4[0], matrix4[4], matrix4[8], matrix4[12],
+                        matrix4[1], matrix4[5], matrix4[9], matrix4[13],
+                        matrix4[2], matrix4[6], matrix4[10], matrix4[14],
+                        matrix4[3], matrix4[7], matrix4[11], matrix4[15]));
 }
 
 void Canvas::clipRect(double left,

--- a/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvas.dart
@@ -305,7 +305,7 @@ class CkCanvas {
   }
 
   void transform(Float32List matrix4) {
-    skCanvas.concat(toSkMatrixFromFloat32(matrix4));
+    skCanvas.concat(toSkM44FromFloat32(matrix4));
   }
 
   void translate(double dx, double dy) {
@@ -680,7 +680,7 @@ class CkTransformCommand extends CkPaintCommand {
 
   @override
   void apply(SkCanvas canvas) {
-    canvas.concat(toSkMatrixFromFloat32(matrix4));
+    canvas.concat(toSkM44FromFloat32(matrix4));
   }
 }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/canvaskit_api.dart
@@ -966,6 +966,19 @@ class SkPathNamespace {
   external SkPath MakeFromOp(SkPath path1, SkPath path2, SkPathOp pathOp);
 }
 
+/// Converts a 4x4 Flutter matrix (represented as a [Float32List] in
+/// column major order) to an SkM44 which is a 4x4 matrix represented
+/// as a [Float32List] in row major order.
+Float32List toSkM44FromFloat32(Float32List matrix4) {
+  final Float32List skM44 = Float32List(16);
+  for (int r = 0; r < 4; r++) {
+    for (int c = 0; c < 4; c++) {
+      skM44[c * 4 + r] = matrix4[r * 4 + c];
+    }
+  }
+  return skM44;
+}
+
 // Mappings from SkMatrix-index to input-index.
 const List<int> _skMatrixIndexToMatrix4Index = <int>[
   0, 4, 12, // Row 1

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:test/bootstrap/browser.dart';
@@ -45,6 +46,8 @@ void testMain() {
     _toSkPointTests();
     _toSkColorStopsTests();
     _toSkMatrixFromFloat32Tests();
+    _toSkM44FromFloat32Tests();
+    _matrix4x4CompositionTests();
     _toSkRectTests();
     _skVerticesTests();
     _paragraphTests();
@@ -589,6 +592,108 @@ void _toSkMatrixFromFloat32Tests() {
           0,
           1,
         ]));
+  });
+}
+
+void _toSkM44FromFloat32Tests() {
+  test('toSkM44FromFloat32', () {
+    final Matrix4 matrix = Matrix4.identity()
+      ..translate(1, 2, 3)
+      ..rotateZ(4);
+    expect(
+        toSkM44FromFloat32(matrix.storage),
+        Float32List.fromList(<double>[
+          -0.6536436080932617,
+          0.756802499294281,
+          0,
+          1,
+          -0.756802499294281,
+          -0.6536436080932617,
+          0,
+          2,
+          0,
+          0,
+          1,
+          3,
+          0,
+          0,
+          0,
+          1,
+        ]));
+  });
+}
+
+typedef CanvasCallback = void Function(ui.Canvas canvas);
+
+Future<ui.Image> toImage(CanvasCallback callback, int width, int height) {
+  final ui.PictureRecorder recorder = ui.PictureRecorder();
+  final ui.Canvas canvas = ui.Canvas(recorder, ui.Rect.fromLTRB(0, 0, width.toDouble(), height.toDouble()));
+  callback(canvas);
+  final ui.Picture picture = recorder.endRecording();
+  return picture.toImage(width, height);
+}
+
+/// @returns true When the images are reasonably similar.
+/// @todo Make the search actually fuzzy to a certain degree.
+Future<bool> fuzzyCompareImages(ui.Image golden, ui.Image img) async {
+  if (golden.width != img.width || golden.height != img.height) {
+    return false;
+  }
+  int getPixel(ByteData data, int x, int y) => data.getUint32((x + y * golden.width) * 4);
+  final ByteData goldenData = (await golden.toByteData())!;
+  final ByteData imgData = (await img.toByteData())!;
+  for (int y = 0; y < golden.height; y++) {
+    for (int x = 0; x < golden.width; x++) {
+      if (getPixel(goldenData, x, y) != getPixel(imgData, x, y)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+void _matrix4x4CompositionTests() {
+  test('compose4x4MatrixInCanvas', () async {
+    final double rotateAroundX = pi / 6;  // 30 degrees
+    final double rotateAroundY = pi / 9;  // 20 degrees
+    const int width = 150;
+    const int height = 150;
+    const ui.Color black = ui.Color.fromARGB(255, 0, 0, 0);
+    const ui.Color green = ui.Color.fromARGB(255, 0, 255, 0);
+    void paint(ui.Canvas canvas, CanvasCallback rotate) {
+      canvas.translate(width * 0.5, height * 0.5);
+      rotate(canvas);
+      const double width3 = width / 3.0;
+      const double width5 = width / 5.0;
+      const double width10 = width / 10.0;
+      canvas.drawRect(const ui.Rect.fromLTRB(-width3, -width3, width3, width3), ui.Paint()..color = green);
+      canvas.drawRect(const ui.Rect.fromLTRB(-width5, -width5, -width10, width5), ui.Paint()..color = black);
+      canvas.drawRect(const ui.Rect.fromLTRB(-width5, -width5, width5, -width10), ui.Paint()..color = black);
+    }
+
+    final ui.Image incrementalMatrixImage = await toImage((ui.Canvas canvas) {
+      paint(canvas, (ui.Canvas canvas) {
+        final Matrix4 matrix = Matrix4.identity();
+        matrix.setEntry(3, 2, 0.001);
+        canvas.transform(matrix.toFloat64());
+        matrix.setRotationX(rotateAroundX);
+        canvas.transform(matrix.toFloat64());
+        matrix.setRotationY(rotateAroundY);
+        canvas.transform(matrix.toFloat64());
+      });
+    }, width, height);
+    final ui.Image combinedMatrixImage = await toImage((ui.Canvas canvas) {
+      paint(canvas, (ui.Canvas canvas) {
+        final Matrix4 matrix = Matrix4.identity();
+        matrix.setEntry(3, 2, 0.001);
+        matrix.rotate(Vector3(1, 0, 0), rotateAroundX);
+        matrix.rotate(Vector3(0, 1, 0), rotateAroundY);
+        canvas.transform(matrix.toFloat64());
+      });
+    }, width, height);
+
+    final bool areEqual = await fuzzyCompareImages(incrementalMatrixImage, combinedMatrixImage);
+    expect(areEqual, true);
   });
 }
 

--- a/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
+++ b/lib/web_ui/test/canvaskit/canvaskit_api_test.dart
@@ -654,8 +654,8 @@ Future<bool> fuzzyCompareImages(ui.Image golden, ui.Image img) async {
 
 void _matrix4x4CompositionTests() {
   test('compose4x4MatrixInCanvas', () async {
-    final double rotateAroundX = pi / 6;  // 30 degrees
-    final double rotateAroundY = pi / 9;  // 20 degrees
+    const double rotateAroundX = pi / 6;  // 30 degrees
+    const double rotateAroundY = pi / 9;  // 20 degrees
     const int width = 150;
     const int height = 150;
     const ui.Color black = ui.Color.fromARGB(255, 0, 0, 0);

--- a/testing/dart/pubspec.yaml
+++ b/testing/dart/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   litetest: any
   path: any
   sky_engine: any
+  vector_math: any
   vm_service: any
 
 dependency_overrides:

--- a/testing/dart/pubspec.yaml
+++ b/testing/dart/pubspec.yaml
@@ -38,5 +38,7 @@ dependency_overrides:
     path: ../../lib/spirv
   sky_engine:
     path: ../../sky/packages/sky_engine
+  vector_math:
+    path: ../../../third_party/pkg/vector_math
   vm_service:
     path: ../../../third_party/dart/pkg/vm_service


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/82955

I did some renaming (and reformatting) of the transform parameters to maintain a consistent terminology all the way through.

One minor change in behavior I discovered during testing is that `SkCanvas::concat(SkMatrix::Identity)` would be NOPed by the call and not stored in an SkPicture (or passed along to the DisplayList), but now that I'm providing the full 16 matrix entries in a `concat(SkM44)` call, that check is not done. At least for DisplayList, I do the check anyway, so this would only affect the (soon to be legacy) SkPicture usages.

The fix has its own tests in this change, but it was also tested using the test case in the Github Issue on MacOS and Android (both with and without DisplayList), and Chrome/CanvasKit. The problem didn't originally happen with the HTML/DOM renderer and is still working fine.