### PR TITLE
Switch skipped UWP tests to disabled

### DIFF
--- a/shell/common/persistent_cache_unittests.cc
+++ b/shell/common/persistent_cache_unittests.cc
@@ -40,11 +40,14 @@ static void WaitForRaster(Shell* shell) {
   raster_task_finished.get_future().wait();
 }
 
-TEST_F(PersistentCacheTest, CacheSkSLWorks) {
+TEST_F(PersistentCacheTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires vm service sandboxing fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_CacheSkSLWorks
+#else
+       CacheSkSLWorks
 #endif  // defined(WINUWP)
+) {
 
   // Create a temp dir to store the persistent cache
   fml::ScopedTemporaryDirectory dir;
@@ -208,11 +211,14 @@ static void CheckTwoSkSLsAreLoaded() {
   ASSERT_EQ(shaders.size(), 2u);
 }
 
-TEST_F(PersistentCacheTest, CanLoadSkSLsFromAsset) {
+TEST_F(PersistentCacheTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires filesystem sandboxing fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_CanLoadSkSLsFromAsset
+#else
+       CanLoadSkSLsFromAsset
 #endif  // defined(WINUWP)
+) {
 
   // Avoid polluting unit tests output by hiding INFO level logging.
   fml::LogSettings warning_only = {fml::LOG_WARNING};
@@ -277,11 +283,14 @@ TEST_F(PersistentCacheTest, CanLoadSkSLsFromAsset) {
   fml::UnlinkFile(asset_dir.fd(), PersistentCache::kAssetFileName);
 }
 
-TEST_F(PersistentCacheTest, CanRemoveOldPersistentCache) {
+TEST_F(PersistentCacheTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires filesystem sandboxing fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_CanRemoveOldPersistentCache
+#else
+       CanRemoveOldPersistentCache
 #endif  // defined(WINUWP)
+) {
 
   fml::ScopedTemporaryDirectory base_dir;
   ASSERT_TRUE(base_dir.fd().is_valid());
@@ -312,11 +321,14 @@ TEST_F(PersistentCacheTest, CanRemoveOldPersistentCache) {
   fml::RemoveFilesInDirectory(base_dir.fd());
 }
 
-TEST_F(PersistentCacheTest, CanPurgePersistentCache) {
+TEST_F(PersistentCacheTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires filesystem sandboxing fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_CanPurgePersistentCache
+#else
+       CanPurgePersistentCache
 #endif  // defined(WINUWP)
+) {
 
   fml::ScopedTemporaryDirectory base_dir;
   ASSERT_TRUE(base_dir.fd().is_valid());
@@ -349,11 +361,14 @@ TEST_F(PersistentCacheTest, CanPurgePersistentCache) {
   DestroyShell(std::move(shell));
 }
 
-TEST_F(PersistentCacheTest, PurgeAllowsFutureSkSLCache) {
+TEST_F(PersistentCacheTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires filesystem sandboxing fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_PurgeAllowsFutureSkSLCache
+#else
+       PurgeAllowsFutureSkSLCache
 #endif  // defined(WINUWP)
+) {
 
   sk_sp<SkData> shader_key = SkData::MakeWithCString("key");
   sk_sp<SkData> shader_value = SkData::MakeWithCString("value");

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -439,12 +439,14 @@ TEST_F(ShellTest, LastEntrypoint) {
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
-TEST_F(ShellTest, DisallowedDartVMFlag) {
+TEST_F(ShellTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_DisallowedDartVMFlag
+#else
+       DisallowedDartVMFlag
 #endif  // defined(WINUWP)
-
+) {
   // Run this test in a thread-safe manner, otherwise gtest will complain.
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
 
@@ -458,11 +460,14 @@ TEST_F(ShellTest, DisallowedDartVMFlag) {
   ASSERT_DEATH(flutter::SettingsFromCommandLine(command_line), expected);
 }
 
-TEST_F(ShellTest, AllowedDartVMFlag) {
+TEST_F(ShellTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_AllowedDartVMFlag
+#else
+       AllowedDartVMFlag
 #endif  // defined(WINUWP)
+) {
   std::vector<const char*> flags = {
       "--enable-isolate-groups",
       "--no-enable-isolate-groups",
@@ -758,18 +763,15 @@ TEST_F(ShellTest,
   DestroyShell(std::move(shell));
 }
 
-// TODO(https://github.com/flutter/flutter/issues/59816): Enable on fuchsia.
 TEST_F(ShellTest,
-#if defined(OS_FUCHSIA)
+#if defined(OS_FUCHSIA) || defined(WINUWP)
+       // TODO(dworsham): https://github.com/flutter/flutter/issues/59816
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
        DISABLED_OnPlatformViewDestroyDisablesThreadMerger
 #else
        OnPlatformViewDestroyDisablesThreadMerger
 #endif
 ) {
-#if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP. Not yet implemented";
-#endif  // defined(WINUWP)
   auto settings = CreateSettingsForFixture();
   fml::RefPtr<fml::RasterThreadMerger> raster_thread_merger;
   auto end_frame_callback =
@@ -1349,12 +1351,14 @@ TEST_F(ShellTest, ReloadSystemFonts) {
   shell.reset();
 }
 
-TEST_F(ShellTest, WaitForFirstFrame) {
+TEST_F(ShellTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires fix";
-#endif  // defined(WINUWP)
-
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_WaitForFirstFrame
+#else
+       WaitForFirstFrame
+#endif
+) {
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);
 
@@ -1409,11 +1413,14 @@ TEST_F(ShellTest, WaitForFirstFrameTimeout) {
   DestroyShell(std::move(shell));
 }
 
-TEST_F(ShellTest, WaitForFirstFrameMultiple) {
+TEST_F(ShellTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires threading fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_WaitForFirstFrameMultiple
+#else
+       WaitForFirstFrameMultiple
 #endif  // defined(WINUWP)
+) {
 
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);
@@ -1438,11 +1445,14 @@ TEST_F(ShellTest, WaitForFirstFrameMultiple) {
 
 /// Makes sure that WaitForFirstFrame works if we rendered a frame with the
 /// single-thread setup.
-TEST_F(ShellTest, WaitForFirstFrameInlined) {
+TEST_F(ShellTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires threading fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_WaitForFirstFrameInlined
+#else
+       WaitForFirstFrameInlined
 #endif  // defined(WINUWP)
+) {
 
   Settings settings = CreateSettingsForFixture();
   auto task_runner = CreateNewThread();
@@ -2029,12 +2039,14 @@ TEST_F(ShellTest, CanRegisterImageDecoders) {
   DestroyShell(std::move(shell));
 }
 
-TEST_F(ShellTest, OnServiceProtocolGetSkSLsWorks) {
+TEST_F(ShellTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires vm service sandboxing fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_OnServiceProtocolGetSkSLsWorks
+#else
+       OnServiceProtocolGetSkSLsWorks
 #endif  // defined(WINUWP)
-
+) {
   fml::ScopedTemporaryDirectory base_dir;
   ASSERT_TRUE(base_dir.fd().is_valid());
   PersistentCache::SetCacheDirectoryPath(base_dir.path());
@@ -2465,11 +2477,14 @@ TEST_F(ShellTest, IgnoresInvalidMetrics) {
   DestroyShell(std::move(shell), std::move(task_runners));
 }
 
-TEST_F(ShellTest, OnServiceProtocolSetAssetBundlePathWorks) {
+TEST_F(ShellTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires vm service sandboxing fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_OnServiceProtocolSetAssetBundlePathWorks
+#else
+       OnServiceProtocolSetAssetBundlePathWorks
 #endif  // defined(WINUWP)
+) {
 
   Settings settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);
@@ -2542,11 +2557,14 @@ TEST_F(ShellTest, EngineRootIsolateLaunchesDontTakeVMDataSettings) {
   isolate_create_latch.Wait();
 }
 
-TEST_F(ShellTest, AssetManagerSingle) {
+TEST_F(ShellTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires filesystem sandboxing fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_AssetManagerSingle
+#else
+       AssetManagerSingle
 #endif  // defined(WINUWP)
+) {
 
   fml::ScopedTemporaryDirectory asset_dir;
   fml::UniqueFD asset_dir_fd = fml::OpenDirectory(
@@ -2572,11 +2590,14 @@ TEST_F(ShellTest, AssetManagerSingle) {
   ASSERT_TRUE(result == content);
 }
 
-TEST_F(ShellTest, AssetManagerMulti) {
+TEST_F(ShellTest,
 #if defined(WINUWP)
-  // TODO(cbracken): Re-enable. https://github.com/flutter/flutter/issues/90481
-  GTEST_SKIP() << "Skipped on WinUWP; requires filesystem sandboxing fix";
+       // TODO(cbracken): https://github.com/flutter/flutter/issues/90481
+       DISABLED_AssetManagerMulti
+#else
+       AssetManagerMulti
 #endif  // defined(WINUWP)
+) {
 
   fml::ScopedTemporaryDirectory asset_dir;
   fml::UniqueFD asset_dir_fd = fml::OpenDirectory(


### PR DESCRIPTION
This ensures that they show up in the disabled test count at the end of the run.

Issue: https://github.com/flutter/flutter/issues/90481

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
