### PR TITLE
fuchsia: Implement WakeUp using zx::timer

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -196,6 +196,7 @@ FILE: ../../../flutter/fml/message_loop.cc
 FILE: ../../../flutter/fml/message_loop.h
 FILE: ../../../flutter/fml/message_loop_impl.cc
 FILE: ../../../flutter/fml/message_loop_impl.h
+FILE: ../../../flutter/fml/message_loop_impl_unittests.cc
 FILE: ../../../flutter/fml/message_loop_task_queues.cc
 FILE: ../../../flutter/fml/message_loop_task_queues.h
 FILE: ../../../flutter/fml/message_loop_task_queues_benchmark.cc

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -277,6 +277,7 @@ if (enable_unittests) {
       "memory/ref_counted_unittest.cc",
       "memory/task_runner_checker_unittest.cc",
       "memory/weak_ptr_unittest.cc",
+      "message_loop_impl_unittests.cc",
       "message_loop_task_queues_merge_unmerge_unittests.cc",
       "message_loop_task_queues_unittests.cc",
       "message_loop_unittests.cc",

--- a/fml/message_loop_impl_unittests.cc
+++ b/fml/message_loop_impl_unittests.cc
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#define FML_USED_ON_EMBEDDER
+
+#include "flutter/fml/message_loop_impl.h"
+
+#include "flutter/fml/time/time_delta.h"
+#include "flutter/fml/time/time_point.h"
+#include "gtest/gtest.h"
+
+#define TIMESENSITIVE(x) TimeSensitiveTest_##x
+
+TEST(MessageLoopImpl, TIMESENSITIVE(WakeUpTimersAreSingletons)) {
+  auto loop_impl = fml::MessageLoopImpl::Create();
+
+  const auto t1 = fml::TimeDelta::FromMilliseconds(10);
+  const auto t2 = fml::TimeDelta::FromMilliseconds(30);
+
+  const auto begin = fml::TimePoint::Now();
+
+  // Register a task scheduled in the future. This schedules a WakeUp call on
+  // the MessageLoopImpl with that fml::TimePoint.
+  loop_impl->PostTask(
+      [&]() {
+        auto delta = fml::TimePoint::Now() - begin;
+        auto ms = delta.ToMillisecondsF();
+        ASSERT_GE(ms, 20);
+        ASSERT_LE(ms, 40);
+
+        loop_impl->Terminate();
+      },
+      begin + t1);
+
+  // Call WakeUp manually to change the WakeUp time further in the future. If
+  // the timer is correctly set up to be rearmed instead of a task being
+  // scheduled for each WakeUp, the above task will be executed at t2 instead of
+  // t1 now.
+  loop_impl->WakeUp(begin + t2);
+
+  loop_impl->Run();
+}

--- a/fml/platform/fuchsia/message_loop_fuchsia.h
+++ b/fml/platform/fuchsia/message_loop_fuchsia.h
@@ -6,6 +6,8 @@
 #define FLUTTER_FML_PLATFORM_FUCHSIA_MESSAGE_LOOP_FUCHSIA_H_
 
 #include <lib/async-loop/cpp/loop.h>
+#include <lib/async/cpp/wait.h>
+#include <lib/zx/timer.h>
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop_impl.h"
@@ -25,6 +27,8 @@ class MessageLoopFuchsia : public MessageLoopImpl {
   void WakeUp(fml::TimePoint time_point) override;
 
   async::Loop loop_;
+  std::unique_ptr<async::Wait> timer_wait_;
+  zx::timer timer_;
 
   FML_FRIEND_MAKE_REF_COUNTED(MessageLoopFuchsia);
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopFuchsia);


### PR DESCRIPTION
This PR fixes a performance regression that https://github.com/flutter/engine/pull/26783 introduced, where many empty tasks get posted onto the async::Loop backing an fml::MessageLoop.  

A long time ago, when gw280 was working on the precursor to https://github.com/flutter/engine/pull/26783, he ran into this same dire performance problems due to the use of async::PostDelayedTask() inside of WakeUp().  Each call to WakeUp() would post a new async::Task to drain flutter's task queue, but draining the task queue itself calls WakeUp() repeatedly.  This can cause a storm of empty tasks to be posted to the queue, severely bogging down performance. 

The correct fix is to manage draining flutter's task queue using an async::Wait on a zx::timer.  WakeUp() just manipulates the timer value.  This is very similar to how MessageLoop is implemented on other platforms.  gw280's original fix contained this code, but he had to abandon it due to other issues that couldn't be solved at the time (stack overflow errors).

When @hjfreyer and I re-landed the PR, we fixed the stack overflow errors, but we did not adjust the implementation of WakeUp(). It continued to rely on async::PostDelayedTask().  This really impacts performance; even idle CPU usage is higher than it would be otherwise.

The performance loss is especially noticeable in situations where a smart_display is under heavy load (ex. 'Set a 10 minute timer').  The extra CPU load is noticeable enough that even "top" can be used to confirm the regression.  The load can become so bad in some situations that FIDL and gRPC deadlines get missed, which causes a cascade of downstream failures.

Test: Added to message_loop_unittests
Fixes: https://b.corp.google.com/issues/201906431
Fixes: https://github.com/flutter/flutter/issues/50678