### PR TITLE
Exit with failure code if clang-tidy finds linter issues

### DIFF
--- a/tools/clang_tidy/bin/main.dart
+++ b/tools/clang_tidy/bin/main.dart
@@ -12,8 +12,14 @@
 //
 // User environment variable FLUTTER_LINT_ALL to run on all files.
 
+import 'dart:io' as io;
+
 import 'package:clang_tidy/clang_tidy.dart';
 
 Future<int> main(List<String> arguments) async {
-  return ClangTidy.fromCommandLine(arguments).run();
+  final int result = await ClangTidy.fromCommandLine(arguments).run();
+  if (result != 0) {
+    io.exit(result);
+  }
+  return result;
 }


### PR DESCRIPTION
Exit clang_tidy script with nonzero exit code if linter issues are found.  This will allow the recipe step to fail when linter issues are found.

```
$ dart flutter/tools/clang_tidy/bin/main.dart --compile-commands out/ios_debug/compile_commands.json --repo flutter --verbose --lint-all
...
Lint problems found.
$ echo $?
1
```
Fixes https://github.com/flutter/flutter/issues/93357

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
