### PR TITLE
Expose updateSystemUiOverlays in FlutterActivity and FlutterFragment

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -1127,6 +1127,13 @@ public class FlutterActivity extends Activity
     return false;
   }
 
+  @Override
+  public void updateSystemUiOverlays() {
+    if (delegate != null) {
+      delegate.updateSystemUiOverlays();
+    }
+  }
+
   private boolean stillAttachedForEvent(String event) {
     if (delegate == null) {
       Log.w(TAG, "FlutterActivity " + hashCode() + " " + event + " called after release.");

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -507,16 +507,22 @@ import java.util.Arrays;
     Log.v(TAG, "onPostResume()");
     ensureAlive();
     if (flutterEngine != null) {
-      if (platformPlugin != null) {
-        // TODO(mattcarroll): find a better way to handle the update of UI overlays than calling
-        // through
-        //                    to platformPlugin. We're implicitly entangling the Window, Activity,
-        // Fragment,
-        //                    and engine all with this one call.
-        platformPlugin.updateSystemUiOverlays();
-      }
+      updateSystemUiOverlays();
     } else {
       Log.w(TAG, "onPostResume() invoked before FlutterFragment was attached to an Activity.");
+    }
+  }
+
+  /**
+   * Refreshes Android's window system UI (AKA system chrome) to match Flutter's desired system
+   * chrome style.
+   */
+  void updateSystemUiOverlays() {
+    if (platformPlugin != null) {
+      // TODO(mattcarroll): find a better way to handle the update of UI overlays than calling
+      // through to platformPlugin. We're implicitly entangling the Window, Activity,
+      // Fragment, and engine all with this one call.
+      platformPlugin.updateSystemUiOverlays();
     }
   }
 
@@ -1009,5 +1015,17 @@ import java.util.Arrays;
      * <p>This defaults to true, unless a cached engine is used.
      */
     boolean shouldRestoreAndSaveState();
+
+    /**
+     * Refreshes Android's window system UI (AKA system chrome) to match Flutter's desired system
+     * chrome style.
+     *
+     * <p>This is useful when using the splash screen API available in Android 12. {@code
+     * SplashScreenView#remove} resets the system UI colors to the values set prior to the execution
+     * of the Dart entrypoint. As a result, the values set from Dart are reverted by this API. To
+     * workaround this issue, call this method after removing the splash screen with {@code
+     * SplashScreenView#remove}.
+     */
+    void updateSystemUiOverlays();
   }
 }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -1275,6 +1275,13 @@ public class FlutterFragment extends Fragment
     return true;
   }
 
+  @Override
+  public void updateSystemUiOverlays() {
+    if (delegate != null) {
+      delegate.updateSystemUiOverlays();
+    }
+  }
+
   /**
    * {@inheritDoc}
    *

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterAndroidComponentTest.java
@@ -385,6 +385,9 @@ public class FlutterAndroidComponentTest {
     public void detachFromFlutterEngine() {}
 
     @Override
+    public void updateSystemUiOverlays() {}
+
+    @Override
     public boolean popSystemNavigator() {
       return false;
     }


### PR DESCRIPTION
Internal bugs: b/201727280, b/196550450

`updateSystemUiOverlays` allows to reset the Android's window system UI as set from the Flutter point of view.

This is needed to be able to use `SplashScreenView#remove`.