### PR TITLE
Revert "Reland "Set system bar appearance using WindowInsetsController""

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -570,7 +570,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/embedding_bundle',
-        'version': 'last_updated:2021-10-28T23:34:47-0700'
+        'version': 'last_updated:2021-10-18T13:21:02-0700'
        }
      ],
      'condition': 'download_android_deps',

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformPlugin.java
@@ -20,7 +20,6 @@ import androidx.activity.OnBackPressedDispatcherOwner;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-import androidx.core.view.WindowInsetsControllerCompat;
 import io.flutter.Log;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
 import java.io.FileNotFoundException;
@@ -365,8 +364,7 @@ public class PlatformPlugin {
       PlatformChannel.SystemChromeStyle systemChromeStyle) {
     Window window = activity.getWindow();
     View view = window.getDecorView();
-    WindowInsetsControllerCompat windowInsetsControllerCompat =
-        new WindowInsetsControllerCompat(window, view);
+    int flags = view.getSystemUiVisibility();
 
     // SYSTEM STATUS BAR -------------------------------------------------------------------
     // You can't change the color of the system status bar until SDK 21, and you can't change the
@@ -379,14 +377,11 @@ public class PlatformPlugin {
       if (systemChromeStyle.statusBarIconBrightness != null) {
         switch (systemChromeStyle.statusBarIconBrightness) {
           case DARK:
-            // Dark status bar icon brightness.
-            // Light status bar appearance.
-            windowInsetsControllerCompat.setAppearanceLightStatusBars(true);
+            // View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            flags |= 0x2000;
             break;
           case LIGHT:
-            // Light status bar icon brightness.
-            // Dark status bar appearance.
-            windowInsetsControllerCompat.setAppearanceLightStatusBars(false);
+            flags &= ~0x2000;
             break;
         }
       }
@@ -413,14 +408,11 @@ public class PlatformPlugin {
       if (systemChromeStyle.systemNavigationBarIconBrightness != null) {
         switch (systemChromeStyle.systemNavigationBarIconBrightness) {
           case DARK:
-            // Dark navigation bar icon brightness.
-            // Light navigation bar appearance.
-            windowInsetsControllerCompat.setAppearanceLightNavigationBars(true);
+            // View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+            flags |= 0x10;
             break;
           case LIGHT:
-            // Light navigation bar icon brightness.
-            // Dark navigation bar appearance.
-            windowInsetsControllerCompat.setAppearanceLightNavigationBars(false);
+            flags &= ~0x10;
             break;
         }
       }
@@ -446,6 +438,7 @@ public class PlatformPlugin {
           systemChromeStyle.systemNavigationBarContrastEnforced);
     }
 
+    view.setSystemUiVisibility(flags);
     currentTheme = systemChromeStyle;
   }
 

--- a/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/platform/PlatformPluginTest.java
@@ -1,7 +1,5 @@
 package io.flutter.plugin.platform;
 
-import static android.view.WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS;
-import static android.view.WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -22,7 +20,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.view.View;
 import android.view.Window;
-import android.view.WindowInsetsController;
 import androidx.activity.OnBackPressedCallback;
 import androidx.fragment.app.FragmentActivity;
 import io.flutter.embedding.engine.systemchannels.PlatformChannel;
@@ -216,98 +213,6 @@ public class PlatformPluginTest {
       verify(fakeWindow, times(1)).setNavigationBarContrastEnforced(true);
       verify(fakeWindow, times(1)).setStatusBarContrastEnforced(false);
       verify(fakeWindow, times(1)).setNavigationBarContrastEnforced(false);
-    }
-  }
-
-  @Config(sdk = 30)
-  @Test
-  public void setNavigationBarIconBrightness() {
-    if (Build.VERSION.SDK_INT >= 30) {
-      View fakeDecorView = mock(View.class);
-      WindowInsetsController fakeWindowInsetsController = mock(WindowInsetsController.class);
-      Window fakeWindow = mock(Window.class);
-      when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
-      when(fakeWindow.getInsetsController()).thenReturn(fakeWindowInsetsController);
-      Activity fakeActivity = mock(Activity.class);
-      when(fakeActivity.getWindow()).thenReturn(fakeWindow);
-      PlatformChannel fakePlatformChannel = mock(PlatformChannel.class);
-      PlatformPlugin platformPlugin = new PlatformPlugin(fakeActivity, fakePlatformChannel);
-
-      SystemChromeStyle style =
-          new SystemChromeStyle(
-              null, // statusBarColor
-              null, // statusBarIconBrightness
-              null, // systemStatusBarContrastEnforced
-              null, // systemNavigationBarColor
-              Brightness.LIGHT, // systemNavigationBarIconBrightness
-              null, // systemNavigationBarDividerColor
-              null); // systemNavigationBarContrastEnforced
-
-      platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
-
-      verify(fakeWindowInsetsController)
-          .setSystemBarsAppearance(0, APPEARANCE_LIGHT_NAVIGATION_BARS);
-
-      style =
-          new SystemChromeStyle(
-              null, // statusBarColor
-              null, // statusBarIconBrightness
-              null, // systemStatusBarContrastEnforced
-              null, // systemNavigationBarColor
-              Brightness.DARK, // systemNavigationBarIconBrightness
-              null, // systemNavigationBarDividerColor
-              null); // systemNavigationBarContrastEnforced
-
-      platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
-
-      verify(fakeWindowInsetsController)
-          .setSystemBarsAppearance(
-              APPEARANCE_LIGHT_NAVIGATION_BARS, APPEARANCE_LIGHT_NAVIGATION_BARS);
-    }
-  }
-
-  @Config(sdk = 30)
-  @Test
-  public void setStatusBarIconBrightness() {
-    if (Build.VERSION.SDK_INT >= 30) {
-      View fakeDecorView = mock(View.class);
-      WindowInsetsController fakeWindowInsetsController = mock(WindowInsetsController.class);
-      Window fakeWindow = mock(Window.class);
-      when(fakeWindow.getDecorView()).thenReturn(fakeDecorView);
-      when(fakeWindow.getInsetsController()).thenReturn(fakeWindowInsetsController);
-      Activity fakeActivity = mock(Activity.class);
-      when(fakeActivity.getWindow()).thenReturn(fakeWindow);
-      PlatformChannel fakePlatformChannel = mock(PlatformChannel.class);
-      PlatformPlugin platformPlugin = new PlatformPlugin(fakeActivity, fakePlatformChannel);
-
-      SystemChromeStyle style =
-          new SystemChromeStyle(
-              null, // statusBarColor
-              Brightness.LIGHT, // statusBarIconBrightness
-              null, // systemStatusBarContrastEnforced
-              null, // systemNavigationBarColor
-              null, // systemNavigationBarIconBrightness
-              null, // systemNavigationBarDividerColor
-              null); // systemNavigationBarContrastEnforced
-
-      platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
-
-      verify(fakeWindowInsetsController).setSystemBarsAppearance(0, APPEARANCE_LIGHT_STATUS_BARS);
-
-      style =
-          new SystemChromeStyle(
-              null, // statusBarColor
-              Brightness.DARK, // statusBarIconBrightness
-              null, // systemStatusBarContrastEnforced
-              null, // systemNavigationBarColor
-              null, // systemNavigationBarIconBrightness
-              null, // systemNavigationBarDividerColor
-              null); // systemNavigationBarContrastEnforced
-
-      platformPlugin.mPlatformMessageHandler.setSystemUiOverlayStyle(style);
-
-      verify(fakeWindowInsetsController)
-          .setSystemBarsAppearance(APPEARANCE_LIGHT_STATUS_BARS, APPEARANCE_LIGHT_STATUS_BARS);
     }
   }
 

