### PR TITLE
Win32: Add lifecycle channel support

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1706,6 +1706,7 @@ FILE: ../../../flutter/shell/platform/common/client_wrapper/include/flutter/plug
 FILE: ../../../flutter/shell/platform/common/client_wrapper/include/flutter/standard_codec_serializer.h
 FILE: ../../../flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h
 FILE: ../../../flutter/shell/platform/common/client_wrapper/include/flutter/standard_method_codec.h
+FILE: ../../../flutter/shell/platform/common/client_wrapper/include/flutter/string_message_codec.h
 FILE: ../../../flutter/shell/platform/common/client_wrapper/include/flutter/texture_registrar.h
 FILE: ../../../flutter/shell/platform/common/client_wrapper/method_call_unittests.cc
 FILE: ../../../flutter/shell/platform/common/client_wrapper/method_channel_unittests.cc
@@ -1715,6 +1716,8 @@ FILE: ../../../flutter/shell/platform/common/client_wrapper/plugin_registrar_uni
 FILE: ../../../flutter/shell/platform/common/client_wrapper/standard_codec.cc
 FILE: ../../../flutter/shell/platform/common/client_wrapper/standard_message_codec_unittests.cc
 FILE: ../../../flutter/shell/platform/common/client_wrapper/standard_method_codec_unittests.cc
+FILE: ../../../flutter/shell/platform/common/client_wrapper/string_codec.cc
+FILE: ../../../flutter/shell/platform/common/client_wrapper/string_message_codec_unittests.cc
 FILE: ../../../flutter/shell/platform/common/client_wrapper/texture_registrar_impl.h
 FILE: ../../../flutter/shell/platform/common/client_wrapper/texture_registrar_unittests.cc
 FILE: ../../../flutter/shell/platform/common/engine_switches.cc
@@ -2488,6 +2491,8 @@ FILE: ../../../flutter/shell/platform/windows/keyboard_unittests.cc
 FILE: ../../../flutter/shell/platform/windows/keyboard_utils.cc
 FILE: ../../../flutter/shell/platform/windows/keyboard_utils.h
 FILE: ../../../flutter/shell/platform/windows/keyboard_utils_unittests.cc
+FILE: ../../../flutter/shell/platform/windows/lifecycle_plugin.cc
+FILE: ../../../flutter/shell/platform/windows/lifecycle_plugin.h
 FILE: ../../../flutter/shell/platform/windows/platform_handler.cc
 FILE: ../../../flutter/shell/platform/windows/platform_handler.h
 FILE: ../../../flutter/shell/platform/windows/platform_handler_unittests.cc

--- a/shell/platform/common/client_wrapper/BUILD.gn
+++ b/shell/platform/common/client_wrapper/BUILD.gn
@@ -48,6 +48,7 @@ executable("client_wrapper_unittests") {
     "plugin_registrar_unittests.cc",
     "standard_message_codec_unittests.cc",
     "standard_method_codec_unittests.cc",
+    "string_message_codec_unittests.cc",
     "testing/test_codec_extensions.cc",
     "testing/test_codec_extensions.h",
     "texture_registrar_unittests.cc",

--- a/shell/platform/common/client_wrapper/core_wrapper_files.gni
+++ b/shell/platform/common/client_wrapper/core_wrapper_files.gni
@@ -24,6 +24,7 @@ core_cpp_client_wrapper_includes =
                     "include/flutter/standard_codec_serializer.h",
                     "include/flutter/standard_message_codec.h",
                     "include/flutter/standard_method_codec.h",
+                    "include/flutter/string_message_codec.h",
                     "include/flutter/texture_registrar.h",
                   ],
                   "abspath")
@@ -46,6 +47,7 @@ core_cpp_client_wrapper_sources = get_path_info([
                                                   "core_implementations.cc",
                                                   "plugin_registrar.cc",
                                                   "standard_codec.cc",
+                                                  "string_codec.cc",
                                                 ],
                                                 "abspath")
 

