### PR TITLE
make dart_runner cmx files have valid json

### DIFF
--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
@@ -14,7 +14,7 @@
             "fuchsia.logger.LogSink",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",
-            "fuchsia.tracing.provider.Registry",
+            "fuchsia.tracing.provider.Registry"
         ]
     }
 }

--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
@@ -14,7 +14,7 @@
             "fuchsia.logger.LogSink",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",
-            "fuchsia.tracing.provider.Registry",
+            "fuchsia.tracing.provider.Registry"
         ]
     }
 }

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
@@ -15,7 +15,7 @@
             "fuchsia.logger.LogSink",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",
-            "fuchsia.tracing.provider.Registry",
+            "fuchsia.tracing.provider.Registry"
         ]
     }
 }

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
@@ -15,7 +15,7 @@
             "fuchsia.logger.LogSink",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",
-            "fuchsia.tracing.provider.Registry",
+            "fuchsia.tracing.provider.Registry"
         ]
     }
 }


### PR DESCRIPTION
The dart_runner cmx files had a trailing comma which is not
valid json. This will cause the parsing of the cmx file to crash
when appmgr tries to load it.

tested with the following command:
for f in *.cmx; do cat $f | python -m"json.tool" > /dev/null; done
