### PR TITLE
Treat clang-analyzer-osx warnings as errors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,2 +1,8 @@
 Checks: 'google-*'
+
+# Only warnings treated as errors are reported
+# in the "ci/lint.sh" script and pre-push git hook.
+# Add checks when all warnings are fixed
+# to prevent new warnings from being introduced.
+# https://github.com/flutter/flutter/issues/93279
 WarningsAsErrors: 'clang-analyzer-osx.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,1 +1,2 @@
 Checks: 'google-*'
+WarningsAsErrors: 'clang-analyzer-osx.*'


### PR DESCRIPTION
There are no `clang-analyzer-osx` warnings in the iOS or macOS embedder as of https://github.com/flutter/engine/pull/29623.  Make the clang-tidy linter treat these warnings as errors so they show up locally during pre-push git hook linter.

Note this still isn't running in CI for due to https://github.com/flutter/flutter/issues/61661#issuecomment-964829180.

Pre-submit part of https://github.com/flutter/flutter/issues/93279

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
