### PR TITLE
Support multiple build command json paths passed into clang-tidy script

### DIFF
--- a/tools/clang_tidy/lib/src/command.dart
+++ b/tools/clang_tidy/lib/src/command.dart
@@ -30,6 +30,22 @@ enum LintAction {
 
 /// A compilation command and methods to generate the lint command and job for
 /// it.
+/// Equal to another [UniquedFilePathBuildCommand] if [filePath] is equal.
+class UniquedFilePathBuildCommand extends Command {
+  /// Generate a [UniquedBuildCommand] from a [Map].
+  UniquedFilePathBuildCommand.fromMap(Map<String, dynamic> map) : super.fromMap(map);
+
+  @override
+  bool operator ==(Object other) {
+    return other is Command && other.filePath == filePath;
+  }
+
+  @override
+  int get hashCode => filePath.hashCode;
+}
+
+/// A compilation command and methods to generate the lint command and job for
+/// it.
 class Command {
   /// Generate a [Command] from a [Map].
   Command.fromMap(Map<String, dynamic> map) :
@@ -45,7 +61,7 @@ class Command {
   final io.Directory directory;
 
   /// The compilation command.
-  final String command ;
+  final String command;
 
   /// The file on which the command operates.
   late final String filePath;

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -15,7 +15,10 @@ Future<int> main(List<String> args) async {
     );
     return 1;
   }
+
+  // Supports comma-delineated json list.
   final String buildCommands = args[0];
+  final List<io.File> buildCommandsFiles = buildCommands.split(',').map((String path) => io.File(path)).toList();
   final String repoRoot = args[1];
 
   test('--help gives help', () async {
@@ -126,7 +129,7 @@ Future<int> main(List<String> args) async {
     final StringBuffer outBuffer = StringBuffer();
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
-      buildCommandsPath: io.File(buildCommands),
+      buildCommandsPaths: buildCommandsFiles,
       repoPath: io.Directory(repoRoot),
       lintAll: true,
       outSink: outBuffer,
@@ -140,7 +143,7 @@ Future<int> main(List<String> args) async {
     final StringBuffer outBuffer = StringBuffer();
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
-      buildCommandsPath: io.File(buildCommands),
+      buildCommandsPaths: buildCommandsFiles,
       repoPath: io.Directory(repoRoot),
       outSink: outBuffer,
       errSink: errBuffer,
@@ -153,22 +156,22 @@ Future<int> main(List<String> args) async {
     final StringBuffer outBuffer = StringBuffer();
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
-      buildCommandsPath: io.File(buildCommands),
+      buildCommandsPaths: buildCommandsFiles,
       repoPath: io.Directory(repoRoot),
       lintAll: true,
       outSink: outBuffer,
       errSink: errBuffer,
     );
     const String filePath = '/path/to/a/source_file.cc';
-    final List<dynamic> buildCommandsData = <Map<String, dynamic>>[
-      <String, dynamic>{
+    final List<Object> buildCommandsData = <Map<String, Object>>[
+      <String, Object>{
         'directory': '/unused',
         'command': '../../buildtools/mac-x64/clang/bin/clang $filePath',
         'file': filePath,
       },
     ];
     final List<Command> commands = clangTidy.getLintCommandsForChangedFiles(
-      buildCommandsData,
+      <List<Object>>[buildCommandsData],
       <io.File>[],
     );
 
@@ -179,22 +182,22 @@ Future<int> main(List<String> args) async {
     final StringBuffer outBuffer = StringBuffer();
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
-      buildCommandsPath: io.File(buildCommands),
+      buildCommandsPaths: buildCommandsFiles,
       repoPath: io.Directory(repoRoot),
       lintAll: true,
       outSink: outBuffer,
       errSink: errBuffer,
     );
     const String filePath = '/path/to/a/source_file.cc';
-    final List<dynamic> buildCommandsData = <Map<String, dynamic>>[
-      <String, dynamic>{
+    final List<Object> buildCommandsData = <Map<String, Object>>[
+      <String, Object>{
         'directory': '/unused',
         'command': '../../buildtools/mac-x64/clang/bin/clang $filePath',
         'file': filePath,
       },
     ];
     final List<Command> commands = clangTidy.getLintCommandsForChangedFiles(
-      buildCommandsData,
+      <List<Object>>[buildCommandsData],
       <io.File>[io.File(filePath)],
     );
 

--- a/tools/githooks/lib/src/pre_push_command.dart
+++ b/tools/githooks/lib/src/pre_push_command.dart
@@ -37,14 +37,14 @@ class PrePushCommand extends Command<bool> {
     final Stopwatch sw = Stopwatch()..start();
     // First ensure that out/host_debug/compile_commands.json exists by running
     // //flutter/tools/gn.
-    final io.File compileCommands = io.File(path.join(
+    final io.File hostCompileCommands = io.File(path.join(
       flutterRoot,
       '..',
       'out',
       'host_debug',
       'compile_commands.json',
     ));
-    if (!compileCommands.existsSync()) {
+    if (!hostCompileCommands.existsSync()) {
       final bool gnResult = await _runCheck(
         flutterRoot,
         path.join(flutterRoot, 'tools', 'gn'),
@@ -59,7 +59,7 @@ class PrePushCommand extends Command<bool> {
     final StringBuffer outBuffer = StringBuffer();
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
-      buildCommandsPath: compileCommands,
+      buildCommandsPaths: <io.File>[hostCompileCommands],
       repoPath: io.Directory(flutterRoot),
       outSink: outBuffer,
       errSink: errBuffer,


### PR DESCRIPTION
In preparation for https://github.com/flutter/flutter/issues/91857, allow `compile_commands.json` files from multiple targets to be passed into the clang-tidy script, deduplicated so the same work isn't done on common files, and have the changed files run against `clang-tidy`.

```
$ dart tools/clang_tidy/bin/main.dart --lint-all --compile-commands ../out/ios_debug/compile_commands.json --compile-commands ../out/host_debug/compile_commands.json --repo .
```
shows example file `incoming_message_dispatcher.cc` being linted only once:
```
🔶 linting common/graphics/persistent_cache.cc
```
even though it's in `host_debug/compile_commands.json`
```
  {
    "file": "../../flutter/common/graphics/persistent_cache.cc",
    "directory": "/Users/m/Projects/engine/src/out/host_debug",
...
  },
```
and `ios_debug/compile_commands.json`.
```
  {
    "file": "../../flutter/common/graphics/persistent_cache.cc",
    "directory": "/Users/magder/Projects/engine/src/out/ios_debug",
...
  },
```

Update `pre_push_command.dart` (which worked when I pushed this commit to my fork).
Confirm `ci/lint.sh` still works.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
