### PR TITLE
Provide a default handler for the flutter/navigation channel

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.JSONMethodCodec;
+import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 
 /** TODO(mattcarroll): fill in javadoc for NavigationChannel. */
@@ -19,7 +20,18 @@ public class NavigationChannel {
 
   public NavigationChannel(@NonNull DartExecutor dartExecutor) {
     this.channel = new MethodChannel(dartExecutor, "flutter/navigation", JSONMethodCodec.INSTANCE);
+    channel.setMethodCallHandler(defaultHandler);
   }
+
+  // Provide a default handler that returns an empty response to any messages
+  // on this channel.
+  private final MethodChannel.MethodCallHandler defaultHandler =
+      new MethodChannel.MethodCallHandler() {
+        @Override
+        public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+          result.success(null);
+        }
+      };
 
   public void setInitialRoute(@NonNull String initialRoute) {
     Log.v(TAG, "Sending message to set initial route to '" + initialRoute + "'");


### PR DESCRIPTION
This ensures that messages sent to this channel by the framework will not be
stored indefinitely if buffering is enabled.
(see https://github.com/flutter/engine/pull/29377)