### PR TITLE
Call Dart messenger methods in DartExecutor

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -287,10 +287,14 @@ public class DartExecutor implements BinaryMessenger {
   }
 
   @Override
-  public void enableBufferingIncomingMessages() {}
+  public void enableBufferingIncomingMessages() {
+    dartMessenger.enableBufferingIncomingMessages();
+  }
 
   @Override
-  public void disableBufferingIncomingMessages() {}
+  public void disableBufferingIncomingMessages() {
+    dartMessenger.enableBufferingIncomingMessages();
+  }
 
   /**
    * Configuration options that specify which Dart entrypoint function is executed and where to find

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -473,9 +473,13 @@ public class DartExecutor implements BinaryMessenger {
     }
 
     @Override
-    public void enableBufferingIncomingMessages() {}
+    public void enableBufferingIncomingMessages() {
+      messenger.enableBufferingIncomingMessages();
+    }
 
     @Override
-    public void disableBufferingIncomingMessages() {}
+    public void disableBufferingIncomingMessages() {
+      messenger.disableBufferingIncomingMessages();
+    }
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -227,6 +227,20 @@ public class DartExecutor implements BinaryMessenger {
       @Nullable TaskQueue taskQueue) {
     binaryMessenger.setMessageHandler(channel, handler, taskQueue);
   }
+
+  /** @deprecated Use {@link #getBinaryMessenger()} instead. */
+  @Deprecated
+  @Override
+  public void enableBufferingIncomingMessages() {
+    dartMessenger.enableBufferingIncomingMessages();
+  }
+
+  /** @deprecated Use {@link #getBinaryMessenger()} instead. */
+  @Deprecated
+  @Override
+  public void disableBufferingIncomingMessages() {
+    dartMessenger.disableBufferingIncomingMessages();
+  }
   // ------ END BinaryMessenger -----
 
   /**
@@ -284,16 +298,6 @@ public class DartExecutor implements BinaryMessenger {
     if (flutterJNI.isAttached()) {
       flutterJNI.notifyLowMemoryWarning();
     }
-  }
-
-  @Override
-  public void enableBufferingIncomingMessages() {
-    dartMessenger.enableBufferingIncomingMessages();
-  }
-
-  @Override
-  public void disableBufferingIncomingMessages() {
-    dartMessenger.enableBufferingIncomingMessages();
   }
 
   /**


### PR DESCRIPTION
The `DartExecutor` is exposed in `FlutterEngine`, which is the object available in the consumption side.
