### PR TITLE
Fix 'google-readability-braces-around-statements' analyzer warning in macOS and iOS

### DIFF
--- a/flow/display_list_canvas_unittests.cc
+++ b/flow/display_list_canvas_unittests.cc
@@ -1287,14 +1287,18 @@ class CanvasCompareTester {
       const uint32_t* test_row = test_pixels.addr32(0, y);
       for (int x = 0; x < width; x++) {
         if (bounds && test_row[x] != untouched) {
-          if (minX > x)
+          if (minX > x) {
             minX = x;
-          if (minY > y)
+          }
+          if (minY > y) {
             minY = y;
-          if (maxX <= x)
+          }
+          if (maxX <= x) {
             maxX = x + 1;
-          if (maxY <= y)
+          }
+          if (maxY <= y) {
             maxY = y + 1;
+          }
           if (!i_bounds.contains(x, y)) {
             pixels_oob++;
           }

--- a/flow/display_list_unittests.cc
+++ b/flow/display_list_unittests.cc
@@ -859,8 +859,9 @@ static sk_sp<DisplayList> Build(size_t g_index, size_t v_index) {
   for (size_t i = 0; i < allGroups.size(); i++) {
     DisplayListInvocationGroup& group = allGroups[i];
     size_t j = (i == g_index ? v_index : 0);
-    if (j >= group.variants.size())
+    if (j >= group.variants.size()) {
       continue;
+    }
     DisplayListInvocation& invocation = group.variants[j];
     op_count += invocation.op_count();
     byte_count += invocation.raw_byte_count();

--- a/fml/platform/darwin/string_range_sanitization.mm
+++ b/fml/platform/darwin/string_range_sanitization.mm
@@ -10,8 +10,9 @@ NSRange RangeForCharacterAtIndex(NSString* text, NSUInteger index) {
   if (text == nil || index > text.length) {
     return NSMakeRange(NSNotFound, 0);
   }
-  if (index < text.length)
+  if (index < text.length) {
     return [text rangeOfComposedCharacterSequenceAtIndex:index];
+  }
   return NSMakeRange(index, 0);
 }
 

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -39,8 +39,9 @@ void Window::DispatchPointerDataPacket(const PointerDataPacket& packet) {
 void Window::DispatchKeyDataPacket(const KeyDataPacket& packet,
                                    uint64_t response_id) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
 
   const std::vector<uint8_t>& buffer = packet.data();

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -250,10 +250,12 @@ const uint8_t* DartSnapshot::GetInstructionsMapping() const {
 }
 
 bool DartSnapshot::IsDontNeedSafe() const {
-  if (data_ && !data_->IsDontNeedSafe())
+  if (data_ && !data_->IsDontNeedSafe()) {
     return false;
-  if (instructions_ && !instructions_->IsDontNeedSafe())
+  }
+  if (instructions_ && !instructions_->IsDontNeedSafe()) {
     return false;
+  }
   return true;
 }
 

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -113,8 +113,9 @@ void PlatformView::UpdateSemantics(SemanticsNodeUpdates update,
 
 void PlatformView::HandlePlatformMessage(
     std::unique_ptr<PlatformMessage> message) {
-  if (auto response = message->response())
+  if (auto response = message->response()) {
     response->CompleteEmpty();
+  }
 }
 
 void PlatformView::OnPreEngineRestart() const {}

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -272,8 +272,9 @@ sk_sp<SkImage> Rasterizer::DoMakeRasterSnapshot(
     snapshot_surface = surface_.get();
   } else if (snapshot_surface_producer_) {
     pbuffer_surface = snapshot_surface_producer_->CreateSnapshotSurface();
-    if (pbuffer_surface && pbuffer_surface->GetContext())
+    if (pbuffer_surface && pbuffer_surface->GetContext()) {
       snapshot_surface = pbuffer_surface.get();
+    }
   }
 
   if (!snapshot_surface) {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1212,15 +1212,18 @@ void Shell::HandleEngineSkiaMessage(std::unique_ptr<PlatformMessage> message) {
   rapidjson::Document document;
   document.Parse(reinterpret_cast<const char*>(data.GetMapping()),
                  data.GetSize());
-  if (document.HasParseError() || !document.IsObject())
+  if (document.HasParseError() || !document.IsObject()) {
     return;
+  }
   auto root = document.GetObject();
   auto method = root.FindMember("method");
-  if (method->value != "Skia.setResourceCacheMaxBytes")
+  if (method->value != "Skia.setResourceCacheMaxBytes") {
     return;
+  }
   auto args = root.FindMember("args");
-  if (args == root.MemberEnd() || !args->value.IsInt())
+  if (args == root.MemberEnd() || !args->value.IsInt()) {
     return;
+  }
 
   task_runners_.GetRasterTaskRunner()->PostTask(
       [rasterizer = rasterizer_->GetWeakPtr(), max_bytes = args->value.GetInt(),

--- a/shell/common/vsync_waiter_fallback.cc
+++ b/shell/common/vsync_waiter_fallback.cc
@@ -17,8 +17,9 @@ static fml::TimePoint SnapToNextTick(fml::TimePoint value,
                                      fml::TimePoint tick_phase,
                                      fml::TimeDelta tick_interval) {
   fml::TimeDelta offset = (tick_phase - value) % tick_interval;
-  if (offset != fml::TimeDelta::Zero())
+  if (offset != fml::TimeDelta::Zero()) {
     offset = offset + tick_interval;
+  }
   return value + offset;
 }
 

--- a/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
@@ -61,8 +61,9 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
 
 - (void)sendMessage:(id)message reply:(FlutterReply)callback {
   FlutterBinaryReply reply = ^(NSData* data) {
-    if (callback)
+    if (callback) {
       callback([_codec decode:data]);
+    }
   };
   [_messenger sendOnChannel:_name message:[_codec encode:message] binaryReply:reply];
 }
@@ -118,10 +119,12 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
 }
 
 - (BOOL)isEqual:(id)object {
-  if (self == object)
+  if (self == object) {
     return YES;
-  if (![object isKindOfClass:[FlutterError class]])
+  }
+  if (![object isKindOfClass:[FlutterError class]]) {
     return NO;
+  }
   FlutterError* other = (FlutterError*)object;
   return [self.code isEqual:other.code] &&
          ((!self.message && !other.message) || [self.message isEqual:other.message]) &&
@@ -154,10 +157,12 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
 }
 
 - (BOOL)isEqual:(id)object {
-  if (self == object)
+  if (self == object) {
     return YES;
-  if (![object isKindOfClass:[FlutterMethodCall class]])
+  }
+  if (![object isKindOfClass:[FlutterMethodCall class]]) {
     return NO;
+  }
   FlutterMethodCall* other = (FlutterMethodCall*)object;
   return [self.method isEqual:[other method]] &&
          ((!self.arguments && !other.arguments) || [self.arguments isEqual:other.arguments]);
@@ -242,12 +247,13 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
   FlutterBinaryMessageHandler messageHandler = ^(NSData* message, FlutterBinaryReply callback) {
     FlutterMethodCall* call = [codec decodeMethodCall:message];
     handler(call, ^(id result) {
-      if (result == FlutterMethodNotImplemented)
+      if (result == FlutterMethodNotImplemented) {
         callback(nil);
-      else if ([result isKindOfClass:[FlutterError class]])
+      } else if ([result isKindOfClass:[FlutterError class]]) {
         callback([codec encodeErrorEnvelope:(FlutterError*)result]);
-      else
+      } else {
         callback([codec encodeSuccessEnvelope:result]);
+      }
     });
   };
   _connection = [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:messageHandler];
@@ -309,23 +315,26 @@ static void SetStreamHandlerMessageHandlerOnChannel(NSObject<FlutterStreamHandle
     if ([call.method isEqual:@"listen"]) {
       if (currentSink) {
         FlutterError* error = [handler onCancelWithArguments:nil];
-        if (error)
+        if (error) {
           NSLog(@"Failed to cancel existing stream: %@. %@ (%@)", error.code, error.message,
                 error.details);
+        }
       }
       currentSink = ^(id event) {
-        if (event == FlutterEndOfEventStream)
+        if (event == FlutterEndOfEventStream) {
           [messenger sendOnChannel:name message:nil];
-        else if ([event isKindOfClass:[FlutterError class]])
+        } else if ([event isKindOfClass:[FlutterError class]]) {
           [messenger sendOnChannel:name message:[codec encodeErrorEnvelope:(FlutterError*)event]];
-        else
+        } else {
           [messenger sendOnChannel:name message:[codec encodeSuccessEnvelope:event]];
+        }
       };
       FlutterError* error = [handler onListenWithArguments:call.arguments eventSink:currentSink];
-      if (error)
+      if (error) {
         callback([codec encodeErrorEnvelope:error]);
-      else
+      } else {
         callback([codec encodeSuccessEnvelope:nil]);
+      }
     } else if ([call.method isEqual:@"cancel"]) {
       if (!currentSink) {
         callback(
@@ -336,10 +345,11 @@ static void SetStreamHandlerMessageHandlerOnChannel(NSObject<FlutterStreamHandle
       }
       currentSink = nil;
       FlutterError* error = [handler onCancelWithArguments:call.arguments];
-      if (error)
+      if (error) {
         callback([codec encodeErrorEnvelope:error]);
-      else
+      } else {
         callback([codec encodeSuccessEnvelope:nil]);
+      }
     } else {
       callback(nil);
     }

--- a/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
@@ -35,8 +35,9 @@
 }
 
 - (NSData*)encode:(id)message {
-  if (message == nil)
+  if (message == nil) {
     return nil;
+  }
   NSAssert([message isKindOfClass:[NSString class]], @"");
   NSString* stringMessage = message;
   const char* utf8 = stringMessage.UTF8String;
@@ -44,8 +45,9 @@
 }
 
 - (NSString*)decode:(NSData*)message {
-  if (message == nil)
+  if (message == nil) {
     return nil;
+  }
   return [[[NSString alloc] initWithData:message encoding:NSUTF8StringEncoding] autorelease];
 }
 @end
@@ -60,8 +62,9 @@
 }
 
 - (NSData*)encode:(id)message {
-  if (message == nil)
+  if (message == nil) {
     return nil;
+  }
   NSData* encoding;
   if ([message isKindOfClass:[NSArray class]] || [message isKindOfClass:[NSDictionary class]]) {
     encoding = [NSJSONSerialization dataWithJSONObject:message options:0 error:nil];
@@ -78,8 +81,9 @@
 }
 
 - (id)decode:(NSData*)message {
-  if ([message length] == 0)
+  if ([message length] == 0) {
     return nil;
+  }
   BOOL isSimpleValue = NO;
   id decoded = nil;
   if (0 < message.length) {
@@ -143,8 +147,9 @@
 
 - (id)decodeEnvelope:(NSData*)envelope {
   NSArray* array = [[FlutterJSONMessageCodec sharedInstance] decode:envelope];
-  if (array.count == 1)
+  if (array.count == 1) {
     return [self unwrapNil:array[0]];
+  }
   NSAssert(array.count == 3, @"Invalid JSON envelope");
   id code = array[0];
   id message = [self unwrapNil:array[1]];

--- a/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterStandardCodec.mm
@@ -36,8 +36,9 @@
 }
 
 - (NSData*)encode:(id)message {
-  if (message == nil)
+  if (message == nil) {
     return nil;
+  }
   NSMutableData* data = [NSMutableData dataWithCapacity:32];
   FlutterStandardWriter* writer = [_readerWriter writerWithData:data];
   [writer writeValue:message];
@@ -45,8 +46,9 @@
 }
 
 - (id)decode:(NSData*)message {
-  if ([message length] == 0)
+  if ([message length] == 0) {
     return nil;
+  }
   FlutterStandardReader* reader = [_readerWriter readerWithData:message];
   id value = [reader readValue];
   NSAssert(![reader hasMore], @"Corrupted standard message");
@@ -193,10 +195,12 @@ using namespace flutter;
 }
 
 - (BOOL)isEqual:(id)object {
-  if (self == object)
+  if (self == object) {
     return YES;
-  if (![object isKindOfClass:[FlutterStandardTypedData class]])
+  }
+  if (![object isKindOfClass:[FlutterStandardTypedData class]]) {
     return NO;
+  }
   FlutterStandardTypedData* other = (FlutterStandardTypedData*)object;
   return self.type == other.type && self.elementCount == other.elementCount &&
          [self.data isEqual:other.data];

--- a/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
+++ b/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
@@ -9,25 +9,28 @@
 void checkEncodeDecode(id value, NSData* expectedEncoding) {
   FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
   NSData* encoded = [codec encode:value];
-  if (expectedEncoding == nil)
+  if (expectedEncoding == nil) {
     ASSERT_TRUE(encoded == nil);
-  else
+  } else {
     ASSERT_TRUE([encoded isEqual:expectedEncoding]);
+  }
   id decoded = [codec decode:encoded];
-  if (value == nil || value == [NSNull null])
+  if (value == nil || value == [NSNull null]) {
     ASSERT_TRUE(decoded == nil);
-  else
+  } else {
     ASSERT_TRUE([value isEqual:decoded]);
+  }
 }
 
 void checkEncodeDecode(id value) {
   FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
   NSData* encoded = [codec encode:value];
   id decoded = [codec decode:encoded];
-  if (value == nil || value == [NSNull null])
+  if (value == nil || value == [NSNull null]) {
     ASSERT_TRUE(decoded == nil);
-  else
+  } else {
     ASSERT_TRUE([value isEqual:decoded]);
+  }
 }
 
 TEST(FlutterStandardCodec, CanDecodeZeroLength) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -136,19 +136,21 @@ using namespace flutter;
     mask |= UIInterfaceOrientationMaskAll;
   } else {
     for (NSString* orientation in orientations) {
-      if ([orientation isEqualToString:@"DeviceOrientation.portraitUp"])
+      if ([orientation isEqualToString:@"DeviceOrientation.portraitUp"]) {
         mask |= UIInterfaceOrientationMaskPortrait;
-      else if ([orientation isEqualToString:@"DeviceOrientation.portraitDown"])
+      } else if ([orientation isEqualToString:@"DeviceOrientation.portraitDown"]) {
         mask |= UIInterfaceOrientationMaskPortraitUpsideDown;
-      else if ([orientation isEqualToString:@"DeviceOrientation.landscapeLeft"])
+      } else if ([orientation isEqualToString:@"DeviceOrientation.landscapeLeft"]) {
         mask |= UIInterfaceOrientationMaskLandscapeLeft;
-      else if ([orientation isEqualToString:@"DeviceOrientation.landscapeRight"])
+      } else if ([orientation isEqualToString:@"DeviceOrientation.landscapeRight"]) {
         mask |= UIInterfaceOrientationMaskLandscapeRight;
+      }
     }
   }
 
-  if (!mask)
+  if (!mask) {
     return;
+  }
   [[NSNotificationCenter defaultCenter]
       postNotificationName:@(kOrientationUpdateNotificationName)
                     object:nil
@@ -205,8 +207,9 @@ using namespace flutter;
 
 - (void)setSystemChromeSystemUIOverlayStyle:(NSDictionary*)message {
   NSString* brightness = message[@"statusBarBrightness"];
-  if (brightness == (id)[NSNull null])
+  if (brightness == (id)[NSNull null]) {
     return;
+  }
 
   UIStatusBarStyle statusBarStyle;
   if ([brightness isEqualToString:@"Brightness.dark"]) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -78,29 +78,39 @@ static BOOL shouldShowSystemKeyboard(NSDictionary* type) {
 }
 static UIKeyboardType ToUIKeyboardType(NSDictionary* type) {
   NSString* inputType = type[@"name"];
-  if ([inputType isEqualToString:@"TextInputType.address"])
+  if ([inputType isEqualToString:@"TextInputType.address"]) {
     return UIKeyboardTypeDefault;
-  if ([inputType isEqualToString:@"TextInputType.datetime"])
+  }
+  if ([inputType isEqualToString:@"TextInputType.datetime"]) {
     return UIKeyboardTypeNumbersAndPunctuation;
-  if ([inputType isEqualToString:@"TextInputType.emailAddress"])
+  }
+  if ([inputType isEqualToString:@"TextInputType.emailAddress"]) {
     return UIKeyboardTypeEmailAddress;
-  if ([inputType isEqualToString:@"TextInputType.multiline"])
+  }
+  if ([inputType isEqualToString:@"TextInputType.multiline"]) {
     return UIKeyboardTypeDefault;
-  if ([inputType isEqualToString:@"TextInputType.name"])
+  }
+  if ([inputType isEqualToString:@"TextInputType.name"]) {
     return UIKeyboardTypeNamePhonePad;
+  }
   if ([inputType isEqualToString:@"TextInputType.number"]) {
-    if ([type[@"signed"] boolValue])
+    if ([type[@"signed"] boolValue]) {
       return UIKeyboardTypeNumbersAndPunctuation;
-    if ([type[@"decimal"] boolValue])
+    }
+    if ([type[@"decimal"] boolValue]) {
       return UIKeyboardTypeDecimalPad;
+    }
     return UIKeyboardTypeNumberPad;
   }
-  if ([inputType isEqualToString:@"TextInputType.phone"])
+  if ([inputType isEqualToString:@"TextInputType.phone"]) {
     return UIKeyboardTypePhonePad;
-  if ([inputType isEqualToString:@"TextInputType.text"])
+  }
+  if ([inputType isEqualToString:@"TextInputType.text"]) {
     return UIKeyboardTypeDefault;
-  if ([inputType isEqualToString:@"TextInputType.url"])
+  }
+  if ([inputType isEqualToString:@"TextInputType.url"]) {
     return UIKeyboardTypeURL;
+  }
   return UIKeyboardTypeDefault;
 }
 
@@ -121,39 +131,51 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
   // has "unspecified." These 2 terms seem to mean the same thing but we need
   // to pick just one. "unspecified" was chosen because "default" is often a
   // reserved word in languages with switch statements (dart, java, etc).
-  if ([inputType isEqualToString:@"TextInputAction.unspecified"])
+  if ([inputType isEqualToString:@"TextInputAction.unspecified"]) {
     return UIReturnKeyDefault;
+  }
 
-  if ([inputType isEqualToString:@"TextInputAction.done"])
+  if ([inputType isEqualToString:@"TextInputAction.done"]) {
     return UIReturnKeyDone;
+  }
 
-  if ([inputType isEqualToString:@"TextInputAction.go"])
+  if ([inputType isEqualToString:@"TextInputAction.go"]) {
     return UIReturnKeyGo;
+  }
 
-  if ([inputType isEqualToString:@"TextInputAction.send"])
+  if ([inputType isEqualToString:@"TextInputAction.send"]) {
     return UIReturnKeySend;
+  }
 
-  if ([inputType isEqualToString:@"TextInputAction.search"])
+  if ([inputType isEqualToString:@"TextInputAction.search"]) {
     return UIReturnKeySearch;
+  }
 
-  if ([inputType isEqualToString:@"TextInputAction.next"])
+  if ([inputType isEqualToString:@"TextInputAction.next"]) {
     return UIReturnKeyNext;
+  }
 
-  if (@available(iOS 9.0, *))
-    if ([inputType isEqualToString:@"TextInputAction.continueAction"])
+  if (@available(iOS 9.0, *)) {
+    if ([inputType isEqualToString:@"TextInputAction.continueAction"]) {
       return UIReturnKeyContinue;
+    }
+  }
 
-  if ([inputType isEqualToString:@"TextInputAction.join"])
+  if ([inputType isEqualToString:@"TextInputAction.join"]) {
     return UIReturnKeyJoin;
+  }
 
-  if ([inputType isEqualToString:@"TextInputAction.route"])
+  if ([inputType isEqualToString:@"TextInputAction.route"]) {
     return UIReturnKeyRoute;
+  }
 
-  if ([inputType isEqualToString:@"TextInputAction.emergencyCall"])
+  if ([inputType isEqualToString:@"TextInputAction.emergencyCall"]) {
     return UIReturnKeyEmergencyCall;
+  }
 
-  if ([inputType isEqualToString:@"TextInputAction.newline"])
+  if ([inputType isEqualToString:@"TextInputAction.newline"]) {
     return UIReturnKeyDefault;
+  }
 
   // Present default key if bad input type is given.
   return UIReturnKeyDefault;
@@ -354,8 +376,9 @@ static BOOL isFieldPasswordRelated(NSDictionary* configuration) {
     }
 
     BOOL isSecureTextEntry = [configuration[kSecureTextEntry] boolValue];
-    if (isSecureTextEntry)
+    if (isSecureTextEntry) {
       return YES;
+    }
 
     NSDictionary* autofill = configuration[kAutofillProperties];
     UITextContentType contentType = ToUITextContentType(autofill[kAutofillHints]);
@@ -910,8 +933,9 @@ static BOOL isScribbleAvailable() {
     [self setSelectedTextRangeLocal:[FlutterTextRange rangeWithNSRange:selectedRange]];
 
     _selectionAffinity = _kTextAffinityDownstream;
-    if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
+    if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)]) {
       _selectionAffinity = _kTextAffinityUpstream;
+    }
     [self.inputDelegate selectionDidChange:self];
   }
 
@@ -1136,8 +1160,9 @@ static BOOL isScribbleAvailable() {
   // * reduce the length by the intersection length
   // * adjust the location by newLength - oldLength + intersectionLength
   NSRange intersectionRange = NSIntersectionRange(range, selectedRange);
-  if (range.location <= selectedRange.location)
+  if (range.location <= selectedRange.location) {
     selectedRange.location += text.length - range.length;
+  }
   if (intersectionRange.location != NSNotFound) {
     selectedRange.location += intersectionRange.length;
     selectedRange.length -= intersectionRange.length;
@@ -1230,8 +1255,9 @@ static BOOL isScribbleAvailable() {
     return;
   }
 
-  if (markedText == nil)
+  if (markedText == nil) {
     markedText = @"";
+  }
 
   if (markedTextRange.length > 0) {
     // Replace text in the marked range with the new text.
@@ -1265,8 +1291,9 @@ static BOOL isScribbleAvailable() {
 }
 
 - (void)unmarkText {
-  if (!self.markedTextRange)
+  if (!self.markedTextRange) {
     return;
+  }
   self.markedTextRange = nil;
   if (_enableDeltaModel) {
     [self updateEditingStateWithDelta:[FlutterTextEditingDelta deltaWithNonText:self.text]];
@@ -1314,11 +1341,13 @@ static BOOL isScribbleAvailable() {
   }
 
   if (offset >= 0) {
-    for (NSInteger i = 0; i < offset && offsetPosition < self.text.length; ++i)
+    for (NSInteger i = 0; i < offset && offsetPosition < self.text.length; ++i) {
       offsetPosition = [self incrementOffsetPosition:offsetPosition];
+    }
   } else {
-    for (NSInteger i = 0; i < ABS(offset) && offsetPosition > 0; ++i)
+    for (NSInteger i = 0; i < ABS(offset) && offsetPosition > 0; ++i) {
       offsetPosition = [self decrementOffsetPosition:offsetPosition];
+    }
   }
   return [FlutterTextPosition positionWithIndex:offsetPosition];
 }
@@ -1348,10 +1377,12 @@ static BOOL isScribbleAvailable() {
 - (NSComparisonResult)comparePosition:(UITextPosition*)position toPosition:(UITextPosition*)other {
   NSUInteger positionIndex = ((FlutterTextPosition*)position).index;
   NSUInteger otherIndex = ((FlutterTextPosition*)other).index;
-  if (positionIndex < otherIndex)
+  if (positionIndex < otherIndex) {
     return NSOrderedAscending;
-  if (positionIndex > otherIndex)
+  }
+  if (positionIndex > otherIndex) {
     return NSOrderedDescending;
+  }
   return NSOrderedSame;
 }
 
@@ -1832,8 +1863,9 @@ static BOOL isScribbleAvailable() {
     }
   }
 
-  if (!_selectedTextRange.isEmpty)
+  if (!_selectedTextRange.isEmpty) {
     [self replaceRange:_selectedTextRange withText:@""];
+  }
 }
 
 - (void)postAccessibilityNotification:(UIAccessibilityNotifications)notification target:(id)target {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -242,8 +242,9 @@ typedef enum UIAccessibilityContrast : NSInteger {
 #pragma mark - Common view controller initialization tasks
 
 - (void)performCommonViewControllerInitialization {
-  if (_initialized)
+  if (_initialized) {
     return;
+  }
 
   _initialized = YES;
 
@@ -803,8 +804,9 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 - (void)applicationBecameActive:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationBecameActive");
   self.view.accessibilityElementsHidden = NO;
-  if (_viewportMetrics.physical_width)
+  if (_viewportMetrics.physical_width) {
     [self surfaceUpdated:YES];
+  }
   [self goToApplicationLifecycle:@"AppLifecycleState.resumed"];
 }
 
@@ -1424,8 +1426,9 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 #else
   _isVoiceOverRunning = UIAccessibilityIsVoiceOverRunning();
   bool enabled = _isVoiceOverRunning || UIAccessibilityIsSwitchControlRunning();
-  if (enabled)
+  if (enabled) {
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kAccessibleNavigation);
+  }
   platformView->SetSemanticsEnabled(enabled || UIAccessibilityIsSpeakScreenEnabled());
   platformView->SetAccessibilityFeatures(flags);
 #endif
@@ -1471,32 +1474,33 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
   // We compute the scale as relative difference from size L (large, the default size), where
   // L is assumed to have scale 1.0.
-  if ([category isEqualToString:UIContentSizeCategoryExtraSmall])
+  if ([category isEqualToString:UIContentSizeCategoryExtraSmall]) {
     return xs / l;
-  else if ([category isEqualToString:UIContentSizeCategorySmall])
+  } else if ([category isEqualToString:UIContentSizeCategorySmall]) {
     return s / l;
-  else if ([category isEqualToString:UIContentSizeCategoryMedium])
+  } else if ([category isEqualToString:UIContentSizeCategoryMedium]) {
     return m / l;
-  else if ([category isEqualToString:UIContentSizeCategoryLarge])
+  } else if ([category isEqualToString:UIContentSizeCategoryLarge]) {
     return 1.0;
-  else if ([category isEqualToString:UIContentSizeCategoryExtraLarge])
+  } else if ([category isEqualToString:UIContentSizeCategoryExtraLarge]) {
     return xl / l;
-  else if ([category isEqualToString:UIContentSizeCategoryExtraExtraLarge])
+  } else if ([category isEqualToString:UIContentSizeCategoryExtraExtraLarge]) {
     return xxl / l;
-  else if ([category isEqualToString:UIContentSizeCategoryExtraExtraExtraLarge])
+  } else if ([category isEqualToString:UIContentSizeCategoryExtraExtraExtraLarge]) {
     return xxxl / l;
-  else if ([category isEqualToString:UIContentSizeCategoryAccessibilityMedium])
+  } else if ([category isEqualToString:UIContentSizeCategoryAccessibilityMedium]) {
     return ax1 / l;
-  else if ([category isEqualToString:UIContentSizeCategoryAccessibilityLarge])
+  } else if ([category isEqualToString:UIContentSizeCategoryAccessibilityLarge]) {
     return ax2 / l;
-  else if ([category isEqualToString:UIContentSizeCategoryAccessibilityExtraLarge])
+  } else if ([category isEqualToString:UIContentSizeCategoryAccessibilityExtraLarge]) {
     return ax3 / l;
-  else if ([category isEqualToString:UIContentSizeCategoryAccessibilityExtraExtraLarge])
+  } else if ([category isEqualToString:UIContentSizeCategoryAccessibilityExtraExtraLarge]) {
     return ax4 / l;
-  else if ([category isEqualToString:UIContentSizeCategoryAccessibilityExtraExtraExtraLarge])
+  } else if ([category isEqualToString:UIContentSizeCategoryAccessibilityExtraExtraExtraLarge]) {
     return ax5 / l;
-  else
+  } else {
     return 1.0;
+  }
 }
 
 - (BOOL)isAlwaysUse24HourFormat {

--- a/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
+++ b/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
@@ -439,16 +439,18 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 #pragma mark - UIAccessibility overrides
 
 - (BOOL)isAccessibilityElement {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return false;
+  }
 
   // Note: hit detection will only apply to elements that report
   // -isAccessibilityElement of YES. The framework will continue scanning the
   // entire element tree looking for such a hit.
 
   //  We enforce in the framework that no other useful semantics are merged with these nodes.
-  if ([self node].HasFlag(flutter::SemanticsFlags::kScopesRoute))
+  if ([self node].HasFlag(flutter::SemanticsFlags::kScopesRoute)) {
     return false;
+  }
 
   // If the node is scrollable AND hidden OR
   // The node has a label, value, or hint OR
@@ -465,8 +467,9 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (void)collectRoutes:(NSMutableArray<SemanticsObject*>*)edges {
-  if ([self node].HasFlag(flutter::SemanticsFlags::kScopesRoute))
+  if ([self node].HasFlag(flutter::SemanticsFlags::kScopesRoute)) {
     [edges addObject:self];
+  }
   if ([self hasChildren]) {
     for (SemanticsObject* child in self.children) {
       [child collectRoutes:edges];
@@ -475,8 +478,9 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (BOOL)onCustomAccessibilityAction:(FlutterCustomAccessibilityAction*)action {
-  if (![self node].HasAction(flutter::SemanticsAction::kCustomAction))
+  if (![self node].HasAction(flutter::SemanticsAction::kCustomAction)) {
     return NO;
+  }
   int32_t action_id = action.uid;
   std::vector<uint8_t> args;
   args.push_back(3);  // type=int32.
@@ -491,8 +495,9 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (NSString*)accessibilityLabel {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return nil;
+  }
   NSString* label = nil;
   if (![self node].label.empty()) {
     label = @([self node].label.data());
@@ -506,30 +511,35 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
 - (NSAttributedString*)accessibilityAttributedLabel {
   NSString* label = [self accessibilityLabel];
-  if (label.length == 0)
+  if (label.length == 0) {
     return nil;
+  }
   return [self createAttributedStringFromString:label withAttributes:[self node].labelAttributes];
 }
 
 - (NSString*)accessibilityHint {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return nil;
+  }
 
-  if ([self node].hint.empty())
+  if ([self node].hint.empty()) {
     return nil;
+  }
   return @([self node].hint.data());
 }
 
 - (NSAttributedString*)accessibilityAttributedHint {
   NSString* hint = [self accessibilityHint];
-  if (hint.length == 0)
+  if (hint.length == 0) {
     return nil;
+  }
   return [self createAttributedStringFromString:hint withAttributes:[self node].hintAttributes];
 }
 
 - (NSString*)accessibilityValue {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return nil;
+  }
 
   if (![self node].value.empty()) {
     return @([self node].value.data());
@@ -551,14 +561,16 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 
 - (NSAttributedString*)accessibilityAttributedValue {
   NSString* value = [self accessibilityValue];
-  if (value.length == 0)
+  if (value.length == 0) {
     return nil;
+  }
   return [self createAttributedStringFromString:value withAttributes:[self node].valueAttributes];
 }
 
 - (CGRect)accessibilityFrame {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return CGRectMake(0, 0, 0, 0);
+  }
 
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden)) {
     return [super accessibilityFrame];
@@ -593,9 +605,10 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
   }
 
   if ([self hasChildren] || [self uid] == kRootNodeId) {
-    if (_container == nil)
+    if (_container == nil) {
       _container.reset([[SemanticsObjectContainer alloc] initWithSemanticsObject:self
                                                                           bridge:[self bridge]]);
+    }
     return _container.get();
   }
   if ([self parent] == nil) {
@@ -610,17 +623,20 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 #pragma mark - UIAccessibilityAction overrides
 
 - (BOOL)accessibilityActivate {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return NO;
-  if (![self node].HasAction(flutter::SemanticsAction::kTap))
+  }
+  if (![self node].HasAction(flutter::SemanticsAction::kTap)) {
     return NO;
+  }
   [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kTap);
   return YES;
 }
 
 - (void)accessibilityIncrement {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return;
+  }
   if ([self node].HasAction(flutter::SemanticsAction::kIncrease)) {
     [self node].value = [self node].increasedValue;
     [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kIncrease);
@@ -628,8 +644,9 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (void)accessibilityDecrement {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return;
+  }
   if ([self node].HasAction(flutter::SemanticsAction::kDecrease)) {
     [self node].value = [self node].decreasedValue;
     [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kDecrease);
@@ -637,20 +654,24 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return NO;
+  }
   flutter::SemanticsAction action = GetSemanticsActionForScrollDirection(direction);
-  if (![self node].HasAction(action))
+  if (![self node].HasAction(action)) {
     return NO;
+  }
   [self bridge]->DispatchSemanticsAction([self uid], action);
   return YES;
 }
 
 - (BOOL)accessibilityPerformEscape {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return NO;
-  if (![self node].HasAction(flutter::SemanticsAction::kDismiss))
+  }
+  if (![self node].HasAction(flutter::SemanticsAction::kDismiss)) {
     return NO;
+  }
   [self bridge]->DispatchSemanticsAction([self uid], flutter::SemanticsAction::kDismiss);
   return YES;
 }
@@ -658,8 +679,9 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 #pragma mark UIAccessibilityFocus overrides
 
 - (void)accessibilityElementDidBecomeFocused {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return;
+  }
   [self bridge]->AccessibilityObjectDidBecomeFocused([self uid]);
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden) ||
       [self node].HasFlag(flutter::SemanticsFlags::kIsHeader)) {
@@ -672,8 +694,9 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (void)accessibilityElementDidLoseFocus {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return;
+  }
   [self bridge]->AccessibilityObjectDidLoseFocus([self uid]);
   if ([self node].HasAction(flutter::SemanticsAction::kDidLoseAccessibilityFocus)) {
     [self bridge]->DispatchSemanticsAction([self uid],
@@ -816,29 +839,33 @@ CGRect ConvertRectToGlobal(SemanticsObject* reference, CGRect local_rect) {
 }
 
 - (nullable id)accessibilityElementAtIndex:(NSInteger)index {
-  if (index < 0 || index >= [self accessibilityElementCount])
+  if (index < 0 || index >= [self accessibilityElementCount]) {
     return nil;
+  }
   if (index == 0) {
     return _semanticsObject.nativeAccessibility;
   }
 
   SemanticsObject* child = [_semanticsObject children][index - 1];
 
-  if ([child hasChildren])
+  if ([child hasChildren]) {
     return [child accessibilityContainer];
+  }
   return child.nativeAccessibility;
 }
 
 - (NSInteger)indexOfAccessibilityElement:(id)element {
-  if (element == _semanticsObject)
+  if (element == _semanticsObject) {
     return 0;
+  }
 
   NSArray<SemanticsObject*>* children = [_semanticsObject children];
   for (size_t i = 0; i < [children count]; i++) {
     SemanticsObject* child = children[i];
     if ((![child hasChildren] && child == element) ||
-        ([child hasChildren] && [child accessibilityContainer] == element))
+        ([child hasChildren] && [child accessibilityContainer] == element)) {
       return i + 1;
+    }
   }
   return NSNotFound;
 }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -326,8 +326,9 @@ SemanticsObject* AccessibilityBridge::FindNextFocusableIfNecessary() {
 SemanticsObject* AccessibilityBridge::FindFirstFocusable(SemanticsObject* parent) {
   SemanticsObject* currentObject = parent ?: objects_.get()[@(kRootNodeId)];
   ;
-  if (!currentObject)
+  if (!currentObject) {
     return nil;
+  }
 
   if (currentObject.isAccessibilityElement) {
     return currentObject;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -237,62 +237,73 @@ static const UIAccessibilityTraits UIAccessibilityTraitUndocumentedEmptyLine = 0
 }
 
 - (void)accessibilityElementDidBecomeFocused {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return;
+  }
   [[self textInputSurrogate] accessibilityElementDidBecomeFocused];
   [super accessibilityElementDidBecomeFocused];
 }
 
 - (void)accessibilityElementDidLoseFocus {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return;
+  }
   [[self textInputSurrogate] accessibilityElementDidLoseFocus];
   [super accessibilityElementDidLoseFocus];
 }
 
 - (BOOL)accessibilityElementIsFocused {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return false;
+  }
   return [self node].HasFlag(flutter::SemanticsFlags::kIsFocused);
 }
 
 - (BOOL)accessibilityActivate {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return false;
+  }
   return [[self textInputSurrogate] accessibilityActivate];
 }
 
 - (NSString*)accessibilityLabel {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return nil;
+  }
 
   NSString* label = [super accessibilityLabel];
-  if (label != nil)
+  if (label != nil) {
     return label;
+  }
   return [self textInputSurrogate].accessibilityLabel;
 }
 
 - (NSString*)accessibilityHint {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return nil;
+  }
   NSString* hint = [super accessibilityHint];
-  if (hint != nil)
+  if (hint != nil) {
     return hint;
+  }
   return [self textInputSurrogate].accessibilityHint;
 }
 
 - (NSString*)accessibilityValue {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return nil;
+  }
   NSString* value = [super accessibilityValue];
-  if (value != nil)
+  if (value != nil) {
     return value;
+  }
   return [self textInputSurrogate].accessibilityValue;
 }
 
 - (UIAccessibilityTraits)accessibilityTraits {
-  if (![self isAccessibilityBridgeAlive])
+  if (![self isAccessibilityBridgeAlive]) {
     return 0;
+  }
   // Adding UIAccessibilityTraitKeyboardKey to the trait list so that iOS treats it like
   // a keyboard entry control, thus adding support for text editing features, such as
   // pinch to select text, and up/down fling to move cursor.

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponder.mm
@@ -78,8 +78,9 @@ static uint64_t GetPhysicalKeyForKeyCode(unsigned short keyCode) {
  */
 static uint64_t GetLogicalKeyForModifier(unsigned short keyCode, uint64_t hidCode) {
   NSNumber* fromKeyCode = [keyCodeToLogicalKey objectForKey:@(keyCode)];
-  if (fromKeyCode != nil)
+  if (fromKeyCode != nil) {
     return fromKeyCode.unsignedLongLongValue;
+  }
   return KeyOfPlane(hidCode, kMacosPlane);
 }
 
@@ -120,8 +121,9 @@ static uint64_t toLower(uint64_t n) {
 static uint64_t GetLogicalKeyForEvent(NSEvent* event, uint64_t physicalKey) {
   // Look to see if the keyCode can be mapped from keycode.
   NSNumber* fromKeyCode = [keyCodeToLogicalKey objectForKey:@(event.keyCode)];
-  if (fromKeyCode != nil)
+  if (fromKeyCode != nil) {
     return fromKeyCode.unsignedLongLongValue;
+  }
 
   NSString* keyLabel = event.charactersIgnoringModifiers;
   NSUInteger keyLabelLength = [keyLabel length];

--- a/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEmbedderKeyResponderUnittests.mm
@@ -51,8 +51,9 @@
 }
 
 - (void)dealloc {
-  if (_data->character != nullptr)
+  if (_data->character != nullptr) {
     delete[] _data->character;
+  }
   delete _data;
 }
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMouseCursorPlugin.mm
@@ -51,8 +51,9 @@ static NSCursor* GetCursorForKind(NSString* kind) {
     };
   }
   NSCursor* result = [systemCursors objectForKey:kind];
-  if (result == nil)
+  if (result == nil) {
     return [NSCursor arrowCursor];
+  }
   return result;
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -404,8 +404,9 @@ static void CommonInit(FlutterViewController* controller) {
                                          ([[event window] firstResponder] ==
                                           weakSelf.flutterView) &&
                                          ([event modifierFlags] & NSEventModifierFlagCommand) &&
-                                         ([event type] == NSEventTypeKeyUp))
+                                         ([event type] == NSEventTypeKeyUp)) {
                                        [weakSelf keyUp:event];
+                                     }
                                      return event;
                                    }];
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTest.mm
@@ -518,8 +518,9 @@ TEST(FlutterViewControllerTest, TestKeyboardIsRestartedOnEngineRestart) {
 + (void)respondFalseForSendEvent:(const FlutterKeyEvent&)event
                         callback:(nullable FlutterKeyEventCallback)callback
                         userData:(nullable void*)userData {
-  if (callback != nullptr)
+  if (callback != nullptr) {
     callback(false, userData);
+  }
 }
 
 @end


### PR DESCRIPTION
Run `clang-tidy` on `host_debug` and `ios_debug` for [`google-readability-braces-around-statements`](https://clang.llvm.org/extra/clang-tidy/checks/readability-braces-around-statements.html) analyzer check.

Mostly done with the automatic `clang-tidy` fixes, though it choked on a few Objective-C files, which I fixed manually.

See https://github.com/flutter/flutter/issues/93576.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
