### PR TITLE
UWP: Add mouse leave handling

### DIFF
--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -234,9 +234,9 @@ void FlutterWindowWinUWP::OnPointerExited(
     winrt::Windows::Foundation::IInspectable const&,
     winrt::Windows::UI::Core::PointerEventArgs const& args) {
   FlutterPointerDeviceKind device_kind = GetPointerDeviceKind(args);
+  auto pointer_id = GetPointerId(args);
 
-  binding_handler_delegate_->OnPointerLeave(device_kind,
-                                            kDefaultPointerDeviceId);
+  binding_handler_delegate_->OnPointerLeave(device_kind, pointer_id);
 }
 
 void FlutterWindowWinUWP::OnPointerMoved(

--- a/shell/platform/windows/flutter_window_winuwp.cc
+++ b/shell/platform/windows/flutter_window_winuwp.cc
@@ -158,15 +158,13 @@ void FlutterWindowWinUWP::SetEventHandlers() {
 
   window_.PointerPressed({this, &FlutterWindowWinUWP::OnPointerPressed});
   window_.PointerReleased({this, &FlutterWindowWinUWP::OnPointerReleased});
+  window_.PointerExited({this, &FlutterWindowWinUWP::OnPointerExited});
   window_.PointerMoved({this, &FlutterWindowWinUWP::OnPointerMoved});
   window_.PointerWheelChanged(
       {this, &FlutterWindowWinUWP::OnPointerWheelChanged});
 
   ui_settings_.ColorValuesChanged(
       {this, &FlutterWindowWinUWP::OnColorValuesChanged});
-
-  // TODO(clarkezone) support mouse leave handling
-  // https://github.com/flutter/flutter/issues/70199
 
   // TODO(clarkezone) support system font changed
   // https://github.com/flutter/flutter/issues/70198
@@ -230,6 +228,15 @@ void FlutterWindowWinUWP::OnPointerReleased(
   binding_handler_delegate_->OnPointerUp(x, y, device_kind, pointer_id,
                                          mouse_button);
   ReleasePointer(args);
+}
+
+void FlutterWindowWinUWP::OnPointerExited(
+    winrt::Windows::Foundation::IInspectable const&,
+    winrt::Windows::UI::Core::PointerEventArgs const& args) {
+  FlutterPointerDeviceKind device_kind = GetPointerDeviceKind(args);
+
+  binding_handler_delegate_->OnPointerLeave(device_kind,
+                                            kDefaultPointerDeviceId);
 }
 
 void FlutterWindowWinUWP::OnPointerMoved(

--- a/shell/platform/windows/flutter_window_winuwp.h
+++ b/shell/platform/windows/flutter_window_winuwp.h
@@ -95,7 +95,8 @@ class FlutterWindowWinUWP : public WindowBindingHandler {
       winrt::Windows::UI::ViewManagement::ApplicationView const& appView,
       winrt::Windows::Foundation::IInspectable const&);
 
-  // Notifies current |WindowBindingHandlerDelegate| of pointer left events.
+  // Notifies current |WindowBindingHandlerDelegate| of pointer went out of
+  // window events.
   void OnPointerExited(winrt::Windows::Foundation::IInspectable const&,
                        winrt::Windows::UI::Core::PointerEventArgs const& args);
 

--- a/shell/platform/windows/flutter_window_winuwp.h
+++ b/shell/platform/windows/flutter_window_winuwp.h
@@ -95,6 +95,10 @@ class FlutterWindowWinUWP : public WindowBindingHandler {
       winrt::Windows::UI::ViewManagement::ApplicationView const& appView,
       winrt::Windows::Foundation::IInspectable const&);
 
+  // Notifies current |WindowBindingHandlerDelegate| of pointer left events.
+  void OnPointerExited(winrt::Windows::Foundation::IInspectable const&,
+                       winrt::Windows::UI::Core::PointerEventArgs const& args);
+
   // Notifies current |WindowBindingHandlerDelegate| of pointer moved events.
   void OnPointerMoved(winrt::Windows::Foundation::IInspectable const&,
                       winrt::Windows::UI::Core::PointerEventArgs const& args);


### PR DESCRIPTION
This PR adds mouse leave handling for winuwp.
Example in MouseRegion docs will be able to count cursor exiting when mouse cursor went another window above blue rect.

This PR will close flutter/flutter#70199 with #28098 and #28100.

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.