### PR TITLE
Windows: Add SystemSound support

### DIFF
--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -14,6 +14,7 @@ static constexpr char kSetClipboardDataMethod[] = "Clipboard.setData";
 
 static constexpr char kTextPlainFormat[] = "text/plain";
 static constexpr char kTextKey[] = "text";
+static constexpr char kValueKey[] = "value";
 
 static constexpr char kUnknownClipboardFormatMessage[] =
     "Unknown clipboard format";
@@ -55,7 +56,7 @@ void PlatformHandler::HandleMethodCall(
       result->Error(kClipboardError, kUnknownClipboardFormatMessage);
       return;
     }
-    GetHasStrings(std::move(result));
+    GetHasStrings(std::move(result), kValueKey);
   } else if (method.compare(kSetClipboardDataMethod) == 0) {
     const rapidjson::Value& document = *method_call.arguments();
     rapidjson::Value::ConstMemberIterator itr = document.FindMember(kTextKey);

--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -11,6 +11,7 @@ static constexpr char kChannelName[] = "flutter/platform";
 static constexpr char kGetClipboardDataMethod[] = "Clipboard.getData";
 static constexpr char kHasStringsClipboardMethod[] = "Clipboard.hasStrings";
 static constexpr char kSetClipboardDataMethod[] = "Clipboard.setData";
+static constexpr char kPlaySoundMethod[] = "SystemSound.play";
 
 static constexpr char kTextPlainFormat[] = "text/plain";
 static constexpr char kTextKey[] = "text";
@@ -65,6 +66,11 @@ void PlatformHandler::HandleMethodCall(
       return;
     }
     SetPlainText(itr->value.GetString(), std::move(result));
+  } else if (method.compare(kPlaySoundMethod) == 0) {
+    // Only one string argument is expected.
+    const rapidjson::Value& sound_type = method_call.arguments()[0];
+
+    SystemSoundPlay(sound_type.GetString(), std::move(result));
   } else {
     result->NotImplemented();
   }

--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -15,7 +15,6 @@ static constexpr char kPlaySoundMethod[] = "SystemSound.play";
 
 static constexpr char kTextPlainFormat[] = "text/plain";
 static constexpr char kTextKey[] = "text";
-static constexpr char kValueKey[] = "value";
 
 static constexpr char kUnknownClipboardFormatMessage[] =
     "Unknown clipboard format";
@@ -57,7 +56,7 @@ void PlatformHandler::HandleMethodCall(
       result->Error(kClipboardError, kUnknownClipboardFormatMessage);
       return;
     }
