### PR TITLE
Windows: Client wrapper: Support querying the graphics adapter used

### DIFF
--- a/shell/platform/windows/client_wrapper/flutter_view_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_view_unittests.cc
@@ -17,9 +17,8 @@ namespace {
 class TestWindowsApi : public testing::StubFlutterWindowsApi {
   HWND ViewGetHWND() override { return reinterpret_cast<HWND>(7); }
 
-  bool ViewGetGraphicsAdapter(IDXGIAdapter** adapter) override {
-    *adapter = reinterpret_cast<IDXGIAdapter*>(8);
-    return true;
+  IDXGIAdapter* ViewGetGraphicsAdapter() override {
+    return reinterpret_cast<IDXGIAdapter*>(8);
   }
 };
 
@@ -39,8 +38,7 @@ TEST(FlutterViewTest, GraphicsAdapterAccessPassesThrough) {
   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
   FlutterView view(reinterpret_cast<FlutterDesktopViewRef>(2));
 
-  IDXGIAdapter* adapter;
-  EXPECT_TRUE(view.GetGraphicsAdapter(&adapter));
+  IDXGIAdapter* adapter = view.GetGraphicsAdapter();
   EXPECT_EQ(adapter, reinterpret_cast<IDXGIAdapter*>(8));
 }
 

--- a/shell/platform/windows/client_wrapper/flutter_view_unittests.cc
+++ b/shell/platform/windows/client_wrapper/flutter_view_unittests.cc
@@ -16,6 +16,11 @@ namespace {
 // Stub implementation to validate calls to the API.
 class TestWindowsApi : public testing::StubFlutterWindowsApi {
   HWND ViewGetHWND() override { return reinterpret_cast<HWND>(7); }
+
+  bool ViewGetGraphicsAdapter(IDXGIAdapter** adapter) override {
+    *adapter = reinterpret_cast<IDXGIAdapter*>(8);
+    return true;
+  }
 };
 
 }  // namespace
@@ -26,6 +31,17 @@ TEST(FlutterViewTest, HwndAccessPassesThrough) {
   auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
   FlutterView view(reinterpret_cast<FlutterDesktopViewRef>(2));
   EXPECT_EQ(view.GetNativeWindow(), reinterpret_cast<HWND>(7));
+}
+
+TEST(FlutterViewTest, GraphicsAdapterAccessPassesThrough) {
+  testing::ScopedStubFlutterWindowsApi scoped_api_stub(
+      std::make_unique<TestWindowsApi>());
+  auto test_api = static_cast<TestWindowsApi*>(scoped_api_stub.stub());
+  FlutterView view(reinterpret_cast<FlutterDesktopViewRef>(2));
+
+  IDXGIAdapter* adapter;
+  EXPECT_TRUE(view.GetGraphicsAdapter(&adapter));
+  EXPECT_EQ(adapter, reinterpret_cast<IDXGIAdapter*>(8));
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
@@ -23,6 +23,14 @@ class FlutterView {
   // Returns the backing HWND for the view.
   HWND GetNativeWindow() { return FlutterDesktopViewGetHWND(view_); }
 
+  // Attempts to return the underlying DXGI adapter used for rendering.
+  //
+  // Returns true on success or false if the adapter could not be determined
+  // (e.g. when using software rendering).
+  bool GetGraphicsAdapter(IDXGIAdapter** adapter) {
+    return FlutterDesktopViewGetGraphicsAdapter(view_, adapter);
+  }
+
  private:
   // Handle for interacting with the C API's view.
   FlutterDesktopViewRef view_ = nullptr;

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view.h
@@ -23,12 +23,9 @@ class FlutterView {
   // Returns the backing HWND for the view.
   HWND GetNativeWindow() { return FlutterDesktopViewGetHWND(view_); }
 
-  // Attempts to return the underlying DXGI adapter used for rendering.
-  //
-  // Returns true on success or false if the adapter could not be determined
-  // (e.g. when using software rendering).
-  bool GetGraphicsAdapter(IDXGIAdapter** adapter) {
-    return FlutterDesktopViewGetGraphicsAdapter(view_, adapter);
+  // Returns the DXGI adapter used for rendering or nullptr in case of error.
+  IDXGIAdapter* GetGraphicsAdapter() {
+    return FlutterDesktopViewGetGraphicsAdapter(view_);
   }
 
  private:

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -151,6 +151,15 @@ HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef controller) {
   return reinterpret_cast<HWND>(-1);
 }
 
+bool FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef view,
+                                          IDXGIAdapter** adapter) {
+  if (s_stub_implementation) {
+    return s_stub_implementation->ViewGetGraphicsAdapter(adapter);
+  }
+  *adapter = nullptr;
+  return false;
+}
+
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(
     FlutterDesktopPluginRegistrarRef controller) {
   // The stub ignores this, so just return an arbitrary non-zero value.

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.cc
@@ -151,13 +151,11 @@ HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef controller) {
   return reinterpret_cast<HWND>(-1);
 }
 
-bool FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef view,
-                                          IDXGIAdapter** adapter) {
+IDXGIAdapter* FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef view) {
   if (s_stub_implementation) {
-    return s_stub_implementation->ViewGetGraphicsAdapter(adapter);
+    return s_stub_implementation->ViewGetGraphicsAdapter();
   }
-  *adapter = nullptr;
-  return false;
+  return nullptr;
 }
 
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
@@ -73,9 +73,8 @@ class StubFlutterWindowsApi {
   virtual HWND ViewGetHWND() { return reinterpret_cast<HWND>(1); }
 
   // Called for FlutterDesktopViewGetGraphicsAdapter.
-  virtual bool ViewGetGraphicsAdapter(IDXGIAdapter** adapter) {
-    *adapter = reinterpret_cast<IDXGIAdapter*>(2);
-    return true;
+  virtual IDXGIAdapter* ViewGetGraphicsAdapter() {
+    return reinterpret_cast<IDXGIAdapter*>(2);
   }
 
   // Called for FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate.

--- a/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
+++ b/shell/platform/windows/client_wrapper/testing/stub_flutter_windows_api.h
@@ -72,6 +72,12 @@ class StubFlutterWindowsApi {
   // Called for FlutterDesktopViewGetHWND.
   virtual HWND ViewGetHWND() { return reinterpret_cast<HWND>(1); }
 
+  // Called for FlutterDesktopViewGetGraphicsAdapter.
+  virtual bool ViewGetGraphicsAdapter(IDXGIAdapter** adapter) {
+    *adapter = reinterpret_cast<IDXGIAdapter*>(2);
+    return true;
+  }
+
   // Called for FlutterDesktopPluginRegistrarRegisterTopLevelWindowProcDelegate.
   virtual void PluginRegistrarRegisterTopLevelWindowProcDelegate(
       FlutterDesktopWindowProcCallback delegate,

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -188,18 +188,20 @@ HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef view) {
   return ViewFromHandle(view)->GetPlatformWindow();
 }
 
-bool FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef view,
-                                          IDXGIAdapter** adapter) {
+IDXGIAdapter* FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef view) {
   auto surface_manager = ViewFromHandle(view)->GetEngine()->surface_manager();
   if (surface_manager) {
     Microsoft::WRL::ComPtr<ID3D11Device> d3d_device;
     Microsoft::WRL::ComPtr<IDXGIDevice> dxgi_device;
     if (surface_manager->GetDevice(d3d_device.GetAddressOf()) &&
         SUCCEEDED(d3d_device.As(&dxgi_device))) {
-      return SUCCEEDED(dxgi_device->GetAdapter(adapter));
+      IDXGIAdapter* adapter;
+      if (SUCCEEDED(dxgi_device->GetAdapter(&adapter))) {
+        return adapter;
+      }
     }
   }
-  return false;
+  return nullptr;
 }
 
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(

--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -188,6 +188,20 @@ HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef view) {
   return ViewFromHandle(view)->GetPlatformWindow();
 }
 
+bool FlutterDesktopViewGetGraphicsAdapter(FlutterDesktopViewRef view,
+                                          IDXGIAdapter** adapter) {
+  auto surface_manager = ViewFromHandle(view)->GetEngine()->surface_manager();
+  if (surface_manager) {
+    Microsoft::WRL::ComPtr<ID3D11Device> d3d_device;
+    Microsoft::WRL::ComPtr<IDXGIDevice> dxgi_device;
+    if (surface_manager->GetDevice(d3d_device.GetAddressOf()) &&
+        SUCCEEDED(d3d_device.As(&dxgi_device))) {
+      return SUCCEEDED(dxgi_device->GetAdapter(adapter));
+    }
+  }
+  return false;
+}
+
 FlutterDesktopViewRef FlutterDesktopPluginRegistrarGetView(
     FlutterDesktopPluginRegistrarRef registrar) {
   return HandleForView(registrar->engine->view());

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/shell/platform/windows/public/flutter_windows.h"
 
+#include <dxgi.h>
+#include <wrl/client.h>
 #include <thread>
 
 #include "flutter/fml/synchronization/count_down_latch.h"
@@ -251,6 +253,21 @@ TEST_F(WindowsTest, NextFrameCallback) {
   });
 
   captures.frame_drawn_latch.Wait();
+}
+
+TEST_F(WindowsTest, GetGraphicsAdapter) {
+  auto& context = GetContext();
+  WindowsConfigBuilder builder(context);
+  ViewControllerPtr controller{builder.Run()};
+  ASSERT_NE(controller, nullptr);
+  auto view = FlutterDesktopViewControllerGetView(controller.get());
+
+  Microsoft::WRL::ComPtr<IDXGIAdapter> dxgi_adapter;
+  ASSERT_TRUE(
+      FlutterDesktopViewGetGraphicsAdapter(view, dxgi_adapter.GetAddressOf()));
+  ASSERT_NE(dxgi_adapter.Get(), nullptr);
+  DXGI_ADAPTER_DESC desc{};
+  ASSERT_TRUE(SUCCEEDED(dxgi_adapter->GetDesc(&desc)));
 }
 
 }  // namespace testing

--- a/shell/platform/windows/flutter_windows_unittests.cc
+++ b/shell/platform/windows/flutter_windows_unittests.cc
@@ -263,9 +263,8 @@ TEST_F(WindowsTest, GetGraphicsAdapter) {
   auto view = FlutterDesktopViewControllerGetView(controller.get());
 
   Microsoft::WRL::ComPtr<IDXGIAdapter> dxgi_adapter;
-  ASSERT_TRUE(
-      FlutterDesktopViewGetGraphicsAdapter(view, dxgi_adapter.GetAddressOf()));
-  ASSERT_NE(dxgi_adapter.Get(), nullptr);
+  dxgi_adapter = FlutterDesktopViewGetGraphicsAdapter(view);
+  ASSERT_NE(dxgi_adapter, nullptr);
   DXGI_ADAPTER_DESC desc{};
   ASSERT_TRUE(SUCCEEDED(dxgi_adapter->GetDesc(&desc)));
 }

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_WINDOWS_PUBLIC_FLUTTER_H_
 #define FLUTTER_SHELL_PLATFORM_WINDOWS_PUBLIC_FLUTTER_H_
 
+#include <dxgi.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <windows.h>
@@ -200,6 +201,11 @@ FLUTTER_EXPORT void FlutterDesktopEngineSetNextFrameCallback(
 
 // Return backing HWND for manipulation in host application.
 FLUTTER_EXPORT HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef view);
+
+// Attempts to return the DXGI adapter used for rendering.
+FLUTTER_EXPORT bool FlutterDesktopViewGetGraphicsAdapter(
+    FlutterDesktopViewRef view,
+    IDXGIAdapter** adapter);
 
 // ========== Plugin Registrar (extensions) ==========
 // These are Windows-specific extensions to flutter_plugin_registrar.h

--- a/shell/platform/windows/public/flutter_windows.h
+++ b/shell/platform/windows/public/flutter_windows.h
@@ -202,10 +202,9 @@ FLUTTER_EXPORT void FlutterDesktopEngineSetNextFrameCallback(
 // Return backing HWND for manipulation in host application.
 FLUTTER_EXPORT HWND FlutterDesktopViewGetHWND(FlutterDesktopViewRef view);
 
-// Attempts to return the DXGI adapter used for rendering.
-FLUTTER_EXPORT bool FlutterDesktopViewGetGraphicsAdapter(
-    FlutterDesktopViewRef view,
-    IDXGIAdapter** adapter);
+// Returns the DXGI adapter used for rendering or nullptr in case of error.
+FLUTTER_EXPORT IDXGIAdapter* FlutterDesktopViewGetGraphicsAdapter(
+    FlutterDesktopViewRef view);
 
 // ========== Plugin Registrar (extensions) ==========
 // These are Windows-specific extensions to flutter_plugin_registrar.h


### PR DESCRIPTION
This PR adds a method to the Windows client wrapper which allows plugins to query the `IDXGIAdapter` chosen by ANGLE.

**Background**
https://github.com/flutter/engine/pull/26840 introduces a new texture variant for sharing Direct3D textures with Flutter. However, the corresponding D3D device needs to be created using the same adapter as the D3D device used by ANGLE.

The `IDXGIAdapter` returned by `FlutterView::GetGraphicsAdapter` can be passed to `D3D11CreateDevice(the_adapter, D3D_DRIVER_TYPE_UNKNOWN, ....)`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
