### PR TITLE
Embedder VsyncWaiter must schedule a frame for the right time (#29408)

### DIFF
--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -229,8 +229,8 @@ bool EmbedderEngine::OnVsyncEvent(intptr_t baton,
     return false;
   }
 
-  return VsyncWaiterEmbedder::OnEmbedderVsync(baton, frame_start_time,
-                                              frame_target_time);
+  return VsyncWaiterEmbedder::OnEmbedderVsync(
+      task_runners_, baton, frame_start_time, frame_target_time);
 }
 
 bool EmbedderEngine::ReloadSystemFonts() {

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -261,6 +261,13 @@ void EmbedderConfigBuilder::SetPlatformTaskRunner(
   project_args_.custom_task_runners = &custom_task_runners_;
 }
 
+void EmbedderConfigBuilder::SetupVsyncCallback() {
+  project_args_.vsync_callback = [](void* user_data, intptr_t baton) {
+    auto context = reinterpret_cast<EmbedderTestContext*>(user_data);
+    context->RunVsyncCallback(baton);
+  };
+}
+
 void EmbedderConfigBuilder::SetRenderTaskRunner(
     const FlutterTaskRunnerDescription* runner) {
   if (runner == nullptr) {

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -104,6 +104,10 @@ class EmbedderConfigBuilder {
 
   UniqueEngine InitializeEngine() const;
 
+  // Sets up the callback for vsync, the callbacks needs to be specified on the
+  // text context vis `SetVsyncCallback`.
+  void SetupVsyncCallback();
+
  private:
   EmbedderTestContext& context_;
   FlutterProjectArgs project_args_ = {};

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -224,5 +224,14 @@ void EmbedderTestContext::FireRootSurfacePresentCallbackIfPresent(
   callback(image_callback());
 }
 
+void EmbedderTestContext::SetVsyncCallback(
+    std::function<void(intptr_t)> callback) {
+  vsync_callback_ = callback;
+}
+
+void EmbedderTestContext::RunVsyncCallback(intptr_t baton) {
+  vsync_callback_(baton);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -89,6 +89,15 @@ class EmbedderTestContext {
 
   virtual EmbedderTestContextType GetContextType() const = 0;
 
+  // Sets up the callback for vsync. This callback will be invoked
+  // for every vsync. This should be used in conjunction with SetupVsyncCallback
+  // on the EmbedderConfigBuilder. Any callback setup here must call
+  // `FlutterEngineOnVsync` from the platform task runner.
+  void SetVsyncCallback(std::function<void(intptr_t)> callback);
+
+  // Runs the vsync callback.
+  void RunVsyncCallback(intptr_t baton);
+
   // TODO(gw280): encapsulate these properly for subclasses to use
  protected:
   // This allows the builder to access the hooks.
@@ -112,6 +121,7 @@ class EmbedderTestContext {
   std::unique_ptr<EmbedderTestCompositor> compositor_;
   NextSceneCallback next_scene_callback_;
   SkMatrix root_surface_transformation_;
+  std::function<void(intptr_t)> vsync_callback_ = nullptr;
 
   static VoidCallback GetIsolateCreateCallbackHook();
 

--- a/shell/platform/embedder/vsync_waiter_embedder.h
+++ b/shell/platform/embedder/vsync_waiter_embedder.h
@@ -19,7 +19,8 @@ class VsyncWaiterEmbedder final : public VsyncWaiter {
 
   ~VsyncWaiterEmbedder() override;
 
-  static bool OnEmbedderVsync(intptr_t baton,
+  static bool OnEmbedderVsync(const flutter::TaskRunners& task_runners,
+                              intptr_t baton,
                               fml::TimePoint frame_start_time,
                               fml::TimePoint frame_target_time);
 


### PR DESCRIPTION
* commit: https://github.com/flutter/engine/commit/43561d8820e03e08959f791bfbb3097ce6be5756
* commit: https://github.com/flutter/engine/commit/a2b894628179f31689080d555a9d4afa9cce95be
* 
## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
