### PR TITLE
Windows: Clean up FML file debug messages

### DIFF
--- a/fml/platform/win/file_win.cc
+++ b/fml/platform/win/file_win.cc
@@ -57,8 +57,6 @@ static std::string GetFullHandlePath(const fml::UniqueFD& handle) {
   const DWORD buffer_size = ::GetFinalPathNameByHandle(
       handle.get(), buffer, MAX_PATH, FILE_NAME_NORMALIZED);
   if (buffer_size == 0) {
-    FML_DLOG(ERROR) << "Could not get file handle path. "
-                    << GetLastErrorMessage();
     return {};
   }
   return WideStringToString({buffer, buffer_size});
@@ -80,8 +78,6 @@ static std::wstring GetTemporaryDirectoryPath() {
   if (result_size > 0) {
     return {wchar_path, result_size};
   }
-  FML_DLOG(ERROR) << "Could not get temporary directory path. "
-                  << GetLastErrorMessage();
   return {};
 }
 
@@ -131,14 +127,14 @@ std::string CreateTemporaryDirectory() {
   UUID uuid;
   RPC_STATUS status = UuidCreateSequential(&uuid);
   if (status != RPC_S_OK && status != RPC_S_UUID_LOCAL_ONLY) {
-    FML_DLOG(ERROR) << "Could not create UUID";
+    FML_DLOG(ERROR) << "Could not create UUID for temporary directory.";
     return {};
   }
 
   RPC_WSTR uuid_string;
   status = UuidToString(&uuid, &uuid_string);
   if (status != RPC_S_OK) {
-    FML_DLOG(ERROR) << "Could not create UUID to string.";
+    FML_DLOG(ERROR) << "Could not map UUID to string for temporary directory.";
     return {};
   }
 
@@ -154,7 +150,7 @@ std::string CreateTemporaryDirectory() {
   auto dir_fd = OpenDirectory(WideStringToString(temp_dir).c_str(), true,
                               FilePermission::kReadWrite);
   if (!dir_fd.is_valid()) {
-    FML_DLOG(ERROR) << "Could not get temporary directory FD. "
+    FML_DLOG(ERROR) << "Could not get temporary directory file descriptor. "
                     << GetLastErrorMessage();
     return {};
   }
@@ -199,7 +195,6 @@ fml::UniqueFD OpenFile(const char* path,
       );
 
   if (handle == INVALID_HANDLE_VALUE) {
-    FML_DLOG(ERROR) << "Could not open file. " << GetLastErrorMessage();
     return {};
   }
 
@@ -252,7 +247,6 @@ fml::UniqueFD OpenDirectory(const char* path,
       );
 
   if (handle == INVALID_HANDLE_VALUE) {
-    FML_DLOG(ERROR) << "Could not open file. " << GetLastErrorMessage();
     return {};
   }
 
@@ -300,8 +294,6 @@ fml::UniqueFD Duplicate(fml::UniqueFD::element_type descriptor) {
 bool IsDirectory(const fml::UniqueFD& directory) {
   BY_HANDLE_FILE_INFORMATION info;
   if (!::GetFileInformationByHandle(directory.get(), &info)) {
-    FML_DLOG(ERROR) << "Could not get file information. "
-                    << GetLastErrorMessage();
     return false;
   }
   return info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY;


### PR DESCRIPTION
Eliminate debug error messages in cases where the operation in question
isn't necessarily an error. An example is failure to open a file; we
don't emit these messages in fml/platform/posix/file_posix.cc, and they
tend to clutter up test logs with red herrings, which in some cases have
led to us drawing incorrect conclusions about test failures.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
