### PR TITLE
Fix partial repaint when TextureLayer is inside retained layer

### DIFF
--- a/flow/diff_context.cc
+++ b/flow/diff_context.cc
@@ -21,6 +21,7 @@ void DiffContext::BeginSubtree() {
   state_stack_.push_back(state_);
   state_.rect_index_ = rects_->size();
   state_.has_filter_bounds_adjustment = false;
+  state_.has_texture = false;
   if (state_.transform_override) {
     state_.transform = *state_.transform_override;
     state_.transform_override = std::nullopt;

--- a/flow/diff_context.h
+++ b/flow/diff_context.h
@@ -104,6 +104,10 @@ class DiffContext {
 
   bool IsSubtreeDirty() const { return state_.dirty; }
 
+  // Marks that current subtree contains a TextureLayer. This is needed to
+  // ensure that we'll Diff the TextureLayer even if inside retained layer.
+  void MarkSubtreeHasTextureLayer();
+
   // Add layer bounds to current paint region; rect is in "local" (layer)
   // coordinates.
   void AddLayerBounds(const SkRect& rect);
@@ -203,6 +207,9 @@ class DiffContext {
     // Whether this subtree has filter bounds adjustment function. If so,
     // it will need to be removed from stack when subtree is closed.
     bool has_filter_bounds_adjustment;
+
+    // Whether there is a texture layer in this subtree.
+    bool has_texture;
   };
 
   std::shared_ptr<std::vector<SkRect>> rects_;

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -77,7 +77,8 @@ void ContainerLayer::DiffChildren(DiffContext* context,
       auto layer = layers_[i];
       auto prev_layer = prev_layers[i_prev];
       auto paint_region = context->GetOldLayerPaintRegion(prev_layer.get());
-      if (layer == prev_layer && !paint_region.has_readback()) {
+      if (layer == prev_layer && !paint_region.has_readback() &&
+          !paint_region.has_texture()) {
         // for retained layers, stop processing the subtree and add existing
         // region; We know current subtree is not dirty (every ancestor up to
         // here matches) so the retained subtree will render identically to

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -35,6 +35,7 @@ void TextureLayer::Diff(DiffContext* context, const Layer* old_layer) {
   // assumption is that the retained subtree will render identically to previous
   // frame. This does not hold true if there is TextureLayer in the hierarchy.
   // See ContainerLayer::DiffChildren
+  // https://github.com/flutter/flutter/issues/92925
   context->AddReadbackRegion(SkIRect::MakeEmpty());
   context->AddLayerBounds(SkRect::MakeXYWH(offset_.x(), offset_.y(),
                                            size_.width(), size_.height()));

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -28,6 +28,14 @@ void TextureLayer::Diff(DiffContext* context, const Layer* old_layer) {
     // dirty
     context->MarkSubtreeDirty(context->GetOldLayerPaintRegion(prev));
   }
+  // This adds a "fake" readback region. The region is empty, so it doesn't
+  // trigger any additional repaints (nothing intersects it), but it is enough
+  // to ensure that `ContainerLayer::DiffChildren` will diff texture layer
+  // even if placed inside a retained subtree. When diffing retained layer the
+  // assumption is that the retained subtree will render identically to previous
+  // frame. This does not hold true if there is TextureLayer in the hierarchy.
+  // See ContainerLayer::DiffChildren
+  context->AddReadbackRegion(SkIRect::MakeEmpty());
   context->AddLayerBounds(SkRect::MakeXYWH(offset_.x(), offset_.y(),
                                            size_.width(), size_.height()));
   context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -28,15 +28,13 @@ void TextureLayer::Diff(DiffContext* context, const Layer* old_layer) {
     // dirty
     context->MarkSubtreeDirty(context->GetOldLayerPaintRegion(prev));
   }
-  // This adds a "fake" readback region. The region is empty, so it doesn't
-  // trigger any additional repaints (nothing intersects it), but it is enough
-  // to ensure that `ContainerLayer::DiffChildren` will diff texture layer
-  // even if placed inside a retained subtree. When diffing retained layer the
-  // assumption is that the retained subtree will render identically to previous
-  // frame. This does not hold true if there is TextureLayer in the hierarchy.
+
+  // Make sure DiffContext knows there is a TextureLayer in this subtree.
+  // This prevents ContainerLayer from skipping TextureLayer diffing when
+  // TextureLayer is inside retained layer.
   // See ContainerLayer::DiffChildren
   // https://github.com/flutter/flutter/issues/92925
-  context->AddReadbackRegion(SkIRect::MakeEmpty());
+  context->MarkSubtreeHasTextureLayer();
   context->AddLayerBounds(SkRect::MakeXYWH(offset_.x(), offset_.y(),
                                            size_.width(), size_.height()));
   context->SetLayerPaintRegion(this, context->CurrentSubtreeRegion());

--- a/flow/paint_region.h
+++ b/flow/paint_region.h
@@ -25,8 +25,13 @@ class PaintRegion {
   PaintRegion(std::shared_ptr<std::vector<SkRect>> rects,
               size_t from,
               size_t to,
-              bool has_readback)
-      : rects_(rects), from_(from), to_(to), has_readback_(has_readback) {}
+              bool has_readback,
+              bool has_texture)
+      : rects_(rects),
+        from_(from),
+        to_(to),
+        has_readback_(has_readback),
+        has_texture_(has_texture) {}
 
   std::vector<SkRect>::const_iterator begin() const {
     FML_DCHECK(is_valid());
@@ -47,11 +52,16 @@ class PaintRegion {
   // that performs readback
   bool has_readback() const { return has_readback_; }
 
+  // Returns whether there is a TextureLayer in subtree represented by this
+  // region.
+  bool has_texture() const { return has_texture_; }
+
  private:
   std::shared_ptr<std::vector<SkRect>> rects_;
   size_t from_ = 0;
   size_t to_ = 0;
   bool has_readback_ = false;
+  bool has_texture_ = false;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/92925

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
