### PR TITLE
Fixed flutter_shell_native_unittests so they are built by default.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -123,6 +123,11 @@ group("flutter") {
     public_deps += [ "//flutter/testing/android_background_image" ]
   }
 
+  if (is_android) {
+    public_deps +=
+        [ "//flutter/shell/platform/android:flutter_shell_native_unittests" ]
+  }
+
   # Compile all unittests targets if enabled.
   if (enable_unittests) {
     public_deps += [
@@ -144,11 +149,6 @@ group("flutter") {
       "//flutter/third_party/tonic/tests:tonic_unittests",
       "//flutter/third_party/txt:txt_unittests",
     ]
-
-    if (is_android) {
-      public_deps +=
-          [ "//flutter/shell/platform/android:flutter_shell_native_unittests" ]
-    }
 
     # The accessibility library only supports Mac and Windows at the moment.
     if (is_mac || is_win) {


### PR DESCRIPTION
This makes the test runner build by default with android targets.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
