### PR TITLE
fix d3d9 fallback

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -127,7 +127,6 @@ bool AngleSurfaceManager::Initialize() {
   const EGLint d3d9_display_attributes[] = {
       EGL_PLATFORM_ANGLE_TYPE_ANGLE,
       EGL_PLATFORM_ANGLE_TYPE_D3D9_ANGLE,
-      EGL_TRUE,
       EGL_NONE,
   };
 


### PR DESCRIPTION
## Description
Fix a bug that current fallback to D3D9 didn't work.

## Issue
[#92650](https://github.com/flutter/flutter/issues/92650)


## Pre-launch Checklist

- [√] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [√ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [√ ] I listed at least one issue that this PR fixes in the description above.
- [√ ] I signed the [CLA].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
