### PR TITLE
Revert "Roll Clang Mac from HpW96jrB8... to JziYOnXHQ..."

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -614,7 +614,7 @@ deps = {
     'packages': [
       {
         'package': 'fuchsia/third_party/clang/mac-amd64',
-        'version': 'JziYOnXHQl5HWEeJFdcM_FLyiZvAH-vzj0MlAUoyPLoC'
+        'version': 'HpW96jrB88KywoOfefFMDzkNHrBnKJb9FCLvDtrxlAEC'
       }
     ],
     'condition': 'host_os == "mac"',


### PR DESCRIPTION
Reverts flutter/engine#29466

GOMA on mac  does not work properly after this roll. Bug: https://github.com/flutter/flutter/issues/92936