-    GetHasStrings(std::move(result), kValueKey);
+    GetHasStrings(std::move(result));
   } else if (method.compare(kSetClipboardDataMethod) == 0) {
     const rapidjson::Value& document = *method_call.arguments();
     rapidjson::Value::ConstMemberIterator itr = document.FindMember(kTextKey);

--- a/shell/platform/windows/platform_handler.h
+++ b/shell/platform/windows/platform_handler.h
@@ -34,7 +34,8 @@ class PlatformHandler {
   // Provides a boolean to |result| as the value in a dictionary at key
   // "value" representing whether or not the clipboard has a non-empty string.
   virtual void GetHasStrings(
-      std::unique_ptr<MethodResult<rapidjson::Document>> result) = 0;
+      std::unique_ptr<MethodResult<rapidjson::Document>> result,
+      std::string_view key) = 0;
 
   // Sets the clipboard's plain text to |text|, and reports the result (either
   // an error, or null for success) to |result|.

--- a/shell/platform/windows/platform_handler.h
+++ b/shell/platform/windows/platform_handler.h
@@ -43,8 +43,14 @@ class PlatformHandler {
       const std::string& text,
       std::unique_ptr<MethodResult<rapidjson::Document>> result) = 0;
 
+  virtual void SystemSoundPlay(
+      const std::string& sound_type,
+      std::unique_ptr<MethodResult<rapidjson::Document>> result) = 0;
+
   // A error type to use for error responses.
   static constexpr char kClipboardError[] = "Clipboard error";
+
+  static constexpr char kSoundTypeAlert[] = "SystemSoundType.alert";
 
  private:
   // Called when a method is called on |channel_|;

--- a/shell/platform/windows/platform_handler.h
+++ b/shell/platform/windows/platform_handler.h
@@ -34,8 +34,7 @@ class PlatformHandler {
   // Provides a boolean to |result| as the value in a dictionary at key
   // "value" representing whether or not the clipboard has a non-empty string.
   virtual void GetHasStrings(
-      std::unique_ptr<MethodResult<rapidjson::Document>> result,
-      std::string_view key) = 0;
+      std::unique_ptr<MethodResult<rapidjson::Document>> result) = 0;
 
   // Sets the clipboard's plain text to |text|, and reports the result (either
   // an error, or null for success) to |result|.

--- a/shell/platform/windows/platform_handler_unittests.cc
+++ b/shell/platform/windows/platform_handler_unittests.cc
@@ -40,8 +40,9 @@ class TestPlatformHandler : public PlatformHandler {
   MOCK_METHOD2(GetPlainText,
                void(std::unique_ptr<MethodResult<rapidjson::Document>>,
                     std::string_view key));
-  MOCK_METHOD1(GetHasStrings,
-               void(std::unique_ptr<MethodResult<rapidjson::Document>>));
+  MOCK_METHOD2(GetHasStrings,
+               void(std::unique_ptr<MethodResult<rapidjson::Document>>,
+                    std::string_view key));
   MOCK_METHOD2(SetPlainText,
                void(const std::string&,
                     std::unique_ptr<MethodResult<rapidjson::Document>>));
@@ -121,11 +122,10 @@ TEST(PlatformHandler, GetHasStringsCallsThrough) {
   // on destruction about leaking.
   ON_CALL(platform_handler, GetHasStrings)
       .WillByDefault(
-          [](std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-            result->NotImplemented();
-          });
+          [](std::unique_ptr<MethodResult<rapidjson::Document>> result,
+             std::string_view key) { result->NotImplemented(); });
 
-  EXPECT_CALL(platform_handler, GetHasStrings(_));
+  EXPECT_CALL(platform_handler, GetHasStrings(_, ::testing::StrEq("value")));
   EXPECT_TRUE(messenger.SimulateEngineMessage(
       kChannelName, encoded->data(), encoded->size(),
       [](const uint8_t* reply, size_t reply_size) {}));

--- a/shell/platform/windows/platform_handler_unittests.cc
+++ b/shell/platform/windows/platform_handler_unittests.cc
@@ -43,9 +43,8 @@ class TestPlatformHandler : public PlatformHandler {
   MOCK_METHOD2(GetPlainText,
                void(std::unique_ptr<MethodResult<rapidjson::Document>>,
                     std::string_view key));
-  MOCK_METHOD2(GetHasStrings,
-               void(std::unique_ptr<MethodResult<rapidjson::Document>>,
-                    std::string_view key));
+  MOCK_METHOD1(GetHasStrings,
+               void(std::unique_ptr<MethodResult<rapidjson::Document>>));
   MOCK_METHOD2(SetPlainText,
                void(const std::string&,
                     std::unique_ptr<MethodResult<rapidjson::Document>>));
@@ -128,10 +127,11 @@ TEST(PlatformHandler, GetHasStringsCallsThrough) {
   // on destruction about leaking.
   ON_CALL(platform_handler, GetHasStrings)
       .WillByDefault(
-          [](std::unique_ptr<MethodResult<rapidjson::Document>> result,
-             std::string_view key) { result->NotImplemented(); });
+          [](std::unique_ptr<MethodResult<rapidjson::Document>> result) {
+            result->NotImplemented();
+          });
 
-  EXPECT_CALL(platform_handler, GetHasStrings(_, ::testing::StrEq("value")));
+  EXPECT_CALL(platform_handler, GetHasStrings(_));
   EXPECT_TRUE(messenger.SimulateEngineMessage(
       kChannelName, encoded->data(), encoded->size(),
       [](const uint8_t* reply, size_t reply_size) {}));

--- a/shell/platform/windows/platform_handler_unittests.cc
+++ b/shell/platform/windows/platform_handler_unittests.cc
@@ -23,9 +23,12 @@ static constexpr char kChannelName[] = "flutter/platform";
 static constexpr char kGetClipboardDataMethod[] = "Clipboard.getData";
 static constexpr char kHasStringsClipboardMethod[] = "Clipboard.hasStrings";
 static constexpr char kSetClipboardDataMethod[] = "Clipboard.setData";
+static constexpr char kPlaySoundMethod[] = "SystemSound.play";
 
 static constexpr char kTextPlainFormat[] = "text/plain";
 static constexpr char kFakeContentType[] = "text/madeupcontenttype";
+
+static constexpr char kSoundTypeAlert[] = "SystemSoundType.alert";
 
 // Test implementation of PlatformHandler to allow testing the PlatformHandler
 // logic.
@@ -44,6 +47,9 @@ class TestPlatformHandler : public PlatformHandler {
                void(std::unique_ptr<MethodResult<rapidjson::Document>>,
                     std::string_view key));
   MOCK_METHOD2(SetPlainText,
+               void(const std::string&,
+                    std::unique_ptr<MethodResult<rapidjson::Document>>));
+  MOCK_METHOD2(SystemSoundPlay,
                void(const std::string&,
                     std::unique_ptr<MethodResult<rapidjson::Document>>));
 };
@@ -199,6 +205,32 @@ TEST(PlatformHandler, RejectsSettingUnknownTypes) {
         JsonMethodCodec::GetInstance().DecodeAndProcessResponseEnvelope(
             reply, reply_size, &result);
       }));
