### PR TITLE
[Linux, Keyboard] Fix synthesization upon different logical keys  

### DIFF
--- a/shell/platform/linux/fl_key_channel_responder.cc
+++ b/shell/platform/linux/fl_key_channel_responder.cc
@@ -132,7 +132,7 @@ static void handle_response(GObject* object,
                             gpointer user_data) {
   g_autoptr(FlKeyChannelUserData) data = FL_KEY_CHANNEL_USER_DATA(user_data);
 
-  // Will also return if the weak pointer has been destroyed.
+  // This is true if the weak pointer has been destroyed.
   if (data->responder == nullptr) {
     return;
   }
@@ -146,12 +146,14 @@ static void handle_response(GObject* object,
   if (self->mock != nullptr && self->mock->value_converter != nullptr) {
     message = self->mock->value_converter(message);
   }
+  bool handled = false;
   if (error != nullptr) {
     g_warning("Unable to retrieve framework response: %s", error->message);
-    return;
+  } else {
+    g_autoptr(FlValue) handled_value =
+        fl_value_lookup_string(message, "handled");
+    handled = fl_value_get_bool(handled_value);
   }
-  g_autoptr(FlValue) handled_value = fl_value_lookup_string(message, "handled");
-  bool handled = fl_value_get_bool(handled_value);
 
   data->callback(handled, data->user_data);
 }

--- a/shell/platform/linux/fl_key_embedder_responder.cc
+++ b/shell/platform/linux/fl_key_embedder_responder.cc
@@ -34,6 +34,23 @@ static uint64_t lookup_hash_table(GHashTable* table, uint64_t key) {
       g_hash_table_lookup(table, uint64_to_gpointer(key)));
 }
 
+static gboolean hash_table_find_equal_value(gpointer key,
+                                            gpointer value,
+                                            gpointer user_data) {
+  return gpointer_to_uint64(value) == gpointer_to_uint64(user_data);
+}
+
+// Look up a hash table that maps a uint64_t to a uint64_t; given its key,
+// find its value.
+//
+// Returns 0 if not found.
+//
+// Both key and value should be directly hashed.
+static uint64_t reverse_lookup_hash_table(GHashTable* table, uint64_t value) {
+  return gpointer_to_uint64(g_hash_table_find(
+      table, hash_table_find_equal_value, uint64_to_gpointer(value)));
+}
+
 static uint64_t to_lower(uint64_t n) {
   constexpr uint64_t lower_a = 0x61;
   constexpr uint64_t upper_a = 0x41;
@@ -427,48 +444,59 @@ static void synchronize_pressed_states_loop_body(gpointer key,
 
   const guint modifier_bit = GPOINTER_TO_INT(key);
   FlKeyEmbedderResponder* self = context->self;
+  // Each TestKey contains up to two logical keys, typically the left modifier
+  // and the right modifier, that correspond to the same modifier_bit. We'd
+  // like to infer whether to synthesize a down or up event for each key.
+  //
+  // The hard part is that, if we want to synthesize a down event, we don't know
+  // which physical key to use. Here we assume the keyboard layout do not change
+  // frequently and use the last physical-logical relationship, recorded in
+  // #mapping_records.
   const uint64_t logical_keys[] = {
       checked_key->primary_logical_key,
       checked_key->secondary_logical_key,
   };
   const guint length = checked_key->secondary_logical_key == 0 ? 1 : 2;
 
-  const bool pressed_by_state = (context->state & modifier_bit) != 0;
+  const bool any_pressed_by_state = (context->state & modifier_bit) != 0;
 
-  bool pressed_by_record = false;
+  bool any_pressed_by_record = false;
 
   // Traverse each logical key of this modifier bit for 2 purposes:
   //
-  //  1. Find if this logical key is pressed before the event,
-  //     and synthesize a release event if needed.
-  //  2. Find if any logical key of this modifier is pressed
-  //     before the event (#pressed_by_record), so that we can decide
-  //     whether to synthesize a press event later.
+  //  1. Perform the synthesization of release events: If the modifier bit is 0
+  //     and the key is pressed, synthesize a release event.
+  //  2. Prepare for the synthesization of press events: If the modifier bit is
+  //     1, and no keys are pressed (discovered here), synthesize a press event
+  //     later.
   for (guint logical_key_idx = 0; logical_key_idx < length; logical_key_idx++) {
     const uint64_t logical_key = logical_keys[logical_key_idx];
-    const uint64_t recorded_physical_key =
-        lookup_hash_table(self->mapping_records, logical_key);
-    const uint64_t pressed_logical_key_before_event =
-        recorded_physical_key == 0
-            ? 0
-            : lookup_hash_table(self->pressing_records, recorded_physical_key);
-    const bool this_key_pressed_before_event =
-        pressed_logical_key_before_event != 0;
+    g_return_if_fail(logical_key != 0);
+    const uint64_t pressing_physical_key =
+        reverse_lookup_hash_table(self->pressing_records, logical_key);
+    const bool this_key_pressed_before_event = pressing_physical_key != 0;
 
-    g_return_if_fail(pressed_logical_key_before_event == 0 ||
-                     pressed_logical_key_before_event == logical_key);
+    any_pressed_by_record =
+        any_pressed_by_record || this_key_pressed_before_event;
 
-    pressed_by_record = pressed_by_record || this_key_pressed_before_event;
-
-    if (this_key_pressed_before_event && !pressed_by_state) {
+    if (this_key_pressed_before_event && !any_pressed_by_state) {
+      const uint64_t recorded_physical_key =
+          lookup_hash_table(self->mapping_records, logical_key);
+      // Since this key has been pressed before, there must have been a recorded
+      // physical key.
+      g_return_if_fail(recorded_physical_key != 0);
+      // In rare cases #recorded_logical_key is different from #logical_key.
+      const uint64_t recorded_logical_key =
+          lookup_hash_table(self->pressing_records, recorded_physical_key);
       synthesize_simple_event(self, kFlutterKeyEventTypeUp,
-                              recorded_physical_key, logical_key,
+                              recorded_physical_key, recorded_logical_key,
                               context->timestamp);
       update_pressing_state(self, recorded_physical_key, 0);
     }
   }
-  // If the modifier should be pressed, press its primary key.
-  if (pressed_by_state && !pressed_by_record) {
+  // If the modifier should be pressed, synthesize a down event for its primary
+  // key.
+  if (any_pressed_by_state && !any_pressed_by_record) {
     const uint64_t logical_key = checked_key->primary_logical_key;
     const uint64_t recorded_physical_key =
         lookup_hash_table(self->mapping_records, logical_key);

--- a/shell/platform/linux/fl_key_embedder_responder_test.cc
+++ b/shell/platform/linux/fl_key_embedder_responder_test.cc
@@ -1641,8 +1641,8 @@ TEST(FlKeyEmbedderResponderTest, SynthesizationOccursOnIgnoredEvents) {
 
 // This test case occurs when the following two cases collide:
 //
-// 1. When holding shift, AltRight key gives logical GDK_KEY_Meta_R with the state
-//    bitmask still MOD3 (Alt).
+// 1. When holding shift, AltRight key gives logical GDK_KEY_Meta_R with the
+//    state bitmask still MOD3 (Alt).
 // 2. When holding AltRight, ShiftLeft key gives logical GDK_KEY_ISO_Next_Group
 //    with the state bitmask RESERVED_14.
 //
@@ -1674,8 +1674,7 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
 
   send_key_event(kPress, GDK_KEY_Shift_L, kKeyCodeShiftLeft, 0x2000000);
   EXPECT_EQ(g_call_records->len, 1u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records,
-    0));
+  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 0));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(record->event->logical, kLogicalShiftLeft);
@@ -1683,8 +1682,7 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
 
   send_key_event(kPress, GDK_KEY_Meta_R, kKeyCodeAltRight, 0x2000001);
   EXPECT_EQ(g_call_records->len, 2u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records,
-    1));
+  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 1));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalAltRight);
   EXPECT_EQ(record->event->logical, kLogicalMetaRight);
