### PR TITLE
[fuchsia] Remove mentions of `fuchsia.deprecatedtimezone`.

### DIFF
--- a/shell/platform/fuchsia/flutter/integration_flutter_tests/embedder/flutter-embedder-test2.cc
+++ b/shell/platform/fuchsia/flutter/integration_flutter_tests/embedder/flutter-embedder-test2.cc
@@ -62,8 +62,6 @@ const std::vector<std::pair<const char*, const char*>> GetInjectedServices() {
   std::vector<std::pair<const char*, const char*>> injected_services = {{
       {"fuchsia.accessibility.semantics.SemanticsManager",
        "fuchsia-pkg://fuchsia.com/a11y-manager#meta/a11y-manager.cmx"},
-      {"fuchsia.deprecatedtimezone.Timezone",
-       "fuchsia-pkg://fuchsia.com/timezone#meta/timezone.cmx"},
       {"fuchsia.fonts.Provider",
        "fuchsia-pkg://fuchsia.com/fonts#meta/fonts.cmx"},
       {"fuchsia.hardware.display.Provider",

--- a/shell/platform/fuchsia/flutter/meta/common.shard.cml
+++ b/shell/platform/fuchsia/flutter/meta/common.shard.cml
@@ -32,7 +32,6 @@
         {
             protocol: [
                 "fuchsia.accessibility.semantics.SemanticsManager",
-                "fuchsia.deprecatedtimezone.Timezone",
                 "fuchsia.device.NameProvider",
                 "fuchsia.feedback.CrashReporter",
                 "fuchsia.fonts.Provider",


### PR DESCRIPTION
The FIDL library `fuchsia.deprecatedtimezone` is has not been used in Flutter
for about a year now.  Removing the mentions here, because the utilities
that used to provide it will be removed too, making these tests fail.

Removing the references will allow us to retire the timezone services.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

Fixes https://github.com/flutter/flutter/issues/93003

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
