### PR TITLE
Make it less likely to GC during application startup on Android

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -4,7 +4,6 @@
 
 package io.flutter.embedding.android;
 
-import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static io.flutter.embedding.android.FlutterActivityLaunchConfigs.DEFAULT_INITIAL_ROUTE;
 
@@ -796,10 +795,7 @@ import java.util.Arrays;
       // Avoid being too aggressive before the first frame is rendered. If it is
       // not at least running critical, we should avoid delaying the frame for
       // an overly aggressive GC.
-      boolean trim =
-          isFirstFrameRendered
-              ? level >= TRIM_MEMORY_RUNNING_LOW
-              : level >= TRIM_MEMORY_RUNNING_CRITICAL;
+      boolean trim = isFirstFrameRendered && level >= TRIM_MEMORY_RUNNING_LOW;
       if (trim) {
         flutterEngine.getDartExecutor().notifyLowMemoryWarning();
         flutterEngine.getSystemChannel().sendMemoryPressureWarning();

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -293,6 +293,9 @@ public class DartExecutor implements BinaryMessenger {
    *
    * <p>This does not notify a Flutter application about memory pressure. For that, use the {@link
    * io.flutter.embedding.engine.systemchannels.SystemChannel#sendMemoryPressureWarning}.
+   *
+   * <p>Calling this method may cause jank or latency in the application. Avoid calling it during
+   * critical periods like application startup or periods of animation.
    */
   public void notifyLowMemoryWarning() {
     if (flutterJNI.isAttached()) {

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -729,8 +729,8 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onTrimMemory(TRIM_MEMORY_COMPLETE);
     delegate.onTrimMemory(TRIM_MEMORY_MODERATE);
     delegate.onTrimMemory(TRIM_MEMORY_UI_HIDDEN);
-    verify(mockFlutterEngine.getDartExecutor(), times(5)).notifyLowMemoryWarning();
-    verify(mockFlutterEngine.getSystemChannel(), times(5)).sendMemoryPressureWarning();
+    verify(mockFlutterEngine.getDartExecutor(), times(0)).notifyLowMemoryWarning();
+    verify(mockFlutterEngine.getSystemChannel(), times(0)).sendMemoryPressureWarning();
 
     verify(mockHost, times(0)).onFlutterUiDisplayed();
 
@@ -745,8 +745,8 @@ public class FlutterActivityAndFragmentDelegateTest {
     verify(mockHost, times(1)).onFlutterUiDisplayed();
 
     delegate.onTrimMemory(TRIM_MEMORY_RUNNING_MODERATE);
-    verify(mockFlutterEngine.getDartExecutor(), times(5)).notifyLowMemoryWarning();
-    verify(mockFlutterEngine.getSystemChannel(), times(5)).sendMemoryPressureWarning();
+    verify(mockFlutterEngine.getDartExecutor(), times(0)).notifyLowMemoryWarning();
+    verify(mockFlutterEngine.getSystemChannel(), times(0)).sendMemoryPressureWarning();
 
     delegate.onTrimMemory(TRIM_MEMORY_RUNNING_LOW);
     delegate.onTrimMemory(TRIM_MEMORY_RUNNING_CRITICAL);
@@ -754,8 +754,8 @@ public class FlutterActivityAndFragmentDelegateTest {
     delegate.onTrimMemory(TRIM_MEMORY_COMPLETE);
     delegate.onTrimMemory(TRIM_MEMORY_MODERATE);
     delegate.onTrimMemory(TRIM_MEMORY_UI_HIDDEN);
-    verify(mockFlutterEngine.getDartExecutor(), times(11)).notifyLowMemoryWarning();
-    verify(mockFlutterEngine.getSystemChannel(), times(11)).sendMemoryPressureWarning();
+    verify(mockFlutterEngine.getDartExecutor(), times(6)).notifyLowMemoryWarning();
+    verify(mockFlutterEngine.getSystemChannel(), times(6)).sendMemoryPressureWarning();
   }
 
   @Test


### PR DESCRIPTION
Doing a GC during application startup can be seen on lower end devices due to low memory warnings. These GCs tend to not recover much memory (because we're busy working towards the first frame).

This is a more aggressive attempt compared with the last patch that changed this (#28891). However, even with that patch internal traces show applications on lower end devices doing inappropriate GCs.

The GC _can_ still run before rendering a frame based on the allocation policy and/or the old gen heap size limit, which is defaulted to half of physical memory. So it is not as if the GC will just accumulate in an unbounded fashion here.

/cc @a-siva @rmacnak-google 
/cc @akbiggs @arbreng in case this might help Fuchsia
