### PR TITLE
Add "clang-tidy --fix" flag to automatically apply fixes

### DIFF
--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -48,6 +48,7 @@ class ClangTidy {
     required io.Directory repoPath,
     String checksArg = '',
     bool lintAll = false,
+    bool fix = false,
     StringSink? outSink,
     StringSink? errSink,
   }) :
@@ -56,6 +57,7 @@ class ClangTidy {
       repoPath: repoPath,
       checksArg: checksArg,
       lintAll: lintAll,
+      fix: fix,
       errSink: errSink,
     ),
     _outSink = outSink ?? io.stdout,
@@ -207,7 +209,7 @@ class ClangTidy {
           break;
         case LintAction.lint:
           _outSink.writeln('🔶 linting $relativePath');
-          jobs.add(command.createLintJob(checks));
+          jobs.add(command.createLintJob(checks, options.fix));
           break;
         case LintAction.skipThirdParty:
           _outSink.writeln('🔷 ignoring $relativePath (third_party)');

--- a/tools/clang_tidy/lib/src/command.dart
+++ b/tools/clang_tidy/lib/src/command.dart
@@ -129,11 +129,13 @@ class Command {
   }
 
   /// The job for the process runner for the lint needed for this command.
-  WorkerJob createLintJob(String? checks) {
+  WorkerJob createLintJob(String? checks, bool fix) {
     final List<String> args = <String>[
       filePath,
       if (checks != null)
         checks,
+      if (fix)
+        '--fix',
       '--',
     ];
     args.addAll(tidyArgs.split(' '));

--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -17,6 +17,7 @@ class Options {
     this.verbose = false,
     this.checksArg = '',
     this.lintAll = false,
+    this.fix = false,
     this.errorMessage,
     StringSink? errSink,
   }) : checks = checksArg.isNotEmpty ? '--checks=$checksArg' : null,
@@ -58,6 +59,7 @@ class Options {
       checksArg: options.wasParsed('checks') ? options['checks'] as String : '',
       lintAll: io.Platform.environment['FLUTTER_LINT_ALL'] != null ||
                options['lint-all'] as bool,
+      fix: options['fix'] as bool,
       errSink: errSink,
     );
   }
@@ -89,6 +91,11 @@ class Options {
     ..addFlag(
       'lint-all',
       help: 'lint all of the sources, regardless of FLUTTER_NOLINT.',
+      defaultsTo: false,
+    )
+    ..addFlag(
+      'fix',
+      help: 'Apply suggested fixes.',
       defaultsTo: false,
     )
     ..addFlag(
@@ -134,6 +141,9 @@ class Options {
   /// Whether all files should be linted.
   final bool lintAll;
 
+  /// Whether checks should apply available fix-ups to the working copy.
+  final bool fix;
+
   /// If there was a problem with the command line arguments, this string
   /// contains the error message.
   final String? errorMessage;
@@ -146,7 +156,7 @@ class Options {
       _errSink.writeln(message);
     }
     _errSink.writeln(
-      'Usage: bin/main.dart [--help] [--lint-all] [--verbose] [--diff-branch]',
+      'Usage: bin/main.dart [--help] [--lint-all] [--fix] [--verbose] [--diff-branch]',
     );
     _errSink.writeln(_argParser.usage);
   }

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -204,10 +204,20 @@ Future<int> main(List<String> args) async {
     expect(commands, isNotEmpty);
     final Command command = commands.first;
     expect(command.tidyPath, contains('clang/bin/clang-tidy'));
-    final WorkerJob job = command.createLintJob(null);
-    expect(job.command, <String>[
+    final WorkerJob jobNoFix = command.createLintJob(null, false);
+    expect(jobNoFix.command, <String>[
       '../../buildtools/mac-x64/clang/bin/clang-tidy',
       filePath,
+      '--',
+      '',
+      filePath,
+    ]);
+
+    final WorkerJob jobWithFix = command.createLintJob(null, true);
+    expect(jobWithFix.command, <String>[
+      '../../buildtools/mac-x64/clang/bin/clang-tidy',
+      filePath,
+      '--fix',
       '--',
       '',
       filePath,


### PR DESCRIPTION
Similar to `ci/format.sh --fix`, add a `ci/lint.sh --fix` to automatically apply fixes suggested by `clang-tidy`.

When I run `ci/lint.sh --fix` locally I see changes applied:
Example:
https://github.com/flutter/engine/blob/ddf4bd598eb3ec0d5b50db38da876cba6ba8451c/flow/display_list.cc#L111
```diff
-  SetStyleOp(SkPaint::Style style) : style(style) {}
+  explicit SetStyleOp(SkPaint::Style style) : style(style) {}
```
https://github.com/flutter/engine/blob/138c91c614d742c52aa5432b4cb921f0ff9fdee2/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm#L13
```diff
-    _sharedInstance = [FlutterBinaryCodec new];
+    _sharedInstance = [[FlutterBinaryCodec alloc] init];
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
