### PR TITLE
Extract AccessibilityBridge::kRootNodeId

### DIFF
--- a/shell/platform/common/accessibility_bridge.h
+++ b/shell/platform/common/accessibility_bridge.h
@@ -100,6 +100,7 @@ class AccessibilityBridge
     virtual std::shared_ptr<FlutterPlatformNodeDelegate>
     CreateFlutterPlatformNodeDelegate() = 0;
   };
+
   //-----------------------------------------------------------------------------
   /// @brief      Creates a new instance of a accessibility bridge.
   ///
@@ -108,6 +109,11 @@ class AccessibilityBridge
   ///                                 through GetUserData().
   AccessibilityBridge(std::unique_ptr<AccessibilityBridgeDelegate> delegate);
   ~AccessibilityBridge();
+
+  //-----------------------------------------------------------------------------
+  /// @brief      The ID of the root node in the accessibility tree. In Flutter,
+  //              this is always 0.
+  static constexpr int32_t kRootNodeId = 0;
 
   //------------------------------------------------------------------------------
   /// @brief      Adds a semantics node update to the pending semantics update.

--- a/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/AccessibilityBridgeMacDelegate.mm
@@ -12,8 +12,6 @@
 
 namespace flutter {
 
-inline constexpr int32_t kRootNode = 0;
-
 // Native mac notifications fired. These notifications are not publicly documented.
 static NSString* const AccessibilityLoadCompleteNotification = @"AXLoadComplete";
 static NSString* const AccessibilityInvalidStatusChangedNotification = @"AXInvalidStatusChanged";
@@ -187,9 +185,10 @@ AccessibilityBridgeMacDelegate::MacOSEventsFromAXEvent(ui::AXEventGenerator::Eve
         if (ax_node.data().HasState(ax::mojom::State::kEditable)) {
           events.push_back({
               .name = NSAccessibilityValueChangedNotification,
-              .target = bridge->GetFlutterPlatformNodeDelegateFromID(kRootNode)
-                            .lock()
-                            ->GetNativeViewAccessible(),
+              .target =
+                  bridge->GetFlutterPlatformNodeDelegateFromID(AccessibilityBridge::kRootNodeId)
+                      .lock()
+                      ->GetNativeViewAccessible(),
               .user_info = nil,
           });
         }


### PR DESCRIPTION
The ID of the root semantics node in Flutter's semantics tree is always
0. Since we'll be adding support for Windows, extract this constant to a
common location.

No new tests added since this just moves a constant.

Issue: https://github.com/flutter/flutter/issues/77838

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide] and the [C++, Objective-C, Java style guides].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt. See [testing the engine] for instructions on
writing and running engine tests.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I signed the [CLA].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[C++, Objective-C, Java style guides]: https://github.com/flutter/engine/blob/main/CONTRIBUTING.md#style
[testing the engine]: https://github.com/flutter/flutter/wiki/Testing-the-engine
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
