### PR TITLE
Defer setup of the default font manager if the embedding prefetched the font manager

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -181,6 +181,10 @@ struct Settings {
   // Font settings
   bool use_test_fonts = false;
 
+  // Indicates whether the embedding started a prefetch of the default font
+  // manager before creating the engine.
+  bool prefetched_default_font_manager = false;
+
   // Selects the SkParagraph implementation of the text layout engine.
   bool enable_skparagraph = false;
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -202,6 +202,13 @@ Engine::RunStatus Engine::Run(RunConfiguration configuration) {
 
   UpdateAssetManager(configuration.GetAssetManager());
 
+  // If the embedding prefetched the default font manager, then set up the
+  // font manager later in the engine launch process.  This makes it less
+  // likely that the setup will need to wait for the prefetch to complete.
+  if (settings_.prefetched_default_font_manager) {
+    SetupDefaultFontManager();
+  }
+
   if (runtime_controller_->IsRootIsolateRunning()) {
     return RunStatus::FailureAlreadyRunning;
   }

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -642,12 +642,14 @@ bool Shell::Setup(std::unique_ptr<PlatformView> platform_view,
   weak_platform_view_ = platform_view_->GetWeakPtr();
 
   // Setup the time-consuming default font manager right after engine created.
-  fml::TaskRunner::RunNowOrPostTask(task_runners_.GetUITaskRunner(),
-                                    [engine = weak_engine_] {
-                                      if (engine) {
-                                        engine->SetupDefaultFontManager();
-                                      }
-                                    });
+  if (!settings_.prefetched_default_font_manager) {
+    fml::TaskRunner::RunNowOrPostTask(task_runners_.GetUITaskRunner(),
+                                      [engine = weak_engine_] {
+                                        if (engine) {
+                                          engine->SetupDefaultFontManager();
+                                        }
+                                      });
+  }
 
   is_setup_ = true;
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -399,6 +399,9 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.enable_skparagraph =
       command_line.HasOption(FlagForSwitch(Switch::EnableSkParagraph));
 
+  settings.prefetched_default_font_manager = command_line.HasOption(
+      FlagForSwitch(Switch::PrefetchedDefaultFontManager));
+
   std::string all_dart_flags;
   if (command_line.GetOptionValue(FlagForSwitch(Switch::DartFlags),
                                   &all_dart_flags)) {

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -169,6 +169,10 @@ DEF_SWITCH(UseTestFonts,
            "will make font resolution default to the Ahem test font on all "
            "platforms (See https://www.w3.org/Style/CSS/Test/Fonts/Ahem/). "
            "This option is only available on the desktop test shells.")
+DEF_SWITCH(PrefetchedDefaultFontManager,
+           "prefetched-default-font-manager",
+           "Indicates whether the embedding started a prefetch of the "
+           "default font manager before creating the engine.")
 DEF_SWITCH(VerboseLogging,
            "verbose-logging",
            "By default, only errors are logged. This flag enabled logging at "

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -288,6 +288,8 @@ public class FlutterLoader {
 
       shellArgs.add("--old-gen-heap-size=" + oldGenHeapSizeMegaBytes);
 
+      shellArgs.add("--prefetched-default-font-manager");
+
       if (metaData != null && metaData.getBoolean(ENABLE_SKPARAGRAPH_META_DATA_KEY)) {
         shellArgs.add("--enable-skparagraph");
       }


### PR DESCRIPTION
SkFontMgr_Android can take a long time to initialize.  On Android,
the embedding will call FlutterJNI.nativePrefetchDefaultFontManager
early during application startup, which will construct the global
default SkFontMgr on a background thread.

SetupDefaultFontManager will need to wait until the prefetch has
completed in order to obtain the default SkFontMgr.  If the embedding
has done a prefetch, then this PR moves SetupDefaultFontManager to a
later phase of engine setup to make waiting less likely.

See https://github.com/flutter/flutter/issues/91045
