### PR TITLE
Add FlutterWindowsEngine::DispatchSemanticsAction

### DIFF
--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -444,4 +444,12 @@ bool FlutterWindowsEngine::MarkExternalTextureFrameAvailable(
               engine_, texture_id) == kSuccess);
 }
 
+bool FlutterWindowsEngine::DispatchSemanticsAction(
+    uint64_t target,
+    FlutterSemanticsAction action,
+    const std::vector<uint8_t>& data) {
+  return (embedder_api_.DispatchSemanticsAction(
+              engine_, target, action, data.data(), data.size()) == kSuccess);
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -144,6 +144,11 @@ class FlutterWindowsEngine {
   // given |texture_id|.
   bool MarkExternalTextureFrameAvailable(int64_t texture_id);
 
+  // Dispatches a semantics action to the specified semantics node.
+  bool DispatchSemanticsAction(uint64_t id,
+                               FlutterSemanticsAction action,
+                               const std::vector<uint8_t>& data);
+
  private:
   // Allows swapping out embedder_api_ calls in tests.
   friend class EngineModifier;

--- a/shell/platform/windows/flutter_windows_engine_unittests.cc
+++ b/shell/platform/windows/flutter_windows_engine_unittests.cc
@@ -231,5 +231,29 @@ TEST(FlutterWindowsEngine, SendPlatformMessageWithResponse) {
   EXPECT_TRUE(send_message_called);
 }
 
+TEST(FlutterWindowsEngine, DispatchSemanticsAction) {
+  std::unique_ptr<FlutterWindowsEngine> engine = GetTestEngine();
+  EngineModifier modifier(engine.get());
+
+  bool called = false;
+  std::string test_data = "Hello";
+  modifier.embedder_api().DispatchSemanticsAction = MOCK_ENGINE_PROC(
+      DispatchSemanticsAction,
+      ([&called, &test_data](auto engine, auto target, auto action, auto data,
+                             auto data_length) {
+        called = true;
+        EXPECT_EQ(target, 42);
+        EXPECT_EQ(action, kFlutterSemanticsActionDismiss);
+        EXPECT_EQ(memcmp(data, test_data.c_str(), test_data.size()), 0);
+        EXPECT_EQ(data_length, test_data.size());
+        return kSuccess;
+      }));
+
+  engine->DispatchSemanticsAction(
+      42, kFlutterSemanticsActionDismiss,
+      std::vector<uint8_t>(test_data.begin(), test_data.end()));
+  EXPECT_TRUE(called);
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
Adds method for dispatching a semantics action received from the OS to
the matching node in Flutter's semantics tree.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
