### PR TITLE
[web] Add goldctl as a dependency in LUCI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -208,6 +208,10 @@ targets:
     properties:
       add_recipes_cq: "true"
       gcs_goldens_bucket: flutter_logs
+      dependencies: >-
+        [
+          {"dependency": "goldctl"}
+        ]
     timeout: 60
     scheduler: luci
     runIf:
@@ -274,6 +278,10 @@ targets:
     recipe: web_engine
     properties:
       gcs_goldens_bucket: flutter_logs
+      dependencies: >-
+        [
+          {"dependency": "goldctl"}
+        ]
     timeout: 60
     scheduler: luci
     runIf:


### PR DESCRIPTION
This is a pre-requisite for https://github.com/flutter/engine/pull/29139.

It basically adds the dependency on `goldctl` so we can use it during our tests.