### PR TITLE
[web] Fix warning about the non-nullable flag

### DIFF
--- a/lib/web_ui/dev/felt
+++ b/lib/web_ui/dev/felt
@@ -33,14 +33,13 @@ HOST_DEBUG_UNOPT_DIR="${ENGINE_SRC_DIR}/out/host_debug_unopt"
 DART_SDK_DIR="${ENGINE_SRC_DIR}/out/host_debug_unopt/dart-sdk"
 GN="${FLUTTER_DIR}/tools/gn"
 DART_TOOL_DIR="${WEB_UI_DIR}/.dart_tool"
-PUB_PATH="$DART_SDK_DIR/bin/pub"
 DART_PATH="$DART_SDK_DIR/bin/dart"
 SNAPSHOT_PATH="${DART_TOOL_DIR}/felt.snapshot"
 STAMP_PATH="${DART_TOOL_DIR}/felt.snapshot.stamp"
 SCRIPT_PATH="${DEV_DIR}/felt.dart"
 REVISION="$(cd "$FLUTTER_DIR"; git rev-parse HEAD)"
 
-if [ ! -f "${PUB_PATH}" -o ! -f "${DART_PATH}" ]
+if [ ! -f "${DART_PATH}" ]
 then
   echo "Compiling the Dart SDK."
   gclient sync
@@ -49,11 +48,11 @@ then
 fi
 
 install_deps() {
-  echo "Running \`pub get\` in 'engine/src/flutter/lib/web_ui'"
-  (cd "$WEB_UI_DIR"; $PUB_PATH get)
+  echo "Running \`dart pub get\` in 'engine/src/flutter/lib/web_ui'"
+  (cd "$WEB_UI_DIR"; $DART_PATH pub get)
 
-  echo "Running \`pub get\` in 'engine/src/flutter/web_sdk/web_engine_tester'"
-  (cd "$FLUTTER_DIR/web_sdk/web_engine_tester"; $PUB_PATH get)
+  echo "Running \`dart pub get\` in 'engine/src/flutter/web_sdk/web_engine_tester'"
+  (cd "$FLUTTER_DIR/web_sdk/web_engine_tester"; $DART_PATH pub get)
 }
 
 KERNEL_NAME=`uname`

--- a/lib/web_ui/dev/steps/compile_tests_step.dart
+++ b/lib/web_ui/dev/steps/compile_tests_step.dart
@@ -141,7 +141,6 @@ Future<bool> compileUnitTest(FilePath input, { required bool forCanvasKit }) asy
     '--no-minify',
     '--disable-inlining',
     '--enable-asserts',
-    '--enable-experiment=non-nullable',
     '--no-sound-null-safety',
 
     // We do not want to auto-select a renderer in tests. As of today, tests

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -519,16 +519,6 @@ double convertSigmaToRadius(double sigma) {
   return sigma * 2.0;
 }
 
-/// Used to check for null values that are non-nullable.
-///
-/// This is useful when some external API (e.g. HTML DOM) disagrees with
-/// Dart type declarations (e.g. `dart:html`). Where `dart:html` may believe
-/// something to be non-null, it may actually be null (e.g. old browsers do
-/// not implement a feature, such as clipboard).
-bool isUnsoundNull(dynamic object) {
-  return object == null;
-}
-
 int clampInt(int value, int min, int max) {
   assert(min <= max);
   if (value < min) {


### PR DESCRIPTION
Remove an unused util function `isUnsoundNull`; and fix 2 warnings when running felt:

* **Warning 1**: happens in `build` and `test`.
```
The top level `pub` command is deprecated. Use `dart pub` instead.
```

* **Warning 2**: happens in `test`:
```
'non-nullable' is now enabled by default; this flag is no longer required.
```