### PR TITLE
Speed up clang-tidy script by skipping third_party files

### DIFF
--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -173,9 +173,8 @@ class ClangTidy {
     for (final dynamic data in buildCommandsData) {
       final Command command = Command.fromMap(data as Map<String, dynamic>);
       final LintAction lintAction = await command.lintAction;
-      if (lintAction != LintAction.skipMissing &&
-          lintAction != LintAction.skipThirdParty &&
-          command.containsAny(changedFiles)) {
+      // Short-circuit the expensive containsAny call for the many third_party files.
+      if (lintAction != LintAction.skipThirdParty && command.containsAny(changedFiles)) {
         buildCommands.add(command);
       }
     }

--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -110,7 +110,7 @@ class ClangTidy {
     final List<dynamic> buildCommandsData = jsonDecode(
       options.buildCommandsPath.readAsStringSync(),
     ) as List<dynamic>;
-    final List<Command> changedFileBuildCommands = getLintCommandsForChangedFiles(
+    final List<Command> changedFileBuildCommands = await getLintCommandsForChangedFiles(
       buildCommandsData,
       changedFiles,
     );
@@ -165,20 +165,21 @@ class ClangTidy {
   /// Given a build commands json file, and the files with local changes,
   /// compute the lint commands to run.
   @visibleForTesting
-  List<Command> getLintCommandsForChangedFiles(
+  Future<List<Command>> getLintCommandsForChangedFiles(
     List<dynamic> buildCommandsData,
     List<io.File> changedFiles,
-  ) {
-    final List<Command> buildCommands = <Command>[
-      for (final dynamic c in buildCommandsData)
-        Command.fromMap(c as Map<String, dynamic>),
-    ];
-
-    return <Command>[
-      for (final Command c in buildCommands)
-        if (c.containsAny(changedFiles))
-          c,
-    ];
+  ) async {
+    final List<Command> buildCommands = <Command>[];
+    for (final dynamic data in buildCommandsData) {
+      final Command command = Command.fromMap(data as Map<String, dynamic>);
+      final LintAction lintAction = await command.lintAction;
+      if (lintAction != LintAction.skipMissing &&
+          lintAction != LintAction.skipThirdParty &&
+          command.containsAny(changedFiles)) {
+        buildCommands.add(command);
+      }
+    }
+    return buildCommands;
   }
 
   Future<_ComputeJobsResult> _computeJobs(
@@ -212,6 +213,9 @@ class ClangTidy {
         case LintAction.skipThirdParty:
           _outSink.writeln('🔷 ignoring $relativePath (third_party)');
           break;
+        case LintAction.skipMissing:
+          _outSink.writeln('🔷 ignoring $relativePath (missing)');
+          break;
       }
     }
     return _ComputeJobsResult(jobs, sawMalformed);
@@ -239,5 +243,3 @@ class ClangTidy {
     return result;
   }
 }
-
-

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -105,7 +105,7 @@ Future<int> main(List<String> args) async {
     final ClangTidy clangTidy = ClangTidy.fromCommandLine(
       <String>[
         '--compile-commands',
-        // This just has to exist.
+        // This file needs to exist, and be UTF8 line-parsable.
         io.Platform.script.path,
         '--repo',
         '/does/not/exist',
@@ -187,7 +187,7 @@ Future<int> main(List<String> args) async {
       errSink: errBuffer,
     );
 
-    // This just has to exist.
+    // This file needs to exist, and be UTF8 line-parsable.
     final String filePath = io.Platform.script.path;
     final List<dynamic> buildCommandsData = <Map<String, dynamic>>[
       <String, dynamic>{
@@ -224,7 +224,7 @@ Future<int> main(List<String> args) async {
 
   test('Command getLintAction flags missing files', () async {
     final LintAction lintAction = await Command.getLintAction(
-      'does/not/exist',
+      '/does/not/exist',
     );
 
     expect(lintAction, equals(LintAction.skipMissing));

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -106,7 +106,7 @@ Future<int> main(List<String> args) async {
       <String>[
         '--compile-commands',
         // This just has to exist.
-        io.Platform.executable,
+        io.Platform.script.path,
         '--repo',
         '/does/not/exist',
       ],
@@ -168,7 +168,7 @@ Future<int> main(List<String> args) async {
         'file': filePath,
       },
     ];
-    final List<Command> commands = clangTidy.getLintCommandsForChangedFiles(
+    final List<Command> commands = await clangTidy.getLintCommandsForChangedFiles(
       buildCommandsData,
       <io.File>[],
     );
@@ -186,7 +186,9 @@ Future<int> main(List<String> args) async {
       outSink: outBuffer,
       errSink: errBuffer,
     );
-    const String filePath = '/path/to/a/source_file.cc';
+
+    // This just has to exist.
+    final String filePath = io.Platform.script.path;
     final List<dynamic> buildCommandsData = <Map<String, dynamic>>[
       <String, dynamic>{
         'directory': '/unused',
@@ -194,7 +196,7 @@ Future<int> main(List<String> args) async {
         'file': filePath,
       },
     ];
-    final List<Command> commands = clangTidy.getLintCommandsForChangedFiles(
+    final List<Command> commands = await clangTidy.getLintCommandsForChangedFiles(
       buildCommandsData,
       <io.File>[io.File(filePath)],
     );
@@ -218,6 +220,14 @@ Future<int> main(List<String> args) async {
     );
 
     expect(lintAction, equals(LintAction.skipThirdParty));
+  });
+
+  test('Command getLintAction flags missing files', () async {
+    final LintAction lintAction = await Command.getLintAction(
+      'does/not/exist',
+    );
+
+    expect(lintAction, equals(LintAction.skipMissing));
   });
 
   test('Command getLintActionFromContents flags FLUTTER_NOLINT', () async {


### PR DESCRIPTION
Significantly speed up the `clang-tidy` script.  The changed files/compile-commands intersection `containsAny` calculation is very expensive.  Short-circuit this call for the `third_party` files that would only have been skipped later.

Reduced `--lint-all` on my machine from 11:54 minutes to 2:28.

Optimize for linting all files in a target with https://github.com/flutter/flutter/issues/61661.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
