### PR TITLE
Accumulate statistics for Picture objects used in a frame

### DIFF
--- a/common/constants.h
+++ b/common/constants.h
@@ -4,4 +4,5 @@
 
 namespace flutter {
 constexpr double kMegaByteSizeInBytes = (1 << 20);
+constexpr double kKiloByteSizeInBytes = (1 << 10);
 }  // namespace flutter

--- a/flow/layers/display_list_layer.cc
+++ b/flow/layers/display_list_layer.cc
@@ -88,6 +88,8 @@ void DisplayListLayer::Preroll(PrerollContext* context,
   TRACE_EVENT0("flutter", "DisplayListLayer::Preroll");
 
   DisplayList* disp_list = display_list();
+  context->picture_count++;
+  context->picture_bytes += disp_list->bytes(true);
 
   SkRect bounds = disp_list->bounds().makeOffset(offset_.x(), offset_.y());
 

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -61,6 +61,9 @@ struct PrerollContext {
   // These allow us to track properties like elevation, opacity, and the
   // prescence of a texture layer during Preroll.
   bool has_texture_layer = false;
+
+  int picture_count = 0;
+  size_t picture_bytes = 0;
 };
 
 class PictureLayer;

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/flow/layers/layer_tree.h"
 
+#include "flutter/common/constants.h"
 #include "flutter/flow/frame_timings.h"
 #include "flutter/flow/layers/layer.h"
 #include "flutter/fml/time/time_point.h"
@@ -52,6 +53,15 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       device_pixel_ratio_};
 
   root_layer_->Preroll(&context, frame.root_surface_transformation());
+
+#if !FLUTTER_RELEASE
+  FML_TRACE_COUNTER("flutter",                                            //
+                    "LayerTree::Usage", reinterpret_cast<int64_t>(this),  //
+                    "PictureCount", context.picture_count,                //
+                    "PictureKBytes",
+                    context.picture_bytes / kKiloByteSizeInBytes);
+#endif  // !FLUTTER_RELEASE
+
   return context.surface_needs_readback;
 }
 

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -111,6 +111,8 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "PictureLayer::Preroll");
 
   SkPicture* sk_picture = picture();
+  context->picture_count++;
+  context->picture_bytes += sk_picture->approximateBytesUsed();
 
   SkRect bounds = sk_picture->cullRect().makeOffset(offset_.x(), offset_.y());
 


### PR DESCRIPTION
Does not Fix~es https://github.com/flutter/flutter/issues/93561~

This PR reports the count and memory size (in kbytes) of the Picture objects used in each frame/layer-tree (whether they are stored ask SkPicture or DisplayList). This information could be tracked in benchmarks to track our memory used and can provide developers with an insight as to when their frames contain large pictures.

From these statistics one can easily verify the figures reported in https://github.com/flutter/flutter/issues/92366#issuecomment-965965579 that the example code uses ~6500kb per frame as written, but only 16-20kb per frame with the ListView suggestion just by examining the traces in the observatory.

For reference, the gallery transitions benchmark uses about 8kb worst case on any of its frames as computed from the trace timeline it leaves behind.

Work to publish these statistics in Skia Perf is TBD when this lands in the framework tree.