### PR TITLE
raster cache Pictures embedded inside other DisplayLists

### DIFF
--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -14,6 +14,7 @@
 #include "third_party/skia/include/core/SkPathEffect.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkShader.h"
+#include "third_party/skia/include/core/SkTextBlob.h"
 #include "third_party/skia/include/core/SkVertices.h"
 
 // The Flutter DisplayList mechanism encapsulates a persistent sequence of

--- a/flow/display_list_canvas.cc
+++ b/flow/display_list_canvas.cc
@@ -172,6 +172,9 @@ void DisplayListCanvasDispatcher::drawPicture(const sk_sp<SkPicture> picture,
                                               bool render_with_attributes) {
   if (cache_ && !render_with_attributes) {
     SkAutoCanvasRestore save(canvas_, true);
+    if (matrix) {
+      canvas_->concat(*matrix);
+    }
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
     canvas_->setMatrix(
         RasterCache::GetIntegralTransCTM(canvas_->getTotalMatrix()));

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -7,6 +7,7 @@
 
 #include "flutter/flow/display_list.h"
 #include "flutter/flow/display_list_utils.h"
+#include "flutter/flow/raster_cache.h"
 #include "flutter/fml/logging.h"
 
 #include "third_party/skia/include/core/SkCanvasVirtualEnforcer.h"
@@ -27,7 +28,9 @@ namespace flutter {
 class DisplayListCanvasDispatcher : public virtual Dispatcher,
                                     public SkPaintDispatchHelper {
  public:
-  DisplayListCanvasDispatcher(SkCanvas* canvas) : canvas_(canvas) {}
+  DisplayListCanvasDispatcher(SkCanvas* canvas,
+                              const RasterCache* cache = nullptr)
+      : canvas_(canvas), cache_(cache) {}
 
   void save() override;
   void restore() override;
@@ -115,6 +118,7 @@ class DisplayListCanvasDispatcher : public virtual Dispatcher,
 
  private:
   SkCanvas* canvas_;
+  const RasterCache* cache_;
 };
 
 // Receives all methods on SkCanvas and sends them to a DisplayListBuilder

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -19,6 +19,7 @@
 // IgnoreAttributeDispatchHelper:
 // IgnoreClipDispatchHelper:
 // IgnoreTransformDispatchHelper
+// IgnoreRenderingDispatchHelper
 //     Empty overrides of all of the associated methods of Dispatcher
 //     for dispatchers that only track some of the rendering operations
 //
@@ -89,6 +90,68 @@ class IgnoreTransformDispatchHelper : public virtual Dispatcher {
       SkScalar mzx, SkScalar mzy, SkScalar mzz, SkScalar mzt,
       SkScalar mwx, SkScalar mwy, SkScalar mwz, SkScalar mwt) override {}
   // clang-format on
+};
+
+class IgnoreRenderingDispatchHelper : public virtual Dispatcher {
+  void drawColor(SkColor color, SkBlendMode mode) override {}
+  void drawPaint() override {}
+  void drawLine(const SkPoint& p0, const SkPoint& p1) override {}
+  void drawRect(const SkRect& rect) override {}
+  void drawOval(const SkRect& bounds) override {}
+  void drawCircle(const SkPoint& center, SkScalar radius) override {}
+  void drawRRect(const SkRRect& rrect) override {}
+  void drawDRRect(const SkRRect& outer, const SkRRect& inner) override {}
+  void drawPath(const SkPath& path) override {}
+  void drawArc(const SkRect& oval_bounds,
+               SkScalar start_degrees,
+               SkScalar sweep_degrees,
+               bool use_center) override {}
+  void drawPoints(SkCanvas::PointMode mode,
+                  uint32_t count,
+                  const SkPoint points[]) override {}
+  void drawVertices(const sk_sp<SkVertices> vertices,
+                    SkBlendMode mode) override {}
+  void drawImage(const sk_sp<SkImage> image,
+                 const SkPoint point,
+                 const SkSamplingOptions& sampling,
+                 bool render_with_attributes) override {}
+  void drawImageRect(const sk_sp<SkImage> image,
+                     const SkRect& src,
+                     const SkRect& dst,
+                     const SkSamplingOptions& sampling,
+                     bool render_with_attributes,
+                     SkCanvas::SrcRectConstraint constraint) override {}
+  void drawImageNine(const sk_sp<SkImage> image,
+                     const SkIRect& center,
+                     const SkRect& dst,
+                     SkFilterMode filter,
+                     bool render_with_attributes) override {}
+  void drawImageLattice(const sk_sp<SkImage> image,
+                        const SkCanvas::Lattice& lattice,
+                        const SkRect& dst,
+                        SkFilterMode filter,
+                        bool render_with_attributes) override {}
+  void drawAtlas(const sk_sp<SkImage> atlas,
+                 const SkRSXform xform[],
+                 const SkRect tex[],
+                 const SkColor colors[],
+                 int count,
+                 SkBlendMode mode,
+                 const SkSamplingOptions& sampling,
+                 const SkRect* cull_rect,
+                 bool render_with_attributes) override {}
+  void drawPicture(const sk_sp<SkPicture> picture,
+                   const SkMatrix* matrix,
+                   bool render_with_attributes) override {}
+  void drawDisplayList(const sk_sp<DisplayList> display_list) override {}
+  void drawTextBlob(const sk_sp<SkTextBlob> blob,
+                    SkScalar x,
+                    SkScalar y) override {}
+  void drawShadow(const SkPath& path,
+                  const SkColor color,
+                  const SkScalar elevation,
+                  bool transparent_occluder,
+                  SkScalar dpr) override {}
 };
 
 // A utility class that will monitor the Dispatcher methods relating

--- a/flow/layers/display_list_layer.h
+++ b/flow/layers/display_list_layer.h
@@ -6,10 +6,36 @@
 #define FLUTTER_FLOW_LAYERS_DISPLAY_LIST_LAYER_H_
 
 #include "flutter/flow/display_list.h"
+#include "flutter/flow/display_list_utils.h"
 #include "flutter/flow/layers/layer.h"
 #include "flutter/flow/skia_gpu_object.h"
 
 namespace flutter {
+
+class DisplayListCacheDispatcher : public virtual Dispatcher,
+                                   public SkMatrixDispatchHelper,
+                                   public IgnoreAttributeDispatchHelper,
+                                   public IgnoreClipDispatchHelper,
+                                   public IgnoreRenderingDispatchHelper {
+ public:
+  DisplayListCacheDispatcher(PrerollContext* context, RasterCache* cache)
+      : context_(context), cache_(cache) {}
+
+  void save() override { SkMatrixDispatchHelper::save(); }
+  void saveLayer(const SkRect* bounds, bool restore_with_paint) override {
+    SkMatrixDispatchHelper::save();
+  }
+  void restore() override { SkMatrixDispatchHelper::restore(); }
+
+  void drawPicture(const sk_sp<SkPicture> picture,
+                   const SkMatrix* matrix,
+                   bool render_with_attributes) override;
+  void drawDisplayList(const sk_sp<DisplayList> display_list) override;
+
+ private:
+  PrerollContext* context_;
+  RasterCache* cache_;
+};
 
 class DisplayListLayer : public Layer {
  public:


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/87584

Prepares sub-pictures of DisplayLists during Preroll and then draws them from the cache during Paint.

Needs tests.

Also needs a little more review of the potential to doubly cache the parent and child pictures.