### PR TITLE
[web] Add support for textScaleFactor

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_dispatcher.dart
+++ b/lib/web_ui/lib/src/engine/platform_dispatcher.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:html' as html;
+import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
@@ -53,8 +54,10 @@ class EnginePlatformDispatcher extends ui.PlatformDispatcher {
   /// The current platform configuration.
   @override
   ui.PlatformConfiguration get configuration => _configuration;
-  ui.PlatformConfiguration _configuration =
-      ui.PlatformConfiguration(locales: parseBrowserLanguages());
+  ui.PlatformConfiguration _configuration = ui.PlatformConfiguration(
+    locales: parseBrowserLanguages(),
+    textScaleFactor: findBrowserTextScaleFactor(),
+  );
 
   /// Receives all events related to platform configuration changes.
   @override
@@ -1075,4 +1078,51 @@ void invoke3<A1, A2, A3>(void Function(A1 a1, A2 a2, A3 a3)? callback,
       callback(arg1, arg2, arg3);
     });
   }
+}
+
+const double _defaultRootFontSize = 16.0;
+
+/// Finds the text scale factor of the browser by looking at the computed style
+/// of the browser's <html> element.
+double findBrowserTextScaleFactor() {
+  final num fontSize = _parseFontSize(html.document.documentElement!) ?? _defaultRootFontSize;
+  return fontSize / _defaultRootFontSize;
+}
+
+/// Parses the font size of [element] and returns the value without a unit.
+num? _parseFontSize(html.Element element) {
+  num? fontSize;
+
+  if (js_util.hasProperty(element, 'computedStyleMap')) {
+    // Use the newer `computedStyleMap` API available on some browsers.
+    final dynamic computedStyleMap =
+        js_util.callMethod(element, 'computedStyleMap', <Object?>[]);
+    if (computedStyleMap is Object) {
+      final dynamic fontSizeObject =
+          js_util.callMethod(computedStyleMap, 'get', <Object?>['font-size']);
+      if (fontSizeObject is Object) {
+        fontSize = js_util.getProperty(fontSizeObject, 'value') as num;
+      }
+    }
+  }
+
+  if (fontSize == null) {
+    // Fallback to `getComputedStyle`.
+    final String fontSizeString = element.getComputedStyle().fontSize;
+    fontSize = _parseFloat(fontSizeString);
+  }
+
+  return fontSize;
+}
+
+num? _parseFloat(String source) {
+  // Using JavaScript's `window.parseFloat` here because it can parse values
+  // like "20px", while Dart's `double.tryParse` fails.
+  final num? result =
+      js_util.callMethod(html.window, 'parseFloat', <Object>[source]) as num?;
+
+  if (result == null || result.isNaN) {
+    return null;
+  }
+  return result;
 }

--- a/lib/web_ui/test/engine/platform_dispatcher_test.dart
+++ b/lib/web_ui/test/engine/platform_dispatcher_test.dart
@@ -82,5 +82,34 @@ void testMain() {
       js_util.setProperty(
           html.window.navigator, 'clipboard', originalClipboard);
     });
+
+    test('can find text scale factor', () async {
+      const double deltaTolerance = 1e-5;
+
+      final html.Element root = html.document.documentElement!;
+      final String oldFontSize = root.style.fontSize;
+
+      addTearDown(() {
+        root.style.fontSize = oldFontSize;
+      });
+
+      root.style.fontSize = '16px';
+      expect(findBrowserTextScaleFactor(), 1.0);
+
+      root.style.fontSize = '20px';
+      expect(findBrowserTextScaleFactor(), 1.25);
+
+      root.style.fontSize = '24px';
+      expect(findBrowserTextScaleFactor(), 1.5);
+
+      root.style.fontSize = '14.4px';
+      expect(findBrowserTextScaleFactor(), closeTo(0.9, deltaTolerance));
+
+      root.style.fontSize = '12.8px';
+      expect(findBrowserTextScaleFactor(), closeTo(0.8, deltaTolerance));
+
+      root.style.fontSize = null;
+      expect(findBrowserTextScaleFactor(), 1.0);
+    });
   });
 }


### PR DESCRIPTION
Read the computed font size of the `<html>` element and use that as a guide to figure out the `textScaleFactor`. The default value should be 16.

```math
textScaleFactor = (font size of `<html>`) / 16.0
```

I was able to try this on Chrome and Firefox. I couldn't find a way to change the text scale factor in Safari.

Fixes https://github.com/flutter/flutter/issues/52061