### PR TITLE
Enable Skia's Vulkan backend on all non-mobile platforms, and test SwiftShader Vulkan on all GL unittests platforms

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1537,15 +1537,8 @@ TEST_F(ShellTest, SetResourceCacheSize) {
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
 
-  // The Vulkan and GL backends set different default values for the resource
-  // cache size.
-#ifdef SHELL_ENABLE_VULKAN
-  EXPECT_EQ(GetRasterizerResourceCacheBytesSync(*shell),
-            vulkan::kGrCacheMaxByteSize);
-#else
   EXPECT_EQ(GetRasterizerResourceCacheBytesSync(*shell),
             static_cast<size_t>(24 * (1 << 20)));
-#endif
 
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -15,6 +15,7 @@ declare_args() {
 declare_args() {
   test_enable_gl = shell_enable_gl
   test_enable_metal = shell_enable_metal
+
   # The Vulkan unittests are combined with the GL unittests.
   test_enable_vulkan = shell_enable_gl
   test_enable_software = shell_enable_software

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -17,6 +17,6 @@ declare_args() {
   test_enable_metal = shell_enable_metal
 
   # The Vulkan unittests are combined with the GL unittests.
-  test_enable_vulkan = shell_enable_gl
+  test_enable_vulkan = is_fuchsia || shell_enable_gl
   test_enable_software = shell_enable_software
 }

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -15,6 +15,7 @@ declare_args() {
 declare_args() {
   test_enable_gl = shell_enable_gl
   test_enable_metal = shell_enable_metal
-  test_enable_vulkan = shell_enable_vulkan
+  # The Vulkan unittests are combined with the GL unittests.
+  test_enable_vulkan = shell_enable_gl
   test_enable_software = shell_enable_software
 }

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -4,9 +4,11 @@
 
 declare_args() {
   shell_enable_gl = !is_fuchsia
-  shell_enable_metal = false
 
-  shell_enable_vulkan = true
+  # The logic for enabling Vulkan and Metal is in tools/gn.
+  shell_enable_metal = false
+  shell_enable_vulkan = false
+
   shell_enable_software = true
 }
 

--- a/shell/config.gni
+++ b/shell/config.gni
@@ -6,14 +6,13 @@ declare_args() {
   shell_enable_gl = !is_fuchsia
   shell_enable_metal = false
 
-  # TODO(dworsham): Enable once Fuchsia supports Vulkan through the embedder.
-  shell_enable_vulkan = false
+  shell_enable_vulkan = true
   shell_enable_software = true
 }
 
 declare_args() {
   test_enable_gl = shell_enable_gl
   test_enable_metal = shell_enable_metal
-  test_enable_vulkan = is_fuchsia
+  test_enable_vulkan = shell_enable_vulkan
   test_enable_software = shell_enable_software
 }

--- a/shell/platform/android/context/BUILD.gn
+++ b/shell/platform/android/context/BUILD.gn
@@ -14,6 +14,7 @@ source_set("context") {
 
   deps = [
     "//flutter/fml",
+    "//flutter/vulkan",
     "//third_party/skia",
   ]
 }

--- a/shell/platform/android/context/BUILD.gn
+++ b/shell/platform/android/context/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//flutter/common/config.gni")
+import("//flutter/shell/config.gni")
 
 source_set("context") {
   sources = [
@@ -14,7 +15,10 @@ source_set("context") {
 
   deps = [
     "//flutter/fml",
-    "//flutter/vulkan",
     "//third_party/skia",
   ]
+
+  if (shell_enable_vulkan) {
+    deps += [ "//flutter/vulkan" ]
+  }
 }

--- a/shell/platform/android/surface/BUILD.gn
+++ b/shell/platform/android/surface/BUILD.gn
@@ -50,6 +50,7 @@ source_set("surface_mock") {
   deps = [
     ":surface",
     "//flutter/shell/gpu:gpu_surface_gl",
+    "//flutter/vulkan",
     "//third_party/googletest:gmock",
     "//third_party/googletest:gtest",
     "//third_party/skia",

--- a/shell/platform/android/surface/BUILD.gn
+++ b/shell/platform/android/surface/BUILD.gn
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/shell/config.gni")
+
 source_set("surface") {
   sources = [
     "android_surface.cc",
@@ -50,9 +52,12 @@ source_set("surface_mock") {
   deps = [
     ":surface",
     "//flutter/shell/gpu:gpu_surface_gl",
-    "//flutter/vulkan",
     "//third_party/googletest:gmock",
     "//third_party/googletest:gtest",
     "//third_party/skia",
   ]
+
+  if (shell_enable_vulkan) {
+    deps += [ "//flutter/vulkan" ]
+  }
 }

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -7,6 +7,7 @@ assert(is_ios)
 import("//build/config/ios/ios_sdk.gni")
 import("//build/toolchain/clang.gni")
 import("//flutter/common/config.gni")
+import("//flutter/shell/config.gni")
 import("//flutter/shell/gpu/gpu.gni")
 import("//flutter/shell/platform/darwin/common/framework_shared.gni")
 import("//flutter/testing/testing.gni")
@@ -212,11 +213,14 @@ source_set("ios_test_flutter_mrc") {
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/third_party/tonic",
     "//flutter/third_party/txt",
-    "//flutter/vulkan",
     "//third_party/ocmock:ocmock_shared",
     "//third_party/rapidjson",
     "//third_party/skia",
   ]
+
+  if (shell_enable_vulkan) {
+    deps += [ "//flutter/vulkan" ]
+  }
 }
 
 shared_library("ios_test_flutter") {

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -212,6 +212,7 @@ source_set("ios_test_flutter_mrc") {
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/third_party/tonic",
     "//flutter/third_party/txt",
+    "//flutter/vulkan",
     "//third_party/ocmock:ocmock_shared",
     "//third_party/rapidjson",
     "//third_party/skia",

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -242,6 +242,13 @@ if (enable_unittests) {
 
       deps += [ "//flutter/testing:metal" ]
     }
+
+    if (test_enable_vulkan) {
+      deps += [
+        "//flutter/testing:vulkan",
+        "//flutter/vulkan",
+      ]
+    }
   }
 
   # Tests the build in FLUTTER_ENGINE_NO_PROTOTYPES mode.

--- a/shell/platform/embedder/tests/embedder_unittests_gl.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_gl.cc
@@ -29,6 +29,7 @@
 #include "flutter/shell/platform/embedder/tests/embedder_unittests_util.h"
 #include "flutter/testing/assertions_skia.h"
 #include "flutter/testing/test_gl_surface.h"
+#include "flutter/testing/test_vulkan_context.h"
 #include "flutter/testing/testing.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/src/gpu/gl/GrGLDefines.h"
@@ -39,8 +40,14 @@ namespace testing {
 
 using EmbedderTest = testing::EmbedderTest;
 
+//------------------------------------------------------------------------------
+/// This is a sanity check to ensure Swiftshader Vulkan is working. Once Vulkan
+/// support lands in the embedder API, it'll be tested via a new
+/// EmbedderTestContext type/config.
+///
 TEST_F(EmbedderTest, CanInitializeTestVulkanContext) {
   TestVulkanContext ctx;
+  ASSERT_TRUE(ctx.is_valid());
 }
 
 TEST_F(EmbedderTest, CanCreateOpenGLRenderingEngine) {

--- a/shell/platform/embedder/tests/embedder_unittests_gl.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_gl.cc
@@ -47,7 +47,7 @@ using EmbedderTest = testing::EmbedderTest;
 ///
 TEST_F(EmbedderTest, CanInitializeTestVulkanContext) {
   TestVulkanContext ctx;
-  ASSERT_TRUE(ctx.is_valid());
+  ASSERT_TRUE(ctx.IsValid());
 }
 
 TEST_F(EmbedderTest, CanCreateOpenGLRenderingEngine) {

--- a/shell/platform/embedder/tests/embedder_unittests_gl.cc
+++ b/shell/platform/embedder/tests/embedder_unittests_gl.cc
@@ -39,6 +39,10 @@ namespace testing {
 
 using EmbedderTest = testing::EmbedderTest;
 
+TEST_F(EmbedderTest, CanInitializeTestVulkanContext) {
+  TestVulkanContext ctx;
+}
+
 TEST_F(EmbedderTest, CanCreateOpenGLRenderingEngine) {
   EmbedderConfigBuilder builder(
       GetEmbedderContext(EmbedderTestContextType::kOpenGLContext));

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -130,9 +130,7 @@ if (enable_unittests) {
       "test_vulkan_context.h",
     ]
 
-    defines = [
-      "TEST_VULKAN_PROCS",
-    ]
+    defines = [ "TEST_VULKAN_PROCS" ]
 
     deps = [
       ":skia",

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -130,6 +130,10 @@ if (enable_unittests) {
       "test_vulkan_context.h",
     ]
 
+    defines = [
+      "TEST_VULKAN_PROCS",
+    ]
+
     deps = [
       ":skia",
       "//flutter/fml",

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -125,6 +125,11 @@ if (enable_unittests) {
   source_set("vulkan") {
     testonly = true
 
+    sources = [
+      "test_vulkan_context.cc",
+      "test_vulkan_context.h",
+    ]
+
     deps = [
       ":skia",
       "//flutter/fml",
@@ -178,6 +183,8 @@ if (enable_unittests) {
       deps = [
         ":skia",
         "//flutter/fml",
+        # Skia's Vulkan support is enabled for all platforms, and so parts of
+        # Skia's graphics context reference Vulkan symbols.
         "//flutter/vulkan",
       ]
     }

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -128,6 +128,7 @@ if (enable_unittests) {
     deps = [
       ":skia",
       "//flutter/fml",
+      "//flutter/vulkan",
     ]
 
     # SwiftShader only supports x86/x86_64
@@ -177,6 +178,7 @@ if (enable_unittests) {
       deps = [
         ":skia",
         "//flutter/fml",
+        "//flutter/vulkan",
       ]
     }
 
@@ -199,6 +201,7 @@ if (enable_unittests) {
       ":testing",
       ":testing_fixtures",
       "//flutter/runtime:libdart",
+      "//flutter/vulkan",
     ]
 
     if (shell_enable_metal) {

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -180,11 +180,11 @@ if (enable_unittests) {
         "test_metal_surface_impl.mm",
       ]
 
+      # Skia's Vulkan support is enabled for all platforms, and so parts of
+      # Skia's graphics context reference Vulkan symbols.
       deps = [
         ":skia",
         "//flutter/fml",
-        # Skia's Vulkan support is enabled for all platforms, and so parts of
-        # Skia's graphics context reference Vulkan symbols.
         "//flutter/vulkan",
       ]
     }

--- a/testing/test_vulkan_context.cc
+++ b/testing/test_vulkan_context.cc
@@ -45,7 +45,7 @@ TestVulkanContext::TestVulkanContext() : valid_(false) {
 
 TestVulkanContext::~TestVulkanContext() = default;
 
-bool TestVulkanContext::is_valid() {
+bool TestVulkanContext::IsValid() {
   return valid_;
 }
 

--- a/testing/test_vulkan_context.cc
+++ b/testing/test_vulkan_context.cc
@@ -1,0 +1,52 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "test_vulkan_context.h"
+
+#include "flutter/vulkan/vulkan_proc_table.h"
+
+#ifdef OS_MACOSX
+#define VULKAN_SO_PATH "libvk_swiftshader.dylib"
+#elif OS_WIN
+#define VULKAN_SO_PATH "vk_swiftshader.dll"
+#else
+#define VULKAN_SO_PATH "libvk_swiftshader.so"
+#endif
+
+namespace flutter {
+
+TestVulkanContext::TestVulkanContext() : valid_(false) {
+  vk_ = fml::MakeRefCounted<vulkan::VulkanProcTable>(VULKAN_SO_PATH);
+  if (!vk_ || !vk_->HasAcquiredMandatoryProcAddresses()) {
+    FML_DLOG(ERROR) << "Proc table has not acquired mandatory proc addresses.";
+    return;
+  }
+
+  application_ = std::unique_ptr<vulkan::VulkanApplication>(
+      new vulkan::VulkanApplication(*vk_, "Flutter Unittests", {}));
+  if (!application_->IsValid()) {
+    FML_DLOG(ERROR) << "Failed to initialize basic Vulkan state.";
+    return;
+  }
+  if (!vk_->AreInstanceProcsSetup()) {
+    FML_DLOG(ERROR) << "Failed to acquire full proc table.";
+    return;
+  }
+
+  logical_device_ = application_->AcquireFirstCompatibleLogicalDevice();
+  if (!logical_device_ || !logical_device_->IsValid()) {
+    FML_DLOG(ERROR) << "Failed to create compatible logical device.";
+    return;
+  }
+
+  valid_ = true;
+}
+
+TestVulkanContext::~TestVulkanContext() = default;
+
+bool TestVulkanContext::is_valid() {
+  return valid_;
+}
+
+}  // namespace flutter

--- a/testing/test_vulkan_context.h
+++ b/testing/test_vulkan_context.h
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_TESTING_TEST_VULKAN_CONTEXT_H_
+#define FLUTTER_TESTING_TEST_VULKAN_CONTEXT_H_
+
+#include "flutter/vulkan/vulkan_application.h"
+#include "flutter/vulkan/vulkan_device.h"
+#include "flutter/vulkan/vulkan_proc_table.h"
+
+namespace flutter {
+
+/// @brief  Utility class to create a Vulkan device context, a corresponding
+///         Skia context, and device resources.
+class TestVulkanContext {
+ public:
+  TestVulkanContext();
+  ~TestVulkanContext();
+  bool is_valid();
+
+ private:
+  bool valid_;
+  fml::RefPtr<vulkan::VulkanProcTable> vk_;
+  std::unique_ptr<vulkan::VulkanApplication> application_;
+  std::unique_ptr<vulkan::VulkanDevice> logical_device_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_TESTING_TEST_VULKAN_CONTEXT_H_

--- a/testing/test_vulkan_context.h
+++ b/testing/test_vulkan_context.h
@@ -17,13 +17,15 @@ class TestVulkanContext {
  public:
   TestVulkanContext();
   ~TestVulkanContext();
-  bool is_valid();
+  bool IsValid();
 
  private:
-  bool valid_;
+  bool valid_ = false;
   fml::RefPtr<vulkan::VulkanProcTable> vk_;
   std::unique_ptr<vulkan::VulkanApplication> application_;
   std::unique_ptr<vulkan::VulkanDevice> logical_device_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(TestVulkanContext);
 };
 
 }  // namespace flutter

--- a/tools/gn
+++ b/tools/gn
@@ -312,12 +312,11 @@ def to_gn_args(args):
       gn_args['skia_use_metal'] = True
       gn_args['shell_enable_metal'] = True
 
-    # Enable Vulkan on everything except iOS. We currently have to exclude iOS
-    # because Skia uses VMA and we target iOS 9. VMA uses C++17 standard
-    # library features only available in iOS 10+.
-    if args.target_os != 'ios':
-      gn_args['skia_use_vulkan'] = True
-      gn_args['shell_enable_vulkan'] = True
+    # Enable Vulkan on all platforms.
+    gn_args['skia_use_vulkan'] = True
+    gn_args['shell_enable_vulkan'] = True
+    if args.target_os == 'ios' or sys.platform.startswith(('cygwin', 'win')):
+      gn_args['skia_enable_vma_shared_mutex'] = False
 
     if sys.platform.startswith(('cygwin', 'win')):
       # The buildroot currently isn't set up to support Vulkan in the

--- a/tools/gn
+++ b/tools/gn
@@ -139,6 +139,7 @@ def to_gn_args(args):
         gn_args['enable_unittests'] = args.enable_unittests
 
     # Skia GN args.
+    gn_args['skia_use_vulkan'] = True
     gn_args['skia_enable_flutter_defines'] = True # Enable Flutter API guards in Skia.
     gn_args['skia_use_dng_sdk'] = False    # RAW image handling.
     gn_args['skia_use_sfntly'] = False     # PDF handling dependency.

--- a/tools/gn
+++ b/tools/gn
@@ -312,11 +312,16 @@ def to_gn_args(args):
       gn_args['skia_use_metal'] = True
       gn_args['shell_enable_metal'] = True
 
-    # Enable Vulkan on all platforms.
-    gn_args['skia_use_vulkan'] = True
-    gn_args['shell_enable_vulkan'] = True
-    if args.target_os == 'ios' or sys.platform.startswith(('cygwin', 'win')):
-      gn_args['skia_enable_vma_shared_mutex'] = False
+    # Enable Vulkan on all platforms except for Android and iOS. This is just
+    # to save on mobile binary size, as there's no reason the Vulkan embedder
+    # features can't work on these platforms.
+    if args.target_os not in ['android', 'ios']:
+      gn_args['skia_use_vulkan'] = True
+      gn_args['shell_enable_vulkan'] = True
+      # Disable VMA's use of std::shared_mutex in environments where the
+      # standard library doesn't support it.
+      if args.target_os == 'ios' or sys.platform.startswith(('cygwin', 'win')):
+        gn_args['skia_disable_vma_stl_shared_mutex'] = True
 
     if sys.platform.startswith(('cygwin', 'win')):
       # The buildroot currently isn't set up to support Vulkan in the

--- a/tools/gn
+++ b/tools/gn
@@ -139,7 +139,6 @@ def to_gn_args(args):
         gn_args['enable_unittests'] = args.enable_unittests
 
     # Skia GN args.
-    gn_args['skia_use_vulkan'] = True
     gn_args['skia_enable_flutter_defines'] = True # Enable Flutter API guards in Skia.
     gn_args['skia_use_dng_sdk'] = False    # RAW image handling.
     gn_args['skia_use_sfntly'] = False     # PDF handling dependency.
@@ -312,6 +311,13 @@ def to_gn_args(args):
       gn_args['allow_deprecated_api_calls'] = True
       gn_args['skia_use_metal'] = True
       gn_args['shell_enable_metal'] = True
+
+    # Enable Vulkan on everything except iOS. We currently have to exclude iOS
+    # because Skia uses VMA and we target iOS 9. VMA uses C++17 standard
+    # library features only available in iOS 10+.
+    if args.target_os != 'ios':
+      gn_args['skia_use_vulkan'] = True
+      gn_args['shell_enable_vulkan'] = True
 
     if sys.platform.startswith(('cygwin', 'win')):
       # The buildroot currently isn't set up to support Vulkan in the

--- a/vulkan/vulkan_debug_report.cc
+++ b/vulkan/vulkan_debug_report.cc
@@ -4,6 +4,7 @@
 
 #include "vulkan_debug_report.h"
 
+#include <algorithm>
 #include <iomanip>
 #include <vector>
 

--- a/vulkan/vulkan_image.cc
+++ b/vulkan/vulkan_image.cc
@@ -31,7 +31,7 @@ bool VulkanImage::InsertImageMemoryBarrier(
     const VulkanCommandBuffer& command_buffer,
     VkPipelineStageFlagBits src_pipline_bits,
     VkPipelineStageFlagBits dest_pipline_bits,
-    VkAccessFlagBits dest_access_flags,
+    VkAccessFlags dest_access_flags,
     VkImageLayout dest_layout) {
   const VkImageMemoryBarrier image_memory_barrier = {
       .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,

--- a/vulkan/vulkan_image.h
+++ b/vulkan/vulkan_image.h
@@ -26,7 +26,7 @@ class VulkanImage {
       const VulkanCommandBuffer& command_buffer,
       VkPipelineStageFlagBits src_pipline_bits,
       VkPipelineStageFlagBits dest_pipline_bits,
-      VkAccessFlagBits dest_access_flags,
+      VkAccessFlags dest_access_flags,
       VkImageLayout dest_layout);
 
  private:

--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -4,8 +4,6 @@
 
 #include "vulkan_proc_table.h"
 
-#include <dlfcn.h>
-
 #include "flutter/fml/logging.h"
 
 #define ACQUIRE_PROC(name, context)                          \
@@ -45,7 +43,7 @@ bool VulkanProcTable::AreDeviceProcsSetup() const {
 }
 
 bool VulkanProcTable::SetupLoaderProcAddresses() {
-  if (handle_ == nullptr) {
+  if (!handle_) {
     return true;
   }
 
@@ -53,8 +51,8 @@ bool VulkanProcTable::SetupLoaderProcAddresses() {
 #if VULKAN_LINK_STATICALLY
       GetInstanceProcAddr = &vkGetInstanceProcAddr;
 #else   // VULKAN_LINK_STATICALLY
-      reinterpret_cast<PFN_vkGetInstanceProcAddr>(
-          dlsym(handle_, "vkGetInstanceProcAddr"));
+      reinterpret_cast<PFN_vkGetInstanceProcAddr>(const_cast<uint8_t*>(
+          handle_->ResolveSymbol("vkGetInstanceProcAddr")));
 #endif  // VULKAN_LINK_STATICALLY
 
   if (!GetInstanceProcAddr) {
@@ -153,36 +151,16 @@ bool VulkanProcTable::SetupDeviceProcAddresses(
 
 bool VulkanProcTable::OpenLibraryHandle(const char* path) {
 #if VULKAN_LINK_STATICALLY
-  static char kDummyLibraryHandle = '\0';
-  handle_ = reinterpret_cast<decltype(handle_)>(&kDummyLibraryHandle);
-  return true;
+  handle_ = fml::NativeLibrary::CreateForCurrentProcess();
 #else   // VULKAN_LINK_STATICALLY
-  dlerror();  // clear existing errors on thread.
-  handle_ = dlopen(path, RTLD_NOW | RTLD_LOCAL);
-  if (handle_ == nullptr) {
-    FML_DLOG(WARNING) << "Could not open the vulkan library: " << dlerror();
-    return false;
-  }
-  return true;
+  handle_ = fml::NativeLibrary::Create(path);
 #endif  // VULKAN_LINK_STATICALLY
+  return !!handle_;
 }
 
 bool VulkanProcTable::CloseLibraryHandle() {
-#if VULKAN_LINK_STATICALLY
   handle_ = nullptr;
   return true;
-#else
-  if (handle_ != nullptr) {
-    dlerror();  // clear existing errors on thread.
-    if (dlclose(handle_) != 0) {
-      FML_DLOG(ERROR) << "Could not close the vulkan library handle. This "
-                         "indicates a leak.";
-      FML_DLOG(ERROR) << dlerror();
-    }
-    handle_ = nullptr;
-  }
-  return handle_ == nullptr;
-#endif
 }
 
 PFN_vkVoidFunction VulkanProcTable::AcquireProc(

--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -129,6 +129,7 @@ bool VulkanProcTable::SetupDeviceProcAddresses(
   ACQUIRE_PROC(ResetCommandBuffer, handle);
   ACQUIRE_PROC(ResetFences, handle);
   ACQUIRE_PROC(WaitForFences, handle);
+#ifndef TEST_VULKAN_PROCS
 #if OS_ANDROID
   ACQUIRE_PROC(AcquireNextImageKHR, handle);
   ACQUIRE_PROC(CreateSwapchainKHR, handle);
@@ -145,6 +146,7 @@ bool VulkanProcTable::SetupDeviceProcAddresses(
   ACQUIRE_PROC(SetBufferCollectionConstraintsFUCHSIAX, handle);
   ACQUIRE_PROC(GetBufferCollectionPropertiesFUCHSIAX, handle);
 #endif  // OS_FUCHSIA
+#endif  // TEST_VULKAN_PROCS
   device_ = {handle, nullptr};
   return true;
 }

--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -16,10 +16,12 @@
 
 namespace vulkan {
 
-VulkanProcTable::VulkanProcTable()
+VulkanProcTable::VulkanProcTable() : VulkanProcTable("libvulkan.so"){};
+
+VulkanProcTable::VulkanProcTable(const char* path)
     : handle_(nullptr), acquired_mandatory_proc_addresses_(false) {
   acquired_mandatory_proc_addresses_ =
-      OpenLibraryHandle() && SetupLoaderProcAddresses();
+      OpenLibraryHandle(path) && SetupLoaderProcAddresses();
 }
 
 VulkanProcTable::~VulkanProcTable() {
@@ -149,14 +151,14 @@ bool VulkanProcTable::SetupDeviceProcAddresses(
   return true;
 }
 
-bool VulkanProcTable::OpenLibraryHandle() {
+bool VulkanProcTable::OpenLibraryHandle(const char* path) {
 #if VULKAN_LINK_STATICALLY
   static char kDummyLibraryHandle = '\0';
   handle_ = reinterpret_cast<decltype(handle_)>(&kDummyLibraryHandle);
   return true;
 #else   // VULKAN_LINK_STATICALLY
   dlerror();  // clear existing errors on thread.
-  handle_ = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+  handle_ = dlopen(path, RTLD_NOW | RTLD_LOCAL);
   if (handle_ == nullptr) {
     FML_DLOG(WARNING) << "Could not open the vulkan library: " << dlerror();
     return false;

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -8,6 +8,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/memory/ref_ptr.h"
+#include "flutter/fml/native_library.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
 #include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
 #include "vulkan_handle.h"
@@ -127,7 +128,7 @@ class VulkanProcTable : public fml::RefCountedThreadSafe<VulkanProcTable> {
 #undef DEFINE_PROC
 
  private:
-  void* handle_;
+  fml::RefPtr<fml::NativeLibrary> handle_;
   bool acquired_mandatory_proc_addresses_;
   VulkanHandle<VkInstance> instance_;
   VulkanHandle<VkDevice> device_;

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -106,6 +106,7 @@ class VulkanProcTable : public fml::RefCountedThreadSafe<VulkanProcTable> {
   DEFINE_PROC(ResetCommandBuffer);
   DEFINE_PROC(ResetFences);
   DEFINE_PROC(WaitForFences);
+#ifndef TEST_VULKAN_PROCS
 #if OS_ANDROID
   DEFINE_PROC(GetPhysicalDeviceSurfaceCapabilitiesKHR);
   DEFINE_PROC(GetPhysicalDeviceSurfaceFormatsKHR);
@@ -124,6 +125,7 @@ class VulkanProcTable : public fml::RefCountedThreadSafe<VulkanProcTable> {
   DEFINE_PROC(SetBufferCollectionConstraintsFUCHSIAX);
   DEFINE_PROC(GetBufferCollectionPropertiesFUCHSIAX);
 #endif  // OS_FUCHSIA
+#endif  // TEST_VULKAN_PROCS
 
 #undef DEFINE_PROC
 

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -133,8 +133,9 @@ class VulkanProcTable : public fml::RefCountedThreadSafe<VulkanProcTable> {
   VulkanHandle<VkDevice> device_;
 
   VulkanProcTable();
+  VulkanProcTable(const char* path);
   ~VulkanProcTable();
-  bool OpenLibraryHandle();
+  bool OpenLibraryHandle(const char* path);
   bool SetupLoaderProcAddresses();
   bool CloseLibraryHandle();
   PFN_vkVoidFunction AcquireProc(


### PR DESCRIPTION
- Enables Skia's Vulkan backend on all platforms (which will be usable through the embedder API).
- Gets SwiftShader Vulkan building anywhere the GL embedder unittests can run.
- Adds a simple test that initializes Vulkan state with SwiftShader (full test harness integration to come).

Patches that need to land before this is merged:
* Skia: https://skia-review.googlesource.com/c/skia/+/469207/
* buildroot: https://github.com/flutter/buildroot/pull/524