### PR TITLE
Set iOS default frame rate to screen max.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1561,6 +1561,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/profiler_metri
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/profiler_metrics_ios.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/module.modulemap
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_context.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_context.mm

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1546,6 +1546,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/KeyCodeMap_Int
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/SemanticsObject.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/SemanticsObjectTest.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge_ios.h
@@ -1561,7 +1562,6 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/profiler_metri
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/profiler_metrics_ios.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
-FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/module.modulemap
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_context.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_context.mm

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -209,6 +209,7 @@ source_set("ios_test_flutter_mrc") {
     "framework/Source/FlutterPlatformViewsTest.mm",
     "framework/Source/FlutterViewTest.mm",
     "framework/Source/accessibility_bridge_test.mm",
+    "framework/Source/VsyncWaiterIosTest.mm",
     "platform_message_handler_ios_test.mm",
   ]
   deps = [

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -208,8 +208,8 @@ source_set("ios_test_flutter_mrc") {
     "framework/Source/FlutterPlatformPluginTest.mm",
     "framework/Source/FlutterPlatformViewsTest.mm",
     "framework/Source/FlutterViewTest.mm",
-    "framework/Source/accessibility_bridge_test.mm",
     "framework/Source/VsyncWaiterIosTest.mm",
+    "framework/Source/accessibility_bridge_test.mm",
     "platform_message_handler_ios_test.mm",
   ]
   deps = [

--- a/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+
+#include "flutter/fml/thread.h"
+
+#import "flutter/shell/platform/darwin/common/framework/Headers/FlutterMacros.h"
+#import "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
+
+FLUTTER_ASSERT_NOT_ARC
+namespace {
+fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
+  auto thread = std::make_unique<fml::Thread>(name);
+  auto runner = thread->GetTaskRunner();
+  return runner;
+}
+}
+
+@interface VsyncWaiterIosTest : XCTestCase
+@end
+
+@implementation VsyncWaiterIosTest
+
+- (void)testCreate {
+  auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
+  auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
+  VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner callback:callback] autorelease];
+  XCTAssertNotNil(vsyncClient);
+}
+
+- (void)testSetCorrectVirableRefreshRates {
+  auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
+  auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
+  VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner callback:callback] autorelease];
+  id bundleMock = OCMPartialMock([NSBundle mainBundle]);
+  OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"]).andReturn(@YES);
+  id mockDisplayLinkManager = [[OCMockObject mockForClass:[DisplayLinkManager class]] autorelease];
+  double maxFrameRate = 120;
+  [[[mockDisplayLinkManager stub] andReturn:@(maxFrameRate)] displayRefreshRate];
+  CADisplayLink *link = [vsyncClient getDisplayLink];
+  if (@available(iOS 15.0, *)) {
+    XCTAssertEqual(link.preferredFrameRateRange.maximum, maxFrameRate);
+    XCTAssertEqual(link.preferredFrameRateRange.preferred, maxFrameRate);
+    XCTAssertEqual(link.preferredFrameRateRange.minimum, maxFrameRate/2);
+  } else if (@available(iOS 10.0, *)) {
+    XCTAssertEqual(link.preferredFramesPerSecond, maxFrameRate);
+  }
+}
+
+@end

--- a/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
@@ -34,8 +34,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   double maxFrameRate = 120;
   [[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
 
-  VSyncClient* vsyncClient = [[VSyncClient alloc] initWithTaskRunner:thread_task_runner
-                                                            callback:callback];
+  VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner
+                                                            callback:callback] autorelease];
   CADisplayLink* link = [vsyncClient getDisplayLink];
   if (@available(iOS 15.0, *)) {
     XCTAssertEqual(link.preferredFrameRateRange.maximum, maxFrameRate);
@@ -44,6 +44,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   } else if (@available(iOS 10.0, *)) {
     XCTAssertEqual(link.preferredFramesPerSecond, maxFrameRate);
   }