@@ -1693,32 +1691,27 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   send_key_event(kRelease, GDK_KEY_ISO_Next_Group, kKeyCodeShiftLeft,
                  0x2000009);
   EXPECT_EQ(g_call_records->len, 5u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records,
-    2));
+  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 2));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalAltLeft);
   EXPECT_EQ(record->event->logical, kLogicalAltLeft);
   EXPECT_EQ(record->event->synthesized, true);
 
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records,
-    3));
+  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 3));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(record->event->physical, kPhysicalAltRight);
   EXPECT_EQ(record->event->logical, kLogicalMetaRight);
   EXPECT_EQ(record->event->synthesized, true);
 
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records,
-    4));
+  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 4));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(record->event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(record->event->logical, kLogicalShiftLeft);
   EXPECT_EQ(record->event->synthesized, false);
 
-  send_key_event(kPress, GDK_KEY_ISO_Next_Group, kKeyCodeShiftLeft,
-                 0x2000008);
+  send_key_event(kPress, GDK_KEY_ISO_Next_Group, kKeyCodeShiftLeft, 0x2000008);
   EXPECT_EQ(g_call_records->len, 6u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records,
-    5));
+  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 5));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeDown);
   EXPECT_EQ(record->event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(record->event->logical, kLogicalGroupNext);
@@ -1727,23 +1720,19 @@ TEST(FlKeyEmbedderResponderTest, HandlesShiftAltVersusGroupNext) {
   send_key_event(kRelease, GDK_KEY_ISO_Level3_Shift, kKeyCodeAltRight,
                  0x2002008);
   EXPECT_EQ(g_call_records->len, 7u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records,
-    6));
+  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 6));
   EXPECT_EQ(record->event->physical, 0u);
   EXPECT_EQ(record->event->logical, 0u);
 
-  send_key_event(kRelease, GDK_KEY_Shift_L, kKeyCodeShiftLeft,
-                 0x2002000);
+  send_key_event(kRelease, GDK_KEY_Shift_L, kKeyCodeShiftLeft, 0x2002000);
   EXPECT_EQ(g_call_records->len, 9u);
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records,
-    7));
+  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 7));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(record->event->physical, kPhysicalAltLeft);
   EXPECT_EQ(record->event->logical, kLogicalAltLeft);
   EXPECT_EQ(record->event->synthesized, true);
 
-  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records,
-    8));
+  record = FL_KEY_EMBEDDER_CALL_RECORD(g_ptr_array_index(g_call_records, 8));
   EXPECT_EQ(record->event->type, kFlutterKeyEventTypeUp);
   EXPECT_EQ(record->event->physical, kPhysicalShiftLeft);
   EXPECT_EQ(record->event->logical, kLogicalGroupNext);


### PR DESCRIPTION
This PR fixes an assertion error when the physical-logical map changes during key synthesization. This error will lead to irregular key sequences, and might occur during an extremely rare edge case described in the unit test in this PR.

This PR fixes one of the two symptoms of https://github.com/flutter/flutter/issues/93278.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
