### PR TITLE
[android] Use existing FlutterJNI in FlutterInjector by default

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -78,7 +78,7 @@ import java.util.Set;
 public class FlutterEngine {
   private static final String TAG = "FlutterEngine";
 
-  @NonNull @VisibleForTesting /*package*/ final FlutterJNI flutterJNI;
+  @NonNull private final FlutterJNI flutterJNI;
   @NonNull private final FlutterRenderer renderer;
   @NonNull private final DartExecutor dartExecutor;
   @NonNull private final FlutterEngineConnectionRegistry pluginRegistry;
@@ -595,6 +595,12 @@ public class FlutterEngine {
   @NonNull
   public ContentProviderControlSurface getContentProviderControlSurface() {
     return pluginRegistry;
+  }
+
+  /** Returns the {@link io.flutter.embedding.engine.FlutterJNI} instance. */
+  @VisibleForTesting
+  public FlutterJNI getFlutterJNI() {
+    return flutterJNI;
   }
 
   /** Lifecycle callbacks for Flutter engine lifecycle events. */

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -9,6 +9,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.AssetManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
@@ -77,7 +78,7 @@ import java.util.Set;
 public class FlutterEngine {
   private static final String TAG = "FlutterEngine";
 
-  @NonNull private final FlutterJNI flutterJNI;
+  @NonNull @VisibleForTesting /*package*/ final FlutterJNI flutterJNI;
   @NonNull private final FlutterRenderer renderer;
   @NonNull private final DartExecutor dartExecutor;
   @NonNull private final FlutterEngineConnectionRegistry pluginRegistry;
@@ -288,7 +289,7 @@ public class FlutterEngine {
     FlutterInjector injector = FlutterInjector.instance();
 
     if (flutterJNI == null) {
-      flutterJNI = injector.getFlutterJNIFactory().provideFlutterJNI();
+      flutterJNI = injector.flutterLoader().getFlutterJNI();
     }
     this.flutterJNI = flutterJNI;
 

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -108,6 +108,12 @@ public class FlutterLoader {
 
   @Nullable Future<InitResult> initResultFuture;
 
+  /** Returns the {@link io.flutter.embedding.engine.FlutterJNI} */
+  @NonNull
+  public FlutterJNI getFlutterJNI() {
+    return flutterJNI;
+  }
+
   /**
    * Starts initialization of the native system.
    *

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -306,18 +306,27 @@ public class FlutterEngineTest {
 
   @Test
   public void itShouldUsesFlutterJNIInFlutterInjectorByDefault() throws NameNotFoundException {
-    Context context = mock(Context.class);
-    Context packageContext = mock(Context.class);
-    when(context.createPackageContext(any(), anyInt())).thenReturn(packageContext);
+    FlutterInjector.reset();
+    FlutterLoader mockFlutterLoader = mock(FlutterLoader.class);
+    when(mockFlutterLoader.getFlutterJNI()).thenReturn(flutterJNI);
+    FlutterInjector.setInstance(
+        new FlutterInjector.Builder().setFlutterLoader(mockFlutterLoader).build());
+    assertEquals(FlutterInjector.instance().flutterLoader(), mockFlutterLoader);
+    assertEquals(mockFlutterLoader.getFlutterJNI(), flutterJNI);
+    assertEquals(FlutterInjector.instance().flutterLoader().getFlutterJNI(), flutterJNI);
 
-    FlutterInjector injector = FlutterInjector.instance();
+    Context mockContext = mock(Context.class);
+    Context packageContext = mock(Context.class);
+    when(mockContext.createPackageContext(any(), anyInt())).thenReturn(packageContext);
+    when(flutterJNI.isAttached()).thenReturn(true);
+
     FlutterEngine engineUnderTest =
         new FlutterEngine(
-            context,
-            /*flutterLoader=*/ null,
-            /*flutterJNI=*/ null,
+            mockContext,
+            /* flutterLoader */ null,
+            /* flutterJNI */ flutterJNI,
             /*dartVmArgs=*/ new String[] {},
             /*automaticallyRegisterPlugins=*/ false);
-    assertEquals(engineUnderTest.getFlutterJNI(), injector.flutterLoader().getFlutterJNI());
+    assertEquals(engineUnderTest.getFlutterJNI(), flutterJNI);
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -303,4 +303,21 @@ public class FlutterEngineTest {
 
     assertTrue(engineUnderTest.getDartExecutor().isExecutingDart());
   }
+
+  @Test
+  public void itShouldUsesFlutterJNIInFlutterInjectorByDefault() throws NameNotFoundException {
+    Context context = mock(Context.class);
+    Context packageContext = mock(Context.class);
+    when(context.createPackageContext(any(), anyInt())).thenReturn(packageContext);
+
+    FlutterInjector injector = FlutterInjector.instance();
+    FlutterEngine engineUnderTest =
+        new FlutterEngine(
+            context,
+            /*flutterLoader=*/ null,
+            /*flutterJNI=*/ null,
+            /*dartVmArgs=*/ new String[] {},
+            /*automaticallyRegisterPlugins=*/ false);
+    assertEquals(engineUnderTest.flutterJNI, injector.flutterLoader().getFlutterJNI());
+  }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -320,13 +320,16 @@ public class FlutterEngineTest {
     when(mockContext.createPackageContext(any(), anyInt())).thenReturn(packageContext);
     when(flutterJNI.isAttached()).thenReturn(true);
 
+    // If the user does not provide FlutterJNI, we should use the existing one in FlutterInjector
+    // instead of creating new instances.
     FlutterEngine engineUnderTest =
         new FlutterEngine(
             mockContext,
             /* flutterLoader */ null,
-            /* flutterJNI */ flutterJNI,
+            /* flutterJNI */ null,
             /*dartVmArgs=*/ new String[] {},
             /*automaticallyRegisterPlugins=*/ false);
+
     assertEquals(engineUnderTest.getFlutterJNI(), flutterJNI);
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -318,6 +318,6 @@ public class FlutterEngineTest {
             /*flutterJNI=*/ null,
             /*dartVmArgs=*/ new String[] {},
             /*automaticallyRegisterPlugins=*/ false);
-    assertEquals(engineUnderTest.flutterJNI, injector.flutterLoader().getFlutterJNI());
+    assertEquals(engineUnderTest.getFlutterJNI(), injector.flutterLoader().getFlutterJNI());
   }
 }


### PR DESCRIPTION
Fixes flutter/flutter#92479

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/master/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
