### PR TITLE
[web] remove platform initialization timeout

### DIFF
--- a/lib/web_ui/lib/src/ui/test_embedding.dart
+++ b/lib/web_ui/lib/src/ui/test_embedding.dart
@@ -19,7 +19,6 @@ Future<dynamic> ensureTestPlatformInitializedThenRunTest(dynamic Function() body
   return _testPlatformInitializedFuture!.then<dynamic>((_) => body());
 }
 
-// TODO(yjbanov): can we make this late non-null? See https://github.com/dart-lang/sdk/issues/42214
 Future<void>? _platformInitializedFuture;
 
 Future<void> webOnlyInitializeTestDomRenderer({double devicePixelRatio = 3.0}) {
@@ -35,14 +34,10 @@ Future<void> webOnlyInitializeTestDomRenderer({double devicePixelRatio = 3.0}) {
   engine.scheduleFrameCallback = () {};
   debugEmulateFlutterTesterEnvironment = true;
 
+  // Initialize platform once and reuse across all tests.
   if (_platformInitializedFuture != null) {
     return _platformInitializedFuture!;
   }
-
-  // Only load the Ahem font once and await the same future in all tests.
   return _platformInitializedFuture =
-      webOnlyInitializePlatform(assetManager: engine.WebOnlyMockAssetManager())
-          .timeout(const Duration(seconds: 2), onTimeout: () async {
-    throw Exception('Timed out loading Ahem font.');
-  });
+      webOnlyInitializePlatform(assetManager: engine.WebOnlyMockAssetManager());
 }


### PR DESCRIPTION
Remove the timeout (along with the incorrect timeout message) from web platform initialization logic.

The timeout doesn't help. If we're unable to initialize the platform, then something is really wrong. The message was incorrect because `webOnlyInitializePlatform` does much more than just load the Ahem font.

Fixes https://github.com/flutter/flutter/issues/91245
