### PR TITLE
Disable iOS simulator flag when targeting mac

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -117,8 +117,8 @@ def can_use_prebuilt_dart(args):
 
 def to_gn_args(args):
     if args.simulator:
-        if args.target_os == 'android':
-            raise Exception('--simulator is not supported on Android')
+        if args.target_os != 'ios':
+            raise Exception('--simulator is only supported for iOS')
 
     runtime_mode = args.runtime_mode
 
@@ -182,6 +182,7 @@ def to_gn_args(args):
       # The GN arg is not available in the windows toolchain.
       gn_args['enable_lto'] = enable_lto
 
+    gn_args['use_ios_simulator'] = False
     if args.target_os == 'android':
         gn_args['target_os'] = 'android'
     elif args.target_os == 'ios':


### PR DESCRIPTION
At the moment, leaving this flag set is resulting in compiling using the clang from XCode when targeting arm64 macOS, but using Flutter's clang when targeting x64 macOS. I'm not sure which we should actually be doing, but controlling the choice using the iOS simulator flag is probably wrong.