+  [vsyncClient release];
 }
 
 - (void)testDoNotSetVirableRefreshRatesIfCADisableMinimumFrameDurationOnPhoneIsNotOn {
@@ -56,8 +57,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   double maxFrameRate = 120;
   [[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
 
-  VSyncClient* vsyncClient = [[VSyncClient alloc] initWithTaskRunner:thread_task_runner
-                                                            callback:callback];
+  VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner
+                                                            callback:callback] autorelease];
   CADisplayLink* link = [vsyncClient getDisplayLink];
   if (@available(iOS 15.0, *)) {
     XCTAssertEqual(link.preferredFrameRateRange.maximum, 0);
@@ -66,6 +67,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   } else if (@available(iOS 10.0, *)) {
     XCTAssertEqual(link.preferredFramesPerSecond, 0);
   }
+  [vsyncClient release];
 }
 
 - (void)testDoNotSetVirableRefreshRatesIfCADisableMinimumFrameDurationOnPhoneIsNotSet {
@@ -74,9 +76,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   id mockDisplayLinkManager = [OCMockObject mockForClass:[DisplayLinkManager class]];
   double maxFrameRate = 120;
   [[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
-
-  VSyncClient* vsyncClient = [[VSyncClient alloc] initWithTaskRunner:thread_task_runner
-                                                            callback:callback];
+  VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner
+                                                            callback:callback] autorelease];
   CADisplayLink* link = [vsyncClient getDisplayLink];
   if (@available(iOS 15.0, *)) {
     XCTAssertEqual(link.preferredFrameRateRange.maximum, 0);
@@ -85,6 +86,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   } else if (@available(iOS 10.0, *)) {
     XCTAssertEqual(link.preferredFramesPerSecond, 0);
   }
+  [vsyncClient release];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
@@ -19,6 +19,12 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
 }
 }
 
+@interface VSyncClient (Testing)
+
+- (CADisplayLink*)getDisplayLink;
+
+@end
+
 @interface VsyncWaiterIosTest : XCTestCase
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
@@ -35,7 +35,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
 
   VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner
-                                                            callback:callback] autorelease];
+                                                             callback:callback] autorelease];
   CADisplayLink* link = [vsyncClient getDisplayLink];
   if (@available(iOS 15.0, *)) {
     XCTAssertEqual(link.preferredFrameRateRange.maximum, maxFrameRate);
@@ -58,7 +58,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
 
   VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner
-                                                            callback:callback] autorelease];
+                                                             callback:callback] autorelease];
   CADisplayLink* link = [vsyncClient getDisplayLink];
   if (@available(iOS 15.0, *)) {
     XCTAssertEqual(link.preferredFrameRateRange.maximum, 0);
@@ -77,7 +77,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   double maxFrameRate = 120;
   [[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
   VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner
-                                                            callback:callback] autorelease];
+                                                             callback:callback] autorelease];
   CADisplayLink* link = [vsyncClient getDisplayLink];
   if (@available(iOS 15.0, *)) {
     XCTAssertEqual(link.preferredFrameRateRange.maximum, 0);

--- a/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
@@ -27,7 +27,8 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
 - (void)testCreate {
   auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
-  VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner callback:callback] autorelease];
+  VSyncClient* vsyncClient = [[[VSyncClient alloc] initWithTaskRunner:thread_task_runner
+                                                             callback:callback] autorelease];
   XCTAssertNotNil(vsyncClient);
 }
 
