### PR TITLE
Add 'explicit' to header files

### DIFF
--- a/benchmarking/benchmarking.h
+++ b/benchmarking/benchmarking.h
@@ -11,7 +11,7 @@ namespace benchmarking {
 
 class ScopedPauseTiming {
  public:
-  ScopedPauseTiming(::benchmark::State& state, bool enabled = true)
+  explicit ScopedPauseTiming(::benchmark::State& state, bool enabled = true)
       : state_(state), enabled_(enabled) {
     if (enabled_) {
       state_.PauseTiming();

--- a/common/graphics/gl_context_switch.h
+++ b/common/graphics/gl_context_switch.h
@@ -57,7 +57,7 @@ class GLContextResult {
   bool GetResult();
 
  protected:
-  GLContextResult(bool static_result);
+  explicit GLContextResult(bool static_result);
   bool result_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(GLContextResult);
@@ -78,7 +78,7 @@ class GLContextDefaultResult : public GLContextResult {
   ///
   /// @param  static_result a static value that will be returned from
   /// |GetResult|
-  GLContextDefaultResult(bool static_result);
+  explicit GLContextDefaultResult(bool static_result);
 
   ~GLContextDefaultResult() override;
 
@@ -99,7 +99,7 @@ class GLContextSwitch final : public GLContextResult {
   /// @param  context The context that is going to be set as the current
   /// context. The |GLContextSwitch| should not outlive the owner of the gl
   /// context wrapped inside the `context`.
-  GLContextSwitch(std::unique_ptr<SwitchableGLContext> context);
+  explicit GLContextSwitch(std::unique_ptr<SwitchableGLContext> context);
 
   ~GLContextSwitch() override;
 

--- a/common/graphics/persistent_cache.h
+++ b/common/graphics/persistent_cache.h
@@ -59,7 +59,7 @@ class PersistentCache : public GrContextOptions::PersistentCache {
     static const uint32_t kSignature = 0xA869593F;
     static const uint32_t kVersion1 = 1;
 
-    CacheObjectHeader(uint32_t p_key_size) : key_size(p_key_size) {}
+    explicit CacheObjectHeader(uint32_t p_key_size) : key_size(p_key_size) {}
 
     uint32_t signature = kSignature;
     uint32_t version = kVersion1;
@@ -163,7 +163,7 @@ class PersistentCache : public GrContextOptions::PersistentCache {
 
   bool IsValid() const;
 
-  PersistentCache(bool read_only = false);
+  explicit PersistentCache(bool read_only = false);
 
   // |GrContextOptions::PersistentCache|
   void store(const SkData& key, const SkData& data) override;

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -138,7 +138,8 @@ class CompositorContext {
     FML_DISALLOW_COPY_AND_ASSIGN(ScopedFrame);
   };
 
-  CompositorContext(fml::Milliseconds frame_budget = fml::kDefaultFrameBudget);
+  explicit CompositorContext(
+      fml::Milliseconds frame_budget = fml::kDefaultFrameBudget);
 
   virtual ~CompositorContext();
 

--- a/flow/display_list.cc
+++ b/flow/display_list.cc
@@ -108,7 +108,7 @@ DEFINE_SET_ENUM_OP(Join)
 struct SetStyleOp final : DLOp {
   static const auto kType = DisplayListOpType::kSetStyle;
 
-  SetStyleOp(SkPaint::Style style) : style(style) {}
+  explicit SetStyleOp(SkPaint::Style style) : style(style) {}
 
   const SkPaint::Style style;
 
@@ -118,7 +118,7 @@ struct SetStyleOp final : DLOp {
 struct SetStrokeWidthOp final : DLOp {
   static const auto kType = DisplayListOpType::kSetStrokeWidth;
 
-  SetStrokeWidthOp(SkScalar width) : width(width) {}
+  explicit SetStrokeWidthOp(SkScalar width) : width(width) {}
 
   const SkScalar width;
 
@@ -130,7 +130,7 @@ struct SetStrokeWidthOp final : DLOp {
 struct SetStrokeMiterOp final : DLOp {
   static const auto kType = DisplayListOpType::kSetStrokeMiter;
 
-  SetStrokeMiterOp(SkScalar limit) : limit(limit) {}
+  explicit SetStrokeMiterOp(SkScalar limit) : limit(limit) {}
 
   const SkScalar limit;
 
@@ -143,7 +143,7 @@ struct SetStrokeMiterOp final : DLOp {
 struct SetColorOp final : DLOp {
   static const auto kType = DisplayListOpType::kSetColor;
 
-  SetColorOp(SkColor color) : color(color) {}
+  explicit SetColorOp(SkColor color) : color(color) {}
 
   const SkColor color;
 
@@ -153,7 +153,7 @@ struct SetColorOp final : DLOp {
 struct SetBlendModeOp final : DLOp {
   static const auto kType = DisplayListOpType::kSetBlendMode;
 
-  SetBlendModeOp(SkBlendMode mode) : mode(mode) {}
+  explicit SetBlendModeOp(SkBlendMode mode) : mode(mode) {}
 
   const SkBlendMode mode;
 
@@ -227,7 +227,7 @@ struct SaveOp final : DLOp {
 struct SaveLayerOp final : DLOp {
   static const auto kType = DisplayListOpType::kSaveLayer;
 
-  SaveLayerOp(bool with_paint) : with_paint(with_paint) {}
+  explicit SaveLayerOp(bool with_paint) : with_paint(with_paint) {}
 
   bool with_paint;
 
@@ -286,7 +286,7 @@ struct ScaleOp final : DLOp {
 struct RotateOp final : DLOp {
   static const auto kType = DisplayListOpType::kRotate;
 
-  RotateOp(SkScalar degrees) : degrees(degrees) {}
+  explicit RotateOp(SkScalar degrees) : degrees(degrees) {}
 
   const SkScalar degrees;
 
@@ -457,7 +457,7 @@ DEFINE_DRAW_1ARG_OP(RRect, SkRRect, rrect)
 struct DrawPathOp final : DLOp {
   static const auto kType = DisplayListOpType::kDrawPath;
 
-  DrawPathOp(SkPath path) : path(path) {}
+  explicit DrawPathOp(SkPath path) : path(path) {}
 
   const SkPath path;
 
@@ -807,7 +807,7 @@ struct DrawSkPictureMatrixOp final : DLOp {
 struct DrawDisplayListOp final : DLOp {
   static const auto kType = DisplayListOpType::kDrawDisplayList;
 
-  DrawDisplayListOp(const sk_sp<DisplayList> display_list)
+  explicit DrawDisplayListOp(const sk_sp<DisplayList> display_list)
       : display_list(std::move(display_list)) {}
 
   sk_sp<DisplayList> display_list;

--- a/flow/display_list.h
+++ b/flow/display_list.h
@@ -470,7 +470,7 @@ class Dispatcher {
 // the DisplayListCanvasRecorder class.
 class DisplayListBuilder final : public virtual Dispatcher, public SkRefCnt {
  public:
-  DisplayListBuilder(const SkRect& cull_rect = kMaxCullRect_);
+  explicit DisplayListBuilder(const SkRect& cull_rect = kMaxCullRect_);
   ~DisplayListBuilder();
 
   void setAntiAlias(bool aa) override;

--- a/flow/display_list_canvas.h
+++ b/flow/display_list_canvas.h
@@ -27,7 +27,7 @@ namespace flutter {
 class DisplayListCanvasDispatcher : public virtual Dispatcher,
                                     public SkPaintDispatchHelper {
  public:
-  DisplayListCanvasDispatcher(SkCanvas* canvas) : canvas_(canvas) {}
+  explicit DisplayListCanvasDispatcher(SkCanvas* canvas) : canvas_(canvas) {}
 
   void save() override;
   void restore() override;
@@ -122,7 +122,7 @@ class DisplayListCanvasRecorder
     : public SkCanvasVirtualEnforcer<SkNoDrawCanvas>,
       public SkRefCnt {
  public:
-  DisplayListCanvasRecorder(const SkRect& bounds);
+  explicit DisplayListCanvasRecorder(const SkRect& bounds);
 
   const sk_sp<DisplayListBuilder> builder() { return builder_; }
 

--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -199,7 +199,7 @@ class ClipBoundsDispatchHelper : public virtual Dispatcher,
  public:
   ClipBoundsDispatchHelper() : ClipBoundsDispatchHelper(nullptr) {}
 
-  ClipBoundsDispatchHelper(const SkRect* cull_rect)
+  explicit ClipBoundsDispatchHelper(const SkRect* cull_rect)
       : has_clip_(cull_rect),
         bounds_(cull_rect && !cull_rect->isEmpty() ? *cull_rect
                                                    : SkRect::MakeEmpty()) {}
@@ -278,7 +278,7 @@ class DisplayListBoundsCalculator final
   // queried using |isUnbounded| if an alternate plan is available
   // for such cases.
   // The flag should never be set if a cull_rect is provided.
-  DisplayListBoundsCalculator(const SkRect* cull_rect = nullptr);
+  explicit DisplayListBoundsCalculator(const SkRect* cull_rect = nullptr);
 
   void setStrokeCap(SkPaint::Cap cap) override;
   void setStrokeJoin(SkPaint::Join join) override;
@@ -402,7 +402,8 @@ class DisplayListBoundsCalculator final
     // the stack.
     // Some layers may substitute their own accumulator to compute
     // their own local bounds while they are on the stack.
-    LayerData(BoundsAccumulator* outer) : outer_(outer), is_unbounded_(false) {}
+    explicit LayerData(BoundsAccumulator* outer)
+        : outer_(outer), is_unbounded_(false) {}
     virtual ~LayerData() = default;
 
     // The accumulator to use while this layer is put in play by

--- a/flow/frame_timings.h
+++ b/flow/frame_timings.h
@@ -41,7 +41,7 @@ class FrameTimingsRecorder {
   FrameTimingsRecorder();
 
   /// Constructor with a pre-populated frame number.
-  FrameTimingsRecorder(uint64_t frame_number);
+  explicit FrameTimingsRecorder(uint64_t frame_number);
 
   ~FrameTimingsRecorder();
 

--- a/flow/instrumentation.h
+++ b/flow/instrumentation.h
@@ -16,7 +16,7 @@ namespace flutter {
 
 class Stopwatch {
  public:
-  Stopwatch(fml::Milliseconds frame_budget = fml::kDefaultFrameBudget);
+  explicit Stopwatch(fml::Milliseconds frame_budget = fml::kDefaultFrameBudget);
 
   ~Stopwatch();
 

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -11,7 +11,8 @@ namespace flutter {
 
 class ClipPathLayer : public ContainerLayer {
  public:
-  ClipPathLayer(const SkPath& clip_path, Clip clip_behavior = Clip::antiAlias);
+  explicit ClipPathLayer(const SkPath& clip_path,
+                         Clip clip_behavior = Clip::antiAlias);
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
 

--- a/flow/layers/color_filter_layer.h
+++ b/flow/layers/color_filter_layer.h
@@ -12,7 +12,7 @@ namespace flutter {
 
 class ColorFilterLayer : public ContainerLayer {
  public:
-  ColorFilterLayer(sk_sp<SkColorFilter> filter);
+  explicit ColorFilterLayer(sk_sp<SkColorFilter> filter);
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
 

--- a/flow/layers/image_filter_layer.h
+++ b/flow/layers/image_filter_layer.h
@@ -12,7 +12,7 @@ namespace flutter {
 
 class ImageFilterLayer : public MergedContainerLayer {
  public:
-  ImageFilterLayer(sk_sp<SkImageFilter> filter);
+  explicit ImageFilterLayer(sk_sp<SkImageFilter> filter);
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
 

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -13,7 +13,7 @@ namespace flutter {
 // at all. Hence |set_transform| must be called with an initialized SkMatrix.
 class TransformLayer : public ContainerLayer {
  public:
-  TransformLayer(const SkMatrix& transform);
+  explicit TransformLayer(const SkMatrix& transform);
 
   void Diff(DiffContext* context, const Layer* old_layer) override;
 

--- a/flow/testing/gl_context_switch_test.h
+++ b/flow/testing/gl_context_switch_test.h
@@ -20,7 +20,7 @@ class GLContextSwitchTest : public ::testing::Test {
 /// The renderer context used for testing
 class TestSwitchableGLContext : public SwitchableGLContext {
  public:
-  TestSwitchableGLContext(int context);
+  explicit TestSwitchableGLContext(int context);
 
   ~TestSwitchableGLContext() override;
 

--- a/flow/testing/mock_layer.h
+++ b/flow/testing/mock_layer.h
@@ -16,10 +16,10 @@ namespace testing {
 // verify the data against expected values.
 class MockLayer : public Layer {
  public:
-  MockLayer(SkPath path,
-            SkPaint paint = SkPaint(),
-            bool fake_has_platform_view = false,
-            bool fake_reads_surface = false);
+  explicit MockLayer(SkPath path,
+                     SkPaint paint = SkPaint(),
+                     bool fake_has_platform_view = false,
+                     bool fake_reads_surface = false);
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;

--- a/flow/testing/mock_raster_cache.h
+++ b/flow/testing/mock_raster_cache.h
@@ -24,7 +24,7 @@ namespace testing {
  */
 class MockRasterCacheResult : public RasterCacheResult {
  public:
-  MockRasterCacheResult(SkIRect device_rect);
+  explicit MockRasterCacheResult(SkIRect device_rect);
 
   void draw(SkCanvas& canvas, const SkPaint* paint = nullptr) const override{};
 

--- a/fml/closure.h
+++ b/fml/closure.h
@@ -33,7 +33,8 @@ class ScopedCleanupClosure {
  public:
   ScopedCleanupClosure() = default;
 
-  ScopedCleanupClosure(const fml::closure& closure) : closure_(closure) {}
+  explicit ScopedCleanupClosure(const fml::closure& closure)
+      : closure_(closure) {}
 
   ~ScopedCleanupClosure() {
     if (closure_) {

--- a/fml/concurrent_message_loop.h
+++ b/fml/concurrent_message_loop.h
@@ -46,7 +46,7 @@ class ConcurrentMessageLoop
   std::map<std::thread::id, std::vector<fml::closure>> thread_tasks_;
   bool shutdown_ = false;
 
-  ConcurrentMessageLoop(size_t worker_count);
+  explicit ConcurrentMessageLoop(size_t worker_count);
 
   void WorkerMain();
 
@@ -61,7 +61,7 @@ class ConcurrentMessageLoop
 
 class ConcurrentTaskRunner : public BasicTaskRunner {
  public:
-  ConcurrentTaskRunner(std::weak_ptr<ConcurrentMessageLoop> weak_loop);
+  explicit ConcurrentTaskRunner(std::weak_ptr<ConcurrentMessageLoop> weak_loop);
 
   virtual ~ConcurrentTaskRunner();
 

--- a/fml/log_settings.h
+++ b/fml/log_settings.h
@@ -37,7 +37,7 @@ int GetMinLogLevel();
 
 class ScopedSetLogSettings {
  public:
-  ScopedSetLogSettings(const LogSettings& settings);
+  explicit ScopedSetLogSettings(const LogSettings& settings);
   ~ScopedSetLogSettings();
 
  private:

--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -44,9 +44,9 @@ class FileMapping final : public Mapping {
     kExecute,
   };
 
-  FileMapping(const fml::UniqueFD& fd,
-              std::initializer_list<Protection> protection = {
-                  Protection::kRead});
+  explicit FileMapping(const fml::UniqueFD& fd,
+                       std::initializer_list<Protection> protection = {
+                           Protection::kRead});
 
   ~FileMapping() override;
 
@@ -91,9 +91,9 @@ class FileMapping final : public Mapping {
 
 class DataMapping final : public Mapping {
  public:
-  DataMapping(std::vector<uint8_t> data);
+  explicit DataMapping(std::vector<uint8_t> data);
 
-  DataMapping(const std::string& string);
+  explicit DataMapping(const std::string& string);
 
   ~DataMapping() override;
 

--- a/fml/memory/ref_ptr.h
+++ b/fml/memory/ref_ptr.h
@@ -65,8 +65,8 @@ template <typename T>
 class RefPtr final {
  public:
   RefPtr() : ptr_(nullptr) {}
-  RefPtr(std::nullptr_t)
-      : ptr_(nullptr) {}  // NOLINT(google-explicit-constructor)
+  RefPtr(std::nullptr_t)  // NOLINT(google-explicit-constructor)
+      : ptr_(nullptr) {}
 
   // Explicit constructor from a plain pointer (to an object that must have
   // already been adopted). (Note that in |T::T()|, references to |this| cannot
@@ -80,22 +80,25 @@ class RefPtr final {
   }
 
   // Copy constructor.
-  RefPtr(const RefPtr<T>& r) : ptr_(r.ptr_) {
+  RefPtr(const RefPtr<T>& r)  // NOLINT(google-explicit-constructor)
+      : ptr_(r.ptr_) {
     if (ptr_) {
       ptr_->AddRef();
     }
   }
 
   template <typename U>
-  RefPtr(const RefPtr<U>& r)
-      : ptr_(r.ptr_) {  // NOLINT(google-explicit-constructor)
+  RefPtr(const RefPtr<U>& r)  // NOLINT(google-explicit-constructor)
+      : ptr_(r.ptr_) {
     if (ptr_) {
       ptr_->AddRef();
     }
   }
 
   // Move constructor.
-  RefPtr(RefPtr<T>&& r) : ptr_(r.ptr_) { r.ptr_ = nullptr; }
+  RefPtr(RefPtr<T>&& r) : ptr_(r.ptr_) {  // NOLINT(google-explicit-constructor)
+    r.ptr_ = nullptr;
+  }
 
   template <typename U>
   RefPtr(RefPtr<U>&& r) : ptr_(r.ptr_) {  // NOLINT(google-explicit-constructor)

--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -49,17 +49,18 @@ class WeakPtr {
   WeakPtr() : ptr_(nullptr) {}
 
   // Copy constructor.
-  explicit WeakPtr(const WeakPtr<T>& r) = default;
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  WeakPtr(const WeakPtr<T>& r) = default;
 
   template <typename U>
-  WeakPtr(const WeakPtr<U>& r)
+  WeakPtr(const WeakPtr<U>& r)  // NOLINT(google-explicit-constructor)
       : ptr_(static_cast<T*>(r.ptr_)), flag_(r.flag_), checker_(r.checker_) {}
 
   // Move constructor.
   WeakPtr(WeakPtr<T>&& r) = default;
 
   template <typename U>
-  WeakPtr(WeakPtr<U>&& r)
+  WeakPtr(WeakPtr<U>&& r)  // NOLINT(google-explicit-constructor)
       : ptr_(static_cast<T*>(r.ptr_)),
         flag_(std::move(r.flag_)),
         checker_(r.checker_) {}
@@ -155,12 +156,14 @@ class TaskRunnerAffineWeakPtr : public WeakPtr<T> {
   TaskRunnerAffineWeakPtr(const TaskRunnerAffineWeakPtr<T>& r) = default;
 
   template <typename U>
+  // NOLINTNEXTLINE(google-explicit-constructor)
   TaskRunnerAffineWeakPtr(const TaskRunnerAffineWeakPtr<U>& r)
       : WeakPtr<T>(r), checker_(r.checker_) {}
 
   TaskRunnerAffineWeakPtr(TaskRunnerAffineWeakPtr<T>&& r) = default;
 
   template <typename U>
+  // NOLINTNEXTLINE(google-explicit-constructor)
   TaskRunnerAffineWeakPtr(TaskRunnerAffineWeakPtr<U>&& r)
       : WeakPtr<T>(r), checker_(r.checker_) {}
 

--- a/fml/native_library.h
+++ b/fml/native_library.h
@@ -56,7 +56,7 @@ class NativeLibrary : public fml::RefCountedThreadSafe<NativeLibrary> {
   Handle handle_ = nullptr;
   bool close_handle_ = true;
 
-  NativeLibrary(const char* path);
+  explicit NativeLibrary(const char* path);
 
   NativeLibrary(Handle handle, bool close_handle);
 

--- a/fml/synchronization/atomic_object.h
+++ b/fml/synchronization/atomic_object.h
@@ -14,7 +14,7 @@ template <typename T>
 class AtomicObject {
  public:
   AtomicObject() = default;
-  AtomicObject(T object) : object_(object) {}
+  explicit AtomicObject(T object) : object_(object) {}
 
   T Load() const {
     std::scoped_lock lock(mutex_);

--- a/fml/synchronization/count_down_latch.h
+++ b/fml/synchronization/count_down_latch.h
@@ -14,7 +14,7 @@ namespace fml {
 
 class CountDownLatch {
  public:
-  CountDownLatch(size_t count);
+  explicit CountDownLatch(size_t count);
 
   ~CountDownLatch();
 

--- a/fml/task_queue_id.h
+++ b/fml/task_queue_id.h
@@ -21,7 +21,9 @@ class TaskQueueId {
   /// Intializes a task queue with the given value as it's ID.
   explicit TaskQueueId(size_t value) : value_(value) {}
 
-  operator size_t() const { return value_; }
+  operator size_t() const {  // NOLINT(google-explicit-constructor)
+    return value_;
+  }
 
  private:
   size_t value_ = kUnmerged;

--- a/fml/task_runner.h
+++ b/fml/task_runner.h
@@ -63,7 +63,7 @@ class TaskRunner : public fml::RefCountedThreadSafe<TaskRunner>,
                                const fml::closure& task);
 
  protected:
-  TaskRunner(fml::RefPtr<MessageLoopImpl> loop);
+  explicit TaskRunner(fml::RefPtr<MessageLoopImpl> loop);
 
  private:
   fml::RefPtr<MessageLoopImpl> loop_;

--- a/fml/thread_local.h
+++ b/fml/thread_local.h
@@ -26,7 +26,7 @@ namespace internal {
 
 class ThreadLocalPointer {
  public:
-  ThreadLocalPointer(void (*destroy)(void*));
+  explicit ThreadLocalPointer(void (*destroy)(void*));
   ~ThreadLocalPointer();
 
   void* get() const;

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -343,7 +343,7 @@ void TraceEventFlowEnd0(TraceArg category_group, TraceArg name, TraceIDArg id);
 
 class ScopedInstantEnd {
  public:
-  ScopedInstantEnd(const char* str) : label_(str) {}
+  explicit ScopedInstantEnd(const char* str) : label_(str) {}
 
   ~ScopedInstantEnd() { TraceEventEnd(label_); }
 
@@ -360,7 +360,7 @@ class ScopedInstantEnd {
 // leads to corrupted or missing traces in the UI.
 class TraceFlow {
  public:
-  TraceFlow(const char* label) : label_(label), nonce_(TraceNonce()) {
+  explicit TraceFlow(const char* label) : label_(label), nonce_(TraceNonce()) {
     TraceEventFlowBegin0("flutter", label_, nonce_);
   }
 

--- a/lib/ui/painting/fragment_shader.h
+++ b/lib/ui/painting/fragment_shader.h
@@ -37,7 +37,7 @@ class FragmentShader : public Shader {
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  FragmentShader(sk_sp<SkShader> shader);
+  explicit FragmentShader(sk_sp<SkShader> shader);
 
   sk_sp<SkShader> shader_;
 };

--- a/lib/ui/painting/image_generator.h
+++ b/lib/ui/painting/image_generator.h
@@ -133,7 +133,8 @@ class BuiltinSkiaImageGenerator : public ImageGenerator {
  public:
   ~BuiltinSkiaImageGenerator();
 
-  BuiltinSkiaImageGenerator(std::unique_ptr<SkImageGenerator> generator);
+  explicit BuiltinSkiaImageGenerator(
+      std::unique_ptr<SkImageGenerator> generator);
 
   // |ImageGenerator|
   const SkImageInfo& GetInfo() override;
@@ -171,9 +172,9 @@ class BuiltinSkiaCodecImageGenerator : public ImageGenerator {
  public:
   ~BuiltinSkiaCodecImageGenerator();
 
-  BuiltinSkiaCodecImageGenerator(std::unique_ptr<SkCodec> codec);
+  explicit BuiltinSkiaCodecImageGenerator(std::unique_ptr<SkCodec> codec);
 
-  BuiltinSkiaCodecImageGenerator(sk_sp<SkData> buffer);
+  explicit BuiltinSkiaCodecImageGenerator(sk_sp<SkData> buffer);
 
   // |ImageGenerator|
   const SkImageInfo& GetInfo() override;

--- a/lib/ui/painting/multi_frame_codec.h
+++ b/lib/ui/painting/multi_frame_codec.h
@@ -13,7 +13,7 @@ namespace flutter {
 
 class MultiFrameCodec : public Codec {
  public:
-  MultiFrameCodec(std::shared_ptr<ImageGenerator> generator);
+  explicit MultiFrameCodec(std::shared_ptr<ImageGenerator> generator);
 
   ~MultiFrameCodec() override;
 
@@ -37,7 +37,7 @@ class MultiFrameCodec : public Codec {
   // shares it with the IO task runner's decoding work, and sets the live_
   // member to false when it is destructed.
   struct State {
-    State(std::shared_ptr<ImageGenerator> generator);
+    explicit State(std::shared_ptr<ImageGenerator> generator);
 
     const std::shared_ptr<ImageGenerator> generator_;
     const int frameCount_;

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -58,8 +58,8 @@ class Picture : public RefCountedDartWrappable<Picture> {
       Dart_Handle raw_image_callback);
 
  private:
-  Picture(flutter::SkiaGPUObject<SkPicture> picture);
-  Picture(flutter::SkiaGPUObject<DisplayList> display_list);
+  explicit Picture(flutter::SkiaGPUObject<SkPicture> picture);
+  explicit Picture(flutter::SkiaGPUObject<DisplayList> display_list);
 
   flutter::SkiaGPUObject<SkPicture> picture_;
   flutter::SkiaGPUObject<DisplayList> display_list_;

--- a/lib/ui/text/asset_manager_font_provider.h
+++ b/lib/ui/text/asset_manager_font_provider.h
@@ -44,7 +44,7 @@ class AssetManagerFontStyleSet : public SkFontStyleSet {
   std::string family_name_;
 
   struct TypefaceAsset {
-    TypefaceAsset(std::string a);
+    explicit TypefaceAsset(std::string a);
 
     TypefaceAsset(const TypefaceAsset& other);
 
@@ -60,7 +60,8 @@ class AssetManagerFontStyleSet : public SkFontStyleSet {
 
 class AssetManagerFontProvider : public txt::FontAssetProvider {
  public:
-  AssetManagerFontProvider(std::shared_ptr<AssetManager> asset_manager);
+  explicit AssetManagerFontProvider(
+      std::shared_ptr<AssetManager> asset_manager);
 
   ~AssetManagerFontProvider() override;
 

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -41,7 +41,7 @@ class UIDartState : public tonic::DartState {
   ///         UIDartState, a pointer to the resource can be added to this
   ///         struct with appropriate default construction.
   struct Context {
-    Context(const TaskRunners& task_runners);
+    explicit Context(const TaskRunners& task_runners);
 
     Context(const TaskRunners& task_runners,
             fml::WeakPtr<SnapshotDelegate> snapshot_delegate,

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -415,7 +415,7 @@ class DartIsolate : public UIDartState {
   friend class IsolateConfiguration;
   class AutoFireClosure {
    public:
-    AutoFireClosure(const fml::closure& closure);
+    explicit AutoFireClosure(const fml::closure& closure);
 
     ~AutoFireClosure();
 

--- a/runtime/dart_vm_lifecycle.cc
+++ b/runtime/dart_vm_lifecycle.cc
@@ -82,7 +82,7 @@ DartVMRef DartVMRef::Create(Settings settings,
 
   if (!vm) {
     FML_LOG(ERROR) << "Could not create Dart VM instance.";
-    return {nullptr};
+    return DartVMRef{nullptr};
   }
 
   gVMData = vm->GetVMData();

--- a/runtime/dart_vm_lifecycle.h
+++ b/runtime/dart_vm_lifecycle.h
@@ -49,7 +49,7 @@ class DartVMRef {
 
   static std::shared_ptr<IsolateNameServer> GetIsolateNameServer();
 
-  operator bool() const { return static_cast<bool>(vm_); }
+  explicit operator bool() const { return static_cast<bool>(vm_); }
 
   DartVM* get() {
     FML_DCHECK(vm_);
@@ -81,7 +81,7 @@ class DartVMRef {
 
   std::shared_ptr<DartVM> vm_;
 
-  DartVMRef(std::shared_ptr<DartVM> vm);
+  explicit DartVMRef(std::shared_ptr<DartVM> vm);
 
   // Only used by Dart Isolate to register itself with the VM.
   static DartVM* GetRunningVM();

--- a/runtime/embedder_resources.h
+++ b/runtime/embedder_resources.h
@@ -21,7 +21,7 @@ namespace flutter {
 
 class EmbedderResources {
  public:
-  EmbedderResources(runtime::ResourcesEntry* resources_table);
+  explicit EmbedderResources(runtime::ResourcesEntry* resources_table);
 
   static const int kNoSuchInstance;
 

--- a/runtime/skia_concurrent_executor.h
+++ b/runtime/skia_concurrent_executor.h
@@ -37,7 +37,7 @@ class SkiaConcurrentExecutor : public SkExecutor {
   ///
   /// @param[in]  on_work  The work callback.
   ///
-  SkiaConcurrentExecutor(const OnWorkCallback& on_work);
+  explicit SkiaConcurrentExecutor(const OnWorkCallback& on_work);
 
   // |SkExecutor|
   ~SkiaConcurrentExecutor() override;

--- a/shell/common/canvas_spy.h
+++ b/shell/common/canvas_spy.h
@@ -24,7 +24,7 @@ class DidDrawCanvas;
 /// are specific to empty canvases.
 class CanvasSpy {
  public:
-  CanvasSpy(SkCanvas* target_canvas);
+  explicit CanvasSpy(SkCanvas* target_canvas);
 
   //----------------------------------------------------------------------------
   /// @brief      Returns true if any non transparent content has been drawn

--- a/shell/common/pipeline.h
+++ b/shell/common/pipeline.h
@@ -71,7 +71,7 @@ class Pipeline {
       return result;
     }
 
-    operator bool() const { return continuation_ != nullptr; }
+    explicit operator bool() const { return continuation_ != nullptr; }
 
    private:
     friend class Pipeline;

--- a/shell/common/pointer_data_dispatcher.h
+++ b/shell/common/pointer_data_dispatcher.h
@@ -84,7 +84,8 @@ class PointerDataDispatcher {
 ///
 class DefaultPointerDataDispatcher : public PointerDataDispatcher {
  public:
-  DefaultPointerDataDispatcher(Delegate& delegate) : delegate_(delegate) {}
+  explicit DefaultPointerDataDispatcher(Delegate& delegate)
+      : delegate_(delegate) {}
 
   // |PointerDataDispatcer|
   void DispatchPacket(std::unique_ptr<PointerDataPacket> packet,
@@ -138,7 +139,7 @@ class DefaultPointerDataDispatcher : public PointerDataDispatcher {
 /// See also input_events_unittests.cc where we test all our claims above.
 class SmoothPointerDataDispatcher : public DefaultPointerDataDispatcher {
  public:
-  SmoothPointerDataDispatcher(Delegate& delegate);
+  explicit SmoothPointerDataDispatcher(Delegate& delegate);
 
   // |PointerDataDispatcer|
   void DispatchPacket(std::unique_ptr<PointerDataPacket> packet,

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -105,7 +105,7 @@ class Rasterizer final : public SnapshotDelegate {
   ///
   /// @param[in]  delegate                   The rasterizer delegate.
   ///
-  Rasterizer(Delegate& delegate);
+  explicit Rasterizer(Delegate& delegate);
 
   //----------------------------------------------------------------------------
   /// @brief      Destroys the rasterizer. This must happen on the raster task

--- a/shell/common/run_configuration.h
+++ b/shell/common/run_configuration.h
@@ -66,7 +66,8 @@ class RunConfiguration {
   ///
   /// @param[in]  configuration  The configuration
   ///
-  RunConfiguration(std::unique_ptr<IsolateConfiguration> configuration);
+  explicit RunConfiguration(
+      std::unique_ptr<IsolateConfiguration> configuration);
 
   //----------------------------------------------------------------------------
   /// @brief      Creates a run configuration with the specified isolate

--- a/shell/common/vsync_waiters_test.h
+++ b/shell/common/vsync_waiters_test.h
@@ -49,7 +49,7 @@ class ConstantFiringVsyncWaiter : public VsyncWaiter {
   static constexpr fml::TimePoint frame_target_time =
       fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromSeconds(100));
 
-  ConstantFiringVsyncWaiter(TaskRunners task_runners)
+  explicit ConstantFiringVsyncWaiter(TaskRunners task_runners)
       : VsyncWaiter(std::move(task_runners)) {}
 
  protected:

--- a/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
+++ b/shell/platform/android/platform_view_android_delegate/platform_view_android_delegate.h
@@ -16,7 +16,7 @@ namespace flutter {
 
 class PlatformViewAndroidDelegate {
  public:
-  PlatformViewAndroidDelegate(
+  explicit PlatformViewAndroidDelegate(
       std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
   void UpdateSemantics(flutter::SemanticsNodeUpdates update,
                        flutter::CustomAccessibilityActionUpdates actions);

--- a/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/client_wrapper/include/flutter/encodable_value.h
@@ -63,7 +63,9 @@ class CustomEncodableValue {
   ~CustomEncodableValue() = default;
 
   // Allow implicit conversion to std::any to allow direct use of any_cast.
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator std::any&() { return value_; }
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator const std::any&() const { return value_; }
 
 #if defined(FLUTTER_ENABLE_RTTI) && FLUTTER_ENABLE_RTTI
@@ -182,6 +184,7 @@ class EncodableValue : public internal::EncodableValueVariant {
   // to use it with EncodableValue, so the risk of unintended conversions is
   // minimal, and it avoids the need for the verbose:
   //   EncodableValue(CustomEncodableValue(...)).
+  // NOLINTNEXTLINE(google-explicit-constructor)
   EncodableValue(const CustomEncodableValue& v) : super(v) {}
 
   // Override the conversion constructors from std::variant to make them

--- a/shell/platform/common/client_wrapper/include/flutter/engine_method_result.h
+++ b/shell/platform/common/client_wrapper/include/flutter/engine_method_result.h
@@ -21,7 +21,7 @@ namespace internal {
 // vary based on the template type.
 class ReplyManager {
  public:
-  ReplyManager(BinaryReply reply_handler_);
+  explicit ReplyManager(BinaryReply reply_handler_);
   ~ReplyManager();
 
   // Prevent copying.

--- a/shell/platform/common/client_wrapper/include/flutter/texture_registrar.h
+++ b/shell/platform/common/client_wrapper/include/flutter/texture_registrar.h
@@ -27,7 +27,7 @@ class PixelBufferTexture {
   // As the callback is usually invoked from the render thread, the callee must
   // take care of proper synchronization. It also needs to be ensured that the
   // returned buffer isn't released prior to unregistering this texture.
-  PixelBufferTexture(CopyBufferCallback copy_buffer_callback)
+  explicit PixelBufferTexture(CopyBufferCallback copy_buffer_callback)
       : copy_buffer_callback_(copy_buffer_callback) {}
 
   // Returns the callback-provided FlutterDesktopPixelBuffer that contains the

--- a/shell/platform/common/client_wrapper/testing/stub_flutter_api.h
+++ b/shell/platform/common/client_wrapper/testing/stub_flutter_api.h
@@ -87,7 +87,7 @@ class StubFlutterApi {
 class ScopedStubFlutterApi {
  public:
   // Calls SetTestFlutterStub with |stub|.
-  ScopedStubFlutterApi(std::unique_ptr<StubFlutterApi> stub);
+  explicit ScopedStubFlutterApi(std::unique_ptr<StubFlutterApi> stub);
 
   // Restores the previous test stub.
   ~ScopedStubFlutterApi();

--- a/shell/platform/embedder/embedder_external_view.h
+++ b/shell/platform/embedder/embedder_external_view.h
@@ -26,7 +26,8 @@ class EmbedderExternalView {
 
     ViewIdentifier() {}
 
-    ViewIdentifier(PlatformViewID view_id) : platform_view_id(view_id) {}
+    explicit ViewIdentifier(PlatformViewID view_id)
+        : platform_view_id(view_id) {}
 
     struct Hash {
       constexpr std::size_t operator()(const ViewIdentifier& desc) const {

--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -72,15 +72,16 @@ void EmbedderExternalViewEmbedder::BeginFrame(
 void EmbedderExternalViewEmbedder::PrerollCompositeEmbeddedView(
     int view_id,
     std::unique_ptr<EmbeddedViewParams> params) {
-  FML_DCHECK(pending_views_.count(view_id) == 0);
+  auto vid = EmbedderExternalView::ViewIdentifier(view_id);
+  FML_DCHECK(pending_views_.count(vid) == 0);
 
-  pending_views_[view_id] = std::make_unique<EmbedderExternalView>(
+  pending_views_[vid] = std::make_unique<EmbedderExternalView>(
       pending_frame_size_,              // frame size
       pending_surface_transformation_,  // surface xformation
-      view_id,                          // view identifier
+      vid,                              // view identifier
       std::move(params)                 // embedded view params
   );
-  composition_order_.push_back(view_id);
+  composition_order_.push_back(vid);
 }
 
 // |ExternalViewEmbedder|
@@ -111,7 +112,8 @@ std::vector<SkCanvas*> EmbedderExternalViewEmbedder::GetCurrentCanvases() {
 
 // |ExternalViewEmbedder|
 SkCanvas* EmbedderExternalViewEmbedder::CompositeEmbeddedView(int view_id) {
-  auto found = pending_views_.find(view_id);
+  auto vid = EmbedderExternalView::ViewIdentifier(view_id);
+  auto found = pending_views_.find(vid);
   if (found == pending_views_.end()) {
     FML_DCHECK(false) << "Attempted to composite a view that was not "
                          "pre-rolled.";

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -36,9 +36,10 @@ class EmbedderConfigBuilder {
     kNoInitialize,
   };
 
-  EmbedderConfigBuilder(EmbedderTestContext& context,
-                        InitializationPreference preference =
-                            InitializationPreference::kSnapshotsInitialize);
+  explicit EmbedderConfigBuilder(
+      EmbedderTestContext& context,
+      InitializationPreference preference =
+          InitializationPreference::kSnapshotsInitialize);
 
   ~EmbedderConfigBuilder();
 

--- a/shell/platform/embedder/tests/embedder_test_compositor_software.h
+++ b/shell/platform/embedder/tests/embedder_test_compositor_software.h
@@ -12,7 +12,7 @@ namespace testing {
 
 class EmbedderTestCompositorSoftware : public EmbedderTestCompositor {
  public:
-  EmbedderTestCompositorSoftware(SkISize surface_size);
+  explicit EmbedderTestCompositorSoftware(SkISize surface_size);
 
   ~EmbedderTestCompositorSoftware() override;
 

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -48,7 +48,7 @@ enum class EmbedderTestContextType {
 
 class EmbedderTestContext {
  public:
-  EmbedderTestContext(std::string assets_path = "");
+  explicit EmbedderTestContext(std::string assets_path = "");
 
   virtual ~EmbedderTestContext();
 

--- a/shell/platform/embedder/tests/embedder_test_context_gl.h
+++ b/shell/platform/embedder/tests/embedder_test_context_gl.h
@@ -16,7 +16,7 @@ class EmbedderTestContextGL : public EmbedderTestContext {
   using GLGetFBOCallback = std::function<void(FlutterFrameInfo frame_info)>;
   using GLPresentCallback = std::function<void(uint32_t fbo_id)>;
 
-  EmbedderTestContextGL(std::string assets_path = "");
+  explicit EmbedderTestContextGL(std::string assets_path = "");
 
   ~EmbedderTestContextGL() override;
 

--- a/shell/platform/embedder/tests/embedder_test_context_software.h
+++ b/shell/platform/embedder/tests/embedder_test_context_software.h
@@ -12,7 +12,7 @@ namespace testing {
 
 class EmbedderTestContextSoftware : public EmbedderTestContext {
  public:
-  EmbedderTestContextSoftware(std::string assets_path = "");
+  explicit EmbedderTestContextSoftware(std::string assets_path = "");
 
   ~EmbedderTestContextSoftware() override;
 

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
@@ -98,7 +98,7 @@ class StubFlutterGlfwApi {
 class ScopedStubFlutterGlfwApi {
  public:
   // Calls SetTestFlutterStub with |stub|.
-  ScopedStubFlutterGlfwApi(std::unique_ptr<StubFlutterGlfwApi> stub);
+  explicit ScopedStubFlutterGlfwApi(std::unique_ptr<StubFlutterGlfwApi> stub);
 
   // Restores the previous test stub.
   ~ScopedStubFlutterGlfwApi();

--- a/testing/test_gl_surface.h
+++ b/testing/test_gl_surface.h
@@ -15,7 +15,7 @@ namespace testing {
 
 class TestGLSurface {
  public:
-  TestGLSurface(SkISize surface_size);
+  explicit TestGLSurface(SkISize surface_size);
 
   ~TestGLSurface();
 

--- a/testing/test_timeout_listener.h
+++ b/testing/test_timeout_listener.h
@@ -19,7 +19,7 @@ class PendingTests;
 
 class TestTimeoutListener : public ::testing::EmptyTestEventListener {
  public:
-  TestTimeoutListener(fml::TimeDelta timeout);
+  explicit TestTimeoutListener(fml::TimeDelta timeout);
 
   ~TestTimeoutListener();
 

--- a/third_party/tonic/dart_args.h
+++ b/third_party/tonic/dart_args.h
@@ -16,7 +16,7 @@ namespace tonic {
 
 class DartArgIterator {
  public:
-  DartArgIterator(Dart_NativeArguments args, int start_index = 1)
+  explicit DartArgIterator(Dart_NativeArguments args, int start_index = 1)
       : args_(args), index_(start_index), had_exception_(false) {}
 
   template <typename T>

--- a/third_party/tonic/dart_state.h
+++ b/third_party/tonic/dart_state.h
@@ -38,8 +38,9 @@ class DartState : public std::enable_shared_from_this<DartState> {
     DartApiScope api_scope_;
   };
 
-  DartState(int dirfd = -1,
-            std::function<void(Dart_Handle)> message_epilogue = nullptr);
+  explicit DartState(
+      int dirfd = -1,
+      std::function<void(Dart_Handle)> message_epilogue = nullptr);
   virtual ~DartState();
 
   static DartState* From(Dart_Isolate isolate);

--- a/third_party/tonic/file_loader/file_loader.h
+++ b/third_party/tonic/file_loader/file_loader.h
@@ -18,7 +18,7 @@ namespace tonic {
 
 class FileLoader {
  public:
-  FileLoader(int dirfd = -1);
+  explicit FileLoader(int dirfd = -1);
   ~FileLoader();
 
   bool LoadPackagesMap(const std::string& packages);

--- a/third_party/txt/src/minikin/FontFamily.h
+++ b/third_party/txt/src/minikin/FontFamily.h
@@ -41,7 +41,7 @@ class FontStyle {
       : FontStyle(0 /* variant */, 4 /* weight */, false /* italic */) {}
   FontStyle(int weight, bool italic)
       : FontStyle(0 /* variant */, weight, italic) {}
-  FontStyle(uint32_t langListId)  // NOLINT(implicit)
+  FontStyle(uint32_t langListId)  // NOLINT(google-explicit-constructor)
       : FontStyle(langListId,
                   0 /* variant */,
                   4 /* weight */,

--- a/third_party/txt/src/minikin/Hyphenator.h
+++ b/third_party/txt/src/minikin/Hyphenator.h
@@ -110,7 +110,8 @@ class HyphenEdit {
   static uint32_t editForNextLine(HyphenationType type);
 
   HyphenEdit() : hyphen(NO_EDIT) {}
-  HyphenEdit(uint32_t hyphenInt) : hyphen(hyphenInt) {}  // NOLINT(implicit)
+  HyphenEdit(uint32_t hyphenInt)  // NOLINT(google-explicit-constructor)
+      : hyphen(hyphenInt) {}
   uint32_t getHyphen() const { return hyphen; }
   bool operator==(const HyphenEdit& other) const {
     return hyphen == other.hyphen;

--- a/third_party/txt/src/txt/asset_font_manager.h
+++ b/third_party/txt/src/txt/asset_font_manager.h
@@ -29,7 +29,7 @@ namespace txt {
 
 class AssetFontManager : public SkFontMgr {
  public:
-  AssetFontManager(std::unique_ptr<FontAssetProvider> font_provider);
+  explicit AssetFontManager(std::unique_ptr<FontAssetProvider> font_provider);
 
   ~AssetFontManager() override;
 

--- a/third_party/txt/src/txt/run_metrics.h
+++ b/third_party/txt/src/txt/run_metrics.h
@@ -25,7 +25,7 @@ namespace txt {
 // Contains the font metrics and TextStyle of a unique run.
 class RunMetrics {
  public:
-  RunMetrics(const TextStyle* style) : text_style(style) {}
+  explicit RunMetrics(const TextStyle* style) : text_style(style) {}
 
   RunMetrics(const TextStyle* style, const SkFontMetrics& metrics)
       : text_style(style), font_metrics(metrics) {}


### PR DESCRIPTION
This PR adds `explicit` to constructor declarations that are asked for in a `host_debug` build on Linux using the following `.clang-tidy` file:

```
Checks: '-*,google-explicit-constructor'
WarningsAsErrors: '-*,google-explicit-constructor'
HeaderFilterRegex: '.*/flutter/.*h$'
```

For https://github.com/flutter/flutter/issues/93576