### PR TITLE
Update third-party benchmark library

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -99,16 +99,13 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'b0c315b5e6964fd85dd87b8d0195ddb5c3b60a34',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'bfa04ad85fed176aa909f880ef5c8009c945ba03',
 
    # Fuchsia compatibility
    #
    # The dependencies in this section should match the layout in the Fuchsia gn
    # build. Eventually, we'll manage these dependencies together with Fuchsia
    # and not have to specific specific hashes.
-
-  'src/third_party/benchmark':
-   Var('fuchsia_git') + '/third_party/benchmark' + '@' + 'a779ffce872b4c811beef482e18bd0b63626aa42',
 
   'src/third_party/rapidjson':
    Var('fuchsia_git') + '/third_party/rapidjson' + '@' + 'ef3564c5c8824989393b87df25355baf35ff544b',
@@ -154,6 +151,9 @@ deps = {
 
   'src/third_party/khronos':
    Var('chromium_git') + '/chromium/src/third_party/khronos.git' + '@' + '7122230e90547962e0f0c627f62eeed3c701f275',
+
+  'src/third_party/benchmark':
+   Var('github_git') + '/google/benchmark' + '@' + '431abd149fd76a072f821913c0340137cc755f36',
 
   'src/third_party/googletest':
    Var('github_git') + '/google/googletest' + '@' + 'f5e592d8ee5ffb1d9af5be7f715ce3576b8bf9c4',

--- a/DEPS
+++ b/DEPS
@@ -427,7 +427,7 @@ deps = {
   Var('github_git') + '/google/file.dart.git' + '@' + '427bb20ccc852425d67f2880da2a9b4707c266b4', # 6.1.0
 
   'src/third_party/pkg/flutter_packages':
-  Var('github_git') + '/flutter/packages.git' + '@' + '5617d089f26dd52da3bf05c9fa4620ef11a7419b', # various
+  Var('github_git') + '/flutter/packages.git' + '@' + 'b1fdbabbe70caa21566f6a815235d624c716ea16', # various
 
   'src/third_party/pkg/gcloud':
   Var('github_git') + '/dart-lang/gcloud.git' + '@' + '92a33a9d95ea94a4354b052a28b98088d660e0e7', # 0.8.0-dev

--- a/benchmarking/benchmarking.h
+++ b/benchmarking/benchmarking.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_BENCHMARKING_BENCHMARKING_H_
 #define FLUTTER_BENCHMARKING_BENCHMARKING_H_
 
-#include "benchmark/benchmark_api.h"
+#include "benchmark/benchmark.h"
 
 namespace benchmarking {
 

--- a/testing/benchmark/bin/parse_and_send.dart
+++ b/testing/benchmark/bin/parse_and_send.dart
@@ -121,5 +121,6 @@ Future<void> main(List<String> args) async {
       int.parse(pointsAndDate.date) * 1000,
       isUtc: true,
     ),
+    'flutter-engine-benchmark',
   );
 }

--- a/testing/benchmark/bin/parse_and_send.dart
+++ b/testing/benchmark/bin/parse_and_send.dart
@@ -121,6 +121,6 @@ Future<void> main(List<String> args) async {
       int.parse(pointsAndDate.date) * 1000,
       isUtc: true,
     ),
-    'flutter-engine-benchmark',
+    'flutter_engine_benchmark',
   );
 }

--- a/third_party/txt/benchmarks/paint_record_benchmarks.cc
+++ b/third_party/txt/benchmarks/paint_record_benchmarks.cc
@@ -17,7 +17,7 @@
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
-#include "third_party/benchmark/include/benchmark/benchmark_api.h"
+#include "third_party/benchmark/include/benchmark/benchmark.h"
 #include "txt/paint_record.h"
 #include "txt/text_style.h"
 

--- a/third_party/txt/benchmarks/paragraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/paragraph_benchmarks.cc
@@ -22,7 +22,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
 #include "minikin/LayoutUtils.h"
-#include "third_party/benchmark/include/benchmark/benchmark_api.h"
+#include "third_party/benchmark/include/benchmark/benchmark.h"
 #include "third_party/icu/source/common/unicode/unistr.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkCanvas.h"

--- a/third_party/txt/benchmarks/paragraph_builder_benchmarks.cc
+++ b/third_party/txt/benchmarks/paragraph_builder_benchmarks.cc
@@ -16,7 +16,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
-#include "third_party/benchmark/include/benchmark/benchmark_api.h"
+#include "third_party/benchmark/include/benchmark/benchmark.h"
 #include "third_party/icu/source/common/unicode/unistr.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "txt/font_collection.h"

--- a/third_party/txt/benchmarks/skparagraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/skparagraph_benchmarks.cc
@@ -19,7 +19,7 @@
 #include "flutter/fml/command_line.h"
 #include "flutter/fml/logging.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
-#include "third_party/benchmark/include/benchmark/benchmark_api.h"
+#include "third_party/benchmark/include/benchmark/benchmark.h"
 #include "third_party/icu/source/common/unicode/unistr.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkCanvas.h"

--- a/third_party/txt/benchmarks/txt_run_all_benchmarks.cc
+++ b/third_party/txt/benchmarks/txt_run_all_benchmarks.cc
@@ -18,7 +18,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/testing/testing.h"
 #include "flutter/third_party/txt/tests/txt_test_utils.h"
-#include "third_party/benchmark/include/benchmark/benchmark_api.h"
+#include "third_party/benchmark/include/benchmark/benchmark.h"
 
 // We will use a custom main to allow custom font directories for consistency.
 int main(int argc, char** argv) {


### PR DESCRIPTION
This rolls benchmark to upstream github @ 431abd149fd76a072f821913c0340137cc755f36, rolls buildroot to bfa04ad85fed176aa909f880ef5c8009c945ba03 to get build files for benchmark and also fixes our benchmarks to use benchmark.h instead of benchmark_api.h

https://github.com/flutter/flutter/issues/93345

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.