### PR TITLE
Set system bar appearance using WindowInsetsControllerCompat instead of the deprecated View#setSystemUiVisibility

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -574,7 +574,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/embedding_bundle',
-        'version': 'last_updated:2021-08-10T22:12:57-0700'
+        'version': 'last_updated:2021-10-08T14:22:08-0700'
        }
      ],
      'condition': 'download_android_deps',

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -20,6 +20,7 @@ import androidx.activity.OnBackPressedDispatcherOwner;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.view.WindowInsetsControllerCompat;
 import io.flutter.Log;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import java.io.FileNotFoundException;
@@ -364,7 +365,8 @@ public class PlatformPlugin {
       PlatformChannel.SystemChromeStyle systemChromeStyle) {
     Window window = activity.getWindow();
     View view = window.getDecorView();
-    int flags = view.getSystemUiVisibility();
+    WindowInsetsControllerCompat windowInsetsControllerCompat =
+        new WindowInsetsControllerCompat(window, view);
 
     // SYSTEM STATUS BAR -------------------------------------------------------------------
     // You can't change the color of the system status bar until SDK 21, and you can't change the
@@ -377,11 +379,14 @@ public class PlatformPlugin {
       if (systemChromeStyle.statusBarIconBrightness != null) {
         switch (systemChromeStyle.statusBarIconBrightness) {
           case DARK:
-            // View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-            flags |= 0x2000;
+            // Dark status bar icon brightness.
+            // Light status bar appearance.
+            windowInsetsControllerCompat.setAppearanceLightStatusBars(true);
             break;
           case LIGHT:
-            flags &= ~0x2000;
+            // Light status bar icon brightness.
+            // Dark status bar appearance.
+            windowInsetsControllerCompat.setAppearanceLightStatusBars(false);
             break;
         }
       }
@@ -408,11 +413,14 @@ public class PlatformPlugin {
       if (systemChromeStyle.systemNavigationBarIconBrightness != null) {
         switch (systemChromeStyle.systemNavigationBarIconBrightness) {
           case DARK:
-            // View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-            flags |= 0x10;
+            // Dark navigation bar icon brightness.
+            // Light navigation bar appearance.
+            windowInsetsControllerCompat.setAppearanceLightNavigationBars(true);
             break;
           case LIGHT:
-            flags &= ~0x10;
+            // Light navigation bar icon brightness.
+            // Dark navigation bar appearance.
+            windowInsetsControllerCompat.setAppearanceLightNavigationBars(false);
             break;
         }
       }
@@ -438,7 +446,6 @@ public class PlatformPlugin {
           systemChromeStyle.systemNavigationBarContrastEnforced);
     }
 
-    view.setSystemUiVisibility(flags);
     currentTheme = systemChromeStyle;
   }
 

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -1,5 +1,7 @@
 package io.flutter.plugin.platform;
 
+import static android.view.WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS;
+import static android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -20,6 +22,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.view.View;
 import android.view.Window;
+import android.view.WindowInsetsController;
 import androidx.activity.OnBackPressedCallback;
 import androidx.fragment.app.FragmentActivity;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
@@ -213,6 +216,98 @@ public class PlatformPluginTest {
       verify(fakeWindow, times(1)).setNavigationBarContrastEnforced(true);
       verify(fakeWindow, times(1)).setStatusBarContrastEnforced(false);
       verify(fakeWindow, times(1)).setNavigationBarContrastEnforced(false);
+    }
+  }
+
+  @Config(sdk = 30)
+  @Test
+  public void setNavigationBarIconBrightness() {
+    if (Build.VERSION.SDK_INT >= 30) {
+      View fakeDecorView = mock(View.class);
+      WindowInsetsController fakeWindowInsetsController = mock(WindowInsetsController.class);
+      Window fakeWindow = mock(Window.class);
+      when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
+      when(fakeWindow.getInsetsController()).thenReturn(fakeWindowInsetsController);
+      Activity fakeActivity = mock(Activity.class);
+      when(fakeActivity.getWindow()).thenReturn(fakeWindow);
+      PlatformChannel fakePlatformChannel = mock(PlatformChannel.class);
+      PlatformPlugin platformPlugin = new PlatformPlugin(fakeActivity, fakePlatformChannel);
+
+      SystemChromeStyle style =
+          new SystemChromeStyle(
+              null, // statusBarColor
+              null, // statusBarIconBrightness
+              null, // systemStatusBarContrastEnforced
+              null, // systemNavigationBarColor
+              Brightness.LIGHT, // systemNavigationBarIconBrightness
+              null, // systemNavigationBarDividerColor
+              null); // systemNavigationBarContrastEnforced
+
+      platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
+
+      verify(fakeWindowInsetsController)
+          .setSystemBarsAppearance(0, APPEARANCE_LIGHT_NAVIGATION_BARS);
+
+      style =
+          new SystemChromeStyle(
+              null, // statusBarColor
+              null, // statusBarIconBrightness
+              null, // systemStatusBarContrastEnforced
+              null, // systemNavigationBarColor
+              Brightness.DARK, // systemNavigationBarIconBrightness
+              null, // systemNavigationBarDividerColor
+              null); // systemNavigationBarContrastEnforced
+
+      platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
+
+      verify(fakeWindowInsetsController)
+          .setSystemBarsAppearance(
+              APPEARANCE_LIGHT_NAVIGATION_BARS, APPEARANCE_LIGHT_NAVIGATION_BARS);
+    }
+  }
+
+  @Config(sdk = 30)
+  @Test
+  public void setStatusBarIconBrightness() {
+    if (Build.VERSION.SDK_INT >= 30) {
+      View fakeDecorView = mock(View.class);
+      WindowInsetsController fakeWindowInsetsController = mock(WindowInsetsController.class);
+      Window fakeWindow = mock(Window.class);
+      when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
+      when(fakeWindow.getInsetsController()).thenReturn(fakeWindowInsetsController);
+      Activity fakeActivity = mock(Activity.class);
+      when(fakeActivity.getWindow()).thenReturn(fakeWindow);
+      PlatformChannel fakePlatformChannel = mock(PlatformChannel.class);
+      PlatformPlugin platformPlugin = new PlatformPlugin(fakeActivity, fakePlatformChannel);
+
+      SystemChromeStyle style =
+          new SystemChromeStyle(
+              null, // statusBarColor
+              Brightness.LIGHT, // statusBarIconBrightness
+              null, // systemStatusBarContrastEnforced
+              null, // systemNavigationBarColor
+              null, // systemNavigationBarIconBrightness
+              null, // systemNavigationBarDividerColor
+              null); // systemNavigationBarContrastEnforced
+
+      platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
+
+      verify(fakeWindowInsetsController).setSystemBarsAppearance(0, APPEARANCE_LIGHT_STATUS_BARS);
+
+      style =
+          new SystemChromeStyle(
+              null, // statusBarColor
+              Brightness.DARK, // statusBarIconBrightness
+              null, // systemStatusBarContrastEnforced
+              null, // systemNavigationBarColor
+              null, // systemNavigationBarIconBrightness
+              null, // systemNavigationBarDividerColor
+              null); // systemNavigationBarContrastEnforced
+
+      platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
+
+      verify(fakeWindowInsetsController)
+          .setSystemBarsAppearance(APPEARANCE_LIGHT_STATUS_BARS, APPEARANCE_LIGHT_STATUS_BARS);
     }
   }
 

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -37,6 +37,7 @@ android {
   dependencies {
     testImplementation files(project.property("flutter_jar"))
     testImplementation "androidx.annotation:annotation:1.1.0"
+    testImplementation "androidx.core:core:1.6.0"
     testImplementation "androidx.fragment:fragment:1.1.0"
     testImplementation "androidx.lifecycle:lifecycle-runtime:2.2.0"
     testImplementation "androidx.lifecycle:lifecycle-common-java8:2.2.0"

--- a/tools/cipd/android_embedding_bundle/build.gradle
+++ b/tools/cipd/android_embedding_bundle/build.gradle
@@ -41,6 +41,7 @@ android {
 
   dependencies {
     embedding "androidx.annotation:annotation:1.1.0"
+    embedding "androidx.core:core:1.6.0"
     embedding "androidx.fragment:fragment:1.1.0"
 
     def lifecycle_version = "2.2.0"


### PR DESCRIPTION
The deprecated APIs conflict with Android 12's `SplashScreenView#remove` behavior causing light status bar icon on light background.

Part of flutter/flutter#91128
Internal bugs: b/199402891, b/201727280

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
