### PR TITLE
Use Fuchsia's Windows Clang SDK

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -99,7 +99,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '56abd46299ece891869a4e4e0dbb1a5615ef16b6',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '3dc3ec56b3dc76ba60c8348053a9f6ef3446b0f2',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -99,7 +99,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'bfa04ad85fed176aa909f880ef5c8009c945ba03',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '56abd46299ece891869a4e4e0dbb1a5615ef16b6',
 
    # Fuchsia compatibility
    #
@@ -632,12 +632,11 @@ deps = {
     'dep_type': 'cipd',
   },
 
-  # TODO(fxb/4443): Remove this when Fuchsia can provide the Windows Clang Toolchain
-  'src/third_party/llvm-build/Release+Asserts': {
+  'src/buildtools/windows-x64/clang': {
     'packages': [
       {
-        'package': 'flutter/clang/win-amd64',
-        'version': 'git_revision:5ec206df8534d2dd8cb9217c3180e5ddba587393'
+        'package': 'fuchsia/third_party/clang/windows-amd64',
+        'version': 'a4WSJSNW8w7fYZ5GoOcCM7PlBxrXknK4ni71zZV1R_gC'
       }
     ],
     'condition': 'download_windows_deps',

--- a/shell/platform/windows/testing/wm_builders.h
+++ b/shell/platform/windows/testing/wm_builders.h
@@ -26,22 +26,22 @@ struct Win32Message {
   HWND hWnd;
 };
 
-typedef enum {
+typedef enum WmFieldExtended {
   kNotExtended = 0,
   kExtended = 1,
 } WmFieldExtended;
 
-typedef enum {
+typedef enum WmFieldContext {
   kNoContext = 0,
   kAltHeld = 1,
 } WmFieldContext;
 
-typedef enum {
+typedef enum WmFieldPrevState {
   kWasUp = 0,
   kWasDown = 1,
 } WmFieldPrevState;
 
-typedef enum {
+typedef enum WmFieldTransitionState {
   kBeingReleased = 0,
   kBeingPressed = 1,
 } WmFieldTransitionState;
@@ -49,7 +49,7 @@ typedef enum {
 // WM_KEYDOWN messages.
 //
 // See https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keydown.
-typedef struct {
+typedef struct WmKeyDownInfo {
   uint32_t key;
 
   uint8_t scan_code;
@@ -74,7 +74,7 @@ typedef struct {
 // WM_KEYUP  messages.
 //
 // See https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keyup.
-typedef struct {
+typedef struct WmKeyUpInfo {
   uint32_t key;
 
   uint8_t scan_code;
@@ -96,7 +96,7 @@ typedef struct {
 // WM_CHAR  messages.
 //
 // See https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-char.
-typedef struct {
+typedef struct WmCharInfo {
   uint32_t char_code;
 
   uint8_t scan_code;
@@ -118,7 +118,7 @@ typedef struct {
 // WM_SYSKEYUP  messages.
 //
 // See https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-syskeyup.
-typedef struct {
+typedef struct WmSysKeyUpInfo {
   uint32_t key;
 
   uint8_t scan_code;
@@ -140,7 +140,7 @@ typedef struct {
 // WM_DEADCHAR messages.
 //
 // See https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-deadchar.
-typedef struct {
+typedef struct WmDeadCharInfo {
   uint32_t char_code;
 
   uint8_t scan_code;

--- a/tools/dia_dll.py
+++ b/tools/dia_dll.py
@@ -19,8 +19,8 @@ import sys
 
 # Path constants. (All of these should be absolute paths.)
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
-LLVM_BUILD_DIR = os.path.abspath(os.path.join(THIS_DIR, '..', '..', 'third_party',
-                                              'llvm-build', 'Release+Asserts'))
+LLVM_BUILD_DIR = os.path.abspath(os.path.join(THIS_DIR, '..', '..', 'buildtools',
+                                              'windows-x64', 'clang'))
 
 
 def GetDiaDll():


### PR DESCRIPTION
I had a desire to use an accurate clangd among other common tools while debugging some things on Windows, so since the upstream bug referenced in DEPS is closed, I tried switching to the Fuchsia Clang SDK distribution to great effect.

This starts us off at the current integration label for the cipd package, but see the autoroller PR below.

* buildroot PR: https://github.com/flutter/buildroot/pull/525
* autoroller PR: https://skia-review.googlesource.com/c/buildbot/+/471198