### PR TITLE
Use the debug build of CanvasKit when running Flutter in debug mode

### DIFF
--- a/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/initialization.dart
@@ -10,7 +10,7 @@ import 'dart:js' as js;
 
 import 'package:js/js.dart';
 
-import '../../engine.dart' show kProfileMode;
+import '../../engine.dart' show kReleaseMode;
 import '../browser_detection.dart';
 import '../dom_renderer.dart';
 import 'canvaskit_api.dart';
@@ -94,7 +94,7 @@ const String canvasKitBaseUrl = String.fromEnvironment(
   defaultValue: 'https://unpkg.com/canvaskit-wasm@$canvaskitVersion/bin/',
 );
 const String canvasKitBuildUrl =
-    canvasKitBaseUrl + (kProfileMode ? 'profiling/' : '');
+    canvasKitBaseUrl + (!kReleaseMode ? 'profiling/' : '');
 const String canvasKitJavaScriptBindingsUrl =
     canvasKitBuildUrl + 'canvaskit.js';
 String canvasKitWasmModuleUrl(String file) => _currentCanvasKitBase! + file;
@@ -184,7 +184,8 @@ void _startDownloadingCanvasKit(String? canvasKitBase) {
 
     // First check if `exports` and `module` are already defined. If so, then
     // CommonJS is being used, and we shouldn't have any problems.
-    final js.JsFunction objectConstructor = js.context['Object'] as js.JsFunction;
+    final js.JsFunction objectConstructor =
+        js.context['Object'] as js.JsFunction;
     if (js.context['exports'] == null) {
       final js.JsObject exportsAccessor = js.JsObject.jsify(<String, dynamic>{
         'get': js.allowInterop(() {


### PR DESCRIPTION
When running Flutter in `--debug` mode, use the debug build of CanvasKit. With this change, the only mode which uses the release version of CanvasKit is `--release` mode.



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
