### PR TITLE
Make the frontend_server validate kernel files more strictly

### DIFF
--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -273,7 +273,7 @@ template("application_snapshot") {
   #
   # (Instead of ensuring every user of the "application_snapshot" passes it's
   # own)
-  snapshot_vm_args += ["-Dsdk_hash=$sdk_hash"]
+  snapshot_vm_args += [ "-Dsdk_hash=$sdk_hash" ]
 
   if (flutter_prebuilt_dart_sdk) {
     action(target_name) {

--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -8,6 +8,7 @@ import("//build/compiled_action.gni")
 import("//build/module_args/dart.gni")
 import("//flutter/common/config.gni")
 import("//third_party/dart/build/dart/dart_action.gni")
+import("//third_party/dart/sdk_args.gni")
 
 frontend_server_files =
     exec_script("//third_party/dart/tools/list_dart_files.py",
@@ -266,6 +267,13 @@ template("application_snapshot") {
   } else {
     assert(false, "Bad snapshot_kind: '$snapshot_kind'")
   }
+
+  # Ensure the compiled appliation (e.g. frontend-server, ...) will use this
+  # Dart SDK hash when consuming/producing kernel.
+  #
+  # (Instead of ensuring every user of the "application_snapshot" passes it's
+  # own)
+  snapshot_vm_args += ["-Dsdk_hash=$sdk_hash"]
 
   if (flutter_prebuilt_dart_sdk) {
     action(target_name) {


### PR DESCRIPTION
This change will make Flutter's frontend_server validate that any kernel
file given to it was produced by the same Dart SDK hash as the
frontend_server itself is based upon.

Notice that this implies one cannot use the prebuilt Dart SDK's
frontend_server and give it kernel files produced in the current build
iff //third_party/dart is at a different SDK hash. (By-default the
prebuilt Dart SDK and //third_party/dart are based on the same git
commit hash)

=> This is mainly relevant for people who change //third_party/dart
   during local development (e.g. for preparing rolls, ...)

=> In such cases one should pass "--no-prebuilt-dart-sdk" to
   flutter/tools/gn

The effect of this change is that one will get a clear message on
mismatched kernel files instead of possibly an exception from the CFE.

The change is changing the Flutter build actions similar to how [0]
changed the Dart build actions.

Issue https://github.com/flutter/flutter/issues/92679

[0] https://dart-review.googlesource.com/c/sdk/+/152802