### PR TITLE
Fix Kanji switch in Japanese IME on WIndows

### DIFF
--- a/shell/platform/windows/flutter_window_win32_unittests.cc
+++ b/shell/platform/windows/flutter_window_win32_unittests.cc
@@ -234,10 +234,12 @@ class TestFlutterWindowsView : public FlutterWindowsView {
  public:
   TestFlutterWindowsView(std::unique_ptr<WindowBindingHandler> window_binding,
                          WPARAM virtual_key,
-                         bool is_printable = true)
+                         bool is_printable = true,
+                         bool is_syskey = false)
       : FlutterWindowsView(std::move(window_binding)),
         virtual_key_(virtual_key),
-        is_printable_(is_printable) {}
+        is_printable_(is_printable),
+        is_syskey_(is_syskey) {}
 
   SpyKeyboardKeyHandler* key_event_handler;
   SpyTextInputPlugin* text_input_plugin;
@@ -271,9 +273,10 @@ class TestFlutterWindowsView : public FlutterWindowsView {
     // Simulate the event loop by just sending the event sent to
     // "SendInput" directly to the window.
     const KEYBDINPUT kbdinput = pInputs->ki;
-    const UINT message =
-        (kbdinput.dwFlags & KEYEVENTF_KEYUP) ? WM_KEYUP : WM_KEYDOWN;
     const bool is_key_up = kbdinput.dwFlags & KEYEVENTF_KEYUP;
+    const UINT message = is_key_up ? (is_syskey_ ? WM_SYSKEYUP : WM_KEYUP)
+                                   : (is_syskey_ ? WM_SYSKEYDOWN : WM_KEYDOWN);
+
     const LPARAM lparam = CreateKeyEventLparam(
         kbdinput.wScan, kbdinput.dwFlags & KEYEVENTF_EXTENDEDKEY, is_key_up);
     // Windows would normally fill in the virtual key code for us, so we
@@ -297,6 +300,7 @@ class TestFlutterWindowsView : public FlutterWindowsView {
   std::vector<Win32Message> pending_responds_;
   WPARAM virtual_key_;
   bool is_printable_;
+  bool is_syskey_;
 };
 
 // The static value to return as the "handled" value from the framework for key
@@ -380,6 +384,59 @@ TEST(FlutterWindowWin32Test, NonPrintableKeyDownPropagation) {
         .Times(0);
     win32window.InjectMessages(1,
                                Win32Message{WM_KEYDOWN, virtual_key, lparam});
+    flutter_windows_view.InjectPendingEvents(&win32window);
+  }
+}
+
+// Tests key event propagation of system (WM_SYSKEYDOWN) key down events.
+TEST(FlutterWindowWin32Test, SystemKeyDownPropagation) {
+  ::testing::InSequence in_sequence;
+
+  constexpr WPARAM virtual_key = VK_LEFT;
+  constexpr WPARAM scan_code = 10;
+  constexpr char32_t character = 0;
+  MockFlutterWindowWin32 win32window;
+  auto window_binding_handler =
+      std::make_unique<::testing::NiceMock<MockWindowBindingHandler>>();
+  TestFlutterWindowsView flutter_windows_view(
+      std::move(window_binding_handler), virtual_key, false /* is_printable */,
+      true /* is_syskey */);
+  win32window.SetView(&flutter_windows_view);
+  LPARAM lparam = CreateKeyEventLparam(scan_code, false, false);
+
+  // Test an event not handled by the framework
+  {
+    test_response = false;
+    flutter_windows_view.SetEngine(std::move(GetTestEngine()));
+    EXPECT_CALL(*flutter_windows_view.key_event_handler,
+                KeyboardHook(_, virtual_key, scan_code, WM_SYSKEYDOWN,
+                             character, false /* extended */, _))
+        .Times(2)
+        .RetiresOnSaturation();
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin,
+                KeyboardHook(_, _, _, _, _, _, _))
+        .Times(1)
+        .RetiresOnSaturation();
+    EXPECT_CALL(*flutter_windows_view.key_event_handler, TextHook(_, _))
+        .Times(0);
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin, TextHook(_, _))
+        .Times(0);
+    win32window.InjectMessages(
+        1, Win32Message{WM_SYSKEYDOWN, virtual_key, lparam, kWmResultDefault});
+    flutter_windows_view.InjectPendingEvents(&win32window);
+  }
+
+  // Test an event handled by the framework
+  {
+    test_response = true;
+    EXPECT_CALL(*flutter_windows_view.key_event_handler,
+                KeyboardHook(_, _, _, _, _, _, _))
+        .Times(0);
+    EXPECT_CALL(*flutter_windows_view.text_input_plugin,
+                KeyboardHook(_, _, _, _, _, _, _))
+        .Times(0);
+    win32window.InjectMessages(
+        1, Win32Message{WM_SYSKEYDOWN, virtual_key, lparam, kWmResultDefault});
     flutter_windows_view.InjectPendingEvents(&win32window);
   }
 }

