### PR TITLE
[web] Workaround iOS 15 Safari crash

### DIFF
--- a/lib/web_ui/lib/src/engine/browser_detection.dart
+++ b/lib/web_ui/lib/src/engine/browser_detection.dart
@@ -227,6 +227,18 @@ bool get isMacOrIOS =>
     operatingSystem == OperatingSystem.iOs ||
     operatingSystem == OperatingSystem.macOs;
 
+/// Detect iOS 15.
+bool get isIOS15 {
+  if (debugIsIOS15 != null) {
+    return debugIsIOS15!;
+  }
+  return operatingSystem == OperatingSystem.iOs &&
+      html.window.navigator.userAgent.contains('OS 15_');
+}
+
+/// Use in tests to simulate the detection of iOS 15.
+bool? debugIsIOS15;
+
 int? _cachedWebGLVersion;
 
 /// The highest WebGL version supported by the current browser, or -1 if WebGL

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -422,8 +422,20 @@ const Set<String> _genericFontFamilies = <String>{
 ///
 /// For iOS, default to -apple-system, where it should be available, otherwise
 /// default to Arial. BlinkMacSystemFont is used for Chrome on iOS.
-final String _fallbackFontFamily =
-    isMacOrIOS ? '-apple-system, BlinkMacSystemFont' : 'Arial';
+String get _fallbackFontFamily {
+  if (isIOS15) {
+    // Remove the "-apple-system" fallback font because it causes a crash in
+    // iOS 15.
+    //
+    // See github issue: https://github.com/flutter/flutter/issues/90705
+    // See webkit bug: https://bugs.webkit.org/show_bug.cgi?id=231686
+    return 'BlinkMacSystemFont';
+  }
+  if (isMacOrIOS) {
+    return '-apple-system, BlinkMacSystemFont';
+  }
+  return 'Arial';
+}
 
 /// Create a font-family string appropriate for CSS.
 ///

--- a/lib/web_ui/test/engine/util_test.dart
+++ b/lib/web_ui/test/engine/util_test.dart
@@ -39,4 +39,44 @@ void testMain() {
     expect(transformKindOf(rotation2d), TransformKind.transform2d);
     expect(isIdentityFloat32ListTransform(rotation2d), isFalse);
   });
+
+  test('canonicalizes font families correctly on iOS', () {
+    debugOperatingSystemOverride = OperatingSystem.iOs;
+
+    expect(
+      canonicalizeFontFamily('sans-serif'),
+      'sans-serif',
+    );
+    expect(
+      canonicalizeFontFamily('foo'),
+      '"foo", -apple-system, BlinkMacSystemFont, sans-serif',
+    );
+    expect(
+      canonicalizeFontFamily('.SF Pro Text'),
+      '-apple-system, BlinkMacSystemFont',
+    );
+
+    debugOperatingSystemOverride = null;
+  });
+
+  test('does not use -apple-system on iOS 15', () {
+    debugOperatingSystemOverride = OperatingSystem.iOs;
+    debugIsIOS15 = true;
+
+    expect(
+      canonicalizeFontFamily('sans-serif'),
+      'sans-serif',
+    );
+    expect(
+      canonicalizeFontFamily('foo'),
+      '"foo", BlinkMacSystemFont, sans-serif',
+    );
+    expect(
+      canonicalizeFontFamily('.SF Pro Text'),
+      'BlinkMacSystemFont',
+    );
+
+    debugOperatingSystemOverride = null;
+    debugIsIOS15 = null;
+  });
 }


### PR DESCRIPTION
When drawing Japanese or Chinese text on a canvas (e.g. "こんにちは世界" or "測試") with a font chain that includes "-apple-system", the Safari browser in iOS 15 crashes.

To work around the crash, this PR removes "-apple-system" from the fallback font that we use for iOS. We only do this when we detect iOS 15.

Filed this webkit bug: https://bugs.webkit.org/show_bug.cgi?id=231686

Fixes https://github.com/flutter/flutter/issues/90705