### PR TITLE
[fuchsia] Add more logging for error cases.

### DIFF
--- a/shell/platform/fuchsia/flutter/component_v1.cc
+++ b/shell/platform/fuchsia/flutter/component_v1.cc
@@ -484,6 +484,11 @@ void ComponentV1::OnEngineTerminate(const Engine* shell_holder) {
                             });
 
   if (found == shell_holders_.end()) {
+    // This indicates a deeper issue with memory management and should never
+    // happen.
+    FML_LOG(ERROR) << "Tried to terminate an unregistered shell holder.";
+    FML_DCHECK(false);
+
     return;
   }
 
@@ -493,11 +498,15 @@ void ComponentV1::OnEngineTerminate(const Engine* shell_holder) {
   auto return_code = shell_holder->GetEngineReturnCode();
   if (return_code.has_value()) {
     last_return_code_ = {true, return_code.value()};
+  } else {
+    FML_LOG(ERROR) << "Failed to get return code from terminated shell holder.";
   }
 
   shell_holders_.erase(found);
 
   if (shell_holders_.size() == 0) {
+    FML_VLOG(-1) << "Killing component because all shell holders have been "
+                    "terminated.";
     Kill();
     // WARNING: Don't do anything past this point because the delegate may have
     // collected this instance via the termination callback.

--- a/shell/platform/fuchsia/flutter/component_v2.cc
+++ b/shell/platform/fuchsia/flutter/component_v2.cc
@@ -526,6 +526,11 @@ void ComponentV2::OnEngineTerminate(const Engine* shell_holder) {
                             });
 
   if (found == shell_holders_.end()) {
+    // This indicates a deeper issue with memory management and should never
+    // happen.
+    FML_LOG(ERROR) << "Tried to terminate an unregistered shell holder.";
+    FML_DCHECK(false);
+
     return;
   }
 
@@ -535,11 +540,15 @@ void ComponentV2::OnEngineTerminate(const Engine* shell_holder) {
   auto return_code = shell_holder->GetEngineReturnCode();
   if (return_code.has_value()) {
     last_return_code_ = {true, return_code.value()};
+  } else {
+    FML_LOG(ERROR) << "Failed to get return code from terminated shell holder.";
   }
 
   shell_holders_.erase(found);
 
   if (shell_holders_.size() == 0) {
+    FML_VLOG(-1) << "Killing component because all shell holders have been "
+                    "terminated.";
     Kill();
     // WARNING: Don't do anything past this point because the delegate may have
     // collected this instance via the termination callback.

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -221,6 +221,7 @@ void Engine::Initialize(
                                          weak = weak_factory_.GetWeakPtr()]() {
     task_runner->PostTask([weak]() {
       if (weak) {
+        FML_LOG(ERROR) << "Terminating from session_error_callback";
         weak->Terminate();
       }
     });
@@ -339,6 +340,8 @@ void Engine::Initialize(
        weak = weak_factory_.GetWeakPtr()]() {
         task_runner->PostTask([weak]() {
           if (weak) {
+            FML_LOG(ERROR) << "Terminating from "
+                              "on_session_listener_error_callback";
             weak->Terminate();
           }
         });
@@ -615,6 +618,7 @@ void Engine::Initialize(
     // The engine could have been killed by the caller right after the
     // constructor was called but before it could run on the UI thread.
     if (weak) {
+      FML_LOG(ERROR) << "Terminating from on_run_failure";
       weak->Terminate();
     }
   };

--- a/shell/platform/fuchsia/flutter/gfx_session_connection.cc
+++ b/shell/platform/fuchsia/flutter/gfx_session_connection.cc
@@ -4,12 +4,11 @@
 
 #include "gfx_session_connection.h"
 
+#include <lib/async/cpp/task.h>
 #include <lib/async/cpp/time.h>
 #include <lib/async/default.h>
-
-#include <lib/async/cpp/task.h>
-#include <lib/async/default.h>
 #include <lib/fit/function.h>
+#include <zircon/status.h>
 
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/time/time_point.h"
@@ -222,8 +221,11 @@ GfxSessionConnection::GfxSessionConnection(
 
   next_presentation_info_.set_presentation_time(0);
 
-  session_wrapper_.set_error_handler(
-      [callback = session_error_callback](zx_status_t status) { callback(); });
+  session_wrapper_.set_error_handler([callback = session_error_callback](
+                                         zx_status_t status) {
+    FML_LOG(ERROR) << "scenic::Session error: " << zx_status_get_string(status);
+    callback();
+  });
 
   // Set the |fuchsia::ui::scenic::OnFramePresented()| event handler that will
   // fire every time a set of one or more frames is presented.


### PR DESCRIPTION
To give us more detailed information about what's going on when components terminate.

I think these cases are safe from doing log spam because they're only error cases.