### PR TITLE
ios test script checks for `ios_test_flutter` artifacts

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -9,6 +9,7 @@ A top level harness to run all unit-tests in a specific engine build.
 """
 
 import argparse
+from genericpath import exists
 import glob
 import os
 import re
@@ -297,12 +298,13 @@ def EnsureDebugUnoptSkyPackagesAreBuilt():
 def EnsureIosTestsAreBuilt(ios_out_dir):
   """Builds the engine variant and the test dylib containing the XCTests"""
   tmp_out_dir = os.path.join(out_dir, ios_out_dir)
+  ios_test_lib = os.path.join(tmp_out_dir, 'libios_test_flutter.dylib')
   message = []
   message.append('gn --ios --unoptimized --runtime-mode=debug --no-lto --simulator')
   message.append('autoninja -C %s ios_test_flutter' % ios_out_dir)
-  final_message = '%s doesn\'t exist. Please run the following commands: \n%s' % (
-      ios_out_dir, '\n'.join(message))
-  assert os.path.exists(tmp_out_dir), final_message
+  final_message = '%s or %s doesn\'t exist. Please run the following commands: \n%s' % (
+      ios_out_dir, ios_test_lib, '\n'.join(message))
+  assert os.path.exists(tmp_out_dir) and os.path.exists(ios_test_lib), final_message
 
 
 def AssertExpectedXcodeVersion():

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -9,7 +9,6 @@ A top level harness to run all unit-tests in a specific engine build.
 """
 
 import argparse
-from genericpath import exists
 import glob
 import os
 import re


### PR DESCRIPTION
Add a check for the existence of `libios_test_flutter.dylib` in `EnsureIosTestsAreBuilt`. This ensures the `ios_test_flutter` artifacts are built and display the intended error message if it wasn't built.

I didn't add test for this change, this is a change in the test script itself.

Fixes https://github.com/flutter/flutter/issues/93144

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