--- a/shell/platform/windows/keyboard_key_channel_handler.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler.cc
@@ -189,9 +189,11 @@ void KeyboardKeyChannelHandler::KeyboardHook(
   event.AddMember(kModifiersKey, GetModsForKeyState(), allocator);
 
   switch (action) {
+    case WM_SYSKEYDOWN:
     case WM_KEYDOWN:
       event.AddMember(kTypeKey, kKeyDown, allocator);
       break;
+    case WM_SYSKEYUP:
     case WM_KEYUP:
       event.AddMember(kTypeKey, kKeyUp, allocator);
       break;

--- a/shell/platform/windows/keyboard_key_channel_handler_unittests.cc
+++ b/shell/platform/windows/keyboard_key_channel_handler_unittests.cc
@@ -67,6 +67,22 @@ TEST(KeyboardKeyChannelHandlerTest, KeyboardHookHandling) {
       [&last_handled](bool handled) { last_handled = handled; });
   EXPECT_EQ(received_scancode, kUnhandledScanCode);
   EXPECT_EQ(last_handled, false);
+
+  received_scancode = 0;
+
+  handler.KeyboardHook(
+      64, kHandledScanCode, WM_SYSKEYDOWN, L'a', false, false,
+      [&last_handled](bool handled) { last_handled = handled; });
+  EXPECT_EQ(received_scancode, kHandledScanCode);
+  EXPECT_EQ(last_handled, true);
+
+  received_scancode = 0;
+
+  handler.KeyboardHook(
+      64, kUnhandledScanCode, WM_SYSKEYDOWN, L'c', false, false,
+      [&last_handled](bool handled) { last_handled = handled; });
+  EXPECT_EQ(received_scancode, kUnhandledScanCode);
+  EXPECT_EQ(last_handled, false);
 }
 
 TEST(KeyboardKeyChannelHandlerTest, ExtendedKeysAreSentToRedispatch) {

--- a/shell/platform/windows/keyboard_key_embedder_handler.cc
+++ b/shell/platform/windows/keyboard_key_embedder_handler.cc
@@ -167,8 +167,9 @@ void KeyboardKeyEmbedderHandler::KeyboardHookImpl(
     std::function<void(bool)> callback) {
   const uint64_t physical_key = GetPhysicalKey(scancode, extended);
   const uint64_t logical_key = GetLogicalKey(key, extended, scancode);
-  assert(action == WM_KEYDOWN || action == WM_KEYUP);
-  const bool is_physical_down = action == WM_KEYDOWN;
+  assert(action == WM_KEYDOWN || action == WM_KEYUP ||
+         action == WM_SYSKEYDOWN || action == WM_SYSKEYUP);
+  const bool is_physical_down = action == WM_KEYDOWN || action == WM_SYSKEYDOWN;
 
   auto last_logical_record_iter = pressingRecords_.find(physical_key);
   const bool had_record = last_logical_record_iter != pressingRecords_.end();

--- a/shell/platform/windows/keyboard_key_handler.cc
+++ b/shell/platform/windows/keyboard_key_handler.cc
@@ -67,7 +67,8 @@ static bool IsKeyDownAltRight(int action, int virtual_key, bool extended) {
 #ifdef WINUWP
   return false;
 #else
-  return virtual_key == VK_RMENU && extended && action == WM_KEYDOWN;
+  return virtual_key == VK_RMENU && extended &&
+         (action == WM_KEYDOWN || action == WM_SYSKEYDOWN);
 #endif
 }
 
@@ -78,7 +79,8 @@ static bool IsKeyUpAltRight(int action, int virtual_key, bool extended) {
 #ifdef WINUWP
   return false;
 #else
-  return virtual_key == VK_RMENU && extended && action == WM_KEYUP;
+  return virtual_key == VK_RMENU && extended &&
+         (action == WM_KEYUP || action == WM_SYSKEYUP);
 #endif
 }
 
@@ -89,7 +91,8 @@ static bool IsKeyDownCtrlLeft(int action, int virtual_key) {
 #ifdef WINUWP
   return false;
 #else
-  return virtual_key == VK_LCONTROL && action == WM_KEYDOWN;
+  return virtual_key == VK_LCONTROL &&
+         (action == WM_KEYDOWN || action == WM_SYSKEYDOWN);
 #endif
 }
 
@@ -125,6 +128,10 @@ void KeyboardKeyHandler::DispatchEvent(const PendingEvent& event) {
   return;
 #else
   char32_t character = event.character;
+
+  if (event.action == WM_SYSKEYDOWN || event.action == WM_SYSKEYUP) {
+    return;
+  }
 
   INPUT input_event{
       .type = INPUT_KEYBOARD,

--- a/shell/platform/windows/keyboard_unittests.cc
+++ b/shell/platform/windows/keyboard_unittests.cc
@@ -766,9 +766,11 @@ TEST(KeyboardTest, AltGrModifiedKey) {
   EXPECT_EQ(key_calls.size(), 0);
 
   // Release AltGr. Win32 doesn't dispatch ControlLeft up. Instead Flutter will
-  // dispatch one.
+  // dispatch one. The AltGr is a system key, so will be handled by Win32's
+  // default WndProc.
   tester.InjectMessages(
-      1, WmSysKeyUpInfo{VK_MENU, kScanCodeAlt, kExtended}.Build(kWmResultZero));
+      1,
+      WmSysKeyUpInfo{VK_MENU, kScanCodeAlt, kExtended}.Build(kWmResultDefault));
 
   EXPECT_EQ(key_calls.size(), 1);
   EXPECT_CALL_IS_EVENT(key_calls[0], kFlutterKeyEventTypeUp, kPhysicalAltRight,

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -70,7 +70,7 @@ bool TextInputPlugin::KeyboardHook(FlutterWindowsView* view,
   if (active_model_ == nullptr) {
     return false;
   }
-  if (action == WM_KEYDOWN) {
+  if (action == WM_KEYDOWN || action == WM_SYSKEYDOWN) {
     // Most editing keys (arrow keys, backspace, delete, etc.) are handled in
     // the framework, so don't need to be handled at this layer.
     switch (key) {

--- a/shell/platform/windows/window_win32_unittests.cc
+++ b/shell/platform/windows/window_win32_unittests.cc
@@ -142,6 +142,22 @@ TEST(MockWin32Window, KeyUp) {
   window.InjectWindowMessage(WM_KEYUP, 16, lparam);
 }
 
+TEST(MockWin32Window, SysKeyDown) {
+  MockWin32Window window;
+  EXPECT_CALL(window, OnKey(_, _, _, _, _, _)).Times(1);
+  LPARAM lparam = CreateKeyEventLparam(42, false, false);
+  // send a "Shift" key down event.
+  window.InjectWindowMessage(WM_SYSKEYDOWN, 16, lparam);
+}
+
+TEST(MockWin32Window, SysKeyUp) {
+  MockWin32Window window;
+  EXPECT_CALL(window, OnKey(_, _, _, _, _, _)).Times(1);
+  LPARAM lparam = CreateKeyEventLparam(42, false, true);
+  // send a "Shift" key up event.
+  window.InjectWindowMessage(WM_SYSKEYUP, 16, lparam);
+}
+
 TEST(MockWin32Window, KeyDownPrintable) {
   MockWin32Window window;
   LPARAM lparam = CreateKeyEventLparam(30, false, false);


### PR DESCRIPTION
## Description

This fixes https://github.com/flutter/flutter/issues/93422 by sending any WM_SYSKEYDOWN/WM_SYSKEYUP messages to the Windows default window proc regardless of whether the framework handles it or not.  It will also send them to the Framework, but if the framework handles them, they will already have been sent to the default window proc, and so will also still be propagated.

This is because the Kanji switch is a system key that can't be synthesized, so the mode switch is lost when Flutter responded with "handled" (the previous behavior), and then it couldn't synthesize one that works when the framework said it didn't handle it.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/93422

## Tests
 - Added tests for WM_SYSKEYDOWN/WM_SYSKEYUP to several of the unit tests that already test for WM_KEYDOWN/WM_KEYUP.