### PR TITLE
Lazily obtain the default SkFontMgr upon its first usage in the FontCollection

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -641,13 +641,7 @@ bool Shell::Setup(std::unique_ptr<PlatformView> platform_view,
   weak_rasterizer_ = rasterizer_->GetWeakPtr();
   weak_platform_view_ = platform_view_->GetWeakPtr();
 
-  // Setup the time-consuming default font manager right after engine created.
-  fml::TaskRunner::RunNowOrPostTask(task_runners_.GetUITaskRunner(),
-                                    [engine = weak_engine_] {
-                                      if (engine) {
-                                        engine->SetupDefaultFontManager();
-                                      }
-                                    });
+  engine_->SetupDefaultFontManager();
 
   is_setup_ = true;
 

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -43,7 +43,7 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
 
   ~FontCollection();
 
-  size_t GetFontManagersCount() const;
+  size_t GetFontManagersCount();
 
   void SetupDefaultFontManager(uint32_t font_initialization_data);
   void SetDefaultFontManager(sk_sp<SkFontMgr> font_manager);
@@ -90,6 +90,8 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
     };
   };
 
+  std::optional<uint32_t> default_font_manager_init_data_;
+
   sk_sp<SkFontMgr> default_font_manager_;
   sk_sp<SkFontMgr> asset_font_manager_;
   sk_sp<SkFontMgr> dynamic_font_manager_;
@@ -119,7 +121,9 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
       uint32_t ch,
       std::string locale);
 
-  std::vector<sk_sp<SkFontMgr>> GetFontManagerOrder() const;
+  std::vector<sk_sp<SkFontMgr>> GetFontManagerOrder();
+
+  sk_sp<SkFontMgr> GetDefaultFontManager();
 
   std::shared_ptr<minikin::FontFamily> FindFontFamilyInManagers(
       const std::string& family_name);


### PR DESCRIPTION
SkFontMgr_Android can take a long time to initialize.  On Android,
the embedding will call FlutterJNI.nativePrefetchDefaultFontManager
early during application startup, which will construct the global
default SkFontMgr on a background thread.

The FontCollection will then retrieve the default SkFontMgr the first
time the application requests fonts.  By that time the SkFontMgr should
be fully initialized and the UI thread will not need to wait to use it.

See https://github.com/flutter/flutter/issues/91045
