### PR TITLE
[Windows] fix misuse of _BitScanReverse and _BitScanReverse64

### DIFF
--- a/third_party/txt/src/utils/WindowsUtils.h
+++ b/third_party/txt/src/utils/WindowsUtils.h
@@ -36,14 +36,20 @@
 
 inline unsigned int clz_win(unsigned int num) {
   unsigned long r = 0;
-  _BitScanReverse(&r, num);
-  return r;
+  if (_BitScanReverse(&r, num)) {
+    return 31 - r;
+  } else {
+    return 31;
+  }
 }
 
 inline unsigned int clzl_win(unsigned long num) {
   unsigned long r = 0;
-  _BitScanReverse64(&r, num);
-  return r;
+  if (_BitScanReverse64(&r, num)) {
+    return 61 - r;
+  } else {
+    return 61;
+  }
 }
 
 inline unsigned int ctz_win(unsigned int num) {


### PR DESCRIPTION
In windows build, SparseBitSet uses  _BitScanReverse to count leading zeros of an unsigned 32-bit integer and _BitScanReverse64 to calculate leading zeros of an unsigned 64-bit integer, but it uses these two functions in the wrong way.
According to  the [MSDN BitScanReverse](https://docs.microsoft.com/en-us/cpp/intrinsics/bitscanreverse-bitscanreverse64?view=msvc-160) document and it's example section.When the mask argument is 12, the _BitScanReverse function will give back index value as 3 which in binary form is ```0000 0000 0000 0000 0000 0000 0000 1100```. This index is counted from least significant bit (LSB) to most significant bit (MSB), which is opposite to the __builtin_clz intrinsic of GCC. This PR fixes this problem.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

