### PR TITLE
[fuchsia] Add Launcher & Resolver to Dart JIT CMX.

### DIFF
--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
@@ -15,6 +15,8 @@
             "fuchsia.logger.LogSink",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",
+            "fuchsia.process.Launcher",
+            "fuchsia.process.Resolver",
             "fuchsia.tracing.provider.Registry"
         ]
     }

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
@@ -15,6 +15,8 @@
             "fuchsia.logger.LogSink",
             "fuchsia.net.name.Lookup",
             "fuchsia.posix.socket.Provider",
+            "fuchsia.process.Launcher",
+            "fuchsia.process.Resolver",
             "fuchsia.tracing.provider.Registry"
         ]
     }


### PR DESCRIPTION
Accidentally removed in #28905 when moving NameProvider into a few files, leading to tests breaking downstream.