### PR TITLE
Hide a11y elements when resigning active

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -780,6 +780,7 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 
 - (void)applicationBecameActive:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationBecameActive");
+  self.view.accessibilityElementsHidden = NO;
   if (_viewportMetrics.physical_width)
     [self surfaceUpdated:YES];
   [self goToApplicationLifecycle:@"AppLifecycleState.resumed"];
@@ -787,6 +788,7 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 
 - (void)applicationWillResignActive:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationWillResignActive");
+  self.view.accessibilityElementsHidden = YES;
   [self goToApplicationLifecycle:@"AppLifecycleState.inactive"];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -757,7 +757,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
                                                                          bundle:nil];
   XCTAssertFalse(realVC.view.accessibilityElementsHidden, @"");
   [realVC applicationWillResignActive:nil];
-  XCTAssertTrue(realVC.view.accessibilityElementsHidden, @"");
+  XCTAssertTrue(realVC.view.accessibilityElementsHidden);
   [realVC applicationBecameActive:nil];
   XCTAssertFalse(realVC.view.accessibilityElementsHidden, @"");
   engine.viewController = nil;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -124,6 +124,8 @@ typedef enum UIAccessibilityContrast : NSInteger {
 - (void)scrollEvent:(UIPanGestureRecognizer*)recognizer;
 - (void)updateViewportMetrics;
 - (void)onUserSettingsChanged:(NSNotification*)notification;
+- (void)applicationWillResignActive:(NSNotification*)notification;
+- (void)applicationBecameActive:(NSNotification*)notification;
 @end
 
 @interface FlutterViewControllerTest : XCTestCase
@@ -743,6 +745,21 @@ typedef enum UIAccessibilityContrast : NSInteger {
   [[NSNotificationCenter defaultCenter] postNotificationName:FlutterViewControllerHideHomeIndicator
                                                       object:nil];
   XCTAssertTrue(realVC.prefersHomeIndicatorAutoHidden, @"");
+  engine.viewController = nil;
+}
+
+- (void)testHideA11yElements {
+  FlutterDartProject* project = [[FlutterDartProject alloc] init];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
+  [engine createShell:@"" libraryURI:@"" initialRoute:nil];
+  FlutterViewController* realVC = [[FlutterViewController alloc] initWithEngine:engine
+                                                                        nibName:nil
+                                                                         bundle:nil];
+  XCTAssertFalse(realVC.view.accessibilityElementsHidden, @"");
+  [realVC applicationWillResignActive:nil];
+  XCTAssertTrue(realVC.view.accessibilityElementsHidden, @"");
+  [realVC applicationBecameActive:nil];
+  XCTAssertFalse(realVC.view.accessibilityElementsHidden, @"");
   engine.viewController = nil;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.mm
@@ -124,8 +124,6 @@ typedef enum UIAccessibilityContrast : NSInteger {
 - (void)scrollEvent:(UIPanGestureRecognizer*)recognizer;
 - (void)updateViewportMetrics;
 - (void)onUserSettingsChanged:(NSNotification*)notification;
-- (void)applicationWillResignActive:(NSNotification*)notification;
-- (void)applicationBecameActive:(NSNotification*)notification;
 @end
 
 @interface FlutterViewControllerTest : XCTestCase
@@ -755,11 +753,15 @@ typedef enum UIAccessibilityContrast : NSInteger {
   FlutterViewController* realVC = [[FlutterViewController alloc] initWithEngine:engine
                                                                         nibName:nil
                                                                          bundle:nil];
-  XCTAssertFalse(realVC.view.accessibilityElementsHidden, @"");
-  [realVC applicationWillResignActive:nil];
+  XCTAssertFalse(realVC.view.accessibilityElementsHidden);
+  [[NSNotificationCenter defaultCenter]
+      postNotificationName:UIApplicationWillResignActiveNotification
+                    object:nil];
   XCTAssertTrue(realVC.view.accessibilityElementsHidden);
-  [realVC applicationBecameActive:nil];
-  XCTAssertFalse(realVC.view.accessibilityElementsHidden, @"");
+  [[NSNotificationCenter defaultCenter]
+      postNotificationName:UIApplicationDidBecomeActiveNotification
+                    object:nil];
+  XCTAssertFalse(realVC.view.accessibilityElementsHidden);
   engine.viewController = nil;
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/93030

When we resign active, we should hide the a11y elements.

We should probably use the same mechanism for when we launch a modal dialog, but refactoring those tests is a little painful right now (I tried to do it twice while working on this today only to find that there was some failure I hadn't accounted for).  I'd like to get this fixed and we can look into fixing that in a separate PR.

/cc @chunhtai @gaaclarke fyi