### PR TITLE
include nested Picture stats in DisplayList byte and op counts

### DIFF
--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -1068,6 +1068,7 @@ sk_sp<DisplayList> DisplayListBuilder::Build() {
   size_t nested_bytes = nested_bytes_;
   int nested_count = nested_op_count_;
   used_ = allocated_ = op_count_ = 0;
+  nested_bytes_ = nested_op_count_ = 0;
   storage_.realloc(bytes);
   return sk_sp<DisplayList>(new DisplayList(storage_.release(), bytes, count,
                                             nested_bytes, nested_count,

--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -1428,7 +1428,7 @@ void DisplayListBuilder::drawPicture(const sk_sp<SkPicture> picture,
                                     render_with_attributes)
       : Push<DrawSkPictureOp>(0, 1, std::move(picture), render_with_attributes);
   nested_bytes_ += picture->approximateBytesUsed();
-  nested_op_count_ += picture->approximateOpCount();
+  nested_op_count_ += picture->approximateOpCount(true);
 }
 void DisplayListBuilder::drawDisplayList(
     const sk_sp<DisplayList> display_list) {

--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -987,7 +987,7 @@ void DisplayList::RenderTo(SkCanvas* canvas) const {
 }
 
 bool DisplayList::Equals(const DisplayList& other) const {
-  if (used_ != other.used_ || op_count_ != other.op_count_) {
+  if (byte_count_ != other.byte_count_ || op_count_ != other.op_count_) {
     return false;
   }
   uint8_t* ptr = storage_.get();
@@ -995,18 +995,22 @@ bool DisplayList::Equals(const DisplayList& other) const {
   if (ptr == o_ptr) {
     return true;
   }
-  return CompareOps(ptr, ptr + used_, o_ptr, o_ptr + other.used_);
+  return CompareOps(ptr, ptr + byte_count_, o_ptr, o_ptr + other.byte_count_);
 }
 
 DisplayList::DisplayList(uint8_t* ptr,
-                         size_t used,
+                         size_t byte_count,
                          int op_count,
-                         const SkRect& cull)
+                         size_t nested_byte_count,
+                         int nested_op_count,
+                         const SkRect& cull_rect)
     : storage_(ptr),
-      used_(used),
+      byte_count_(byte_count),
       op_count_(op_count),
+      nested_byte_count_(nested_byte_count),
+      nested_op_count_(nested_op_count),
       bounds_({0, 0, -1, -1}),
-      bounds_cull_(cull) {
+      bounds_cull_(cull_rect) {
   static std::atomic<uint32_t> nextID{1};
   do {
     unique_id_ = nextID.fetch_add(+1, std::memory_order_relaxed);
@@ -1015,7 +1019,7 @@ DisplayList::DisplayList(uint8_t* ptr,
 
 DisplayList::~DisplayList() {
   uint8_t* ptr = storage_.get();
-  DisposeOps(ptr, ptr + used_);
+  DisposeOps(ptr, ptr + byte_count_);
 }
 
 #define DL_BUILDER_PAGE 4096
@@ -1059,15 +1063,19 @@ sk_sp<DisplayList> DisplayListBuilder::Build() {
   while (save_level_ > 0) {
     restore();
   }
-  size_t used = used_;
+  size_t bytes = used_;
   int count = op_count_;
+  size_t nested_bytes = nested_bytes_;
+  int nested_count = nested_op_count_;
   used_ = allocated_ = op_count_ = 0;
-  storage_.realloc(used);
-  return sk_sp<DisplayList>(
-      new DisplayList(storage_.release(), used, count, cull_));
+  storage_.realloc(bytes);
+  return sk_sp<DisplayList>(new DisplayList(storage_.release(), bytes, count,
+                                            nested_bytes, nested_count,
+                                            cull_rect_));
 }
 
-DisplayListBuilder::DisplayListBuilder(const SkRect& cull) : cull_(cull) {}
+DisplayListBuilder::DisplayListBuilder(const SkRect& cull_rect)
+    : cull_rect_(cull_rect) {}
 
 DisplayListBuilder::~DisplayListBuilder() {
   uint8_t* ptr = storage_.get();
@@ -1418,10 +1426,14 @@ void DisplayListBuilder::drawPicture(const sk_sp<SkPicture> picture,
       ? Push<DrawSkPictureMatrixOp>(0, 1, std::move(picture), *matrix,
                                     render_with_attributes)
       : Push<DrawSkPictureOp>(0, 1, std::move(picture), render_with_attributes);
+  nested_bytes_ += picture->approximateBytesUsed();
+  nested_op_count_ += picture->approximateOpCount();
 }
 void DisplayListBuilder::drawDisplayList(
     const sk_sp<DisplayList> display_list) {
   Push<DrawDisplayListOp>(0, 1, std::move(display_list));
+  nested_bytes_ += display_list->bytes(true);
+  nested_op_count_ += display_list->op_count(true);
 }
 void DisplayListBuilder::drawTextBlob(const sk_sp<SkTextBlob> blob,
                                       SkScalar x,

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -222,20 +222,41 @@ static sk_sp<SkTextBlob> TestBlob2 = MakeTextBlob("TestBlob2");
 typedef const std::function<void(DisplayListBuilder&)> DlInvoker;
 
 struct DisplayListInvocation {
-  int op_count;
-  size_t byte_count;
+  int op_count_;
+  size_t byte_count_;
 
   // in some cases, running the sequence through an SkCanvas will result
   // in fewer ops/bytes. Attribute invocations are recorded in an SkPaint
   // and not forwarded on, and SkCanvas culls unused save/restore/transforms.
-  int sk_op_count;
-  size_t sk_byte_count;
+  int sk_op_count_;
+  size_t sk_byte_count_;
 
   DlInvoker invoker;
 
   bool sk_version_matches() {
-    return (op_count == sk_op_count && byte_count == sk_byte_count);
+    return (op_count_ == sk_op_count_ && byte_count_ == sk_byte_count_);
   }
+
+  // A negative sk_op_count means "do not test this op".
+  // Used mainly for these cases:
+  // - we cannot encode a DrawShadowRec (Skia private header)
+  // - SkCanvas cannot receive a DisplayList
+  // - SkCanvas may or may not inline an SkPicture
+  bool sk_testing_invalid() { return sk_op_count_ < 0; }
+
+  bool is_empty() { return byte_count_ == 0; }
+
+  int op_count() { return op_count_; }
+  // byte count for the individual ops, no DisplayList overhead
+  size_t raw_byte_count() { return byte_count_; }
+  // byte count for the ops with DisplayList overhead, comparable
+  // to |DisplayList.byte_count().
+  size_t byte_count() { return sizeof(DisplayList) + byte_count_; }
+
+  int sk_op_count() { return sk_op_count_; }
+  // byte count for the ops with DisplayList overhead as translated
+  // through an SkCanvas interface, comparable to |DisplayList.byte_count().
+  size_t sk_byte_count() { return sizeof(DisplayList) + sk_byte_count_; }
 
   sk_sp<DisplayList> Build() {
     DisplayListBuilder builder;
@@ -714,8 +735,8 @@ TEST(DisplayList, SingleOpSizes) {
       auto& invocation = group.variants[i];
       sk_sp<DisplayList> dl = invocation.Build();
       auto desc = group.op_name + "(variant " + std::to_string(i + 1) + ")";
-      ASSERT_EQ(dl->op_count(), invocation.op_count) << desc;
-      EXPECT_EQ(dl->bytes(), invocation.byte_count) << desc;
+      ASSERT_EQ(dl->op_count(false), invocation.op_count()) << desc;
+      EXPECT_EQ(dl->bytes(false), invocation.byte_count()) << desc;
     }
   }
 }
@@ -727,12 +748,12 @@ TEST(DisplayList, SingleOpDisplayListsNotEqualEmpty) {
       sk_sp<DisplayList> dl = group.variants[i].Build();
       auto desc =
           group.op_name + "(variant " + std::to_string(i + 1) + " != empty)";
-      if (group.variants[i].byte_count != 0) {
-        ASSERT_FALSE(dl->Equals(*empty)) << desc;
-        ASSERT_FALSE(empty->Equals(*dl)) << desc;
-      } else {
+      if (group.variants[i].is_empty()) {
         ASSERT_TRUE(dl->Equals(*empty)) << desc;
         ASSERT_TRUE(empty->Equals(*dl)) << desc;
+      } else {
+        ASSERT_FALSE(dl->Equals(*empty)) << desc;
+        ASSERT_FALSE(empty->Equals(*dl)) << desc;
       }
     }
   }
@@ -749,8 +770,10 @@ TEST(DisplayList, SingleOpDisplayListsRecapturedAreEqual) {
       sk_sp<DisplayList> copy = builder.Build();
       auto desc =
           group.op_name + "(variant " + std::to_string(i + 1) + " == copy)";
-      ASSERT_EQ(copy->op_count(), dl->op_count()) << desc;
-      ASSERT_EQ(copy->bytes(), dl->bytes()) << desc;
+      ASSERT_EQ(copy->op_count(false), dl->op_count(false)) << desc;
+      ASSERT_EQ(copy->bytes(false), dl->bytes(false)) << desc;
+      ASSERT_EQ(copy->op_count(true), dl->op_count(true)) << desc;
+      ASSERT_EQ(copy->bytes(true), dl->bytes(true)) << desc;
       ASSERT_EQ(copy->bounds(), dl->bounds()) << desc;
       ASSERT_TRUE(copy->Equals(*dl)) << desc;
       ASSERT_TRUE(dl->Equals(*copy)) << desc;
@@ -761,12 +784,7 @@ TEST(DisplayList, SingleOpDisplayListsRecapturedAreEqual) {
 TEST(DisplayList, SingleOpDisplayListsRecapturedViaSkCanvasAreEqual) {
   for (auto& group : allGroups) {
     for (size_t i = 0; i < group.variants.size(); i++) {
-      if (group.variants[i].sk_op_count < 0) {
-        // A negative sk_op_count means "do not test this op".
-        // Used mainly for these cases:
-        // - we cannot encode a DrawShadowRec (Skia private header)
-        // - SkCanvas cannot receive a DisplayList
-        // - SkCanvas may or may not inline an SkPicture
+      if (group.variants[i].sk_testing_invalid()) {
         continue;
       }
       // Verify a DisplayList (re)built by "rendering" it to an
@@ -782,8 +800,8 @@ TEST(DisplayList, SingleOpDisplayListsRecapturedViaSkCanvasAreEqual) {
       dl->RenderTo(&recorder);
       sk_sp<DisplayList> sk_copy = recorder.Build();
       auto desc = group.op_name + "[variant " + std::to_string(i + 1) + "]";
-      EXPECT_EQ(sk_copy->op_count(), group.variants[i].sk_op_count) << desc;
-      EXPECT_EQ(sk_copy->bytes(), group.variants[i].sk_byte_count) << desc;
+      EXPECT_EQ(sk_copy->op_count(false), group.variants[i].sk_op_count()) << desc;
+      EXPECT_EQ(sk_copy->bytes(false), group.variants[i].sk_byte_count()) << desc;
       if (group.variants[i].sk_version_matches()) {
         EXPECT_EQ(sk_copy->bounds(), dl->bounds()) << desc;
         EXPECT_TRUE(dl->Equals(*sk_copy)) << desc << " == sk_copy";
@@ -814,8 +832,10 @@ TEST(DisplayList, SingleOpDisplayListsCompareToEachOther) {
         auto desc = group.op_name + "(variant " + std::to_string(i + 1) +
                     " ==? variant " + std::to_string(j + 1) + ")";
         if (i == j) {
-          ASSERT_EQ(listA->op_count(), listB->op_count()) << desc;
-          ASSERT_EQ(listA->bytes(), listB->bytes()) << desc;
+          ASSERT_EQ(listA->op_count(false), listB->op_count(false)) << desc;
+          ASSERT_EQ(listA->bytes(false), listB->bytes(false)) << desc;
+          ASSERT_EQ(listA->op_count(true), listB->op_count(true)) << desc;
+          ASSERT_EQ(listA->bytes(true), listB->bytes(true)) << desc;
           ASSERT_EQ(listA->bounds(), listB->bounds()) << desc;
           ASSERT_TRUE(listA->Equals(*listB)) << desc;
           ASSERT_TRUE(listB->Equals(*listA)) << desc;
@@ -840,8 +860,8 @@ static sk_sp<DisplayList> Build(size_t g_index, size_t v_index) {
     if (j >= group.variants.size())
       continue;
     DisplayListInvocation& invocation = group.variants[j];
-    op_count += invocation.op_count;
-    byte_count += invocation.byte_count;
+    op_count += invocation.op_count();
+    byte_count += invocation.raw_byte_count();
     invocation.invoker(builder);
   }
   sk_sp<DisplayList> dl = builder.Build();
@@ -856,8 +876,8 @@ static sk_sp<DisplayList> Build(size_t g_index, size_t v_index) {
       name += " variant " + std::to_string(v_index + 1);
     }
   }
-  EXPECT_EQ(dl->op_count(), op_count) << name;
-  EXPECT_EQ(dl->bytes(), byte_count) << name;
+  EXPECT_EQ(dl->op_count(false), op_count) << name;
+  EXPECT_EQ(dl->bytes(false), byte_count + sizeof(DisplayList)) << name;
   return dl;
 }
 
@@ -883,12 +903,12 @@ TEST(DisplayList, DisplayListsWithVaryingOpComparisons) {
         ASSERT_FALSE(variant_dl->Equals(*default_dl)) << desc << " != Default";
         ASSERT_FALSE(default_dl->Equals(*variant_dl)) << "Default != " << desc;
       }
-      if (group.variants[vi].byte_count != 0) {
-        ASSERT_FALSE(variant_dl->Equals(*missing_dl)) << desc << " != omitted";
-        ASSERT_FALSE(missing_dl->Equals(*variant_dl)) << "omitted != " << desc;
-      } else {
+      if (group.variants[vi].is_empty()) {
         ASSERT_TRUE(variant_dl->Equals(*missing_dl)) << desc << " != omitted";
         ASSERT_TRUE(missing_dl->Equals(*variant_dl)) << "omitted != " << desc;
+      } else {
+        ASSERT_FALSE(variant_dl->Equals(*missing_dl)) << desc << " != omitted";
+        ASSERT_FALSE(missing_dl->Equals(*variant_dl)) << "omitted != " << desc;
       }
     }
   }

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -800,8 +800,10 @@ TEST(DisplayList, SingleOpDisplayListsRecapturedViaSkCanvasAreEqual) {
       dl->RenderTo(&recorder);
       sk_sp<DisplayList> sk_copy = recorder.Build();
       auto desc = group.op_name + "[variant " + std::to_string(i + 1) + "]";
-      EXPECT_EQ(sk_copy->op_count(false), group.variants[i].sk_op_count()) << desc;
-      EXPECT_EQ(sk_copy->bytes(false), group.variants[i].sk_byte_count()) << desc;
+      EXPECT_EQ(sk_copy->op_count(false), group.variants[i].sk_op_count())
+          << desc;
+      EXPECT_EQ(sk_copy->bytes(false), group.variants[i].sk_byte_count())
+          << desc;
       if (group.variants[i].sk_version_matches()) {
         EXPECT_EQ(sk_copy->bounds(), dl->bounds()) << desc;
         EXPECT_TRUE(dl->Equals(*sk_copy)) << desc << " == sk_copy";


### PR DESCRIPTION
SkPicture.approximateBytes() will automatically included nested pictures and the size of the SkPicture object, but the analogous method on DisplayList was not doing so.

SkPicture.approximateOps() has a boolean to optionally include nested op counts, but the analogous DisplayList method had no option.

This PR introduces options on the DisplayList::op_count() and DisplayList::byte_count() accessors to include or exclude nested stats (defaults to true for bytes, false for ops)