### PR TITLE
Fix darwin namespace-comments and brace lint issues

### DIFF
--- a/flow/display_list_utils.h
+++ b/flow/display_list_utils.h
@@ -229,14 +229,18 @@ class BoundsAccumulator {
  public:
   void accumulate(const SkPoint& p) { accumulate(p.fX, p.fY); }
   void accumulate(SkScalar x, SkScalar y) {
-    if (min_x_ > x)
+    if (min_x_ > x) {
       min_x_ = x;
-    if (min_y_ > y)
+    }
+    if (min_y_ > y) {
       min_y_ = y;
-    if (max_x_ < x)
+    }
+    if (max_x_ < x) {
       max_x_ = x;
-    if (max_y_ < y)
+    }
+    if (max_y_ < y) {
       max_y_ = y;
+    }
   }
   void accumulate(const SkRect& r) {
     if (r.fLeft <= r.fRight && r.fTop <= r.fBottom) {

--- a/fml/command_line.h
+++ b/fml/command_line.h
@@ -182,13 +182,15 @@ inline CommandLine CommandLineFromIteratorsFindFirstPositionalArg(
     InputIterator first,
     InputIterator last,
     InputIterator* first_positional_arg) {
-  if (first_positional_arg)
+  if (first_positional_arg) {
     *first_positional_arg = last;
+  }
   internal::CommandLineBuilder builder;
   for (auto it = first; it < last; ++it) {
     if (builder.ProcessArg(*it)) {
-      if (first_positional_arg)
+      if (first_positional_arg) {
         *first_positional_arg = it;
+      }
     }
   }
   return builder.Build();
@@ -213,8 +215,9 @@ inline CommandLine CommandLineFromIteratorsWithArgv0(const std::string& argv0,
                                                      InputIterator last) {
   internal::CommandLineBuilder builder;
   builder.ProcessArg(argv0);
-  for (auto it = first; it < last; ++it)
+  for (auto it = first; it < last; ++it) {
     builder.ProcessArg(*it);
+  }
   return builder.Build();
 }
 

--- a/fml/memory/ref_counted.h
+++ b/fml/memory/ref_counted.h
@@ -69,8 +69,9 @@ class RefCountedThreadSafe : public internal::RefCountedThreadSafeBase {
   // Releases a reference to this object. This will destroy this object once the
   // last reference is released.
   void Release() const {
-    if (internal::RefCountedThreadSafeBase::Release())
+    if (internal::RefCountedThreadSafeBase::Release()) {
       delete static_cast<const T*>(this);
+    }
   }
 
   // Returns true if there is exactly one reference to this object. Use of this

--- a/fml/platform/darwin/scoped_block.h
+++ b/fml/platform/darwin/scoped_block.h
@@ -30,18 +30,21 @@ class ScopedBlock {
   explicit ScopedBlock(B block = nullptr,
                        OwnershipPolicy policy = OwnershipPolicy::Assume)
       : block_(block) {
-    if (block_ && policy == OwnershipPolicy::Retain)
+    if (block_ && policy == OwnershipPolicy::Retain) {
       block_ = Block_copy(block);
+    }
   }
 
   ScopedBlock(const ScopedBlock<B>& that) : block_(that.block_) {
-    if (block_)
+    if (block_) {
       block_ = Block_copy(block_);
+    }
   }
 
   ~ScopedBlock() {
-    if (block_)
+    if (block_) {
       Block_release(block_);
+    }
   }
 
   ScopedBlock& operator=(const ScopedBlock<B>& that) {
@@ -51,10 +54,12 @@ class ScopedBlock {
 
   void reset(B block = nullptr,
              OwnershipPolicy policy = OwnershipPolicy::Assume) {
-    if (block && policy == OwnershipPolicy::Retain)
+    if (block && policy == OwnershipPolicy::Retain) {
       block = Block_copy(block);
-    if (block_)
+    }
+    if (block_) {
       Block_release(block_);
+    }
     block_ = block;
   }
 

--- a/shell/platform/darwin/ios/framework/Source/profiler_metrics_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/profiler_metrics_ios.mm
@@ -29,7 +29,7 @@ class MachThreads {
   FML_DISALLOW_COPY_AND_ASSIGN(MachThreads);
 };
 
-}
+}  // namespace
 
 namespace flutter {
 namespace {

--- a/shell/platform/darwin/ios/ios_switchable_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_switchable_gl_context.mm
@@ -22,4 +22,4 @@ bool IOSSwitchableGLContext::RemoveCurrent() {
   FML_DCHECK_CREATION_THREAD_IS_CURRENT(checker);
   return [EAGLContext setCurrentContext:previous_context_];
 };
-}
+}  // namespace flutter

--- a/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProviderUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterFrameBufferProviderUnittests.mm
@@ -38,4 +38,4 @@ TEST(FlutterFrameBufferProviderTest, TestCreate) {
   EXPECT_TRUE(status == GL_FRAMEBUFFER_COMPLETE);
 }
 
-}  // flutter::testing
+}  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterGLCompositorUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterGLCompositorUnittests.mm
@@ -26,4 +26,4 @@ TEST(FlutterGLCompositorTest, TestPresent) {
   ASSERT_TRUE(flag);
 }
 
-}  // flutter::testing
+}  // namespace flutter::testing

--- a/shell/platform/darwin/macos/framework/Source/FlutterMetalCompositorUnittests.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterMetalCompositorUnittests.mm
@@ -68,4 +68,4 @@ TEST(FlutterMetalCompositorTest, TestCompositing) {
   ASSERT_EQ(texture.height, 600u);
 }
 
-}  // flutter::testing
+}  // namespace flutter::testing


### PR DESCRIPTION
Run clang-tidy on macOS and iOS headers to fix brace and namespace comment lint warnings.
Headers version of https://github.com/flutter/engine/pull/29723
See https://github.com/flutter/flutter/issues/93576.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I signed the [CLA].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
