### PR TITLE
Add 'explicit' to darwin embedder constructors

### DIFF
--- a/fml/platform/darwin/cf_utils.h
+++ b/fml/platform/darwin/cf_utils.h
@@ -58,8 +58,7 @@ class CFRef {
   // NOLINTNEXTLINE(google-explicit-constructor)
   operator T() const { return instance_; }
 
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  operator bool() const { return instance_ != nullptr; }
+  explicit operator bool() const { return instance_ != nullptr; }
 
  private:
   T instance_;

--- a/fml/platform/darwin/cf_utils.h
+++ b/fml/platform/darwin/cf_utils.h
@@ -16,6 +16,7 @@ class CFRef {
  public:
   CFRef() : instance_(nullptr) {}
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   CFRef(T instance) : instance_(instance) {}
 
   CFRef(const CFRef& other) : instance_(other.instance_) {
@@ -54,8 +55,10 @@ class CFRef {
     return instance;
   }
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator T() const { return instance_; }
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator bool() const { return instance_ != nullptr; }
 
  private:

--- a/fml/platform/darwin/scoped_block.h
+++ b/fml/platform/darwin/scoped_block.h
@@ -67,6 +67,7 @@ class ScopedBlock {
 
   bool operator!=(B that) const { return block_ != that; }
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   operator B() const { return block_; }
 
   B get() const { return block_; }

--- a/fml/platform/darwin/scoped_nsobject.h
+++ b/fml/platform/darwin/scoped_nsobject.h
@@ -45,6 +45,7 @@ class scoped_nsprotocol {
   scoped_nsprotocol(const scoped_nsprotocol<NST>& that) : object_([that.object_ retain]) {}
 
   template <typename NSU>
+  // NOLINTNEXTLINE(google-explicit-constructor)
   scoped_nsprotocol(const scoped_nsprotocol<NSU>& that) : object_([that.get() retain]) {}
 
   ~scoped_nsprotocol() { [object_ release]; }
@@ -66,7 +67,7 @@ class scoped_nsprotocol {
   bool operator==(NST that) const { return object_ == that; }
   bool operator!=(NST that) const { return object_ != that; }
 
-  operator NST() const { return object_; }
+  operator NST() const { return object_; }  // NOLINT(google-explicit-constructor)
 
   NST get() const { return object_; }
 
@@ -116,6 +117,7 @@ class scoped_nsobject : public scoped_nsprotocol<NST*> {
   scoped_nsobject(const scoped_nsobject<NST>& that) : scoped_nsprotocol<NST*>(that) {}
 
   template <typename NSU>
+  // NOLINTNEXTLINE(google-explicit-constructor)
   scoped_nsobject(const scoped_nsobject<NSU>& that) : scoped_nsprotocol<NST*>(that) {}
 
   scoped_nsobject& operator=(const scoped_nsobject<NST>& that) {
@@ -133,6 +135,7 @@ class scoped_nsobject<id> : public scoped_nsprotocol<id> {
   scoped_nsobject(const scoped_nsobject<id>& that) : scoped_nsprotocol<id>(that) {}
 
   template <typename NSU>
+  // NOLINTNEXTLINE(google-explicit-constructor)
   scoped_nsobject(const scoped_nsobject<NSU>& that) : scoped_nsprotocol<id>(that) {}
 
   scoped_nsobject& operator=(const scoped_nsobject<id>& that) {

--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -106,7 +106,8 @@ class AccessibilityBridge
   /// @param[in]  user_data           A custom pointer to the data of your
   ///                                 choice. This pointer can be retrieve later
   ///                                 through GetUserData().
-  AccessibilityBridge(std::unique_ptr<AccessibilityBridgeDelegate> delegate);
+  explicit AccessibilityBridge(
+      std::unique_ptr<AccessibilityBridgeDelegate> delegate);
   ~AccessibilityBridge();
 
   //------------------------------------------------------------------------------

--- a/shell/platform/common/text_editing_delta.h
+++ b/shell/platform/common/text_editing_delta.h
@@ -23,11 +23,9 @@ struct TextEditingDelta {
                    TextRange range,
                    const std::string& text);
 
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  TextEditingDelta(const std::u16string& text);
+  explicit TextEditingDelta(const std::u16string& text);
 
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  TextEditingDelta(const std::string& text);
+  explicit TextEditingDelta(const std::string& text);
 
   virtual ~TextEditingDelta() = default;
 

--- a/shell/platform/common/text_editing_delta.h
+++ b/shell/platform/common/text_editing_delta.h
@@ -23,8 +23,10 @@ struct TextEditingDelta {
                    TextRange range,
                    const std::string& text);
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   TextEditingDelta(const std::u16string& text);
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   TextEditingDelta(const std::string& text);
 
   virtual ~TextEditingDelta() = default;

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -40,7 +40,7 @@ namespace flutter {
 
 class VsyncWaiterIOS final : public VsyncWaiter {
  public:
-  VsyncWaiterIOS(flutter::TaskRunners task_runners);
+  explicit VsyncWaiterIOS(flutter::TaskRunners task_runners);
 
   ~VsyncWaiterIOS() override;
 

--- a/shell/platform/darwin/ios/ios_switchable_gl_context.h
+++ b/shell/platform/darwin/ios/ios_switchable_gl_context.h
@@ -26,7 +26,7 @@ namespace flutter {
 /// |GLContextSwitch| and should be destroyed when The |GLContectSwitch| destroys.
 class IOSSwitchableGLContext final : public SwitchableGLContext {
  public:
-  IOSSwitchableGLContext(EAGLContext* context);
+  explicit IOSSwitchableGLContext(EAGLContext* context);
 
   bool SetCurrent() override;
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterCompositor.h
@@ -19,7 +19,7 @@ namespace flutter {
 // Platform views are not yet supported.
 class FlutterCompositor {
  public:
-  FlutterCompositor(FlutterViewController* view_controller);
+  explicit FlutterCompositor(FlutterViewController* view_controller);
 
   virtual ~FlutterCompositor() = default;
 


### PR DESCRIPTION
Add `explicit` to constructor declarations in macOS `host_debug` and `ios_debug`

Include headers using header filter regex:
```
Checks: '-*,google-explicit-constructor'
WarningsAsErrors: '-*,google-explicit-constructor'
HeaderFilterRegex: '.*/flutter/.*h$'
```
https://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html

macOS and iOS version of https://github.com/flutter/engine/pull/29741
For https://github.com/flutter/flutter/issues/93576