### PR TITLE
[fuchsia] Remove unused SettingsManager protocol

### DIFF
--- a/shell/platform/fuchsia/flutter/meta/common.shard.cml
+++ b/shell/platform/fuchsia/flutter/meta/common.shard.cml
@@ -31,7 +31,6 @@
         },
         {
             protocol: [
-                "fuchsia.accessibility.SettingsManager",
                 "fuchsia.accessibility.semantics.SemanticsManager",
                 "fuchsia.deprecatedtimezone.Timezone",
                 "fuchsia.device.NameProvider",


### PR DESCRIPTION
This protocol no longer exists: https://cs.opensource.google/fuchsia/fuchsia/+/main:sdk/fidl/fuchsia.accessibility/