### PR TITLE
Windows: Make `task_runner_unittests.cc` more deterministic.

### DIFF
--- a/shell/platform/windows/task_runner.cc
+++ b/shell/platform/windows/task_runner.cc
@@ -15,7 +15,7 @@ TaskRunner::TaskRunner(CurrentTimeProc get_current_time,
       on_task_expired_(std::move(on_task_expired)) {}
 
 std::chrono::nanoseconds TaskRunner::ProcessTasks() {
-  const TaskTimePoint now = TaskTimePoint::clock::now();
+  const TaskTimePoint now = GetCurrentTimeForTask();
 
   std::vector<Task> expired_tasks;
 
@@ -64,7 +64,7 @@ std::chrono::nanoseconds TaskRunner::ProcessTasks() {
 
 TaskRunner::TaskTimePoint TaskRunner::TimePointFromFlutterTime(
     uint64_t flutter_target_time_nanos) const {
-  const auto now = TaskTimePoint::clock::now();
+  const auto now = GetCurrentTimeForTask();
   const auto flutter_duration = flutter_target_time_nanos - get_current_time_();
   return now + std::chrono::nanoseconds(flutter_duration);
 }
@@ -79,7 +79,7 @@ void TaskRunner::PostFlutterTask(FlutterTask flutter_task,
 
 void TaskRunner::PostTask(TaskClosure closure) {
   Task task;
-  task.fire_time = TaskTimePoint::clock::now();
+  task.fire_time = GetCurrentTimeForTask();
   task.variant = std::move(closure);
   EnqueueTask(std::move(task));
 }

--- a/shell/platform/windows/task_runner.h
+++ b/shell/platform/windows/task_runner.h
@@ -66,6 +66,14 @@ class TaskRunner {
   // Each platform implementations must call this to schedule the tasks.
   std::chrono::nanoseconds ProcessTasks();
 
+  // Returns the current TaskTimePoint that can be used to determine whether a
+  // task is expired.
+  //
+  // Tests can override this to mock up the time.
+  virtual TaskTimePoint GetCurrentTimeForTask() const {
+    return TaskTimePoint::clock::now();
+  }
+
  private:
   typedef std::variant<FlutterTask, TaskClosure> TaskVariant;
 

--- a/shell/platform/windows/task_runner_unittests.cc
+++ b/shell/platform/windows/task_runner_unittests.cc
@@ -25,6 +25,12 @@ class MockTaskRunner : public TaskRunner {
     // Do nothing to avoid processing tasks immediately after the tasks is
     // posted.
   }
+
+  virtual TaskTimePoint GetCurrentTimeForTask() const override {
+    return TaskTimePoint(
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::nanoseconds(10000)));
+  }
 };
 
 uint64_t MockGetCurrentTime() {


### PR DESCRIPTION
This PR is cleanup #28013 from https://github.com/flutter/engine/pull/29484#issuecomment-958586332.
This PR will enable `task_runner_unittests.cc` to mock `TaskTimePoint::clock::now()` by overriding, and make `task_runner_unittests.cc` more deterministic.

No tests in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [ ] All existing and new tests are passing.