+}
+
+TEST(PlatformHandler, PlayingSystemSoundCallsThrough) {
+  TestBinaryMessenger messenger;
+  TestPlatformHandler platform_handler(&messenger);
+
+  auto args = std::make_unique<rapidjson::Document>(rapidjson::kStringType);
+  auto& allocator = args->GetAllocator();
+  args->SetString(kSoundTypeAlert);
+  auto encoded = JsonMethodCodec::GetInstance().EncodeMethodCall(
+      MethodCall<rapidjson::Document>(kPlaySoundMethod, std::move(args)));
+
+  // Set up a handler to call a response on |result| so that it doesn't log
+  // on destruction about leaking.
+  ON_CALL(platform_handler, SystemSoundPlay)
+      .WillByDefault(
+          [](auto sound_type,
+             std::unique_ptr<MethodResult<rapidjson::Document>> result) {
+            result->NotImplemented();
+          });
+
+  EXPECT_CALL(platform_handler,
+              SystemSoundPlay(::testing::StrEq(kSoundTypeAlert), _));
+  EXPECT_TRUE(messenger.SimulateEngineMessage(
+      kChannelName, encoded->data(), encoded->size(),
+      [](const uint8_t* reply, size_t reply_size) {}));
 }
 
 }  // namespace testing

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -13,6 +13,8 @@
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/string_conversion.h"
 
