### PR TITLE
[web] use 'dart compile js' instead of 'dart2js' in web_ui and felt

### DIFF
--- a/lib/web_ui/dev/environment.dart
+++ b/lib/web_ui/dev/environment.dart
@@ -92,10 +92,6 @@ class Environment {
   /// The "pub" executable file.
   String get pubExecutable => pathlib.join(dartSdkDir.path, 'bin', 'pub');
 
-  /// The "dart2js" executable file.
-  String get dart2jsExecutable =>
-      pathlib.join(dartSdkDir.path, 'bin', 'dart2js');
-
   /// Path to where github.com/flutter/engine is checked out inside the engine workspace.
   io.Directory get flutterDirectory =>
       io.Directory(pathlib.join(engineSrcDir.path, 'flutter'));

--- a/lib/web_ui/dev/felt
+++ b/lib/web_ui/dev/felt
@@ -34,13 +34,13 @@ DART_SDK_DIR="${ENGINE_SRC_DIR}/out/host_debug_unopt/dart-sdk"
 GN="${FLUTTER_DIR}/tools/gn"
 DART_TOOL_DIR="${WEB_UI_DIR}/.dart_tool"
 PUB_PATH="$DART_SDK_DIR/bin/pub"
-DART2JS_PATH="$DART_SDK_DIR/bin/dart2js"
+DART_PATH="$DART_SDK_DIR/bin/dart"
 SNAPSHOT_PATH="${DART_TOOL_DIR}/felt.snapshot"
 STAMP_PATH="${DART_TOOL_DIR}/felt.snapshot.stamp"
 SCRIPT_PATH="${DEV_DIR}/felt.dart"
 REVISION="$(cd "$FLUTTER_DIR"; git rev-parse HEAD)"
 
-if [ ! -f "${PUB_PATH}" -o ! -f "${DART2JS_PATH}" ]
+if [ ! -f "${PUB_PATH}" -o ! -f "${DART_PATH}" ]
 then
   echo "Compiling the Dart SDK."
   gclient sync

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -136,6 +136,8 @@ Future<bool> compileUnitTest(FilePath input, { required bool forCanvasKit }) asy
   }
 
   final List<String> arguments = <String>[
+    'compile',
+    'js',
     '--no-minify',
     '--disable-inlining',
     '--enable-asserts',
@@ -155,7 +157,7 @@ Future<bool> compileUnitTest(FilePath input, { required bool forCanvasKit }) asy
   ];
 
   final int exitCode = await runProcess(
-    environment.dart2jsExecutable,
+    environment.dartExecutable,
     arguments,
     workingDirectory: environment.webUiRootDir.path,
   );
@@ -196,8 +198,10 @@ Future<void> buildHostPage() async {
   }
 
   final int exitCode = await runProcess(
-    environment.dart2jsExecutable,
+    environment.dartExecutable,
     <String>[
+      'compile',
+      'js',
       hostDartPath,
       '-o',
       '$hostDartPath.js',

--- a/web_sdk/web_test_utils/lib/environment.dart
+++ b/web_sdk/web_test_utils/lib/environment.dart
@@ -111,10 +111,6 @@ class Environment {
   /// The "pub" executable file.
   String get pubExecutable => pathlib.join(dartSdkDir.path, 'bin', 'pub');
 
-  /// The "dart2js" executable file.
-  String get dart2jsExecutable =>
-      pathlib.join(dartSdkDir.path, 'bin', 'dart2js');
-
   /// Path to where github.com/flutter/engine is checked out inside the engine workspace.
   io.Directory get flutterDirectory =>
       io.Directory(pathlib.join(engineSrcDir.path, 'flutter'));


### PR DESCRIPTION
This change is needed in preparation for an upcoming deprecation of the dart2js script. The compiler will be
available going forward from `dart compile js` instead.