### PR TITLE
[iOS] Make sure spawnee's isGpuDisabled is set correctly when FlutterEngine spawn

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -1041,6 +1041,7 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
   result->_threadHost = _threadHost;
   result->_profiler = _profiler;
   result->_profiler_metrics = _profiler_metrics;
+  result->_isGpuDisabled = _isGpuDisabled;
   [result setupShell:std::move(shell) withObservatoryPublication:NO];
   return result;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineGroupTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineGroupTest.mm
@@ -24,10 +24,12 @@ FLUTTER_ASSERT_ARC
 - (void)testSpawn {
   FlutterEngineGroup* group = [[FlutterEngineGroup alloc] initWithName:@"foo" project:nil];
   FlutterEngine* spawner = [group makeEngineWithEntrypoint:nil libraryURI:nil];
+  spawner.isGpuDisabled = YES;
   FlutterEngine* spawnee = [group makeEngineWithEntrypoint:nil libraryURI:nil];
   XCTAssertNotNil(spawner);
   XCTAssertNotNil(spawnee);
   XCTAssertEqual(&spawner.threadHost, &spawnee.threadHost);
+  XCTAssertEqual(spawner.isGpuDisabled, spawnee.isGpuDisabled);
 }
 
 - (void)testDeleteLastEngine {


### PR DESCRIPTION
make sure spawnee's isGpuDisabled is set correctly when FlutterEngine spawn

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
