### PR TITLE
Use clang-tidy config file from repo instead of default

### DIFF
--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -184,7 +184,7 @@ class ClangTidy {
   Future<_ComputeJobsResult> _computeJobs(
     List<Command> commands,
     io.Directory repoPath,
-    String checks,
+    String? checks,
   ) async {
     bool sawMalformed = false;
     final List<WorkerJob> jobs = <WorkerJob>[];

--- a/tools/clang_tidy/lib/src/command.dart
+++ b/tools/clang_tidy/lib/src/command.dart
@@ -126,8 +126,13 @@ class Command {
   }
 
   /// The job for the process runner for the lint needed for this command.
-  WorkerJob createLintJob(String checks) {
-    final List<String> args = <String>[filePath, checks, '--'];
+  WorkerJob createLintJob(String? checks) {
+    final List<String> args = <String>[
+      filePath,
+      if (checks != null)
+        checks,
+      '--',
+    ];
     args.addAll(tidyArgs.split(' '));
     return WorkerJob(
       <String>[tidyPath, ...args],

--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -19,10 +19,8 @@ class Options {
     this.lintAll = false,
     this.errorMessage,
     StringSink? errSink,
-  }) {
-    checks = checksArg.isNotEmpty ? '--checks=$checksArg' : '--config=';
-    _errSink = errSink ?? io.stderr;
-  }
+  }) : checks = checksArg.isNotEmpty ? '--checks=$checksArg' : null,
+       _errSink = errSink ?? io.stderr;
 
   factory Options._error(
     String message, {
@@ -131,7 +129,7 @@ class Options {
   final String checksArg;
 
   /// Check arguments to plumb through to clang-tidy.
-  late final String checks;
+  final String? checks;
 
   /// Whether all files should be linted.
   final bool lintAll;
@@ -140,7 +138,7 @@ class Options {
   /// contains the error message.
   final String? errorMessage;
 
-  late final StringSink _errSink;
+  final StringSink _errSink;
 
   /// Print command usage with an additional message.
   void printUsage({String? message}) {

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -7,6 +7,7 @@ import 'dart:io' as io show Directory, File, Platform, stderr;
 import 'package:clang_tidy/clang_tidy.dart';
 import 'package:clang_tidy/src/command.dart';
 import 'package:litetest/litetest.dart';
+import 'package:process_runner/process_runner.dart';
 
 Future<int> main(List<String> args) async {
   if (args.length < 2) {
@@ -199,7 +200,16 @@ Future<int> main(List<String> args) async {
     );
 
     expect(commands, isNotEmpty);
-    expect(commands.first.tidyPath, contains('clang/bin/clang-tidy'));
+    final Command command = commands.first;
+    expect(command.tidyPath, contains('clang/bin/clang-tidy'));
+    final WorkerJob job = command.createLintJob(null);
+    expect(job.command, <String>[
+      '../../buildtools/mac-x64/clang/bin/clang-tidy',
+      filePath,
+      '--',
+      '',
+      filePath,
+    ]);
   });
 
   test('Command getLintAction flags third_party files', () async {


### PR DESCRIPTION
Validated `--config=` is no longer passed into the generated `clang-tidy` command (due to https://github.com/flutter/flutter/issues/93279 I don't see the warnings from `ci/lint.sh`). When I run that `clang-tidy` command manually, I now see `google-` linter warnings:
```
shell/platform/darwin/macos/framework/Source/FlutterTextureRegistrar.mm:29:17: warning: do not create objects with +new [google-objc-avoid-nsobject-new]
    _textures = [NSMutableDictionary new];
                ^~~~~~~~~~~~~~~~~~~~~~~~~
                [[NSMutableDictionary alloc] init]
```
Fixes https://github.com/flutter/flutter/issues/93280

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
