### PR TITLE
Fix "google-objc-*" clang analyzer warning in macOS and iOS

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,12 @@
-Checks: 'google-*'
+# Prefix check with "-" to ignore.
+Checks: "google-*,\
+-google-objc-global-variable-declaration,\
+-google-objc-avoid-throwing-exception"
 
 # Only warnings treated as errors are reported
 # in the "ci/lint.sh" script and pre-push git hook.
 # Add checks when all warnings are fixed
-# to prevent new warnings from being introduced.
+# to prevent new warnings being introduced.
 # https://github.com/flutter/flutter/issues/93279
-WarningsAsErrors: 'clang-analyzer-osx.*'
+WarningsAsErrors: "clang-analyzer-osx.*,\
+google-objc-*"

--- a/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
@@ -173,7 +173,7 @@ static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
 }
 @end
 
-NSObject const* FlutterMethodNotImplemented = [NSObject new];
+NSObject const* FlutterMethodNotImplemented = [[NSObject alloc] init];
 
 @implementation FlutterMethodChannel {
   NSObject<FlutterBinaryMessenger>* _messenger;
@@ -267,7 +267,7 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
 
 #pragma mark - Event channel
 
-NSObject const* FlutterEndOfEventStream = [NSObject new];
+NSObject const* FlutterEndOfEventStream = [[NSObject alloc] init];
 
 @implementation FlutterEventChannel {
   NSObject<FlutterBinaryMessenger>* _messenger;

--- a/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
+++ b/shell/platform/darwin/common/framework/Source/flutter_standard_codec_unittest.mm
@@ -6,7 +6,7 @@
 
 #include "gtest/gtest.h"
 
-void checkEncodeDecode(id value, NSData* expectedEncoding) {
+static void CheckEncodeDecode(id value, NSData* expectedEncoding) {
   FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
   NSData* encoded = [codec encode:value];
   if (expectedEncoding == nil) {
@@ -22,7 +22,7 @@ void checkEncodeDecode(id value, NSData* expectedEncoding) {
   }
 }
 
-void checkEncodeDecode(id value) {
+static void CheckEncodeDecode(id value) {
   FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
   NSData* encoded = [codec encode:value];
   id decoded = [codec decode:encoded];
@@ -40,40 +40,40 @@ TEST(FlutterStandardCodec, CanDecodeZeroLength) {
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeNil) {
-  checkEncodeDecode(nil, nil);
+  CheckEncodeDecode(nil, nil);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeNSNull) {
   uint8_t bytes[1] = {0x00};
-  checkEncodeDecode([NSNull null], [NSData dataWithBytes:bytes length:1]);
+  CheckEncodeDecode([NSNull null], [NSData dataWithBytes:bytes length:1]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeYes) {
   uint8_t bytes[1] = {0x01};
-  checkEncodeDecode(@YES, [NSData dataWithBytes:bytes length:1]);
+  CheckEncodeDecode(@YES, [NSData dataWithBytes:bytes length:1]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeNo) {
   uint8_t bytes[1] = {0x02};
-  checkEncodeDecode(@NO, [NSData dataWithBytes:bytes length:1]);
+  CheckEncodeDecode(@NO, [NSData dataWithBytes:bytes length:1]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeUInt8) {
   uint8_t bytes[5] = {0x03, 0xfe, 0x00, 0x00, 0x00};
   UInt8 value = 0xfe;
-  checkEncodeDecode(@(value), [NSData dataWithBytes:bytes length:5]);
+  CheckEncodeDecode(@(value), [NSData dataWithBytes:bytes length:5]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeUInt16) {
   uint8_t bytes[5] = {0x03, 0xdc, 0xfe, 0x00, 0x00};
   UInt16 value = 0xfedc;
-  checkEncodeDecode(@(value), [NSData dataWithBytes:bytes length:5]);
+  CheckEncodeDecode(@(value), [NSData dataWithBytes:bytes length:5]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeUInt32) {
   uint8_t bytes[9] = {0x04, 0x09, 0xba, 0xdc, 0xfe, 0x00, 0x00, 0x00, 0x00};
   UInt32 value = 0xfedcba09;
-  checkEncodeDecode(@(value), [NSData dataWithBytes:bytes length:9]);
+  CheckEncodeDecode(@(value), [NSData dataWithBytes:bytes length:9]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeUInt64) {
@@ -87,56 +87,56 @@ TEST(FlutterStandardCodec, CanEncodeUInt64) {
 TEST(FlutterStandardCodec, CanEncodeAndDecodeSInt8) {
   uint8_t bytes[5] = {0x03, 0xfe, 0xff, 0xff, 0xff};
   SInt8 value = 0xfe;
-  checkEncodeDecode(@(value), [NSData dataWithBytes:bytes length:5]);
+  CheckEncodeDecode(@(value), [NSData dataWithBytes:bytes length:5]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeSInt16) {
   uint8_t bytes[5] = {0x03, 0xdc, 0xfe, 0xff, 0xff};
   SInt16 value = 0xfedc;
-  checkEncodeDecode(@(value), [NSData dataWithBytes:bytes length:5]);
+  CheckEncodeDecode(@(value), [NSData dataWithBytes:bytes length:5]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeSInt32) {
   uint8_t bytes[5] = {0x03, 0x78, 0x56, 0x34, 0x12};
-  checkEncodeDecode(@(0x12345678), [NSData dataWithBytes:bytes length:5]);
+  CheckEncodeDecode(@(0x12345678), [NSData dataWithBytes:bytes length:5]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeSInt64) {
   uint8_t bytes[9] = {0x04, 0xef, 0xcd, 0xab, 0x90, 0x78, 0x56, 0x34, 0x12};
-  checkEncodeDecode(@(0x1234567890abcdef), [NSData dataWithBytes:bytes length:9]);
+  CheckEncodeDecode(@(0x1234567890abcdef), [NSData dataWithBytes:bytes length:9]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeFloat32) {
   uint8_t bytes[16] = {0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                        0x00, 0x00, 0x00, 0x60, 0xfb, 0x21, 0x09, 0x40};
-  checkEncodeDecode(@3.1415927f, [NSData dataWithBytes:bytes length:16]);
+  CheckEncodeDecode(@3.1415927f, [NSData dataWithBytes:bytes length:16]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeFloat64) {
   uint8_t bytes[16] = {0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                        0x18, 0x2d, 0x44, 0x54, 0xfb, 0x21, 0x09, 0x40};
-  checkEncodeDecode(@3.14159265358979311599796346854, [NSData dataWithBytes:bytes length:16]);
+  CheckEncodeDecode(@3.14159265358979311599796346854, [NSData dataWithBytes:bytes length:16]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeString) {
   uint8_t bytes[13] = {0x07, 0x0b, 0x68, 0x65, 0x6c, 0x6c, 0x6f,
                        0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64};
-  checkEncodeDecode(@"hello world", [NSData dataWithBytes:bytes length:13]);
+  CheckEncodeDecode(@"hello world", [NSData dataWithBytes:bytes length:13]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeStringWithNonAsciiCodePoint) {
   uint8_t bytes[7] = {0x07, 0x05, 0x68, 0xe2, 0x98, 0xba, 0x77};
-  checkEncodeDecode(@"h\u263Aw", [NSData dataWithBytes:bytes length:7]);
+  CheckEncodeDecode(@"h\u263Aw", [NSData dataWithBytes:bytes length:7]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeStringWithNonBMPCodePoint) {
   uint8_t bytes[8] = {0x07, 0x06, 0x68, 0xf0, 0x9f, 0x98, 0x82, 0x77};
-  checkEncodeDecode(@"h\U0001F602w", [NSData dataWithBytes:bytes length:8]);
+  CheckEncodeDecode(@"h\U0001F602w", [NSData dataWithBytes:bytes length:8]);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeArray) {
   NSArray* value = @[ [NSNull null], @"hello", @3.14, @47, @{@42 : @"nested"} ];
-  checkEncodeDecode(value);
+  CheckEncodeDecode(value);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeDictionary) {
@@ -145,14 +145,14 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeDictionary) {
         @"b" : @47,
         [NSNull null] : [NSNull null],
         @3.14 : @[ @"nested" ]};
-  checkEncodeDecode(value);
+  CheckEncodeDecode(value);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeByteArray) {
   uint8_t bytes[4] = {0xBA, 0x5E, 0xBA, 0x11};
   NSData* data = [NSData dataWithBytes:bytes length:4];
   FlutterStandardTypedData* value = [FlutterStandardTypedData typedDataWithBytes:data];
-  checkEncodeDecode(value);
+  CheckEncodeDecode(value);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeNSData) {
@@ -169,21 +169,21 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeInt32Array) {
   uint8_t bytes[8] = {0xBA, 0x5E, 0xBA, 0x11, 0xff, 0xff, 0xff, 0xff};
   NSData* data = [NSData dataWithBytes:bytes length:8];
   FlutterStandardTypedData* value = [FlutterStandardTypedData typedDataWithInt32:data];
-  checkEncodeDecode(value);
+  CheckEncodeDecode(value);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeInt64Array) {
   uint8_t bytes[8] = {0xBA, 0x5E, 0xBA, 0x11, 0xff, 0xff, 0xff, 0xff};
   NSData* data = [NSData dataWithBytes:bytes length:8];
   FlutterStandardTypedData* value = [FlutterStandardTypedData typedDataWithInt64:data];
-  checkEncodeDecode(value);
+  CheckEncodeDecode(value);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeFloat32Array) {
   uint8_t bytes[8] = {0xd8, 0x0f, 0x49, 0x40, 0x00, 0x00, 0x7a, 0x44};
   NSData* data = [NSData dataWithBytes:bytes length:8];
   FlutterStandardTypedData* value = [FlutterStandardTypedData typedDataWithFloat32:data];
-  checkEncodeDecode(value);
+  CheckEncodeDecode(value);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeFloat64Array) {
@@ -191,7 +191,7 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeFloat64Array) {
                        0xBA, 0x5E, 0xBA, 0x11, 0xff, 0xff, 0xff, 0xff};
   NSData* data = [NSData dataWithBytes:bytes length:16];
   FlutterStandardTypedData* value = [FlutterStandardTypedData typedDataWithFloat64:data];
-  checkEncodeDecode(value);
+  CheckEncodeDecode(value);
 }
 
 TEST(FlutterStandardCodec, HandlesMethodCallsWithNilArguments) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -95,7 +95,7 @@
   int err = DNSServiceRegister(&_dnsServiceRef, flags, interfaceIndex,
                                FlutterObservatoryPublisher.serviceName.UTF8String, registrationType,
                                domain, NULL, htons(port), txtData.length, txtData.bytes,
-                               registrationCallback, NULL);
+                               RegistrationCallback, NULL);
 
   if (err != 0) {
     FML_LOG(ERROR) << "Failed to register observatory port with mDNS with error " << err << ".";
@@ -125,7 +125,7 @@ static const DNSServiceErrorType kFlutter_DNSServiceErr_PolicyDenied =
     -65570;
 #endif  // __IPHONE_OS_VERSION_MAX_ALLOWED
 
-static void DNSSD_API registrationCallback(DNSServiceRef sdRef,
+static void DNSSD_API RegistrationCallback(DNSServiceRef sdRef,
                                            DNSServiceFlags flags,
                                            DNSServiceErrorType errorCode,
                                            const char* name,

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -21,6 +21,14 @@
 // TODO(amirh): once GL support is in evaluate if we can merge this with FlutterView.
 @implementation FlutterOverlayView
 
+- (instancetype)initWithFrame:(CGRect)frame {
+  NSAssert(NO, @"FlutterOverlayView must init or initWithContentsScale");
+}
+
+- (instancetype)initWithCoder:(NSCoder*)aDecoder {
+  NSAssert(NO, @"FlutterOverlayView must init or initWithContentsScale");
+}
+
 - (instancetype)init {
   self = [super initWithFrame:CGRectZero];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -21,18 +21,6 @@
 // TODO(amirh): once GL support is in evaluate if we can merge this with FlutterView.
 @implementation FlutterOverlayView
 
-- (instancetype)initWithFrame:(CGRect)frame {
-  @throw([NSException exceptionWithName:@"FlutterOverlayView must init or initWithContentsScale"
-                                 reason:nil
-                               userInfo:nil]);
-}
-
-- (instancetype)initWithCoder:(NSCoder*)aDecoder {
-  @throw([NSException exceptionWithName:@"FlutterOverlayView must init or initWithContentsScale"
-                                 reason:nil
-                               userInfo:nil]);
-}
-
 - (instancetype)init {
   self = [super initWithFrame:CGRectZero];
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -23,10 +23,12 @@
 
 - (instancetype)initWithFrame:(CGRect)frame {
   NSAssert(NO, @"FlutterOverlayView must init or initWithContentsScale");
+  return nil;
 }
 
 - (instancetype)initWithCoder:(NSCoder*)aDecoder {
   NSAssert(NO, @"FlutterOverlayView must init or initWithContentsScale");
+  return nil;
 }
 
 - (instancetype)init {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -39,12 +39,6 @@ using namespace flutter;
   fml::WeakPtr<FlutterEngine> _engine;
 }
 
-- (instancetype)init {
-  @throw([NSException exceptionWithName:@"FlutterPlatformPlugin must initWithEngine"
-                                 reason:nil
-                               userInfo:nil]);
-}
-
 - (instancetype)initWithEngine:(fml::WeakPtr<FlutterEngine>)engine {
   FML_DCHECK(engine) << "engine must be set";
   self = [super init];

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -71,7 +71,7 @@ static const SEL selectorsHandledByPlugins[] = {
   [super dealloc];
 }
 
-static BOOL isPowerOfTwo(NSUInteger x) {
+static BOOL IsPowerOfTwo(NSUInteger x) {
   return x != 0 && (x & (x - 1)) == 0;
 }
 
@@ -98,7 +98,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 
 - (void)addDelegate:(NSObject<FlutterApplicationLifeCycleDelegate>*)delegate {
   [_delegates addPointer:(__bridge void*)delegate];
-  if (isPowerOfTwo([_delegates count])) {
+  if (IsPowerOfTwo([_delegates count])) {
     [_delegates compact];
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterRestorationPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterRestorationPlugin.mm
@@ -20,13 +20,6 @@ FLUTTER_ASSERT_NOT_ARC
   BOOL _restorationEnabled;
 }
 
-- (instancetype)init {
-  @throw([NSException
-      exceptionWithName:@"FlutterRestorationPlugin must initWithChannel:restorationEnabled:"
-                 reason:nil
-               userInfo:nil]);
-}
-
 - (instancetype)initWithChannel:(FlutterMethodChannel*)channel
              restorationEnabled:(BOOL)restorationEnabled {
   FML_DCHECK(channel) << "channel must be set";

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -72,7 +72,7 @@ static NSString* const kAutocorrectionType = @"autocorrect";
 // used when there's an in-app virtual keyboard. If
 // "TextInputType.none" is specified, disable the system
 // keyboard.
-static BOOL shouldShowSystemKeyboard(NSDictionary* type) {
+static BOOL ShouldShowSystemKeyboard(NSDictionary* type) {
   NSString* inputType = type[@"name"];
   return ![inputType isEqualToString:@"TextInputType.none"];
 }
@@ -299,7 +299,7 @@ static UITextContentType ToUITextContentType(NSArray<NSString*>* hints) {
 
 // Retrieves the autofillId from an input field's configuration. Returns
 // nil if the field is nil and the input field is not a password field.
-static NSString* autofillIdFromDictionary(NSDictionary* dictionary) {
+static NSString* AutofillIdFromDictionary(NSDictionary* dictionary) {
   NSDictionary* autofill = dictionary[kAutofillProperties];
   if (autofill) {
     return autofill[kAutofillId];
@@ -368,10 +368,10 @@ typedef NS_ENUM(NSInteger, FlutterAutofillType) {
   FlutterAutofillTypePassword,
 };
 
-static BOOL isFieldPasswordRelated(NSDictionary* configuration) {
+static BOOL IsFieldPasswordRelated(NSDictionary* configuration) {
   if (@available(iOS 10.0, *)) {
     // Autofill is explicitly disabled if the id isn't present.
-    if (!autofillIdFromDictionary(configuration)) {
+    if (!AutofillIdFromDictionary(configuration)) {
       return NO;
     }
 
@@ -399,14 +399,14 @@ static BOOL isFieldPasswordRelated(NSDictionary* configuration) {
   return NO;
 }
 
-static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
+static FlutterAutofillType AutofillTypeOf(NSDictionary* configuration) {
   for (NSDictionary* field in configuration[kAssociatedAutofillFields]) {
-    if (isFieldPasswordRelated(field)) {
+    if (IsFieldPasswordRelated(field)) {
       return FlutterAutofillTypePassword;
     }
   }
 
-  if (isFieldPasswordRelated(configuration)) {
+  if (IsFieldPasswordRelated(configuration)) {
     return FlutterAutofillTypePassword;
   }
 
@@ -420,7 +420,7 @@ static FlutterAutofillType autofillTypeOf(NSDictionary* configuration) {
   return FlutterAutofillTypeNone;
 }
 
-static BOOL isApproximatelyEqual(float x, float y, float delta) {
+static BOOL IsApproximatelyEqual(float x, float y, float delta) {
   return fabsf(x - y) <= delta;
 }
 
@@ -435,7 +435,7 @@ static BOOL isApproximatelyEqual(float x, float y, float delta) {
 // First, the closer vertical distance is determined. Within the closest y distance, if the point is
 // above the bottom of the closest rect, the x distance will be minimized; however, if the point is
 // below the bottom of the rect, the x value will be maximized.
-static BOOL isSelectionRectCloserToPoint(CGPoint point,
+static BOOL IsSelectionRectCloserToPoint(CGPoint point,
                                          CGRect selectionRect,
                                          CGRect otherSelectionRect,
                                          BOOL checkRightBoundary) {
@@ -451,11 +451,11 @@ static BOOL isSelectionRectCloserToPoint(CGPoint point,
   float yDistOther = fabs(pointForOtherSelectionRect.y - point.y);
   float xDistOther = fabs(pointForOtherSelectionRect.x - point.x);
 
-  // This serves a similar purpose to isApproximatelyEqual, allowing a little buffer before
+  // This serves a similar purpose to IsApproximatelyEqual, allowing a little buffer before
   // declaring something closer vertically to account for the small variations in size and position
   // of SelectionRects, especially when dealing with emoji.
   BOOL isCloserVertically = yDist < yDistOther - 1;
-  BOOL isEqualVertically = isApproximatelyEqual(yDist, yDistOther, 1);
+  BOOL isEqualVertically = IsApproximatelyEqual(yDist, yDistOther, 1);
   BOOL isAboveBottomOfLine = point.y <= selectionRect.origin.y + selectionRect.size.height;
   BOOL isCloserHorizontally = xDist <= xDistOther;
   BOOL isBelowBottomOfLine = point.y > selectionRect.origin.y + selectionRect.size.height;
@@ -469,7 +469,7 @@ static BOOL isSelectionRectCloserToPoint(CGPoint point,
 
 // Checks whether Scribble features are possibly available – meaning this is an iPad running iOS
 // 14 or higher.
-static BOOL isScribbleAvailable() {
+static BOOL IsScribbleAvailable() {
   if (@available(iOS 14.0, *)) {
     if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
       return YES;
@@ -796,7 +796,7 @@ static BOOL isScribbleAvailable() {
   self.secureTextEntry = [configuration[kSecureTextEntry] boolValue];
   self.enableDeltaModel = [configuration[kEnableDeltaModel] boolValue];
 
-  _isSystemKeyboardEnabled = shouldShowSystemKeyboard(inputType);
+  _isSystemKeyboardEnabled = ShouldShowSystemKeyboard(inputType);
   self.keyboardType = ToUIKeyboardType(inputType);
   self.returnKeyType = ToUIReturnKeyType(configuration[kInputAction]);
   self.autocapitalizationType = ToUITextAutoCapitalizationType(configuration);
@@ -825,7 +825,7 @@ static BOOL isScribbleAvailable() {
                                 ? UITextAutocorrectionTypeNo
                                 : UITextAutocorrectionTypeDefault;
   if (@available(iOS 10.0, *)) {
-    self.autofillId = autofillIdFromDictionary(configuration);
+    self.autofillId = AutofillIdFromDictionary(configuration);
     if (autofill == nil) {
       self.textContentType = @"";
     } else {
@@ -864,7 +864,7 @@ static BOOL isScribbleAvailable() {
   }
 
   if (!_inputViewController) {
-    _inputViewController = [UIInputViewController new];
+    _inputViewController = [[UIInputViewController alloc] init];
   }
   return _inputViewController;
 }
@@ -1041,7 +1041,7 @@ static BOOL isScribbleAvailable() {
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender {
   // When scribble is available, the FlutterTextInputView will display the native toolbar unless
   // these text editing actions are disabled.
-  if (isScribbleAvailable()) {
+  if (IsScribbleAvailable()) {
     return NO;
   }
   if (action == @selector(paste:)) {
@@ -1624,7 +1624,7 @@ static BOOL isScribbleAvailable() {
     NSUInteger position = _selectionRects[i].position;
     if (position >= start && position <= end) {
       BOOL isFirst = _closestIndex == 0;
-      if (isFirst || isSelectionRectCloserToPoint(point, _selectionRects[i].rect, _closestRect,
+      if (isFirst || IsSelectionRectCloserToPoint(point, _selectionRects[i].rect, _closestRect,
                                                   /*checkRightBoundary=*/NO)) {
         _closestIndex = i;
         _closestRect = _selectionRects[i].rect;
@@ -1640,7 +1640,7 @@ static BOOL isScribbleAvailable() {
     NSUInteger i = [_selectionRects count] - 1;
     NSUInteger position = _selectionRects[i].position + 1;
     if (position <= end) {
-      if (isSelectionRectCloserToPoint(point, _selectionRects[i].rect, _closestRect,
+      if (IsSelectionRectCloserToPoint(point, _selectionRects[i].rect, _closestRect,
                                        /*checkRightBoundary=*/YES)) {
         _closestIndex = [_selectionRects count];
         _closestPosition = position;
@@ -2044,7 +2044,7 @@ static BOOL isScribbleAvailable() {
 
 - (void)setEditableSizeAndTransform:(NSDictionary*)dictionary {
   [_activeView setEditableTransform:dictionary[@"transform"]];
-  if (isScribbleAvailable()) {
+  if (IsScribbleAvailable()) {
     // This is necessary to set up where the scribble interactable element will be.
     int leftIndex = 12;
     int topIndex = 13;
@@ -2143,7 +2143,7 @@ static BOOL isScribbleAvailable() {
   [self changeInputViewsAutofillVisibility:NO];
 
   // Update the current active view.
-  switch (autofillTypeOf(configuration)) {
+  switch (AutofillTypeOf(configuration)) {
     case FlutterAutofillTypeNone:
       self.activeView = [self createInputViewWith:configuration];
       break;
@@ -2182,7 +2182,7 @@ static BOOL isScribbleAvailable() {
 // views) to decide whether the IME's internal states should be reset. See:
 // https://github.com/flutter/flutter/issues/79031 .
 - (FlutterTextInputView*)createInputViewWith:(NSDictionary*)configuration {
-  NSString* autofillId = autofillIdFromDictionary(configuration);
+  NSString* autofillId = AutofillIdFromDictionary(configuration);
   if (autofillId) {
     [_autofillContext removeObjectForKey:autofillId];
   }
@@ -2192,8 +2192,8 @@ static BOOL isScribbleAvailable() {
   newView.textInputDelegate = _textInputDelegate;
 
   for (NSDictionary* field in configuration[kAssociatedAutofillFields]) {
-    NSString* autofillId = autofillIdFromDictionary(field);
-    if (autofillId && autofillTypeOf(field) == FlutterAutofillTypeNone) {
+    NSString* autofillId = AutofillIdFromDictionary(field);
+    if (autofillId && AutofillTypeOf(field) == FlutterAutofillTypeNone) {
       [_autofillContext removeObjectForKey:autofillId];
     }
   }
@@ -2204,7 +2204,7 @@ static BOOL isScribbleAvailable() {
                                        focusedField:(NSDictionary*)focusedField
                                   isPasswordRelated:(BOOL)isPassword {
   FlutterTextInputView* focused = nil;
-  NSString* focusedId = autofillIdFromDictionary(focusedField);
+  NSString* focusedId = AutofillIdFromDictionary(focusedField);
   NSAssert(focusedId, @"autofillId must not be null for the focused field: %@", focusedField);
 
   if (!fields) {
@@ -2215,10 +2215,10 @@ static BOOL isScribbleAvailable() {
   }
 
   for (NSDictionary* field in fields) {
-    NSString* autofillId = autofillIdFromDictionary(field);
+    NSString* autofillId = AutofillIdFromDictionary(field);
     NSAssert(autofillId, @"autofillId must not be null for field: %@", field);
 
-    BOOL hasHints = autofillTypeOf(field) != FlutterAutofillTypeNone;
+    BOOL hasHints = AutofillTypeOf(field) != FlutterAutofillTypeNone;
     BOOL isFocused = [focusedId isEqualToString:autofillId];
 
     if (isFocused) {
@@ -2247,7 +2247,7 @@ static BOOL isScribbleAvailable() {
 // for autofill purposes so they should not be reused for a different type of views).
 - (FlutterTextInputView*)getOrCreateAutofillableView:(NSDictionary*)field
                                   isPasswordAutofill:(BOOL)needsPasswordAutofill {
-  NSString* autofillId = autofillIdFromDictionary(field);
+  NSString* autofillId = AutofillIdFromDictionary(field);
   FlutterTextInputView* inputView = _autofillContext[autofillId];
   if (!inputView) {
     inputView =

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -23,14 +23,17 @@
 
 - (instancetype)init {
   NSAssert(NO, @"FlutterView must initWithDelegate");
+  return nil;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame {
   NSAssert(NO, @"FlutterView must initWithDelegate");
+  return nil;
 }
 
 - (instancetype)initWithCoder:(NSCoder*)aDecoder {
   NSAssert(NO, @"FlutterView must initWithDelegate");
+  return nil;
 }
 
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate opaque:(BOOL)opaque {

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -21,24 +21,6 @@
   id<FlutterViewEngineDelegate> _delegate;
 }
 
-- (instancetype)init {
-  @throw([NSException exceptionWithName:@"FlutterView must initWithDelegate"
-                                 reason:nil
-                               userInfo:nil]);
-}
-
-- (instancetype)initWithFrame:(CGRect)frame {
-  @throw([NSException exceptionWithName:@"FlutterView must initWithDelegate"
-                                 reason:nil
-                               userInfo:nil]);
-}
-
-- (instancetype)initWithCoder:(NSCoder*)aDecoder {
-  @throw([NSException exceptionWithName:@"FlutterView must initWithDelegate"
-                                 reason:nil
-                               userInfo:nil]);
-}
-
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate opaque:(BOOL)opaque {
   if (delegate == nil) {
     NSLog(@"FlutterView delegate was nil.");

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -21,6 +21,18 @@
   id<FlutterViewEngineDelegate> _delegate;
 }
 
+- (instancetype)init {
+  NSAssert(NO, @"FlutterView must initWithDelegate");
+}
+
+- (instancetype)initWithFrame:(CGRect)frame {
+  NSAssert(NO, @"FlutterView must initWithDelegate");
+}
+
+- (instancetype)initWithCoder:(NSCoder*)aDecoder {
+  NSAssert(NO, @"FlutterView must initWithDelegate");
+}
+
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate opaque:(BOOL)opaque {
   if (delegate == nil) {
     NSLog(@"FlutterView delegate was nil.");

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -422,7 +422,7 @@ static UIView* GetViewOrPlaceholder(UIView* existing_view) {
   _scrollView.reset(scrollView);
 }
 
-static void sendFakeTouchEvent(FlutterEngine* engine,
+static void SendFakeTouchEvent(FlutterEngine* engine,
                                CGPoint location,
                                flutter::PointerData::Change change) {
   const CGFloat scale = [UIScreen mainScreen].scale;
@@ -443,8 +443,8 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
     return NO;
   }
   CGPoint statusBarPoint = CGPointZero;
-  sendFakeTouchEvent(_engine.get(), statusBarPoint, flutter::PointerData::Change::kDown);
-  sendFakeTouchEvent(_engine.get(), statusBarPoint, flutter::PointerData::Change::kUp);
+  SendFakeTouchEvent(_engine.get(), statusBarPoint, flutter::PointerData::Change::kDown);
+  SendFakeTouchEvent(_engine.get(), statusBarPoint, flutter::PointerData::Change::kUp);
   return NO;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -110,7 +110,7 @@ void VsyncWaiterIOS::AwaitVSync() {
 + (double)displayRefreshRate {
   if (@available(iOS 10.3, *)) {
     fml::scoped_nsobject<CADisplayLink> display_link = fml::scoped_nsobject<CADisplayLink> {
-      [[CADisplayLink displayLinkWithTarget:[[DisplayLinkManager new] autorelease]
+      [[CADisplayLink displayLinkWithTarget:[[[DisplayLinkManager alloc] init] autorelease]
                                    selector:@selector(onDisplayLink:)] retain]
     };
     display_link.get().paused = YES;

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextureRegistrar.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextureRegistrar.mm
@@ -15,12 +15,6 @@
   NSMutableDictionary<NSNumber*, id<FlutterMacOSExternalTexture>>* _textures;
 }
 
-- (instancetype)init {
-  @throw([NSException exceptionWithName:@"FlutterTextureRegistrar must initWithDelegate"
-                                 reason:nil
-                               userInfo:nil]);
-}
-
 - (instancetype)initWithDelegate:(id<FlutterTextureRegistrarDelegate>)delegate
                           engine:(FlutterEngine*)engine {
   if (self = [super init]) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewControllerTestUtils.mm
@@ -27,4 +27,4 @@ id CreateMockViewController(NSString* pasteboardString) {
   }
 }
 
-}
+}  // namespace flutter::testing


### PR DESCRIPTION
Run `clang-tidy` on `host_debug` and `ios_debug` for [`google-objc-*`](https://clang.llvm.org/extra/clang-tidy/checks/list.html) analyzer checks.

Part of https://github.com/flutter/flutter/issues/93279 and https://github.com/flutter/flutter/issues/91857

```
$ ../buildtools/mac-x64/clang/bin/clang-tidy --dump-config
Checks:          'clang-diagnostic-*,clang-analyzer-*,google-*,-google-objc-global-variable-declaration,-google-objc-avoid-throwing-exception'
WarningsAsErrors: 'clang-analyzer-osx.*,google-objc-*'
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.
