### PR TITLE
Revert "Guard task queue id for fuchsia"

### DIFF
--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -133,13 +133,8 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
 
     TRACE_FLOW_BEGIN("flutter", kVsyncFlowName, flow_identifier);
 
-    fml::TaskQueueId ui_task_queue_id = fml::_kUnmerged;
-    if (pause_secondary_tasks) {
-      // Guarding `GetTaskQueueId` behind `pause_secondary_tasks` as on Fuchsia
-      // the task runners don't initialize message loop task queues.
-      // Once the migration to embedder API is done, this can be deleted.
-      ui_task_queue_id = task_runners_.GetUITaskRunner()->GetTaskQueueId();
-    }
+    fml::TaskQueueId ui_task_queue_id =
+        task_runners_.GetUITaskRunner()->GetTaskQueueId();
 
     task_runners_.GetUITaskRunner()->PostTask(
         [ui_task_queue_id, callback, flow_identifier, frame_start_time,


### PR DESCRIPTION
Reverts flutter/engine#26542

Now that https://github.com/flutter/engine/pull/26783 landed and Fuchsia uses fml::MessageLoop along with other platforms, we no longer need this workaround.