### PR TITLE
[fuchsia] publish dart runner v2 protocol

### DIFF
--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -165,6 +165,13 @@ DartRunner::DartRunner(sys::ComponentContext* context) : context_(context) {
         bindings_.AddBinding(this, std::move(request));
       });
 
+  context_->outgoing()
+      ->AddPublicService<fuchsia::component::runner::ComponentRunner>(
+          [this](fidl::InterfaceRequest<
+                 fuchsia::component::runner::ComponentRunner> request) {
+            component_runner_bindings_.AddBinding(this, std::move(request));
+          });
+
 #if !defined(DART_PRODUCT)
   // The VM service isolate uses the process-wide namespace. It writes the
   // vm service protocol port under /tmp. The VMServiceObject exposes that

--- a/shell/platform/fuchsia/dart_runner/dart_runner.h
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.h
@@ -36,6 +36,8 @@ class DartRunner : public fuchsia::sys::Runner,
   // Not owned by DartRunner.
   sys::ComponentContext* context_;
   fidl::BindingSet<fuchsia::sys::Runner> bindings_;
+  fidl::BindingSet<fuchsia::component::runner::ComponentRunner>
+      component_runner_bindings_;
 
 #if !defined(AOT_RUNTIME)
   dart_utils::MappedResource vm_snapshot_data_;

--- a/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
+++ b/shell/platform/fuchsia/dart_runner/meta/common.shard.cml
@@ -17,7 +17,6 @@
         },
         {
             protocol: [
-                "fuchsia.component.runner.ComponentRunner",
                 "fuchsia.device.NameProvider",  // For fdio uname()
                 "fuchsia.feedback.CrashReporter",
                 "fuchsia.intl.PropertyProvider",  // For dartVM timezone support


### PR DESCRIPTION
Exposes the fuchsia.component.runner protocol in the dart v2 runner.

Tested change by running the fidl compatibility test suite
1000 times in fuchsia.git with the new runner.