### PR TITLE
[fuchsia] Remove unused deps on fidl optional.h.

### DIFF
--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -11,7 +11,6 @@
 #include <lib/fdio/directory.h>
 #include <lib/fdio/fd.h>
 #include <lib/fdio/namespace.h>
-#include <lib/fidl/cpp/optional.h>
 #include <lib/fidl/cpp/string.h>
 #include <lib/sys/cpp/service_directory.h>
 #include <lib/syslog/global.h>

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller_v2.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller_v2.cc
@@ -12,7 +12,6 @@
 #include <lib/fdio/directory.h>
 #include <lib/fdio/fd.h>
 #include <lib/fdio/namespace.h>
-#include <lib/fidl/cpp/optional.h>
 #include <lib/fidl/cpp/string.h>
 #include <lib/sys/cpp/service_directory.h>
 #include <lib/syslog/global.h>


### PR DESCRIPTION
Removed in https://fuchsia-review.googlesource.com/c/fuchsia/+/585444
making our SDK roll fail in #28862.