### PR TITLE
add trace events to cache sweeps

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -410,9 +410,12 @@ void RasterCache::PrepareNewFrame() {
 void RasterCache::CleanupAfterFrame() {
   picture_metrics_ = {};
   layer_metrics_ = {};
-  SweepOneCacheAfterFrame(picture_cache_, picture_metrics_);
-  SweepOneCacheAfterFrame(display_list_cache_, picture_metrics_);
-  SweepOneCacheAfterFrame(layer_cache_, layer_metrics_);
+  {
+    TRACE_EVENT0("flutter", "RasterCache::SweepCaches");
+    SweepOneCacheAfterFrame(picture_cache_, picture_metrics_);
+    SweepOneCacheAfterFrame(display_list_cache_, picture_metrics_);
+    SweepOneCacheAfterFrame(layer_cache_, layer_metrics_);
+  }
   TraceStatsToTimeline();
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/92289

This PR adds one event around all 3 cache sweeps, but this could be broken down into 3 events, one for each cache. Would developers understand the difference and care?

Would they be confused with a nearly empty event for SkPicture cache when the default is DisplayList and vice versa? That could be moot if I do one event around the layer cache and another around both of the Skp/DL caches so all they see are 2 events.

Or is one event like coded here better?