### PR TITLE
Use a prebuilt Dart SDK during Fuchsia builds

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -32,11 +32,19 @@ config("export_dynamic_symbols") {
 
 if (flutter_prebuilt_dart_sdk) {
   copy_trees("_copy_trees") {
+    # There is no prebuilt Dart SDK targeting Fuchsia, but we also don't need
+    # one, so even when the build is targeting Fuchsia, use the prebuilt
+    # Dart SDK for the host.
+    if (current_toolchain == host_toolchain || is_fuchsia) {
+      prebuilt_dart_sdk = host_prebuilt_dart_sdk
+    } else {
+      prebuilt_dart_sdk = target_prebuilt_dart_sdk
+    }
     sources = [
       {
         target = "copy_dart_sdk"
         visibility = [ ":dart_sdk" ]
-        source = target_prebuilt_dart_sdk
+        source = prebuilt_dart_sdk
         dest = "$root_out_dir/dart-sdk"
         ignore_patterns = "{}"
       },

--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -282,7 +282,7 @@ template("application_snapshot") {
                                "testonly",
                                "visibility",
                              ])
-      deps = extra_deps + [ "//flutter:dart_sdk" ]
+      deps = extra_deps
       script = "//build/gn_run_binary.py"
       inputs = extra_inputs
       outputs = [ output ]
@@ -293,7 +293,7 @@ template("application_snapshot") {
       if (is_win) {
         ext = ".exe"
       }
-      dart = rebase_path("$host_prebuilt_dart_sdk/bin/dart$ext", root_out_dir)
+      dart = rebase_path("$host_prebuilt_dart_sdk/bin/dart$ext", root_build_dir)
 
       args = [ dart ]
       args += snapshot_vm_args

--- a/common/config.gni
+++ b/common/config.gni
@@ -69,13 +69,22 @@ if (is_ios || is_mac) {
 # prebuilt Dart SDK location
 
 if (flutter_prebuilt_dart_sdk) {
-  _os_name = target_os
-  if (_os_name == "mac") {
-    _os_name = "macos"
-  } else if (_os_name == "win" || _os_name == "winuwp") {
-    _os_name = "windows"
+  _target_os_name = target_os
+  if (_target_os_name == "mac") {
+    _target_os_name = "macos"
+  } else if (_target_os_name == "win" || _target_os_name == "winuwp") {
+    _target_os_name = "windows"
   }
+
+  _host_os_name = host_os
+  if (_host_os_name == "mac") {
+    _host_os_name = "macos"
+  } else if (_host_os_name == "win" || _host_os_name == "winuwp") {
+    _host_os_name = "windows"
+  }
+
   target_prebuilt_dart_sdk =
-      "//flutter/prebuilts/$_os_name-$target_cpu/dart-sdk"
-  host_prebuilt_dart_sdk = "//flutter/prebuilts/$_os_name-$host_cpu/dart-sdk"
+      "//flutter/prebuilts/$_target_os_name-$target_cpu/dart-sdk"
+  host_prebuilt_dart_sdk =
+      "//flutter/prebuilts/$_host_os_name-$host_cpu/dart-sdk"
 }

--- a/testing/dart/compile_test.gni
+++ b/testing/dart/compile_test.gni
@@ -57,7 +57,7 @@ template("compile_flutter_dart_test") {
   if (flutter_prebuilt_dart_sdk) {
     action(target_name) {
       testonly = true
-      deps = common_deps + [ "//flutter:dart_sdk" ]
+      deps = common_deps
       pool = "//flutter/build/dart:dart_pool"
       script = "//build/gn_run_binary.py"
       inputs = [ invoker.dart_file ]

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -58,7 +58,7 @@ template("_frontend_server") {
   if (flutter_prebuilt_dart_sdk) {
     action(target_name) {
       testonly = invoker.testonly
-      deps = invoker.deps + [ "//flutter:dart_sdk" ]
+      deps = invoker.deps
       script = "//build/gn_run_binary.py"
       inputs = invoker.inputs
       outputs = invoker.outputs
@@ -71,7 +71,7 @@ template("_frontend_server") {
       }
       dart = rebase_path("$host_prebuilt_dart_sdk/bin/dart$ext", root_out_dir)
       frontend_server = rebase_path(
-              "$root_out_dir/dart-sdk/bin/snapshots/frontend_server.dart.snapshot")
+              "$host_prebuilt_dart_sdk/bin/snapshots/frontend_server.dart.snapshot")
 
       args = [
                dart,

--- a/tools/gn
+++ b/tools/gn
@@ -92,11 +92,15 @@ def is_host_build(args):
 
 # Determines whether a prebuilt Dart SDK can be used instead of building one.
 # We can use a prebuilt Dart SDK when:
-# 1. It is a host build, or a build targeting desktop
+# 1. It is a host build, a build targeting Fuchsia, or a build targeting desktop.
 # 2. The prebuilt SDK exists under //flutter/prebuilts/$OS-$ARCH.
 def can_use_prebuilt_dart(args):
   prebuilt = None
-  if args.target_os == None:
+  # In a Fuchsia build, we can use a prebuilt Dart SDK for the host to build
+  # platform agnostic artifacts (e.g. kernel snapshots), and a Dart SDK
+  # targeting Fuchsia is not needed. So, it is safe to say that the prebuilt
+  # Dart SDK in a Fuchsia build is the host prebuilt Dart SDK.
+  if args.target_os == None or args.target_os == 'fuchsia':
     if sys.platform.startswith(('cygwin', 'win')):
       prebuilt = 'windows-x64'
     elif sys.platform == 'darwin':


### PR DESCRIPTION
Fuchsia is an unusual target because we need to build the "engine artifacts", and there is a prebuilt Dart SDK for the host (mac, linuix), but no prebuilt Dart SDK for the target (fuchsia). In order to use the prebuilt Dart SDK for the host, which we need to make snapshot building go faster, this PR teaches the GN build that the prebuilt Dart SDK for the host and target can be for different OSes as well as for a different CPU architectures.

This brings the Fuchsia arm64 build down to ~2 minutes from ~15 minutes on CI, and unblocks building/running more Fuchsia tests.

In the future, if we need a prebuilt Dart SDK to target Fuchsia, we should follow the same pattern as for other platforms, and consume one vended by Dart infrastructure.

Fixes https://github.com/flutter/flutter/issues/93084