--- a/shell/platform/common/client_wrapper/include/flutter/string_message_codec.h
+++ b/shell/platform/common/client_wrapper/include/flutter/string_message_codec.h
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_COMMON_CLIENT_WRAPPER_INCLUDE_FLUTTER_STRING_MESSAGE_CODEC_H_
+#define FLUTTER_SHELL_PLATFORM_COMMON_CLIENT_WRAPPER_INCLUDE_FLUTTER_STRING_MESSAGE_CODEC_H_
+
+#include <memory>
+#include <string>
+
+#include "message_codec.h"
+
+namespace flutter {
+
+// An implementation of MethodCodec that uses UTF-8 strings as the
+// serialization.
+class StringMessageCodec : public MessageCodec<std::string> {
+ public:
+  // Returns an instance of the codec.
+  static const StringMessageCodec& GetInstance();
+
+  ~StringMessageCodec() = default;
+
+  // Prevent copying.
+  StringMessageCodec(StringMessageCodec const&) = delete;
+  StringMessageCodec& operator=(StringMessageCodec const&) = delete;
+
+ protected:
+  // Instances should be obtained via GetInstance.
+  StringMessageCodec() = default;
+
+  // |flutter::MessageCodec|
+  std::unique_ptr<std::string> DecodeMessageInternal(
+      const uint8_t* binary_message,
+      const size_t message_size) const override;
+
+  // |flutter::MessageCodec|
+  std::unique_ptr<std::vector<uint8_t>> EncodeMessageInternal(
+      const std::string& message) const override;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_COMMON_CLIENT_WRAPPER_INCLUDE_FLUTTER_STRING_MESSAGE_CODEC_H_

--- a/shell/platform/common/client_wrapper/string_codec.cc
+++ b/shell/platform/common/client_wrapper/string_codec.cc
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "include/flutter/string_message_codec.h"
+
+namespace flutter {
+
+// static
+const StringMessageCodec& StringMessageCodec::GetInstance() {
+  static StringMessageCodec sInstance;
+  return sInstance;
+}
+
+std::unique_ptr<std::string> StringMessageCodec::DecodeMessageInternal(
+    const uint8_t* binary_message,
+    const size_t message_size) const {
+  return std::make_unique<std::string>(
+      reinterpret_cast<const char*>(binary_message), message_size);
+}
+
+std::unique_ptr<std::vector<uint8_t>> StringMessageCodec::EncodeMessageInternal(
+    const std::string& message) const {
+  std::vector<uint8_t> string_message(message.length());
+  std::copy(message.begin(), message.end(), string_message.begin());
+
+  return std::make_unique<std::vector<uint8_t>>(string_message);
+}
+
+}  // namespace flutter

--- a/shell/platform/common/client_wrapper/string_message_codec_unittests.cc
+++ b/shell/platform/common/client_wrapper/string_message_codec_unittests.cc
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/string_message_codec.h"
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+
+// Validates round-trip encoding and decoding of |value|, and checks that the
+// encoded value matches |expected_encoding|.
+static void CheckEncodeDecode(const std::string& value,
+                              const std::vector<uint8_t>& expected_encoding) {
+  const StringMessageCodec& codec = StringMessageCodec::GetInstance();
+  auto encoded = codec.EncodeMessage(value);
+  ASSERT_TRUE(encoded);
+  EXPECT_EQ(*encoded, expected_encoding);
+
+  auto decoded = codec.DecodeMessage(*encoded);
+  EXPECT_EQ(value, *decoded);
+}
+
+TEST(StringMessageCodec, CanEncodeAndDecodeString) {
+  std::vector<uint8_t> bytes = {0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20,
+                                0x77, 0x6f, 0x72, 0x6c, 0x64};
+  CheckEncodeDecode(u8"hello world", bytes);
+}
+
+TEST(StringMessageCodec, CanEncodeAndDecodeStringWithNonAsciiCodePoint) {
+  std::vector<uint8_t> bytes = {0x68, 0xe2, 0x98, 0xba, 0x77};
+  CheckEncodeDecode(u8"h\u263Aw", bytes);
+}
+
+TEST(StringMessageCodec, CanEncodeAndDecodeStringWithNonBMPCodePoint) {
+  std::vector<uint8_t> bytes = {0x68, 0xf0, 0x9f, 0x98, 0x82, 0x77};
+  CheckEncodeDecode(u8"h\U0001F602w", bytes);
+}
+
+TEST(StringMessageCodec, CanEncodeAndDecodeEmptyString) {
+  std::vector<uint8_t> bytes = {};
+  CheckEncodeDecode(u8"", bytes);
+}
+
+}  // namespace flutter

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -80,6 +80,8 @@ source_set("flutter_windows_source") {
     "keyboard_manager.h",
     "keyboard_utils.cc",
     "keyboard_utils.h",
+    "lifecycle_plugin.cc",
+    "lifecycle_plugin.h",
     "platform_handler.cc",
     "platform_handler.h",
     "sequential_id_generator.cc",

--- a/shell/platform/windows/flutter_window.cc
+++ b/shell/platform/windows/flutter_window.cc
@@ -241,6 +241,22 @@ void FlutterWindow::OnScroll(double delta_x,
                                       device_id);
 }
 
+void FlutterWindow::OnSetFocus() {
+  binding_handler_delegate_->OnResumed();
+}
+
+void FlutterWindow::OnKillFocus() {
+  binding_handler_delegate_->OnInactive();
+}
+
+void FlutterWindow::OnMinimized() {
+  binding_handler_delegate_->OnPaused();
+}
+
+void FlutterWindow::OnRestoredFromMinimized() {
+  binding_handler_delegate_->OnInactive();
+}
+
 void FlutterWindow::OnCursorRectUpdated(const Rect& rect) {
   // Convert the rect from Flutter logical coordinates to device coordinates.
   auto scale = GetDpiScale();

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -108,6 +108,18 @@ class FlutterWindow : public Window, public WindowBindingHandler {
                 int32_t device_id) override;
 
   // |Window|
+  void OnSetFocus() override;
+
+  // |Window|
+  void OnKillFocus() override;
+
+  // |Window|
+  void OnMinimized() override;
+
+  // |Window|
+  void OnRestoredFromMinimized() override;
+
+  // |Window|
   gfx::NativeViewAccessible GetNativeViewAccessible() override;
 
   // |FlutterWindowBindingHandler|

--- a/shell/platform/windows/flutter_window.h
+++ b/shell/platform/windows/flutter_window.h
@@ -161,6 +161,9 @@ class FlutterWindow : public Window, public WindowBindingHandler {
   void SendInitialAccessibilityFeatures() override;
 
  private:
+  // Sends a lifecycle event based on |has_focus_| and |is_visible_|.
+  void SendLifecycleEvent();
+
   // A pointer to a FlutterWindowsView that can be used to update engine
   // windowing and input state.
   WindowBindingHandlerDelegate* binding_handler_delegate_;
@@ -170,6 +173,12 @@ class FlutterWindow : public Window, public WindowBindingHandler {
 
   // The cursor rect set by Flutter.
   RECT cursor_rect_;
+
+  // True when the window has focus.
+  bool has_focus_ = false;
+
+  // True when the window is visible.
+  bool is_visible_ = false;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/flutter_window_unittests.cc
+++ b/shell/platform/windows/flutter_window_unittests.cc
@@ -400,5 +400,29 @@ TEST(FlutterWindowTest, InitialAccessibilityFeatures) {
   win32window.SendInitialAccessibilityFeatures();
 }
 
+TEST(FlutterWindowTest, SendLifecycleEvent) {
+  MockFlutterWindow win32window;
+  MockWindowBindingHandlerDelegate delegate;
+  win32window.SetView(&delegate);
+
+  // Fix the states.
+  win32window.OnMinimized();
+  win32window.OnKillFocus();
+
+  // Simulates restoring window size.
+  EXPECT_CALL(delegate, OnInactive()).Times(1);
+  win32window.OnRestoredFromMinimized();
+
+  EXPECT_CALL(delegate, OnResumed()).Times(1);
+  win32window.OnSetFocus();
+
+  // Simulates minimizing window.
+  EXPECT_CALL(delegate, OnInactive()).Times(1);
+  win32window.OnKillFocus();
+
+  EXPECT_CALL(delegate, OnPaused()).Times(1);
+  win32window.OnMinimized();
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -552,10 +552,9 @@ void FlutterWindowsEngine::SendSystemLocales() {
   // Convert the locale list to the locale pointer list that must be provided.
   std::vector<const FlutterLocale*> flutter_locale_list;
   flutter_locale_list.reserve(flutter_locales.size());
-  std::transform(
-      flutter_locales.begin(), flutter_locales.end(),
-      std::back_inserter(flutter_locale_list),
-      [](const auto& arg) -> const auto* { return &arg; });
+  std::transform(flutter_locales.begin(), flutter_locales.end(),
+                 std::back_inserter(flutter_locale_list),
+                 [](const auto& arg) -> const auto* { return &arg; });
   embedder_api_.UpdateLocales(engine_, flutter_locale_list.data(),
                               flutter_locale_list.size());
 }

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -195,7 +195,6 @@ FlutterWindowsEngine::FlutterWindowsEngine(const FlutterProjectBundle& project)
 
   lifecycle_plugin_ =
       std::make_unique<LifecyclePlugin>(messenger_wrapper_.get());
-  lifecycle_plugin_->SendAppIsDetached();
 }
 
 FlutterWindowsEngine::~FlutterWindowsEngine() {
@@ -367,8 +366,6 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
 
   settings_plugin_->StartWatching();
   settings_plugin_->SendSettings();
-
-  lifecycle_plugin_->SendAppIsResumed();
 
   return true;
 }

--- a/shell/platform/windows/flutter_windows_engine.h
+++ b/shell/platform/windows/flutter_windows_engine.h
@@ -22,6 +22,7 @@
 #include "flutter/shell/platform/windows/angle_surface_manager.h"
 #include "flutter/shell/platform/windows/flutter_project_bundle.h"
 #include "flutter/shell/platform/windows/flutter_windows_texture_registrar.h"
+#include "flutter/shell/platform/windows/lifecycle_plugin.h"
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 #include "flutter/shell/platform/windows/settings_plugin.h"
 #include "flutter/shell/platform/windows/task_runner.h"
@@ -174,6 +175,15 @@ class FlutterWindowsEngine {
   // Informs the engine that the system font list has changed.
   void ReloadSystemFonts();
 
+  // Informs the engine that the app is resumed.
+  void SendAppIsResumed();
+
+  // Informs the engine that the app is inactive.
+  void SendAppIsInactive();
+
+  // Informs the engine that the app is paused.
+  void SendAppIsPaused();
+
   // Informs the engine that a new frame is needed to redraw the content.
   void ScheduleFrame();
 
@@ -286,6 +296,9 @@ class FlutterWindowsEngine {
 
   // The settings plugin.
   std::unique_ptr<SettingsPlugin> settings_plugin_;
+
+  // The lifecycle plugin.
+  std::unique_ptr<LifecyclePlugin> lifecycle_plugin_;
 
   // Callbacks to be called when the engine (and thus the plugin registrar) is
   // being destroyed.

--- a/shell/platform/windows/flutter_windows_view.cc
+++ b/shell/platform/windows/flutter_windows_view.cc
@@ -546,6 +546,18 @@ void FlutterWindowsView::SendPointerEventWithData(
   }
 }
 
+void FlutterWindowsView::OnResumed() {
+  engine_->SendAppIsResumed();
+}
+
+void FlutterWindowsView::OnInactive() {
+  engine_->SendAppIsInactive();
+}
+
+void FlutterWindowsView::OnPaused() {
+  engine_->SendAppIsPaused();
+}
+
 bool FlutterWindowsView::MakeCurrent() {
   return engine_->surface_manager()->MakeCurrent();
 }

--- a/shell/platform/windows/flutter_windows_view.h
+++ b/shell/platform/windows/flutter_windows_view.h
@@ -184,6 +184,15 @@ class FlutterWindowsView : public WindowBindingHandlerDelegate,
   virtual void OnUpdateSemanticsEnabled(bool enabled) override;
 
   // |WindowBindingHandlerDelegate|
+  void OnResumed() override;
+
+  // |WindowBindingHandlerDelegate|
+  void OnInactive() override;
+
+  // |WindowBindingHandlerDelegate|
+  void OnPaused() override;
+
+  // |WindowBindingHandlerDelegate|
   virtual gfx::NativeViewAccessible GetNativeViewAccessible() override;
 
   // |TextInputPluginDelegate|

--- a/shell/platform/windows/lifecycle_plugin.cc
+++ b/shell/platform/windows/lifecycle_plugin.cc
@@ -1,0 +1,44 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/windows/lifecycle_plugin.h"
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/string_message_codec.h"
+
+namespace flutter {
+
+namespace {
+
+constexpr char kChannelName[] = "flutter/lifecycle";
+
+constexpr char kStateResumed[] = "AppLifecycleState.resumed";
+constexpr char kStateInactive[] = "AppLifecycleState.inactive";
+constexpr char kStatePaused[] = "AppLifecycleState.paused";
+constexpr char kStateDetached[] = "AppLifecycleState.detached";
+
+}  // namespace
+
+LifecyclePlugin::LifecyclePlugin(BinaryMessenger* messenger)
+    : channel_(std::make_unique<flutter::BasicMessageChannel<std::string>>(
+          messenger,
+          kChannelName,
+          &StringMessageCodec::GetInstance())) {}
+
+void LifecyclePlugin::SendAppIsResumed() {
+  channel_->Send(kStateResumed);
+}
+
+void LifecyclePlugin::SendAppIsInactive() {
+  channel_->Send(kStateInactive);
+}
+
+void LifecyclePlugin::SendAppIsPaused() {
+  channel_->Send(kStatePaused);
+}
+
+void LifecyclePlugin::SendAppIsDetached() {
+  channel_->Send(kStateDetached);
+}
+
+}  // namespace flutter

--- a/shell/platform/windows/lifecycle_plugin.h
+++ b/shell/platform/windows/lifecycle_plugin.h
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_LIFECYCLE_PLUGIN_H_
+#define FLUTTER_SHELL_PLATFORM_WINDOWS_LIFECYCLE_PLUGIN_H_
+
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/basic_message_channel.h"
+#include "flutter/shell/platform/common/client_wrapper/include/flutter/binary_messenger.h"
+
+namespace flutter {
+
+// Implements a lifecycle plugin.
+class LifecyclePlugin {
+ public:
+  explicit LifecyclePlugin(flutter::BinaryMessenger* messenger);
+
+  // Send to engine that the app is resumed.
+  void SendAppIsResumed();
+
+  // Send to engine that the app is inactive.
+  void SendAppIsInactive();
+
+  // Send to engine that the app is paused.
+  void SendAppIsPaused();
+
+  // Send to engine that the app is detached.
+  void SendAppIsDetached();
+
+ private:
+  // The MethodChannel used for communication with the Flutter engine.
+  std::unique_ptr<flutter::BasicMessageChannel<std::string>> channel_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_WINDOWS_LIFECYCLE_PLUGIN_H_

--- a/shell/platform/windows/testing/mock_window.h
+++ b/shell/platform/windows/testing/mock_window.h
@@ -59,6 +59,10 @@ class MockWindow : public Window {
   MOCK_METHOD0(GetNativeViewAccessible, gfx::NativeViewAccessible());
   MOCK_METHOD4(OnScroll,
                void(double, double, FlutterPointerDeviceKind, int32_t));
+  MOCK_METHOD0(OnSetFocus, void());
+  MOCK_METHOD0(OnKillFocus, void());
+  MOCK_METHOD0(OnMinimized, void());
+  MOCK_METHOD0(OnRestoredFromMinimized, void());
   MOCK_METHOD0(OnComposeBegin, void());
   MOCK_METHOD0(OnComposeCommit, void());
   MOCK_METHOD0(OnComposeEnd, void());

--- a/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
+++ b/shell/platform/windows/testing/mock_window_binding_handler_delegate.h
@@ -62,6 +62,9 @@ class MockWindowBindingHandlerDelegate : public WindowBindingHandlerDelegate {
                     int32_t));
   MOCK_METHOD0(OnPlatformBrightnessChanged, void());
   MOCK_METHOD1(UpdateHighContrastEnabled, void(bool enabled));
+  MOCK_METHOD0(OnResumed, void());
+  MOCK_METHOD0(OnInactive, void());
+  MOCK_METHOD0(OnPaused, void());
 };
 
 }  // namespace testing

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -321,6 +321,7 @@ Window::HandleMessage(UINT const message,
                       LPARAM const lparam) noexcept {
   LPARAM result_lparam = lparam;
   int xPos = 0, yPos = 0;
+  UINT width = 0, height = 0;
   UINT button_pressed = 0;
   FlutterPointerDeviceKind device_kind;
 
@@ -329,19 +330,14 @@ Window::HandleMessage(UINT const message,
       current_dpi_ = GetDpiForHWND(window_handle_);
       OnDpiScale(current_dpi_);
       return 0;
-    case WM_SIZE: {
-      UINT width = 0, height = 0;
+    case WM_SIZE:
       width = LOWORD(lparam);
       height = HIWORD(lparam);
 
       current_width_ = width;
       current_height_ = height;
-
-      bool minimized = wparam == SIZE_MINIMIZED;
-
-      HandleResize(width, height, minimized);
+      HandleResize(width, height);
       break;
-    }
     case WM_PAINT:
       OnPaint();
       break;
@@ -605,11 +601,12 @@ void Window::Destroy() {
   UnregisterClass(window_class_name_.c_str(), nullptr);
 }
 
-void Window::HandleResize(UINT width, UINT height, bool minimized) {
-  if (current_minimized_ != minimized) {
-    current_minimized_ = minimized;
+void Window::HandleResize(UINT width, UINT height) {
+  bool next_minimized = (width <= 0) && (height <= 0);
+  if (current_minimized_ != next_minimized) {
+    current_minimized_ = next_minimized;
 
-    if (minimized) {
+    if (next_minimized) {
       OnMinimized();
     } else {
       OnRestoredFromMinimized();

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -602,11 +602,11 @@ void Window::Destroy() {
 }
 
 void Window::HandleResize(UINT width, UINT height) {
-  bool next_mimimized = (width <= 0) && (height <= 0);
-  if (current_mimimized != next_mimimized) {
-    current_mimimized = next_mimimized;
+  bool next_minimized = (width <= 0) && (height <= 0);
+  if (current_minimized_ != next_minimized) {
+    current_minimized_ = next_minimized;
 
-    if (next_mimimized) {
+    if (next_minimized) {
       OnMinimized();
     } else {
       OnRestoredFromMinimized();

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -602,6 +602,11 @@ void Window::Destroy() {
 }
 
 void Window::HandleResize(UINT width, UINT height) {
+  // The engine's window doesn't receive SIZE_MINIMIZED and SIZE_RESTORED
+  // because the template's window doesn't transfer the changes of the
+  // visibility on WM_SIZE.
+  // 
+  // Therefore use the window's size to consider the visibility.
   bool next_minimized = (width <= 0) && (height <= 0);
   if (current_minimized_ != next_minimized) {
     current_minimized_ = next_minimized;

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -605,7 +605,7 @@ void Window::HandleResize(UINT width, UINT height) {
   // The engine's window doesn't receive SIZE_MINIMIZED and SIZE_RESTORED
   // because the template's window doesn't transfer the changes of the
   // visibility on WM_SIZE.
-  // 
+  //
   // Therefore use the window's size to consider the visibility.
   bool next_minimized = (width <= 0) && (height <= 0);
   if (current_minimized_ != next_minimized) {

--- a/shell/platform/windows/window.cc
+++ b/shell/platform/windows/window.cc
@@ -408,8 +408,10 @@ Window::HandleMessage(UINT const message,
     }
     case WM_SETFOCUS:
       ::CreateCaret(window_handle_, nullptr, 1, 1);
+      OnSetFocus();
       break;
     case WM_KILLFOCUS:
+      OnKillFocus();
       ::DestroyCaret();
       break;
     case WM_LBUTTONDOWN:
@@ -600,6 +602,17 @@ void Window::Destroy() {
 }
 
 void Window::HandleResize(UINT width, UINT height) {
+  bool next_mimimized = (width <= 0) && (height <= 0);
+  if (current_mimimized != next_mimimized) {
+    current_mimimized = next_mimimized;
+
+    if (next_mimimized) {
+      OnMinimized();
+    } else {
+      OnRestoredFromMinimized();
+    }
+  }
+
   current_width_ = width;
   current_height_ = height;
   if (direct_manipulation_owner_) {

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -198,10 +198,10 @@ class Window : public KeyboardManager::WindowDelegate {
                         FlutterPointerDeviceKind device_kind,
                         int32_t device_id) = 0;
 
-  // Called when window has been received focus.
+  // Called when window has received focus.
   virtual void OnSetFocus() = 0;
 
-  // Called when window has been lost focus.
+  // Called when window has lost focus.
   virtual void OnKillFocus() = 0;
 
   // Called when window has been minimized.

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -198,6 +198,18 @@ class Window : public KeyboardManager::WindowDelegate {
                         FlutterPointerDeviceKind device_kind,
                         int32_t device_id) = 0;
 
+  // Called when window has been received focus.
+  virtual void OnSetFocus() = 0;
+
+  // Called when window has been lost focus.
+  virtual void OnKillFocus() = 0;
+
+  // Called when window has been minimized.
+  virtual void OnMinimized() = 0;
+
+  // Called when window has been restored from minimized.
+  virtual void OnRestoredFromMinimized() = 0;
+
   UINT GetCurrentDPI();
 
   UINT GetCurrentWidth();
@@ -249,6 +261,7 @@ class Window : public KeyboardManager::WindowDelegate {
   int current_dpi_ = 0;
   int current_width_ = 0;
   int current_height_ = 0;
+  int current_mimimized = false;
 
   // Holds the conversion factor from lines scrolled to pixels scrolled.
   float scroll_offset_multiplier_;

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -250,7 +250,7 @@ class Window : public KeyboardManager::WindowDelegate {
   void TrackMouseLeaveEvent(HWND hwnd);
 
   // Stores new width and height and calls |OnResize| to notify inheritors
-  void HandleResize(UINT width, UINT height, bool minimized);
+  void HandleResize(UINT width, UINT height);
 
   // Retrieves a class instance pointer for |window|
   static Window* GetThisFromHandle(HWND const window) noexcept;

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -261,7 +261,7 @@ class Window : public KeyboardManager::WindowDelegate {
   int current_dpi_ = 0;
   int current_width_ = 0;
   int current_height_ = 0;
-  int current_mimimized = false;
+  int current_minimized_ = false;
 
   // Holds the conversion factor from lines scrolled to pixels scrolled.
   float scroll_offset_multiplier_;

--- a/shell/platform/windows/window.h
+++ b/shell/platform/windows/window.h
@@ -250,7 +250,7 @@ class Window : public KeyboardManager::WindowDelegate {
   void TrackMouseLeaveEvent(HWND hwnd);
 
   // Stores new width and height and calls |OnResize| to notify inheritors
-  void HandleResize(UINT width, UINT height);
+  void HandleResize(UINT width, UINT height, bool minimized);
 
   // Retrieves a class instance pointer for |window|
   static Window* GetThisFromHandle(HWND const window) noexcept;

--- a/shell/platform/windows/window_binding_handler_delegate.h
+++ b/shell/platform/windows/window_binding_handler_delegate.h
@@ -126,6 +126,15 @@ class WindowBindingHandlerDelegate {
   // disabled.
   virtual void OnUpdateSemanticsEnabled(bool enabled) = 0;
 
+  // Notifies delegate that backing window is resumed.
+  virtual void OnResumed() = 0;
+
+  // Notifies delegate that backing window is inactive.
+  virtual void OnInactive() = 0;
+
+  // Notifies delegate that backing window is paused.
+  virtual void OnPaused() = 0;
+
   // Returns the root view accessibility node, or nullptr if none.
   virtual gfx::NativeViewAccessible GetNativeViewAccessible() = 0;
 

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -371,7 +371,7 @@ TEST(MockWindow, WindowOnSetAndKillFocus) {
 }
 
 TEST(MockWindow, WindowOnMinimized) {
-  MockWindow window;
+  ::testing::NiceMock<MockWindow> window;
   window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(1, 1));
 
   EXPECT_CALL(window, OnMinimized()).Times(1);
@@ -383,7 +383,7 @@ TEST(MockWindow, WindowOnMinimized) {
 }
 
 TEST(MockWindow, WindowOnRestoredFromMinimized) {
-  MockWindow window;
+  ::testing::NiceMock<MockWindow> window;
   window.InjectWindowMessage(WM_SIZE, SIZE_MINIMIZED, MAKEWPARAM(0, 0));
 
   EXPECT_CALL(window, OnRestoredFromMinimized()).Times(1);

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -389,9 +389,10 @@ TEST(MockWindow, WindowOnRestoredFromMinimized) {
   EXPECT_CALL(window, OnRestoredFromMinimized()).Times(1);
   window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(1, 1));
 
-  // Notify only when type of resizing changes.
+  // Notify only when resizing type changes from minimized.
   EXPECT_CALL(window, OnRestoredFromMinimized()).Times(0);
-  window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(1, 1));
+  window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(2, 2));
+  window.InjectWindowMessage(WM_SIZE, SIZE_MAXIMIZED, MAKEWPARAM(3, 3));
 }
 
 }  // namespace testing

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -360,6 +360,16 @@ TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
 }
 
+TEST(MockWindow, WindowOnSetAndKillFocus) {
+  MockWindow window;
+
+  EXPECT_CALL(window, OnSetFocus()).Times(1);
+  window.InjectWindowMessage(WM_SETFOCUS, 0, 0);
+
+  EXPECT_CALL(window, OnKillFocus()).Times(1);
+  window.InjectWindowMessage(WM_KILLFOCUS, 0, 0);
+}
+
 TEST(MockWindow, WindowOnMinimized) {
   MockWindow window;
   window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(1, 1));

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -360,5 +360,29 @@ TEST(MockWindow, UnknownPointerTypeSkipsDirectManipulation) {
   window.InjectWindowMessage(DM_POINTERHITTEST, MAKEWPARAM(pointer_id, 0), 0);
 }
 
+TEST(MockWindow, WindowOnMinimized) {
+  MockWindow window;
+  window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(1, 1));
+
+  EXPECT_CALL(window, OnMinimized()).Times(1);
+  window.InjectWindowMessage(WM_SIZE, SIZE_MINIMIZED, MAKEWPARAM(0, 0));
+
+  // notify only when window size is different.
+  EXPECT_CALL(window, OnMinimized()).Times(0);
+  window.InjectWindowMessage(WM_SIZE, SIZE_MINIMIZED, MAKEWPARAM(0, 0));
+}
+
+TEST(MockWindow, WindowOnRestoredFromMinimized) {
+  MockWindow window;
+  window.InjectWindowMessage(WM_SIZE, SIZE_MINIMIZED, MAKEWPARAM(0, 0));
+
+  EXPECT_CALL(window, OnRestoredFromMinimized()).Times(1);
+  window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(1, 1));
+
+  // notify only when window size is different.
+  EXPECT_CALL(window, OnRestoredFromMinimized()).Times(0);
+  window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(1, 1));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/windows/window_unittests.cc
+++ b/shell/platform/windows/window_unittests.cc
@@ -367,7 +367,7 @@ TEST(MockWindow, WindowOnMinimized) {
   EXPECT_CALL(window, OnMinimized()).Times(1);
   window.InjectWindowMessage(WM_SIZE, SIZE_MINIMIZED, MAKEWPARAM(0, 0));
 
-  // notify only when window size is different.
+  // Notify only when type of resizing changes.
   EXPECT_CALL(window, OnMinimized()).Times(0);
   window.InjectWindowMessage(WM_SIZE, SIZE_MINIMIZED, MAKEWPARAM(0, 0));
 }
@@ -379,7 +379,7 @@ TEST(MockWindow, WindowOnRestoredFromMinimized) {
   EXPECT_CALL(window, OnRestoredFromMinimized()).Times(1);
   window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(1, 1));
 
-  // notify only when window size is different.
+  // Notify only when type of resizing changes.
   EXPECT_CALL(window, OnRestoredFromMinimized()).Times(0);
   window.InjectWindowMessage(WM_SIZE, SIZE_RESTORED, MAKEWPARAM(1, 1));
 }


### PR DESCRIPTION
This PR adds flutter/lifecycle channel support for win32 ~~and winuwp~~(removed), and enable apps to receive window focused/minimized event.
This PR adds `StringMessageCodec` to `shell/platform/common`.

This PR will support part of flutter/flutter#103637

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.


Example (`main.dart`, modified from `WidgetsBindingObserver` example in docs):
This app displays last event and print it to stdout.
```main.dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'Flutter Demo',
      theme: ThemeData(
        primarySwatch: Colors.blue,
      ),
      home: const AppLifecycleReactor(),
    );
  }
}

class AppLifecycleReactor extends StatefulWidget {
  const AppLifecycleReactor({Key? key}) : super(key: key);

  @override
  State<AppLifecycleReactor> createState() => _AppLifecycleReactorState();
}

class _AppLifecycleReactorState extends State<AppLifecycleReactor>
    with WidgetsBindingObserver {
  @override
  void initState() {
    super.initState();
    WidgetsBinding.instance!.addObserver(this);
  }

  @override
  void dispose() {
    WidgetsBinding.instance!.removeObserver(this);
    super.dispose();
  }

  AppLifecycleState? _notification;

  @override
  void didChangeAppLifecycleState(AppLifecycleState state) {
    print('Last notification: $state\n');
    setState(() {
      _notification = state;
    });
  }

  @override
  Widget build(BuildContext context) {
    return Text('Last notification: $_notification');
  }
}
```