### PR TITLE
Ensure that frameTimeNanos passed to VsyncWaiterAndroid is not greater than System.nanoTime

### DIFF
--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -31,6 +31,13 @@ public class VsyncWaiter {
                   new Choreographer.FrameCallback() {
                     @Override
                     public void doFrame(long frameTimeNanos) {
+                      // Some device is calling doFrame with a timestamp that is greater than
+                      // System.nanoTime. We should ensure that frameTimeNanos passed to
+                      // VsyncWaiterAndroid is not greater than System.nanoTime.
+                      long now = System.nanoTime();
+                      if (frameTimeNanos > now) {
+                        frameTimeNanos = now;
+                      }
                       long refreshPeriodNanos = (long) (1000000000.0 / fps);
                       FlutterJNI.nativeOnVsync(
                           frameTimeNanos, frameTimeNanos + refreshPeriodNanos, cookie);


### PR DESCRIPTION
The following assertion will cause abort when running Flutter App with an unoptimized local engine.
https://github.com/flutter/engine/blob/edf8fc8b7ab2aaacfb4070445002e5e558f2831d/shell/common/vsync_waiter.cc#L100 

This patch will fix it.
Related PR: https://github.com/flutter/engine/pull/28817

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.


