### PR TITLE
[web] use typed SVG API

### DIFF
--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -29,6 +29,8 @@ import 'dart:js' as js;
 import 'dart:js_util' as js_util;
 // ignore: unused_import
 import 'dart:math' as math;
+// ignore: unused_import
+import 'dart:svg' as svg;
 import 'dart:typed_data';
 
 import 'package:js/js.dart';
@@ -474,13 +476,6 @@ void _addUrlStrategyListener() {
   registerHotRestartListener(() {
     jsSetUrlStrategy = null;
   });
-}
-
-/// Sanitizer used to convert const svg filter and clippath snippets to
-/// SvgElement without sanitization.
-class NullTreeSanitizer implements html.NodeTreeSanitizer {
-  @override
-  void sanitizeTree(html.Node node) {}
 }
 
 /// The shared instance of PlatformViewManager shared across the engine to handle

--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -899,7 +899,7 @@ class ContextStateHandle {
     if (blendMode != _currentBlendMode) {
       _currentBlendMode = blendMode;
       context.globalCompositeOperation =
-          stringForBlendMode(blendMode) ?? 'source-over';
+          blendModeToCssMixBlendMode(blendMode) ?? 'source-over';
     }
   }
 

--- a/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
+++ b/lib/web_ui/lib/src/engine/canvaskit/embedded_views.dart
@@ -4,10 +4,11 @@
 
 import 'dart:html' as html;
 import 'dart:math' as math;
+import 'dart:svg' as svg;
 
 import 'package:ui/ui.dart' as ui;
 
-import '../../engine.dart' show NullTreeSanitizer, platformViewManager;
+import '../../engine.dart' show platformViewManager;
 import '../configuration.dart';
 import '../html/path_to_svg_clip.dart';
 import '../platform_views/slots.dart';
