### PR TITLE
Call rapidjson::ParseResult::IsError to check for JSON parsing errors

### DIFF
--- a/common/graphics/persistent_cache.cc
+++ b/common/graphics/persistent_cache.cc
@@ -253,7 +253,7 @@ std::vector<PersistentCache::SkSLCache> PersistentCache::LoadSkSLs() const {
     rapidjson::ParseResult parse_result =
         json_doc.Parse(reinterpret_cast<const char*>(mapping->GetMapping()),
                        mapping->GetSize());
-    if (parse_result != rapidjson::ParseErrorCode::kParseErrorNone) {
+    if (parse_result.IsError()) {
       FML_LOG(ERROR) << "Failed to parse json file: " << kAssetFileName;
     } else {
       for (auto& item : json_doc["data"].GetObject()) {

--- a/shell/platform/common/json_message_codec.cc
+++ b/shell/platform/common/json_message_codec.cc
@@ -37,9 +37,7 @@ std::unique_ptr<rapidjson::Document> JsonMessageCodec::DecodeMessageInternal(
   auto json_message = std::make_unique<rapidjson::Document>();
   rapidjson::ParseResult result =
       json_message->Parse(raw_message, message_size);
-  bool parsing_successful =
-      result == rapidjson::ParseErrorCode::kParseErrorNone;
-  if (!parsing_successful) {
+  if (result.IsError()) {
     std::cerr << "Unable to parse JSON message:" << std::endl
               << rapidjson::GetParseError_En(result.Code()) << std::endl;
     return nullptr;


### PR DESCRIPTION
Older versions of RapidJSON may not have the overloaded != operator
in rapidjson::ParseResult.  This can produce unexpected results.
