### PR TITLE
Add check for empty compose string

### DIFF
--- a/shell/platform/windows/text_input_manager_win32.cc
+++ b/shell/platform/windows/text_input_manager_win32.cc
@@ -157,7 +157,7 @@ std::optional<std::u16string> TextInputManagerWin32::GetString(int type) const {
     const long compose_bytes =
         ::ImmGetCompositionString(imm_context.get(), type, nullptr, 0);
     const long compose_length = compose_bytes / sizeof(wchar_t);
-    if (compose_length <= 0) {
+    if (compose_length < 0) {
       return std::nullopt;
     }
 


### PR DESCRIPTION
## Description

Fixes the problem where deleting a composing string leaves the last character of the composing string in the text field.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/92132

## Tests
 - None currently, since I'm not sure how to write an IME test. (still draft because of this).