### PR TITLE
Start animator paused

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -27,7 +27,6 @@ Animator::Animator(Delegate& delegate,
     : delegate_(delegate),
       task_runners_(std::move(task_runners)),
       waiter_(std::move(waiter)),
-      dart_frame_deadline_(0),
 #if SHELL_ENABLE_METAL
       layer_tree_pipeline_(std::make_shared<LayerTreePipeline>(2)),
 #else   // SHELL_ENABLE_METAL
@@ -41,11 +40,6 @@ Animator::Animator(Delegate& delegate,
               : 2)),
 #endif  // SHELL_ENABLE_METAL
       pending_frame_semaphore_(1),
-      paused_(false),
-      regenerate_layer_tree_(false),
-      frame_scheduled_(false),
-      notify_idle_task_id_(0),
-      dimension_change_pending_(false),
       weak_factory_(this) {
 }
 

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -86,10 +86,10 @@ const char* Animator::FrameParity() {
   return (frame_number % 2) ? "even" : "odd";
 }
 
-static int64_t FxlToDartOrEarlier(fml::TimePoint time) {
-  int64_t dart_now = Dart_TimelineGetMicros();
+static fml::TimePoint FxlToDartOrEarlier(fml::TimePoint time) {
+  auto dart_now = fml::TimeDelta::FromMicroseconds(Dart_TimelineGetMicros());
   fml::TimePoint fxl_now = fml::TimePoint::Now();
-  return (time - fxl_now).ToMicroseconds() + dart_now;
+  return fml::TimePoint::FromEpochDelta(time - fxl_now + dart_now);
 }
 
 void Animator::BeginFrame(
@@ -269,7 +269,8 @@ void Animator::AwaitVSync() {
         }
       });
 
-  delegate_.OnAnimatorNotifyIdle(dart_frame_deadline_);
+  delegate_.OnAnimatorNotifyIdle(
+      dart_frame_deadline_.ToEpochDelta().ToMicroseconds());
 }
 
 void Animator::ScheduleSecondaryVsyncCallback(uintptr_t id,

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -106,7 +106,7 @@ class Animator final {
 
   std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder_;
   uint64_t frame_request_number_ = 1;
-  int64_t dart_frame_deadline_ = 0;
+  fml::TimePoint dart_frame_deadline_;
   std::shared_ptr<LayerTreePipeline> layer_tree_pipeline_;
   fml::Semaphore pending_frame_semaphore_;
   LayerTreePipeline::ProducerContinuation producer_continuation_;

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -106,15 +106,15 @@ class Animator final {
 
   std::unique_ptr<FrameTimingsRecorder> frame_timings_recorder_;
   uint64_t frame_request_number_ = 1;
-  int64_t dart_frame_deadline_;
+  int64_t dart_frame_deadline_ = 0;
   std::shared_ptr<LayerTreePipeline> layer_tree_pipeline_;
   fml::Semaphore pending_frame_semaphore_;
   LayerTreePipeline::ProducerContinuation producer_continuation_;
-  bool paused_;
-  bool regenerate_layer_tree_;
-  bool frame_scheduled_;
-  int notify_idle_task_id_;
-  bool dimension_change_pending_;
+  bool paused_ = true;
+  bool regenerate_layer_tree_ = false;
+  bool frame_scheduled_ = false;
+  int notify_idle_task_id_ = 0;
+  bool dimension_change_pending_ = false;
   SkISize last_layer_tree_size_ = {0, 0};
   std::deque<uint64_t> trace_flow_ids_;
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -265,7 +265,6 @@ tonic::DartErrorHandleType Engine::GetUIIsolateLastError() {
 
 void Engine::OnOutputSurfaceCreated() {
   have_surface_ = true;
-  StartAnimatorIfPossible();
   ScheduleFrame();
 }
 
@@ -465,6 +464,7 @@ std::string Engine::DefaultRouteName() {
 }
 
 void Engine::ScheduleFrame(bool regenerate_layer_tree) {
+  StartAnimatorIfPossible();
   animator_->RequestFrame(regenerate_layer_tree);
 }
 

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -381,5 +381,22 @@ void ShellTest::DestroyShell(std::unique_ptr<Shell> shell,
   latch.Wait();
 }
 
+bool ShellTest::IsAnimatorRunning(Shell* shell) {
+  fml::AutoResetWaitableEvent latch;
+  bool running = false;
+  if (!shell) {
+    return running;
+  }
+  fml::TaskRunner::RunNowOrPostTask(
+      shell->GetTaskRunners().GetUITaskRunner(), [shell, &running, &latch]() {
+        if (shell && shell->engine_ && shell->engine_->animator_) {
+          running = !shell->engine_->animator_->paused_;
+        }
+        latch.Signal();
+      });
+  latch.Wait();
+  return running;
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -96,6 +96,8 @@ class ShellTest : public FixtureTest {
                                    const SkData& key,
                                    const SkData& value);
 
+  static bool IsAnimatorRunning(Shell* shell);
+
   enum ServiceProtocolEnum {
     kGetSkSLs,
     kEstimateRasterCacheMemory,


### PR DESCRIPTION
Starts the animator in a paused state, and only starts it once we get a request to schedule frame _and_ we have a surface to render to.

This avoids the animator doing unnecessary work during application startup, and in particular avoids it potentially signaling that we have idle time for a GC when we haven't even rendered a frame yet.

Part of https://github.com/flutter/flutter/issues/91209