### PR TITLE
Win32: Set default bgcolor to black

### DIFF
--- a/shell/platform/windows/window_win32.cc
+++ b/shell/platform/windows/window_win32.cc
@@ -101,7 +101,7 @@ WNDCLASS WindowWin32::RegisterWindowClass(std::wstring& title) {
   window_class.cbWndExtra = 0;
   window_class.hInstance = GetModuleHandle(nullptr);
   window_class.hIcon = nullptr;
-  window_class.hbrBackground = 0;
+  window_class.hbrBackground = static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH));
   window_class.lpszMenuName = nullptr;
   window_class.lpfnWndProc = WndProc;
   RegisterClass(&window_class);

--- a/shell/platform/windows/window_win32_unittests.cc
+++ b/shell/platform/windows/window_win32_unittests.cc
@@ -20,6 +20,16 @@ TEST(MockWin32Window, GetDpiAfterCreate) {
   ASSERT_TRUE(window.GetDpi() > 0);
 }
 
+TEST(MockWin32Window, BackgroundColor) {
+  MockWin32Window window;
+  window.InitializeChild("FLUTTERVIEW", 100, 100);
+
+  WNDCLASS window_class;
+  GetClassInfo(GetModuleHandle(nullptr), L"FLUTTERVIEW", &window_class);
+  HBRUSH bg_brush = static_cast<HBRUSH>(GetStockObject(BLACK_BRUSH));
+  ASSERT_EQ(window_class.hbrBackground, bg_brush);
+}
+
 TEST(MockWin32Window, VerticalScroll) {
   MockWin32Window window;
   const int scroll_amount = 10;


### PR DESCRIPTION
Default the background colour for Flutter views to black in the Win32
embedder.

Issue: https://github.com/flutter/flutter/issues/76082

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
