### PR TITLE
Call AwaitVSync directly when Animator.RequestFrame is calling

### DIFF
--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -95,6 +95,8 @@ class Animator final {
 
   void AwaitVSync();
 
+  void NotifyIdle();
+
   const char* FrameParity();
 
   // Clear |trace_flow_ids_| if |frame_scheduled_| is false.

--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -159,6 +159,10 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
   }
 }
 
+bool VsyncWaiter::ShouldAwaitVSyncOnIdle() {
+  return true;
+}
+
 void VsyncWaiter::PauseDartMicroTasks() {
   auto ui_task_queue_id = task_runners_.GetUITaskRunner()->GetTaskQueueId();
   auto task_queues = fml::MessageLoopTaskQueues::GetInstance();

--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -32,6 +32,10 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
   /// |Animator::ScheduleMaybeClearTraceFlowIds|.
   void ScheduleSecondaryCallback(uintptr_t id, const fml::closure& callback);
 
+  /// The |AwaitVSync| should be called on Idle or not. The default result is
+  /// true.
+  virtual bool ShouldAwaitVSyncOnIdle();
+
  protected:
   // On some backends, the |FireCallback| needs to be made from a static C
   // method.

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -38,6 +38,11 @@ void VsyncWaiterAndroid::AwaitVSync() {
   });
 }
 
+// |VsyncWaiter|
+bool VsyncWaiterAndroid::ShouldAwaitVSyncOnIdle() {
+  return false;
+}
+
 // static
 void VsyncWaiterAndroid::OnNativeVsync(JNIEnv* env,
                                        jclass jcaller,

--- a/shell/platform/android/vsync_waiter_android.h
+++ b/shell/platform/android/vsync_waiter_android.h
@@ -26,6 +26,9 @@ class VsyncWaiterAndroid final : public VsyncWaiter {
   // |VsyncWaiter|
   void AwaitVSync() override;
 
+  // |VsyncWaiter|
+  bool ShouldAwaitVSyncOnIdle() override;
+
   static void OnNativeVsync(JNIEnv* env,
                             jclass jcaller,
                             jlong frameDelayNanos,

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -50,6 +50,9 @@ class VsyncWaiterIOS final : public VsyncWaiter {
   // |VsyncWaiter|
   void AwaitVSync() override;
 
+  // |VsyncWaiter|
+  bool ShouldAwaitVSyncOnIdle() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterIOS);
 };
 

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -39,6 +39,10 @@ void VsyncWaiterIOS::AwaitVSync() {
   [client_.get() await];
 }
 
+bool VsyncWaiterIOS::ShouldAwaitVSyncOnIdle() {
+  return false;
+}
+
 }  // namespace flutter
 
 @implementation VSyncClient {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/92258

Currently this new feature is only support on Android and iOS，I have tried to enable this feature on all platforms, but the unit test AnimatorDoesNotNotifyIdleBeforeRender will fail due to timeout.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.