### PR TITLE
Allow engine variants other than "host_debug" to be clang-tidy linted

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -41,6 +41,6 @@ cd "$SCRIPT_DIR"
 "$DART" \
   --disable-dart-dev \
   "$SRC_DIR/flutter/tools/clang_tidy/bin/main.dart" \
-  --compile-commands="$COMPILE_COMMANDS" \
   --repo="$SRC_DIR/flutter" \
+  --src-dir="$SRC_DIR" \
   "$@"

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -41,6 +41,5 @@ cd "$SCRIPT_DIR"
 "$DART" \
   --disable-dart-dev \
   "$SRC_DIR/flutter/tools/clang_tidy/bin/main.dart" \
-  --repo="$SRC_DIR/flutter" \
   --src-dir="$SRC_DIR" \
   "$@"

--- a/tools/clang_tidy/README.md
+++ b/tools/clang_tidy/README.md
@@ -1,9 +1,15 @@
 # clang_tidy
 
-This is a Dart program/library that runs clang_tidy over modified files. It
-takes two mandatory arguments that point at a compile_commands.json command
-and the root of the Flutter engine repo:
+This is a Dart program/library that runs clang_tidy over modified files in the Flutter engine repo.
+
+By default the linter runs on the repo files changed contained in `src/out/host_debug/compile_commands.json` command.
+To check files other than in `host_debug` use `--target-variant android_debug_unopt`,
+`--target-variant ios_debug_sim_unopt`, etc.
+
+Alternatively, use `--compile-commands` to specify a path to a `compile_commands.json` file.
 
 ```
+$ bin/main.dart --target-variant <engine-variant> --repo <path-to-repo>
 $ bin/main.dart --compile-commands <compile_commands.json-path> --repo <path-to-repo>
+$ bin/main.dart --help
 ```

--- a/tools/clang_tidy/README.md
+++ b/tools/clang_tidy/README.md
@@ -9,7 +9,7 @@ To check files other than in `host_debug` use `--target-variant android_debug_un
 Alternatively, use `--compile-commands` to specify a path to a `compile_commands.json` file.
 
 ```
