### PR TITLE
[fuchsia] Pass WeakPtrs to GfxConnection FIDL fns.

### DIFF
--- a/shell/platform/fuchsia/flutter/gfx_session_connection.cc
+++ b/shell/platform/fuchsia/flutter/gfx_session_connection.cc
@@ -260,6 +260,10 @@ GfxSessionConnection::GfxSessionConnection(
         // adjust accordingly.
         async::PostTask(weak->inspect_dispatcher_, [weak, now = Now(),
                                                     num_presents_handled]() {
+          if (!weak) {
+            return;
+          }
+
           weak->presents_completed_.Add(num_presents_handled);
           weak->last_frame_completed_.Set(now.ToEpochDelta().ToNanoseconds());
         });

--- a/shell/platform/fuchsia/flutter/gfx_session_connection.h
+++ b/shell/platform/fuchsia/flutter/gfx_session_connection.h
@@ -174,6 +174,10 @@ class GfxSessionConnection final {
   // thread.
   FireCallbackCallback fire_callback_;
 
+  // Generates WeakPtrs to the instance of the class for use in FIDL callbacks.
+  // This must be the last field in the class.
+  fml::WeakPtrFactory<GfxSessionConnection> weak_factory_;
+
   FML_DISALLOW_COPY_AND_ASSIGN(GfxSessionConnection);
 };
 

--- a/shell/platform/fuchsia/flutter/gfx_session_connection.h
+++ b/shell/platform/fuchsia/flutter/gfx_session_connection.h
@@ -174,7 +174,8 @@ class GfxSessionConnection final {
   // thread.
   FireCallbackCallback fire_callback_;
 
-  // Generates WeakPtrs to the instance of the class for use in FIDL callbacks.
+  // Generates WeakPtrs to the instance of the class so callbacks can verify
+  // that the instance is still in-scope before accessing state.
   // This must be the last field in the class.
   fml::WeakPtrFactory<GfxSessionConnection> weak_factory_;
 


### PR DESCRIPTION
Bug: fxb/85211
Tested: Ran Spinning Square with flutter_jit_runner.

Crash occurs in `GfxSessionConnection::FireCallbackMaybe` on session restart. This implies that the crash might be happening as a result of state that has been destroyed when the callback fires. We pass a WeakPtr to the current GfxSessionConnection into FIDL callbacks to check that we haven't already been destroyed when the FIDL callback fires.

I haven't been able to reproduce the crash locally so I'm not 100% sure if this fixes the issue or not, but it seems like it will make the code safer.