--- a/shell/platform/android/test_runner/build.gradle
+++ b/shell/platform/android/test_runner/build.gradle
@@ -37,7 +37,6 @@ android {
   dependencies {
     testImplementation files(project.property("flutter_jar"))
     testImplementation "androidx.annotation:annotation:1.1.0"
-    testImplementation "androidx.core:core:1.6.0"
     testImplementation "androidx.fragment:fragment:1.1.0"
     testImplementation "androidx.lifecycle:lifecycle-runtime:2.2.0"
     testImplementation "androidx.lifecycle:lifecycle-common-java8:2.2.0"

--- a/tools/androidx/files.json
+++ b/tools/androidx/files.json
@@ -57,13 +57,5 @@
     "provides": [
       "androidx.tracing.Trace"
     ]
-  },
-  {
-    "url": "https://dl.google.com/android/maven2/androidx/core/core/1.6.0/core-1.6.0.aar",
-    "out_file_name": "androidx_core.aar",
-    "maven_dependency": "androidx.core:core:1.6.0",
-    "provides": [
-      "androidx.core.view.WindowInsetsControllerCompat"
-    ]
   }
 ]

--- a/tools/cipd/android_embedding_bundle/build.gradle
+++ b/tools/cipd/android_embedding_bundle/build.gradle
@@ -41,7 +41,6 @@ android {
 
   dependencies {
     embedding "androidx.annotation:annotation:1.1.0"
-    embedding "androidx.core:core:1.6.0"
     embedding "androidx.fragment:fragment:1.1.0"
     embedding "androidx.tracing:tracing:1.0.0"
 


### PR DESCRIPTION
Unfortunately, `androidx.core.view.WindowInsetsControllerCompat` cannot be used in g3 at the moment, only the support version `android.support.v4.view.WindowInsetsControllerCompat` with Jetifier is available.


Reverts flutter/engine#29403