### PR TITLE
FragmentProgram constructed asynchronously

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3773,8 +3773,15 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
   /// well-specified.  Because of this, it is reccommended to construct
   /// `FragmentProgram` asynchronously, outside of a widget's `build`
   /// method; this will minimize the chance of UI jank.
+  static Future<FragmentProgram> compile({
+    required ByteBuffer spirv,
+    bool debugPrint = false,
+  }) async {
+    return FragmentProgram._(spirv: spirv, debugPrint: debugPrint);
+  }
+
   @pragma('vm:entry-point')
-  FragmentProgram({
+  FragmentProgram._({
     required ByteBuffer spirv,
     bool debugPrint = false,
   }) {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3768,11 +3768,6 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
   ///
   /// [A current specification of valid SPIR-V is here.](https://github.com/flutter/engine/blob/master/lib/spirv/README.md)
   /// SPIR-V not meeting this specification will throw an exception.
-  ///
-  /// Performance of shader-compilation is platform dependent and is not
-  /// well-specified.  Because of this, it is reccommended to construct
-  /// `FragmentProgram` asynchronously, outside of a widget's `build`
-  /// method; this will minimize the chance of UI jank.
   static Future<FragmentProgram> compile({
     required ByteBuffer spirv,
     bool debugPrint = false,

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3771,8 +3771,8 @@ class FragmentProgram extends NativeFieldWrapperClass1 {
   static Future<FragmentProgram> compile({
     required ByteBuffer spirv,
     bool debugPrint = false,
-  }) async {
-    return FragmentProgram._(spirv: spirv, debugPrint: debugPrint);
+  }) {
+    return Future<FragmentProgram>(() => FragmentProgram._(spirv: spirv, debugPrint: debugPrint));
   }
 
   @pragma('vm:entry-point')

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -797,12 +797,7 @@ class FragmentProgram {
     throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
   }
 
-  FragmentProgram._({
-    required ByteBuffer spirv, // ignore: avoid_unused_constructor_parameters
-    bool debugPrint = false, // ignore: avoid_unused_constructor_parameters
-  }) {
-    throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
-  }
+  FragmentProgram._();
 
   Shader shader({
     required Float32List floatUniforms,

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -793,7 +793,7 @@ class FragmentProgram {
   static Future<FragmentProgram> compile({
     required ByteBuffer spirv,
     bool debugPrint = false,
-  }) async {
+  }) {
     throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
   }
 

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -790,7 +790,14 @@ class ImageDescriptor {
 }
 
 class FragmentProgram {
-  FragmentProgram({
+  static Future<FragmentProgram> compile({
+    required ByteBuffer spirv,
+    bool debugPrint = false,
+  }) async {
+    throw UnsupportedError('FragmentProgram is not supported for the CanvasKit or HTML renderers.');
+  }
+
+  FragmentProgram._({
     required ByteBuffer spirv, // ignore: avoid_unused_constructor_parameters
     bool debugPrint = false, // ignore: avoid_unused_constructor_parameters
   }) {


### PR DESCRIPTION
Return a `Future<FragmentProgram>` from a new static `compile` method, and make the synchronous constructor private.

https://github.com/flutter/flutter/issues/92021

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.