### PR TITLE
[web] move browser installation to BrowserEnvironment.prepare

### DIFF
--- a/lib/web_ui/dev/browser.dart
+++ b/lib/web_ui/dev/browser.dart
@@ -26,12 +26,12 @@ abstract class BrowserEnvironment {
 
   /// Prepares the OS environment to run tests for this browser.
   ///
-  /// This may include things like staring web drivers, iOS Simulators, and/or
-  /// Android emulators.
+  /// This may include things like installing browsers, and starting web drivers,
+  /// iOS Simulators, and/or Android emulators.
   ///
   /// Typically the browser environment is prepared once and supports multiple
   /// browser instances.
-  Future<void> prepareEnvironment();
+  Future<void> prepare();
 
   /// Launches a browser instance.
   ///

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -11,7 +11,6 @@ import 'package:archive/archive_io.dart';
 import 'package:http/http.dart';
 import 'package:path/path.dart' as path;
 
-import 'browser_lock.dart';
 import 'common.dart';
 import 'environment.dart';
 import 'exceptions.dart';
@@ -156,9 +155,9 @@ class ChromeInstaller {
       versionDir.createSync(recursive: true);
     }
 
-    print('INFO: Starting Chrome download.');
-
     final String url = PlatformBinding.instance.getChromeDownloadUrl(version);
+    print('Downloading Chrome from $url');
+
     final StreamedResponse download = await client.send(Request(
       'GET',
       Uri.parse(url),
@@ -254,26 +253,5 @@ Future<String> fetchLatestChromeVersion() async {
     return response.body;
   } finally {
     client.close();
-  }
-}
-
-/// Make sure LUCI bot has the pinned Chrome version and return the executable.
-///
-/// We are using CIPD packages in LUCI. The pinned chrome version from the
-/// `browser_lock.yaml` file will already be installed in the LUCI bot.
-/// Verify if Chrome is installed and use it for the integration tests.
-String preinstalledChromeExecutable() {
-  // Note that build number and major version is different for Chrome.
-  // For example for a build number `753189`, major version is 83.
-  final String buildNumber = browserLock.chromeLock.versionForCurrentPlatform;
-  final ChromeInstaller chromeInstaller = ChromeInstaller(version: buildNumber);
-  if (chromeInstaller.isInstalled) {
-    final String executable = chromeInstaller.getInstallation()!.executable;
-    print('INFO: Found chrome executable for LUCI: $executable');
-    return executable;
-  } else {
-    throw StateError(
-      'Failed to locate pinned Chrome build: $buildNumber on LUCI.',
-    );
   }
 }

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -139,21 +139,17 @@ class ChromeInstaller {
   }
 
   Future<void> install() async {
-    if (versionDir.existsSync() && !isLuci) {
-      versionDir.deleteSync(recursive: true);
-      versionDir.createSync(recursive: true);
-    } else if (versionDir.existsSync() && isLuci) {
-      print('INFO: Chrome version directory in LUCI: '
-          '${versionDir.path}');
-    } else if (!versionDir.existsSync() && isLuci) {
-      // Chrome should have been deployed as a CIPD package on LUCI.
-      // Throw if it does not exists.
-      throw StateError('Failed to locate Chrome on LUCI on path:'
-          '${versionDir.path}');
-    } else {
-      // If the directory does not exists and felt is not running on LUCI.
-      versionDir.createSync(recursive: true);
+    if (isLuci) {
+      throw StateError(
+        'Rejecting attempt to install Chromium on LUCI. LUCI is expected to '
+        'provide Chromium as a CIPD dependency managed using .ci.yaml.',
+      );
     }
+
+    if (versionDir.existsSync()) {
+      versionDir.deleteSync(recursive: true);
+    }
+    versionDir.createSync(recursive: true);
 
     final String url = PlatformBinding.instance.getChromeDownloadUrl(version);
     print('Downloading Chrome from $url');

--- a/lib/web_ui/dev/edge.dart
+++ b/lib/web_ui/dev/edge.dart
@@ -23,7 +23,7 @@ class EdgeEnvironment implements BrowserEnvironment {
   Runtime get packageTestRuntime => Runtime.internetExplorer;
 
   @override
-  Future<void> prepareEnvironment() async {
+  Future<void> prepare() async {
     // Edge doesn't need any special prep.
   }
 

--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -18,17 +18,22 @@ import 'firefox_installer.dart';
 
 /// Provides an environment for the desktop Firefox.
 class FirefoxEnvironment implements BrowserEnvironment {
+  late final BrowserInstallation _installation;
+
   @override
   Browser launchBrowserInstance(Uri url, {bool debug = false}) {
-    return Firefox(url, debug: debug);
+    return Firefox(url, this, debug: debug);
   }
 
   @override
   Runtime get packageTestRuntime => Runtime.firefox;
 
   @override
-  Future<void> prepareEnvironment() async {
-    // Firefox doesn't need any special prep.
+  Future<void> prepare() async {
+    _installation = await getOrInstallFirefox(
+      browserLock.firefoxLock.version,
+      infoLog: isCirrus ? stdout : DevNull(),
+    );
   }
 
   @override
@@ -54,14 +59,10 @@ class Firefox extends Browser {
 
   /// Starts a new instance of Firefox open to the given [url], which may be a
   /// [Uri] or a [String].
-  factory Firefox(Uri url, {bool debug = false}) {
+  factory Firefox(Uri url, FirefoxEnvironment firefoxEnvironment, {bool debug = false}) {
+    final BrowserInstallation installation = firefoxEnvironment._installation;
     final Completer<Uri> remoteDebuggerCompleter = Completer<Uri>.sync();
     return Firefox._(() async {
-      final BrowserInstallation installation = await getOrInstallFirefox(
-        browserLock.firefoxLock.version,
-        infoLog: isCirrus ? stdout : DevNull(),
-      );
-
       // Using a profile on opening will prevent popups related to profiles.
       const String _profile = '''
 user_pref("browser.shell.checkDefaultBrowser", false);
@@ -79,9 +80,9 @@ user_pref("dom.max_script_run_time", 0);
         temporaryProfileDirectory.deleteSync(recursive: true);
       }
       temporaryProfileDirectory.createSync(recursive: true);
-
       File(path.join(temporaryProfileDirectory.path, 'prefs.js'))
           .writeAsStringSync(_profile);
+
       final bool isMac = Platform.isMacOS;
       final List<String> args = <String>[
         url.toString(),

--- a/lib/web_ui/dev/safari_ios.dart
+++ b/lib/web_ui/dev/safari_ios.dart
@@ -28,7 +28,7 @@ class SafariIosEnvironment implements BrowserEnvironment {
   Runtime get packageTestRuntime => Runtime.safari;
 
   @override
-  Future<void> prepareEnvironment() async {
+  Future<void> prepare() async {
     await initIosSimulator();
   }
 

--- a/lib/web_ui/dev/safari_macos.dart
+++ b/lib/web_ui/dev/safari_macos.dart
@@ -23,7 +23,7 @@ class SafariMacOsEnvironment implements BrowserEnvironment {
   Runtime get packageTestRuntime => Runtime.safari;
 
   @override
-  Future<void> prepareEnvironment() async {
+  Future<void> prepare() async {
     // Nothing extra to prepare for desktop Safari.
   }
 

--- a/lib/web_ui/dev/steps/run_tests_step.dart
+++ b/lib/web_ui/dev/steps/run_tests_step.dart
@@ -71,7 +71,7 @@ class RunTestsStep implements PipelineStep {
   @override
   Future<void> run() async {
     await _prepareTestResultsDirectory();
-    await _browserEnvironment.prepareEnvironment();
+    await _browserEnvironment.prepare();
 
     final SkiaGoldClient? skiaClient = await _createSkiaClient();
 


### PR DESCRIPTION
This way browser installation happens early in the build process, and if it fails we get reasonable errors in the output.

Prior to this PR the browser was installed on-demand while the test framework was attempting to run a test. If the browser fails to install the test simply hangs (internally it is awaiting for the browser-localhost handshake), and there's no log output (probably because the test framework sets up a custom zone and intercepts console output).