### PR TITLE
Fix undefined symbol in firebase_testlab.py

### DIFF
--- a/ci/firebase_testlab.py
+++ b/ci/firebase_testlab.py
@@ -98,8 +98,8 @@ def main():
       print(line.strip())
     return_code = process.wait()
     if return_code != 0:
-      print('Firebase test failed ' + returncode)
-      sys.exit(process.returncode)
+      print('Firebase test failed with code: %s' % return_code)
+      sys.exit(return_code)
 
     print('Checking logcat for %s' % results_dir)
     CheckLogcat(results_dir)


### PR DESCRIPTION
Fix

```
Traceback (most recent call last):
  File "./flutter/ci/firebase_testlab.py", line 115, in <module>
    sys.exit(main())
  File "./flutter/ci/firebase_testlab.py", line 101, in main
    print('Firebase test failed ' + returncode)
NameError: global name 'returncode' is not defined
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
