### PR TITLE
fuchsia: Build tests behind flag

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -68,7 +68,7 @@ group("flutter") {
     "//flutter/sky",
   ]
 
-  # If enbaled, compile the SDK / snapshot.
+  # If enabled, compile the SDK / snapshot.
   if (!is_fuchsia) {
     public_deps += [ "//flutter/lib/snapshot:generate_snapshot_bins" ]
 
@@ -150,10 +150,6 @@ group("flutter") {
           [ "//flutter/third_party/accessibility:accessibility_unittests" ]
     }
 
-    if (is_fuchsia) {
-      public_deps += [ "//flutter/shell/platform/fuchsia:tests" ]
-    }
-
     if (is_mac) {
       public_deps +=
           [ "//flutter/shell/platform/darwin:flutter_channels_unittests" ]
@@ -172,18 +168,10 @@ group("flutter") {
     if (enable_desktop_embeddings) {
       public_deps += [
         "//flutter/shell/platform/common:common_cpp_core_unittests",
+        "//flutter/shell/platform/common:common_cpp_unittests",
         "//flutter/shell/platform/common/client_wrapper:client_wrapper_unittests",
+        "//flutter/shell/platform/glfw/client_wrapper:client_wrapper_glfw_unittests",
       ]
-
-      if (!is_fuchsia) {
-        # These tests require the embedder and thus cannot run on fuchsia.
-        # TODO(): Enable when embedder works on fuchsia.
-        public_deps +=
-            [ "//flutter/shell/platform/common:common_cpp_unittests" ]
-
-        # These tests require GLFW and thus cannot run on fuchsia.
-        public_deps += [ "//flutter/shell/platform/glfw/client_wrapper:client_wrapper_glfw_unittests" ]
-      }
 
       if (is_linux) {
         public_deps +=
@@ -219,12 +207,4 @@ group("dist") {
   testonly = true
 
   deps = [ "//flutter/sky/dist" ]
-}
-
-if (is_fuchsia && enable_unittests) {
-  group("fuchsia_tests") {
-    testonly = true
-
-    deps = [ "//flutter/shell/platform/fuchsia:tests" ]
-  }
 }

--- a/shell/BUILD.gn
+++ b/shell/BUILD.gn
@@ -3,5 +3,7 @@
 # found in the LICENSE file.
 
 group("shell") {
+  testonly = true
+
   deps = [ "platform" ]
 }

--- a/shell/platform/BUILD.gn
+++ b/shell/platform/BUILD.gn
@@ -6,6 +6,8 @@ import("//build/fuchsia/sdk.gni")
 import("//flutter/shell/platform/config.gni")
 
 group("platform") {
+  testonly = true
+
   if (is_mac || is_ios) {
     deps = [ "darwin" ]
   } else if (is_android) {

--- a/shell/platform/config.gni
+++ b/shell/platform/config.gni
@@ -4,5 +4,5 @@
 
 declare_args() {
   # Whether or not to include desktop embedding targets in the build.
-  enable_desktop_embeddings = true
+  enable_desktop_embeddings = !is_fuchsia
 }

--- a/shell/platform/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/BUILD.gn
@@ -75,6 +75,8 @@ fuchsia_host_bundle("dart_binaries") {
 }
 
 group("fuchsia") {
+  testonly = true
+
   deps = [
     ":dart_binaries",
     ":flutter_binaries",
@@ -83,12 +85,7 @@ group("fuchsia") {
     "flutter:flutter_aot_${product_suffix}runner",
     "flutter:flutter_jit_${product_suffix}runner",
   ]
-}
-
-if (enable_unittests) {
-  group("tests") {
-    testonly = true
-
-    deps = [ "flutter:tests" ]
+  if (enable_unittests) {
+    deps += [ "flutter:tests" ]
   }
 }

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -10,9 +10,9 @@ import("//third_party/dart/sdk_args.gni")
 is_aot_test =
     flutter_runtime_mode == "profile" || flutter_runtime_mode == "release"
 
-# Unit tests targets are only enabled for host machines and Fuchsia right now
+# Unit tests targets are only enabled for host machines right now.
 declare_args() {
-  enable_unittests = current_toolchain == host_toolchain || is_fuchsia
+  enable_unittests = current_toolchain == host_toolchain
 }
 
 # Creates a translation unit that defines the flutter::testing::GetFixturesPath


### PR DESCRIPTION
When building locally, this puts fuchsia unit&integration tests behind the --enable-unittests flag, similar to android & iOS.
 
Fixes: https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=87849