@@ -332,12 +333,13 @@ class HtmlViewEmbedder {
                 _svgPathDefs!.querySelector('#sk_path_defs')!;
             _clipPathCount += 1;
             final String clipId = 'svgClip$_clipPathCount';
-            final html.Node newClipPath = html.DocumentFragment.svg(
-              '<clipPath id="$clipId">'
-              '<path d="${path.toSvgString()}">'
-              '</path></clipPath>',
-              treeSanitizer: NullTreeSanitizer(),
+            final svg.ClipPathElement newClipPath = svg.ClipPathElement();
+            newClipPath.id = clipId;
+            newClipPath.append(
+              svg.PathElement()
+                ..setAttribute('d', path.toSvgString()!)
             );
+
             pathDefs.append(newClipPath);
             // Store the id of the node instead of [newClipPath] directly. For
             // some reason, calling `newClipPath.remove()` doesn't remove it
@@ -351,11 +353,11 @@ class HtmlViewEmbedder {
                 _svgPathDefs!.querySelector('#sk_path_defs')!;
             _clipPathCount += 1;
             final String clipId = 'svgClip$_clipPathCount';
-            final html.Node newClipPath = html.DocumentFragment.svg(
-              '<clipPath id="$clipId">'
-              '<path d="${path.toSvgString()}">'
-              '</path></clipPath>',
-              treeSanitizer: NullTreeSanitizer(),
+            final svg.ClipPathElement newClipPath = svg.ClipPathElement();
+            newClipPath.id = clipId;
+            newClipPath.append(
+              svg.PathElement()
+                ..setAttribute('d', path.toSvgString()!)
             );
             pathDefs.append(newClipPath);
             // Store the id of the node instead of [newClipPath] directly. For
@@ -409,10 +411,8 @@ class HtmlViewEmbedder {
     if (_svgPathDefs != null) {
       return;
     }
-    _svgPathDefs = html.Element.html(
-      '$kSvgResourceHeader<defs id="sk_path_defs"></defs></svg>',
-      treeSanitizer: NullTreeSanitizer(),
-    );
+    _svgPathDefs = kSvgResourceHeader.clone(false) as svg.SvgSvgElement;
+    _svgPathDefs!.append(svg.DefsElement()..id = 'sk_path_defs');
     skiaSceneHost!.append(_svgPathDefs!);
   }
 

--- a/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/html/bitmap_canvas.dart
@@ -8,7 +8,6 @@ import 'dart:typed_data';
 
 import 'package:ui/ui.dart' as ui;
 
-import '../../engine.dart' show NullTreeSanitizer;
 import '../browser_detection.dart';
 import '../canvas_pool.dart';
 import '../canvaskit/color_filter.dart';
@@ -468,7 +467,7 @@ class BitmapCanvas extends EngineCanvas {
     }
     final ui.BlendMode? blendMode = paint.blendMode;
     if (blendMode != null) {
-      element.style.mixBlendMode = stringForBlendMode(blendMode) ?? '';
+      element.style.mixBlendMode = blendModeToCssMixBlendMode(blendMode) ?? '';
     }
     // Switch to preferring DOM from now on, and close the current canvas.
     _closeCurrentCanvas();
@@ -669,7 +668,7 @@ class BitmapCanvas extends EngineCanvas {
       // No Blending, create an image by cloning original loaded image.
       imgElement = _reuseOrCreateImage(htmlImage);
     }
-    imgElement.style.mixBlendMode = stringForBlendMode(blendMode) ?? '';
+    imgElement.style.mixBlendMode = blendModeToCssMixBlendMode(blendMode) ?? '';
     if (_canvasPool.isClipped) {
       // Reset width/height since they may have been previously set.
       imgElement.style..removeProperty('width')..removeProperty('height');
@@ -837,7 +836,7 @@ class BitmapCanvas extends EngineCanvas {
         style
           ..position = 'absolute'
           ..backgroundImage = "url('${image.imgElement.src}')"
-          ..backgroundBlendMode = stringForBlendMode(colorFilterBlendMode) ?? ''
+          ..backgroundBlendMode = blendModeToCssMixBlendMode(colorFilterBlendMode) ?? ''
           ..backgroundColor = colorToCssString(filterColor);
         break;
     }
@@ -851,14 +850,11 @@ class BitmapCanvas extends EngineCanvas {
       ui.BlendMode colorFilterBlendMode,
       SurfacePaintData paint) {
     // For srcIn blendMode, we use an svg filter to apply to image element.
-    final String? svgFilter =
-        svgFilterFromBlendMode(filterColor, colorFilterBlendMode);
-    final html.Element filterElement =
-        html.Element.html(svgFilter, treeSanitizer: NullTreeSanitizer());
-    rootElement.append(filterElement);
-    _children.add(filterElement);
+    final SvgFilter svgFilter = svgFilterFromBlendMode(filterColor, colorFilterBlendMode);
+    rootElement.append(svgFilter.element);
+    _children.add(svgFilter.element);
     final html.HtmlElement imgElement = _reuseOrCreateImage(image);
-    imgElement.style.filter = 'url(#_fcf$filterIdCounter)';
+    imgElement.style.filter = 'url(#${svgFilter.id})';
     if (colorFilterBlendMode == ui.BlendMode.saturation) {
       imgElement.style.backgroundColor = colorToCssString(filterColor);
     }
@@ -869,13 +865,11 @@ class BitmapCanvas extends EngineCanvas {
   html.HtmlElement _createImageElementWithSvgColorMatrixFilter(
       HtmlImage image, List<double> matrix, SurfacePaintData paint) {
     // For srcIn blendMode, we use an svg filter to apply to image element.
-    final String? svgFilter = svgFilterFromColorMatrix(matrix);
-    final html.Element filterElement =
-        html.Element.html(svgFilter, treeSanitizer: NullTreeSanitizer());
-    rootElement.append(filterElement);
-    _children.add(filterElement);
+    final SvgFilter svgFilter = svgFilterFromColorMatrix(matrix);
+    rootElement.append(svgFilter.element);
+    _children.add(svgFilter.element);
     final html.HtmlElement imgElement = _reuseOrCreateImage(image);
-    imgElement.style.filter = 'url(#_fcf$filterIdCounter)';
+    imgElement.style.filter = 'url(#${svgFilter.id})';
     return imgElement;
   }
 
@@ -1104,7 +1098,15 @@ class BitmapCanvas extends EngineCanvas {
   }
 }
 
-String? stringForBlendMode(ui.BlendMode? blendMode) {
+/// The CSS value for the `mix-blend-mode` CSS property.
+///
+/// This list includes values supposrted by SVG, but it's not the same.
+///
+/// See also:
+///
+///  * https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode
+///  * [blendModeToSvgEnum], which specializes on SVG blend modes
+String? blendModeToCssMixBlendMode(ui.BlendMode? blendMode) {
   if (blendMode == null) {
     return null;
   }
@@ -1167,6 +1169,140 @@ String? stringForBlendMode(ui.BlendMode? blendMode) {
     default:
       throw UnimplementedError(
           'Flutter Web does not support the blend mode: $blendMode');
+  }
+}
+
+// Source: https://www.w3.org/TR/SVG11/filters.html#InterfaceSVGFEBlendElement
+// These constant names deviate from Dart's camelCase convention on purpose to
+// make it easier to search for them in W3 specs and in Chromium sources.
+const int SVG_FEBLEND_MODE_UNKNOWN = 0;
+const int SVG_FEBLEND_MODE_NORMAL = 1;
+const int SVG_FEBLEND_MODE_MULTIPLY = 2;
+const int SVG_FEBLEND_MODE_SCREEN = 3;
+const int SVG_FEBLEND_MODE_DARKEN = 4;
+const int SVG_FEBLEND_MODE_LIGHTEN = 5;
+const int SVG_FEBLEND_MODE_OVERLAY = 6;
+const int SVG_FEBLEND_MODE_COLOR_DODGE = 7;
+const int SVG_FEBLEND_MODE_COLOR_BURN = 8;
+const int SVG_FEBLEND_MODE_HARD_LIGHT = 9;
+const int SVG_FEBLEND_MODE_SOFT_LIGHT = 10;
+const int SVG_FEBLEND_MODE_DIFFERENCE = 11;
+const int SVG_FEBLEND_MODE_EXCLUSION = 12;
+const int SVG_FEBLEND_MODE_HUE = 13;
+const int SVG_FEBLEND_MODE_SATURATION = 14;
+const int SVG_FEBLEND_MODE_COLOR = 15;
+const int SVG_FEBLEND_MODE_LUMINOSITY = 16;
+
+// Source: https://github.com/chromium/chromium/blob/e1e495b29e1178a451f65980a6c4ae017c34dc94/third_party/blink/renderer/platform/graphics/graphics_types.cc#L55
+const String kCompositeClear = 'clear';
+const String kCompositeCopy = 'copy';
+const String kCompositeSourceOver = 'source-over';
+const String kCompositeSourceIn = 'source-in';
+const String kCompositeSourceOut = 'source-out';
+const String kCompositeSourceAtop = 'source-atop';
+const String kCompositeDestinationOver = 'destination-over';
+const String kCompositeDestinationIn = 'destination-in';
+const String kCompositeDestinationOut = 'destination-out';
+const String kCompositeDestinationAtop = 'destination-atop';
+const String kCompositeXor = 'xor';
+const String kCompositeLighter = 'lighter';
+
+/// Compositing and blending operation in SVG.
+///
+/// Flutter's [BlendMode] flattens what SVG expresses as two orthogonal
+/// properties, a composite operator and blend mode. Instances of this class
+/// are returned from [blendModeToSvgEnum] by mapping Flutter's [BlendMode]
+/// enum onto the SVG equivalent.
+///
+/// See also:
+///
+///  * https://www.w3.org/TR/compositing-1
+///  * https://github.com/chromium/chromium/blob/e1e495b29e1178a451f65980a6c4ae017c34dc94/third_party/blink/renderer/platform/graphics/graphics_types.cc#L55
+///  * https://github.com/chromium/chromium/blob/e1e495b29e1178a451f65980a6c4ae017c34dc94/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc#L725
+class SvgBlendMode {
+  const SvgBlendMode(this.compositeOperator, this.blendMode);
+
+  /// The name of the SVG composite operator.
+  ///
+  /// If this mode represents a blend mode, this is set to [kCompositeSourceOver].
+  final String compositeOperator;
+
+  /// The identifier of the SVG blend mode.
+  ///
+  /// This is mode represents a compositing operation, this is set to [SVG_FEBLEND_MODE_UNKNOWN].
+  final int blendMode;
+}
+
+/// Converts Flutter's [ui.BlendMode] to SVG's <compositing operation, blend mode> pair.
+SvgBlendMode? blendModeToSvgEnum(ui.BlendMode? blendMode) {
+  if (blendMode == null) {
+    return null;
+  }
+  switch (blendMode) {
+    case ui.BlendMode.clear:
+      return const SvgBlendMode(kCompositeClear, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.srcOver:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.srcIn:
+      return const SvgBlendMode(kCompositeSourceIn, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.srcOut:
+      return const SvgBlendMode(kCompositeSourceOut, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.srcATop:
+      return const SvgBlendMode(kCompositeSourceAtop, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.dstOver:
+      return const SvgBlendMode(kCompositeDestinationOver, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.dstIn:
+      return const SvgBlendMode(kCompositeDestinationIn, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.dstOut:
+      return const SvgBlendMode(kCompositeDestinationOut, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.dstATop:
+      return const SvgBlendMode(kCompositeDestinationAtop, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.plus:
+      return const SvgBlendMode(kCompositeLighter, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.src:
+      return const SvgBlendMode(kCompositeCopy, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.xor:
+      return const SvgBlendMode(kCompositeXor, SVG_FEBLEND_MODE_UNKNOWN);
+    case ui.BlendMode.multiply:
+    // Falling back to multiply, ignoring alpha channel.
+    // TODO(ferhat): only used for debug, find better fallback for web.
+    case ui.BlendMode.modulate:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_MULTIPLY);
+    case ui.BlendMode.screen:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_SCREEN);
+    case ui.BlendMode.overlay:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_OVERLAY);
+    case ui.BlendMode.darken:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_DARKEN);
+    case ui.BlendMode.lighten:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_LIGHTEN);
+    case ui.BlendMode.colorDodge:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_COLOR_DODGE);
+    case ui.BlendMode.colorBurn:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_COLOR_BURN);
+    case ui.BlendMode.hardLight:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_HARD_LIGHT);
+    case ui.BlendMode.softLight:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_SOFT_LIGHT);
+    case ui.BlendMode.difference:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_DIFFERENCE);
+    case ui.BlendMode.exclusion:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_EXCLUSION);
+    case ui.BlendMode.hue:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_HUE);
+    case ui.BlendMode.saturation:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_SATURATION);
+    case ui.BlendMode.color:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_COLOR);
+    case ui.BlendMode.luminosity:
+      return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_LUMINOSITY);
+    default:
+      assert(
+        false,
+        'Flutter Web does not support the blend mode: $blendMode',
+      );
+
+    return const SvgBlendMode(kCompositeSourceOver, SVG_FEBLEND_MODE_NORMAL);
   }
 }
 
@@ -1273,10 +1409,8 @@ List<html.Element> _clipContent(List<SaveClipEntry> clipStack,
         curElement.style
           ..transform = matrix4ToCssTransform(newClipTransform)
           ..transformOrigin = '0 0 0';
-        final String svgClipPath =
-            createSvgClipDef(curElement as html.HtmlElement, entry.path!);
         final html.Element clipElement =
-            html.Element.html(svgClipPath, treeSanitizer: NullTreeSanitizer());
+            createSvgClipDef(curElement as html.HtmlElement, entry.path!);
         clipDefs.add(clipElement);
       }
     }

--- a/lib/web_ui/lib/src/engine/html/clip.dart
+++ b/lib/web_ui/lib/src/engine/html/clip.dart
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:html' as html;
+import 'dart:svg' as svg;
 
 import 'package:ui/ui.dart' as ui;
 
-import '../../engine.dart'  show NullTreeSanitizer;
 import '../dom_renderer.dart';
 import '../shadow.dart';
 import '../util.dart';
@@ -344,7 +344,7 @@ class PersistedPhysicalShape extends PersistedContainerSurface
     /// we size the inner container to cover full pathBounds instead of sizing
     /// to clipping rect bounds (which is the case for elevation == 0.0 where
     /// we shift outer/inner clip area instead to position clip-path).
-    final String svgClipPath = elevation == 0.0
+    final svg.SvgSvgElement svgClipPath = elevation == 0.0
         ? pathToSvgClipPath(path,
             offsetX: -pathBounds.left,
             offsetY: -pathBounds.top,
@@ -360,8 +360,7 @@ class PersistedPhysicalShape extends PersistedContainerSurface
     /// svg clip and render elements.
     _clipElement?.remove();
     _svgElement?.remove();
-    _clipElement =
-        html.Element.html(svgClipPath, treeSanitizer: NullTreeSanitizer());
+    _clipElement = svgClipPath;
     domRenderer.append(rootElement!, _clipElement!);
     if (elevation == 0.0) {
       DomRenderer.setClipPath(rootElement!, createSvgClipUrl());
@@ -486,10 +485,7 @@ class PersistedClipPath extends PersistedContainerSurface
   @override
   void apply() {
     _clipElement?.remove();
-    final String svgClipPath =
-        createSvgClipDef(childContainer! as html.HtmlElement, clipPath);
-    _clipElement =
-        html.Element.html(svgClipPath, treeSanitizer: NullTreeSanitizer());
+    _clipElement = createSvgClipDef(childContainer! as html.HtmlElement, clipPath);
     domRenderer.append(childContainer!, _clipElement!);
   }
 
@@ -518,9 +514,9 @@ class PersistedClipPath extends PersistedContainerSurface
 }
 
 /// Creates an svg clipPath and applies it to [element].
-String createSvgClipDef(html.HtmlElement element, ui.Path clipPath) {
+svg.SvgSvgElement createSvgClipDef(html.HtmlElement element, ui.Path clipPath) {
   final ui.Rect pathBounds = clipPath.getBounds();
-  final String svgClipPath = pathToSvgClipPath(clipPath,
+  final svg.SvgSvgElement svgClipPath = pathToSvgClipPath(clipPath,
       scaleX: 1.0 / pathBounds.right, scaleY: 1.0 / pathBounds.bottom);
   DomRenderer.setClipPath(element, createSvgClipUrl());
   // We need to set width and height for the clipElement to cover the

--- a/lib/web_ui/lib/src/engine/html/path/path_to_svg.dart
+++ b/lib/web_ui/lib/src/engine/html/path/path_to_svg.dart
@@ -12,25 +12,25 @@ import 'path_utils.dart';
 
 /// Converts [path] to SVG path syntax to be used as "d" attribute in path
 /// element.
-void pathToSvg(PathRef pathRef, StringBuffer sb,
-    {double offsetX = 0, double offsetY = 0}) {
+String pathToSvg(PathRef pathRef, {double offsetX = 0, double offsetY = 0}) {
+  final StringBuffer buffer = StringBuffer();
   final PathRefIterator iter = PathRefIterator(pathRef);
   int verb = 0;
   final Float32List outPts = Float32List(PathRefIterator.kMaxBufferSize);
   while ((verb = iter.next(outPts)) != SPath.kDoneVerb) {
     switch (verb) {
       case SPath.kMoveVerb:
-        sb.write('M ${outPts[0] + offsetX} ${outPts[1] + offsetY}');
+        buffer.write('M ${outPts[0] + offsetX} ${outPts[1] + offsetY}');
         break;
       case SPath.kLineVerb:
-        sb.write('L ${outPts[2] + offsetX} ${outPts[3] + offsetY}');
+        buffer.write('L ${outPts[2] + offsetX} ${outPts[3] + offsetY}');
         break;
       case SPath.kCubicVerb:
-        sb.write('C ${outPts[2] + offsetX} ${outPts[3] + offsetY} '
+        buffer.write('C ${outPts[2] + offsetX} ${outPts[3] + offsetY} '
             '${outPts[4] + offsetX} ${outPts[5] + offsetY} ${outPts[6] + offsetX} ${outPts[7] + offsetY}');
         break;
       case SPath.kQuadVerb:
-        sb.write('Q ${outPts[2] + offsetX} ${outPts[3] + offsetY} '
+        buffer.write('Q ${outPts[2] + offsetX} ${outPts[3] + offsetY} '
             '${outPts[4] + offsetX} ${outPts[5] + offsetY}');
         break;
       case SPath.kConicVerb:
@@ -44,15 +44,16 @@ void pathToSvg(PathRef pathRef, StringBuffer sb,
           final double p1y = points[i].dy;
           final double p2x = points[i + 1].dx;
           final double p2y = points[i + 1].dy;
-          sb.write('Q ${p1x + offsetX} ${p1y + offsetY} '
+          buffer.write('Q ${p1x + offsetX} ${p1y + offsetY} '
               '${p2x + offsetX} ${p2y + offsetY}');
         }
         break;
       case SPath.kCloseVerb:
-        sb.write('Z');
+        buffer.write('Z');
         break;
       default:
         throw UnimplementedError('Unknown path verb $verb');
     }
   }
+  return buffer.toString();
 }

--- a/lib/web_ui/lib/src/engine/html/path_to_svg_clip.dart
+++ b/lib/web_ui/lib/src/engine/html/path_to_svg_clip.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:svg' as svg;
+
 import 'package:ui/ui.dart' as ui;
 
 import '../browser_detection.dart';
@@ -15,38 +17,43 @@ int _clipIdCounter = 0;
 ///
 /// Position needs to be absolute since these svgs are sandwiched between
 /// canvas elements and can cause layout shifts otherwise.
-const String kSvgResourceHeader = '<svg width="0" height="0" '
-    'style="position:absolute">';
+final svg.SvgSvgElement kSvgResourceHeader = svg.SvgSvgElement()
+  ..setAttribute('width', 0)
+  ..setAttribute('height', 0)
+  ..style.position = 'absolute';
 
 /// Converts Path to svg element that contains a clip-path definition.
 ///
 /// Calling this method updates [_clipIdCounter]. The HTML id of the generated
 /// clip is set to "svgClip${_clipIdCounter}", e.g. "svgClip123".
-String pathToSvgClipPath(ui.Path path,
+svg.SvgSvgElement pathToSvgClipPath(ui.Path path,
     {double offsetX = 0,
     double offsetY = 0,
     double scaleX = 1.0,
     double scaleY = 1.0}) {
   _clipIdCounter += 1;
-  final StringBuffer sb = StringBuffer();
-  sb.write(kSvgResourceHeader);
-  sb.write('<defs>');
+  final svg.SvgSvgElement root = kSvgResourceHeader.clone(false) as svg.SvgSvgElement;
+  final svg.DefsElement defs = svg.DefsElement();
+  root.append(defs);
 
   final String clipId = 'svgClip$_clipIdCounter';
+  final svg.ClipPathElement clipPath = svg.ClipPathElement();
+  defs.append(clipPath);
+  clipPath.id = clipId;
 
-  if (browserEngine == BrowserEngine.firefox) {
-    // Firefox objectBoundingBox fails to scale to 1x1 units, instead use
-    // no clipPathUnits but write the path in target units.
-    sb.write('<clipPath id=$clipId>');
-    sb.write('<path fill="#FFFFFF" d="');
-  } else {
-    sb.write('<clipPath id=$clipId clipPathUnits="objectBoundingBox">');
-    sb.write('<path transform="scale($scaleX, $scaleY)" fill="#FFFFFF" d="');
+  final svg.PathElement svgPath = svg.PathElement();
+  clipPath.append(svgPath);
+  svgPath.setAttribute('fill', '#FFFFFF');
+
+  // Firefox objectBoundingBox fails to scale to 1x1 units, instead use
+  // no clipPathUnits but write the path in target units.
+  if (browserEngine != BrowserEngine.firefox) {
+    clipPath.setAttribute('clipPathUnits', 'objectBoundingBox');
+    svgPath.setAttribute('transform', 'scale($scaleX, $scaleY)');
   }
 
-  pathToSvg((path as SurfacePath).pathRef, sb, offsetX: offsetX, offsetY: offsetY);
-  sb.write('"></path></clipPath></defs></svg');
-  return sb.toString();
+  svgPath.setAttribute('d', pathToSvg((path as SurfacePath).pathRef, offsetX: offsetX, offsetY: offsetY));
+  return root;
 }
 
 String createSvgClipUrl() => 'url(#svgClip$_clipIdCounter)';

--- a/lib/web_ui/test/html/path_to_svg_golden_test.dart
+++ b/lib/web_ui/test/html/path_to_svg_golden_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:html' as html;
+import 'dart:svg' as svg;
 
 import 'package:test/bootstrap/browser.dart';
 import 'package:test/test.dart';
@@ -186,29 +187,27 @@ Future<void> testMain() async {
 
 html.Element pathToSvgElement(Path path, Paint paint, bool enableFill) {
   final Rect bounds = path.getBounds();
-  final StringBuffer sb = StringBuffer();
-  sb.write('<svg viewBox="0 0 ${bounds.right} ${bounds.bottom}" '
-      'width="${bounds.right}" height="${bounds.bottom}">');
-  sb.write('<path ');
+  final svg.SvgSvgElement root = svg.SvgSvgElement();
+  root.style.transform = 'translate(200px, 0px)';
+  root.setAttribute('viewBox', '0 0 ${bounds.right} ${bounds.bottom}');
+  root.width!.baseVal!.newValueSpecifiedUnits(svg.Length.SVG_LENGTHTYPE_NUMBER, bounds.right);
+  root.height!.baseVal!.newValueSpecifiedUnits(svg.Length.SVG_LENGTHTYPE_NUMBER, bounds.bottom);
+
+  final svg.PathElement pathElement = svg.PathElement();
+  root.append(pathElement);
   if (paint.style == PaintingStyle.stroke ||
       paint.strokeWidth != 0.0) {
-    sb.write('stroke="${colorToCssString(paint.color)}" ');
-    sb.write('stroke-width="${paint.strokeWidth}" ');
+    pathElement.setAttribute('stroke', colorToCssString(paint.color)!);
+    pathElement.setAttribute('stroke-width', paint.strokeWidth);
     if (!enableFill) {
-      sb.write('fill="none" ');
+      pathElement.setAttribute('fill', 'none');
     }
   }
   if (paint.style == PaintingStyle.fill) {
-    sb.write('fill="${colorToCssString(paint.color)}" ');
+    pathElement.setAttribute('fill', colorToCssString(paint.color)!);
   }
-  sb.write('d="');
-  pathToSvg((path as SurfacePath).pathRef, sb); // This is what we're testing!
-  sb.write('"></path>');
-  sb.write('</svg>');
-  final html.Element svgElement =
-      html.Element.html(sb.toString(), treeSanitizer: NullTreeSanitizer());
-  svgElement.style.transform = 'translate(200px, 0px)';
-  return svgElement;
+  pathElement.setAttribute('d', pathToSvg((path as SurfacePath).pathRef)); // This is what we're testing!
+  return root;
 }
 
 class ArcSample {
@@ -216,6 +215,7 @@ class ArcSample {
   final bool largeArc;
   final bool clockwise;
   final double distance;
+
   ArcSample(this.offset,
       {this.largeArc = false, this.clockwise = false, this.distance = 0});
 


### PR DESCRIPTION
- Use typed SVG API instead of SVG strings for compatibility with [TrustedTypes](https://w3c.github.io/webappsec-trusted-types/dist/spec/).
- Remove `NullTreeSanitizer`.

Fixes b/198428641