@@ -35,17 +36,19 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
-  OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"]).andReturn(@YES);
+  OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"])
+      .andReturn(@YES);
   id mockDisplayLinkManager = [OCMockObject mockForClass:[DisplayLinkManager class]];
   double maxFrameRate = 120;
   [[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
 
-  VSyncClient* vsyncClient = [[VSyncClient alloc] initWithTaskRunner:thread_task_runner callback:callback];
-  CADisplayLink *link = [vsyncClient getDisplayLink];
+  VSyncClient* vsyncClient = [[VSyncClient alloc] initWithTaskRunner:thread_task_runner
+                                                            callback:callback];
+  CADisplayLink* link = [vsyncClient getDisplayLink];
   if (@available(iOS 15.0, *)) {
     XCTAssertEqual(link.preferredFrameRateRange.maximum, maxFrameRate);
     XCTAssertEqual(link.preferredFrameRateRange.preferred, maxFrameRate);
-    XCTAssertEqual(link.preferredFrameRateRange.minimum, maxFrameRate/2);
+    XCTAssertEqual(link.preferredFrameRateRange.minimum, maxFrameRate / 2);
   } else if (@available(iOS 10.0, *)) {
     XCTAssertEqual(link.preferredFramesPerSecond, maxFrameRate);
   }
@@ -55,13 +58,15 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
-  OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"]).andReturn(@NO);
+  OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"])
+      .andReturn(@NO);
   id mockDisplayLinkManager = [OCMockObject mockForClass:[DisplayLinkManager class]];
   double maxFrameRate = 120;
   [[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];
 
-  VSyncClient* vsyncClient = [[VSyncClient alloc] initWithTaskRunner:thread_task_runner callback:callback];
-  CADisplayLink *link = [vsyncClient getDisplayLink];
+  VSyncClient* vsyncClient = [[VSyncClient alloc] initWithTaskRunner:thread_task_runner
+                                                            callback:callback];
+  CADisplayLink* link = [vsyncClient getDisplayLink];
   if (@available(iOS 15.0, *)) {
     XCTAssertEqual(link.preferredFrameRateRange.maximum, 0);
     XCTAssertEqual(link.preferredFrameRateRange.preferred, 0);

--- a/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
@@ -71,9 +71,6 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
 - (void)testDoNotSetVirableRefreshRatesIfCADisableMinimumFrameDurationOnPhoneIsNotSet {
   auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
-  //   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
-  //   OCMStub([bundleMock objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"])
-  //       .andReturn(nil);
   id mockDisplayLinkManager = [OCMockObject mockForClass:[DisplayLinkManager class]];
   double maxFrameRate = 120;
   [[[mockDisplayLinkManager stub] andReturnValue:@(maxFrameRate)] displayRefreshRate];

--- a/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/VsyncWaiterIosTest.mm
@@ -30,7 +30,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
 
 @implementation VsyncWaiterIosTest
 
-- (void)testSetCorrectVirableRefreshRates {
+- (void)testSetCorrectVariableRefreshRates {
   auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
@@ -53,7 +53,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [vsyncClient release];
 }
 
-- (void)testDoNotSetVirableRefreshRatesIfCADisableMinimumFrameDurationOnPhoneIsNotOn {
+- (void)testDoNotSetVariableRefreshRatesIfCADisableMinimumFrameDurationOnPhoneIsNotOn {
   auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
   id bundleMock = OCMPartialMock([NSBundle mainBundle]);
@@ -76,7 +76,7 @@ fml::RefPtr<fml::TaskRunner> CreateNewThread(std::string name) {
   [vsyncClient release];
 }
 
-- (void)testDoNotSetVirableRefreshRatesIfCADisableMinimumFrameDurationOnPhoneIsNotSet {
+- (void)testDoNotSetVariableRefreshRatesIfCADisableMinimumFrameDurationOnPhoneIsNotSet {
   auto thread_task_runner = CreateNewThread("VsyncWaiterIosTest");
   auto callback = [](std::unique_ptr<flutter::FrameTimingsRecorder> recorder) {};
   id mockDisplayLinkManager = [OCMockObject mockForClass:[DisplayLinkManager class]];

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -39,9 +39,6 @@
 
 - (double)getRefreshRate;
 
-// For testing only.
-- (CADisplayLink*)getDisplayLink;
-
 @end
 
 namespace flutter {

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -40,7 +40,7 @@
 - (double)getRefreshRate;
 
 // For testing only.
-- (CADisplayLink *)getDisplayLink;
+- (CADisplayLink*)getDisplayLink;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_VSYNC_WAITER_IOS_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_VSYNC_WAITER_IOS_H_
 
+#include <QuartzCore/CADisplayLink.h>
+
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
@@ -36,6 +38,9 @@
 - (void)invalidate;
 
 - (double)getRefreshRate;
+
+// For testing only.
+- (CADisplayLink *)getDisplayLink;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -7,7 +7,6 @@
 #include <utility>
 
 #include <Foundation/Foundation.h>
-#include <QuartzCore/CADisplayLink.h>
 #include <UIKit/UIKit.h>
 #include <mach/mach_time.h>
 
@@ -64,6 +63,8 @@ double VsyncWaiterIOS::GetRefreshRate() const {
     };
     display_link_.get().paused = YES;
 
+    [self setMaxRefreshRateIfEnabled];
+
     task_runner->PostTask([client = [self retain]]() {
       [client->display_link_.get() addToRunLoop:[NSRunLoop currentRunLoop]
                                         forMode:NSRunLoopCommonModes];
@@ -72,6 +73,23 @@ double VsyncWaiterIOS::GetRefreshRate() const {
   }
 
   return self;
+}
+
+- (void)setMaxRefreshRateIfEnabled {
+  NSNumber* minimumFrameRateDisabled =
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CADisableMinimumFrameDurationOnPhone"];
+  if (![minimumFrameRateDisabled boolValue]) {
+    return;
+  }
+  double maxFrameRate = fmax([DisplayLinkManager displayRefreshRate], 60);
+  double minFrameRate = fmax(maxFrameRate / 2, 60);
+
+  if (@available(iOS 15.0, *)) {
+    display_link_.get().preferredFrameRateRange =
+        CAFrameRateRangeMake(minFrameRate, maxFrameRate, maxFrameRate);
+  } else if (@available(iOS 10.0, *)) {
+    display_link_.get().preferredFramesPerSecond = maxFrameRate;
+  }
 }
 
 - (void)await {
@@ -99,7 +117,6 @@ double VsyncWaiterIOS::GetRefreshRate() const {
 
   recorder->RecordVsync(frame_start_time, frame_target_time);
   display_link_.get().paused = YES;
-
   callback_(std::move(recorder));
 }
 
@@ -115,6 +132,10 @@ double VsyncWaiterIOS::GetRefreshRate() const {
 
 - (double)getRefreshRate {
   return current_refresh_rate_;
+}
+
+- (CADisplayLink *)getDisplayLink {
+  return display_link_.get();
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -134,7 +134,7 @@ double VsyncWaiterIOS::GetRefreshRate() const {
   return current_refresh_rate_;
 }
 
-- (CADisplayLink *)getDisplayLink {
+- (CADisplayLink*)getDisplayLink {
   return display_link_.get();
 }
 

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		0D6AB6C922BB05E200EEE540 /* IosUnitTestsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = IosUnitTestsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D6AB6CF22BB05E200EEE540 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FlutterEngineConfig.xcconfig; sourceTree = "<group>"; };
+		68B6091227F62F990036AC78 /* VsyncWaiterIosTest.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VsyncWaiterIosTest.mm; sourceTree = "<group>"; };
 		F7521D7226BB671E005F15C5 /* libios_test_flutter.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libios_test_flutter.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libios_test_flutter.dylib"; sourceTree = "<group>"; };
 		F7521D7526BB673E005F15C5 /* libocmock_shared.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libocmock_shared.dylib; path = "../../../../out/$(FLUTTER_ENGINE)/libocmock_shared.dylib"; sourceTree = "<group>"; };
 		F77E081726FA9CE6003E6E4C /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = "../../../../out/$(FLUTTER_ENGINE)/Flutter.framework"; sourceTree = "<group>"; };
@@ -96,6 +97,7 @@
 		0AC232E924BA71D300A85907 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				68B6091227F62F990036AC78 /* VsyncWaiterIosTest.mm */,
 				F7A3FDE026B9E0A300EADD61 /* FlutterAppDelegateTest.mm */,
 				0AC232F424BA71D300A85907 /* SemanticsObjectTest.mm */,
 				0AC232F724BA71D300A85907 /* FlutterEngineTest.mm */,


### PR DESCRIPTION
The default iOS frame rate is set to 60 by default. This PR explicitly sets the preferred rate to the maximum refresh rate supported by the display. (120 on iPhone 13 pro, 60 on slower devices)
On iOS 15 and above, we also set the frame rate range, where the preferred and max are both screen max, the min is max/2.
Also, we avoid setting the preferred frame rate to a value lower than 60.

Fixes https://github.com/flutter/flutter/issues/90675

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
