### PR TITLE
Revert "Acquire context reference at the correct time for FlGlArea."

### DIFF
--- a/shell/platform/linux/fl_gl_area.cc
+++ b/shell/platform/linux/fl_gl_area.cc
@@ -118,7 +118,7 @@ GtkWidget* fl_gl_area_new(GdkGLContext* context) {
   g_return_val_if_fail(GDK_IS_GL_CONTEXT(context), nullptr);
   FlGLArea* area =
       reinterpret_cast<FlGLArea*>(g_object_new(fl_gl_area_get_type(), nullptr));
-  area->context = GDK_GL_CONTEXT(g_object_ref(context));
+  area->context = context;
   return GTK_WIDGET(area);
 }
 

--- a/shell/platform/linux/fl_renderer_gl.cc
+++ b/shell/platform/linux/fl_renderer_gl.cc
@@ -103,6 +103,7 @@ static gboolean fl_renderer_gl_present_layers(FlRenderer* renderer,
       case kFlutterLayerContentTypeBackingStore: {
         const FlutterBackingStore* backing_store = layer->backing_store;
         auto framebuffer = &backing_store->open_gl.framebuffer;
+        g_object_ref(context);
         fl_view_add_gl_area(
             view, context,
             reinterpret_cast<FlBackingStoreProvider*>(framebuffer->user_data));


### PR DESCRIPTION
Reverts flutter/engine#29542

This was landed on master branch during the migration of master branch to main. Reverting and relanding on main.