### PR TITLE
Fix bug where ImageGenerator factories with the same priority get dropped in release mode

### DIFF
--- a/lib/ui/painting/image_generator_registry.cc
+++ b/lib/ui/painting/image_generator_registry.cc
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 
-#include "flutter/fml/trace_event.h"
 #include "flutter/lib/ui/painting/image_generator_registry.h"
 #include "third_party/skia/include/codec/SkCodec.h"
 #include "third_party/skia/include/core/SkImageGenerator.h"
@@ -48,8 +47,7 @@ ImageGeneratorRegistry::~ImageGeneratorRegistry() = default;
 
 void ImageGeneratorRegistry::AddFactory(ImageGeneratorFactory factory,
                                         int32_t priority) {
-  image_generator_factories_.insert(
-      {factory, priority, fml::tracing::TraceNonce()});
+  image_generator_factories_.insert({factory, priority, ++nonce_});
 }
 
 std::shared_ptr<ImageGenerator>

--- a/lib/ui/painting/image_generator_registry.h
+++ b/lib/ui/painting/image_generator_registry.h
@@ -84,6 +84,7 @@ class ImageGeneratorRegistry {
 
   using FactorySet = std::set<PrioritizedFactory, Compare>;
   FactorySet image_generator_factories_;
+  size_t nonce_;
   fml::WeakPtrFactory<ImageGeneratorRegistry> weak_factory_;
 };
 

--- a/lib/ui/painting/image_generator_registry_unittests.cc
+++ b/lib/ui/painting/image_generator_registry_unittests.cc
@@ -111,5 +111,42 @@ TEST_F(ShellTest, DefaultGeneratorsTakePrecedentOverNegativePriority) {
   ASSERT_EQ(result->GetInfo().width(), 3024);
 }
 
+TEST_F(ShellTest, DefaultGeneratorsTakePrecedentOverZeroPriority) {
+  ImageGeneratorRegistry registry;
+
+  registry.AddFactory(
+      [](sk_sp<SkData> buffer) {
+        return std::make_unique<FakeImageGenerator>(1337);
+      },
+      0);
+
+  // Fetch the generator and query for basic info.
+  auto result = registry.CreateCompatibleGenerator(LoadValidImageFixture());
+  // If the real width of the image pops out, then the default generator was
+  // returned rather than the fake one.
+  ASSERT_EQ(result->GetInfo().width(), 3024);
+}
+
+TEST_F(ShellTest, ImageGeneratorsWithSamePriorityCascadeChronologically) {
+  ImageGeneratorRegistry registry;
+
+  // Add 2 factories with the same high priority.
+  registry.AddFactory(
+      [](sk_sp<SkData> buffer) {
+        return std::make_unique<FakeImageGenerator>(1337);
+      },
+      5);
+  registry.AddFactory(
+      [](sk_sp<SkData> buffer) {
+        return std::make_unique<FakeImageGenerator>(7777);
+      },
+      5);
+
+  // Feed empty data so that Skia's image generators will reject it, but ours
+  // won't.
+  auto result = registry.CreateCompatibleGenerator(SkData::MakeEmpty());
+  ASSERT_EQ(result->GetInfo().width(), 1337);
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/91421.

This was a silly one. I naively assumed that `fml::tracing::TraceNonce()` was intended for global use, but in retrospect it's quite obvious that it's only intended for trace ordering. In release mode it's preprocessed out and only returns 0.