### PR TITLE
Disallow pasting non-text into FlutterTextInputPlugin

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -900,6 +900,15 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   return _textInputClient != 0;
 }
 
+- (BOOL)canPerformAction:(SEL)action withSender:(nullable id)sender {
+  if (action == @selector(paste:)) {
+    // Forbid pasting images, memojis, or other non-string content.
+    return [UIPasteboard generalPasteboard].string != nil;
+  }
+
+  return [super canPerformAction:action withSender:sender];
+}
+
 #pragma mark - UIResponderStandardEditActions Overrides
 
 - (void)cut:(id)sender {
@@ -912,7 +921,10 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
 }
 
 - (void)paste:(id)sender {
-  [self insertText:[UIPasteboard generalPasteboard].string];
+  NSString* pasteboardString = [UIPasteboard generalPasteboard].string;
+  if (pasteboardString != nil) {
+    [self insertText:pasteboardString];
+  }
 }
 
 - (void)delete:(id)sender {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm
@@ -86,6 +86,9 @@ FLUTTER_ASSERT_ARC
   textInputPlugin.textInputDelegate = engine;
   viewController = [FlutterViewController new];
   textInputPlugin.viewController = viewController;
+
+  // Clear pasteboard between tests.
+  UIPasteboard.generalPasteboard.items = @[];
 }
 
 - (void)tearDown {
@@ -268,6 +271,7 @@ FLUTTER_ASSERT_ARC
   [inputView selectAll:nil];
   [inputView cut:nil];
   [inputView insertText:@"bbbb"];
+  XCTAssertTrue([inputView canPerformAction:@selector(paste:) withSender:nil]);
   [inputView paste:nil];
   [inputView selectAll:nil];
   [inputView copy:nil];
@@ -280,6 +284,20 @@ FLUTTER_ASSERT_ARC
   UITextRange* range = [FlutterTextRange rangeWithNSRange:NSMakeRange(0, 30)];
   NSString* substring = [inputView textInRange:range];
   XCTAssertEqualObjects(substring, @"bbbbaaaabbbbaaaa");
+}
+
+- (void)testPastingNonTextDisallowed {
+  NSDictionary* config = self.mutableTemplateCopy;
+  [self setClientId:123 configuration:config];
+  NSArray<FlutterTextInputView*>* inputFields = self.installedInputViews;
+  FlutterTextInputView* inputView = inputFields[0];
+
+  UIPasteboard.generalPasteboard.color = UIColor.redColor;
+  XCTAssertNil(UIPasteboard.generalPasteboard.string);
+  XCTAssertFalse([inputView canPerformAction:@selector(paste:) withSender:nil]);
+  [inputView paste:nil];
+
+  XCTAssertEqualObjects(inputView.text, @"");
 }
 
 - (void)testNoZombies {


### PR DESCRIPTION
When memojis are inserted, under the covers it is pasting (although `UIPasteboard.generalPasteboard.image` is nil in this case, it's doing something magic with memojis). There is no `string` in the pasteboard.

Return `NO` for `canPerformAction:@selector(paste:)` when there is no `string`.  That seems to prevent the memoji from showing up in the keyboard at all.  Also check there is a string when the paste directly happens.

Add a `testPastingNonTextDisallowed` test that fails  and reproduces the original reported crash without the code change:
```
/../../flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPluginTest.mm:298: error: -[FlutterTextInputPluginTest testPastingNonTextDisallowed] : (([inputView canPerformAction:@selector(paste:) withSender:nil]) is false) failed
<unknown>:0: error: -[FlutterTextInputPluginTest testPastingNonTextDisallowed] : -[__NSCFString replaceCharactersInRange:withString:]: nil argument (NSInvalidArgumentException)
Test Case '-[FlutterTextInputPluginTest testPastingNonTextDisallowed]' failed (0.303 seconds).
```

Fixes https://github.com/flutter/flutter/issues/92623

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
