### PR TITLE
Remove D3D9 fallback path

### DIFF
--- a/shell/platform/windows/angle_surface_manager.cc
+++ b/shell/platform/windows/angle_surface_manager.cc
@@ -122,20 +122,10 @@ bool AngleSurfaceManager::Initialize() {
       EGL_NONE,
   };
 
-  // These are used to request ANGLE's D3D9 renderer as a fallback if D3D11
-  // is not available.
-  const EGLint d3d9_display_attributes[] = {
-      EGL_PLATFORM_ANGLE_TYPE_ANGLE,
-      EGL_PLATFORM_ANGLE_TYPE_D3D9_ANGLE,
-      EGL_TRUE,
-      EGL_NONE,
-  };
-
   std::vector<const EGLint*> display_attributes_configs = {
       d3d11_display_attributes,
       d3d11_fl_9_3_display_attributes,
       d3d11_warp_display_attributes,
-      d3d9_display_attributes,
   };
 
   PFNEGLGETPLATFORMDISPLAYEXTPROC egl_get_platform_display_EXT =
@@ -147,7 +137,7 @@ bool AngleSurfaceManager::Initialize() {
   }
 
   // Attempt to initialize ANGLE's renderer in order of: D3D11, D3D11 Feature
-  // Level 9_3, D3D11 WARP and finally D3D9.
+  // Level 9_3 and finally D3D11 WARP.
   for (auto config : display_attributes_configs) {
     bool should_log = (config == display_attributes_configs.back());
     if (InitializeEGL(egl_get_platform_display_EXT, config, should_log)) {


### PR DESCRIPTION
Remove the untested D3D9 fallback codepath that isn't necessary anymore.

https://github.com/flutter/flutter/issues/92650

No tests as we are deleting code that is untested.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