-$ bin/main.dart --target-variant <engine-variant> --repo <path-to-repo>
-$ bin/main.dart --compile-commands <compile_commands.json-path> --repo <path-to-repo>
+$ bin/main.dart --target-variant <engine-variant>
+$ bin/main.dart --compile-commands <compile_commands.json-path>
 $ bin/main.dart --help
 ```

--- a/tools/clang_tidy/bin/main.dart
+++ b/tools/clang_tidy/bin/main.dart
@@ -7,8 +7,8 @@
 // Runs clang-tidy on files with changes.
 //
 // Basic Usage:
-// dart bin/main.dart --compile-commands <path to compile_commands.json> \
-//                    --repo <path to git repository> \
+// dart bin/main.dart --compile-commands <path to compile_commands.json>
+// dart bin/main.dart --target-variant <engine-variant>
 //
 // User environment variable FLUTTER_LINT_ALL to run on all files.
 

--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -229,16 +229,8 @@ class ClangTidy {
       if (job.result.exitCode == 0) {
         continue;
       }
-      if (job.exception != null) {
-        _errSink.writeln(
-          '\n❗ A clang-tidy job failed to run, aborting:\n${job.exception}',
-        );
-        result = 1;
-        break;
-      } else {
-        _errSink.writeln('❌ Failures for ${job.name}:');
-        _errSink.writeln(job.result.stdout);
-      }
+      _errSink.writeln('❌ Failures for ${job.name}:');
+      _errSink.writeln(job.result.stdout);
       result = 1;
     }
     return result;

--- a/tools/clang_tidy/lib/clang_tidy.dart
+++ b/tools/clang_tidy/lib/clang_tidy.dart
@@ -45,7 +45,6 @@ class ClangTidy {
   /// will otherwise go to stderr.
   ClangTidy({
     required io.File buildCommandsPath,
-    required io.Directory repoPath,
     String checksArg = '',
     bool lintAll = false,
     bool fix = false,
@@ -54,7 +53,6 @@ class ClangTidy {
   }) :
     options = Options(
       buildCommandsPath: buildCommandsPath,
-      repoPath: repoPath,
       checksArg: checksArg,
       lintAll: lintAll,
       fix: fix,

--- a/tools/clang_tidy/lib/src/command.dart
+++ b/tools/clang_tidy/lib/src/command.dart
@@ -134,8 +134,10 @@ class Command {
       filePath,
       if (checks != null)
         checks,
-      if (fix)
+      if (fix) ...<String>[
         '--fix',
+        '--format-style=file',
+      ],
       '--',
     ];
     args.addAll(tidyArgs.split(' '));

--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -5,6 +5,10 @@
 import 'dart:io' as io show Directory, File, Platform, stderr;
 
 import 'package:args/args.dart';
+import 'package:path/path.dart' as path;
+
+// Path to root of the flutter/engine repository containing this script.
+final String _engineRoot = path.dirname(path.dirname(path.dirname(path.dirname(path.fromUri(io.Platform.script)))));
 
 /// A class for organizing the options to the Engine linter, and the files
 /// that it operates on.
@@ -49,12 +53,13 @@ class Options {
   /// Builds an [Options] instance with an [ArgResults] instance.
   factory Options._fromArgResults(
     ArgResults options, {
+    required io.File buildCommandsPath,
     StringSink? errSink,
   }) {
     return Options(
       help: options['help'] as bool,
       verbose: options['verbose'] as bool,
-      buildCommandsPath: io.File(options['compile-commands'] as String),
+      buildCommandsPath: buildCommandsPath,
       repoPath: io.Directory(options['repo'] as String),
       checksArg: options.wasParsed('checks') ? options['checks'] as String : '',
       lintAll: io.Platform.environment['FLUTTER_LINT_ALL'] != null ||
@@ -70,7 +75,17 @@ class Options {
     StringSink? errSink,
   }) {
     final ArgResults argResults = _argParser.parse(arguments);
-    final String? message = _checkArguments(argResults);
+
+    String? buildCommandsPath = argResults['compile-commands'] as String?;
+    // path/to/engine/src/out/variant/compile_commands.json
+    buildCommandsPath ??= path.join(
+      argResults['src-dir'] as String,
+      'out',
+      argResults['target-variant'] as String,
+      'compile_commands.json',
+    );
+    final io.File buildCommands = io.File(buildCommandsPath);
+    final String? message = _checkArguments(argResults, buildCommands);
     if (message != null) {
       return Options._error(message, errSink: errSink);
     }
@@ -79,6 +94,7 @@ class Options {
     }
     return Options._fromArgResults(
       argResults,
+      buildCommandsPath: buildCommands,
       errSink: errSink,
     );
   }
@@ -86,7 +102,9 @@ class Options {
   static final ArgParser _argParser = ArgParser()
     ..addFlag(
       'help',
+      abbr: 'h',
       help: 'Print help.',
+      negatable: false,
     )
     ..addFlag(
       'lint-all',
@@ -111,6 +129,20 @@ class Options {
       'compile-commands',
       help: 'Use the given path as the source of compile_commands.json. This '
             'file is created by running tools/gn',
+    )
+    ..addOption(
+      'target-variant',
+      aliases: <String>['variant'],
+      help: 'The engine variant directory containing compile_commands.json '
+            'created by running tools/gn. Ignored if --compile-commands is also passed.',
+      valueHelp: 'host_debug|android_debug_unopt|ios_debug|ios_debug_sim_unopt',
+      defaultsTo: 'host_debug',
+    )
+    ..addOption(
+      'src-dir',
+      help: 'Path to the engine src directory. Ignored if --compile-commands is also passed.',
+      valueHelp: 'path/to/engine/src',
+      defaultsTo: path.dirname(_engineRoot),
     )
     ..addOption(
       'checks',
@@ -156,26 +188,21 @@ class Options {
       _errSink.writeln(message);
     }
     _errSink.writeln(
-      'Usage: bin/main.dart [--help] [--lint-all] [--fix] [--verbose] [--diff-branch]',
+      'Usage: bin/main.dart [--help] [--lint-all] [--fix] [--verbose] [--diff-branch] [--target-variant variant] [--src-dir path/to/engine/src]',
     );
     _errSink.writeln(_argParser.usage);
   }
 
   /// Command line argument validation.
-  static String? _checkArguments(ArgResults argResults) {
+  static String? _checkArguments(ArgResults argResults, io.File buildCommandsPath) {
     if (argResults.wasParsed('help')) {
       return null;
-    }
-
-    if (!argResults.wasParsed('compile-commands')) {
-      return 'ERROR: The --compile-commands argument is required.';
     }
 
     if (!argResults.wasParsed('repo')) {
       return 'ERROR: The --repo argument is required.';
     }
 
-    final io.File buildCommandsPath = io.File(argResults['compile-commands'] as String);
     if (!buildCommandsPath.existsSync()) {
       return "ERROR: Build commands path ${buildCommandsPath.absolute.path} doesn't exist.";
     }

--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -199,8 +199,17 @@ class Options {
       return null;
     }
 
+    final bool compileCommandsParsed = argResults.wasParsed('compile-commands');
+    if (compileCommandsParsed && argResults.wasParsed('target-variant')) {
+      return 'ERROR: --compile-commands option cannot be used with --target-variant.';
+    }
+
+    if (compileCommandsParsed && argResults.wasParsed('src-dir')) {
+      return 'ERROR: --compile-commands option cannot be used with --src-dir.';
+    }
+
     if (!argResults.wasParsed('repo')) {
-      return 'ERROR: The --repo argument is required.';
+      return 'ERROR: The --repo option is required.';
     }
 
     if (!buildCommandsPath.existsSync()) {

--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -16,7 +16,6 @@ class Options {
   /// Builds an instance of [Options] from the arguments.
   Options({
     required this.buildCommandsPath,
-    required this.repoPath,
     this.help = false,
     this.verbose = false,
     this.checksArg = '',
@@ -34,7 +33,6 @@ class Options {
     return Options(
       errorMessage: message,
       buildCommandsPath: io.File('none'),
-      repoPath: io.Directory('none'),
       errSink: errSink,
     );
   }
@@ -45,7 +43,6 @@ class Options {
     return Options(
       help: true,
       buildCommandsPath: io.File('none'),
-      repoPath: io.Directory('none'),
       errSink: errSink,
     );
   }
@@ -60,7 +57,6 @@ class Options {
       help: options['help'] as bool,
       verbose: options['verbose'] as bool,
       buildCommandsPath: buildCommandsPath,
-      repoPath: io.Directory(options['repo'] as String),
       checksArg: options.wasParsed('checks') ? options['checks'] as String : '',
       lintAll: io.Platform.environment['FLUTTER_LINT_ALL'] != null ||
                options['lint-all'] as bool,
@@ -122,10 +118,6 @@ class Options {
       defaultsTo: false,
     )
     ..addOption(
-      'repo',
-      help: 'Use the given path as the repo path',
-    )
-    ..addOption(
       'compile-commands',
       help: 'Use the given path as the source of compile_commands.json. This '
             'file is created by running "tools/gn". Cannot be used with --target-variant '
@@ -162,7 +154,7 @@ class Options {
   final io.File buildCommandsPath;
 
   /// The root of the flutter/engine repository.
-  final io.Directory repoPath;
+  final io.Directory repoPath = io.Directory(_engineRoot);
 
   /// Arguments to plumb through to clang-tidy formatted as a command line
   /// argument.
@@ -209,17 +201,8 @@ class Options {
       return 'ERROR: --compile-commands option cannot be used with --src-dir.';
     }
 
-    if (!argResults.wasParsed('repo')) {
-      return 'ERROR: The --repo option is required.';
-    }
-
     if (!buildCommandsPath.existsSync()) {
       return "ERROR: Build commands path ${buildCommandsPath.absolute.path} doesn't exist.";
-    }
-
-    final io.Directory repoPath = io.Directory(argResults['repo'] as String);
-    if (!repoPath.existsSync()) {
-      return "ERROR: Repo path ${repoPath.absolute.path} doesn't exist.";
     }
 
     return null;

--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -128,19 +128,20 @@ class Options {
     ..addOption(
       'compile-commands',
       help: 'Use the given path as the source of compile_commands.json. This '
-            'file is created by running tools/gn',
+            'file is created by running "tools/gn". Cannot be used with --target-variant '
+            'or --src-dir.',
     )
     ..addOption(
       'target-variant',
       aliases: <String>['variant'],
       help: 'The engine variant directory containing compile_commands.json '
-            'created by running tools/gn. Ignored if --compile-commands is also passed.',
+            'created by running "tools/gn". Cannot be used with --compile-commands.',
       valueHelp: 'host_debug|android_debug_unopt|ios_debug|ios_debug_sim_unopt',
       defaultsTo: 'host_debug',
     )
     ..addOption(
       'src-dir',
-      help: 'Path to the engine src directory. Ignored if --compile-commands is also passed.',
+      help: 'Path to the engine src directory. Cannot be used with --compile-commands.',
       valueHelp: 'path/to/engine/src',
       defaultsTo: path.dirname(_engineRoot),
     )

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io' as io show Directory, File, Platform, stderr;
+import 'dart:io' as io show File, Platform, stderr;
 
 import 'package:clang_tidy/clang_tidy.dart';
 import 'package:clang_tidy/src/command.dart';
@@ -10,14 +10,13 @@ import 'package:litetest/litetest.dart';
 import 'package:process_runner/process_runner.dart';
 
 Future<int> main(List<String> args) async {
-  if (args.length < 2) {
+  if (args.isEmpty) {
     io.stderr.writeln(
-      'Usage: clang_tidy_test.dart [path/to/compile_commands.json] [repo root]',
+      'Usage: clang_tidy_test.dart [path/to/compile_commands.json]',
     );
     return 1;
   }
   final String buildCommands = args[0];
-  final String repoRoot = args[1];
 
   test('--help gives help', () async {
     final StringBuffer outBuffer = StringBuffer();
@@ -42,8 +41,6 @@ Future<int> main(List<String> args) async {
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy.fromCommandLine(
       <String>[
-        '--repo',
-        '/unused',
         '--compile-commands',
         '/unused',
         '--target-variant',
@@ -67,8 +64,6 @@ Future<int> main(List<String> args) async {
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy.fromCommandLine(
       <String>[
-        '--repo',
-        '/unused',
         '--compile-commands',
         '/unused',
         '--src-dir',
@@ -87,27 +82,6 @@ Future<int> main(List<String> args) async {
     ));
   });
 
-  test('Error when --repo is missing', () async {
-    final StringBuffer outBuffer = StringBuffer();
-    final StringBuffer errBuffer = StringBuffer();
-    final ClangTidy clangTidy = ClangTidy.fromCommandLine(
-      <String>[
-        '--compile-commands',
-        '/unused',
-      ],
-      outSink: outBuffer,
-      errSink: errBuffer,
-    );
-
-    final int result = await clangTidy.run();
-
-    expect(clangTidy.options.help, isFalse);
-    expect(result, equals(1));
-    expect(errBuffer.toString(), contains(
-      'ERROR: The --repo option is required.',
-    ));
-  });
-
   test('Error when --compile-commands path does not exist', () async {
     final StringBuffer outBuffer = StringBuffer();
     final StringBuffer errBuffer = StringBuffer();
@@ -115,8 +89,6 @@ Future<int> main(List<String> args) async {
       <String>[
         '--compile-commands',
         '/does/not/exist',
-        '--repo',
-        '/unused',
       ],
       outSink: outBuffer,
       errSink: errBuffer,
@@ -140,8 +112,6 @@ Future<int> main(List<String> args) async {
         '/does/not/exist',
         '--target-variant',
         'ios_debug_unopt',
-        '--repo',
-        '/unused',
       ],
       outSink: outBuffer,
       errSink: errBuffer,
@@ -156,36 +126,11 @@ Future<int> main(List<String> args) async {
     ));
   });
 
-  test('Error when --repo path does not exist', () async {
-    final StringBuffer outBuffer = StringBuffer();
-    final StringBuffer errBuffer = StringBuffer();
-    final ClangTidy clangTidy = ClangTidy.fromCommandLine(
-      <String>[
-        '--compile-commands',
-        // This file needs to exist, and be UTF8 line-parsable.
-        io.Platform.script.path,
-        '--repo',
-        '/does/not/exist',
-      ],
-      outSink: outBuffer,
-      errSink: errBuffer,
-    );
-
-    final int result = await clangTidy.run();
-
-    expect(clangTidy.options.help, isFalse);
-    expect(result, equals(1));
-    expect(errBuffer.toString(), contains(
-      "ERROR: Repo path /does/not/exist doesn't exist.",
-    ));
-  });
-
   test('lintAll=true checks all files', () async {
     final StringBuffer outBuffer = StringBuffer();
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
       buildCommandsPath: io.File(buildCommands),
-      repoPath: io.Directory(repoRoot),
       lintAll: true,
       outSink: outBuffer,
       errSink: errBuffer,
@@ -199,7 +144,6 @@ Future<int> main(List<String> args) async {
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
       buildCommandsPath: io.File(buildCommands),
-      repoPath: io.Directory(repoRoot),
       outSink: outBuffer,
       errSink: errBuffer,
     );
@@ -212,7 +156,6 @@ Future<int> main(List<String> args) async {
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
       buildCommandsPath: io.File(buildCommands),
-      repoPath: io.Directory(repoRoot),
       lintAll: true,
       outSink: outBuffer,
       errSink: errBuffer,
@@ -238,7 +181,6 @@ Future<int> main(List<String> args) async {
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
       buildCommandsPath: io.File(buildCommands),
-      repoPath: io.Directory(repoRoot),
       lintAll: true,
       outSink: outBuffer,
       errSink: errBuffer,

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -275,6 +275,7 @@ Future<int> main(List<String> args) async {
       '../../buildtools/mac-x64/clang/bin/clang-tidy',
       filePath,
       '--fix',
+      '--format-style=file',
       '--',
       '',
       filePath,

--- a/tools/clang_tidy/test/clang_tidy_test.dart
+++ b/tools/clang_tidy/test/clang_tidy_test.dart
@@ -37,6 +37,56 @@ Future<int> main(List<String> args) async {
     expect(errBuffer.toString(), contains('Usage: '));
   });
 
+  test('Error when --compile-commands and --target-variant are used together', () async {
+    final StringBuffer outBuffer = StringBuffer();
+    final StringBuffer errBuffer = StringBuffer();
+    final ClangTidy clangTidy = ClangTidy.fromCommandLine(
+      <String>[
+        '--repo',
+        '/unused',
+        '--compile-commands',
+        '/unused',
+        '--target-variant',
+        'unused'
+      ],
+      outSink: outBuffer,
+      errSink: errBuffer,
+    );
+
+    final int result = await clangTidy.run();
+
+    expect(clangTidy.options.help, isFalse);
+    expect(result, equals(1));
+    expect(errBuffer.toString(), contains(
+      'ERROR: --compile-commands option cannot be used with --target-variant.',
+    ));
+  });
+
+  test('Error when --compile-commands and --src-dir are used together', () async {
+    final StringBuffer outBuffer = StringBuffer();
+    final StringBuffer errBuffer = StringBuffer();
+    final ClangTidy clangTidy = ClangTidy.fromCommandLine(
+      <String>[
+        '--repo',
+        '/unused',
+        '--compile-commands',
+        '/unused',
+        '--src-dir',
+        '/unused',
+      ],
+      outSink: outBuffer,
+      errSink: errBuffer,
+    );
+
+    final int result = await clangTidy.run();
+
+    expect(clangTidy.options.help, isFalse);
+    expect(result, equals(1));
+    expect(errBuffer.toString(), contains(
+      'ERROR: --compile-commands option cannot be used with --src-dir.',
+    ));
+  });
+
   test('Error when --repo is missing', () async {
     final StringBuffer outBuffer = StringBuffer();
     final StringBuffer errBuffer = StringBuffer();
@@ -54,7 +104,7 @@ Future<int> main(List<String> args) async {
     expect(clangTidy.options.help, isFalse);
     expect(result, equals(1));
     expect(errBuffer.toString(), contains(
-      'ERROR: The --repo argument is required.',
+      'ERROR: The --repo option is required.',
     ));
   });
 

--- a/tools/githooks/lib/src/pre_push_command.dart
+++ b/tools/githooks/lib/src/pre_push_command.dart
@@ -60,7 +60,6 @@ class PrePushCommand extends Command<bool> {
     final StringBuffer errBuffer = StringBuffer();
     final ClangTidy clangTidy = ClangTidy(
       buildCommandsPath: compileCommands,
-      repoPath: io.Directory(flutterRoot),
       outSink: outBuffer,
       errSink: errBuffer,
     );


### PR DESCRIPTION
Add a new `--target-variant` and `--src-dir` option to the `clang-tidy` linter script.  
Update `lint.sh` to pass along the `src-dir` instead of the `compile-commands` path.  The dart script will interpret this as `src-dir/out/host_debug/compile_commands.json` by default.  Alternative `--target-variant` can be passed into the shell script.

```sh
$ ci/lint.sh --target-variant ios_debug
```
 
This will allow variants (is that the right word here?) other than `host_debug` to be run by the linter.

The recipe can then run the script for different targets
https://flutter.googlesource.com/recipes/+/refs/heads/main/recipes/engine_unopt.py#99
will become something like:
```python
Lint(api, 'ios_debug_unopt')
```
```python
def Lint(api, variant):
  checkout = GetCheckoutPath(api)
  with api.context(cwd=checkout):
    lint_cmd = checkout.join('flutter', 'ci', 'lint.sh', '--lint-all', '--target-variant', variant)
    api.step(api.test_utils.test_step_name('lint test'), [lint_cmd])
```

Note: in the future when the recipe is updated to use `--target-variant`, any outstanding PRs older than this script change will fail until merged in/rebased.  I don't think it will impact future releases since they are versioned (will a beta release without this change run with that recipe? @christopherfujino )

Git pre-push hook continues to pass in `--compile-commands` and still works.

Other improvements:
- `--format-style=file` to use `.clang-format` file for fixes.
- Show all linter errors, not just the first one found.
- Remove the `--repo` option, calculate that directory relative to the script path.

https://github.com/flutter/flutter/issues/61661

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
