### PR TITLE
[iOSTextInput] remove floating cursor asserts

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -1368,7 +1368,6 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   // It seems impossible to use a negative "width" or "height", as the "convertRect"
   // call always turns a CGRect's negative dimensions into non-negative values, e.g.,
   // (1, 2, -3, -4) would become (-2, -2, 3, 4).
-  NSAssert(!_isFloatingCursorActive, @"Another floating cursor is currently active.");
   _isFloatingCursorActive = true;
   [self.textInputDelegate updateFloatingCursor:FlutterFloatingCursorDragStateStart
                                     withClient:_textInputClient
@@ -1376,16 +1375,13 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 }
 
 - (void)updateFloatingCursorAtPoint:(CGPoint)point {
-  NSAssert(_isFloatingCursorActive,
-           @"updateFloatingCursorAtPoint is called without an active floating cursor.");
+  _isFloatingCursorActive = true;
   [self.textInputDelegate updateFloatingCursor:FlutterFloatingCursorDragStateUpdate
                                     withClient:_textInputClient
                                   withPosition:@{@"X" : @(point.x), @"Y" : @(point.y)}];
 }
 
 - (void)endFloatingCursor {
-  NSAssert(_isFloatingCursorActive,
-           @"endFloatingCursor is called without an active floating cursor.");
   _isFloatingCursorActive = false;
   [self.textInputDelegate updateFloatingCursor:FlutterFloatingCursorDragStateEnd
                                     withClient:_textInputClient

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -825,6 +825,16 @@ FLUTTER_ASSERT_ARC
   }
 }
 
+- (void)testFloatingCursorDoesNotThrow {
+  // The keyboard implementation may send unbalanced calls to the input view.
+  FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
+  [inputView beginFloatingCursorAtPoint:CGPointMake(123, 321)];
+  [inputView beginFloatingCursorAtPoint:CGPointMake(123, 321)];
+  [inputView endFloatingCursor];
+  [inputView beginFloatingCursorAtPoint:CGPointMake(123, 321)];
+  [inputView endFloatingCursor];
+}
+
 - (void)testBoundsForFloatingCursor {
   FlutterTextInputView* inputView = [[FlutterTextInputView alloc] init];
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/90416

The iOS software keyboard implementation can generate unbalanced `begin/endFloatingCursor` calls with force touch:  

```
begin: (196.0, 22.75)
begin: (196.0, 22.75)
end
begin: (176.775, 22.75)
begin: (176.775, 22.75)
end
begin: (76.42452273960339, 25.057977690767668)
begin: (99.67666547701577, 26.862070369224)
end
begin: (38.84782525825079, 25.41603114976771)
begin: (38.84782525825079, 24.91103114976771)
end
begin: (91.95749288600321, 31.02630523768684)
end
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
