### PR TITLE
Fix synchronization of lock states.

### DIFF
--- a/shell/platform/windows/keyboard_key_channel_handler.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler.cc
@@ -204,7 +204,7 @@ void KeyboardKeyChannelHandler::KeyboardHook(
                                                          size_t reply_size) {
     auto decoded = flutter::JsonMessageCodec::GetInstance().DecodeMessage(
         reply, reply_size);
-    bool handled = (*decoded)[kHandledKey].GetBool();
+    bool handled = !decoded ? false : (*decoded)[kHandledKey].GetBool();
     callback(handled);
   });
 }

--- a/shell/platform/windows/keyboard_key_embedder_handler.h
+++ b/shell/platform/windows/keyboard_key_embedder_handler.h
@@ -102,15 +102,15 @@ class KeyboardKeyEmbedderHandler
   // Assign |critical_keys_| with basic information.
   void InitCriticalKeys();
   // Update |critical_keys_| with last seen logical and physical key.
-  void UpdateLastSeenCritialKey(int virtual_key,
-                                uint64_t physical_key,
-                                uint64_t logical_key);
+  void UpdateLastSeenCriticalKey(int virtual_key,
+                                 uint64_t physical_key,
+                                 uint64_t logical_key);
   // Check each key's state from |get_key_state_| and synthesize events
   // if their toggling states have been desynchronized.
-  void SynchronizeCritialToggledStates(int this_virtual_key);
+  void SynchronizeCriticalToggledStates(int this_virtual_key);
   // Check each key's state from |get_key_state_| and synthesize events
   // if their pressing states have been desynchronized.
-  void SynchronizeCritialPressedStates();
+  void SynchronizeCriticalPressedStates();
 
   // Wraps perform_send_event_ with state tracking. Use this instead of
   // |perform_send_event_| to send events to the framework.


### PR DESCRIPTION
## Description

Fixes https://github.com/flutter/flutter/issues/88662 by modifying the lock state synchronization in `KeyboardKeyEmbedderHandler::SynchronizeCriticalToggledStates` to avoid changing the pressed state of the key, and instead always send a pair of synthesized events that will modify the lock state without changing the pressed state. It swaps the order of the synthesized events (down/up vs up/down) depending on whether the key was pressed already or not.

Currently, if the lock states don't match, `SynchronizeCriticalToggledStates` sends a synthesized key up event if the key is already pressed, and then always sends a synthesized key down event, and marks the key as being currently pressed in the case where it wasn't already. This means that if the lock state is out of sync, it changes the engine's concept of which keys are down, but is not communicating that change to the framework, and so when the framework receives both the synthesized key down and then the real one, it asserts because it thought the key should already be down.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/88662

## Tests
 - (none yet, just a draft)