### PR TITLE
[web] improve Firefox launch process

### DIFF
--- a/lib/web_ui/dev/common.dart
+++ b/lib/web_ui/dev/common.dart
@@ -16,6 +16,10 @@ import 'safari_macos.dart';
 
 /// The port number for debugging.
 const int kDevtoolsPort = 12345;
+
+/// The port number for the temporary local server used to health-check the
+/// browser.
+const int kHealthCheckServerPort = 12346;
 const int kMaxScreenshotWidth = 1024;
 const int kMaxScreenshotHeight = 1024;
 const double kMaxDiffRateFailure = 0.28 / 100; // 0.28%

--- a/lib/web_ui/dev/test_platform.dart
+++ b/lib/web_ui/dev/test_platform.dart
@@ -573,7 +573,7 @@ class BrowserManager {
   }) {
     final Browser browser = _newBrowser(url, browserEnvironment, debug: debug);
 
-    final Completer<BrowserManager> completer = Completer<BrowserManager>();
+    final Completer<BrowserManager?> completer = Completer<BrowserManager?>();
 
     // For the cases where we use a delegator such as `adb` (for Android) or
     // `xcrun` (for IOS), these delegator processes can shut down before the


### PR DESCRIPTION
- Change the type of `Completer<BrowserManager>` to `Completer<BrowserManager?>`. This was causing cryptic stack traces and hanging of the process. Also filed https://github.com/dart-lang/sdk/issues/47308 about it.
- Insert a trampoline page between the browser and the test page. Listen to the browser loading the trampoline page and use it as a proof that the browser has successfully launched. If the browser exits before the trampoline page is loaded, abort the launch process.
- Have `Browser` retry launching the browser 3 times before giving up.

This is a somewhat speculative fix for https://github.com/flutter/flutter/issues/90831 (I cannot reproduce Firefox crashing locally, so I just emulated the crash)