### PR TITLE
Listen for display refresh changes and report them correctly

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -694,6 +694,7 @@ FILE: ../../../flutter/shell/common/canvas_spy_unittests.cc
 FILE: ../../../flutter/shell/common/context_options.cc
 FILE: ../../../flutter/shell/common/context_options.h
 FILE: ../../../flutter/shell/common/dart_native_benchmarks.cc
+FILE: ../../../flutter/shell/common/display.cc
 FILE: ../../../flutter/shell/common/display.h
 FILE: ../../../flutter/shell/common/display_manager.cc
 FILE: ../../../flutter/shell/common/display_manager.h
@@ -773,6 +774,8 @@ FILE: ../../../flutter/shell/platform/android/AndroidManifest.xml
 FILE: ../../../flutter/shell/platform/android/android_context_gl.cc
 FILE: ../../../flutter/shell/platform/android/android_context_gl.h
 FILE: ../../../flutter/shell/platform/android/android_context_gl_unittests.cc
+FILE: ../../../flutter/shell/platform/android/android_display.cc
+FILE: ../../../flutter/shell/platform/android/android_display.h
 FILE: ../../../flutter/shell/platform/android/android_environment_gl.cc
 FILE: ../../../flutter/shell/platform/android/android_environment_gl.h
 FILE: ../../../flutter/shell/platform/android/android_exports.lst

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -66,6 +66,7 @@ source_set("common") {
     "canvas_spy.h",
     "context_options.cc",
     "context_options.h",
+    "display.cc",
     "display.h",
     "display_manager.cc",
     "display_manager.h",

--- a/shell/common/display.cc
+++ b/shell/common/display.cc
@@ -1,0 +1,13 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/common/display.h"
+
+#include "flutter/fml/logging.h"
+
+namespace flutter {
+double Display::GetRefreshRate() const {
+  return refresh_rate_;
+}
+}  // namespace flutter

--- a/shell/common/display.h
+++ b/shell/common/display.h
@@ -7,6 +7,8 @@
 
 #include <optional>
 
+#include "flutter/fml/macros.h"
+
 namespace flutter {
 
 /// Unique ID per display that is stable until the Flutter application restarts.
@@ -36,11 +38,11 @@ class Display {
   explicit Display(double refresh_rate)
       : display_id_({}), refresh_rate_(refresh_rate) {}
 
-  ~Display() = default;
+  virtual ~Display() = default;
 
   // Get the display's maximum refresh rate in the unit of frame per second.
   // Return `kUnknownDisplayRefreshRate` if the refresh rate is unknown.
-  double GetRefreshRate() const { return refresh_rate_; }
+  virtual double GetRefreshRate() const;
 
   /// Returns the `DisplayId` of the display.
   std::optional<DisplayId> GetDisplayId() const { return display_id_; }
@@ -48,6 +50,8 @@ class Display {
  private:
   std::optional<DisplayId> display_id_;
   double refresh_rate_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(Display);
 };
 
 }  // namespace flutter

--- a/shell/common/display_manager.cc
+++ b/shell/common/display_manager.cc
@@ -18,18 +18,19 @@ double DisplayManager::GetMainDisplayRefreshRate() const {
   if (displays_.empty()) {
     return kUnknownDisplayRefreshRate;
   } else {
-    return displays_[0].GetRefreshRate();
+    return displays_[0]->GetRefreshRate();
   }
 }
 
-void DisplayManager::HandleDisplayUpdates(DisplayUpdateType update_type,
-                                          std::vector<Display> displays) {
+void DisplayManager::HandleDisplayUpdates(
+    DisplayUpdateType update_type,
+    std::vector<std::unique_ptr<Display>> displays) {
   std::scoped_lock lock(displays_mutex_);
   CheckDisplayConfiguration(displays);
   switch (update_type) {
     case DisplayUpdateType::kStartup:
       FML_CHECK(displays_.empty());
-      displays_ = displays;
+      displays_ = std::move(displays);
       return;
     default:
       FML_CHECK(false) << "Unknown DisplayUpdateType.";
@@ -37,11 +38,11 @@ void DisplayManager::HandleDisplayUpdates(DisplayUpdateType update_type,
 }
 
 void DisplayManager::CheckDisplayConfiguration(
-    std::vector<Display> displays) const {
+    const std::vector<std::unique_ptr<Display>>& displays) const {
   FML_CHECK(!displays.empty());
   if (displays.size() > 1) {
     for (auto& display : displays) {
-      FML_CHECK(display.GetDisplayId().has_value());
+      FML_CHECK(display->GetDisplayId().has_value());
     }
   }
 }

--- a/shell/common/display_manager.h
+++ b/shell/common/display_manager.h
@@ -40,18 +40,19 @@ class DisplayManager {
 
   /// Handles the display updates.
   void HandleDisplayUpdates(DisplayUpdateType update_type,
-                            std::vector<Display> displays);
+                            std::vector<std::unique_ptr<Display>> displays);
 
  private:
   /// Guards `displays_` vector.
   mutable std::mutex displays_mutex_;
-  std::vector<Display> displays_;
+  std::vector<std::unique_ptr<Display>> displays_;
 
   /// Checks that the provided display configuration is valid. Currently this
   /// ensures that all the displays have an id in the case there are multiple
   /// displays. In case where there is a single display, it is valid for the
   /// display to not have an id.
-  void CheckDisplayConfiguration(std::vector<Display> displays) const;
+  void CheckDisplayConfiguration(
+      const std::vector<std::unique_ptr<Display>>& displays) const;
 };
 
 }  // namespace flutter

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1867,8 +1867,8 @@ void Shell::SetGpuAvailability(GpuAvailability availability) {
 }
 
 void Shell::OnDisplayUpdates(DisplayUpdateType update_type,
-                             std::vector<Display> displays) {
-  display_manager_->HandleDisplayUpdates(update_type, displays);
+                             std::vector<std::unique_ptr<Display>> displays) {
+  display_manager_->HandleDisplayUpdates(update_type, std::move(displays));
 }
 
 fml::TimePoint Shell::GetCurrentTimePoint() {

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -373,7 +373,7 @@ class Shell final : public PlatformView::Delegate,
   /// @brief      Notifies the display manager of the updates.
   ///
   void OnDisplayUpdates(DisplayUpdateType update_type,
-                        std::vector<Display> displays);
+                        std::vector<std::unique_ptr<Display>> displays);
 
   //----------------------------------------------------------------------------
   /// @brief Queries the `DisplayManager` for the main display refresh rate.

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -64,6 +64,8 @@ source_set("flutter_shell_native_src") {
     "$root_build_dir/flutter_icu/icudtl.o",
     "android_context_gl.cc",
     "android_context_gl.h",
+    "android_display.cc",
+    "android_display.h",
     "android_environment_gl.cc",
     "android_environment_gl.h",
     "android_external_texture_gl.cc",

--- a/shell/platform/android/android_display.cc
+++ b/shell/platform/android/android_display.cc
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/android/android_display.h"
+#include "android_display.h"
+
+namespace flutter {
+
+AndroidDisplay::AndroidDisplay(
+    std::shared_ptr<PlatformViewAndroidJNI> jni_facade)
+    : Display(jni_facade->GetDisplayRefreshRate()),
+      jni_facade_(std::move(jni_facade)) {}
+
+double AndroidDisplay::GetRefreshRate() const {
+  return jni_facade_->GetDisplayRefreshRate();
+}
+
+}  // namespace flutter

--- a/shell/platform/android/android_display.h
+++ b/shell/platform/android/android_display.h
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_ANDROID_DISPLAY_H_
+#define FLUTTER_SHELL_PLATFORM_ANDROID_DISPLAY_H_
+
+#include <cstdint>
+
+#include "flutter/fml/macros.h"
+#include "flutter/shell/common/display.h"
+#include "flutter/shell/platform/android/jni/platform_view_android_jni.h"
+
+namespace flutter {
+
+/// A |Display| that listens to refresh rate changes.
+class AndroidDisplay : public Display {
+ public:
+  explicit AndroidDisplay(std::shared_ptr<PlatformViewAndroidJNI> jni_facade);
+  ~AndroidDisplay() = default;
+
+  // |Display|
+  double GetRefreshRate() const override;
+
+ private:
+  std::shared_ptr<PlatformViewAndroidJNI> jni_facade_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AndroidDisplay);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_ANDROID_DISPLAY_H_

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -25,6 +25,7 @@
 #include "flutter/shell/common/rasterizer.h"
 #include "flutter/shell/common/run_configuration.h"
 #include "flutter/shell/common/thread_host.h"
+#include "flutter/shell/platform/android/android_display.h"
 #include "flutter/shell/platform/android/android_image_generator.h"
 #include "flutter/shell/platform/android/context/android_context.h"
 #include "flutter/shell/platform/android/platform_view_android.h"
@@ -61,8 +62,10 @@ AndroidShellHolder::AndroidShellHolder(
                 .enable_software_rendering  // use software rendering
         );
         weak_platform_view = platform_view_android->GetWeakPtr();
-        auto display = Display(jni_facade->GetDisplayRefreshRate());
-        shell.OnDisplayUpdates(DisplayUpdateType::kStartup, {display});
+        std::vector<std::unique_ptr<Display>> displays;
+        displays.push_back(std::make_unique<AndroidDisplay>(jni_facade));
+        shell.OnDisplayUpdates(DisplayUpdateType::kStartup,
+                               std::move(displays));
         return platform_view_android;
       };
 
@@ -209,8 +212,10 @@ std::unique_ptr<AndroidShellHolder> AndroidShellHolder::Spawn(
             android_context          // Android context
         );
         weak_platform_view = platform_view_android->GetWeakPtr();
-        auto display = Display(jni_facade->GetDisplayRefreshRate());
-        shell.OnDisplayUpdates(DisplayUpdateType::kStartup, {display});
+        std::vector<std::unique_ptr<Display>> displays;
+        displays.push_back(std::make_unique<AndroidDisplay>(jni_facade));
+        shell.OnDisplayUpdates(DisplayUpdateType::kStartup,
+                               std::move(displays));
         return platform_view_android;
       };
 

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -15,7 +15,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
-import android.view.Display;
 import android.view.WindowManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -148,18 +147,18 @@ public class FlutterLoader {
       initStartTimestampMillis = SystemClock.uptimeMillis();
       flutterApplicationInfo = ApplicationInfoLoader.load(appContext);
 
-      float fps;
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      VsyncWaiter waiter;
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 /* 17 */) {
         final DisplayManager dm = appContext.getSystemService(DisplayManager.class);
-        final Display primaryDisplay = dm.getDisplay(Display.DEFAULT_DISPLAY);
-        fps = primaryDisplay.getRefreshRate();
+        waiter = VsyncWaiter.getInstance(dm, flutterJNI);
       } else {
-        fps =
+        float fps =
             ((WindowManager) appContext.getSystemService(Context.WINDOW_SERVICE))
                 .getDefaultDisplay()
                 .getRefreshRate();
+        waiter = VsyncWaiter.getInstance(fps, flutterJNI);
       }
-      VsyncWaiter.getInstance(fps).init();
+      waiter.init();
 
       // Use a background thread for initialization tasks that require disk access.
       Callable<InitResult> initTask =

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -149,7 +149,8 @@ public class FlutterLoader {
 
       VsyncWaiter waiter;
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 /* 17 */) {
-        final DisplayManager dm = appContext.getSystemService(DisplayManager.class);
+        final DisplayManager dm =
+            (DisplayManager) appContext.getSystemService(Context.DISPLAY_SERVICE);
         waiter = VsyncWaiter.getInstance(dm, flutterJNI);
       } else {
         float fps =

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -4,24 +4,78 @@
 
 package io.flutter.view;
 
+import android.annotation.TargetApi;
+import android.hardware.display.DisplayManager;
 import android.view.Choreographer;
+import android.view.Display;
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import io.flutter.embedding.engine.FlutterJNI;
 
 // TODO(mattcarroll): add javadoc.
 public class VsyncWaiter {
+  @TargetApi(17)
+  class DisplayListener implements DisplayManager.DisplayListener {
+    DisplayListener(DisplayManager displayManager) {
+      this.displayManager = displayManager;
+    }
+
+    private DisplayManager displayManager;
+
+    void register() {
+      displayManager.registerDisplayListener(this, null);
+    }
+
+    @Override
+    public void onDisplayAdded(int displayId) {}
+
+    @Override
+    public void onDisplayRemoved(int displayId) {}
+
+    @Override
+    public void onDisplayChanged(int displayId) {
+      if (displayId == Display.DEFAULT_DISPLAY) {
+        final Display primaryDisplay = displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+        float fps = primaryDisplay.getRefreshRate();
+        VsyncWaiter.this.refreshPeriodNanos = (long) (1000000000.0 / fps);
+        VsyncWaiter.this.flutterJNI.setRefreshRateFPS(fps);
+      }
+    }
+  }
+
   private static VsyncWaiter instance;
+  private static DisplayListener listener;
+  private long refreshPeriodNanos;
+  private FlutterJNI flutterJNI;
 
   @NonNull
-  public static VsyncWaiter getInstance(float fps) {
+  public static VsyncWaiter getInstance(float fps, FlutterJNI flutterJNI) {
     if (instance == null) {
-      instance = new VsyncWaiter(fps);
+      instance = new VsyncWaiter(flutterJNI);
+    }
+    flutterJNI.setRefreshRateFPS(fps);
+    instance.refreshPeriodNanos = (long) (1000000000.0 / fps);
+    return instance;
+  }
+
+  @TargetApi(17)
+  @NonNull
+  public static VsyncWaiter getInstance(DisplayManager displayManager, FlutterJNI flutterJNI) {
+    if (instance == null) {
+      instance = new VsyncWaiter(flutterJNI);
+    }
+    if (listener == null) {
+      listener = instance.new DisplayListener(displayManager);
+      listener.register();
     }
     return instance;
   }
 
-  private final float fps;
-  private final long refreshPeriodNanos;
+  // For tests, to reset the singleton between tests.
+  @VisibleForTesting
+  public static void reset() {
+    instance = null;
+  }
 
   private final FlutterJNI.AsyncWaitForVsyncDelegate asyncWaitForVsyncDelegate =
       new FlutterJNI.AsyncWaitForVsyncDelegate() {
@@ -36,21 +90,17 @@ public class VsyncWaiter {
                       if (delay < 0) {
                         delay = 0;
                       }
-                      FlutterJNI.nativeOnVsync(delay, refreshPeriodNanos, cookie);
+                      flutterJNI.nativeOnVsync(delay, refreshPeriodNanos, cookie);
                     }
                   });
         }
       };
 
-  private VsyncWaiter(float fps) {
-    this.fps = fps;
-    refreshPeriodNanos = (long) (1000000000.0 / fps);
+  private VsyncWaiter(FlutterJNI flutterJNI) {
+    this.flutterJNI = flutterJNI;
   }
 
   public void init() {
-    FlutterJNI.setAsyncWaitForVsyncDelegate(asyncWaitForVsyncDelegate);
-
-    // TODO(mattcarroll): look into moving FPS reporting to a plugin
-    FlutterJNI.setRefreshRateFPS(fps);
+    flutterJNI.setAsyncWaitForVsyncDelegate(asyncWaitForVsyncDelegate);
   }
 }

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -45,7 +45,7 @@ public class VsyncWaiter {
 
   private static VsyncWaiter instance;
   private static DisplayListener listener;
-  private long refreshPeriodNanos;
+  private long refreshPeriodNanos = -1;
   private FlutterJNI flutterJNI;
 
   @NonNull
@@ -68,6 +68,12 @@ public class VsyncWaiter {
       listener = instance.new DisplayListener(displayManager);
       listener.register();
     }
+    if (instance.refreshPeriodNanos == -1) {
+      final Display primaryDisplay = displayManager.getDisplay(Display.DEFAULT_DISPLAY);
+      float fps = primaryDisplay.getRefreshRate();
+      instance.refreshPeriodNanos = (long) (1000000000.0 / fps);
+      flutterJNI.setRefreshRateFPS(fps);
+    }
     return instance;
   }
 
@@ -75,6 +81,7 @@ public class VsyncWaiter {
   @VisibleForTesting
   public static void reset() {
     instance = null;
+    listener = null;
   }
 
   private final FlutterJNI.AsyncWaitForVsyncDelegate asyncWaitForVsyncDelegate =

--- a/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
+++ b/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.robolectric.Shadows.shadowOf;
 
+import android.annotation.TargetApi;
 import android.hardware.display.DisplayManager;
 import android.os.Looper;
 import android.view.Display;
@@ -49,6 +50,7 @@ public class VsyncWaiterTest {
     verify(mockFlutterJNI, times(1)).nativeOnVsync(anyLong(), eq(1000000000l / 10l), eq(1l));
   }
 
+  @TargetApi(17)
   @Test
   public void itSetsFpsWhenDisplayManagerUpdates() {
     FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);

--- a/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
+++ b/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
@@ -1,0 +1,86 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.view;
+
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.hardware.display.DisplayManager;
+import android.os.Looper;
+import android.view.Display;
+import io.flutter.embedding.engine.FlutterJNI;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class VsyncWaiterTest {
+  @Before
+  public void setUp() {
+    org.robolectric.shadows.ShadowLog.stream = System.out;
+    VsyncWaiter.reset();
+  }
+
+  @Test
+  public void itSetsFpsBelowApi17() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    VsyncWaiter waiter = VsyncWaiter.getInstance(10.0f, mockFlutterJNI);
+    verify(mockFlutterJNI, times(1)).setRefreshRateFPS(10.0f);
+
+    waiter.init();
+
+    ArgumentCaptor<FlutterJNI.AsyncWaitForVsyncDelegate> delegateCaptor =
+        ArgumentCaptor.forClass(FlutterJNI.AsyncWaitForVsyncDelegate.class);
+    verify(mockFlutterJNI, times(1)).setAsyncWaitForVsyncDelegate(delegateCaptor.capture());
+    delegateCaptor.getValue().asyncWaitForVsync(1);
+    shadowOf(Looper.getMainLooper()).idle();
+    verify(mockFlutterJNI, times(1)).nativeOnVsync(anyLong(), eq(1000000000l / 10l), eq(1l));
+  }
+
+  @Test
+  public void itSetsFpsWhenDisplayManagerUpdates() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    DisplayManager mockDisplayManager = mock(DisplayManager.class);
+    Display mockDisplay = mock(Display.class);
+    ArgumentCaptor<VsyncWaiter.DisplayListener> displayListenerCaptor =
+        ArgumentCaptor.forClass(VsyncWaiter.DisplayListener.class);
+    when(mockDisplayManager.getDisplay(Display.DEFAULT_DISPLAY)).thenReturn(mockDisplay);
+
+    VsyncWaiter waiter = VsyncWaiter.getInstance(mockDisplayManager, mockFlutterJNI);
+    verify(mockDisplayManager, times(1))
+        .registerDisplayListener(displayListenerCaptor.capture(), isNull());
+
+    when(mockDisplay.getRefreshRate()).thenReturn(90.0f);
+    displayListenerCaptor.getValue().onDisplayChanged(Display.DEFAULT_DISPLAY);
+    verify(mockFlutterJNI, times(1)).setRefreshRateFPS(90.0f);
+
+    waiter.init();
+
+    ArgumentCaptor<FlutterJNI.AsyncWaitForVsyncDelegate> delegateCaptor =
+        ArgumentCaptor.forClass(FlutterJNI.AsyncWaitForVsyncDelegate.class);
+    verify(mockFlutterJNI, times(1)).setAsyncWaitForVsyncDelegate(delegateCaptor.capture());
+    delegateCaptor.getValue().asyncWaitForVsync(1);
+    shadowOf(Looper.getMainLooper()).idle();
+    verify(mockFlutterJNI, times(1)).nativeOnVsync(anyLong(), eq(1000000000l / 90l), eq(1l));
+
+    when(mockDisplay.getRefreshRate()).thenReturn(60.0f);
+    displayListenerCaptor.getValue().onDisplayChanged(Display.DEFAULT_DISPLAY);
+    verify(mockFlutterJNI, times(1)).setRefreshRateFPS(60.0f);
+
+    delegateCaptor.getValue().asyncWaitForVsync(1);
+    shadowOf(Looper.getMainLooper()).idle();
+    verify(mockFlutterJNI, times(1)).nativeOnVsync(anyLong(), eq(1000000000l / 60l), eq(1l));
+  }
+}

--- a/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
+++ b/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java
@@ -4,6 +4,7 @@
 
 package io.flutter.view;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
@@ -83,5 +84,20 @@ public class VsyncWaiterTest {
     delegateCaptor.getValue().asyncWaitForVsync(1);
     shadowOf(Looper.getMainLooper()).idle();
     verify(mockFlutterJNI, times(1)).nativeOnVsync(anyLong(), eq(1000000000l / 60l), eq(1l));
+  }
+
+  @TargetApi(17)
+  @Test
+  public void itSetsFpsWhenDisplayManagerDoesNotUpdate() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    DisplayManager mockDisplayManager = mock(DisplayManager.class);
+    Display mockDisplay = mock(Display.class);
+    when(mockDisplayManager.getDisplay(Display.DEFAULT_DISPLAY)).thenReturn(mockDisplay);
+    when(mockDisplay.getRefreshRate()).thenReturn(90.0f);
+
+    VsyncWaiter waiter = VsyncWaiter.getInstance(mockDisplayManager, mockFlutterJNI);
+    verify(mockDisplayManager, times(1)).registerDisplayListener(any(), isNull());
+
+    verify(mockFlutterJNI, times(1)).setRefreshRateFPS(90.0f);
   }
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -689,8 +689,9 @@ static void SetEntryPoint(flutter::Settings* settings, NSString* entrypoint, NSS
 
 - (void)initializeDisplays {
   double refresh_rate = [DisplayLinkManager displayRefreshRate];
-  auto display = flutter::Display(refresh_rate);
-  _shell->OnDisplayUpdates(flutter::DisplayUpdateType::kStartup, {display});
+  std::vector<std::unique_ptr<flutter::Display>> displays;
+  displays.push_back(std::make_unique<flutter::Display>(refresh_rate));
+  _shell->OnDisplayUpdates(flutter::DisplayUpdateType::kStartup, std::move(displays));
 }
 
 - (BOOL)run {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2267,18 +2267,19 @@ FlutterEngineResult FlutterEngineNotifyDisplayUpdate(
 
   switch (update_type) {
     case kFlutterEngineDisplaysUpdateTypeStartup: {
-      std::vector<flutter::Display> displays;
+      std::vector<std::unique_ptr<flutter::Display>> displays;
       for (size_t i = 0; i < display_count; i++) {
-        flutter::Display display =
-            flutter::Display(embedder_displays[i].refresh_rate);
-        if (!embedder_displays[i].single_display) {
-          display = flutter::Display(embedder_displays[i].display_id,
-                                     embedder_displays[i].refresh_rate);
+        if (embedder_displays[i].single_display) {
+          displays.push_back(std::make_unique<flutter::Display>(
+              embedder_displays[i].refresh_rate));
+        } else {
+          displays.push_back(std::make_unique<flutter::Display>(
+              embedder_displays[i].display_id,
+              embedder_displays[i].refresh_rate));
         }
-        displays.push_back(display);
       }
       engine->GetShell().OnDisplayUpdates(flutter::DisplayUpdateType::kStartup,
-                                          displays);
+                                          std::move(displays));
       return kSuccess;
     }
     default:

--- a/tools/android_lint/project.xml
+++ b/tools/android_lint/project.xml
@@ -56,6 +56,7 @@
     <src file="../../../flutter/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java" />
     <src file="../../../flutter/shell/platform/android/test/io/flutter/plugin/localization/LocalizationPluginTest.java" />
     <src file="../../../flutter/shell/platform/android/test/io/flutter/view/AccessibilityBridgeTest.java" />
+    <src file="../../../flutter/shell/platform/android/test/io/flutter/view/VsyncWaiterTest.java" />
     <src file="../../../flutter/shell/platform/android/test/io/flutter/FlutterInjectorTest.java" />
     <src file="../../../flutter/shell/platform/android/test/io/flutter/external/FlutterLaunchTests.java" />
     <src file="../../../flutter/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java" />


### PR DESCRIPTION
See also https://github.com/flutter/engine/pull/29765

Fixes flutter/flutter#93688
Fixes flutter/flutter#93698

This makes sure the frame timings recorder and vsync waiter implementations get the correct refresh rate if or when it adjusts at runtime. This should be OK becuase we'll only query the refresh rate when the display metrics actually change, which is much less frequent than every frame. I experimented with an NDK implementation in the previous patch, but that vastly restricts the API levels we can support, and currently on API 30 and 31 it just calls Java methods through JNI anyway.

I've refactored the way Display updates are reported so that AndroidDisplay can just dynamically get the refresh rate correctly. These values are used by a service protocol extension and by some Stopwatches on the CompositorContext.