### PR TITLE
Avoid GCing aggressively during startup, and forward trim messages beyond low to application

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -79,6 +79,7 @@ import java.util.Arrays;
   @VisibleForTesting @Nullable OnPreDrawListener activePreDrawListener;
   private boolean isFlutterEngineFromHost;
   private boolean isFlutterUiDisplayed;
+  private boolean isFirstFrameRendered;
 
   @NonNull
   private final FlutterUiDisplayListener flutterUiDisplayListener =
@@ -87,6 +88,7 @@ import java.util.Arrays;
         public void onFlutterUiDisplayed() {
           host.onFlutterUiDisplayed();
           isFlutterUiDisplayed = true;
+          isFirstFrameRendered = true;
         }
 
         @Override
@@ -98,6 +100,7 @@ import java.util.Arrays;
 
   FlutterActivityAndFragmentDelegate(@NonNull Host host) {
     this.host = host;
+    this.isFirstFrameRendered = false;
   }
 
   /**
@@ -781,17 +784,17 @@ import java.util.Arrays;
   void onTrimMemory(int level) {
     ensureAlive();
     if (flutterEngine != null) {
-      // This is always an indication that the Dart VM should collect memory
-      // and free any unneeded resources.
-      flutterEngine.getDartExecutor().notifyLowMemoryWarning();
       // Use a trim level delivered while the application is running so the
       // framework has a chance to react to the notification.
-      if (level == TRIM_MEMORY_RUNNING_LOW) {
-        Log.v(TAG, "Forwarding onTrimMemory() to FlutterEngine. Level: " + level);
+      // Avoid being too aggressive before the first frame is rendered. If it is
+      // not at least running critical, we should avoid delaying the frame for
+      // an overly aggressive GC.
+      boolean trim =
+          isFirstFrameRendered ? level >= TRIM_MEMORY_RUNNING_LOW : level > TRIM_MEMORY_RUNNING_LOW;
+      if (trim) {
+        flutterEngine.getDartExecutor().notifyLowMemoryWarning();
         flutterEngine.getSystemChannel().sendMemoryPressureWarning();
       }
-    } else {
-      Log.w(TAG, "onTrimMemory() invoked before FlutterFragment was attached to an Activity.");
     }
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -4,6 +4,7 @@
 
 package io.flutter.embedding.android;
 
+import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DEFAULT_INITIAL_ROUTE;
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -790,7 +790,9 @@ import java.util.Arrays;
       // not at least running critical, we should avoid delaying the frame for
       // an overly aggressive GC.
       boolean trim =
-          isFirstFrameRendered ? level >= TRIM_MEMORY_RUNNING_LOW : level > TRIM_MEMORY_RUNNING_LOW;
+          isFirstFrameRendered
+              ? level >= TRIM_MEMORY_RUNNING_LOW
+              : level >= TRIM_MEMORY_RUNNING_CRITICAL;
       if (trim) {
         flutterEngine.getDartExecutor().notifyLowMemoryWarning();
         flutterEngine.getSystemChannel().sendMemoryPressureWarning();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -713,18 +713,41 @@ public class FlutterActivityAndFragmentDelegateTest {
     // The FlutterEngine is set up in onAttach().
     delegate.onAttach(RuntimeEnvironment.application);
 
+    // Test assumes no frames have been displayed.
+    verify(mockHost, times(0)).onFlutterUiDisplayed();
+
     // Emulate the host and call the method that we expect to be forwarded.
     delegate.onTrimMemory(TRIM_MEMORY_RUNNING_MODERATE);
+    delegate.onTrimMemory(TRIM_MEMORY_RUNNING_LOW);
+    verify(mockFlutterEngine.getDartExecutor(), times(0)).notifyLowMemoryWarning();
+    verify(mockFlutterEngine.getSystemChannel(), times(0)).sendMemoryPressureWarning();
+
+    delegate.onTrimMemory(TRIM_MEMORY_RUNNING_CRITICAL);
+    delegate.onTrimMemory(TRIM_MEMORY_BACKGROUND);
+    delegate.onTrimMemory(TRIM_MEMORY_COMPLETE);
+    delegate.onTrimMemory(TRIM_MEMORY_MODERATE);
+    delegate.onTrimMemory(TRIM_MEMORY_UI_HIDDEN);
+    verify(mockFlutterEngine.getDartExecutor(), times(5)).notifyLowMemoryWarning();
+    verify(mockFlutterEngine.getSystemChannel(), times(5)).sendMemoryPressureWarning();
+
+    verify(mockHost, times(0)).onFlutterUiDisplayed();
+
+    delegate.onCreateView(null, null, null, 0, false);
+
+    verify(mockHost, times(1)).onFlutterUiDisplayed();
+
+    delegate.onTrimMemory(TRIM_MEMORY_RUNNING_MODERATE);
+    verify(mockFlutterEngine.getDartExecutor(), times(5)).notifyLowMemoryWarning();
+    verify(mockFlutterEngine.getSystemChannel(), times(5)).sendMemoryPressureWarning();
+
     delegate.onTrimMemory(TRIM_MEMORY_RUNNING_LOW);
     delegate.onTrimMemory(TRIM_MEMORY_RUNNING_CRITICAL);
     delegate.onTrimMemory(TRIM_MEMORY_BACKGROUND);
     delegate.onTrimMemory(TRIM_MEMORY_COMPLETE);
     delegate.onTrimMemory(TRIM_MEMORY_MODERATE);
     delegate.onTrimMemory(TRIM_MEMORY_UI_HIDDEN);
-
-    // Verify that the call was forwarded to the engine.
-    verify(mockFlutterEngine.getDartExecutor(), times(7)).notifyLowMemoryWarning();
-    verify(mockFlutterEngine.getSystemChannel(), times(1)).sendMemoryPressureWarning();
+    verify(mockFlutterEngine.getDartExecutor(), times(11)).notifyLowMemoryWarning();
+    verify(mockFlutterEngine.getSystemChannel(), times(11)).sendMemoryPressureWarning();
   }
 
   @Test

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -32,6 +32,7 @@ import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
+import io.flutter.embedding.engine.renderer.FlutterUiDisplayListener;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.embedding.engine.systemchannels.KeyEventChannel;
 import io.flutter.embedding.engine.systemchannels.LifecycleChannel;
@@ -46,6 +47,7 @@ import io.flutter.plugin.platform.PlatformViewsController;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
@@ -733,6 +735,12 @@ public class FlutterActivityAndFragmentDelegateTest {
     verify(mockHost, times(0)).onFlutterUiDisplayed();
 
     delegate.onCreateView(null, null, null, 0, false);
+    final FlutterRenderer renderer = mockFlutterEngine.getRenderer();
+    ArgumentCaptor<FlutterUiDisplayListener> listenerCaptor =
+        ArgumentCaptor.forClass(FlutterUiDisplayListener.class);
+    // 2 times: once for engine attachment, once for view creation.
+    verify(renderer, times(2)).addIsDisplayingFlutterUiListener(listenerCaptor.capture());
+    listenerCaptor.getValue().onFlutterUiDisplayed();
 
     verify(mockHost, times(1)).onFlutterUiDisplayed();
 
@@ -982,7 +990,10 @@ public class FlutterActivityAndFragmentDelegateTest {
     when(engine.getMouseCursorChannel()).thenReturn(mock(MouseCursorChannel.class));
     when(engine.getNavigationChannel()).thenReturn(mock(NavigationChannel.class));
     when(engine.getPlatformViewsController()).thenReturn(mock(PlatformViewsController.class));
-    when(engine.getRenderer()).thenReturn(mock(FlutterRenderer.class));
+
+    FlutterRenderer renderer = mock(FlutterRenderer.class);
+    when(engine.getRenderer()).thenReturn(renderer);
+
     when(engine.getSettingsChannel()).thenReturn(fakeSettingsChannel);
     when(engine.getSystemChannel()).thenReturn(mock(SystemChannel.class));
     when(engine.getTextInputChannel()).thenReturn(mock(TextInputChannel.class));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/90551

This PR does the following:

- Instead of unconditionally calling `Dart_NotifyLowMemory` whenever we get a trim signal, use `TRIM_LEVEL_RUNNING_CRITICAL` and above _before_ a first frame and `TRIM_LEVEL_RUNNING_LOW` after as the cutoffs.
- Instead of calling the system channel memory pressure event _only_ for `TRIM_LEVEL_RUNNING_LOW`, call it for all trim levels above `RUNNING_LOW`.

This can slightly raise memory usage during application initialization, but only until a first frame is rendered.