### PR TITLE
Embedder VsyncWaiter must schedule a frame for the right time

### DIFF
--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -229,8 +229,8 @@ bool EmbedderEngine::OnVsyncEvent(intptr_t baton,
     return false;
   }
 
-  return VsyncWaiterEmbedder::OnEmbedderVsync(baton, frame_start_time,
-                                              frame_target_time);
+  return VsyncWaiterEmbedder::OnEmbedderVsync(
+      task_runners_, baton, frame_start_time, frame_target_time);
 }
 
 bool EmbedderEngine::ReloadSystemFonts() {

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -261,6 +261,13 @@ void EmbedderConfigBuilder::SetPlatformTaskRunner(
   project_args_.custom_task_runners = &custom_task_runners_;
 }
 
+void EmbedderConfigBuilder::SetupVsyncCallback() {
+  project_args_.vsync_callback = [](void* user_data, intptr_t baton) {
+    auto context = reinterpret_cast<EmbedderTestContext*>(user_data);
+    context->RunVsyncCallback(baton);
+  };
+}
+
 void EmbedderConfigBuilder::SetRenderTaskRunner(
     const FlutterTaskRunnerDescription* runner) {
   if (runner == nullptr) {

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -104,6 +104,10 @@ class EmbedderConfigBuilder {
 
   UniqueEngine InitializeEngine() const;
 
+  // Sets up the callback for vsync, the callbacks needs to be specified on the
+  // text context vis `SetVsyncCallback`.
+  void SetupVsyncCallback();
+
  private:
   EmbedderTestContext& context_;
   FlutterProjectArgs project_args_ = {};

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -224,5 +224,14 @@ void EmbedderTestContext::FireRootSurfacePresentCallbackIfPresent(
   callback(image_callback());
 }
 
+void EmbedderTestContext::SetVsyncCallback(
+    std::function<void(intptr_t)> callback) {
+  vsync_callback_ = callback;
+}
+
+void EmbedderTestContext::RunVsyncCallback(intptr_t baton) {
+  vsync_callback_(baton);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -89,6 +89,15 @@ class EmbedderTestContext {
 
   virtual EmbedderTestContextType GetContextType() const = 0;
 
+  // Sets up the callback for vsync. This callback will be invoked
+  // for every vsync. This should be used in conjunction with SetupVsyncCallback
+  // on the EmbedderConfigBuilder. Any callback setup here must call
+  // `FlutterEngineOnVsync` from the platform task runner.
+  void SetVsyncCallback(std::function<void(intptr_t)> callback);
+
+  // Runs the vsync callback.
+  void RunVsyncCallback(intptr_t baton);
+
   // TODO(gw280): encapsulate these properly for subclasses to use
  protected:
   // This allows the builder to access the hooks.
@@ -112,6 +121,7 @@ class EmbedderTestContext {
   std::unique_ptr<EmbedderTestCompositor> compositor_;
   NextSceneCallback next_scene_callback_;
   SkMatrix root_surface_transformation_;
+  std::function<void(intptr_t)> vsync_callback_ = nullptr;
 
   static VoidCallback GetIsolateCreateCallbackHook();
 

--- a/shell/platform/embedder/vsync_waiter_embedder.h
+++ b/shell/platform/embedder/vsync_waiter_embedder.h
@@ -19,7 +19,8 @@ class VsyncWaiterEmbedder final : public VsyncWaiter {
 
   ~VsyncWaiterEmbedder() override;
 
-  static bool OnEmbedderVsync(intptr_t baton,
+  static bool OnEmbedderVsync(const flutter::TaskRunners& task_runners,
+                              intptr_t baton,
                               fml::TimePoint frame_start_time,
                               fml::TimePoint frame_target_time);
 


### PR DESCRIPTION
Prior to https://github.com/flutter/engine/pull/28817 super class vsync waiter would post the tast to the future if the frame start time is at a later poit. This change made it so that the sub classes are responsible for posting the task at the right time.

This change makes it so that vsync waiter embedder respects that contract.

Fixes https://github.com/flutter/flutter/issues/92603

