### PR TITLE
Prepare scripts for the master to main migration.

### DIFF
--- a/ci/bin/format.dart
+++ b/ci/bin/format.dart
@@ -804,7 +804,7 @@ Future<String> _getDiffBaseRevision(ProcessManager processManager, Directory rep
   if (upstreamUrl.isEmpty) {
     upstream = 'origin';
   }
-  await _runGit(<String>['fetch', upstream, 'master'], processRunner);
+  await _runGit(<String>['fetch', upstream, 'main'], processRunner);
   String result = '';
   try {
     // This is the preferred command to use, but developer checkouts often do

--- a/tools/clang_tidy/lib/src/git_repo.dart
+++ b/tools/clang_tidy/lib/src/git_repo.dart
@@ -18,7 +18,7 @@ class GitRepo {
   List<io.File>? _changedFiles;
 
   /// Returns a list of all non-deleted files which differ from the nearest
-  /// merge-base with `master`. If it can't find a fork point, uses the default
+  /// merge-base with `main`. If it can't find a fork point, uses the default
   /// merge-base.
   ///
   /// This is only computed once and cached. Subsequent invocations of the
@@ -31,7 +31,7 @@ class GitRepo {
       defaultWorkingDirectory: root,
     );
     final ProcessRunnerResult fetchResult = await processRunner.runProcess(
-      <String>['git', 'fetch', 'upstream', 'master'],
+      <String>['git', 'fetch', 'upstream', 'main'],
       failOk: true,
     );
     if (fetchResult.exitCode != 0) {
@@ -39,7 +39,7 @@ class GitRepo {
         'git',
         'fetch',
         'origin',
-        'master',
+        'main',
       ]);
     }
     final Set<String> result = <String>{};

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -46,7 +46,7 @@ jazzy \
   --author Flutter Team\
   --author_url 'https://flutter.io'\
   --github_url 'https://github.com/flutter'\
-  --github-file-prefix 'http://github.com/flutter/engine/blob/master'\
+  --github-file-prefix 'http://github.com/flutter/engine/blob/main'\
   --module-version 1.0.0\
   --xcodebuild-arguments --objc,"$FLUTTER_UMBRELLA_HEADER",--,-x,objective-c,-isysroot,"$(xcrun --show-sdk-path --sdk iphonesimulator)",-I,"$(pwd)"\
   --module Flutter\


### PR DESCRIPTION
It changes master branch with main to prepare for the migration.
This change will be landed in synchronization with changes to modify
 the engine default branch to main.

Bug: https://github.com/flutter/flutter/issues/90476

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
