### PR TITLE
Add web support for tooltip

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
+++ b/lib/web_ui/lib/src/engine/semantics/label_and_value.dart
@@ -52,17 +52,24 @@ class LabelAndValue extends RoleManager {
   void update() {
     final bool hasValue = semanticsObject.hasValue;
     final bool hasLabel = semanticsObject.hasLabel;
+    final bool hasTooltip = semanticsObject.hasTooltip;
 
     // If the node is incrementable the value is reported to the browser via
     // the respective role manager. We do not need to also render it again here.
     final bool shouldDisplayValue = hasValue && !semanticsObject.isIncrementable;
 
-    if (!hasLabel && !shouldDisplayValue) {
+    if (!hasLabel && !shouldDisplayValue && !hasTooltip) {
       _cleanUpDom();
       return;
     }
 
     final StringBuffer combinedValue = StringBuffer();
+    if (hasTooltip) {
+      combinedValue.write(semanticsObject.tooltip);
+      if (hasLabel || shouldDisplayValue) {
+        combinedValue.write('\n');
+      }
+    }
     if (hasLabel) {
       combinedValue.write(semanticsObject.label);
       if (shouldDisplayValue) {

--- a/lib/web_ui/lib/src/engine/semantics/semantics.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics.dart
@@ -600,6 +600,22 @@ class SemanticsObject {
     _dirtyFields |= _additionalActionsIndex;
   }
 
+  /// See [ui.SemanticsUpdateBuilder.updateNode].
+  String? get tooltip => _tooltip;
+  String? _tooltip;
+
+  /// Whether this object contains a non-empty tooltip.
+  bool get hasTooltip => _tooltip != null && _tooltip!.isNotEmpty;
+
+  static const int _tooltipIndex = 1 << 22;
+
+  /// Whether the [tooltip] field has been updated but has not been
+  /// applied to the DOM yet.
+  bool get isTooltipDirty => _isDirty(_tooltipIndex);
+  void _markTooltipDirty() {
+    _dirtyFields |= _tooltipIndex;
+  }
+
   /// A unique permanent identifier of the semantics node in the tree.
   final int id;
 
@@ -812,6 +828,11 @@ class SemanticsObject {
       _markDecreasedValueDirty();
     }
 
+    if (_tooltip != update.tooltip) {
+      _tooltip = update.tooltip;
+      _markTooltipDirty();
+    }
+
     if (_textDirection != update.textDirection) {
       _textDirection = update.textDirection;
       _markTextDirectionDirty();
@@ -882,7 +903,7 @@ class SemanticsObject {
   /// Detects the roles that this semantics object corresponds to and manages
   /// the lifecycles of [SemanticsObjectRole] objects.
   void _updateRoles() {
-    _updateRole(Role.labelAndValue, (hasLabel || hasValue) && !isTextField && !isVisualOnly);
+    _updateRole(Role.labelAndValue, (hasLabel || hasValue || hasTooltip) && !isTextField && !isVisualOnly);
     _updateRole(Role.textField, isTextField);
 
     final bool shouldUseTappableRole =


### PR DESCRIPTION
previously the tooltip is prepend to semantics label directly in the framework side, but now it will be in its own field and it will be up to the platform to decide how to use it. This pr updates web engine to prepend the tooltip itself.

https://github.com/flutter/flutter/issues/86577

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