+static constexpr char kValueKey[] = "value";
+
 namespace flutter {
 
 namespace {
@@ -230,8 +232,7 @@ void PlatformHandlerWin32::GetPlainText(
 }
 
 void PlatformHandlerWin32::GetHasStrings(
-    std::unique_ptr<MethodResult<rapidjson::Document>> result,
-    std::string_view key) {
+    std::unique_ptr<MethodResult<rapidjson::Document>> result) {
   ScopedClipboard clipboard;
   if (!clipboard.Open(std::get<HWND>(*view_->GetRenderTarget()))) {
     rapidjson::Document error_code;
@@ -243,7 +244,7 @@ void PlatformHandlerWin32::GetHasStrings(
   rapidjson::Document document;
   document.SetObject();
   rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
-  document.AddMember(rapidjson::Value(key.data(), allocator),
+  document.AddMember(rapidjson::Value(kValueKey, allocator),
                      rapidjson::Value(clipboard.HasString()), allocator);
   result->Success(document);
 }

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -13,8 +13,6 @@
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/string_conversion.h"
 
-static constexpr char kValueKey[] = "value";
-
 namespace flutter {
 
 namespace {
@@ -232,7 +230,8 @@ void PlatformHandlerWin32::GetPlainText(
 }
 
 void PlatformHandlerWin32::GetHasStrings(
-    std::unique_ptr<MethodResult<rapidjson::Document>> result) {
+    std::unique_ptr<MethodResult<rapidjson::Document>> result,
+    std::string_view key) {
   ScopedClipboard clipboard;
   if (!clipboard.Open(std::get<HWND>(*view_->GetRenderTarget()))) {
     rapidjson::Document error_code;
@@ -244,7 +243,7 @@ void PlatformHandlerWin32::GetHasStrings(
   rapidjson::Document document;
   document.SetObject();
   rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
-  document.AddMember(rapidjson::Value(kValueKey, allocator),
+  document.AddMember(rapidjson::Value(key.data(), allocator),
                      rapidjson::Value(clipboard.HasString()), allocator);
   result->Success(document);
 }

--- a/shell/platform/windows/platform_handler_win32.cc
+++ b/shell/platform/windows/platform_handler_win32.cc
@@ -267,4 +267,15 @@ void PlatformHandlerWin32::SetPlainText(
   result->Success();
 }
 
+void PlatformHandlerWin32::SystemSoundPlay(
+    const std::string& sound_type,
+    std::unique_ptr<MethodResult<rapidjson::Document>> result) {
+  if (sound_type.compare(kSoundTypeAlert) == 0) {
+    MessageBeep(MB_OK);
+    result->Success();
+  } else {
+    result->NotImplemented();
+  }
+}
+
 }  // namespace flutter

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -37,6 +37,11 @@ class PlatformHandlerWin32 : public PlatformHandler {
       const std::string& text,
       std::unique_ptr<MethodResult<rapidjson::Document>> result) override;
 
+  // |PlatformHandler|
+  void SystemSoundPlay(
+      const std::string& sound_type,
+      std::unique_ptr<MethodResult<rapidjson::Document>> result) override;
+
  private:
   // A reference to the Flutter view.
   FlutterWindowsView* view_;

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -29,8 +29,8 @@ class PlatformHandlerWin32 : public PlatformHandler {
                     std::string_view key) override;
 
   // |PlatformHandler|
-  void GetHasStrings(
-      std::unique_ptr<MethodResult<rapidjson::Document>> result) override;
+  void GetHasStrings(std::unique_ptr<MethodResult<rapidjson::Document>> result,
+                     std::string_view key) override;
 
   // |PlatformHandler|
   void SetPlainText(

--- a/shell/platform/windows/platform_handler_win32.h
+++ b/shell/platform/windows/platform_handler_win32.h
@@ -29,8 +29,8 @@ class PlatformHandlerWin32 : public PlatformHandler {
                     std::string_view key) override;
 
   // |PlatformHandler|
-  void GetHasStrings(std::unique_ptr<MethodResult<rapidjson::Document>> result,
-                     std::string_view key) override;
+  void GetHasStrings(
+      std::unique_ptr<MethodResult<rapidjson::Document>> result) override;
 
   // |PlatformHandler|
   void SetPlainText(

--- a/shell/platform/windows/platform_handler_winuwp.cc
+++ b/shell/platform/windows/platform_handler_winuwp.cc
@@ -111,7 +111,7 @@ void PlatformHandlerWinUwp::SetPlainText(
 void PlatformHandlerWinUwp::SystemSoundPlay(
     const std::string& sound_type,
     std::unique_ptr<MethodResult<rapidjson::Document>> result) {
-    result->NotImplemented();
+  result->NotImplemented();
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/platform_handler_winuwp.cc
+++ b/shell/platform/windows/platform_handler_winuwp.cc
@@ -10,7 +10,6 @@
 
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/string_conversion.h"
-
 namespace flutter {
 
 // static
@@ -105,6 +104,12 @@ void PlatformHandlerWinUwp::SetPlainText(
       content);
 
   result->Success();
+}
+
+void PlatformHandlerWinUwp::SystemSoundPlay(
+    const std::string& sound_type,
+    std::unique_ptr<MethodResult<rapidjson::Document>> result) {
+    result->NotImplemented();
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/platform_handler_winuwp.cc
+++ b/shell/platform/windows/platform_handler_winuwp.cc
@@ -10,6 +10,9 @@
 
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/string_conversion.h"
+
+static constexpr char kValueKey[] = "value";
+
 namespace flutter {
 
 // static
@@ -74,8 +77,7 @@ void PlatformHandlerWinUwp::GetPlainText(
 }
 
 void PlatformHandlerWinUwp::GetHasStrings(
-    std::unique_ptr<MethodResult<rapidjson::Document>> result,
-    std::string_view key) {
+    std::unique_ptr<MethodResult<rapidjson::Document>> result) {
   bool has_string = false;
 
   // We call `Clipboard::GetContent()` when the application window is in
@@ -90,7 +92,7 @@ void PlatformHandlerWinUwp::GetHasStrings(
   rapidjson::Document document;
   document.SetObject();
   rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
-  document.AddMember(rapidjson::Value(key.data(), allocator),
+  document.AddMember(rapidjson::Value(kValueKey, allocator),
                      rapidjson::Value(has_string), allocator);
   result->Success(document);
 }

--- a/shell/platform/windows/platform_handler_winuwp.cc
+++ b/shell/platform/windows/platform_handler_winuwp.cc
@@ -11,8 +11,6 @@
 #include "flutter/shell/platform/windows/flutter_windows_view.h"
 #include "flutter/shell/platform/windows/string_conversion.h"
 
-static constexpr char kValueKey[] = "value";
-
 namespace flutter {
 
 // static
@@ -77,7 +75,8 @@ void PlatformHandlerWinUwp::GetPlainText(
 }
 
 void PlatformHandlerWinUwp::GetHasStrings(
-    std::unique_ptr<MethodResult<rapidjson::Document>> result) {
+    std::unique_ptr<MethodResult<rapidjson::Document>> result,
+    std::string_view key) {
   bool has_string = false;
 
   // We call `Clipboard::GetContent()` when the application window is in
@@ -92,7 +91,7 @@ void PlatformHandlerWinUwp::GetHasStrings(
   rapidjson::Document document;
   document.SetObject();
   rapidjson::Document::AllocatorType& allocator = document.GetAllocator();
-  document.AddMember(rapidjson::Value(kValueKey, allocator),
+  document.AddMember(rapidjson::Value(key.data(), allocator),
                      rapidjson::Value(has_string), allocator);
   result->Success(document);
 }

--- a/shell/platform/windows/platform_handler_winuwp.h
+++ b/shell/platform/windows/platform_handler_winuwp.h
@@ -29,8 +29,8 @@ class PlatformHandlerWinUwp : public PlatformHandler {
                     std::string_view key) override;
 
   // |PlatformHandler|
-  void GetHasStrings(
-      std::unique_ptr<MethodResult<rapidjson::Document>> result) override;
+  void GetHasStrings(std::unique_ptr<MethodResult<rapidjson::Document>> result,
+                     std::string_view key) override;
 
   // |PlatformHandler|
   void SetPlainText(

--- a/shell/platform/windows/platform_handler_winuwp.h
+++ b/shell/platform/windows/platform_handler_winuwp.h
@@ -29,8 +29,8 @@ class PlatformHandlerWinUwp : public PlatformHandler {
                     std::string_view key) override;
 
   // |PlatformHandler|
-  void GetHasStrings(std::unique_ptr<MethodResult<rapidjson::Document>> result,
-                     std::string_view key) override;
+  void GetHasStrings(
+      std::unique_ptr<MethodResult<rapidjson::Document>> result) override;
 
   // |PlatformHandler|
   void SetPlainText(

--- a/shell/platform/windows/platform_handler_winuwp.h
+++ b/shell/platform/windows/platform_handler_winuwp.h
@@ -37,6 +37,11 @@ class PlatformHandlerWinUwp : public PlatformHandler {
       const std::string& text,
       std::unique_ptr<MethodResult<rapidjson::Document>> result) override;
 
+  // |PlatformHandler|
+  void SystemSoundPlay(
+      const std::string& sound_type,
+      std::unique_ptr<MethodResult<rapidjson::Document>> result) override;
+
  private:
   // A reference to the Flutter view.
   FlutterWindowsView* view_;


### PR DESCRIPTION
This PR adds `SystemSound.play` support.

On win32, it calls `MessageBeep`.

On winuwp, it is not implemented because Windows App Cert Kit warns the usage of `MessageBeep` and winrt seems not to have its equivalent API.
I tried `ElementSoundPlayer`, but it seems to work on xbox and can be called only on xaml's thread.

This PR will fix flutter/flutter#62143.

No changes in `flutter/tests`.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [x] All existing and new tests are passing.