### PR TITLE
[iOS] Fixes key press related memory leaks

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -158,7 +158,7 @@ static uint64_t GetLogicalKeyForEvent(FlutterUIPressProxy* press, uint64_t physi
   const char* characters =
       getEventCharacters(press.key.charactersIgnoringModifiers, press.key.keyCode);
   NSString* keyLabel =
-      characters == nullptr ? nil : [[NSString alloc] initWithUTF8String:characters];
+      characters == nullptr ? nil : [[[NSString alloc] initWithUTF8String:characters] autorelease];
   NSUInteger keyLabelLength = [keyLabel length];
   // If this key is printable, generate the logical key from its Unicode
   // value. Control keys such as ESC, CTRL, and SHIFT are not printable. HOME,
@@ -514,11 +514,11 @@ void HandleResponse(bool handled, void* user_data);
   FlutterKeyCallbackGuard* guardedCallback = nil;
   switch (press.phase) {
     case UIPressPhaseBegan:
-      guardedCallback = [[FlutterKeyCallbackGuard alloc] initWithCallback:callback];
+      guardedCallback = [[[FlutterKeyCallbackGuard alloc] initWithCallback:callback] autorelease];
       [self handlePressBegin:press callback:guardedCallback];
       break;
     case UIPressPhaseEnded:
-      guardedCallback = [[FlutterKeyCallbackGuard alloc] initWithCallback:callback];
+      guardedCallback = [[[FlutterKeyCallbackGuard alloc] initWithCallback:callback] autorelease];
       [self handlePressEnd:press callback:guardedCallback];
       break;
     case UIPressPhaseChanged:
@@ -623,7 +623,7 @@ void HandleResponse(bool handled, void* user_data);
   _responseId += 1;
   uint64_t responseId = _responseId;
   FlutterKeyPendingResponse* pending =
-      [[FlutterKeyPendingResponse alloc] initWithHandler:self responseId:responseId];
+      [[[FlutterKeyPendingResponse alloc] initWithHandler:self responseId:responseId] autorelease];
   [callback pendTo:_pendingResponses withId:responseId];
   _sendEvent(event, HandleResponse, pending);
 }


### PR DESCRIPTION
Memory leaks. cc. @gspencergoog @dkwingsmt 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
