### PR TITLE
made it so you can specify which adb to use for android tests

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -351,13 +351,15 @@ def RunJavaTests(filter, android_variant='android_debug_unopt'):
   RunCmd(command, cwd=test_runner_dir, env=env)
 
 
-def RunAndroidTests(android_variant='android_debug_unopt'):
+def RunAndroidTests(android_variant='android_debug_unopt', adb_path=None):
   test_runner_name = 'flutter_shell_native_unittests'
   tests_path = os.path.join(out_dir, android_variant, test_runner_name)
   remote_path = '/data/local/tmp'
   remote_tests_path = os.path.join(remote_path, test_runner_name)
-  RunCmd(['adb', 'push', tests_path, remote_path], cwd=buildroot_dir)
-  RunCmd(['adb', 'shell', remote_tests_path])
+  if adb_path == None:
+    adb_path = 'adb'
+  RunCmd([adb_path, 'push', tests_path, remote_path], cwd=buildroot_dir)
+  RunCmd([adb_path, 'shell', remote_tests_path])
 
 def RunObjcTests(ios_variant='ios_debug_sim_unopt', test_filter=None):
   """Runs Objective-C XCTest unit tests for the iOS embedding"""
@@ -552,6 +554,8 @@ def main():
       default=False, help='Capture core dumps from crashes of engine tests.')
   parser.add_argument('--use-sanitizer-suppressions', dest='sanitizer_suppressions', action='store_true',
       default=False, help='Provide the sanitizer suppressions lists to the via environment to the tests.')
+  parser.add_argument('--adb-path', dest='adb_path', action='store',
+      default=None, help='Provide the path of adb used for android tests.  By default it looks on $PATH.')
 
   args = parser.parse_args()
 
@@ -602,7 +606,7 @@ def main():
 
   if 'android' in types:
     assert not IsWindows(), "Android engine files can't be compiled on Windows."
-    RunAndroidTests(args.android_variant)
+    RunAndroidTests(args.android_variant, args.adb_path)
 
   if 'objc' in types:
     assert IsMac(), "iOS embedding tests can only be run on macOS."


### PR DESCRIPTION
I gave up trying to get $PATH working with adb on LUCI.  It's too hard to debug when dealing with multiple repositories and remote bots.  I'm just going to allow people to specify it in case it isn't on their path.

issue: https://github.com/flutter/flutter/issues/90903

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
