### PR TITLE
[web] reuse browser instance across screenshot tests

### DIFF
--- a/lib/web_ui/dev/steps/run_tests_step.dart
+++ b/lib/web_ui/dev/steps/run_tests_step.dart
@@ -117,7 +117,7 @@ class RunTestsStep implements PipelineStep {
       );
     }
 
-    // Run all unit-tests as a single batch and with high concurrency.
+    // Run non-screenshot tests with high concurrency.
     if (unitTestFiles.isNotEmpty) {
       await _runTestBatch(
         testFiles: unitTestFiles,
@@ -130,11 +130,11 @@ class RunTestsStep implements PipelineStep {
       _checkExitCode('Unit tests');
     }
 
-    // Run screenshot tests one at a time. Otherwise, tests end up
-    // screenshotting each other.
-    for (final FilePath screenshotTestFilePath in screenshotTestFiles) {
+    // Run screenshot tests one at a time to prevent tests from screenshotting
+    // each other.
+    if (screenshotTestFiles.isNotEmpty) {
       await _runTestBatch(
-        testFiles: <FilePath>[screenshotTestFilePath],
+        testFiles: screenshotTestFiles,
         browserEnvironment: browserEnvironment,
         concurrency: 1,
         expectFailure: false,


### PR DESCRIPTION
Run screenshot tests in a single batch to reuse the same browser instance.

Launching the browser fewer times per build will reduce flakiness associated with the browser occasionally failing to launch.

This also speeds up the total test runtime. For example, Firefox is quite slow to start-up, and reusing the browser instance speeds up tests by ~2.4x (from 186 seconds down to 77 seconds on my local workstation).

Fixes https://github.com/flutter/flutter/issues/90831