### PR TITLE
Calculate the frame target time based on targetTimestamp in VsyncWaiterIOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -76,7 +76,14 @@ void VsyncWaiterIOS::AwaitVSync() {
 
   CFTimeInterval delay = CACurrentMediaTime() - link.timestamp;
   fml::TimePoint frame_start_time = fml::TimePoint::Now() - fml::TimeDelta::FromSecondsF(delay);
-  fml::TimePoint frame_target_time = frame_start_time + fml::TimeDelta::FromSecondsF(link.duration);
+
+  CFTimeInterval duration;
+  if (@available(iOS 10.0, *)) {
+    duration = link.targetTimestamp - link.timestamp;
+  } else {
+    duration = link.duration;
+  }
+  fml::TimePoint frame_target_time = frame_start_time + fml::TimeDelta::FromSecondsF(duration);
 
   std::unique_ptr<flutter::FrameTimingsRecorder> recorder =
       std::make_unique<flutter::FrameTimingsRecorder>();


### PR DESCRIPTION
We should use targetTimestamp to calculate the frame target time according to Apple's documentation. Because the refresh rate may change dynamically.

https://developer.apple.com/documentation/quartzcore/cadisplaylink?language=objc
> The `duration` property provides the amount of time between frames at the `maximumFramesPerSecond`. To calculate the actual frame duration, use `targetTimestamp` - `timestamp`. You can use this value in your app to calculate the frame rate of the display, the approximate time the system displays the next frame, and to adjust the drawing behavior so that the next frame is ready in time to display.

Related Issue ( Only related but not fixed ) : https://github.com/flutter/flutter/issues/90675 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
