### PR TITLE
Treat all clang tidy warnings as errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,2 @@
 Checks: 'google-*'
+WarningsAsErrors: '*'

--- a/tools/clang_tidy/lib/src/options.dart
+++ b/tools/clang_tidy/lib/src/options.dart
@@ -105,7 +105,7 @@ class Options {
     ..addFlag(
       'lint-all',
       help: 'lint all of the sources, regardless of FLUTTER_NOLINT.',
-      defaultsTo: false,
+      defaultsTo: true,
     )
     ..addFlag(
       'fix',


### PR DESCRIPTION
This should not be checked in.

Clang tidy is running in the Linux Unopt builder, but it's not reporting issues due to https://github.com/flutter/flutter/issues/93279.

Run the linter for real to see what issues need to be fixed before all warnings can be made errors.
