### PR TITLE
Add 'explicit' to Android embedder constructors

### DIFF
--- a/fml/platform/android/scoped_java_ref.h
+++ b/fml/platform/android/scoped_java_ref.h
@@ -164,6 +164,7 @@ class ScopedJavaGlobalRef : public JavaRef<T> {
  public:
   ScopedJavaGlobalRef() {}
 
+  // NOLINTNEXTLINE(google-explicit-constructor)
   explicit ScopedJavaGlobalRef(const ScopedJavaGlobalRef<T>& other) {
     this->Reset(other);
   }

--- a/shell/platform/android/android_image_generator.h
+++ b/shell/platform/android/android_image_generator.h
@@ -16,7 +16,7 @@ namespace flutter {
 
 class AndroidImageGenerator : public ImageGenerator {
  private:
-  AndroidImageGenerator(sk_sp<SkData> buffer);
+  explicit AndroidImageGenerator(sk_sp<SkData> buffer);
 
  public:
   ~AndroidImageGenerator();

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -38,7 +38,7 @@ AssetResolver::AssetResolverType APKAssetProvider::GetType() const {
 
 class APKAssetMapping : public fml::Mapping {
  public:
-  APKAssetMapping(AAsset* asset) : asset_(asset) {}
+  explicit APKAssetMapping(AAsset* asset) : asset_(asset) {}
 
   ~APKAssetMapping() override { AAsset_close(asset_); }
 

--- a/shell/platform/android/flutter_main.h
+++ b/shell/platform/android/flutter_main.h
@@ -27,7 +27,7 @@ class FlutterMain {
   const flutter::Settings settings_;
   DartServiceIsolate::CallbackHandle observatory_uri_callback_;
 
-  FlutterMain(flutter::Settings settings);
+  explicit FlutterMain(flutter::Settings settings);
 
   static void Init(JNIEnv* env,
                    jclass clazz,

--- a/shell/platform/android/platform_message_handler_android.h
+++ b/shell/platform/android/platform_message_handler_android.h
@@ -17,7 +17,7 @@
 namespace flutter {
 class PlatformMessageHandlerAndroid : public PlatformMessageHandler {
  public:
-  PlatformMessageHandlerAndroid(
+  explicit PlatformMessageHandlerAndroid(
       const std::shared_ptr<PlatformViewAndroidJNI>& jni_facade);
   void HandlePlatformMessage(std::unique_ptr<PlatformMessage> message) override;
   void InvokePlatformMessageResponseCallback(

--- a/shell/platform/android/platform_view_android_jni_impl.h
+++ b/shell/platform/android/platform_view_android_jni_impl.h
@@ -16,7 +16,8 @@ namespace flutter {
 ///
 class PlatformViewAndroidJNIImpl final : public PlatformViewAndroidJNI {
  public:
-  PlatformViewAndroidJNIImpl(fml::jni::JavaObjectWeakGlobalRef java_object);
+  explicit PlatformViewAndroidJNIImpl(
+      fml::jni::JavaObjectWeakGlobalRef java_object);
 
   ~PlatformViewAndroidJNIImpl() override;
 

--- a/shell/platform/android/vsync_waiter_android.h
+++ b/shell/platform/android/vsync_waiter_android.h
@@ -18,7 +18,7 @@ class VsyncWaiterAndroid final : public VsyncWaiter {
  public:
   static bool Register(JNIEnv* env);
 
-  VsyncWaiterAndroid(flutter::TaskRunners task_runners);
+  explicit VsyncWaiterAndroid(flutter::TaskRunners task_runners);
 
   ~VsyncWaiterAndroid() override;
 


### PR DESCRIPTION
Add `explicit` to constructor declarations in `android_debug`.

Include headers using header filter regex:
```
Checks: '-*,google-explicit-constructor'
WarningsAsErrors: '-*,google-explicit-constructor'
HeaderFilterRegex: '.*/flutter/.*h$'
```
https://clang.llvm.org/extra/clang-tidy/checks/google-explicit-constructor.html

Android version of https://github.com/flutter/engine/pull/29741
For https://github.com/flutter/flutter/issues/93576