### PR TITLE
[test] Fixes testing/run_tests.py py3 support.

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -42,7 +42,7 @@ def RunCmd(cmd, forbidden_output=[], expect_failure=False, env=None, **kwargs):
   start_time = time.time()
   stdout_pipe = sys.stdout if not forbidden_output else subprocess.PIPE
   stderr_pipe = sys.stderr if not forbidden_output else subprocess.PIPE
-  process = subprocess.Popen(cmd, stdout=stdout_pipe, stderr=stderr_pipe, env=env, **kwargs)
+  process = subprocess.Popen(cmd, stdout=stdout_pipe, stderr=stderr_pipe, env=env, universal_newlines=True, **kwargs)
   stdout, stderr = process.communicate()
   end_time = time.time()
 


### PR DESCRIPTION
Makes `testing/run_tests.py` compatible with python3 (in addition to python2).

This fixes an exception in `testing/run_tests.py` where in Python 3 `Popen.communicate` will return two bytes objects, which cannot be used with `str in bytes`:
https://github.com/flutter/engine/blob/master/testing/run_tests.py#L69

See https://github.com/flutter/flutter/issues/93319 for additional details.