### PR TITLE
[fuchsia] Fixes the HID usage handling

### DIFF
--- a/shell/platform/fuchsia/flutter/keyboard.h
+++ b/shell/platform/fuchsia/flutter/keyboard.h
@@ -28,8 +28,25 @@ class Keyboard final {
   // the state of the modifier keys.
   uint32_t LastCodePoint();
 
-  // Gets the last encountered HID usage.
+  // Gets the last encountered HID usage.  This is a 32-bit number, with the
+  // upper 16 bits equal to `LastHidUsagePage()`, and the lower 16 bits equal
+  // to `LastHIDUsageID()`.
+  //
+  // The key corresponding to A will have the usage 0x7004. This function will
+  // return 0x7004 in that case.
   uint32_t LastHIDUsage();
+
+  // Gets the last encountered HID usage page.
+  //
+  // The key corresponding to A will have the usage 0x7004. This function will
+  // return 0x7 in that case.
+  uint16_t LastHIDUsagePage();
+
+  // Gets the last encountered HID usage ID.
+  //
+  // The key corresponding to A will have the usage 0x7004. This function will
+  // return 0x4 in that case.
+  uint16_t LastHIDUsageID();
 
  private:
   // Return true if any level shift is active.
@@ -38,6 +55,9 @@ class Keyboard final {
   // Returns true if the last key event was about a key that may have a code
   // point associated.
   bool IsKeys();
+
+  // Returns the value of the last key as a uint32_t.
+  uint32_t GetLastKey();
 
   // Set to false until any event is received.
   bool any_events_received_ : 1;

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -1250,18 +1250,19 @@ TEST_F(PlatformViewTests, OnKeyEvent) {
 
   std::vector<EventFlow> events;
   // Press A.  Get 'a'.
+  // The HID usage for the key A is 0x70004, or 458756.
   events.emplace_back(EventFlow{
       MakeEvent(fuchsia::ui::input3::KeyEventType::PRESSED, std::nullopt,
                 fuchsia::input::Key::A),
       fuchsia::ui::input3::KeyEventStatus::HANDLED,
-      R"({"type":"keydown","keymap":"fuchsia","hidUsage":4,"codePoint":97,"modifiers":0})",
+      R"({"type":"keydown","keymap":"fuchsia","hidUsage":458756,"codePoint":97,"modifiers":0})",
   });
   // Release A. Get 'a' release.
   events.emplace_back(EventFlow{
       MakeEvent(fuchsia::ui::input3::KeyEventType::RELEASED, std::nullopt,
                 fuchsia::input::Key::A),
       fuchsia::ui::input3::KeyEventStatus::HANDLED,
-      R"({"type":"keyup","keymap":"fuchsia","hidUsage":4,"codePoint":97,"modifiers":0})",
+      R"({"type":"keyup","keymap":"fuchsia","hidUsage":458756,"codePoint":97,"modifiers":0})",
   });
   // Press CAPS_LOCK.  Modifier now active.
   events.emplace_back(EventFlow{
@@ -1269,14 +1270,14 @@ TEST_F(PlatformViewTests, OnKeyEvent) {
                 fuchsia::ui::input3::Modifiers::CAPS_LOCK,
                 fuchsia::input::Key::CAPS_LOCK),
       fuchsia::ui::input3::KeyEventStatus::HANDLED,
-      R"({"type":"keydown","keymap":"fuchsia","hidUsage":57,"codePoint":0,"modifiers":1})",
+      R"({"type":"keydown","keymap":"fuchsia","hidUsage":458809,"codePoint":0,"modifiers":1})",
   });
-  // Pres A.  Get 'A'.
+  // Press A.  Get 'A'.
   events.emplace_back(EventFlow{
       MakeEvent(fuchsia::ui::input3::KeyEventType::PRESSED, std::nullopt,
                 fuchsia::input::Key::A),
       fuchsia::ui::input3::KeyEventStatus::HANDLED,
-      R"({"type":"keydown","keymap":"fuchsia","hidUsage":4,"codePoint":65,"modifiers":1})",
+      R"({"type":"keydown","keymap":"fuchsia","hidUsage":458756,"codePoint":65,"modifiers":1})",
   });
   // Release CAPS_LOCK.
   events.emplace_back(EventFlow{
@@ -1284,7 +1285,7 @@ TEST_F(PlatformViewTests, OnKeyEvent) {
                 fuchsia::ui::input3::Modifiers::CAPS_LOCK,
                 fuchsia::input::Key::CAPS_LOCK),
       fuchsia::ui::input3::KeyEventStatus::HANDLED,
-      R"({"type":"keyup","keymap":"fuchsia","hidUsage":57,"codePoint":0,"modifiers":1})",
+      R"({"type":"keyup","keymap":"fuchsia","hidUsage":458809,"codePoint":0,"modifiers":1})",
   });
   // Press A again.  This time get 'A'.
   // CAPS_LOCK is latched active even if it was just released.
@@ -1292,7 +1293,7 @@ TEST_F(PlatformViewTests, OnKeyEvent) {
       MakeEvent(fuchsia::ui::input3::KeyEventType::PRESSED, std::nullopt,
                 fuchsia::input::Key::A),
       fuchsia::ui::input3::KeyEventStatus::HANDLED,
-      R"({"type":"keydown","keymap":"fuchsia","hidUsage":4,"codePoint":65,"modifiers":1})",
+      R"({"type":"keydown","keymap":"fuchsia","hidUsage":458756,"codePoint":65,"modifiers":1})",
   });
 
   for (const auto& event : events) {


### PR DESCRIPTION
The old code stripped the USB hid usage page value from the Fuchsia
key.  It shouldn't be doing that.  This change fixes the issue,
and adds tests that rely on the key constants to verify that the
change indeed does what it is supposed to do.

Fixes: https://github.com/flutter/flutter/issues/93890

> *Note:* I'm not sure whether the usage should or the key values with `kFuchsiaPlane` or not - I didn't add that bit.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.
